### PR TITLE
feat(desktop): Obsidian-style live-preview markdown in scratchpad

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
     "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@lezer/common": "^1.2.3",
     "@lezer/highlight": "^1.2.3",
     "@monaco-editor/react": "^4",
     "@proliferate/cloud-sdk": "workspace:*",

--- a/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
+++ b/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
@@ -38,7 +38,7 @@ describe("ScratchCodeMirrorEditor", () => {
     expect(styleText).toContain("font-size: var(--scratch-font-size)");
     expect(styleText).toContain("line-height: var(--scratch-line-height)");
     expect(styleText).toContain("white-space: normal");
-    expect(styleText).toContain("height: 1.1em !important");
+    expect(styleText).toContain("height: 1em !important");
     expect(styleText).not.toContain("min-height: 1.1em");
   });
 });

--- a/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
+++ b/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
@@ -38,7 +38,7 @@ describe("ScratchCodeMirrorEditor", () => {
     expect(styleText).toContain("font-size: var(--scratch-font-size)");
     expect(styleText).toContain("line-height: var(--scratch-line-height)");
     expect(styleText).toContain("white-space: normal");
-    expect(styleText).toContain("height: 1.25em !important");
+    expect(styleText).toContain("height: 1.1em !important");
     expect(styleText).not.toContain("min-height: 1.1em");
   });
 });

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -25,19 +25,18 @@ export function scratchMarkdownLanguage() {
 }
 
 export const scratchHighlightStyle = HighlightStyle.define([
+  // Heading scale/spacing lives on the line (see scratchEditorTheme) so it
+  // survives the caret revealing the raw "#"; here we only carry weight/colour.
   { tag: tags.heading, color: "var(--color-foreground)", fontWeight: "600" },
-  { tag: tags.heading1, fontSize: "1.4em", lineHeight: "1.35" },
-  { tag: tags.heading2, fontSize: "1.25em", lineHeight: "1.35" },
-  { tag: tags.heading3, fontSize: "1.12em", lineHeight: "1.35" },
   { tag: tags.emphasis, fontStyle: "italic" },
   { tag: tags.strong, fontWeight: "600" },
   { tag: tags.strikethrough, textDecoration: "line-through", color: "var(--color-muted-foreground)" },
   { tag: tags.link, color: "var(--color-foreground)", textDecoration: "underline" },
   {
     tag: tags.monospace,
-    color: "var(--color-muted-foreground)",
+    color: "var(--color-foreground)",
     fontFamily: "var(--scratch-code-font-family)",
-    fontSize: "0.93em",
+    fontSize: "0.9em",
   },
 ]);
 
@@ -68,6 +67,25 @@ export const scratchEditorTheme = EditorView.theme({
     padding: "0",
     lineHeight: "var(--scratch-line-height)",
   },
+  ".cm-line.scratch-heading": {
+    fontWeight: "600",
+    paddingTop: "0.7em",
+    paddingBottom: "0.1em",
+  },
+  // The first line shouldn't carry top space on top of the content padding.
+  ".cm-content > .cm-line:first-child.scratch-heading": {
+    paddingTop: "0",
+  },
+  ".cm-line.scratch-heading-1": { fontSize: "1.5em", lineHeight: "1.3" },
+  ".cm-line.scratch-heading-2": { fontSize: "1.28em", lineHeight: "1.3" },
+  ".cm-line.scratch-heading-3": { fontSize: "1.14em", lineHeight: "1.35" },
+  ".cm-line.scratch-heading-4": { fontSize: "1.05em", lineHeight: "1.4" },
+  ".cm-line.scratch-heading-5": { fontSize: "1em", lineHeight: "1.45" },
+  ".cm-line.scratch-heading-6": {
+    fontSize: "0.95em",
+    lineHeight: "1.45",
+    color: "var(--color-muted-foreground)",
+  },
   ".cm-focused": {
     outline: "none",
   },
@@ -90,8 +108,12 @@ export const scratchEditorTheme = EditorView.theme({
   },
   ".scratch-inline-code": {
     backgroundColor: "color-mix(in oklab, var(--color-foreground) 6%, transparent)",
-    borderRadius: "0.25em",
-    padding: "0.1em 0.25em",
+    border: "1px solid color-mix(in oklab, var(--color-foreground) 8%, transparent)",
+    borderRadius: "0.35em",
+    padding: "0.03em 0.32em",
+    // Keep the chip from stretching the line box and clone its box when it wraps.
+    boxDecorationBreak: "clone",
+    WebkitBoxDecorationBreak: "clone",
   },
   ".scratch-list-marker": {
     display: "inline-flex",

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -59,7 +59,9 @@ export const scratchEditorTheme = EditorView.theme({
   ".cm-content": {
     minHeight: "100%",
     padding: "0.9rem 1.05rem",
-    caretColor: "var(--color-foreground)",
+    // drawSelection() paints the caret as a .cm-cursor element; hide the native
+    // one so we don't get two carets.
+    caretColor: "transparent",
     fontFamily: "inherit",
     lineHeight: "var(--scratch-line-height)",
   },
@@ -92,8 +94,10 @@ export const scratchEditorTheme = EditorView.theme({
   ".cm-cursor": {
     borderLeftColor: "var(--color-foreground)",
     borderLeftWidth: "1px",
-    height: "1.1em !important",
-    marginTop: "0.21em",
+    // Match the caret to the text's own height (ascender→baseline), centred in
+    // the line box, instead of the full line-height. Scales with headings.
+    height: "1em !important",
+    marginTop: "0.33em",
   },
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
     backgroundColor: "color-mix(in oklab, var(--color-foreground) 18%, transparent)",

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -1,3 +1,4 @@
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { HighlightStyle } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import {
@@ -13,10 +14,24 @@ import {
   parseScratchMarkdownListPrefix,
 } from "@/lib/domain/workspaces/scratch/scratch-list-formatting";
 
+export function scratchMarkdownLanguage() {
+  return markdown({
+    addKeymap: false,
+    base: markdownLanguage,
+    // A lone "-"/"=" under a paragraph otherwise reparses the previous line as
+    // a setext heading, bolding it mid-typing when starting a bullet.
+    extensions: [{ remove: ["SetextHeading"] }],
+  });
+}
+
 export const scratchHighlightStyle = HighlightStyle.define([
   { tag: tags.heading, color: "var(--color-foreground)", fontWeight: "600" },
+  { tag: tags.heading1, fontSize: "1.4em", lineHeight: "1.35" },
+  { tag: tags.heading2, fontSize: "1.25em", lineHeight: "1.35" },
+  { tag: tags.heading3, fontSize: "1.12em", lineHeight: "1.35" },
   { tag: tags.emphasis, fontStyle: "italic" },
   { tag: tags.strong, fontWeight: "600" },
+  { tag: tags.strikethrough, textDecoration: "line-through", color: "var(--color-muted-foreground)" },
   { tag: tags.link, color: "var(--color-foreground)", textDecoration: "underline" },
   {
     tag: tags.monospace,
@@ -59,8 +74,8 @@ export const scratchEditorTheme = EditorView.theme({
   ".cm-cursor": {
     borderLeftColor: "var(--color-foreground)",
     borderLeftWidth: "1px",
-    height: "1.25em !important",
-    marginTop: "0.14em",
+    height: "1.1em !important",
+    marginTop: "0.21em",
   },
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
     backgroundColor: "color-mix(in oklab, var(--color-foreground) 18%, transparent)",
@@ -72,6 +87,11 @@ export const scratchEditorTheme = EditorView.theme({
     fontSize: "var(--scratch-font-size)",
     lineHeight: "var(--scratch-line-height)",
     whiteSpace: "normal",
+  },
+  ".scratch-inline-code": {
+    backgroundColor: "color-mix(in oklab, var(--color-foreground) 6%, transparent)",
+    borderRadius: "0.25em",
+    padding: "0.1em 0.25em",
   },
   ".scratch-list-marker": {
     display: "inline-flex",

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts
@@ -3,7 +3,7 @@
 import { syntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   scratchMarkdownLanguage,
 } from "@/hooks/workspaces/lifecycle/scratch-codemirror-extensions";
@@ -12,20 +12,30 @@ import {
 } from "@/hooks/workspaces/lifecycle/scratch-codemirror-live-preview";
 
 let view: EditorView | null = null;
+let hasFocusSpy: ReturnType<typeof vi.spyOn> | null = null;
 
-function createView(doc: string, cursor: number) {
+// jsdom's document.hasFocus() is always false, so CM's view.hasFocus never
+// flips on its own — stub it (and move the caret) to model a focused editor.
+function createView(doc: string, cursor: number, { focus = true }: { focus?: boolean } = {}) {
   view = new EditorView({
     parent: document.body,
     state: EditorState.create({
       doc,
-      selection: { anchor: cursor },
       extensions: [scratchMarkdownLanguage(), scratchLivePreview],
     }),
   });
+  if (focus) {
+    hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    view.focus();
+  }
+  // Dispatching the selection forces a decoration rebuild against the focus state.
+  view.dispatch({ selection: { anchor: cursor } });
   return view;
 }
 
 afterEach(() => {
+  hasFocusSpy?.mockRestore();
+  hasFocusSpy = null;
   view?.destroy();
   view = null;
 });
@@ -40,6 +50,12 @@ describe("scratchLivePreview", () => {
   it("reveals raw markers when the selection touches the formatted span", () => {
     const editor = createView("note **bold** end", 8);
     expect(editor.contentDOM.textContent).toContain("**bold**");
+  });
+
+  it("renders fully when the editor is not focused, even on the caret line", () => {
+    const editor = createView("note **bold** end", 8, { focus: false });
+    expect(editor.contentDOM.textContent).toContain("bold");
+    expect(editor.contentDOM.textContent).not.toContain("**");
   });
 
   it("hides backticks and wraps inline code in a chip", () => {
@@ -59,6 +75,13 @@ describe("scratchLivePreview", () => {
     const doc = "para\n\n# Title";
     const editor = createView(doc, doc.length);
     expect(editor.contentDOM.textContent).toContain("# Title");
+  });
+
+  it("applies a level-scaled line class to headings so they keep their size", () => {
+    const doc = "# Big\n\n### Small";
+    const editor = createView(doc, doc.length);
+    expect(editor.contentDOM.querySelector(".scratch-heading-1")).not.toBeNull();
+    expect(editor.contentDOM.querySelector(".scratch-heading-3")).not.toBeNull();
   });
 
   it("hides link syntax and keeps the link text", () => {

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { syntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  scratchMarkdownLanguage,
+} from "@/hooks/workspaces/lifecycle/scratch-codemirror-extensions";
+import {
+  scratchLivePreview,
+} from "@/hooks/workspaces/lifecycle/scratch-codemirror-live-preview";
+
+let view: EditorView | null = null;
+
+function createView(doc: string, cursor: number) {
+  view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc,
+      selection: { anchor: cursor },
+      extensions: [scratchMarkdownLanguage(), scratchLivePreview],
+    }),
+  });
+  return view;
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+describe("scratchLivePreview", () => {
+  it("hides strong-emphasis markers when the selection is elsewhere", () => {
+    const editor = createView("note **bold** end", 0);
+    expect(editor.contentDOM.textContent).toContain("bold");
+    expect(editor.contentDOM.textContent).not.toContain("**");
+  });
+
+  it("reveals raw markers when the selection touches the formatted span", () => {
+    const editor = createView("note **bold** end", 8);
+    expect(editor.contentDOM.textContent).toContain("**bold**");
+  });
+
+  it("hides backticks and wraps inline code in a chip", () => {
+    const editor = createView("see `code` here", 0);
+    expect(editor.contentDOM.textContent).not.toContain("`");
+    const chip = editor.contentDOM.querySelector(".scratch-inline-code");
+    expect(chip?.textContent).toBe("code");
+  });
+
+  it("hides the heading marker when the selection is on another line", () => {
+    const editor = createView("para\n\n# Title", 0);
+    expect(editor.contentDOM.textContent).toContain("Title");
+    expect(editor.contentDOM.textContent).not.toContain("# Title");
+  });
+
+  it("reveals the heading marker when the selection is on the heading line", () => {
+    const doc = "para\n\n# Title";
+    const editor = createView(doc, doc.length);
+    expect(editor.contentDOM.textContent).toContain("# Title");
+  });
+
+  it("hides link syntax and keeps the link text", () => {
+    const editor = createView("see [docs](https://example.com) here", 0);
+    expect(editor.contentDOM.textContent).toContain("docs");
+    expect(editor.contentDOM.textContent).not.toContain("https://example.com");
+    expect(editor.contentDOM.textContent).not.toContain("[");
+  });
+
+  it("does not parse a lone dash under a paragraph as a setext heading", () => {
+    const editor = createView("hello\n- ", 8);
+    let sawSetextHeading = false;
+    syntaxTree(editor.state).iterate({
+      enter: (node) => {
+        if (node.name.startsWith("SetextHeading")) {
+          sawSetextHeading = true;
+        }
+      },
+    });
+    expect(sawSetextHeading).toBe(false);
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts
@@ -1,0 +1,143 @@
+import { syntaxTree } from "@codemirror/language";
+import { type Range } from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  type DecorationSet,
+  type ViewUpdate,
+} from "@codemirror/view";
+import type { SyntaxNode } from "@lezer/common";
+
+// Obsidian-style live preview: markdown stays the source of truth; syntax
+// markers are hidden with replace decorations unless the selection touches the
+// formatted span, which reveals the raw markdown for in-place editing.
+const FORMATTED_NODE_NAMES = new Set([
+  "ATXHeading1",
+  "ATXHeading2",
+  "ATXHeading3",
+  "ATXHeading4",
+  "ATXHeading5",
+  "ATXHeading6",
+  "Emphasis",
+  "StrongEmphasis",
+  "Strikethrough",
+  "InlineCode",
+  "Link",
+  "Image",
+]);
+
+const HEADING_MARK_NAMES = ["HeaderMark"];
+const EMPHASIS_MARK_NAMES = ["EmphasisMark", "StrikethroughMark"];
+const LINK_MARK_NAMES = ["LinkMark", "URL", "LinkTitle"];
+const CODE_MARK_NAMES = ["CodeMark"];
+
+const inlineCodeDecoration = Decoration.mark({ class: "scratch-inline-code" });
+const hideMarkDecoration = Decoration.replace({});
+
+export const scratchLivePreview = ViewPlugin.fromClass(class {
+  decorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.decorations = buildScratchLivePreviewDecorations(view);
+  }
+
+  update(update: ViewUpdate) {
+    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+      this.decorations = buildScratchLivePreviewDecorations(update.view);
+    }
+  }
+}, {
+  decorations: (plugin) => plugin.decorations,
+});
+
+function buildScratchLivePreviewDecorations(view: EditorView): DecorationSet {
+  const decorations: Range<Decoration>[] = [];
+  for (const { from, to } of view.visibleRanges) {
+    syntaxTree(view.state).iterate({
+      from,
+      to,
+      enter: (node) => {
+        if (!FORMATTED_NODE_NAMES.has(node.name)) {
+          return;
+        }
+        decorateFormattedNode(view, node.node, decorations);
+      },
+    });
+  }
+  return Decoration.set(decorations, true);
+}
+
+function decorateFormattedNode(
+  view: EditorView,
+  node: SyntaxNode,
+  decorations: Range<Decoration>[],
+) {
+  const revealed = selectionTouches(view, revealRange(view, node));
+
+  if (node.name === "InlineCode") {
+    const marks = childrenOfType(node, CODE_MARK_NAMES);
+    const contentFrom = marks[0]?.to ?? node.from;
+    const contentTo = marks[marks.length - 1]?.from ?? node.to;
+    if (contentFrom < contentTo) {
+      decorations.push(inlineCodeDecoration.range(contentFrom, contentTo));
+    }
+    if (!revealed) {
+      for (const mark of marks) {
+        decorations.push(hideMarkDecoration.range(mark.from, mark.to));
+      }
+    }
+    return;
+  }
+
+  if (revealed) {
+    return;
+  }
+
+  if (node.name.startsWith("ATXHeading")) {
+    for (const mark of childrenOfType(node, HEADING_MARK_NAMES)) {
+      // Swallow the space separating the marker from the heading text so the
+      // rendered heading starts flush with the line.
+      const isOpeningMark = mark.from === node.from;
+      const from = !isOpeningMark && view.state.doc.sliceString(mark.from - 1, mark.from) === " "
+        ? mark.from - 1
+        : mark.from;
+      const to = isOpeningMark && view.state.doc.sliceString(mark.to, mark.to + 1) === " "
+        ? mark.to + 1
+        : mark.to;
+      decorations.push(hideMarkDecoration.range(from, to));
+    }
+    return;
+  }
+
+  const markNames = node.name === "Link" || node.name === "Image"
+    ? LINK_MARK_NAMES
+    : EMPHASIS_MARK_NAMES;
+  for (const mark of childrenOfType(node, markNames)) {
+    decorations.push(hideMarkDecoration.range(mark.from, mark.to));
+  }
+}
+
+function revealRange(view: EditorView, node: SyntaxNode) {
+  if (node.name.startsWith("ATXHeading")) {
+    const line = view.state.doc.lineAt(node.from);
+    return { from: line.from, to: line.to };
+  }
+  return { from: node.from, to: node.to };
+}
+
+function selectionTouches(view: EditorView, range: { from: number; to: number }) {
+  return view.state.selection.ranges.some(
+    (selectionRange) => selectionRange.to >= range.from && selectionRange.from <= range.to,
+  );
+}
+
+function childrenOfType(node: SyntaxNode, names: readonly string[]) {
+  const children: SyntaxNode[] = [];
+  for (let child = node.firstChild; child; child = child.nextSibling) {
+    if (names.includes(child.name)) {
+      children.push(child);
+    }
+  }
+  return children;
+}

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts
@@ -34,6 +34,14 @@ const CODE_MARK_NAMES = ["CodeMark"];
 
 const inlineCodeDecoration = Decoration.mark({ class: "scratch-inline-code" });
 const hideMarkDecoration = Decoration.replace({});
+const headingLineDecorations: Record<number, Decoration> = {
+  1: Decoration.line({ class: "scratch-heading scratch-heading-1" }),
+  2: Decoration.line({ class: "scratch-heading scratch-heading-2" }),
+  3: Decoration.line({ class: "scratch-heading scratch-heading-3" }),
+  4: Decoration.line({ class: "scratch-heading scratch-heading-4" }),
+  5: Decoration.line({ class: "scratch-heading scratch-heading-5" }),
+  6: Decoration.line({ class: "scratch-heading scratch-heading-6" }),
+};
 
 export const scratchLivePreview = ViewPlugin.fromClass(class {
   decorations: DecorationSet;
@@ -43,7 +51,12 @@ export const scratchLivePreview = ViewPlugin.fromClass(class {
   }
 
   update(update: ViewUpdate) {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    if (
+      update.docChanged
+      || update.viewportChanged
+      || update.selectionSet
+      || update.focusChanged
+    ) {
       this.decorations = buildScratchLivePreviewDecorations(update.view);
     }
   }
@@ -90,23 +103,30 @@ function decorateFormattedNode(
     return;
   }
 
-  if (revealed) {
+  if (node.name.startsWith("ATXHeading")) {
+    const level = Number(node.name.slice("ATXHeading".length)) || 1;
+    const line = view.state.doc.lineAt(node.from);
+    // Size and space the whole line, so the heading keeps its scale even while
+    // the cursor is on it revealing the raw "#" marker.
+    decorations.push(headingLineDecorations[level].range(line.from));
+    if (!revealed) {
+      for (const mark of childrenOfType(node, HEADING_MARK_NAMES)) {
+        // Swallow the space separating the marker from the heading text so the
+        // rendered heading starts flush with the line.
+        const isOpeningMark = mark.from === node.from;
+        const from = !isOpeningMark && view.state.doc.sliceString(mark.from - 1, mark.from) === " "
+          ? mark.from - 1
+          : mark.from;
+        const to = isOpeningMark && view.state.doc.sliceString(mark.to, mark.to + 1) === " "
+          ? mark.to + 1
+          : mark.to;
+        decorations.push(hideMarkDecoration.range(from, to));
+      }
+    }
     return;
   }
 
-  if (node.name.startsWith("ATXHeading")) {
-    for (const mark of childrenOfType(node, HEADING_MARK_NAMES)) {
-      // Swallow the space separating the marker from the heading text so the
-      // rendered heading starts flush with the line.
-      const isOpeningMark = mark.from === node.from;
-      const from = !isOpeningMark && view.state.doc.sliceString(mark.from - 1, mark.from) === " "
-        ? mark.from - 1
-        : mark.from;
-      const to = isOpeningMark && view.state.doc.sliceString(mark.to, mark.to + 1) === " "
-        ? mark.to + 1
-        : mark.to;
-      decorations.push(hideMarkDecoration.range(from, to));
-    }
+  if (revealed) {
     return;
   }
 
@@ -127,6 +147,11 @@ function revealRange(view: EditorView, node: SyntaxNode) {
 }
 
 function selectionTouches(view: EditorView, range: { from: number; to: number }) {
+  // An unfocused scratchpad renders fully, like Obsidian — raw markdown is only
+  // revealed for the span the caret is actually sitting in while editing.
+  if (!view.hasFocus) {
+    return false;
+  }
   return view.state.selection.ranges.some(
     (selectionRange) => selectionRange.to >= range.from && selectionRange.from <= range.to,
   );

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -1,5 +1,4 @@
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { markdown } from "@codemirror/lang-markdown";
 import { syntaxHighlighting } from "@codemirror/language";
 import { Compartment, EditorState } from "@codemirror/state";
 import {
@@ -16,8 +15,10 @@ import {
   scratchEditorTheme,
   scratchHighlightStyle,
   scratchListDecorations,
+  scratchMarkdownLanguage,
   wordWrapExtension,
 } from "@/hooks/workspaces/lifecycle/scratch-codemirror-extensions";
+import { scratchLivePreview } from "@/hooks/workspaces/lifecycle/scratch-codemirror-live-preview";
 
 interface UseScratchCodeMirrorEditorOptions {
   hostRef: RefObject<HTMLDivElement | null>;
@@ -85,8 +86,9 @@ export function useScratchCodeMirrorEditor({
   // Owns the imperative CodeMirror editor lifecycle and keeps React as the source of saved text.
   const extensions = useMemo(() => [
     history(),
-    markdown({ addKeymap: false }),
+    scratchMarkdownLanguage(),
     syntaxHighlighting(scratchHighlightStyle),
+    scratchLivePreview,
     placeholderCompartmentRef.current.of(placeholder(placeholderText)),
     scratchEditorTheme,
     scratchListDecorations,

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -2,6 +2,7 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { syntaxHighlighting } from "@codemirror/language";
 import { Compartment, EditorState } from "@codemirror/state";
 import {
+  drawSelection,
   EditorView,
   keymap,
   placeholder,
@@ -86,6 +87,9 @@ export function useScratchCodeMirrorEditor({
   // Owns the imperative CodeMirror editor lifecycle and keeps React as the source of saved text.
   const extensions = useMemo(() => [
     history(),
+    // Replaces the native contentEditable caret (whose height we can't control
+    // and which spans the full line box) with a styleable .cm-cursor element.
+    drawSelection(),
     scratchMarkdownLanguage(),
     syntaxHighlighting(scratchHighlightStyle),
     scratchLivePreview,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@fontsource-variable/space-grotesk':
         specifier: ^5.2.10
         version: 5.2.10
+      '@lezer/common':
+        specifier: ^1.2.3
+        version: 1.5.2
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3


### PR DESCRIPTION
## What

Obsidian-style live preview for the scratchpad: the markdown text stays the source of truth, and a CodeMirror `ViewPlugin` hides syntax markers with selection-aware decorations — click into a span to reveal and edit the raw markdown, click out and it re-renders.

## Fixes

- **Random bold on newline bullets**: typing `-` under a paragraph made the markdown parser reparse the previous line as a setext heading and bold it. The `SetextHeading` parser is now removed from the scratchpad language config (regression test included).
- **Backtick rendering**: `inline code` now renders as a subtle background chip with the backticks hidden (revealed on click-in).
- **Oversized caret**: scratchpad caret slimmed from 1.25em to 1.1em and recentered. (Chat input uses a native textarea whose caret height can't be styled — left unchanged.)

## Also

- Per-level heading sizes (h1–h3 scale up), markers hidden unless the cursor is on the heading line
- GFM base parser → `~~strikethrough~~` support
- `[text](url)` renders as underlined text with the URL/brackets hidden
- Added `@lezer/common` as a direct dep for syntax-node types

## Testing

- New `scratch-codemirror-live-preview.test.ts` covering hide/reveal for strong emphasis, inline-code chip, headings, links, and the setext regression
- `tsc --noEmit` clean; full desktop suite: only failures are 4 tests that already fail on a clean checkout of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)