### PR TITLE
feat(desktop): tab-strip playground, workspace UI polish, and session runtime updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,15 +34,15 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.2.4"
+version = "0.2.9"
 dependencies = [
  "anyharness-credential-discovery",
  "base64 0.22.1",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -73,6 +73,14 @@ const UpdatePlaygroundPage = import.meta.env.DEV
     )
   : null
 
+const TabStripPlaygroundPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("@/pages/TabStripPlaygroundPage").then((m) => ({
+        default: m.TabStripPlaygroundPage,
+      })),
+    )
+  : null
+
 function isTauriDesktop(): boolean {
   return typeof window !== "undefined"
     && "__TAURI_INTERNALS__" in (window as unknown as Record<string, unknown>)
@@ -285,6 +293,16 @@ function AppRuntime() {
                 element={
                   <Suspense fallback={null}>
                     <UpdatePlaygroundPage />
+                  </Suspense>
+                }
+              />
+            )}
+            {import.meta.env.DEV && TabStripPlaygroundPage && (
+              <Route
+                path="/playground/tabs"
+                element={
+                  <Suspense fallback={null}>
+                    <TabStripPlaygroundPage />
                   </Suspense>
                 }
               />

--- a/apps/desktop/src/components/workspace/open-target/SplitButton.tsx
+++ b/apps/desktop/src/components/workspace/open-target/SplitButton.tsx
@@ -67,9 +67,7 @@ export function SplitButton({
             onClick={onClick}
             title={label}
             aria-label={label}
-            className={showLabel
-              ? "workspace-shell-action-button workspace-shell-split-button-left inline-flex items-center whitespace-nowrap flex-1 justify-start font-mono font-medium"
-              : "workspace-shell-icon-button workspace-shell-split-button-left inline-flex items-center justify-center whitespace-nowrap"}
+            className={`${primaryClassName} workspace-shell-split-button-left ${showLabel ? "flex-1 justify-start" : ""}`}
           >
             {content}
           </Button>
@@ -80,11 +78,10 @@ export function SplitButton({
             onClick={toggle}
             aria-haspopup="menu"
             aria-expanded={isOpen}
+            data-state={isOpen ? "open" : "closed"}
             title={`Choose ${label}`}
             aria-label={`Choose ${label}`}
-            className={showLabel
-              ? "workspace-shell-action-button workspace-shell-split-button-right inline-flex items-center justify-center whitespace-nowrap gap-1.5 font-[450]"
-              : "workspace-shell-icon-button workspace-shell-split-button-right inline-flex items-center justify-center whitespace-nowrap"}
+            className="workspace-shell-icon-button workspace-shell-split-button-right inline-flex items-center justify-center whitespace-nowrap"
           >
             <ChevronDown className="size-3" />
           </Button>

--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
@@ -21,7 +21,7 @@ export function RightPanelHeaderActions({
         <IconButton
           size="xs"
           tone="sidebar"
-          className="ui-icon-button workspace-shell-icon-button workspace-shell-toolbar-button glass-editor-panel-new-tab-menu-trigger"
+          className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger"
           onClick={onOpenRepoSettings}
         >
           <Settings className="ui-icon" />
@@ -32,7 +32,7 @@ export function RightPanelHeaderActions({
         <IconButton
           size="xs"
           tone="sidebar"
-          className="ui-icon-button workspace-shell-icon-button workspace-shell-toolbar-button glass-editor-panel-new-tab-menu-trigger relative"
+          className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
           onClick={onTogglePanel}
         >
           <SplitPanel className="ui-icon" />

--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx
@@ -48,11 +48,6 @@ export function RightPanelHeaderEntryDropZone({
       onLostPointerCapture={onPointerCancel}
     >
       {children}
-      <div
-        className="right-panel-header-entry-separator"
-        data-app-shell-tab-separator="true"
-        aria-hidden="true"
-      />
     </div>
   );
 }

--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -35,7 +35,7 @@ export function RightPanelNewTabMenu({
         <IconButton
           size="xs"
           tone="sidebar"
-          className="ui-icon-button workspace-shell-icon-button workspace-shell-toolbar-button glass-editor-panel-new-tab-menu-trigger relative"
+          className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
         >
           <AppShellPlusIcon className="ui-icon" />
           <span className="sr-only">Open new tab menu</span>

--- a/apps/desktop/src/components/workspace/shell/tabs/ChromeWorkspaceTab.tsx
+++ b/apps/desktop/src/components/workspace/shell/tabs/ChromeWorkspaceTab.tsx
@@ -21,7 +21,6 @@ interface ChromeWorkspaceTabProps extends Omit<HTMLAttributes<HTMLDivElement>, "
   badge?: ReactNode;
   shortcutLabel?: string | null;
   shortcutRevealVisible?: boolean;
-  rightAccessory?: ReactNode;
   groupColor?: string | null;
   isChild?: boolean;
   hideLeftDivider?: boolean;
@@ -41,7 +40,6 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
     badge,
     shortcutLabel = null,
     shortcutRevealVisible = false,
-    rightAccessory,
     groupColor: _groupColor,
     isChild: _isChild = false,
     hideLeftDivider: _hideLeftDivider = false,
@@ -57,7 +55,6 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
     const showTitle = !isMini && !isSmaller;
     const showBadge = !isSmall;
     const showShortcut = Boolean(shortcutLabel) && !isSmall;
-    const showCloseButton = !isMini || isActive;
     const titleMaskEnd = showShortcut ? 36 : 20;
     const titleMask = `linear-gradient(90deg, #000 0%, #000 calc(100% - ${titleMaskEnd}px), transparent)`;
 
@@ -77,14 +74,14 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
       >
         <span
           aria-hidden="true"
-          className="workspace-shell-tab__surface pointer-events-none absolute inset-0 rounded-lg border transition-[background-color,border-color] duration-150"
+          className="workspace-shell-tab__surface pointer-events-none absolute inset-0 rounded-[var(--workspace-shell-tab-radius,0.5rem)] border transition-[background-color,border-color] duration-150"
         />
         <div
-          className={`absolute inset-0 flex items-center overflow-hidden rounded-lg py-1 ${
+          className={`absolute inset-0 flex items-center overflow-hidden rounded-[var(--workspace-shell-tab-radius,0.5rem)] py-1 ${
             isMini ? "gap-1 px-1" : isSmall ? "gap-1 px-2" : "gap-2 px-2"
           }`}
         >
-          {showCloseButton && (
+          {isMini ? (
             <span className="workspace-shell-tab__leading relative z-20 flex size-4 shrink-0 items-center justify-center">
               <span className="workspace-shell-tab__icon flex size-4 shrink-0 items-center justify-center group-hover/tab:hidden group-focus-within/tab:hidden">
                 {icon}
@@ -105,6 +102,10 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
                 <X className="size-2.5" />
               </Button>
             </span>
+          ) : (
+            <span className="workspace-shell-tab__icon relative z-20 flex size-4 shrink-0 items-center justify-center">
+              {icon}
+            </span>
           )}
           <Button
             type="button"
@@ -122,14 +123,9 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
                 : "font-medium text-muted-foreground group-hover/tab:text-foreground"
             } ${isSmall ? "gap-1" : "gap-2"}`}
           >
-            {!showCloseButton && (
-              <span className="workspace-shell-tab__icon flex size-4 shrink-0 items-center justify-center">
-                {icon}
-              </span>
-            )}
             {showTitle && (
               <span
-                className="workspace-shell-tab__label min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left text-base"
+                className="workspace-shell-tab__label min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left"
                 style={{
                   WebkitMaskImage: titleMask,
                   maskImage: titleMask,
@@ -138,7 +134,11 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
                 {label}
               </span>
             )}
-            {showBadge && badge}
+            {showBadge && badge && (
+              <span className="flex shrink-0 items-center transition-opacity duration-150 group-hover/tab:opacity-0 group-focus-within/tab:opacity-0">
+                {badge}
+              </span>
+            )}
           </Button>
           {showShortcut && shortcutLabel ? (
             <ShortcutBadge
@@ -148,7 +148,23 @@ export const ChromeWorkspaceTab = forwardRef<HTMLDivElement, ChromeWorkspaceTabP
               }`}
             />
           ) : null}
-          {!isMini && rightAccessory}
+          {!isMini && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              data-tab-drag-ignore="true"
+              onClick={(event) => {
+                event.stopPropagation();
+                onClose();
+              }}
+              title="Close tab"
+              aria-label="Close tab"
+              className="workspace-shell-tab__close absolute right-1.5 top-1/2 z-20 hidden size-4 shrink-0 -translate-y-1/2 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/tab:inline-flex group-focus-within/tab:inline-flex focus-visible:inline-flex"
+            >
+              <X className="size-2.5" />
+            </Button>
+          )}
         </div>
       </div>
     );

--- a/apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -23,10 +23,8 @@ import type { Workspace } from "@anyharness/sdk";
 import { useDebugRenderCount } from "@/hooks/ui/debug/use-debug-render-count";
 import { workspaceHeaderTitle } from "@/lib/domain/workspaces/display/workspace-display";
 
-const HEADER_ICON_BUTTON_CLASS =
-  "workspace-shell-icon-button workspace-shell-toolbar-button";
-const HEADER_RUN_BUTTON_CLASS =
-  "workspace-shell-action-button workspace-shell-toolbar-button text-xs font-medium";
+const HEADER_ICON_BUTTON_CLASS = "workspace-shell-icon-button";
+const HEADER_RUN_BUTTON_CLASS = "workspace-shell-action-button font-medium";
 
 interface GlobalHeaderProps {
   selectedWorkspace: Workspace | undefined;
@@ -84,7 +82,7 @@ export const GlobalHeader = memo(function GlobalHeader({
     <DebugProfiler id="global-header">
       <div className="flex h-full min-w-0 flex-1 items-center gap-1.5 px-4">
         <div
-          className="min-w-0 max-w-[220px] shrink-0 truncate px-1 text-base font-medium leading-5 text-foreground"
+          className="min-w-0 max-w-[220px] shrink-0 truncate px-1 text-sm font-medium leading-5 text-muted-foreground"
           title={title}
           data-telemetry-mask="true"
         >
@@ -97,9 +95,8 @@ export const GlobalHeader = memo(function GlobalHeader({
 
         <DebugProfiler id="global-header-actions">
           <div className="flex shrink-0 items-center gap-1.5">
-            <div className="h-4 w-px bg-border/70" aria-hidden="true" />
             <Button
-              variant="secondary"
+              variant="ghost"
               size="sm"
               loading={runLoading}
               disabled={runDisabled}

--- a/apps/desktop/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
@@ -10,9 +10,9 @@ import type {
 } from "@/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
 
 const HEADER_ICON_BUTTON_CLASS =
-  "workspace-shell-icon-button workspace-shell-toolbar-button shrink-0 disabled:pointer-events-none disabled:opacity-40";
+  "workspace-shell-icon-button shrink-0 disabled:pointer-events-none disabled:opacity-40";
 const HEADER_FILTER_BUTTON_CLASS =
-  "workspace-shell-action-button workspace-shell-toolbar-button shrink-0 gap-1 px-1.5 text-xs disabled:pointer-events-none disabled:opacity-40";
+  "workspace-shell-action-button shrink-0 gap-1 px-1.5 disabled:pointer-events-none disabled:opacity-40";
 
 interface HeaderTabsActionsProps {
   closedChatTabs: HeaderChatMenuEntry[];
@@ -37,9 +37,8 @@ export function HeaderTabsActions({
       type="button"
       variant="ghost"
       size="sm"
-      disabled={closedCount === 0}
-      aria-label={closedCount > 0 ? `Closed sessions (${closedCount})` : "No closed sessions"}
-      title={closedCount > 0 ? `Closed sessions (${closedCount})` : "No closed sessions"}
+      aria-label={`Closed sessions (${closedCount})`}
+      title={`Closed sessions (${closedCount})`}
       className={HEADER_FILTER_BUTTON_CLASS}
     >
       <ListFilter className="size-3.5" />
@@ -64,7 +63,7 @@ export function HeaderTabsActions({
         </span>
       </Button>
 
-      {closedCount > 0 ? (
+      {closedCount > 0 && (
         <PopoverButton
           align="end"
           trigger={closedSessionsTrigger}
@@ -85,8 +84,6 @@ export function HeaderTabsActions({
             />
           )}
         </PopoverButton>
-      ) : (
-        closedSessionsTrigger
       )}
     </>
   );

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   logLatency: vi.fn(),
   mutateAsync: vi.fn(),
   patchSessionRecord: vi.fn(),
+  prepareLocalRuntimeConfigForTarget: vi.fn(),
   promptAttachmentSnapshotsToBlocks: vi.fn(),
   rehydrateSessionSlotFromHistory: vi.fn(),
   sendCloudPromptCommand: vi.fn(),
@@ -26,6 +27,10 @@ vi.mock("@/lib/access/browser/prompt-attachment-blocks", () => ({
 
 vi.mock("@/lib/access/anyharness/session-runtime", () => ({
   getSessionClientAndWorkspace: mocks.getSessionClientAndWorkspace,
+}));
+
+vi.mock("@/lib/access/anyharness/session-runtime-config", () => ({
+  prepareLocalRuntimeConfigForTarget: mocks.prepareLocalRuntimeConfigForTarget,
 }));
 
 vi.mock("@/lib/access/cloud/session-commands", () => ({
@@ -61,11 +66,16 @@ describe("dispatchPromptIntent", () => {
     vi.clearAllMocks();
     mocks.getLatencyFlowRequestHeaders.mockReturnValue(null);
     mocks.getSessionClientAndWorkspace.mockResolvedValue({
+      connection: {
+        runtimeUrl: "http://runtime.local",
+        anyharnessWorkspaceId: "workspace-1",
+      },
       target: { location: "local" },
       workspaceId: "workspace-1",
       materializedSessionId: "session-1",
     });
     mocks.getSessionRecord.mockReturnValue({ lastPromptAt: "2026-06-04T09:00:00Z" });
+    mocks.prepareLocalRuntimeConfigForTarget.mockResolvedValue(null);
     mocks.waitForSessionMaterialization.mockResolvedValue("session-1");
   });
 
@@ -170,6 +180,34 @@ describe("dispatchPromptIntent", () => {
 
     expect(deps.maybeGenerateSessionTitle).not.toHaveBeenCalled();
     expect(deps.maybeGenerateWorkspaceName).not.toHaveBeenCalled();
+  });
+
+  it("reapplies local runtime config before dispatching a local prompt", async () => {
+    const entry = useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "client-session-1",
+      workspaceId: "workspace-1",
+      text: "Build please",
+      blocks: [{ type: "text", text: "Build please" }],
+    });
+    mocks.mutateAsync.mockResolvedValue({
+      session: { id: "session-1" },
+      status: "queued",
+      queuedSeq: 1,
+    });
+
+    await dispatchPromptIntent(entry, createDeps());
+
+    expect(mocks.prepareLocalRuntimeConfigForTarget).toHaveBeenCalledWith(
+      { location: "local" },
+      {
+        runtimeUrl: "http://runtime.local",
+        anyharnessWorkspaceId: "workspace-1",
+      },
+      undefined,
+    );
+    expect(mocks.prepareLocalRuntimeConfigForTarget.mock.invocationCallOrder[0]!)
+      .toBeLessThan(mocks.mutateAsync.mock.invocationCallOrder[0]!);
   });
 });
 

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
@@ -22,6 +22,9 @@ import {
 import {
   getSessionClientAndWorkspace,
 } from "@/lib/access/anyharness/session-runtime";
+import {
+  prepareLocalRuntimeConfigForTarget,
+} from "@/lib/access/anyharness/session-runtime-config";
 import { sendCloudPromptCommand } from "@/lib/access/cloud/session-commands";
 import {
   waitForSessionMaterialization,
@@ -121,12 +124,18 @@ export async function dispatchPromptIntent(
       return;
     }
     const {
+      connection,
       target,
       workspaceId,
       materializedSessionId: resolvedSessionId,
     } = await getSessionClientAndWorkspace(entry.clientSessionId);
     requestHeaders = getLatencyFlowRequestHeaders(entry.latencyFlowId) ?? null;
     const requestOptions = requestHeaders ? { headers: requestHeaders } : undefined;
+    await prepareLocalRuntimeConfigForTarget(
+      target,
+      connection,
+      requestOptions,
+    );
 
     useSessionIntentStore.getState().patchIntent(entry.intentId, {
       status: "dispatching",

--- a/apps/desktop/src/lib/access/anyharness/session-runtime-config.ts
+++ b/apps/desktop/src/lib/access/anyharness/session-runtime-config.ts
@@ -68,6 +68,18 @@ export async function prepareLocalSessionRuntimeConfig(
   }
 }
 
+export async function prepareLocalRuntimeConfigForTarget(
+  target: RuntimeTarget,
+  connection: AnyHarnessRuntimeConfigConnection,
+  options?: ApplyRuntimeConfigOptions,
+  config?: PrepareLocalSessionRuntimeConfigOptions,
+): Promise<RuntimeConfigRevisionExpectation | null> {
+  if (target.location !== "local") {
+    return null;
+  }
+  return prepareLocalSessionRuntimeConfig(connection, options, config);
+}
+
 async function loadDesktopRuntimeConfigApplyRequest(
   timeoutMs: number,
 ): Promise<DesktopRuntimeConfigApplyRequestResponse | null> {

--- a/apps/desktop/src/lib/access/anyharness/session-runtime.ts
+++ b/apps/desktop/src/lib/access/anyharness/session-runtime.ts
@@ -25,6 +25,9 @@ import {
   type AnyHarnessWorkspaceSessionConnection,
   type ListSessionsOptions,
 } from "@/lib/access/anyharness/sessions";
+import {
+  prepareLocalRuntimeConfigForTarget,
+} from "@/lib/access/anyharness/session-runtime-config";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import {
@@ -220,20 +223,26 @@ export async function resumeSession(
   },
 ) {
   const measurementOperationId = options?.measurementOperationId;
-  const { connection, materializedSessionId } = await measureSessionWorkflowStep(
+  const { connection, target, materializedSessionId } = await measureSessionWorkflowStep(
     measurementOperationId,
     "session.resume.resolve_target",
     () => getSessionClientAndWorkspace(sessionId),
+  );
+  const requestOptions = getMeasurementRequestOptions({
+    operationId: measurementOperationId,
+    category: "session.resume",
+    headers: options?.requestHeaders,
+  });
+  await prepareLocalRuntimeConfigForTarget(
+    target,
+    connection,
+    requestOptions,
   );
   return resumeRuntimeSession(
     connection,
     materializedSessionId,
     undefined,
-    getMeasurementRequestOptions({
-      operationId: measurementOperationId,
-      category: "session.resume",
-      headers: options?.requestHeaders,
-    }),
+    requestOptions,
   );
 }
 

--- a/apps/desktop/src/lib/workflows/sessions/session-runtime.test.ts
+++ b/apps/desktop/src/lib/workflows/sessions/session-runtime.test.ts
@@ -424,17 +424,54 @@ describe("pruneInactiveSessionStreams", () => {
 });
 
 describe("resumeSession", () => {
-  it("resumes without per-session MCP or plugin payloads", async () => {
+  it("reapplies local runtime config before resuming without per-session MCP or plugin payloads", async () => {
     mocks.resolveRuntimeTargetForWorkspace.mockResolvedValue({
       anyharnessWorkspaceId: "runtime-workspace-1",
       baseUrl: "http://runtime.local",
       location: "local",
       runtimeGeneration: 0,
     });
+    mocks.ensurePersonalSandboxProfile.mockResolvedValue({
+      id: "profile-1",
+      primaryTargetId: "target-1",
+    });
+    mocks.getSandboxProfileDesktopRuntimeConfigApplyRequest.mockResolvedValue({
+      applyRequest: {
+        source: "desktop",
+        revision: {
+          id: "revision-1",
+          sequence: 2,
+          contentHash: "hash-1",
+          externalScope: {
+            provider: "proliferate-cloud",
+            id: "profile-1",
+            targetId: "target-1",
+          },
+        },
+        manifest: {},
+      },
+    });
+    mocks.applyRuntimeConfig.mockResolvedValue({
+      applied: true,
+      status: "applied",
+      revision: {
+        id: "revision-1",
+        sequence: 2,
+        contentHash: "hash-1",
+        externalScope: {
+          provider: "proliferate-cloud",
+          id: "profile-1",
+          targetId: "target-1",
+        },
+      },
+    });
     mocks.resume.mockResolvedValue({ id: "session-1" });
 
     await resumeSession("session-1");
 
+    expect(mocks.applyRuntimeConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.applyRuntimeConfig.mock.invocationCallOrder[0]!)
+      .toBeLessThan(mocks.resume.mock.invocationCallOrder[0]!);
     expect(mocks.resume).toHaveBeenCalledTimes(1);
     const [sessionId, resumeOptions, requestOptions] = mocks.resume.mock.calls[0]!;
     expect(sessionId).toBe("session-1");

--- a/apps/desktop/src/pages/TabStripPlaygroundPage.tsx
+++ b/apps/desktop/src/pages/TabStripPlaygroundPage.tsx
@@ -1,0 +1,494 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { ChromeWorkspaceTab } from "@/components/workspace/shell/tabs/ChromeWorkspaceTab";
+import {
+  renderChatTabIcon,
+  renderChatTabStatusBadge,
+} from "@/components/workspace/shell/tabs/tab-rendering";
+import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
+
+// Dev-only visual bench for the workspace session tab. Drives the REAL
+// ChromeWorkspaceTab via its CSS custom properties so every knob below
+// reflects exactly what shipping the value would look like. Route: /playground/tabs
+
+type IconFixture = {
+  agentKind: string;
+  viewState: SessionViewState;
+  delegatedAgent: null;
+  isResolvingSession: boolean;
+};
+
+interface TabState {
+  label: string;
+  caption: string;
+  agentKind: string;
+  viewState: SessionViewState;
+  isResolvingSession?: boolean;
+  hasUnreadActivity?: boolean;
+  isActive?: boolean;
+  isMultiSelected?: boolean;
+}
+
+const STATES: TabState[] = [
+  { label: "auth refactor", caption: "inactive", agentKind: "claude", viewState: "idle" },
+  { label: "billing webhook", caption: "← selected tab", agentKind: "codex", viewState: "idle", isActive: true },
+  { label: "migration script", caption: "working", agentKind: "claude", viewState: "working" },
+  { label: "review comments", caption: "needs input", agentKind: "codex", viewState: "needs_input" },
+  { label: "flaky e2e", caption: "errored", agentKind: "claude", viewState: "errored" },
+  { label: "seed data", caption: "unread", agentKind: "gemini", viewState: "idle", hasUnreadActivity: true },
+  { label: "perf pass", caption: "← multi-select", agentKind: "claude", viewState: "idle", isMultiSelected: true },
+  { label: "loading…", caption: "resolving", agentKind: "claude", viewState: "idle", isResolvingSession: true },
+];
+
+const WIDTHS = [160, 120, 84, 60, 44];
+
+type Tint = "foreground" | "accent" | "overlay";
+
+interface Knobs {
+  fillBase: Tint; // selected + active
+  restBase: Tint; // inactive + hover
+  inactivePct: number;
+  hoverPct: number;
+  activePct: number;
+  selectedPct: number;
+  borderPct: number;
+  radius: number;
+  gap: number;
+  weight: number;
+  underline: boolean;
+  underlineColor: string;
+  separators: boolean;
+  showBadge: boolean;
+}
+
+const SHIPPING: Knobs = {
+  fillBase: "foreground",
+  restBase: "foreground",
+  inactivePct: 0,
+  hoverPct: 4,
+  activePct: 8,
+  selectedPct: 10,
+  borderPct: 0,
+  radius: 8,
+  gap: 3,
+  weight: 500,
+  underline: false,
+  underlineColor: "var(--color-border-highlight)",
+  separators: false,
+  showBadge: true,
+};
+
+// One-click looks for the active/selected treatment — the thing under debate.
+const PRESETS: { name: string; hint: string; knobs: Knobs }[] = [
+  {
+    name: "Dark chip + soft rest",
+    hint: "dark rounded selected, light hover rest",
+    knobs: {
+      ...SHIPPING,
+      fillBase: "overlay",
+      restBase: "foreground",
+      inactivePct: 3,
+      hoverPct: 9,
+      activePct: 26,
+      selectedPct: 34,
+      borderPct: 12,
+      radius: 10,
+    },
+  },
+  {
+    name: "Dark + rim",
+    hint: "darker than bar, subtle border",
+    knobs: { ...SHIPPING, fillBase: "overlay", restBase: "overlay", hoverPct: 8, activePct: 24, selectedPct: 32, borderPct: 12 },
+  },
+  { name: "Shipping", hint: "current — light wash", knobs: SHIPPING },
+  {
+    name: "Stronger",
+    hint: "same wash, more contrast",
+    knobs: { ...SHIPPING, hoverPct: 6, activePct: 15, selectedPct: 20 },
+  },
+  {
+    name: "Defined chip",
+    hint: "light fill + hairline border",
+    knobs: { ...SHIPPING, activePct: 10, selectedPct: 13, borderPct: 16 },
+  },
+  {
+    name: "Recessed",
+    hint: "darker, no border",
+    knobs: { ...SHIPPING, fillBase: "overlay", restBase: "overlay", hoverPct: 10, activePct: 32, selectedPct: 42 },
+  },
+  {
+    name: "Underline",
+    hint: "quiet fill + accent bar",
+    knobs: { ...SHIPPING, activePct: 6, selectedPct: 9, underline: true },
+  },
+];
+
+const ACCENT_SWATCHES: { label: string; value: string }[] = [
+  { label: "blue", value: "var(--color-border-highlight)" },
+  { label: "fg", value: "var(--color-foreground)" },
+  { label: "green", value: "var(--color-success)" },
+  { label: "amber", value: "var(--color-warning-foreground)" },
+];
+
+function mix(base: string, pct: number): string {
+  if (pct <= 0) return "transparent";
+  return `color-mix(in oklab, ${base} ${pct}%, transparent)`;
+}
+
+const FILL_BASE_VAR: Record<Knobs["fillBase"], string> = {
+  foreground: "var(--color-foreground)",
+  accent: "var(--color-border-highlight)",
+  overlay: "var(--color-overlay)",
+};
+
+function knobsToVars(k: Knobs): Record<string, string> {
+  const selBase = FILL_BASE_VAR[k.fillBase];
+  const restBase = FILL_BASE_VAR[k.restBase];
+  // Rim is always a faint light line so it reads against a dark fill.
+  const activeBorder = mix("var(--color-foreground)", k.borderPct);
+  return {
+    "--workspace-shell-tab-inactive-background": mix(restBase, k.inactivePct),
+    "--workspace-shell-tab-inactive-border": "transparent",
+    "--workspace-shell-tab-hover-background": mix(restBase, k.hoverPct),
+    "--workspace-shell-tab-hover-border": "transparent",
+    "--workspace-shell-tab-active-background": mix(selBase, k.activePct),
+    "--workspace-shell-tab-active-border": activeBorder,
+    "--workspace-shell-tab-selected-background": mix(selBase, k.selectedPct),
+    "--workspace-shell-tab-selected-border": activeBorder,
+    "--workspace-shell-tab-radius": `${k.radius}px`,
+    "--workspace-shell-tab-font-weight": String(k.weight),
+  };
+}
+
+function knobsEqual(a: Knobs, b: Knobs): boolean {
+  return (Object.keys(a) as (keyof Knobs)[]).every((key) => a[key] === b[key]);
+}
+
+function Tab({ state, width, knobs }: { state: TabState; width: number; knobs: Knobs }) {
+  const iconFixture: IconFixture = {
+    agentKind: state.agentKind,
+    viewState: state.viewState,
+    delegatedAgent: null,
+    isResolvingSession: state.isResolvingSession ?? false,
+  };
+  const badge = knobs.showBadge
+    ? renderChatTabStatusBadge({
+        viewState: state.viewState,
+        hasUnreadActivity: state.hasUnreadActivity ?? false,
+      })
+    : undefined;
+  const showUnderline = knobs.underline && (state.isActive ?? false);
+  return (
+    <div className="relative flex shrink-0">
+      <ChromeWorkspaceTab
+        isActive={state.isActive ?? false}
+        isMultiSelected={state.isMultiSelected ?? false}
+        width={width}
+        icon={renderChatTabIcon(iconFixture)}
+        label={state.label}
+        badge={badge}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />
+      {showUnderline && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -bottom-px left-2 right-2 h-0.5 rounded-full"
+          style={{ backgroundColor: knobs.underlineColor }}
+        />
+      )}
+    </div>
+  );
+}
+
+function Strip({
+  states,
+  knobs,
+  widthFor,
+  captioned = false,
+}: {
+  states: TabState[];
+  knobs: Knobs;
+  widthFor: (s: TabState, i: number) => number;
+  captioned?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center rounded-lg border border-border/40 bg-background px-3 ${captioned ? "py-3" : "h-12"}`}
+      style={knobsToVars(knobs) as CSSProperties}
+    >
+      <span className="shrink-0 truncate px-1 pr-3 text-sm font-medium text-muted-foreground">
+        proliferate
+      </span>
+      <div className="flex min-w-0 flex-1 items-start overflow-hidden" style={{ gap: knobs.gap }}>
+        {states.map((s, i) => (
+          <div key={i} className="flex items-start" style={{ gap: knobs.gap }}>
+            {knobs.separators && i > 0 && (
+              <span aria-hidden className="mt-2 h-3 w-px shrink-0 bg-border/60" />
+            )}
+            <div className="flex flex-col items-start gap-1">
+              <Tab state={s} width={widthFor(s, i)} knobs={knobs} />
+              {captioned && (
+                <span className="px-1 text-[10px] leading-tight text-muted-foreground">
+                  {s.caption}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+      <span className="shrink-0">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Slider({
+  value,
+  min,
+  max,
+  step = 1,
+  suffix = "",
+  onChange,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  suffix?: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <span className="flex items-center gap-2">
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-40"
+      />
+      <span className="w-12 text-right tabular-nums text-foreground">
+        {value}
+        {suffix}
+      </span>
+    </span>
+  );
+}
+
+function TintPicker({ value, onChange }: { value: Tint; onChange: (v: Tint) => void }) {
+  return (
+    <span className="flex gap-1">
+      {(["foreground", "accent", "overlay"] as const).map((b) => (
+        <button
+          key={b}
+          type="button"
+          onClick={() => onChange(b)}
+          className={`rounded-md border px-2 py-1 text-xs ${
+            value === b
+              ? "border-transparent bg-primary text-primary-foreground"
+              : "border-border text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {b === "foreground" ? "light" : b === "accent" ? "accent" : "dark"}
+        </button>
+      ))}
+    </span>
+  );
+}
+
+function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!value)}
+      className={`h-5 w-9 shrink-0 rounded-full border transition-colors ${
+        value ? "border-transparent bg-primary" : "border-border bg-transparent"
+      }`}
+    >
+      <span
+        className={`block size-4 rounded-full bg-background transition-transform ${
+          value ? "translate-x-4" : "translate-x-0.5"
+        }`}
+      />
+    </button>
+  );
+}
+
+export function TabStripPlaygroundPage() {
+  const [k, setK] = useState<Knobs>(PRESETS[0].knobs);
+  const [width, setWidth] = useState(140);
+  const set = <K extends keyof Knobs>(key: K, value: Knobs[K]) =>
+    setK((prev) => ({ ...prev, [key]: value }));
+
+  const cssReadout = Object.entries(knobsToVars(k))
+    .map(([key, value]) => `  ${key}: ${value};`)
+    .join("\n");
+
+  return (
+    <div className="flex min-h-screen bg-sidebar text-foreground">
+      {/* Controls */}
+      <aside className="flex w-80 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border/40 bg-background/40 p-5">
+        <div className="flex items-center justify-between">
+          <h1 className="text-sm font-semibold">Session tab bench</h1>
+          <button
+            type="button"
+            onClick={() => setK(SHIPPING)}
+            className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            Reset
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Presets
+          </span>
+          <div className="flex flex-col gap-1">
+            {PRESETS.map((p) => {
+              const selected = knobsEqual(k, p.knobs);
+              return (
+                <button
+                  key={p.name}
+                  type="button"
+                  onClick={() => setK(p.knobs)}
+                  className={`flex items-baseline justify-between rounded-md border px-2 py-1.5 text-left ${
+                    selected
+                      ? "border-transparent bg-accent text-foreground"
+                      : "border-border/60 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  }`}
+                >
+                  <span className="text-xs font-medium">{p.name}</span>
+                  <span className="text-[10px] opacity-70">{p.hint}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="h-px bg-border/50" />
+
+        <div className="flex flex-col gap-2.5">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+            Non-selected tabs
+          </span>
+          <Row label="Rest tint">
+            <TintPicker value={k.restBase} onChange={(v) => set("restBase", v)} />
+          </Row>
+          <Row label="Inactive fill">
+            <Slider value={k.inactivePct} min={0} max={12} suffix="%" onChange={(v) => set("inactivePct", v)} />
+          </Row>
+          <Row label="Hover fill">
+            <Slider value={k.hoverPct} min={0} max={20} suffix="%" onChange={(v) => set("hoverPct", v)} />
+          </Row>
+
+          <div className="my-1 h-px bg-border/50" />
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+            Selected tab
+          </span>
+          <Row label="Selected tint">
+            <TintPicker value={k.fillBase} onChange={(v) => set("fillBase", v)} />
+          </Row>
+          <Row label="Selected fill">
+            <Slider value={k.activePct} min={0} max={48} suffix="%" onChange={(v) => set("activePct", v)} />
+          </Row>
+          <Row label="Multi-select">
+            <Slider value={k.selectedPct} min={0} max={48} suffix="%" onChange={(v) => set("selectedPct", v)} />
+          </Row>
+          <Row label="Border">
+            <Slider value={k.borderPct} min={0} max={30} suffix="%" onChange={(v) => set("borderPct", v)} />
+          </Row>
+          <Row label="Radius">
+            <Slider value={k.radius} min={0} max={16} suffix="px" onChange={(v) => set("radius", v)} />
+          </Row>
+          <Row label="Gap">
+            <Slider value={k.gap} min={0} max={12} suffix="px" onChange={(v) => set("gap", v)} />
+          </Row>
+          <Row label="Font weight">
+            <Slider value={k.weight} min={400} max={600} step={50} onChange={(v) => set("weight", v)} />
+          </Row>
+
+          <div className="my-1 h-px bg-border/50" />
+
+          <Row label="Active underline">
+            <Toggle value={k.underline} onChange={(v) => set("underline", v)} />
+          </Row>
+          {k.underline && (
+            <Row label="Underline color">
+              <span className="flex gap-1">
+                {ACCENT_SWATCHES.map((s) => (
+                  <button
+                    key={s.label}
+                    type="button"
+                    onClick={() => set("underlineColor", s.value)}
+                    aria-label={s.label}
+                    className={`size-5 rounded-full border ${
+                      k.underlineColor === s.value ? "ring-2 ring-ring ring-offset-1 ring-offset-background" : "border-border"
+                    }`}
+                    style={{ backgroundColor: s.value }}
+                  />
+                ))}
+              </span>
+            </Row>
+          )}
+          <Row label="Separators">
+            <Toggle value={k.separators} onChange={(v) => set("separators", v)} />
+          </Row>
+          <Row label="Status badge">
+            <Toggle value={k.showBadge} onChange={(v) => set("showBadge", v)} />
+          </Row>
+        </div>
+
+        <div className="mt-2 flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            CSS values
+          </span>
+          <pre className="overflow-x-auto rounded-md border border-border/50 bg-surface-under p-2 text-[11px] leading-relaxed text-foreground-secondary">
+            {cssReadout}
+          </pre>
+        </div>
+      </aside>
+
+      {/* Preview */}
+      <main className="flex flex-1 flex-col gap-10 overflow-y-auto p-10">
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              All states
+            </h2>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              width
+              <Slider value={width} min={44} max={200} suffix="px" onChange={setWidth} />
+            </label>
+          </div>
+          <Strip states={STATES} knobs={k} widthFor={() => width} captioned />
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Responsive widths (active tab)
+          </h2>
+          <Strip
+            states={WIDTHS.map(() => ({ ...STATES[1], label: "billing webhook" }))}
+            knobs={k}
+            widthFor={(_s, i) => WIDTHS[i]}
+          />
+        </section>
+
+        <p className="max-w-prose text-xs text-muted-foreground">
+          Drives the real <code className="font-mono">ChromeWorkspaceTab</code> through its CSS
+          custom properties — what you see is what shipping these values looks like. Land on a look
+          and I&apos;ll bake the <span className="text-foreground">CSS values</span> into the theme
+          (and port underline/separators into the component if you keep them).
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -2159,53 +2159,31 @@ body {
   --workspace-shell-tab-font-weight: 500;
   --workspace-shell-tab-icon-size: 0.875rem; /* 14px */
   --workspace-shell-tab-content-gap: 0.5rem;
-  --workspace-shell-tab-inactive-background: color-mix(
-    in oklab,
-    var(--color-foreground) 2%,
-    var(--color-background)
-  );
-  --workspace-shell-tab-inactive-border: color-mix(in oklab, var(--color-border) 15%, transparent);
-  --workspace-shell-tab-hover-background: var(--workspace-shell-tab-inactive-background);
-  --workspace-shell-tab-hover-border: color-mix(in oklab, var(--color-border) 35%, transparent);
-  --workspace-shell-tab-active-background: color-mix(
-    in oklab,
-    var(--color-foreground) 6%,
-    var(--color-background)
-  );
-  --workspace-shell-tab-active-border: color-mix(in oklab, var(--color-border) 70%, transparent);
-  --workspace-shell-tab-selected-background: color-mix(
-    in oklab,
-    var(--color-foreground) 8%,
-    var(--color-background)
-  );
-  --workspace-shell-tab-selected-border: color-mix(in oklab, var(--color-border) 60%, transparent);
+  --workspace-shell-tab-radius: 0.625rem; /* 10px */
+  /* Border-only tabs: the clean neutral rim defines each tab, no fill at rest
+     or on hover. The selected tab is the exception — a subtle lighter fill
+     (plus a heavier rim and brighter text) lifts it above the rest. */
+  --workspace-shell-tab-border: var(--color-border);
+  --workspace-shell-tab-inactive-background: transparent;
+  --workspace-shell-tab-inactive-border: var(--workspace-shell-tab-border);
+  --workspace-shell-tab-hover-background: transparent;
+  --workspace-shell-tab-hover-border: var(--color-border-heavy);
+  --workspace-shell-tab-active-background: color-mix(in oklab, var(--color-foreground) 7%, transparent);
+  --workspace-shell-tab-active-border: var(--color-border-heavy);
+  --workspace-shell-tab-selected-background: color-mix(in oklab, var(--color-foreground) 10%, transparent);
+  --workspace-shell-tab-selected-border: var(--color-border-heavy);
   --workspace-shell-action-size: 1.75rem; /* 28px */
-  --workspace-shell-action-font-size: var(--text-xs);
-  --workspace-shell-action-line-height: var(--text-xs--line-height);
+  --workspace-shell-action-font-size: var(--text-sm);
+  --workspace-shell-action-line-height: var(--text-sm--line-height);
   --workspace-shell-action-font-weight: 500;
   --workspace-shell-action-icon-size: 0.8125rem; /* 13px */
   --workspace-shell-action-radius: 0.5rem;
-  --workspace-shell-action-border: var(--color-border);
-  --workspace-shell-action-background: var(--color-background);
+  /* Header action buttons (+, Run, open-in) match the tabs: border-only, no
+     fill at rest (hover adds a tint). Right-panel buttons opt out below. */
+  --workspace-shell-action-border: var(--workspace-shell-tab-border);
+  --workspace-shell-action-background: transparent;
   --workspace-shell-action-foreground: var(--color-muted-foreground);
-  --workspace-shell-action-hover-background: var(--color-accent);
-  --workspace-shell-action-hover-foreground: var(--color-foreground);
-}
-
-:root[data-theme="mono"][data-mode="light"],
-:root[data-theme="original"][data-mode="light"] {
-  --workspace-shell-tab-inactive-background: transparent;
-  --workspace-shell-tab-inactive-border: transparent;
-  --workspace-shell-tab-hover-background: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --workspace-shell-tab-hover-border: transparent;
-  --workspace-shell-tab-active-background: color-mix(in oklab, var(--color-foreground) 5%, transparent);
-  --workspace-shell-tab-active-border: transparent;
-  --workspace-shell-tab-selected-background: color-mix(in oklab, var(--color-foreground) 7%, transparent);
-  --workspace-shell-tab-selected-border: transparent;
-  --workspace-shell-action-border: var(--color-border);
-  --workspace-shell-action-background: var(--color-surface-elevated-secondary);
-  --workspace-shell-action-foreground: var(--color-foreground-secondary);
-  --workspace-shell-action-hover-background: var(--color-list-hover);
+  --workspace-shell-action-hover-background: var(--color-composer-control-hover);
   --workspace-shell-action-hover-foreground: var(--color-foreground);
 }
 
@@ -2256,6 +2234,13 @@ body {
   font-size: var(--workspace-shell-action-font-size);
   line-height: var(--workspace-shell-action-line-height);
   font-weight: var(--workspace-shell-action-font-weight);
+  transition: background-color 150ms, color 150ms, border-color 150ms;
+}
+
+/* Right-panel trigger buttons stay flat (no chip rim/fill). */
+.glass-editor-panel-new-tab-menu-trigger {
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .workspace-shell-action-button {
@@ -2288,11 +2273,9 @@ body {
   color: var(--workspace-shell-action-hover-foreground);
 }
 
-.workspace-shell-toolbar-button {
-  border-color: transparent;
-  background-color: transparent;
-}
-
+/* Split control: primary action + chevron menu segment sharing one pill.
+   The left segment drops its inner edge so the right segment's border is the
+   single divider seam (no doubled line). */
 .workspace-shell-split-button-left {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -2305,12 +2288,8 @@ body {
 }
 
 .workspace-shell-split-button-right.workspace-shell-icon-button {
-  width: calc(var(--workspace-shell-action-size) - 0.25rem);
-  min-width: calc(var(--workspace-shell-action-size) - 0.25rem);
-}
-
-.workspace-shell-split-button-right.workspace-shell-action-button {
-  padding-inline: 0.375rem;
+  width: calc(var(--workspace-shell-action-size) - 0.5rem);
+  min-width: calc(var(--workspace-shell-action-size) - 0.5rem);
 }
 
 /* ---- Right panel tabs ---- */
@@ -2343,8 +2322,6 @@ body {
   --right-panel-tab-text-primary: var(--color-sidebar-foreground);
   --right-panel-tab-text-secondary: color-mix(in srgb, var(--color-sidebar-foreground) 65%, transparent);
   --right-panel-tab-text-tertiary: var(--color-sidebar-muted-foreground);
-  --right-panel-tab-border: color-mix(in oklab, var(--color-sidebar-border) 80%, transparent);
-  --right-panel-tab-outer-border: var(--right-panel-tab-border);
   --right-panel-tab-focus: var(--color-sidebar-ring);
   --right-panel-tab-font-size: var(--workspace-shell-tab-font-size);
   --right-panel-tab-line-height: var(--workspace-shell-tab-line-height);
@@ -2368,7 +2345,6 @@ body {
   color: var(--right-panel-tab-text-secondary);
   font-size: var(--right-panel-tab-font-size);
   line-height: var(--right-panel-tab-line-height);
-  border-bottom: 1px solid var(--right-panel-tab-outer-border);
 }
 
 :root[data-theme="mono"][data-mode="light"] .right-panel-tab-system,
@@ -2378,8 +2354,6 @@ body {
   --right-panel-tab-hover-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-active-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-text-secondary: color-mix(in oklab, var(--color-foreground) 65%, transparent);
-  --right-panel-tab-border: var(--color-border-light);
-  --right-panel-tab-outer-border: transparent;
 }
 
 .right-panel-tab-system .ui-tab-system-bar {
@@ -2890,20 +2864,6 @@ body {
 
 .right-panel-tab-system .right-panel-tool-drop-target {
   width: var(--tab-gap);
-}
-
-.right-panel-tab-system .right-panel-header-entry-separator {
-  position: absolute;
-  inset-inline-end: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1px;
-  height: 12px;
-  flex-shrink: 0;
-  border-radius: 9999px;
-  background-color: var(--right-panel-tab-border);
-  opacity: 1;
-  transition: opacity 100ms ease;
 }
 
 .right-panel-tab-system .ui-tab-system-live-region {


### PR DESCRIPTION
## Summary

- Adds `TabStripPlaygroundPage` (dev page for iterating on tab-strip layouts).
- Polishes Chrome workspace tabs, right-panel (header actions, drop zone, new-tab menu), global header, header tab actions, and `SplitButton`.
- Session runtime + intent-prompt-dispatch updates, with test coverage.
- Design CSS tweaks; syncs desktop crate version in `Cargo.lock`.

## PR Metadata
- Title format: `<type>(<scope>): …`
- Labels: `release:minor-feature`, `area:desktop`

## Verification
- `tsc --noEmit` clean.
- `vitest run` on changed suites: **17/17 pass** (session-intent-prompt-dispatch, session-runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)