### PR TITLE
fix(readme): make release/license badges static

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 <p>
   <a href="https://github.com/proliferate-ai/proliferate/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/proliferate-ai/proliferate?style=flat&amp;logo=github&amp;label=stars" /></a>
-  <a href="https://proliferate.com/changelog"><img alt="Latest release" src="https://img.shields.io/github/v/release/proliferate-ai/proliferate?style=flat&amp;sort=semver&amp;label=release" /></a>
-  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/github/license/proliferate-ai/proliferate?style=flat&amp;label=license" /></a>
+  <a href="https://proliferate.com/changelog"><img alt="Latest release" src="https://img.shields.io/badge/release-changelog-0969DA?style=flat" /></a>
+  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat" /></a>
   <a href="https://proliferate.com/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-view-0969DA?style=flat" /></a>
   <a href="https://proliferate.com"><img alt="Website" src="https://img.shields.io/badge/website-visit-0969DA?style=flat" /></a>
   <a href="https://discord.gg/wCEgUnEuF"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2?style=flat&amp;logo=discord&amp;logoColor=white" /></a>


### PR DESCRIPTION
## What

Replace the two dynamic shields.io GitHub-API badges (release, license) with static badges.

## Why

The dynamic badges intermittently render **"Unable to select next GitHub token from pool"** — a transient token-pool exhaustion on shields.io's side that affects any GitHub-API-backed badge. GitHub's `camo` image proxy then caches the broken image, making it sticky in the rendered README.

- `release` → static badge linking to the changelog
- `license` → static `AGPL-3.0` badge (license never changes)

Stars badge left dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)