### PR TITLE
test(server): make api-path-prefix assertions robust to Starlette router nesting

### DIFF
--- a/server/tests/unit/test_api_path_prefix.py
+++ b/server/tests/unit/test_api_path_prefix.py
@@ -10,7 +10,13 @@ from proliferate.main import create_app
 
 
 def _route_paths() -> set[str]:
-    return {getattr(route, "path", "") for route in create_app().router.routes}
+    # Resolve mounted paths via the OpenAPI schema rather than walking
+    # ``router.routes`` directly. Starlette >= 1.3 keeps included sub-routers as
+    # opaque ``_IncludedRouter`` objects whose nested paths no longer surface as
+    # top-level ``route.path`` values, so naive introspection silently misses
+    # every mounted route. ``openapi()`` reconstructs the full, prefix-aware paths
+    # the same way across Starlette versions.
+    return set(create_app().openapi()["paths"].keys())
 
 
 def _request(path: str = "/api/auth/web/github/start") -> Request:


### PR DESCRIPTION
## Summary
Fixes the red **Server CI `test`** job on `main` (2 failures in `tests/unit/test_api_path_prefix.py`).

## Root cause
`main` went red between Jun 13 and Jun 15 with **no relevant code change** — because Server CI installs Python deps **unlocked** (`uv pip install --system -e ".[dev]"`, which ignores `uv.lock`). When **FastAPI 0.137 / Starlette 1.3** were published in that window, CI floated to them:

| | FastAPI | Starlette |
|---|---|---|
| `uv.lock` (local dev, cloud-tests) | 0.135.2 | 1.0.0 |
| Server CI fresh install | **0.137.1** | **1.3.1** |

Starlette ≥1.3 keeps included sub-routers as opaque `_IncludedRouter` objects whose nested paths no longer surface as top-level `route.path` values. So `_route_paths()` (which walked `create_app().router.routes`) saw **zero** mounted routes and the two "create_app mounts routes" assertions failed.

**The app is unaffected** — every endpoint still routes, and all other 950 tests pass on 0.137. Only the test's introspection was naive.

## Fix
Resolve paths via the OpenAPI schema (`create_app().openapi()["paths"]`), which reconstructs full, prefix-aware paths consistently across Starlette versions.

**Verified 9/9 pass on both** locked (FastAPI 0.135.2) and floated (0.137.1, in a Linux container matching CI).

## Follow-up (not in this PR)
Server CI and the server `Dockerfile` both install deps **unlocked**, so `main` can spontaneously break on any upstream release (this is how it broke). Worth deciding whether to pin them to `uv.lock` via `uv sync` — the way `cloud-tests.yml` / `cloud-live-webhook.yml` already do.