### PR TITLE
chore(release): add dependabot, CODEOWNERS, CodeQL, and security docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS — https://docs.github.com/articles/about-code-owners
+# Listed owners are requested for review automatically when matching files change.
+# The last matching pattern wins, so keep more specific paths below the default.
+
+# Default owner for everything in the repo.
+* @pablonyx
+
+# Security & community-health surfaces — review changes here carefully.
+/SECURITY.md            @pablonyx
+/.github/               @pablonyx
+/.github/workflows/     @pablonyx
+/.github/dependabot.yml @pablonyx
+/.github/CODEOWNERS     @pablonyx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Dependabot configuration — https://docs.github.com/code-security/dependabot
+# Keeps each ecosystem's dependencies patched. PRs carry the release:*/area:*
+# labels required by .github/workflows/pr-metadata.yml so they pass CI checks.
+version: 2
+updates:
+  # JavaScript / TypeScript — pnpm workspace (root lockfile covers all packages)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "release:maintenance"
+      - "area:release"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Rust — Cargo workspace (root lockfile covers all crates)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "release:maintenance"
+      - "area:release"
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Python — server (uv-managed)
+  - package-ecosystem: "uv"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "release:maintenance"
+      - "area:server"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker — server image
+  - package-ecosystem: "docker"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "release:maintenance"
+      - "area:server"
+
+  # GitHub Actions — workflow pinned actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "release:maintenance"
+      - "area:release"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Weekly scan — Mondays 03:27 UTC.
+    - cron: "27 3 * * 1"
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
 
 ## Open Source
 
-Proliferate is AGPL-3.0. The desktop and web apps are fully open today, and self-hosting for the complete cloud control plane is coming soon.
+Proliferate is AGPL-3.0. The desktop and web apps are fully open today.
+Self-hosting the full cloud control plane is in beta — see
+[Self-hosting](#self-hosting) below.
 
 ## Getting Started
 
@@ -148,12 +150,27 @@ generated Tauri config, and app labels.
 
 </details>
 
-<details>
-<summary>Self-host Proliferate Cloud (coming soon)</summary>
+<details id="self-hosting">
+<summary>Self-host Proliferate Cloud (beta)</summary>
 
-Self-hosting the full Proliferate Cloud control plane is coming soon. Teams
-that want an early self-hosted deployment can reach out through
-[proliferate.com](https://proliferate.com) for access and deployment support.
+### Self-hosting
+
+Self-hosting the full Proliferate Cloud control plane is in **beta**. The
+deployment path works today via Docker Compose, with polished end-to-end docs
+on the way.
+
+- **Docker Compose:** [self-hosted-deploy.md](./specs/developing/deploying/self-hosted-deploy.md) —
+  Caddy + Postgres + API, with bootstrap and update scripts
+- **AWS (one-click):** [self-hosted-aws.md](./specs/developing/deploying/self-hosted-aws.md) —
+  CloudFormation wrapper that provisions the stack on EC2
+- **Configuration:** [`server/deploy/.env.production.example`](./server/deploy/.env.production.example)
+  documents every required and optional setting
+
+Point the desktop app at your control plane by setting `apiBaseUrl` in
+`~/.proliferate/config.json`. Since this is beta, expect rough edges — please
+[open an issue](../../issues/new/choose) or ask in
+[Discord](https://discord.gg/wCEgUnEuF) if you hit problems, and see
+[SECURITY.md](./SECURITY.md) for reporting vulnerabilities.
 
 </details>
 
@@ -173,9 +190,10 @@ that want an early self-hosted deployment can reach out through
 - 🔐 **Credential gateway** - your keys and subscriptions never touch the sandbox; sandboxes only get short-lived tokens
 - 🏢 **Organizations** - team seats, shared settings, cloud limits, and governance controls
 - 📱 **Mobile** - coming soon: dispatch work, approve actions, and follow runs from your phone
-- 🏗️ **Self-hosted Proliferate Cloud** - coming soon: run the full cloud control plane yourself
+- 🏗️ **Self-hosted Proliferate Cloud** - beta: run the full cloud control plane yourself ([docs](#self-hosting))
 
-Proliferate Cloud will be fully self-hostable and open source once it's out of beta.
+Proliferate Cloud is open source (AGPL-3.0) and self-hostable today in beta; the
+self-host experience will be fully polished as Cloud moves toward GA.
 
 ## Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+We take the security of Proliferate seriously. Thank you for helping keep
+Proliferate and its users safe.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use one of the following private channels:
+
+1. **GitHub Private Vulnerability Reporting (preferred)** — open a report via the
+   repository's **Security → Report a vulnerability** tab
+   ([advisories/new](../../security/advisories/new)). This keeps the discussion
+   private until a fix is released.
+2. **Email** — `security@proliferate.com`
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof-of-concept
+- Affected component(s) and version(s) (desktop, web, server/control plane,
+  AnyHarness runtime, SDK)
+- Any relevant logs or configuration (redact secrets)
+
+## What to Expect
+
+- **Acknowledgement** within 3 business days.
+- **Assessment & triage** with an initial severity estimate shortly after.
+- **Progress updates** as we work on a fix.
+- **Coordinated disclosure** — we'll agree on a disclosure timeline with you and
+  credit you (if you wish) once a fix is available.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure.
+
+## Supported Versions
+
+Proliferate ships frequently. Security fixes target the **latest released
+version** on the default branch. Self-hosters should track the latest release;
+see [self-hosted-deploy.md](./specs/developing/deploying/self-hosted-deploy.md)
+for the update flow.
+
+## Scope Notes
+
+- **Proliferate Cloud** and **self-hosting the control plane** are in **beta** —
+  we especially welcome reports against these surfaces.
+- When self-hosting, your keys, OAuth apps, and sandbox provider credentials are
+  your responsibility; never commit them. See
+  [`server/deploy/.env.production.example`](./server/deploy/.env.production.example).


### PR DESCRIPTION
## Summary

Adds community-health / security infrastructure to the repo:

- **`.github/dependabot.yml`** — weekly dependency updates across every ecosystem in the repo:
  - `npm` at `/` (covers the whole pnpm workspace via the root lockfile)
  - `cargo` at `/` (covers the whole Cargo workspace)
  - `uv` at `/server` (Python)
  - `docker` at `/server`
  - `github-actions` at `/`
  - Minor/patch updates are grouped to cut PR noise; every PR is auto-labeled `release:maintenance` + an `area:*` label so it passes the `pr-metadata` check.
- **`.github/CODEOWNERS`** — `@pablonyx` as the default owner, with security-sensitive paths (`SECURITY.md`, `.github/`, workflows) called out.
- **`.github/workflows/codeql.yml`** — CodeQL code scanning for **JS/TS, Python, and Rust** on push/PR to `main` plus a weekly cron (`build-mode: none`, so no project build needed).
- **`SECURITY.md`** — vulnerability reporting policy: private channels (GitHub advisories + email), response SLAs, supported versions, and self-hosting scope notes.
- **`README.md`** — promotes self-hosting from "coming soon" to a real **beta** section and links to `SECURITY.md` and the issue chooser.

## PR Metadata

- Title format: `<type>(<scope>): <plain-English change>`
- Required: exactly one `release:*` label
- Required: at least one `area:*` label

## Verification

- All new YAML validated (`ruby -ryaml`).
- Confirmed every label Dependabot applies (`release:maintenance`, `area:release`, `area:server`) already exists, so Dependabot won't error.
- Confirmed Dependabot's `build(deps): …` titles + labels satisfy `.github/workflows/pr-metadata.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
