### PR TITLE
chore(ci): ignore Expo SDK packages in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     labels:
       - "release:maintenance"
       - "area:release"
+    ignore:
+      # Expo SDK packages are version-locked to the installed Expo SDK and must be
+      # upgraded together via `expo install` during an SDK bump — never piecemeal by
+      # Dependabot (it proposes SDK-56 versions while apps/mobile is pinned to SDK 54,
+      # which fails "Repo shape checks"). See apps/mobile/package.json.
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-*"
     groups:
       npm-minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary
Dependabot's npm updater was proposing the **Expo SDK 56** versions of `expo-*` packages while `apps/mobile` is pinned to **Expo SDK 54** (`expo: ~54.0.33`). These bumps are wrong by construction — Expo packages are version-locked to the installed SDK and must be upgraded together via `expo install` during an SDK bump — and they fail the `Repo shape checks` job.

Adds an `ignore` rule for `expo`, `expo-*`, `react-native`, and `react-native-*` to the npm ecosystem so these stop recurring.

Already closed the 4 bad PRs this produced: #694, #697, #698, #699.

## Why this is safe
Config-only change to `.github/dependabot.yml`; affects future Dependabot runs only. Expo/RN upgrades will continue to happen intentionally via the Expo SDK upgrade flow.