### PR TITLE
fix(db): disable asyncpg statement cache to survive index recreation

### DIFF
--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -21,6 +21,11 @@ engine = create_async_engine(
     # connections keep replaying plans against the dead OID and fail forever with
     # "no unique or exclusion constraint matching the ON CONFLICT specification".
     # pool_pre_ping does not help — it only runs SELECT 1, it does not re-plan.
+    # Tradeoff: every query now goes through a full Parse/Bind/Execute cycle with
+    # no plan reuse, which costs throughput under load (asyncpg benchmarks ~10-20%).
+    # We accept that for correctness. TODO: revisit re-enabling the cache once the
+    # migration divergence is cleaned up and index OIDs stop churning under live
+    # connections — at which point pool_recycle below is sufficient on its own.
     connect_args={"statement_cache_size": 0},
     # Defense-in-depth: age connections out so no pooled connection lives
     # indefinitely across a schema change.

--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -15,6 +15,16 @@ engine = create_async_engine(
     settings.database_url,
     echo=settings.database_echo,
     pool_pre_ping=True,
+    # Disable asyncpg's per-connection prepared-statement cache. Cached plans are
+    # bound to the OID of the objects they reference, so when an index is dropped
+    # and recreated by a migration (new OID) while connections stay open, those
+    # connections keep replaying plans against the dead OID and fail forever with
+    # "no unique or exclusion constraint matching the ON CONFLICT specification".
+    # pool_pre_ping does not help — it only runs SELECT 1, it does not re-plan.
+    connect_args={"statement_cache_size": 0},
+    # Defense-in-depth: age connections out so no pooled connection lives
+    # indefinitely across a schema change.
+    pool_recycle=1800,
 )
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 _AFTER_COMMIT_CALLBACKS_KEY = "proliferate_after_commit_callbacks"


### PR DESCRIPTION
## Symptom

Intermittent \`load failed (app.proliferate.com)\` popups in the app when opening a new session or sending a message. Over a 24h window, \`POST /api/v1/cloud/sandbox-profiles/personal\` (called when initializing a session) returned ~52× 200 and ~32× 500 — genuinely intermittent on the **same** DB, split evenly across both prod ECS tasks.

Every 500 was:

```
asyncpg InvalidColumnReferenceError: there is no unique or exclusion
constraint matching the ON CONFLICT specification
  at db/store/cloud_sandbox_profiles.py  (INSERT ... ON CONFLICT)
```

## Why it's intermittent, not a schema bug

The schema is actually correct. Querying prod directly, the index the upsert needs exists, is valid, unique, and matches the code exactly:

```
uq_sandbox_profile_active_personal_user
  UNIQUE (owner_user_id) WHERE owner_scope='personal' AND archived_at IS NULL
```

So why do identical requests sometimes succeed and sometimes fail on the same database? **Stale prepared-statement plans on long-lived pooled connections.**

- The async engine was built with \`pool_pre_ping=True\` but **no \`pool_recycle\`** → pooled connections live forever.
- asyncpg caches prepared statements **per physical connection**. The \`INSERT … ON CONFLICT\` plan is bound to the unique index's **OID**.
- The stacked live-sessions / catalog-v2 migrations **dropped and recreated** that index (new OID) *after* the running tasks had already opened and prepared their connections.
- Connections that prepared the statement before the recreate now point at a dead index OID and fail **every time**. \`pool_pre_ping\` doesn't catch this — it only runs \`SELECT 1\`, it never re-plans.
- With no \`pool_recycle\`, the poisoned connections never age out. Which pooled connection serves a given request decides 200 vs 500 → the "occasional" failures (bleeding for ~3 days).

## Fix

In \`server/proliferate/db/engine.py\`:

- \`connect_args={"statement_cache_size": 0}\` — disables asyncpg's per-connection prepared-statement cache, removing the failure mode entirely.
- \`pool_recycle=1800\` — defense-in-depth so no connection lives indefinitely across a schema change.

## Immediate mitigation (already done)

Prod was already mitigated with \`aws ecs update-service --force-new-deployment\` so every connection re-prepares against the current index. This PR prevents recurrence.

## Follow-up (not in this PR)

The underlying trigger was a migration divergence: \`uq_sandbox_profile_active_personal_user\` is defined with two different predicates across migrations (phase1 \`deleted_at IS NULL AND status='active'\` vs foundation \`archived_at IS NULL\`), and prod's alembic head is on a different branch tip than the foundation migration's parent. The physical schema landed correct, but that divergence is worth cleaning up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)