### PR TITLE
fix(live): restore live model switching for Gemini via session/set_model

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -473,9 +473,34 @@ pub(in crate::live::sessions::actor) async fn apply_model_via_direct_setter(
         }))?
         .into();
     let ext = acp::schema::ExtRequest::new(ACP_SET_SESSION_MODEL_METHOD, params);
-    conn.send_request(acp::AgentRequest::ExtMethodRequest(ext))
+    tracing::info!(
+        method = ACP_SET_SESSION_MODEL_METHOD,
+        native_session_id,
+        model_id = desired_model_id,
+        "[model-switch] sending session/set_model"
+    );
+    let response = match conn
+        .send_request(acp::AgentRequest::ExtMethodRequest(ext))
         .block_task()
-        .await?;
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(
+                native_session_id,
+                model_id = desired_model_id,
+                error = %error,
+                "[model-switch] agent rejected session/set_model"
+            );
+            return Err(error.into());
+        }
+    };
+    tracing::info!(
+        native_session_id,
+        model_id = desired_model_id,
+        response = %response,
+        "[model-switch] agent accepted session/set_model"
+    );
 
     startup_state.current_model_id = Some(desired_model_id.to_string());
     set_select_option_current_value_for_purpose(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -436,25 +436,68 @@ pub(in crate::live::sessions::actor) async fn apply_config_option_if_possible_wi
     Ok(ConfigApplyOutcome::AppliedAuthoritative)
 }
 
+/// Wire method for the legacy `session/set_model` RPC. ACP 0.14 dropped the
+/// typed `SetSessionModelRequest`, but harnesses that predate the
+/// model-as-config-option migration (e.g. Gemini CLI, via its
+/// `unstable_setSessionModel` handler) still listen on this method. We reach it
+/// through ACP's extension-method channel: the method string is serialized
+/// verbatim, so the lack of a `_` prefix (which only gates *inbound* ext
+/// routing) is irrelevant on the outbound path.
+const ACP_SET_SESSION_MODEL_METHOD: &str = "session/set_model";
+
+/// Switch the model on a session whose harness exposes no `model` config option
+/// (so `set_session_config_option` has no target). Mirrors
+/// [`apply_mode_via_direct_setter_legacy`], but the typed request was removed in
+/// ACP 0.14, so we send the legacy `session/set_model` as an extension method.
+/// The agent is the sole authority: a rejection comes back as an error and
+/// surfaces cleanly (the session stays Idle, the connection intact).
 pub(in crate::live::sessions::actor) async fn apply_model_via_direct_setter(
-    _conn: &acp::ConnectionTo<acp::Agent>,
-    _native_session_id: &str,
-    _startup_state: &mut SessionStartupState,
-    _desired_model_id: &str,
+    conn: &acp::ConnectionTo<acp::Agent>,
+    native_session_id: &str,
+    startup_state: &mut SessionStartupState,
+    desired_model_id: &str,
 ) -> anyhow::Result<ConfigApplyOutcome> {
-    // set_session_model was removed from ACP in 0.14; model selection is now
-    // config-option-only via set_session_config_option.
-    Ok(ConfigApplyOutcome::NotApplied)
+    if startup_state.current_model_id.as_deref() == Some(desired_model_id) {
+        return Ok(ConfigApplyOutcome::NoChange);
+    }
+
+    if !should_apply_model_via_direct_setter(startup_state, desired_model_id) {
+        return Ok(ConfigApplyOutcome::NotApplied);
+    }
+
+    // Params mirror acp.SetSessionModelRequest: { sessionId, modelId }.
+    let params: Arc<serde_json::value::RawValue> =
+        serde_json::value::to_raw_value(&serde_json::json!({
+            "sessionId": native_session_id,
+            "modelId": desired_model_id,
+        }))?
+        .into();
+    let ext = acp::schema::ExtRequest::new(ACP_SET_SESSION_MODEL_METHOD, params);
+    conn.send_request(acp::AgentRequest::ExtMethodRequest(ext))
+        .block_task()
+        .await?;
+
+    startup_state.current_model_id = Some(desired_model_id.to_string());
+    set_select_option_current_value_for_purpose(
+        &mut startup_state.config_options,
+        ConfigPurpose::Model,
+        desired_model_id,
+    );
+
+    Ok(ConfigApplyOutcome::AppliedAuthoritative)
 }
 
 pub(in crate::live::sessions::actor) fn should_apply_model_via_direct_setter(
-    _startup_state: &SessionStartupState,
+    startup_state: &SessionStartupState,
     _desired_model_id: &str,
 ) -> bool {
-    // set_session_model was removed in ACP 0.14; available_models is always empty
-    // and the setter stub returns NotApplied. Always return false so callers reject
-    // model requests that have no config-option target rather than silently accepting.
-    false
+    // Attempt the legacy `session/set_model` only when the harness reports no live
+    // model control at all. ACP 0.14 drops the legacy models block, so Gemini-style
+    // harnesses surface neither a `model` config option nor `available_models` — the
+    // write cannot be gated locally, and the agent is the sole authority on validity.
+    // When a live model list IS present, membership is enforced upstream; don't
+    // override that.
+    !startup_state.has_direct_model_control()
 }
 
 pub(in crate::live::sessions::actor) async fn apply_mode_via_direct_setter_legacy(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
@@ -277,11 +277,12 @@ fn pending_config_rank_treats_synthetic_acp_model_control_as_model() {
 }
 
 #[test]
-fn direct_model_setter_is_permanently_disabled() {
-    // set_session_model was removed from ACP in 0.14; the setter stub always
-    // returns NotApplied. should_apply_model_via_direct_setter must always return
-    // false so callers reject model requests rather than silently accepting them.
-    let startup_state = SessionStartupState {
+fn direct_model_setter_engages_only_without_live_model_control() {
+    // Harnesses that report no live model control (ACP 0.14 drops the legacy
+    // models block, so Gemini surfaces neither a model config option nor
+    // available_models) route a switch through the legacy `session/set_model`
+    // ext call; the agent is the sole authority on validity.
+    let no_model_control = SessionStartupState {
         current_mode_id: None,
         legacy_mode_state: None,
         config_options: Vec::new(),
@@ -289,13 +290,23 @@ fn direct_model_setter_is_permanently_disabled() {
         available_models: Vec::new(),
         prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
     };
-
-    assert!(!should_apply_model_via_direct_setter(
-        &startup_state,
-        "sonnet"
+    assert!(should_apply_model_via_direct_setter(
+        &no_model_control,
+        "gemini-2.5-pro"
     ));
+
+    // When a live model list IS present, membership is enforced upstream — the
+    // direct setter must not override it.
+    let with_model_control = SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: Vec::new(),
+        current_model_id: Some("sonnet".to_string()),
+        available_models: session_model_options(&["sonnet", "haiku"]),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    };
     assert!(!should_apply_model_via_direct_setter(
-        &startup_state,
+        &with_model_control,
         "opus"
     ));
 }

--- a/apps/desktop/src/lib/domain/chat/models/model-display.test.ts
+++ b/apps/desktop/src/lib/domain/chat/models/model-display.test.ts
@@ -94,6 +94,34 @@ describe("resolveModelDisplayName", () => {
       }),
     ).toBe("GPT 5.5");
   });
+
+  it("derives a Gemini label even when the catalog label is the raw id", () => {
+    // The catalog ships "Gemini-2.5-Pro", which lowercases to the model id and
+    // would be discarded as a raw label; the formatter must still produce a name.
+    expect(
+      resolveModelDisplayName({
+        agentKind: "gemini",
+        modelId: "gemini-2.5-pro",
+        sourceLabels: ["Gemini-2.5-Pro"],
+        preferKnownAlias: true,
+      }),
+    ).toBe("Gemini 2.5 Pro");
+  });
+
+  it("formats Gemini preview and flash variants", () => {
+    expect(
+      resolveModelDisplayName({
+        agentKind: "gemini",
+        modelId: "gemini-3-pro-preview",
+      }),
+    ).toBe("Gemini 3 Pro Preview");
+    expect(
+      resolveModelDisplayName({
+        agentKind: "gemini",
+        modelId: "gemini-2.5-flash",
+      }),
+    ).toBe("Gemini 2.5 Flash");
+  });
 });
 
 describe("shouldHideModel", () => {

--- a/apps/desktop/src/lib/domain/chat/models/model-display.ts
+++ b/apps/desktop/src/lib/domain/chat/models/model-display.ts
@@ -101,6 +101,24 @@ function formatGptModelId(modelId: string): string | null {
   );
 }
 
+function formatGeminiModelId(modelId: string): string | null {
+  const match = /^gemini-(\d+(?:\.\d+)?)-(.+)$/.exec(modelId);
+  if (!match) {
+    return null;
+  }
+
+  const [, version, suffix = ""] = match;
+  const suffixLabel = suffix
+    .split("-")
+    .filter(Boolean)
+    .map(titleCaseToken)
+    .join(" ");
+
+  return normalizeWhitespace(
+    `Gemini ${version}${suffixLabel ? ` ${suffixLabel}` : ""}`,
+  );
+}
+
 function formatClaudeModelId(modelId: string): string | null {
   const match = /claude-([a-z]+)-(\d)-(\d)(?:-[\d-]+)?/.exec(modelId);
   if (!match) {
@@ -156,7 +174,7 @@ export function resolveModelDisplayName(args: {
   }
 
   if (preferKnownAlias) {
-    const formatted = formatClaudeModelId(modelId);
+    const formatted = formatClaudeModelId(modelId) ?? formatGeminiModelId(modelId);
     if (formatted) {
       return withContextHint(formatted, sourceLabels);
     }
@@ -179,5 +197,6 @@ export function resolveModelDisplayName(args: {
   }
 
   return formatGptModelId(modelId)
-    ?? formatClaudeModelId(modelId);
+    ?? formatClaudeModelId(modelId)
+    ?? formatGeminiModelId(modelId);
 }


### PR DESCRIPTION
## Problem

Switching models mid-session is broken for **Gemini** (works for Claude). Creating a new workspace with a chosen Gemini model works — only the **live switch** fails.

ACP **0.14 removed the typed `set_session_model` RPC**, and the harness migrated to "model is a config option." Gemini CLI exposes **no `model` config option** (it still implements `unstable_setSessionModel` / `session/set_model` and reports models via the legacy block the 0.14 client no longer reads). So for a live Gemini session: no config-option target + the direct setter was **stubbed out** ⇒ the switch is rejected (*"Value '…' is not valid for config option 'model'"*). Creation works because the model is chosen at `session/new` via `createField: modelId`, a separate path.

Gemini installs from upstream npm in prod, so the fix must live in our harness — which is what `specs/.../harnesses/gemini.md` already prescribes ("route it to ACP `unstable_setSessionModel`").

## Fix

`live/sessions/actor/config/apply.rs`:

- **`apply_model_via_direct_setter`** — un-stubbed. Sends Gemini's surviving `session/set_model` handler through ACP's **extension-method channel** (`AgentRequest::ExtMethodRequest`, params `{ sessionId, modelId }`), mirroring the `apply_mode_via_direct_setter_legacy` twin directly below it. The method string serializes verbatim, so the `_`-prefix rule (which only gates *inbound* ext routing) doesn't apply outbound.
- **`should_apply_model_via_direct_setter`** — re-enabled to `!has_direct_model_control()`: engages only when the harness reports no live model control (exactly Gemini under 0.14), leaving live-model-list harnesses to enforce membership upstream. The agent is the sole authority; a rejection surfaces cleanly (session Idle, connection intact).

No caller-chain edits — the routing already funnels the no-config-option model case into the direct setter; this just makes it act again.

Wire method (`session/set_model`) and param shape (`{ sessionId, modelId }`) verified empirically against `@agentclientprotocol/sdk@0.16.1`.

## Testing

- `cargo check` clean; **51 config + 35 actor tests pass**.
- Updated the obsolete "permanently disabled" test → `direct_model_setter_engages_only_without_live_model_control` (asserts both gate branches).
- Preserved `model_config_request_without_raw_option_rejects_values_outside_acp_models` still passes — confirms the narrow gate doesn't regress live-model-list harnesses.

## Not yet covered

Live end-to-end (the actual wire round-trip to a running Gemini agent) — build `~/gemini-cli/bundle`, start a Gemini session, switch model in the picker, confirm in-place switch (no fork) + next prompt runs on the new model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)