### PR TITLE
docs(release): add GitHub issue form templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug Report
+description: Report something that is broken or behaving unexpectedly
+title: "[Bug]: "
+labels: ["release:fix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much as you
+        can — reproduction steps and environment details are the most useful.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can a maintainer reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Recordings
+      description: If applicable, add screenshots or a screen recording to help explain.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the repo does this affect? (matches our `area:*` labels)
+      options:
+        - desktop
+        - anyharness
+        - sdk
+        - server
+        - cloud
+        - docs
+        - website
+        - release
+        - product
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, app/CLI version, browser, etc.
+      placeholder: |
+        - OS: macOS 15.5
+        - App/CLI version: 1.2.3
+        - Browser (if relevant): Chrome 140
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Any relevant config, profiles, or flags in use.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste any relevant log output. This is automatically formatted, no backticks needed.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution Guide
+    url: https://github.com/proliferate-ai/proliferate/blob/main/CONTRIBUTING.md
+    about: Read this before opening an issue or PR.
+  - name: Discussions
+    url: https://github.com/proliferate-ai/proliferate/discussions
+    about: Questions, ideas, and general discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature Request
+description: Suggest an enhancement or new capability
+title: "[Feature]: "
+labels: ["release:minor-feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the problem first — it helps
+        us understand the goal before evaluating a specific solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve? What is the current pain?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the change or feature you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you thought about and why you ruled them out.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the repo would this touch? (matches our `area:*` labels)
+      options:
+        - desktop
+        - anyharness
+        - sdk
+        - server
+        - cloud
+        - docs
+        - website
+        - release
+        - product
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Mockups, references, or related issues.
+    validations:
+      required: false
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation Ideas
+      description: If you have thoughts on how this could be built, share them here.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/` with GitHub **YAML issue forms** (not plain `.md`) so new issues collect consistent, structured details.
- `bug_report.yml` — `[Bug]:` form: description, repro steps, expected behavior, screenshots, **area dropdown**, environment, config, logs, additional context. Auto-applies `release:fix`.
- `feature_request.yml` — `[Feature]:` form: problem statement, proposed solution, alternatives, **area dropdown**, additional context, implementation ideas. Auto-applies `release:minor-feature`.
- `config.yml` — contact links to `CONTRIBUTING.md` and Discussions.

### Notes / deviations from the issues
- **Used YAML forms instead of `.md`.** The existing issues already use `[Bug]:`/`[Feature]:` title prefixes (the forms convention), and forms can enforce required fields and auto-label.
- **Repo-aware:** the area dropdowns mirror the actual `area:*` labels and the templates auto-apply a `release:*` label, matching `CONTRIBUTING.md` / CI conventions.
- **PR template (#651) was already satisfied** — `.github/pull_request_template.md` already exists and is repo-tailored, so this PR does not touch it.

Closes #650
Re #651 (already satisfied by existing `.github/pull_request_template.md`)

Thanks @sundaram2021 for raising #650 and #651 👍

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label
- Required: at least one `area:*` label

## Verification

- Validated all three YAML files parse cleanly (`ruby -ryaml`).
- Forms render via GitHub's "New issue" chooser once merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
