### PR TITLE
feat(anyharness): catalog-lockfile harness pins — fenced, sha-verified installer + producer

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/agents_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agents_errors.rs
@@ -93,6 +93,16 @@ fn install_error_to_api(error: InstallError) -> ApiError {
             "ACP registry lookup failed",
             "AGENT_REGISTRY_FAILED",
         ),
+        InstallError::ChecksumMismatch { .. } => (
+            StatusCode::BAD_GATEWAY,
+            "Downloaded agent artifact failed checksum verification",
+            "AGENT_CHECKSUM_MISMATCH",
+        ),
+        InstallError::NoPinForPlatform(_) => (
+            StatusCode::BAD_REQUEST,
+            "No pinned agent download for this platform",
+            "AGENT_NO_PIN_FOR_PLATFORM",
+        ),
         InstallError::Io(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Agent install failed",

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -85,7 +85,7 @@ pub struct AgentCatalogArtifactPin {
 /// trust anchor: install downloads the url, verifies the hash, and refuses
 /// anything else — so a url living in the catalog cannot fetch unintended bytes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum AgentCatalogArtifactSource {
     /// A single executable: download + chmod. Per-platform url+sha.
     Binary {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -69,8 +69,58 @@ pub struct AgentCatalogHarnessPins {
 #[serde(rename_all = "camelCase")]
 pub struct AgentCatalogArtifactPin {
     pub version: String,
+    /// Legacy single-hash field; superseded by `source`. Kept for migration so
+    /// pre-lockfile catalogs still parse.
     #[serde(default)]
     pub sha256: Option<String>,
+    /// The resolved, fenced install source (the lockfile's executable truth).
+    /// When present, install materializes EXACTLY this — sha256-verified — and
+    /// never consults registry install specs. When absent, the legacy
+    /// registry-spec path is used (deleted once every pin carries a source).
+    #[serde(default)]
+    pub source: Option<AgentCatalogArtifactSource>,
+}
+
+/// Resolved install source for one artifact. The per-target `sha256` is the
+/// trust anchor: install downloads the url, verifies the hash, and refuses
+/// anything else — so a url living in the catalog cannot fetch unintended bytes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentCatalogArtifactSource {
+    /// A single executable: download + chmod. Per-platform url+sha.
+    Binary {
+        targets: BTreeMap<String, AgentCatalogPinTarget>,
+    },
+    /// A tar/zip archive: extract + find `expectedBinary`. Per-platform url+sha.
+    Archive {
+        targets: BTreeMap<String, AgentCatalogPinTarget>,
+    },
+    /// An npm-registry package pinned to an exact version.
+    Npm {
+        package: String,
+        #[serde(default)]
+        sha256: Option<String>,
+    },
+    /// A git specifier (our adapter forks) installed/built from a pinned ref.
+    Git {
+        repo: String,
+        git_ref: String,
+        #[serde(default)]
+        package_subdir: Option<String>,
+        executable_relpath: String,
+    },
+}
+
+/// One platform's resolved download for a `Binary`/`Archive` source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogPinTarget {
+    /// Keyed in `targets` by the registry platform key (`macos_arm64`, …).
+    pub url: String,
+    pub sha256: String,
+    /// For `Archive`: the binary name inside the extracted tree.
+    #[serde(default)]
+    pub expected_binary: Option<String>,
 }
 
 /// Pinned data dependency that gates model lists (e.g. opencode models.dev).

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service.rs
@@ -18,11 +18,15 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use super::schema::{
-    AgentCatalogAgent, AgentCatalogAuthContext, AgentCatalogDocument, AgentCatalogHarnessPins,
-    AgentCatalogModel, AgentCatalogModelControl,
+    AgentCatalogAgent, AgentCatalogArtifactPin, AgentCatalogArtifactSource, AgentCatalogAuthContext,
+    AgentCatalogDocument, AgentCatalogHarnessPins, AgentCatalogModel, AgentCatalogModelControl,
+    AgentCatalogPinTarget,
 };
 use super::sync::CatalogSyncService;
 use crate::domains::agents::auth::context::ActiveAuthContexts;
+use crate::domains::agents::installer::install_policy::{
+    PinOverrides, ResolvedPinSource, ResolvedPinTarget,
+};
 use crate::domains::agents::model::ModelCatalogStatus;
 
 /// Read surface over the active catalog held by [`CatalogSyncService`].
@@ -37,11 +41,9 @@ impl AgentCatalogService {
     }
 
     /// Catalog pin overrides for the installer (None when the kind is
-    /// unknown to the active catalog).
-    pub fn pin_overrides(
-        &self,
-        kind: &str,
-    ) -> Option<crate::domains::agents::installer::install_policy::PinOverrides> {
+    /// unknown to the active catalog). Carries both the version (drift) and
+    /// the resolved, fenced install source (materialization) per role.
+    pub fn pin_overrides(&self, kind: &str) -> Option<PinOverrides> {
         let active = self.active_catalog();
         let pins = active.pins(kind)?;
         // Placeholder pins ("unknown" — e.g. cursor pre manifest-provenance)
@@ -49,17 +51,61 @@ impl AgentCatalogService {
         let usable = |version: &str| {
             (!version.is_empty() && version != "unknown").then(|| version.to_string())
         };
-        Some(
-            crate::domains::agents::installer::install_policy::PinOverrides {
-                agent_process: usable(&pins.agent_process.version),
-                native: pins.native.as_ref().and_then(|pin| usable(&pin.version)),
-            },
-        )
+        Some(PinOverrides {
+            agent_process: usable(&pins.agent_process.version),
+            native: pins.native.as_ref().and_then(|pin| usable(&pin.version)),
+            agent_process_source: project_source(&pins.agent_process),
+            native_source: pins.native.as_ref().and_then(project_source),
+        })
     }
 
     pub fn active_catalog(&self) -> ActiveCatalog {
         ActiveCatalog::new(self.sync.active().document)
     }
+}
+
+/// Project a catalog artifact pin's resolved source (schema) into the
+/// installer-domain `ResolvedPinSource`. `None` when the pin has no source
+/// (legacy pre-lockfile pin) — the installer then uses the registry spec.
+fn project_source(pin: &AgentCatalogArtifactPin) -> Option<ResolvedPinSource> {
+    let targets = |targets: &BTreeMap<String, AgentCatalogPinTarget>| {
+        targets
+            .iter()
+            .map(|(platform, target)| {
+                (
+                    platform.clone(),
+                    ResolvedPinTarget {
+                        url: target.url.clone(),
+                        sha256: target.sha256.clone(),
+                        expected_binary: target.expected_binary.clone(),
+                    },
+                )
+            })
+            .collect()
+    };
+    Some(match pin.source.as_ref()? {
+        AgentCatalogArtifactSource::Binary { targets: t } => {
+            ResolvedPinSource::Binary { targets: targets(t) }
+        }
+        AgentCatalogArtifactSource::Archive { targets: t } => {
+            ResolvedPinSource::Archive { targets: targets(t) }
+        }
+        AgentCatalogArtifactSource::Npm { package, sha256 } => ResolvedPinSource::Npm {
+            package: package.clone(),
+            sha256: sha256.clone(),
+        },
+        AgentCatalogArtifactSource::Git {
+            repo,
+            git_ref,
+            package_subdir,
+            executable_relpath,
+        } => ResolvedPinSource::Git {
+            repo: repo.clone(),
+            git_ref: git_ref.clone(),
+            package_subdir: package_subdir.clone(),
+            executable_relpath: executable_relpath.clone(),
+        },
+    })
 }
 
 /// A pinned catalog snapshot: readers borrow from it for as long as they

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -52,6 +52,40 @@ fn pins_surface_catalog_harness_versions() {
 }
 
 #[test]
+fn bundled_catalog_is_a_complete_lockfile() {
+    use super::schema::{AgentCatalogArtifactPin, AgentCatalogArtifactSource};
+
+    let sync = Arc::new(CatalogSyncService::from_bundled());
+    let catalog = AgentCatalogService::new(sync).active_catalog();
+
+    let check = |kind: &str, role: &str, pin: &AgentCatalogArtifactPin| {
+        let source = pin
+            .source
+            .as_ref()
+            .unwrap_or_else(|| panic!("{kind} {role} pin must carry a resolved source (lockfile)"));
+        if let AgentCatalogArtifactSource::Binary { targets }
+        | AgentCatalogArtifactSource::Archive { targets } = source
+        {
+            assert!(!targets.is_empty(), "{kind} {role} has no platform targets");
+            for (platform, target) in targets {
+                assert_eq!(
+                    target.sha256.len(),
+                    64,
+                    "{kind} {role} {platform} sha256 must be a full hash"
+                );
+            }
+        }
+    };
+
+    for agent in catalog.agents() {
+        check(&agent.kind, "agentProcess", &agent.harness.agent_process);
+        if let Some(native) = &agent.harness.native {
+            check(&agent.kind, "native", native);
+        }
+    }
+}
+
+#[test]
 fn models_intersect_availability_with_active_contexts() {
     let catalog = draft_catalog();
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use chrono::DateTime;
 
 use super::schema::{
-    AgentCatalogAgent, AgentCatalogAuthContext, AgentCatalogAuthSignal, AgentCatalogDocument,
-    AgentCatalogModel,
+    AgentCatalogAgent, AgentCatalogArtifactPin, AgentCatalogArtifactSource, AgentCatalogAuthContext,
+    AgentCatalogAuthSignal, AgentCatalogDocument, AgentCatalogModel,
 };
 use crate::domains::agents::model::AgentKind;
 
@@ -57,6 +57,7 @@ fn validate_agent(
             agent.kind
         );
     }
+    validate_artifact_pin(&agent.kind, "agentProcess", &agent.harness.agent_process)?;
     if let Some(native) = &agent.harness.native {
         if native.version.trim().is_empty() {
             anyhow::bail!(
@@ -64,6 +65,7 @@ fn validate_agent(
                 agent.kind
             );
         }
+        validate_artifact_pin(&agent.kind, "native", native)?;
     }
 
     let mut context_ids = HashSet::new();
@@ -77,6 +79,50 @@ fn validate_agent(
     let mut seen_models = HashSet::new();
     for model in &agent.session.models {
         validate_model(&agent.kind, model, &context_ids, &mut seen_models)?;
+    }
+    Ok(())
+}
+
+/// A resolved pin source is the lockfile's executable truth, so its fields must
+/// be materializable: per-target downloads need a url and the trust-anchor
+/// sha256; npm/git need a package/ref. A pin with no source is fine (legacy).
+fn validate_artifact_pin(kind: &str, role: &str, pin: &AgentCatalogArtifactPin) -> anyhow::Result<()> {
+    let Some(source) = &pin.source else {
+        return Ok(());
+    };
+    match source {
+        AgentCatalogArtifactSource::Binary { targets }
+        | AgentCatalogArtifactSource::Archive { targets } => {
+            if targets.is_empty() {
+                anyhow::bail!("agent '{kind}' {role} source has no platform targets");
+            }
+            for (platform, target) in targets {
+                if target.url.trim().is_empty() {
+                    anyhow::bail!("agent '{kind}' {role} target '{platform}' has empty url");
+                }
+                if target.sha256.trim().is_empty() {
+                    anyhow::bail!("agent '{kind}' {role} target '{platform}' has empty sha256");
+                }
+            }
+        }
+        AgentCatalogArtifactSource::Npm { package, .. } => {
+            if package.trim().is_empty() {
+                anyhow::bail!("agent '{kind}' {role} npm source has empty package");
+            }
+        }
+        AgentCatalogArtifactSource::Git {
+            repo,
+            git_ref,
+            executable_relpath,
+            ..
+        } => {
+            if repo.trim().is_empty() || git_ref.trim().is_empty() {
+                anyhow::bail!("agent '{kind}' {role} git source needs repo and gitRef");
+            }
+            if executable_relpath.trim().is_empty() {
+                anyhow::bail!("agent '{kind}' {role} git source needs executableRelpath");
+            }
+        }
     }
     Ok(())
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use sha2::{Digest, Sha256};
+
 use super::InstallError;
 
 const CURL_CONNECT_TIMEOUT: &str = "10";
@@ -132,4 +134,114 @@ fn find_binary_in_dir(dir: &Path, name: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Lowercase-hex sha256 of a file, streamed.
+fn sha256_hex(path: &Path) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Verify a downloaded file against an expected sha256. On mismatch the file is
+/// removed and a `ChecksumMismatch` error is returned — this is the trust
+/// anchor for fenced, catalog-pinned installs.
+fn verify_sha256(url: &str, path: &Path, expected: &str) -> Result<(), InstallError> {
+    let actual = sha256_hex(path)?;
+    if !actual.eq_ignore_ascii_case(expected) {
+        let _ = std::fs::remove_file(path);
+        return Err(InstallError::ChecksumMismatch {
+            url: url.to_string(),
+            expected: expected.to_string(),
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Download a single binary and verify its sha256 before it is used.
+pub(super) fn curl_download_binary_verified(
+    url: &str,
+    dest: &Path,
+    expected_sha256: &str,
+) -> Result<(), InstallError> {
+    curl_download_binary(url, dest)?;
+    verify_sha256(url, dest, expected_sha256)
+}
+
+/// Download an archive (`.tar.gz`/`.tgz` or `.zip`) to a temp file, verify its
+/// sha256, then extract and place `expected_binary` at `target_path`.
+pub(super) fn download_and_extract_archive_verified(
+    url: &str,
+    expected_binary: &str,
+    managed_dir: &Path,
+    target_path: &Path,
+    expected_sha256: &str,
+) -> Result<(), InstallError> {
+    let staging_dir = managed_dir.join("_staging");
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    std::fs::create_dir_all(&staging_dir)?;
+    let archive_path = staging_dir.join("_archive.download");
+
+    if let Err(e) = curl_download_binary(url, &archive_path)
+        .and_then(|()| verify_sha256(url, &archive_path, expected_sha256))
+    {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return Err(e);
+    }
+
+    let is_zip = url.ends_with(".zip");
+    let extract = if is_zip {
+        Command::new("unzip")
+            .arg("-q")
+            .arg(&archive_path)
+            .arg("-d")
+            .arg(&staging_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+    } else {
+        Command::new("tar")
+            .arg("xzf")
+            .arg(&archive_path)
+            .arg("-C")
+            .arg(&staging_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+    };
+    let output = extract.map_err(|e| InstallError::FetchFailed {
+        url: url.into(),
+        message: e.to_string(),
+    })?;
+    if !output.status.success() {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return Err(InstallError::FetchFailed {
+            url: url.into(),
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+
+    let extracted = staging_dir.join(expected_binary);
+    if extracted.exists() {
+        std::fs::rename(&extracted, target_path)?;
+    } else if let Some(found) = find_binary_in_dir(&staging_dir, expected_binary) {
+        std::fs::rename(&found, target_path)?;
+    } else {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return Err(InstallError::MissingManagedArtifact(PathBuf::from(
+            expected_binary,
+        )));
+    }
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    Ok(())
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
@@ -91,10 +91,46 @@ pub fn plan_artifact(facts: &ArtifactFacts, reinstall_requested: bool) -> Option
 
 /// Catalog-supplied pin overrides (the WHICH document wins over registry
 /// specs when an active v2 catalog declares versions for this agent).
+///
+/// The `*_source` fields carry the resolved, fenced install source from the
+/// lockfile. When present, the materializer downloads EXACTLY that (sha256
+/// verified) instead of consulting the registry install spec.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PinOverrides {
     pub agent_process: Option<String>,
     pub native: Option<String>,
+    pub agent_process_source: Option<ResolvedPinSource>,
+    pub native_source: Option<ResolvedPinSource>,
+}
+
+/// Installer-domain mirror of `catalog::schema::AgentCatalogArtifactSource`
+/// (kept here so `installer/` does not depend on `catalog/` structs). The
+/// per-target `sha256` is the trust anchor enforced at download.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedPinSource {
+    Binary {
+        targets: std::collections::BTreeMap<String, ResolvedPinTarget>,
+    },
+    Archive {
+        targets: std::collections::BTreeMap<String, ResolvedPinTarget>,
+    },
+    Npm {
+        package: String,
+        sha256: Option<String>,
+    },
+    Git {
+        repo: String,
+        git_ref: String,
+        package_subdir: Option<String>,
+        executable_relpath: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPinTarget {
+    pub url: String,
+    pub sha256: String,
+    pub expected_binary: Option<String>,
 }
 
 /// The effective pin: catalog override first, registry spec as the fallback.
@@ -108,6 +144,18 @@ pub fn effective_pin(
         ArtifactRole::NativeCli => overrides.native.clone(),
     });
     from_catalog.or_else(|| pinned_version_for(descriptor, role))
+}
+
+/// The resolved, fenced install source for this role, when the active catalog
+/// declares one. `None` means the legacy registry-spec path applies.
+pub fn effective_source(
+    overrides: Option<&PinOverrides>,
+    role: &ArtifactRole,
+) -> Option<ResolvedPinSource> {
+    overrides.and_then(|overrides| match role {
+        ArtifactRole::AgentProcess => overrides.agent_process_source.clone(),
+        ArtifactRole::NativeCli => overrides.native_source.clone(),
+    })
 }
 
 /// The declared version pin for an agent-process install spec, when the spec
@@ -219,6 +267,7 @@ mod tests {
         let overrides = PinOverrides {
             agent_process: Some("9.9.9".into()),
             native: Some("2.0.0".into()),
+            ..Default::default()
         };
         assert_eq!(
             effective_pin(Some(&overrides), &claude, &ArtifactRole::AgentProcess).as_deref(),

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod managed_npm;
 pub mod manifest;
 mod native;
 mod npm;
+mod pinned;
 pub mod reconcile;
 pub mod seed;
 mod service;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/pinned.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/pinned.rs
@@ -1,0 +1,178 @@
+//! The fenced materializer: install EXACTLY a resolved pin's bytes, sha256
+//! verified. No latest-fetch, no PATH adoption, no registry re-fetch — this is
+//! the install-time half of "the catalog pin is law".
+//!
+//! Scope (Seam 1): `Binary` and `Archive` sources — the native CLIs and the
+//! binary-distributed adapters, where the reproducibility hole and the
+//! supply-chain surface live. `Npm`/`Git` sources stay on the existing
+//! version/ref-pinned managed-npm path until Seam 2 deletes the legacy routes.
+
+use std::path::Path;
+
+use super::downloads::{curl_download_binary_verified, download_and_extract_archive_verified};
+use super::install_policy::{ResolvedPinSource, ResolvedPinTarget};
+use super::{InstallError, InstalledArtifactResult};
+use crate::domains::agents::model::{AgentKind, ArtifactRole, Platform};
+use crate::domains::agents::readiness::paths::artifact_root;
+use crate::integrations::agent_cli::executable::make_executable;
+
+/// True when this source is materialized by the fenced binary/archive path.
+/// `Npm`/`Git` go through the managed-npm path (already version/ref pinned).
+pub(super) fn is_binary_or_archive(source: &ResolvedPinSource) -> bool {
+    matches!(
+        source,
+        ResolvedPinSource::Binary { .. } | ResolvedPinSource::Archive { .. }
+    )
+}
+
+/// Materialize one artifact from its pinned, fenced `Binary`/`Archive` source:
+/// resolve this platform's target, download it, verify the sha256, place the
+/// executable at the managed artifact path. Refuses anything that doesn't match
+/// the pinned checksum.
+pub(super) fn install_binary_or_archive_from_pin(
+    source: &ResolvedPinSource,
+    version: &str,
+    kind: &AgentKind,
+    role: &ArtifactRole,
+    runtime_home: &Path,
+) -> Result<InstalledArtifactResult, InstallError> {
+    let managed_dir = artifact_root(runtime_home, kind, role);
+    std::fs::create_dir_all(&managed_dir)?;
+    let target_path = managed_dir.join(kind.as_str());
+
+    match source {
+        ResolvedPinSource::Binary { targets } => {
+            let target = pick_target(targets)?;
+            let temp_path = managed_dir.join(format!(".{}.downloading", kind.as_str()));
+            curl_download_binary_verified(&target.url, &temp_path, &target.sha256)?;
+            make_executable(&temp_path)?;
+            std::fs::rename(&temp_path, &target_path)?;
+            Ok(InstalledArtifactResult {
+                role: role.clone(),
+                path: target_path,
+                source: "pinned_binary".into(),
+                version: Some(version.to_string()),
+            })
+        }
+        ResolvedPinSource::Archive { targets } => {
+            let target = pick_target(targets)?;
+            let expected_binary = target
+                .expected_binary
+                .clone()
+                .unwrap_or_else(|| kind.as_str().to_string());
+            download_and_extract_archive_verified(
+                &target.url,
+                &expected_binary,
+                &managed_dir,
+                &target_path,
+                &target.sha256,
+            )?;
+            make_executable(&target_path)?;
+            Ok(InstalledArtifactResult {
+                role: role.clone(),
+                path: target_path,
+                source: "pinned_archive".into(),
+                version: Some(version.to_string()),
+            })
+        }
+        ResolvedPinSource::Npm { .. } | ResolvedPinSource::Git { .. } => {
+            Err(InstallError::InvalidInstallSpec(
+                "npm/git pins are not materialized by the binary/archive path".into(),
+            ))
+        }
+    }
+}
+
+/// Resolve this platform's pinned download, or refuse (no silent fallback).
+fn pick_target(
+    targets: &std::collections::BTreeMap<String, ResolvedPinTarget>,
+) -> Result<&ResolvedPinTarget, InstallError> {
+    let platform = Platform::detect().ok_or(InstallError::UnsupportedPlatform)?;
+    targets
+        .get(platform.registry_key())
+        .ok_or_else(|| InstallError::NoPinForPlatform(platform.registry_key().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::collections::BTreeMap;
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("{name}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn binary_pin(url: &str, sha256: &str) -> ResolvedPinSource {
+        let platform = Platform::detect().expect("supported test platform");
+        let mut targets = BTreeMap::new();
+        targets.insert(
+            platform.registry_key().to_string(),
+            ResolvedPinTarget {
+                url: url.to_string(),
+                sha256: sha256.to_string(),
+                expected_binary: None,
+            },
+        );
+        ResolvedPinSource::Binary { targets }
+    }
+
+    #[test]
+    fn correct_sha_installs_the_pinned_binary() {
+        let scratch = temp_dir("pinned-ok");
+        let source_file = scratch.join("claude-payload");
+        let bytes = b"#!/bin/sh\necho claude\n";
+        std::fs::write(&source_file, bytes).expect("write payload");
+        let url = format!("file://{}", source_file.display());
+
+        let home = scratch.join("home");
+        let result = install_binary_or_archive_from_pin(
+            &binary_pin(&url, &sha256_hex(bytes)),
+            "2.1.170",
+            &AgentKind::Claude,
+            &ArtifactRole::NativeCli,
+            &home,
+        )
+        .expect("pinned install");
+
+        assert_eq!(result.version.as_deref(), Some("2.1.170"));
+        assert!(result.path.exists(), "installed binary should exist");
+        assert_eq!(std::fs::read(&result.path).expect("read"), bytes);
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn wrong_sha_is_refused_and_nothing_is_installed() {
+        let scratch = temp_dir("pinned-bad");
+        let source_file = scratch.join("claude-payload");
+        std::fs::write(&source_file, b"tampered bytes").expect("write payload");
+        let url = format!("file://{}", source_file.display());
+
+        let home = scratch.join("home");
+        let err = install_binary_or_archive_from_pin(
+            &binary_pin(&url, &"0".repeat(64)),
+            "2.1.170",
+            &AgentKind::Claude,
+            &ArtifactRole::NativeCli,
+            &home,
+        )
+        .expect_err("checksum mismatch must fail");
+
+        assert!(
+            matches!(err, InstallError::ChecksumMismatch { .. }),
+            "expected ChecksumMismatch, got {err:?}"
+        );
+        let target = artifact_root(&home, &AgentKind::Claude, &ArtifactRole::NativeCli)
+            .join(AgentKind::Claude.as_str());
+        assert!(!target.exists(), "no artifact may survive a bad checksum");
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/service.rs
@@ -1,10 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use super::agent_process::{self, install_agent_process_artifact, is_agent_process_installable};
+use super::install_policy::effective_source;
 use super::lock::AgentInstallLock;
 use super::native::{install_native_artifact, is_native_installable};
+use super::pinned;
 use crate::domains::agents::installer::seed;
 use crate::domains::agents::model::*;
+use crate::domains::agents::readiness::paths::artifact_root;
+use crate::integrations::agent_cli::executable::is_valid_executable;
 use crate::integrations::agent_cli::launcher::LauncherError;
 
 #[derive(Debug, Clone)]
@@ -38,6 +42,14 @@ pub enum InstallError {
     FetchFailed { url: String, message: String },
     #[error("ACP registry error: {0}")]
     RegistryFailed(String),
+    #[error("checksum mismatch for {url}: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        url: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("pinned source has no download for this platform: {0}")]
+    NoPinForPlatform(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -100,12 +112,33 @@ pub fn install_agent_with_pins(
         if is_native_installable(&native_spec.install) {
             has_installable = true;
             let native_options = options_for_role(options, &plan, &ArtifactRole::NativeCli);
-            if let Some(result) = install_native_artifact(
-                native_spec,
-                &descriptor.kind,
-                runtime_home,
-                &native_options,
-            )? {
+            // Fenced path: when the catalog declares a Binary/Archive source for
+            // the native CLI, install EXACTLY that (sha256-verified) instead of
+            // resolving the registry spec. Otherwise the legacy path runs.
+            let pinned_source = effective_source(catalog_pins, &ArtifactRole::NativeCli)
+                .filter(pinned::is_binary_or_archive);
+            let result = if let Some(source) = pinned_source {
+                install_pinned_role(
+                    &source,
+                    super::install_policy::effective_pin(
+                        catalog_pins,
+                        descriptor,
+                        &ArtifactRole::NativeCli,
+                    ),
+                    &native_options,
+                    &descriptor.kind,
+                    &ArtifactRole::NativeCli,
+                    runtime_home,
+                )?
+            } else {
+                install_native_artifact(
+                    native_spec,
+                    &descriptor.kind,
+                    runtime_home,
+                    &native_options,
+                )?
+            };
+            if let Some(result) = result {
                 tracing::info!(
                     agent = descriptor.kind.as_str(),
                     role = "native_cli",
@@ -221,4 +254,29 @@ fn options_for_role(
         native_version: options.native_version.clone(),
         agent_process_version: options.agent_process_version.clone(),
     }
+}
+
+/// Install one role from a fenced Binary/Archive pin (sha256-verified), with
+/// the same idempotent skip as the legacy mechanisms: an already-installed
+/// artifact is left alone unless the plan forced a reinstall.
+fn install_pinned_role(
+    source: &super::install_policy::ResolvedPinSource,
+    version: Option<String>,
+    options: &InstallOptions,
+    kind: &AgentKind,
+    role: &ArtifactRole,
+    runtime_home: &Path,
+) -> Result<Option<InstalledArtifactResult>, InstallError> {
+    let target_path = artifact_root(runtime_home, kind, role).join(kind.as_str());
+    if is_valid_executable(&target_path) && !options.reinstall {
+        return Ok(None);
+    }
+    let result = pinned::install_binary_or_archive_from_pin(
+        source,
+        version.as_deref().unwrap_or_default(),
+        kind,
+        role,
+        runtime_home,
+    )?;
+    Ok(Some(result))
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model.rs
@@ -169,6 +169,19 @@ impl Platform {
             _ => "node",
         }
     }
+
+    /// The registry/catalog platform-map key (`macos_arm64`, `linux_x64`, …)
+    /// used to index a pin's per-target downloads.
+    pub fn registry_key(self) -> &'static str {
+        match self {
+            Self::MacosArm64 => "macos_arm64",
+            Self::MacosX64 => "macos_x64",
+            Self::LinuxX64 => "linux_x64",
+            Self::LinuxArm64 => "linux_arm64",
+            Self::WindowsX64 => "windows_x64",
+            Self::WindowsArm64 => "windows_arm64",
+        }
+    }
 }
 
 /// Describes the native CLI artifact for an agent (optional; not all agents have one).

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -11,10 +11,33 @@
       "displayName": "Claude",
       "harness": {
         "agentProcess": {
-          "version": "0.29.0"
+          "version": "0.29.0",
+          "source": {
+            "kind": "git",
+            "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
+            "gitRef": "3ff484e671de5fe9275d2e7596d683df06b99e14",
+            "executableRelpath": "node_modules/.bin/claude-agent-acp"
+          }
         },
         "native": {
-          "version": "2.1.170 (Claude Code)"
+          "version": "2.1.178",
+          "source": {
+            "kind": "binary",
+            "targets": {
+              "macos_arm64": {
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.178/darwin-arm64/claude",
+                "sha256": "473495d0c15d6616cd0870480db5eb8aa0402fe4f8ead3277a1b521e94110309"
+              },
+              "macos_x64": {
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.178/darwin-x64/claude",
+                "sha256": "e6c5f5eec2b4d18f6234c3ba500e285f07a2e5ffb4c67d4ba0494c28c70dfe79"
+              },
+              "linux_x64": {
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.178/linux-x64/claude",
+                "sha256": "17ed1a983a49404c4673de286419a8fd6617c92440a2e0f789bcc413a3b14de1"
+              }
+            }
+          }
         }
       },
       "authContexts": [
@@ -842,10 +865,37 @@
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.11.8"
+          "version": "0.11.8",
+          "source": {
+            "kind": "git",
+            "repo": "https://github.com/proliferate-ai/codex-acp.git",
+            "gitRef": "988bd156960d038104ae60e5bbbf5d190502a0f3",
+            "packageSubdir": "npm",
+            "executableRelpath": "node_modules/.bin/codex-acp"
+          }
         },
         "native": {
-          "version": "codex-cli 0.139.0"
+          "version": "rust-v0.140.0",
+          "source": {
+            "kind": "archive",
+            "targets": {
+              "macos_arm64": {
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.140.0/codex-aarch64-apple-darwin.tar.gz",
+                "sha256": "c81eaf1b4c9aee0e81e2b39dec1742a57b61be6c109f8811e7fcd41f55c2233d",
+                "expectedBinary": "codex-aarch64-apple-darwin"
+              },
+              "macos_x64": {
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.140.0/codex-x86_64-apple-darwin.tar.gz",
+                "sha256": "2bd0edf75fd1451425736bae41470c3b800fe8eb372c194a668434f9526df9f0",
+                "expectedBinary": "codex-x86_64-apple-darwin"
+              },
+              "linux_x64": {
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.140.0/codex-x86_64-unknown-linux-musl.tar.gz",
+                "sha256": "48e591964d4bbaab7c0433daed41c65ea8f152fc0f1dd2334a42e3dd322a4906",
+                "expectedBinary": "codex-x86_64-unknown-linux-musl"
+              }
+            }
+          }
         }
       },
       "authContexts": [
@@ -1561,7 +1611,27 @@
       "displayName": "Cursor",
       "harness": {
         "agentProcess": {
-          "version": "unknown"
+          "version": "2026.06.15",
+          "source": {
+            "kind": "archive",
+            "targets": {
+              "macos_arm64": {
+                "url": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/darwin/arm64/agent-cli-package.tar.gz",
+                "sha256": "9de9e9669a008ec670617b42413a9b04a1404bac2acf899f87e55a80aa51ff14",
+                "expectedBinary": "./dist-package/cursor-agent"
+              },
+              "macos_x64": {
+                "url": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/darwin/x64/agent-cli-package.tar.gz",
+                "sha256": "fa1636a2769809320d4755773e89a3c86b1fbb552bbe0ecd958bd544ee57c926",
+                "expectedBinary": "./dist-package/cursor-agent"
+              },
+              "linux_x64": {
+                "url": "https://downloads.cursor.com/lab/2026.06.15-03-48-54-da23e37/linux/x64/agent-cli-package.tar.gz",
+                "sha256": "c63cf8173606dedea5959d87917f64a729743cf7f8346cf8c7ac8cf68a86ac36",
+                "expectedBinary": "./dist-package/cursor-agent"
+              }
+            }
+          }
         }
       },
       "authContexts": [
@@ -2789,7 +2859,12 @@
       "displayName": "Gemini",
       "harness": {
         "agentProcess": {
-          "version": "0.45.3"
+          "version": "0.46.0",
+          "source": {
+            "kind": "npm",
+            "package": "@google/gemini-cli@0.46.0",
+            "sha256": "sha512-+HZtuuDKsL8mvOUWgK08GkrL1BQM4IplaSzxIjAM262FmJFp3Jo/zlHUq9ulRKcvx0agZ4KAzuj7jG9yIAxFBw=="
+          }
         }
       },
       "authContexts": [
@@ -3068,7 +3143,27 @@
       "displayName": "OpenCode",
       "harness": {
         "agentProcess": {
-          "version": "1.16.2"
+          "version": "1.17.7",
+          "source": {
+            "kind": "archive",
+            "targets": {
+              "macos_arm64": {
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-arm64.zip",
+                "sha256": "7a63aeb5a15b29da2681ac2b8c74d4cb3a64fa13b61198a3c7dc771243c23972",
+                "expectedBinary": "./opencode"
+              },
+              "macos_x64": {
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-x64.zip",
+                "sha256": "4953e7c3c8db8c623ea726d8ecb6657ba04806b7b4d906c078fc072fb172cfe0",
+                "expectedBinary": "./opencode"
+              },
+              "linux_x64": {
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-linux-x64.tar.gz",
+                "sha256": "60fe5a92dc9af64ec079348fedde17e12da6a867efe7e8353be8038480607924",
+                "expectedBinary": "./opencode"
+              }
+            }
+          }
         }
       },
       "authContexts": [

--- a/scripts/agent-catalog/resolve-pins.mjs
+++ b/scripts/agent-catalog/resolve-pins.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// Resolve each agent harness into a fenced, reproducible install pin and write
+// it into catalogs/agents/catalog.json. This is the producer half of the
+// "catalog is the lockfile" design: it turns the registry's probe-time
+// discovery config (latest-version URLs, ACP registry ids, git refs) into a
+// frozen `source` block carrying a concrete, per-platform {url, sha256} (or an
+// npm/git specifier). The runtime installer then materializes EXACTLY that,
+// sha-verified, with no latest-fetch at install time.
+//
+//   node scripts/agent-catalog/resolve-pins.mjs [--agent claude,codex]
+//       [--no-download]   resolve URLs only, leave sha256 empty (inspection)
+//       [--catalog PATH] [--registry PATH]
+//
+// Real shas require downloading each platform artifact (binaries/archives);
+// npm pins capture `npm view dist.integrity`; git pins are anchored by commit.
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const args = parseArgs(process.argv.slice(2));
+const catalogPath = resolve(args.catalog ?? join(REPO_ROOT, "catalogs/agents/catalog.json"));
+const registryPath = resolve(args.registry ?? join(REPO_ROOT, "catalogs/agents/registry.json"));
+const onlyAgents = args.agent ? new Set(args.agent.split(",")) : null;
+const noDownload = Boolean(args.noDownload);
+// Platforms we actually ship today: desktop (macOS arm64/x64) + cloud E2B
+// (linux x64). Override with --platforms to resolve the full matrix in CI.
+const DEFAULT_PLATFORMS = ["macos_arm64", "macos_x64", "linux_x64"];
+const platforms = new Set(args.platforms ? args.platforms.split(",") : DEFAULT_PLATFORMS);
+
+const ACP_REGISTRY_URL =
+  process.env.ANYHARNESS_ACP_REGISTRY_URL ??
+  "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
+
+// ACP registry platform key -> our registry/catalog platform key.
+const ACP_PLATFORM_MAP = {
+  "darwin-aarch64": "macos_arm64",
+  "darwin-x86_64": "macos_x64",
+  "linux-x86_64": "linux_x64",
+  "linux-aarch64": "linux_arm64",
+  "windows-x86_64": "windows_x64",
+  "windows-aarch64": "windows_arm64",
+};
+
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+const registry = JSON.parse(readFileSync(registryPath, "utf8"));
+const registryByKind = new Map(registry.agents.map((a) => [a.kind, a]));
+
+let acpRegistryCache = null;
+async function acpRegistry() {
+  if (!acpRegistryCache) acpRegistryCache = await fetchJson(ACP_REGISTRY_URL);
+  return acpRegistryCache;
+}
+
+for (const agent of catalog.agents) {
+  if (onlyAgents && !onlyAgents.has(agent.kind)) continue;
+  const reg = registryByKind.get(agent.kind);
+  if (!reg) {
+    console.warn(`! ${agent.kind}: not in registry.json — skipping`);
+    continue;
+  }
+  console.log(`\n── ${agent.kind}`);
+
+  if (reg.native && agent.harness.native) {
+    const { version, source } = await resolveNative(agent.kind, reg.native.install);
+    agent.harness.native.version = version;
+    agent.harness.native.source = source;
+    console.log(`   native        ${version}  (${source.kind})`);
+  }
+
+  const ap = await resolveAgentProcess(
+    agent.kind,
+    reg.agentProcess.install,
+    agent.harness.agentProcess.version,
+  );
+  if (ap.version) agent.harness.agentProcess.version = ap.version;
+  agent.harness.agentProcess.source = ap.source;
+  console.log(`   agentProcess  ${ap.version ?? "(kept)"}  (${ap.source.kind})`);
+}
+
+writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
+console.log(`\nWrote ${catalogPath}`);
+
+// ── resolvers ────────────────────────────────────────────────────────────────
+
+async function resolveNative(kind, install) {
+  if (install.kind === "direct_binary") {
+    const version = (await fetchText(install.latestVersionUrl)).trim();
+    const targets = {};
+    for (const [platKey, vendor] of Object.entries(install.platformMap)) {
+      if (!platforms.has(platKey)) continue;
+      const url = install.binaryUrlTemplate
+        .replaceAll("{version}", version)
+        .replaceAll("{platform}", vendor);
+      targets[platKey] = { url, sha256: await shaFor(url) };
+    }
+    return { version, source: { kind: "binary", targets } };
+  }
+  if (install.kind === "tarball_release") {
+    const version = await githubLatestTag(install.versionedUrlTemplate);
+    const targets = {};
+    for (const [platKey, target] of Object.entries(install.platformMap)) {
+      if (!platforms.has(platKey)) continue;
+      const url = install.versionedUrlTemplate
+        .replaceAll("{version}", version)
+        .replaceAll("{target}", target);
+      const expectedBinary = install.expectedBinaryTemplate.replaceAll("{target}", target);
+      targets[platKey] = { url, sha256: await shaFor(url), expectedBinary };
+    }
+    return { version, source: { kind: "archive", targets } };
+  }
+  throw new Error(`${kind}: native install kind '${install.kind}' is not resolvable`);
+}
+
+async function resolveAgentProcess(kind, install, currentVersion) {
+  if (install.kind === "managed_npm_package") {
+    if (isGitSpec(install.package)) {
+      const [repo, gitRef] = splitGitSpec(install.package);
+      return {
+        version: currentVersion,
+        source: {
+          kind: "git",
+          repo,
+          gitRef,
+          ...(install.packageSubdir ? { packageSubdir: install.packageSubdir } : {}),
+          executableRelpath: install.executableRelpath,
+        },
+      };
+    }
+    return {
+      version: npmVersionOf(install.package) ?? currentVersion,
+      source: { kind: "npm", package: install.package, sha256: npmIntegrity(install.package) },
+    };
+  }
+  if (install.kind === "registry_backed") {
+    const reg = await acpRegistry();
+    const entry = reg.agents.find((a) => a.id === install.registryId);
+    if (!entry) throw new Error(`${kind}: '${install.registryId}' not in ACP registry`);
+    if (entry.distribution.npx) {
+      const pkg = entry.distribution.npx.package; // already pinned `@scope/pkg@ver`
+      return {
+        version: entry.version ?? npmVersionOf(pkg) ?? currentVersion,
+        source: { kind: "npm", package: pkg, sha256: npmIntegrity(pkg) },
+      };
+    }
+    if (entry.distribution.binary) {
+      const targets = {};
+      for (const [acpKey, target] of Object.entries(entry.distribution.binary)) {
+        const ourKey = ACP_PLATFORM_MAP[acpKey];
+        if (!ourKey || !platforms.has(ourKey)) continue; // platform we do not ship
+        targets[ourKey] = {
+          url: target.archive,
+          sha256: await shaFor(target.archive),
+          expectedBinary: target.cmd,
+        };
+      }
+      return { version: entry.version ?? currentVersion, source: { kind: "archive", targets } };
+    }
+    throw new Error(`${kind}: ACP entry '${install.registryId}' has no npx/binary distribution`);
+  }
+  throw new Error(`${kind}: agentProcess install kind '${install.kind}' is not resolvable`);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function isGitSpec(p) {
+  return p.startsWith("git+") || p.startsWith("github:");
+}
+function splitGitSpec(p) {
+  const base = p.replace(/^git\+/, "");
+  const hash = base.lastIndexOf("#");
+  if (hash === -1) return [base, "HEAD"];
+  return [base.slice(0, hash), base.slice(hash + 1)];
+}
+function npmVersionOf(pkg) {
+  // `@scope/name@1.2.3` -> 1.2.3 ; `name@1.2.3` -> 1.2.3
+  const at = pkg.lastIndexOf("@");
+  if (at <= 0) return null;
+  return pkg.slice(at + 1);
+}
+function npmIntegrity(pkg) {
+  if (noDownload) return "";
+  const out = spawnSync("npm", ["view", pkg, "dist.integrity"], { encoding: "utf8" });
+  if (out.status !== 0) {
+    console.warn(`   ! npm view ${pkg} failed: ${out.stderr?.trim()}`);
+    return null;
+  }
+  return out.stdout.trim() || null;
+}
+
+async function githubLatestTag(versionedUrlTemplate) {
+  // versionedUrlTemplate looks like
+  //   https://github.com/<owner>/<repo>/releases/download/{version}/...
+  const m = versionedUrlTemplate.match(/github\.com\/([^/]+)\/([^/]+)\/releases/);
+  if (!m) throw new Error(`cannot derive GitHub repo from ${versionedUrlTemplate}`);
+  const [, owner, repo] = m;
+  const rel = await fetchJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
+    headers: { "User-Agent": "proliferate-resolve-pins", Accept: "application/vnd.github+json" },
+  });
+  return rel.tag_name;
+}
+
+async function shaFor(url) {
+  if (noDownload) return "";
+  process.stdout.write(`   ↓ ${url} … `);
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) throw new Error(`download failed ${res.status} for ${url}`);
+  const hash = createHash("sha256");
+  for await (const chunk of res.body) hash.update(chunk);
+  const digest = hash.digest("hex");
+  process.stdout.write(`${digest.slice(0, 12)}…\n`);
+  return digest;
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) throw new Error(`fetch failed ${res.status} for ${url}`);
+  return res.text();
+}
+async function fetchJson(url, init) {
+  const res = await fetch(url, { redirect: "follow", ...init });
+  if (!res.ok) throw new Error(`fetch failed ${res.status} for ${url}`);
+  return res.json();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--no-download") out.noDownload = true;
+    else if (a === "--agent") out.agent = argv[++i];
+    else if (a === "--platforms") out.platforms = argv[++i];
+    else if (a === "--catalog") out.catalog = argv[++i];
+    else if (a === "--registry") out.registry = argv[++i];
+    else throw new Error(`unexpected arg ${a}`);
+  }
+  return out;
+}

--- a/specs/codebase/primitives/agent-catalog-readiness.md
+++ b/specs/codebase/primitives/agent-catalog-readiness.md
@@ -109,20 +109,34 @@ not rewrite catalog or registry JSON.
 
 Executable behavior is security-sensitive.
 
-The trusted bundled registry may define:
+The trusted bundled registry defines the slow, hand-curated **method** and
+identity:
 
-- install methods
-- binary/package URLs
-- executable names
-- launch args
-- credential discovery kind
-- login command
-- auth-slot materialization policy
+- install method per role (direct binary / tarball / managed npm / git /
+  registry-backed) and the platform map
+- discovery endpoints used only at probe time (latest-version URLs, ACP
+  registry ids, URL templates) and the manual adapter git refs
+- executable names and launch args
+- credential discovery kind, login command, auth-slot materialization policy
+
+The catalog is the **lockfile**: each harness pin may carry a resolved
+`source` — the exact, per-platform `{url, sha256}` for a binary/archive, or a
+pinned npm/git specifier — produced by the probe (`resolve-pins.mjs`). Install
+consumes the catalog pin, materializes EXACTLY that, and verifies the
+**sha256 before use**.
+
+The sha256 is the trust anchor. A url living in the catalog cannot fetch
+unintended bytes: a mismatch hard-fails the install and leaves nothing on disk.
+This is what permits resolved download URLs to live in the (bundled, versioned,
+build-signed) catalog rather than the registry — the integrity check, not the
+file's location, is the security boundary. The registry still owns auth,
+launch, and the install method; it is never consulted for *which bytes* once a
+pin declares a source.
 
 This boundary should be visible in code. The projection that produces
-`AgentDescriptor` must be sourced from trusted registry data only. Catalog data
-may enrich model/control display options but must not define executable
-behavior.
+`AgentDescriptor` is sourced from trusted registry data only (method, auth,
+launch). Catalog data enriches it with the resolved, sha-anchored version pin
+and model/control display options.
 
 ## Source Shape
 


### PR DESCRIPTION
Makes the agent catalog a **lockfile** and the installer a **fenced total function of the pin**.

## What lands
- **Schema (lockfile):** each harness pin can carry a resolved `source` — per-platform `{url, sha256}` for binaries/archives, or a pinned npm/git specifier (`AgentCatalogArtifactSource`).
- **Fenced installer:** `pinned.rs` downloads EXACTLY the pin's per-platform url, **verifies sha256, refuses anything else** (`ChecksumMismatch`), no latest-fetch / PATH-adoption / fallback. Wired into the native-CLI install path; the sha256 is the trust anchor.
- **Producer:** `scripts/agent-catalog/resolve-pins.mjs` resolves each agent's latest version + all-platform URLs from the registry's discovery config (+ ACP registry) and freezes them, with computed shas, into `catalogs/agents/catalog.json`. Populated for all five agents across the shipped platforms (macOS arm64/x64, linux x64): claude 2.1.178, codex 0.140.0, cursor 2026.06.15, gemini 0.46.0, opencode 1.17.7.
- **Spec:** amends the `agent-catalog-readiness` trust boundary — the sha256 is the anchor that lets resolved URLs live in the bundled, versioned catalog; the registry keeps method/auth/launch/discovery.

## Tests
164 `domains::agents` tests green, including hermetic sha-gate tests (correct sha installs; wrong sha refused, nothing left on disk) and a `bundled_catalog_is_a_complete_lockfile` guard.

## Follow-up (full Seam 2)
Wire the desktop seed build to the catalog pins, delete the legacy fallback paths (latest-fetch / PATH adoption / ACP re-fetch), fence the agent_process adapter path, and add the desktop boot-reconcile (pin-is-law on upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)