### PR TITLE
feat(agents): runtime-startup installed-only reconcile (run_startup_pass)

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/agents.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/agents.rs
@@ -215,6 +215,11 @@ pub enum ReconcileJobStatus {
 pub struct ReconcileAgentsRequest {
     #[serde(default)]
     pub reinstall: bool,
+    /// When true, only agents already installed on disk are reconciled to the
+    /// catalog pins; missing agents are skipped (they install on demand at
+    /// session start). Defaults to false (full-scope reconcile).
+    #[serde(default)]
+    pub installed_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -241,4 +246,18 @@ pub struct ReconcileAgentsResponse {
     pub finished_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+/// Coarse, low-cardinality reconcile status for `/health`. Per-agent detail
+/// stays on `GET /v1/agents/reconcile`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentReconcileSummary {
+    pub status: ReconcileJobStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_agent: Option<String>,
+    pub installed: u32,
+    pub already_installed: u32,
+    pub skipped: u32,
+    pub failed: u32,
 }

--- a/anyharness/crates/anyharness-contract/src/v1/health.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/health.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::agents::AgentReconcileSummary;
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HealthResponse {
@@ -9,6 +11,7 @@ pub struct HealthResponse {
     pub runtime_home: String,
     pub capabilities: RuntimeCapabilities,
     pub agent_seed: AgentSeedHealth,
+    pub agent_reconcile: AgentReconcileSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-lib/src/api/http/agents.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agents.rs
@@ -225,7 +225,10 @@ pub async fn reconcile_agents(
     State(state): State<AppState>,
     Json(req): Json<ReconcileAgentsRequest>,
 ) -> (StatusCode, Json<ReconcileAgentsResponse>) {
-    let snapshot = state.agent_runtime.start_reconcile(req.reinstall).await;
+    let snapshot = state
+        .agent_runtime
+        .start_reconcile(req.reinstall, req.installed_only)
+        .await;
     (
         StatusCode::ACCEPTED,
         Json(reconcile_snapshot_to_contract(&snapshot)),

--- a/anyharness/crates/anyharness-lib/src/api/http/agents_contract.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agents_contract.rs
@@ -4,8 +4,8 @@
 use anyharness_contract::v1::{
     AgentCredentialState, AgentInstallState, AgentLaunchModelOption, AgentLaunchOption,
     AgentLaunchOptionsResponse, AgentLoginTerminalRecord, AgentLoginTerminalStatus,
-    AgentReadinessState, AgentSummary, ArtifactStatus, InstallAgentRequest, ReconcileAgentResult,
-    ReconcileAgentsResponse, ReconcileJobStatus, ReconcileOutcome,
+    AgentReadinessState, AgentReconcileSummary, AgentSummary, ArtifactStatus, InstallAgentRequest,
+    ReconcileAgentResult, ReconcileAgentsResponse, ReconcileJobStatus, ReconcileOutcome,
 };
 
 use crate::domains::agents::auth::login_terminal::{
@@ -51,6 +51,40 @@ pub(super) fn reconcile_snapshot_to_contract(
         started_at: snapshot.started_at.clone(),
         finished_at: snapshot.finished_at.clone(),
         message: snapshot.message.clone(),
+    }
+}
+
+pub(super) fn reconcile_summary_to_contract(
+    snapshot: &AgentReconcileJobSnapshot,
+) -> AgentReconcileSummary {
+    let mut installed = 0u32;
+    let mut already_installed = 0u32;
+    let mut skipped = 0u32;
+    let mut failed = 0u32;
+    for result in &snapshot.results {
+        match result.outcome {
+            AgentReconcileOutcome::Installed => installed += 1,
+            AgentReconcileOutcome::AlreadyInstalled => already_installed += 1,
+            AgentReconcileOutcome::Skipped => skipped += 1,
+            AgentReconcileOutcome::Failed => failed += 1,
+        }
+    }
+    AgentReconcileSummary {
+        status: match snapshot.status {
+            AgentReconcileJobStatus::Idle => ReconcileJobStatus::Idle,
+            AgentReconcileJobStatus::Queued => ReconcileJobStatus::Queued,
+            AgentReconcileJobStatus::Running => ReconcileJobStatus::Running,
+            AgentReconcileJobStatus::Completed => ReconcileJobStatus::Completed,
+            AgentReconcileJobStatus::Failed => ReconcileJobStatus::Failed,
+        },
+        current_agent: snapshot
+            .current_agent
+            .as_ref()
+            .map(|kind| kind.as_str().to_string()),
+        installed,
+        already_installed,
+        skipped,
+        failed,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/health.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/health.rs
@@ -1,6 +1,7 @@
 use anyharness_contract::v1::{HealthResponse, RuntimeCapabilities};
 use axum::Json;
 
+use super::agents_contract::reconcile_summary_to_contract;
 use crate::app::AppState;
 
 #[utoipa::path(
@@ -22,5 +23,8 @@ pub async fn get_health(
             replay: crate::domains::sessions::replay::replay_enabled(),
         },
         agent_seed: state.agent_seed_store.health(),
+        agent_reconcile: reconcile_summary_to_contract(
+            &state.agent_runtime.reconcile_status().await,
+        ),
     })
 }

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -419,6 +419,11 @@ impl AppState {
             .map_err(AppStateInitError::InvalidProductMcpRegistry)?;
         #[cfg(not(test))]
         workspace_retention_service.clone().spawn_startup_pass();
+        // Hydrate the bundled agent seed (if pending) and run an installed-only
+        // reconcile against the catalog pins — desktop sidecar AND cloud workers,
+        // non-blocking + best-effort. See AgentRuntime::spawn_startup_pass.
+        #[cfg(not(test))]
+        agent_runtime.clone().spawn_startup_pass();
         Ok(Self {
             runtime_home,
             runtime_base_url,
@@ -475,7 +480,9 @@ fn catalog_applied_reconcile_poke(agent_runtime: Arc<AgentRuntime>) -> Arc<dyn F
     Arc::new(move || {
         let agent_runtime = agent_runtime.clone();
         tokio::spawn(async move {
-            agent_runtime.start_reconcile(false).await;
+            // installed-only: a cloud-catalog swap updates already-installed
+            // agents to the new pins; missing agents install on demand.
+            agent_runtime.start_reconcile(false, true).await;
         });
     })
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use super::{reconcile_agent, AgentReconcileOutcome, AgentReconcileResult};
 use crate::domains::agents::installer::seed::AgentSeedStore;
 use crate::domains::agents::installer::InstallOptions;
-use crate::domains::agents::model::{AgentDescriptor, AgentKind};
+use crate::domains::agents::model::{AgentDescriptor, AgentKind, ResolvedArtifact};
+use crate::domains::agents::readiness::service::resolve_agent;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentReconcileJobStatus {
@@ -81,6 +82,7 @@ impl AgentReconcileService {
         registry: Vec<AgentDescriptor>,
         runtime_home: PathBuf,
         reinstall: bool,
+        installed_only: bool,
         agent_seed_store: Option<AgentSeedStore>,
         catalog: Option<crate::domains::agents::catalog::service::AgentCatalogService>,
     ) -> AgentReconcileJobSnapshot {
@@ -134,6 +136,7 @@ impl AgentReconcileService {
                 registry,
                 runtime_home,
                 reinstall,
+                installed_only,
                 agent_seed_store,
                 catalog,
             )
@@ -165,6 +168,7 @@ async fn run_reconcile_job(
     registry: Vec<AgentDescriptor>,
     runtime_home: PathBuf,
     reinstall: bool,
+    installed_only: bool,
     agent_seed_store: Option<AgentSeedStore>,
     catalog: Option<crate::domains::agents::catalog::service::AgentCatalogService>,
 ) {
@@ -213,6 +217,29 @@ async fn run_reconcile_job(
         let options = options.clone();
         let agent_catalog = catalog.clone();
         let result = match tokio::task::spawn_blocking(move || {
+            // installed-only scope (startup pass): only reconcile agents WE manage
+            // in runtime_home — update those to the catalog pins. Skip agents that
+            // are absent or only present via PATH (source != "managed"); a managed
+            // install over a PATH-provided agent would fail, and missing agents
+            // install on demand at session start. resolve_agent is side-effect-free.
+            if installed_only {
+                let is_managed = |artifact: &ResolvedArtifact| {
+                    artifact.installed && artifact.source.as_deref() == Some("managed")
+                };
+                let resolved = resolve_agent(&descriptor, &agent_runtime_home);
+                let managed_installed = is_managed(&resolved.agent_process)
+                    || resolved.native.as_ref().map(is_managed).unwrap_or(false);
+                if !managed_installed {
+                    return AgentReconcileResult {
+                        kind: descriptor.kind.clone(),
+                        outcome: AgentReconcileOutcome::Skipped,
+                        message: Some(
+                            "not managed-installed; installs on demand at session start".into(),
+                        ),
+                        installed_artifacts: vec![],
+                    };
+                }
+            }
             let pins = agent_catalog
                 .as_ref()
                 .and_then(|catalog| catalog.pin_overrides(descriptor.kind.as_str()));
@@ -355,6 +382,7 @@ mod tests {
                 Vec::new(),
                 PathBuf::from("/tmp/anyharness-test"),
                 true,
+                false,
                 None,
                 None,
             )
@@ -375,6 +403,7 @@ mod tests {
                 Vec::new(),
                 PathBuf::from("/tmp/anyharness-empty"),
                 true,
+                false,
                 None,
                 None,
             )
@@ -396,5 +425,46 @@ mod tests {
         assert_eq!(completed.status, AgentReconcileJobStatus::Completed);
         assert!(completed.results.is_empty());
         assert!(completed.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn installed_only_skips_uninstalled_agents() {
+        // In a fresh empty runtime home no agent_process (ACP adapter) is installed —
+        // those are managed-only, never on system PATH — so installed-only reconcile must
+        // SKIP every agent and never attempt a (network) install.
+        let service = AgentReconcileService::new();
+        let home = std::env::temp_dir().join(format!("anyharness-installed-only-{}", Uuid::new_v4()));
+        let registry = crate::domains::agents::registry::built_in_registry();
+        assert!(!registry.is_empty(), "built-in registry must have agents");
+
+        service
+            .start_or_get(registry, home.clone(), false, true, None, None)
+            .await;
+
+        let completed = timeout(Duration::from_secs(5), async {
+            loop {
+                let snapshot = service.snapshot().await;
+                if snapshot.status == AgentReconcileJobStatus::Completed {
+                    return snapshot;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("installed-only reconcile should complete without network installs");
+
+        assert!(
+            completed
+                .results
+                .iter()
+                .all(|result| result.outcome == AgentReconcileOutcome::Skipped),
+            "installed_only must skip agents with no installed agent_process; got {:?}",
+            completed
+                .results
+                .iter()
+                .map(|result| (result.kind.as_str(), result.outcome.clone()))
+                .collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
@@ -25,6 +25,7 @@ pub struct AgentReconcileJobSnapshot {
     pub status: AgentReconcileJobStatus,
     pub job_id: Option<String>,
     pub reinstall: bool,
+    pub installed_only: bool,
     pub current_agent: Option<AgentKind>,
     pub results: Vec<AgentReconcileResult>,
     pub started_at: Option<String>,
@@ -37,6 +38,7 @@ struct AgentReconcileJob {
     job_id: String,
     status: AgentReconcileJobStatus,
     reinstall: bool,
+    installed_only: bool,
     current_agent: Option<AgentKind>,
     results: Vec<AgentReconcileResult>,
     started_at: Option<String>,
@@ -50,6 +52,7 @@ impl AgentReconcileJob {
             status: self.status.clone(),
             job_id: Some(self.job_id.clone()),
             reinstall: self.reinstall,
+            installed_only: self.installed_only,
             current_agent: self.current_agent.clone(),
             results: self.results.clone(),
             started_at: self.started_at.clone(),
@@ -93,13 +96,32 @@ impl AgentReconcileService {
                     existing.status,
                     AgentReconcileJobStatus::Queued | AgentReconcileJobStatus::Running
                 ) {
+                    // Reuse the in-flight job only if its scope COVERS this request.
+                    // A full job (installed_only=false) covers everything; an
+                    // installed-only job does NOT cover a full request — so a full
+                    // reconcile must supersede an in-flight installed-only pass,
+                    // otherwise missing agents would be silently skipped.
+                    let covers_request = !existing.installed_only || installed_only;
+                    if covers_request {
+                        tracing::info!(
+                            job_id = %existing.job_id,
+                            requested_reinstall = reinstall,
+                            job_reinstall = existing.reinstall,
+                            requested_installed_only = installed_only,
+                            job_installed_only = existing.installed_only,
+                            "agent reconcile request reused active job"
+                        );
+                        return existing.snapshot();
+                    }
                     tracing::info!(
-                        job_id = %existing.job_id,
-                        requested_reinstall = reinstall,
-                        job_reinstall = existing.reinstall,
-                        "agent reconcile request reused active job"
+                        superseded_job_id = %existing.job_id,
+                        job_installed_only = existing.installed_only,
+                        requested_installed_only = installed_only,
+                        "full agent reconcile supersedes in-flight installed-only job"
                     );
-                    return existing.snapshot();
+                    // Fall through: a new full job replaces the slot. The superseded
+                    // task's `update_job` calls no-op once the job_id changes, so it
+                    // self-terminates (its idempotent installs are harmless).
                 }
             }
 
@@ -108,6 +130,7 @@ impl AgentReconcileService {
                 job_id: job_id.clone(),
                 status: AgentReconcileJobStatus::Queued,
                 reinstall,
+                installed_only,
                 current_agent: None,
                 results: Vec::new(),
                 started_at: Some(chrono::Utc::now().to_rfc3339()),
@@ -153,6 +176,7 @@ impl AgentReconcileJobSnapshot {
             status: AgentReconcileJobStatus::Idle,
             job_id: None,
             reinstall: false,
+            installed_only: false,
             current_agent: None,
             results: Vec::new(),
             started_at: None,
@@ -369,6 +393,7 @@ mod tests {
                 job_id: "existing-job".into(),
                 status: AgentReconcileJobStatus::Running,
                 reinstall: false,
+                installed_only: false,
                 current_agent: Some(AgentKind::Codex),
                 results: Vec::new(),
                 started_at: Some(chrono::Utc::now().to_rfc3339()),
@@ -466,5 +491,78 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[tokio::test]
+    async fn full_reconcile_supersedes_in_flight_installed_only_job() {
+        // A full reconcile must NOT be silently swallowed by an in-flight
+        // installed-only startup pass (which skips missing agents).
+        let service = AgentReconcileService::new();
+        {
+            let mut job = service.job.lock().await;
+            *job = Some(AgentReconcileJob {
+                job_id: "startup-installed-only".into(),
+                status: AgentReconcileJobStatus::Running,
+                reinstall: false,
+                installed_only: true,
+                current_agent: None,
+                results: Vec::new(),
+                started_at: Some(chrono::Utc::now().to_rfc3339()),
+                finished_at: None,
+                message: None,
+            });
+        }
+
+        let snapshot = service
+            .start_or_get(
+                Vec::new(),
+                PathBuf::from("/tmp/anyharness-supersede"),
+                false,
+                false, // full scope
+                None,
+                None,
+            )
+            .await;
+
+        assert_ne!(
+            snapshot.job_id.as_deref(),
+            Some("startup-installed-only"),
+            "full reconcile must supersede the in-flight installed-only job, not reuse it"
+        );
+        assert!(!snapshot.installed_only, "the superseding job is full-scope");
+    }
+
+    #[tokio::test]
+    async fn installed_only_reuses_in_flight_installed_only_job() {
+        // Startup-style coalescing still holds: an installed-only request reuses
+        // a running installed-only job.
+        let service = AgentReconcileService::new();
+        {
+            let mut job = service.job.lock().await;
+            *job = Some(AgentReconcileJob {
+                job_id: "running-installed-only".into(),
+                status: AgentReconcileJobStatus::Running,
+                reinstall: false,
+                installed_only: true,
+                current_agent: None,
+                results: Vec::new(),
+                started_at: Some(chrono::Utc::now().to_rfc3339()),
+                finished_at: None,
+                message: None,
+            });
+        }
+
+        let snapshot = service
+            .start_or_get(
+                Vec::new(),
+                PathBuf::from("/tmp/anyharness-reuse"),
+                false,
+                true, // installed-only scope
+                None,
+                None,
+            )
+            .await;
+
+        assert_eq!(snapshot.job_id.as_deref(), Some("running-installed-only"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
@@ -210,16 +210,42 @@ impl AgentRuntime {
         self.reconcile_service.snapshot().await
     }
 
-    pub async fn start_reconcile(&self, reinstall: bool) -> AgentReconcileJobSnapshot {
+    pub async fn start_reconcile(
+        &self,
+        reinstall: bool,
+        installed_only: bool,
+    ) -> AgentReconcileJobSnapshot {
         self.reconcile_service
             .start_or_get(
                 built_in_registry(),
                 self.runtime_home.clone(),
                 reinstall,
+                installed_only,
                 Some(self.seed_store.clone()),
                 Some(self.catalog_service.clone()),
             )
             .await
+    }
+
+    /// Runtime startup pass (desktop sidecar AND cloud workers): hydrate the
+    /// bundled agent seed if it hasn't been laid down yet, then run an
+    /// installed-only reconcile so already-installed agents track the catalog
+    /// pins. Non-blocking (boots the HTTP server immediately), best-effort
+    /// (failures are recorded in the seed/reconcile snapshots, never fatal),
+    /// and idempotent: missing non-seeded agents install on demand at session
+    /// start, and an up-to-date machine does no work.
+    pub fn spawn_startup_pass(self: Arc<Self>) {
+        tokio::spawn(async move {
+            if self.seed_store.hydration_pending() {
+                let home = self.runtime_home.clone();
+                let store = self.seed_store.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    installer::seed::hydrate_configured_agent_seed(&home, &store);
+                })
+                .await;
+            }
+            self.start_reconcile(false, true).await;
+        });
     }
 }
 

--- a/anyharness/crates/anyharness/src/commands/serve.rs
+++ b/anyharness/crates/anyharness/src/commands/serve.rs
@@ -10,9 +10,7 @@ use tower_http::trace::TraceLayer;
 
 use anyharness_lib::api::router::build_router;
 use anyharness_lib::app::{default_runtime_home, ensure_runtime_home, AppState};
-use anyharness_lib::domains::agents::installer::seed::{
-    configured_agent_seed_store, hydrate_configured_agent_seed,
-};
+use anyharness_lib::domains::agents::installer::seed::configured_agent_seed_store;
 use anyharness_lib::persistence::Db;
 
 #[derive(Args)]
@@ -40,14 +38,10 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .unwrap_or_else(default_runtime_home);
 
     ensure_runtime_home(&runtime_home)?;
+    // Seed hydration + the installed-only startup reconcile run behind the
+    // AgentRuntime facade (kicked from AppState::new); the binary only
+    // constructs the store and hands it in, like the Db.
     let agent_seed_store = configured_agent_seed_store();
-    if agent_seed_store.hydration_pending() {
-        let hydration_runtime_home = runtime_home.clone();
-        let hydration_store = agent_seed_store.clone();
-        tokio::task::spawn_blocking(move || {
-            hydrate_configured_agent_seed(&hydration_runtime_home, &hydration_store);
-        });
-    }
 
     let db = Db::open(&runtime_home)?;
     let runtime_base_url = runtime_base_url(&args.host, args.port);

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -6183,6 +6183,48 @@
           "error"
         ]
       },
+      "AgentReconcileSummary": {
+        "type": "object",
+        "description": "Coarse, low-cardinality reconcile status for `/health`. Per-agent detail\nstays on `GET /v1/agents/reconcile`.",
+        "required": [
+          "status",
+          "installed",
+          "alreadyInstalled",
+          "skipped",
+          "failed"
+        ],
+        "properties": {
+          "alreadyInstalled": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "currentAgent": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "failed": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "installed": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "skipped": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "status": {
+            "$ref": "#/components/schemas/ReconcileJobStatus"
+          }
+        }
+      },
       "AgentSeedFailureKind": {
         "type": "string",
         "enum": [
@@ -9269,9 +9311,13 @@
           "version",
           "runtimeHome",
           "capabilities",
-          "agentSeed"
+          "agentSeed",
+          "agentReconcile"
         ],
         "properties": {
+          "agentReconcile": {
+            "$ref": "#/components/schemas/AgentReconcileSummary"
+          },
           "agentSeed": {
             "$ref": "#/components/schemas/AgentSeedHealth"
           },
@@ -12383,6 +12429,10 @@
       "ReconcileAgentsRequest": {
         "type": "object",
         "properties": {
+          "installedOnly": {
+            "type": "boolean",
+            "description": "When true, only agents already installed on disk are reconciled to the\ncatalog pins; missing agents are skipped (they install on demand at\nsession start). Defaults to false (full-scope reconcile)."
+          },
           "reinstall": {
             "type": "boolean"
           }

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -3276,6 +3276,7 @@ export interface components {
             outcome: components["schemas"]["ReconcileOutcome"];
         };
         ReconcileAgentsRequest: {
+            installedOnly?: boolean;
             reinstall?: boolean;
         };
         ReconcileAgentsResponse: {

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -1860,6 +1860,22 @@ export interface components {
         AgentLoginTerminalStatus: "starting" | "running" | "exited" | "failed";
         /** @enum {string} */
         AgentReadinessState: "ready" | "install_required" | "credentials_required" | "login_required" | "unsupported" | "error";
+        /**
+         * @description Coarse, low-cardinality reconcile status for `/health`. Per-agent detail
+         *     stays on `GET /v1/agents/reconcile`.
+         */
+        AgentReconcileSummary: {
+            /** Format: int32 */
+            alreadyInstalled: number;
+            currentAgent?: string | null;
+            /** Format: int32 */
+            failed: number;
+            /** Format: int32 */
+            installed: number;
+            /** Format: int32 */
+            skipped: number;
+            status: components["schemas"]["ReconcileJobStatus"];
+        };
         /** @enum {string} */
         AgentSeedFailureKind: "missing_archive" | "invalid_checksum" | "invalid_manifest" | "invalid_archive" | "io" | "unsupported_target" | "verification_failed";
         AgentSeedHealth: {
@@ -2545,6 +2561,7 @@ export interface components {
             targetSessionId: string;
         };
         HealthResponse: {
+            agentReconcile: components["schemas"]["AgentReconcileSummary"];
             agentSeed: components["schemas"]["AgentSeedHealth"];
             capabilities: components["schemas"]["RuntimeCapabilities"];
             runtimeHome: string;
@@ -3276,6 +3293,11 @@ export interface components {
             outcome: components["schemas"]["ReconcileOutcome"];
         };
         ReconcileAgentsRequest: {
+            /**
+             * @description When true, only agents already installed on disk are reconciled to the
+             *     catalog pins; missing agents are skipped (they install on demand at
+             *     session start). Defaults to false (full-scope reconcile).
+             */
             installedOnly?: boolean;
             reinstall?: boolean;
         };

--- a/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
@@ -103,7 +103,9 @@ export function AgentDefaultsPane() {
   ]);
 
   const handleUpdateLocalInstalls = () => {
-    void reconcileAgents({ reinstall: true })
+    // Update the agents already installed on this machine to the catalog pins.
+    // installed_only: missing agents install on demand at session start, not here.
+    void reconcileAgents({ reinstall: true, installedOnly: true })
       .then(() => {
         showToast(AGENT_SETUP_COPY.updateInstallsStarted);
       })

--- a/apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.test.tsx
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.test.tsx
@@ -6,7 +6,6 @@ import { useAgentAutoReconcile } from "./use-agent-auto-reconcile";
 
 const mocks = vi.hoisted(() => ({
   invalidateAgentListResources: vi.fn(),
-  reconcileAgents: vi.fn(),
   useAgentCatalog: vi.fn(),
   useHarnessConnectionStore: vi.fn(),
   useRuntimeHealthQuery: vi.fn(),
@@ -28,12 +27,6 @@ vi.mock("@/hooks/access/anyharness/agents/use-agent-resources-cache", () => ({
 
 vi.mock("@/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: mocks.useAgentCatalog,
-}));
-
-vi.mock("@/hooks/agents/workflows/use-agent-installation-actions", () => ({
-  useAgentInstallationActions: () => ({
-    reconcileAgents: mocks.reconcileAgents,
-  }),
 }));
 
 describe("useAgentAutoReconcile", () => {
@@ -64,39 +57,10 @@ describe("useAgentAutoReconcile", () => {
       .toHaveBeenLastCalledWith("http://runtime.test");
   });
 
-  it("auto-reconciles install-required agents after seed hydration is ready", async () => {
-    arrange();
-    setRuntimeHealth("ready", 1);
-    setAgentCatalog({
-      agentsNeedingSetup: [{ readiness: "install_required" }],
-    });
-
-    renderHook(() => useAgentAutoReconcile());
-
-    await waitFor(() => {
-      expect(mocks.reconcileAgents).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does not auto-reconcile dev profiles without a configured seed", async () => {
-    arrange();
-    setRuntimeHealth("not_configured_dev", 1);
-    setAgentCatalog({
-      agentsNeedingSetup: [{ readiness: "install_required" }],
-    });
-
-    renderHook(() => useAgentAutoReconcile());
-
-    await waitFor(() => {
-      expect(mocks.useRuntimeHealthQuery).toHaveBeenCalled();
-    });
-    expect(mocks.reconcileAgents).not.toHaveBeenCalled();
-  });
 });
 
 function arrange() {
   mocks.invalidateAgentListResources.mockResolvedValue(undefined);
-  mocks.reconcileAgents.mockResolvedValue(undefined);
   mocks.useHarnessConnectionStore.mockImplementation((
     selector: (state: {
       connectionState: string;

--- a/apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.ts
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.ts
@@ -1,94 +1,40 @@
 import { useEffect, useRef } from "react";
-import {
-  useRuntimeHealthQuery,
-} from "@anyharness/sdk-react";
+import { useRuntimeHealthQuery } from "@anyharness/sdk-react";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useAgentResourcesCache } from "@/hooks/access/anyharness/agents/use-agent-resources-cache";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
-import { useAgentInstallationActions } from "@/hooks/agents/workflows/use-agent-installation-actions";
 
 /**
- * Auto-triggers agent reconciliation on startup when agents need installation,
- * refreshes the agent list while the bundled seed hydrates, and keeps the list
- * current during reconciliation so the UI reflects progress as each agent
- * installs sequentially.
+ * Keeps the desktop agent list in sync with the runtime's OWN startup work.
  *
- * Owns the app-mounted agent reconcile lifecycle. Does not own manual install
- * actions or agent catalog derivation.
+ * The runtime now owns reconciliation: at startup it hydrates the bundled seed
+ * and runs an installed-only reconcile against the catalog pins (see
+ * AgentRuntime::spawn_startup_pass); the reconcile snapshot is polled via
+ * useAgentCatalog. This hook no longer TRIGGERS reconcile — it only refreshes
+ * the agent list while the seed hydrates and as the reconcile job transitions,
+ * so the UI reflects progress. Manual reconcile lives in the settings pane;
+ * missing agents install on demand at session start.
  */
 export function useAgentAutoReconcile() {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
   const { invalidateAgentListResources } = useAgentResourcesCache();
   const {
-    agentsNeedingSetup,
     isReconciling,
-    isLoading: agentsLoading,
-    hasAgents,
     reconcileDataUpdatedAt,
     reconcileStatus,
   } = useAgentCatalog();
-  const {
-    reconcileAgents,
-  } = useAgentInstallationActions();
-  const hasTriggered = useRef(false);
   const previousReconcileStatus = useRef<string>("idle");
   const isHealthy = connectionState === "healthy" && runtimeUrl.trim().length > 0;
   const {
     data: runtimeHealth,
     dataUpdatedAt: runtimeHealthDataUpdatedAt,
-    isLoading: runtimeHealthLoading,
   } = useRuntimeHealthQuery({
     enabled: isHealthy,
     pollWhileAgentSeedHydrating: true,
   });
   const agentSeedStatus = runtimeHealth?.agentSeed?.status;
-  // `partial` can mean the seed preserved a user-owned Claude/Codex install.
-  // Normal reconcile is still safe because non-reinstall installs short-circuit
-  // when managed launchers already exist. `not_configured_dev` intentionally
-  // stays manual so local dev profiles do not start long network installs on
-  // app boot.
-  const seedAllowsReconcile =
-    !agentSeedStatus
-    || agentSeedStatus === "ready"
-    || agentSeedStatus === "partial"
-    || agentSeedStatus === "failed";
-
   const previousAgentSeedStatus = useRef<string | null>(null);
-
-  // Auto-trigger reconcile when agents need installation
-  useEffect(() => {
-    if (
-      !isHealthy
-      || runtimeHealthLoading
-      || agentSeedStatus === "hydrating"
-      || !seedAllowsReconcile
-      || agentsLoading
-      || !hasAgents
-      || hasTriggered.current
-      || reconcileStatus !== "idle"
-    ) {
-      return;
-    }
-
-    const needsInstall = agentsNeedingSetup.some(
-      (a) => a.readiness === "install_required",
-    );
-    if (!needsInstall) return;
-
-    hasTriggered.current = true;
-    void reconcileAgents();
-  }, [
-    isHealthy,
-    runtimeHealthLoading,
-    agentSeedStatus,
-    seedAllowsReconcile,
-    agentsLoading,
-    hasAgents,
-    agentsNeedingSetup,
-    reconcileStatus,
-    reconcileAgents,
-  ]);
 
   // Keep agents fresh during seed hydration and force one final refresh when hydration completes.
   useEffect(() => {

--- a/apps/desktop/src/hooks/support/workflows/use-session-debug-actions.test.ts
+++ b/apps/desktop/src/hooks/support/workflows/use-session-debug-actions.test.ts
@@ -8,6 +8,13 @@ import type { SessionDebugActionState } from "@/lib/domain/support/session-debug
 
 const runtimeUrl = "http://127.0.0.1:7007";
 const replayHealth = {
+  agentReconcile: {
+    status: "idle",
+    installed: 0,
+    alreadyInstalled: 0,
+    skipped: 0,
+    failed: 0,
+  },
   agentSeed: {
     lastAction: "none",
     ownership: "not_configured",

--- a/apps/desktop/src/lib/domain/support/session-debug.test.ts
+++ b/apps/desktop/src/lib/domain/support/session-debug.test.ts
@@ -26,6 +26,13 @@ import { sessionLocatorFromSession } from "@/lib/domain/support/session-debug/se
 
 const generatedAt = "2026-04-16T18:30:00.000Z";
 const localHealth = {
+  agentReconcile: {
+    status: "idle",
+    installed: 0,
+    alreadyInstalled: 0,
+    skipped: 0,
+    failed: 0,
+  },
   agentSeed: {
     lastAction: "none",
     ownership: "not_configured",
@@ -241,6 +248,13 @@ describe("buildSessionDebugLocator", () => {
         location: "cloud",
         url: "https://runtime.example.test",
         health: {
+          agentReconcile: {
+            status: "idle",
+            installed: 0,
+            alreadyInstalled: 0,
+            skipped: 0,
+            failed: 0,
+          },
           agentSeed: {
             lastAction: "none",
             ownership: "not_configured",

--- a/apps/desktop/src/lib/workflows/support/session-debug-export-workflows.test.ts
+++ b/apps/desktop/src/lib/workflows/support/session-debug-export-workflows.test.ts
@@ -21,6 +21,13 @@ import {
 const now = new Date("2026-04-16T18:30:05.000Z");
 const runtimeUrl = "http://127.0.0.1:7007";
 const health = {
+  agentReconcile: {
+    status: "idle",
+    installed: 0,
+    alreadyInstalled: 0,
+    skipped: 0,
+    failed: 0,
+  },
   agentSeed: {
     lastAction: "none",
     ownership: "not_configured",

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -3602,7 +3602,7 @@ export interface components {
              * Kind
              * @enum {string}
              */
-            kind: "claude" | "codex" | "gemini" | "cursor" | "opencode";
+            kind: "claude" | "codex" | "gemini" | "cursor" | "opencode" | "grok";
             /** Displayname */
             displayName: string;
             harness: components["schemas"]["AgentCatalogHarnessPins"];
@@ -5723,7 +5723,7 @@ export interface components {
             /** Organizationid */
             organizationId?: string | null;
             /** Credentialproviderid */
-            credentialProviderId?: ("anthropic" | "openai" | "gemini" | "cursor") | null;
+            credentialProviderId?: ("anthropic" | "openai" | "gemini" | "cursor" | "xai") | null;
             /** Displayname */
             displayName: string;
             /**
@@ -8900,7 +8900,7 @@ export interface components {
             /** Runtimegeneration */
             runtimeGeneration: number;
             /** Allowedagentkinds */
-            allowedAgentKinds: ("claude" | "codex" | "opencode" | "gemini")[];
+            allowedAgentKinds: ("claude" | "codex" | "opencode" | "gemini" | "grok")[];
             /** Readyagentkinds */
             readyAgentKinds: string[];
             runtimeAuth: components["schemas"]["WorkspaceRuntimeAuthState"];
@@ -12046,7 +12046,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                agent_kind: "claude" | "codex" | "opencode" | "gemini";
+                agent_kind: "claude" | "codex" | "opencode" | "gemini" | "grok";
             };
             cookie?: never;
         };
@@ -12278,7 +12278,7 @@ export interface operations {
             header?: never;
             path: {
                 sandbox_profile_id: string;
-                agent_kind: "claude" | "codex" | "opencode" | "gemini";
+                agent_kind: "claude" | "codex" | "opencode" | "gemini" | "grok";
                 auth_slot_id: string;
             };
             cookie?: never;

--- a/specs/codebase/primitives/agent-catalog-readiness.md
+++ b/specs/codebase/primitives/agent-catalog-readiness.md
@@ -328,7 +328,12 @@ Low-level vendor mechanics belong under `integrations/agent_cli/**`.
 Owns batch repair/sync.
 
 It can iterate supported agents and call install/readiness flows to make the
-runtime match desired local state.
+runtime match desired local state. It runs in two scopes via an `installed_only`
+flag: full (install missing too) or installed-only (only update agents already on
+disk; skip missing ones). The runtime drives an installed-only reconcile at
+startup (`AgentRuntime::spawn_startup_pass`, after seed hydration) so installed
+agents track the catalog pins on desktop and cloud workers — non-blocking,
+best-effort, idempotent.
 
 It should not own per-provider install mechanics.
 

--- a/specs/codebase/structures/anyharness/src/agents.md
+++ b/specs/codebase/structures/anyharness/src/agents.md
@@ -204,9 +204,11 @@ Important install cases:
 - managed npm readiness compares the installed package metadata against the
   bundled package spec; stale managed packages report `install_required` so
   normal setup/reconcile can update user-owned older ACP adapters
-- manual reinstall/reconcile is the update path for every installable agent
-  process recipe; the version + source come from the bundled catalog lockfile,
-  resolved at probe time by `scripts/agent-catalog/resolve-pins.mjs`
+- the update path for every installable agent process recipe is reconcile against
+  the catalog pins: the runtime startup pass does this automatically (installed-only),
+  and the desktop "update local installs" button / manual reinstall do it on demand. The
+  version + source come from the bundled catalog lockfile, resolved at probe time by
+  `scripts/agent-catalog/resolve-pins.mjs`
 - installer mutations are serialized by runtime-home file locks under
   `agents/<kind>/.install.lock` so desktop, CLI, and seed hydration do not
   write the same agent at the same time
@@ -249,7 +251,9 @@ vendor CLIs write their usual local auth files.
 Cloud target enrollment, Git bootstrap, and workspace materialization do not
 install agents. A fresh cloud/SSH target may report worker and AnyHarness
 online while `start_session` still fails with an install/readiness error until
-the requested agent is installed through this API.
+the requested agent is installed through this API. The runtime startup pass keeps
+*already-installed* agents on a cloud worker current with the catalog pins, but it
+does not eagerly install missing agents — those still install on demand here.
 
 ### ACP Registry Flow (probe-time only)
 
@@ -280,6 +284,23 @@ returning:
 
 This is the “make the runtime ready” bulk path, not the per-agent resolution
 path.
+
+Reconcile runs in two scopes, selected by the `installed_only` flag:
+
+- **full** (`installed_only=false`, the `POST /v1/agents/reconcile` default): attempt
+  managed install for every registry agent — installs missing ones too.
+- **installed-only** (`installed_only=true`): only agents already installed on disk
+  (`resolve_agent(..).agent_process.installed`) are reconciled to the catalog pins; a
+  missing agent is `skipped` (it installs on demand at session start). This is the scope
+  used by the runtime startup pass and the desktop "update local installs" button.
+
+The runtime drives reconcile itself at startup — `AgentRuntime::spawn_startup_pass`
+(kicked from `app/` wiring, runs on the desktop sidecar AND cloud workers): hydrate the
+bundled seed if pending, then run an installed-only reconcile. It is non-blocking (the
+HTTP server boots and answers `/health` while it runs), best-effort (failures land in the
+reconcile snapshot, never fatal), and idempotent (an up-to-date agent short-circuits with
+no network — see `install_policy` version-drift detection). The catalog-applied poke (a
+newer cloud catalog synced at runtime) also kicks an installed-only reconcile.
 
 ### Bundled Agent Seed Flow
 
@@ -342,9 +363,17 @@ Public health reports low-cardinality seed state only:
 - `lastAction`: `none`, `hydrated`, or `repaired`
 - artifact counts, target, seeded agent names, and a coarse `failureKind`
 
-Desktop auto-reconcile waits while the seed is `hydrating`, then uses the
-existing reconcile path for non-seeded or still-missing agents after the seed
-reaches `ready`, `partial`, `failed`, or `not_configured_dev`.
+`/health` also carries a coarse `agentReconcile` summary (status, current agent, and
+installed / already-installed / skipped / failed counts) for the startup reconcile. The
+per-agent detail stays on `GET /v1/agents/reconcile`.
+
+The runtime startup pass runs the installed-only reconcile after seed hydration
+settles (`AgentRuntime::spawn_startup_pass` awaits hydration, then reconciles), so
+already-installed agents track the catalog pins on both the desktop sidecar and cloud
+workers. The desktop frontend no longer triggers reconcile — it polls the reconcile
+snapshot (`GET /v1/agents/reconcile`) to display per-agent status and refreshes the agent
+list as the job transitions. Missing non-seeded agents are not auto-installed at startup;
+they install on demand at session start or via an explicit per-agent install.
 
 Seed hydration verifies the archive `.sha256`, validates the manifest target and
 schema, rejects unsafe tar entries, extracts into a staging directory under the


### PR DESCRIPTION
## What

The runtime now keeps **installed** agents current with the catalog pins **itself, at startup** — for both the desktop sidecar and cloud workers — replacing the desktop frontend's reconcile trigger.

## Why

Reconcile was client-triggered (`useAgentAutoReconcile` → `POST /v1/agents/reconcile`), so a long-lived **cloud worker** (no frontend) was never kept current when the catalog lockfile moved. And `serve.rs` reached past the `AgentRuntime` facade into `installer::seed::*` (a named smell in `mental-model.md`). This moves reconcile server-side, behind the facade, covering both surfaces.

## Changes

**Backend**
- `AgentRuntime::spawn_startup_pass` — hydrate the bundled seed if pending, then run an **installed-only** reconcile. Non-blocking (server boots + answers `/health` while it runs), best-effort (failures recorded in the reconcile snapshot, never fatal), idempotent (up-to-date agents short-circuit, no network). Kicked from `AppState::new` beside `workspace_retention`.
- `installer/reconcile` — `installed_only` scope: reconcile only agents **we manage** in `runtime_home` (`source == "managed"`); skip PATH-provided + absent agents (those install on demand at session start). Threaded through `start_or_get`/`run_reconcile_job`.
- `serve.rs` — drops the deep `installer::seed::hydrate_*` import (mechanics moved behind the facade); keeps only the store constructor, like `Db`.
- `POST /v1/agents/reconcile` — optional `installedOnly` request field (default `false` ⇒ full-scope preserved for cloud/CLI). Manual desktop "update local installs" sends `installedOnly: true`.
- `/health` — coarse `agentReconcile` summary (status + current agent + installed/already-installed/skipped/failed counts). Per-agent detail stays on `GET /v1/agents/reconcile`.
- catalog-applied poke → installed-only too.

**Frontend**
- `use-agent-auto-reconcile` no longer **triggers** reconcile (runtime owns it); keeps the list-refresh/poll effects so the UI reflects server-driven progress. Obsolete auto-trigger tests pruned.
- "update local installs" button → `installedOnly: true`.

**SDK / Specs**
- Regenerated SDK types (anyharness + cloud) for `agentReconcile` / `AgentReconcileSummary` / `installedOnly`.
- `agents.md` (Reconcile Flow, auto-reconcile paragraph, update-path, cloud note, `/health` list) + `agent-catalog-readiness.md`.

## Behavior notes (intentional)

- **Missing non-seeded agents** (gemini/cursor/opencode/grok) no longer auto-install on desktop first run — they install on demand / via explicit install. Seeded (claude/codex) are present and updated.
- **Dev**: the startup pass runs in dev (`pdev`/`cargo run`) by design. The seed step self-skips (`not_configured_dev`); the installed-only reconcile runs and is a **no-op unless a managed agent has drifted** from the bundled catalog pin.

## Verification

- `cargo check` (lib + binary + contract + all tests) — clean.
- `cargo test` reconcile module — 4/4 pass, incl. a new `installed_only_skips_uninstalled_agents` test (caught a real bug: PATH-discovered agents were being managed-reconciled and failing; fixed to managed-only via `source == "managed"`, now machine-independent).
- `make desktop-build` (tsc + vite) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)