### PR TITLE
feat(desktop): reverse Cmd/Cmd+Opt number shortcuts; always land on a session

### DIFF
--- a/apps/desktop/src/config/shortcuts/workspace-shortcuts.ts
+++ b/apps/desktop/src/config/shortcuts/workspace-shortcuts.ts
@@ -57,15 +57,6 @@ export const WORKSPACE_SHORTCUTS = {
     match: { kind: "fixed-code", code: "KeyC", meta: true, shift: false, alt: true },
     allowInInputs: true,
   },
-  workspaceByIndex: {
-    id: "workspace.by-index",
-    label: "⌘⌥1-9",
-    nonMacLabel: "Ctrl+Alt+1-9",
-    description: "Switch to workspace by index",
-    owner: "js",
-    match: { kind: "digit-code", meta: true, shift: false, alt: true },
-    allowInInputs: true,
-  },
   previousWorkspace: {
     id: "workspace.previous-workspace",
     label: "⌘⌥↑",
@@ -122,13 +113,16 @@ export const WORKSPACE_SHORTCUTS = {
   },
   tabByIndex: {
     id: "workspace.tab-by-index",
-    label: "⌘1-9",
-    nonMacLabel: "Ctrl+1-9",
+    label: "⌘⌥1-9",
+    nonMacLabel: "Ctrl+Alt+1-9",
     description: "Jump to chat by index",
     owner: "js",
-    match: { kind: "digit-key", meta: true, shift: false, alt: false },
+    match: { kind: "digit-code", meta: true, shift: false, alt: true },
     allowInInputs: true,
   },
+  // Declared before workspaceByIndex so the Settings overlay wins the ⌘1-9 overlap
+  // while it is open. When Settings is closed its handler is unregistered, so dispatch
+  // falls through to workspace switching.
   settingsSectionByIndex: {
     id: "settings.section-by-index",
     label: "⌘1-9",
@@ -137,6 +131,15 @@ export const WORKSPACE_SHORTCUTS = {
     owner: "js",
     match: { kind: "digit-key", meta: true, shift: false, alt: false },
     allowInInputs: false,
+  },
+  workspaceByIndex: {
+    id: "workspace.by-index",
+    label: "⌘1-9",
+    nonMacLabel: "Ctrl+1-9",
+    description: "Switch to workspace by index",
+    owner: "js",
+    match: { kind: "digit-key", meta: true, shift: false, alt: false },
+    allowInInputs: true,
   },
   newSessionTab: {
     id: "workspace.new-session-tab",

--- a/apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.ts
@@ -87,14 +87,9 @@ export async function handleEmptyWorkspaceBootstrap(
     count: sessionsIncludingDismissed.length,
   });
 
-  if (hasDismissedSessions) {
-    deps.setActiveSessionId(null);
-    if (input.isCurrent()) {
-      deps.markWorkspaceBootstrappedInSession(input.workspaceId);
-    }
-    return { shouldReturn: true };
-  }
-
+  // Dismissed-only workspaces have no visible session to land on, so fall through to
+  // the default-session creation path below (same as a truly empty workspace) instead
+  // of leaving the user on the empty hero. hasDismissedSessions stays logged above.
   const activeProjectedSessionId = resolveActiveProjectedSessionForPendingWorkspace(
     input.workspaceId,
     deps.getPendingWorkspaceEntry(),

--- a/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -315,7 +315,7 @@ describe("shortcut dispatch policy", () => {
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
-      altKey: false,
+      altKey: true,
       defaultPrevented: true,
       target: null,
     } as KeyboardEvent)).toBe(true);
@@ -326,7 +326,7 @@ describe("shortcut dispatch policy", () => {
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
-      altKey: true,
+      altKey: false,
       defaultPrevented: true,
       target: null,
     } as KeyboardEvent)).toBe(true);
@@ -361,7 +361,7 @@ describe("shortcut dispatch policy", () => {
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
-      altKey: false,
+      altKey: true,
       defaultPrevented: true,
       target: {
         tagName: "TEXTAREA",
@@ -483,7 +483,7 @@ describe("shortcut dispatch policy", () => {
       metaKey: true,
       ctrlKey: false,
       shiftKey: false,
-      altKey: false,
+      altKey: true,
       defaultPrevented: true,
       target: null,
     } as KeyboardEvent)).toBe(true);

--- a/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
@@ -75,7 +75,7 @@ function canBypassDefaultPrevented(
 
   if (
     (
-      shortcut.id === SHORTCUTS.tabByIndex.id
+      shortcut.id === SHORTCUTS.workspaceByIndex.id
       || shortcut.id === SHORTCUTS.settingsSectionByIndex.id
     )
     && (event.metaKey || event.ctrlKey)
@@ -87,7 +87,7 @@ function canBypassDefaultPrevented(
   }
 
   if (
-    shortcut.id === SHORTCUTS.workspaceByIndex.id
+    shortcut.id === SHORTCUTS.tabByIndex.id
     && (event.metaKey || event.ctrlKey)
     && event.altKey
     && !event.shiftKey

--- a/apps/desktop/src/lib/domain/shortcuts/presentation.test.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/presentation.test.ts
@@ -9,9 +9,9 @@ describe("shortcut presentation", () => {
       SHORTCUTS.workspaceByIndex,
     );
 
-    expect(labels.get("workspace-1")).toBe("⌘⌥1");
-    expect(labels.get("workspace-8")).toBe("⌘⌥8");
+    expect(labels.get("workspace-1")).toBe("⌘1");
+    expect(labels.get("workspace-8")).toBe("⌘8");
     expect(labels.has("workspace-9")).toBe(false);
-    expect(labels.get("workspace-10")).toBe("⌘⌥9");
+    expect(labels.get("workspace-10")).toBe("⌘9");
   });
 });

--- a/apps/desktop/src/lib/domain/workspaces/selection/selection.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/selection/selection.test.ts
@@ -45,13 +45,13 @@ describe("choosePreferredWorkspaceSession", () => {
     expect(choosePreferredWorkspaceSession(sessions, null)?.id).toBe("prompted");
   });
 
-  it("does not auto-select setup-only sessions", () => {
+  it("falls back to the most recently updated session when none are prompted", () => {
     const sessions = [
       { id: "session-1", updatedAt: "2026-04-07T18:00:00.000Z" },
       { id: "session-2", updatedAt: "2026-04-07T19:00:00.000Z" },
     ];
 
-    expect(choosePreferredWorkspaceSession(sessions, null)).toBeNull();
+    expect(choosePreferredWorkspaceSession(sessions, null)?.id).toBe("session-2");
   });
 });
 

--- a/apps/desktop/src/lib/domain/workspaces/selection/selection.ts
+++ b/apps/desktop/src/lib/domain/workspaces/selection/selection.ts
@@ -31,12 +31,15 @@ export function choosePreferredWorkspaceSession<T extends WorkspaceSelectionSess
     return preferredSession;
   }
 
+  // Prefer prompted sessions, but never strand the user on the empty hero: when a
+  // workspace has only never-prompted sessions (e.g. setup-only sessions), fall back
+  // to the most recently updated one so a workspace switch always lands on a session.
+  // This mirrors resolveOptimisticWorkspaceSessionId's visible-session fallback so the
+  // optimistic and post-load picks agree.
   const promptedSessions = sessions.filter((session) => session.lastPromptAt);
-  if (promptedSessions.length === 0) {
-    return null;
-  }
+  const rankedSessions = promptedSessions.length > 0 ? promptedSessions : sessions;
 
-  return [...promptedSessions].sort((left, right) => sessionTimestamp(right) - sessionTimestamp(left))[0] ?? null;
+  return [...rankedSessions].sort((left, right) => sessionTimestamp(right) - sessionTimestamp(left))[0] ?? null;
 }
 
 export function getLatestWorkspaceInteractionTimestamp<T extends WorkspaceSelectionSessionLike>(


### PR DESCRIPTION
## Summary

Addresses two desktop papercuts:

1. **Reverse `⌘number` ↔ `⌘⌥number`.** Workspaces are the more frequent, top-level navigation and should get the lighter chord.
2. **Switching to a workspace should always land on a session** — currently it sometimes drops you on the empty/ready hero.

## 1 — Reverse the digit shortcuts

| Chord | Before | After |
|---|---|---|
| `⌘1–9` | jump to chat tab | **switch workspace** |
| `⌘⌥1–9` | switch workspace | **jump to chat tab** |

- The alt chord matches by `event.code` (`digit-code`) because macOS rewrites `event.key` into symbols when Option is held; the no-alt chord stays `digit-key`.
- `settingsSectionByIndex` also binds `⌘1–9`. `workspaceByIndex` is now declared **after** it so the Settings overlay wins the overlap while open; when Settings is closed its handler is unregistered and dispatch falls through to workspace switching.
- All shortcut hints (sidebar badges, tab badges, Keyboard Shortcuts pane) are data-driven from the registry, so they update automatically.

Files: `config/shortcuts/workspace-shortcuts.ts`, `lib/domain/shortcuts/dispatch-policy.ts`.

## 2 — Always land on a session

Root cause: the optimistic pre-bootstrap pick falls back to the first visible session, but the post-load pick `choosePreferredWorkspaceSession` returned `null` when no session had been *prompted* (e.g. only setup-script sessions, or the remembered session was deleted). The two disagreed, so the empty-hero landing was **intermittent** (depended on whether the visible-session cache was warm) and **sticky** (the workspace gets marked bootstrapped; the warm-revisit path needs an existing session to reconcile).

- `choosePreferredWorkspaceSession` now falls back to the most recently updated visible session instead of `null`, aligning it with the optimistic fallback.
- Dismissed-only workspaces (no visible sessions, only hidden/dismissed ones) now fall through to create a fresh chat instead of going blank — same as a truly empty workspace.

Files: `lib/domain/workspaces/selection/selection.ts`, `hooks/workspaces/workflows/workspace-bootstrap-empty-session.ts`.

### ⚠️ Reviewer decision
The dismissed-only → fresh-chat behavior is a deliberate product choice (you asked to "always land on a session"). Only **one** session is ever created, since the next visit then has a visible session. If you'd rather keep today's empty state when *everything* is dismissed, drop the `workspace-bootstrap-empty-session.ts` change and keep only the `selection.ts` fix.

## Testing

- ✅ Unit: **33/33** across the four affected files — `dispatch-policy.test.ts`, `presentation.test.ts`, `native-accelerators.test.ts`, `selection.test.ts`.
- ✅ Typecheck: changed files are clean (verified against a clean `tsc --noEmit` baseline of `main`, exit 0).
- ⏳ Manual in-app QA still to do:
  - `⌘1`/`⌘2` switch workspaces (sidebar badges read `⌘1–9`); `⌘⌥1`/`⌘⌥2` jump tabs (badges read `⌘⌥1–9`).
  - In Settings, `⌘1–9` picks sections and does **not** switch workspace behind the overlay; closing Settings restores workspace switching.
  - Right-panel focus: `⌘⌥digit` still targets right-panel tabs.
  - Cold-switch into a workspace whose only sessions are never-prompted/setup-only, one whose remembered session was deleted, and a dismissed-only one — each lands on a chat, and stays on one across revisits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
