### PR TITLE
ci(release): bump CodeQL action to v4 and checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,15 +34,15 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Bumps the CodeQL workflow off deprecated action versions flagged on the first run:
- `actions/checkout@v4` → `@v5` (Node 24)
- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/analyze@v3` → `@v4`

Avoids the Node 20 deprecation (forced to Node 24 on **2026-06-16**) and the CodeQL Action v3 deprecation (Dec 2026).

## Verification
- `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)