### PR TITLE
chore(ci): stop Dependabot major-version churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       - dependency-name: "expo-*"
       - dependency-name: "react-native"
       - dependency-name: "react-native-*"
+      # Major upgrades are handled deliberately (they need manual migration work),
+      # not as routine auto-PRs — this is what stops the recurring major-bump churn.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-and-patch:
         update-types:
@@ -36,6 +40,18 @@ updates:
     labels:
       - "release:maintenance"
       - "area:release"
+    ignore:
+      # Major upgrades are handled deliberately, not as routine auto-PRs.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # 0.x crates with breaking changes that need a dedicated migration
+      # (RustCrypto digest 0.11 generic-array → hybrid-array; see #688/#689/#713).
+      - dependency-name: "hmac"
+        versions: [">=0.13.0"]
+      - dependency-name: "sha2"
+        versions: [">=0.11.0"]
+      - dependency-name: "rfd"
+        versions: [">=0.16.0"]
     groups:
       cargo-minor-and-patch:
         update-types:
@@ -51,6 +67,10 @@ updates:
     labels:
       - "release:maintenance"
       - "area:server"
+    ignore:
+      # Major upgrades are handled deliberately, not as routine auto-PRs.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       python-minor-and-patch:
         update-types:
@@ -65,6 +85,11 @@ updates:
     labels:
       - "release:maintenance"
       - "area:server"
+    ignore:
+      # Base-image major bumps must be verified by building/running the image,
+      # which PR CI doesn't do — handle as a deliberate upgrade.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions — workflow pinned actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
Dependabot was generating a recurring wave of **breaking major-version PRs** (vite 7/8, @vitejs/plugin-react 6, marked 18, keyring 4, hmac/sha2 → digest 0.11, Docker python 3.14, …) that each need manual migration work and just get closed — the "treadmill" behind the PR pile.

This restricts Dependabot to **grouped minor/patch updates** (plus security updates, which ignore rules do not suppress). Major upgrades become deliberate, manually-driven PRs.

- `ignore: version-update:semver-major` for npm, cargo, uv, docker
- Pin the specific 0.x crates whose breaking versions need a dedicated migration first: `hmac >=0.13`, `sha2 >=0.11`, `rfd >=0.16` (see closed #688/#689/#713)
- Existing Expo/react-native ignores retained

## Effect
Going forward you get ~one grouped minor/patch PR per ecosystem per week (auto-mergeable) instead of a stream of breaking majors. Reversible anytime by removing a rule.