### PR TITLE
fix(live): resolve cursor variant model ids to advertised values on switch

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -137,6 +137,15 @@ pub(in crate::live::sessions::actor) async fn apply_select_config_option_with_po
     // `variantSyntax` agents (cursor) only accept their advertised composed
     // values (`composer-2.5[fast=true]`); a switch may carry just the base id.
     let resolved_value = resolve_model_variant_value(option, desired_value);
+    if resolved_value != desired_value {
+        tracing::debug!(
+            native_session_id,
+            config_id,
+            requested = desired_value,
+            resolved = %resolved_value,
+            "[model-switch] resolved variant model id to advertised value"
+        );
+    }
     let desired_value = resolved_value.as_str();
 
     if !select_option_contains_value(option, desired_value) && !allow_foreign_value {
@@ -184,6 +193,24 @@ pub(in crate::live::sessions::actor) async fn apply_specific_config_option(
     let is_mode_request = is_mode_config_request(config_id, option);
     let tracked_purpose = tracked_config_purpose(config_id, option);
     let model_value_authorized = is_model_request && catalog_authorized_model;
+
+    // Resolve a bare variant base to the harness's advertised composed value up
+    // front, so the value we validate, send, AND persist all agree (otherwise
+    // the base id would be stored while the composed value is what applied).
+    let resolved_value = match option {
+        Some(option) => resolve_model_variant_value(option, desired_value),
+        None => desired_value.to_string(),
+    };
+    if resolved_value != desired_value {
+        tracing::debug!(
+            session_id,
+            config_id,
+            requested = desired_value,
+            resolved = %resolved_value,
+            "[model-switch] resolved variant model id to advertised value"
+        );
+    }
+    let desired_value = resolved_value.as_str();
 
     if option.is_none() && !is_model_request && !is_mode_request {
         return Err(SetConfigOptionCommandError::Rejected(format!(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -12,7 +12,7 @@ use crate::live::sessions::actor::config::queue::config_request_matches_current_
 use crate::live::sessions::actor::config::selection::{
     current_select_value, find_select_option_by_purpose, find_select_option_for_request,
     find_select_option_for_value, is_mode_config_request, is_model_config_request,
-    option_matches_purpose, select_option_contains_value,
+    option_matches_purpose, resolve_model_variant_value, select_option_contains_value,
 };
 use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose, PersistedSessionConfigState,
@@ -133,6 +133,11 @@ pub(in crate::live::sessions::actor) async fn apply_select_config_option_with_po
     else {
         return Ok(ConfigApplyOutcome::NotApplied);
     };
+
+    // `variantSyntax` agents (cursor) only accept their advertised composed
+    // values (`composer-2.5[fast=true]`); a switch may carry just the base id.
+    let resolved_value = resolve_model_variant_value(option, desired_value);
+    let desired_value = resolved_value.as_str();
 
     if !select_option_contains_value(option, desired_value) && !allow_foreign_value {
         return Ok(ConfigApplyOutcome::NotApplied);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -9,7 +9,8 @@ use crate::live::sessions::actor::config::apply::{
 use crate::live::sessions::actor::config::persist::persist_requested_config_value_if_changed;
 use crate::live::sessions::actor::config::queue::queue_pending_config_change;
 use crate::live::sessions::actor::config::selection::{
-    find_select_option_by_purpose, find_select_option_for_request, select_option_values,
+    find_select_option_by_purpose, find_select_option_for_request, resolve_model_variant_value,
+    select_option_values,
 };
 use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose,
@@ -124,6 +125,15 @@ impl SessionActor {
     ) -> Result<ConfigApplyState, crate::live::sessions::actor::command::SetConfigOptionCommandError>
     {
         let option = find_select_option_for_request(&self.startup_state.config_options, config_id);
+        // Resolve a bare variant base to the advertised composed value before
+        // queueing/persisting, so the queued + persisted value match what the
+        // idle replay will actually send (mirrors apply_specific_config_option).
+        let resolved_value = match option {
+            Some(option) => resolve_model_variant_value(option, value),
+            None => value.to_string(),
+        };
+        let value = resolved_value.as_str();
+
         queue_pending_config_change(
             self.caps.state.as_ref(),
             &self.session_id,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
@@ -236,3 +236,41 @@ pub(in crate::live::sessions::actor) fn select_option_values(
         _ => Vec::new(),
     }
 }
+
+/// The model id without any `variantSyntax` suffix — everything before the
+/// first `[`. `composer-2.5[fast=true]` -> `composer-2.5`; a bare id is
+/// returned unchanged.
+fn model_variant_base(value: &str) -> &str {
+    value.split('[').next().unwrap_or(value)
+}
+
+/// Resolve a requested model value to the exact string the harness advertises.
+///
+/// `variantSyntax` agents (e.g. cursor, `bracket-params`) only accept their
+/// fully composed values — `composer-2.5[fast=true]`, `kimi-k2.5[]` — whose
+/// default params are decided by the harness at runtime, not the catalog. A
+/// switch request often carries only the base id (`composer-2.5`). When the
+/// model option does not already list the requested value but advertises
+/// exactly one value with the same base, return that advertised value so the
+/// harness receives a string it recognizes. Otherwise the value is returned
+/// unchanged (exact matches, ambiguous bases, and non-model options are
+/// no-ops), leaving the existing accept/reject behavior intact.
+pub(in crate::live::sessions::actor) fn resolve_model_variant_value(
+    option: &acp::schema::SessionConfigOption,
+    desired_value: &str,
+) -> String {
+    if select_option_contains_value(option, desired_value)
+        || !option_matches_purpose(option, ConfigPurpose::Model)
+    {
+        return desired_value.to_string();
+    }
+
+    let base = model_variant_base(desired_value);
+    let mut matches = select_option_values(option)
+        .into_iter()
+        .filter(|value| model_variant_base(value) == base);
+    match (matches.next(), matches.next()) {
+        (Some(only), None) => only,
+        _ => desired_value.to_string(),
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
@@ -244,6 +244,34 @@ fn model_variant_base(value: &str) -> &str {
     value.split('[').next().unwrap_or(value)
 }
 
+/// Whether `value` is a `bracket-params` variant: a base followed by `[]` or
+/// `[k=v,...]`. `composer-2.5[fast=true]` / `kimi-k2.5[]` -> true. A bare
+/// context tag like `sonnet[1m]` -> false (it is a distinct model id, not a
+/// param list), and a bare id -> false. This keeps the resolver scoped to the
+/// bracket-params variant syntax without a catalog lookup.
+fn is_bracket_params_variant(value: &str) -> bool {
+    match value.split_once('[') {
+        Some((_, rest)) => match rest.strip_suffix(']') {
+            Some(inner) => inner.is_empty() || inner.split(',').all(|pair| pair.contains('=')),
+            None => false,
+        },
+        None => false,
+    }
+}
+
+/// Whether the request already names its own variant params, e.g.
+/// `composer-2.5[fast=false]`. An empty `[]` carries no choice and is treated
+/// as bare (resolvable); a bare id is not explicit.
+fn has_explicit_variant_params(value: &str) -> bool {
+    match value.split_once('[') {
+        Some((_, rest)) => match rest.strip_suffix(']') {
+            Some(inner) => !inner.is_empty(),
+            None => true,
+        },
+        None => false,
+    }
+}
+
 /// Resolve a requested model value to the exact string the harness advertises.
 ///
 /// `variantSyntax` agents (e.g. cursor, `bracket-params`) only accept their
@@ -251,15 +279,23 @@ fn model_variant_base(value: &str) -> &str {
 /// default params are decided by the harness at runtime, not the catalog. A
 /// switch request often carries only the base id (`composer-2.5`). When the
 /// model option does not already list the requested value but advertises
-/// exactly one value with the same base, return that advertised value so the
-/// harness receives a string it recognizes. Otherwise the value is returned
-/// unchanged (exact matches, ambiguous bases, and non-model options are
-/// no-ops), leaving the existing accept/reject behavior intact.
+/// exactly one composed variant with the same base, return that advertised
+/// value so the harness receives a string it recognizes.
+///
+/// The value is returned unchanged when any of these hold, so existing
+/// accept/reject behavior is untouched:
+/// - the request already carries its own `[params]` (never override an
+///   explicit choice — only fill in a missing one);
+/// - the option already lists the value, or it is not a model option;
+/// - the base matches zero or more than one advertised value (ambiguous);
+/// - the matching advertised value is not a bracket-params variant (e.g. a
+///   bare `[1m]` context tag), so non-variant agents like claude are no-ops.
 pub(in crate::live::sessions::actor) fn resolve_model_variant_value(
     option: &acp::schema::SessionConfigOption,
     desired_value: &str,
 ) -> String {
-    if select_option_contains_value(option, desired_value)
+    if has_explicit_variant_params(desired_value)
+        || select_option_contains_value(option, desired_value)
         || !option_matches_purpose(option, ConfigPurpose::Model)
     {
         return desired_value.to_string();
@@ -268,7 +304,7 @@ pub(in crate::live::sessions::actor) fn resolve_model_variant_value(
     let base = model_variant_base(desired_value);
     let mut matches = select_option_values(option)
         .into_iter()
-        .filter(|value| model_variant_base(value) == base);
+        .filter(|value| model_variant_base(value) == base && is_bracket_params_variant(value));
     match (matches.next(), matches.next()) {
         (Some(only), None) => only,
         _ => desired_value.to_string(),

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
@@ -482,6 +482,49 @@ fn resolve_model_variant_value_maps_base_id_to_advertised_composed_value() {
 }
 
 #[test]
+fn resolve_model_variant_value_never_overrides_explicit_params() {
+    let mut option = acp::schema::SessionConfigOption::select(
+        "model",
+        "Model",
+        "composer-2.5[fast=true]",
+        vec![acp::schema::SessionConfigSelectOption::new(
+            "composer-2.5[fast=true]",
+            "composer-2.5",
+        )],
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Model);
+
+    // A request that already names its params is left as-is, even though the
+    // base matches the single advertised variant.
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5[fast=false]"),
+        "composer-2.5[fast=false]"
+    );
+    // An empty `[]` carries no choice, so it still resolves to the variant.
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5[]"),
+        "composer-2.5[fast=true]"
+    );
+}
+
+#[test]
+fn resolve_model_variant_value_does_not_collapse_context_tag_variants() {
+    // A `[1m]` context tag is a distinct model id, not a bracket-params
+    // variant — a bare base must never silently resolve into it.
+    let mut option = acp::schema::SessionConfigOption::select(
+        "model",
+        "Model",
+        "sonnet[1m]",
+        vec![acp::schema::SessionConfigSelectOption::new(
+            "sonnet[1m]",
+            "Sonnet (1M context)",
+        )],
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Model);
+    assert_eq!(resolve_model_variant_value(&option, "sonnet"), "sonnet");
+}
+
+#[test]
 fn resolve_model_variant_value_is_noop_for_non_model_options() {
     let mut option = acp::schema::SessionConfigOption::select(
         "mode",

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config.rs
@@ -450,6 +450,53 @@ fn select_option_values_flattens_grouped_options() {
 }
 
 #[test]
+fn resolve_model_variant_value_maps_base_id_to_advertised_composed_value() {
+    let mut option = acp::schema::SessionConfigOption::select(
+        "model",
+        "Model",
+        "kimi-k2.5[]",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("kimi-k2.5[]", "kimi-k2.5"),
+            acp::schema::SessionConfigSelectOption::new("composer-2.5[fast=true]", "composer-2.5"),
+        ],
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Model);
+
+    // A bare base id resolves to the single advertised composed value.
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5"),
+        "composer-2.5[fast=true]"
+    );
+    // An empty-bracket form resolves by the same base.
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5[]"),
+        "composer-2.5[fast=true]"
+    );
+    // An exact advertised value is returned unchanged.
+    assert_eq!(
+        resolve_model_variant_value(&option, "kimi-k2.5[]"),
+        "kimi-k2.5[]"
+    );
+    // An unknown base is left as-is so the harness still decides.
+    assert_eq!(resolve_model_variant_value(&option, "gpt-5.5"), "gpt-5.5");
+}
+
+#[test]
+fn resolve_model_variant_value_is_noop_for_non_model_options() {
+    let mut option = acp::schema::SessionConfigOption::select(
+        "mode",
+        "Mode",
+        "default",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("default", "Default"),
+            acp::schema::SessionConfigSelectOption::new("plan", "Plan"),
+        ],
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Mode);
+    assert_eq!(resolve_model_variant_value(&option, "agent"), "agent");
+}
+
+#[test]
 fn model_config_request_rejects_values_outside_live_select_options() {
     let db = Db::open_in_memory().expect("open db");
     let store = SessionStore::new(db);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -11,7 +11,7 @@ use super::config::persist::{load_startup_restore_snapshot, persisted_control_va
 use super::config::queue::queue_pending_config_change;
 use super::config::selection::{
     find_select_option_for_request, is_mode_config_request, is_model_config_request,
-    pending_config_rank, select_option_values,
+    pending_config_rank, resolve_model_variant_value, select_option_values,
 };
 use super::config::types::{tracked_config_purpose, PersistedSessionConfigState};
 use super::interactions::cleanup::resolve_pending_interactions;


### PR DESCRIPTION
## Problem

Switching the model on a running **cursor** session "always goes back to Auto." Verified live against `cursor-agent` 2026.06.15.

Cursor (`variantSyntax: bracket-params`) exposes a model **config option** whose only valid values are **fully-composed variants**, whose default params are decided by the harness at runtime:
```
composer-2.5[fast=true]
claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]
kimi-k2.5[]   (current)
```
A switch carries the bare catalog id `composer-2.5`. Cursor rejects it (`Invalid model value`); the runtime then falls back to a broken relaunch → HTTP 500 → the model reverts.

Proof it's purely the value format (live test):
```
switch → composer-2.5            HTTP 500 → reverts          (before)
switch → composer-2.5[fast=true] HTTP 200 → sticks
```

## Fix

Resolve the requested model value to the harness's advertised value in the live-apply path: when the model option doesn't list the requested value but advertises **exactly one** value with the same base id (text before `[`), send that advertised value. New `resolve_model_variant_value` in `config/selection.rs`.

**Why the live option, not the catalog:** the catalog *can* echo back a pre-composed `composer-2.5[fast=true]` (it's in `provenance.variantIds`), but it **cannot derive that composed default from a bare base id** — `resolve_requested_model`/`compose_variant` only match the base (→ bare id) or validate caller-supplied params (→ empty `[]`). The harness's runtime default (`fast=true`) is carried **only** by the live ACP option at apply time, which is also where the spec puts post-start truth (`agents-catalog-registry-migration.md` §5.5). Apply-time code has no catalog/`kind`/contexts in scope, so routing through `validate_launch` is both impossible-for-defaults and a far larger change.

### Hardening (from adversarial review)
- **Never override an explicit choice:** only fill in a *missing* variant — `composer-2.5[fast=false]` is left untouched; empty `[]` still resolves.
- **Scoped to bracket-params shape:** a match must be `[]` or `[k=v,...]`, never a bare context tag like `sonnet[1m]` — so the resolver is a no-op for non-variant agents (claude) regardless of their option shape.
- **No persistence drift:** resolve once up front on both the idle (`apply_specific_config_option`) and busy/queue (`handle_busy_config_command`) paths, so the value validated, sent, queued, AND persisted all agree (`requested_model_id` stores the composed value).
- **Observability:** `tracing::debug!` logs `requested → resolved` on substitution.

## Testing
- `cargo test -p anyharness-lib config` — 55 pass (incl. resolver unit tests: base→composed, explicit-param non-override, `[1m]` non-collapse, non-model no-op).
- **Live** (real cursor-agent 2026.06.15): bare `composer-2.5`, `gpt-5.5`, `claude-opus-4-8` (multi-param), `gemini-2.5-flash` all switch in place (200) and stick; **persisted record `requested = current = composer-2.5[fast=true]`**; composed model reloads correctly after a runtime restart; no relaunch/500s.

## Known follow-ups (out of scope, tracked)
- **Codex `slash-effort`** (`gpt-5.5/high`) is not covered by the live resolver (it gates on `[`-shape); fine since codex isn't the target, but the variant grammar now lives in two places (catalog `compose_variant` by declared `variantSyntax`, live resolver by shape). Unify once apply-time gains `variantSyntax` access.
- **Membership-gate relaxation** (`same-harness-model-switch-design.md` §5) and **catalog ∪ live switch-menu** union (§5.5) — separate sub-problems.
- The **relaunch fallback** still has latent bugs (composed value → launch env; native-session-not-found on restart) and violates "never recreate on same-harness switch." This fix avoids hitting it for cursor.

Independent of #715 (gemini `session/set_model`). Rebased on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)