### PR TITLE
fix(desktop): snappier chat input — optimistic model switch + instant transcript reflow

### DIFF
--- a/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
@@ -1,4 +1,4 @@
-import { getPendingSessionConfigChange, type PendingSessionConfigChanges } from "@proliferate/product-domain/sessions/pending-config";
+import { DEFAULT_MODEL_CONFIG_ID, getPendingSessionConfigChange, type PendingSessionConfigChanges } from "@proliferate/product-domain/sessions/pending-config";
 import {
   pendingConfigChangesForSessionIntents,
 } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
@@ -81,13 +81,13 @@ export function useActiveSessionLaunchState(): {
   );
 
   const pendingModelId = useMemo(() => {
-    if (!slice.currentModelConfigId) {
-      return null;
-    }
-    return getPendingSessionConfigChange(
-      pendingConfigChanges,
-      slice.currentModelConfigId,
-    )?.value ?? null;
+    // Prefer the live model control's config id; fall back to the default
+    // "model" key so an optimistic switch made before the session exposes a
+    // model control (pending/not-yet-connected session) is still reflected.
+    const change =
+      getPendingSessionConfigChange(pendingConfigChanges, slice.currentModelConfigId)
+      ?? getPendingSessionConfigChange(pendingConfigChanges, DEFAULT_MODEL_CONFIG_ID);
+    return change?.value ?? null;
   }, [pendingConfigChanges, slice.currentModelConfigId]);
 
   const currentLaunchIdentity = useMemo<ActiveLaunchIdentity | null>(() => {

--- a/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
+++ b/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
@@ -4,7 +4,7 @@ import { CHAT_MODEL_SELECTOR_LABELS } from "@/copy/chat/chat-copy";
 import { getProviderDisplayName } from "@/lib/domain/agents/provider-display";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/facade/use-selected-cloud-runtime-state";
-import { getPendingSessionConfigChange } from "@proliferate/product-domain/sessions/pending-config";
+import { DEFAULT_MODEL_CONFIG_ID, getPendingSessionConfigChange } from "@proliferate/product-domain/sessions/pending-config";
 import {
   resolveMatchingModelControlLabel,
 } from "@/lib/domain/chat/models/model-display";
@@ -78,7 +78,7 @@ export function useChatModelSelectorState(options?: { suppressActiveSessionState
 
   const pendingModelChange = getPendingSessionConfigChange(
     scopedPendingConfigChanges,
-    scopedModelControl?.rawConfigId ?? null,
+    scopedModelControl?.rawConfigId ?? DEFAULT_MODEL_CONFIG_ID,
   );
   const currentSelection = scopedLaunchIdentity ?? launchIntentIdentity ?? configuredLaunch.selection;
   const displayedModelValue =

--- a/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -5,8 +5,6 @@ import {
   computeChatSurfaceBottomInsetPx,
 } from "@/config/chat-layout";
 
-const CHAT_DOCK_RESIZE_SETTLE_MS = 90;
-
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   const [metrics, setMetrics] = useState({
@@ -54,21 +52,18 @@ export function useChatDockInset() {
       return;
     }
 
-    let settleTimer: number | null = null;
+    // Coalesce ResizeObserver bursts to one measurement per animation frame so
+    // the transcript inset tracks composer height changes within a frame instead
+    // of lagging behind a debounce. measure() self-dedupes when metrics are
+    // unchanged, so per-frame measurement stays cheap during resize storms.
     const scheduleMeasure = () => {
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
+      if (frameId !== null) {
+        return;
       }
-      settleTimer = window.setTimeout(() => {
-        settleTimer = null;
-        if (frameId !== null) {
-          window.cancelAnimationFrame(frameId);
-        }
-        frameId = window.requestAnimationFrame(() => {
-          frameId = null;
-          measure();
-        });
-      }, CHAT_DOCK_RESIZE_SETTLE_MS);
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        measure();
+      });
     };
 
     const observer = new ResizeObserver(() => {
@@ -87,9 +82,6 @@ export function useChatDockInset() {
 
     return () => {
       observer.disconnect();
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
-      }
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }

--- a/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.ts
+++ b/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.ts
@@ -12,6 +12,7 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 import { useActiveSessionLaunchState } from "@/hooks/chat/derived/use-active-session-config-state";
 import { useConfiguredLaunchReadiness } from "@/hooks/chat/derived/use-configured-launch-readiness";
 import { resolveAvailableLaunchSelection } from "@/lib/domain/chat/models/launch-selection-defaults";
+import { DEFAULT_MODEL_CONFIG_ID } from "@proliferate/product-domain/sessions/pending-config";
 import {
   EMPTY_CHAT_DRAFT,
   serializeChatDraftToPrompt,
@@ -71,9 +72,10 @@ export function useChatLaunchActions(options?: { suppressActiveSessionState?: bo
       // Same-harness switch always keeps the session (decision 10). The
       // runtime accepts catalog-authorized values beyond the live option
       // list and falls back to relaunching the agent process under the same
-      // session when the harness has no live mechanism (gemini). "model" is
-      // the generic model config id when the session exposes no control.
-      void setActiveSessionConfigOption(scopedCurrentModelConfigId ?? "model", selection.modelId)
+      // session when the harness has no live mechanism (gemini).
+      // DEFAULT_MODEL_CONFIG_ID is the generic model config id when the session
+      // exposes no live control (e.g. an optimistic, not-yet-connected session).
+      void setActiveSessionConfigOption(scopedCurrentModelConfigId ?? DEFAULT_MODEL_CONFIG_ID, selection.modelId)
         .then(() => {
           setWorkspaceArrivalEvent(null);
         })

--- a/apps/packages/product-domain/src/sessions/pending-config.ts
+++ b/apps/packages/product-domain/src/sessions/pending-config.ts
@@ -4,6 +4,12 @@ import type {
   SessionLiveConfigSnapshot,
 } from "@anyharness/sdk";
 
+// Fallback model config id used before a session exposes a live model control
+// (e.g. an optimistic, not-yet-connected session). Mirrors the server's
+// ACP_MODEL_COMPAT_CONFIG_ID so optimistic config intents written under this key
+// resolve consistently on the read side.
+export const DEFAULT_MODEL_CONFIG_ID = "model";
+
 export type PendingSessionConfigChangeStatus = "submitting" | "queued";
 
 export interface PendingSessionConfigChange {


### PR DESCRIPTION
## Context

Three chat-composer papercuts, all "the UI is correct but arrives late":

1. **Model changes aren't instant during an optimistic new session** — right after launching a chat (before the harness connects), switching model in the picker left the label showing the old model, with no pending indicator, until connect (often 1s+).
2. **The picker should reflect the change optimistically** instead of waiting on the round-trip.
3. **The transcript lags composer height changes** — adding/removing a line resized the textarea instantly, but the transcript above shifted ~90–110ms later.

## Root causes

- **(1)+(2) — config-id key mismatch.** A model switch in a pending session enqueues a config intent keyed `"model"` (`handleLaunchSelect` → `scopedCurrentModelConfigId ?? "model"`). But both readers looked the change up by the *live* model control's config id, which is null until `liveConfig` arrives, so `getPendingSessionConfigChange` returned null and the label + spinner stayed stale. (For connected sessions the real `rawConfigId` is `"model"` and this already worked — verified against the server's `ACP_MODEL_COMPAT_CONFIG_ID`.)
- **(3) — pure 90ms debounce.** The textarea autosizes synchronously in a `useLayoutEffect`, but `useChatDockInset` debounced every `ResizeObserver` fire by `CHAT_DOCK_RESIZE_SETTLE_MS = 90` before measuring → `setMetrics` → `stickyBottomInsetPx` → the transcript spacer. There is no CSS height transition on the composer/dock, so the 90ms was just a debounce and the entire source of the lag.

## Changes

**Fix A — optimistic model selection (issues 1 & 2)**
- `pending-config.ts`: new shared `DEFAULT_MODEL_CONFIG_ID = "model"` constant (mirrors the server's `ACP_MODEL_COMPAT_CONFIG_ID`; single-sources the magic key).
- `use-active-session-config-state.ts`: `pendingModelId` prefers the live config id, falls back to `DEFAULT_MODEL_CONFIG_ID` → the picker **label** updates immediately.
- `use-chat-model-selector-state.ts`: same fallback for `pendingModelChange` → the **queued indicator** shows during the optimistic window too.
- `use-chat-launch-actions.ts`: write side uses the shared constant (keeps read/write keys in sync).

No revert logic needed: the pending entry is derived from the intent and clears automatically on intent terminalization, so there's no stuck spinner or flicker at the pending→connected transition. Connected-session and home-screen paths are unchanged (the fallback only differs when no live model control exists yet).

**Fix B — instant transcript reflow (issue 3)**
- `use-chat-dock-inset.ts`: dropped the 90ms `setTimeout` debounce; dock measurement now coalesces per animation frame (rAF). Transcript tracks input height within ~1 frame. `measure()` already self-dedupes, and the spacer isn't inside any observed element, so there's no resize-loop risk.

## Verification
- `@proliferate/product-domain` typecheck — clean; tests — **370 passed**
- desktop `tsc --noEmit` (after building all workspace deps) — clean, 0 errors
- targeted desktop vitest (active-session selectors, workspace-entry flow/actions, model-selector-current, composer autosize) — **17 passed**

Manual (recommended): launch `pdev`, (A) launch a chat and switch model before it connects → label flips instantly with a queued indicator; (B) wrap/unwrap a line in the input → transcript shifts in lockstep, stays pinned to bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)