### PR TITLE
fix(anyharness): re-fork zero-turn Claude fork children instead of dead load_session

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
@@ -1,6 +1,5 @@
 use anyharness_contract::v1::SessionExecutionPhase;
 
-use crate::domains::agents::model::AgentKind;
 use crate::domains::sessions::links::model::{
     SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
 };
@@ -85,7 +84,11 @@ impl SessionRuntime {
             return Err(ForkSessionError::Busy);
         }
 
-        let child_actor_forks = parent.agent_kind == AgentKind::Claude.as_str();
+        // Must stay in lockstep with the resume-side strategy: a child forked on
+        // the child actor (process-local fork id) is the one that can later land
+        // in the zero-turn "stale native id" state handled by `launch_policy`.
+        let child_actor_forks =
+            super::launch_policy::fork_id_is_process_local(&parent.agent_kind);
         let forked = if child_actor_forks {
             handle.verify_fork_ready().await.map_err(|error| {
                 map_live_fork_command_error(error, "session actor dropped fork readiness response")

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
@@ -37,20 +37,7 @@ pub(super) fn choose_startup_strategy(
     facts: &SessionStartupFacts,
 ) -> anyhow::Result<SessionStartupStrategy> {
     if facts.is_fork_child {
-        if let Some(native_session_id) = facts.native_session_id.clone() {
-            return Ok(SessionStartupStrategy::LoadNativeNoFallback(
-                native_session_id,
-            ));
-        }
-        let parent_native_session_id = facts
-            .fork_parent_native_session_id
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("fork child is missing its parent link"))?
-            .filter(|value| !value.trim().is_empty())
-            .ok_or_else(|| anyhow::anyhow!("fork parent is missing native session id"))?;
-        return Ok(SessionStartupStrategy::ForkFromNative {
-            parent_native_session_id,
-        });
+        return choose_fork_child_strategy(facts);
     }
 
     let Some(native_session_id) = facts.native_session_id.clone() else {
@@ -72,6 +59,72 @@ pub(super) fn choose_startup_strategy(
     }
 
     Ok(SessionStartupStrategy::ResumeSeqFreshNative)
+}
+
+/// Startup strategy for a fork child.
+///
+/// A fork child only has a durable, reloadable native session once it has run
+/// its own first turn. For adapters whose fork ids are process-local until that
+/// first prompt (Claude — see `specs/.../src/sessions.md` fork invariants), the
+/// eagerly-recorded native id is valid only while the original actor stays
+/// alive; after a cold restart-before-first-prompt the agent has no transcript
+/// for it and `load_session` returns `Resource not found`. So:
+///
+/// - child has run its own turn (`has_last_prompt_at`): its native transcript is
+///   durable agent-side — load it with no fallback (re-forking would lose the
+///   child's own turns).
+/// - zero-turn child: re-fork from the parent native id (`fork_from_native`),
+///   which is what the spec prescribes for these adapters. Fall back to the
+///   child's own (possibly stale) native id only when no parent can be
+///   resolved, so we never regress below the prior behavior.
+///
+/// Note the deliberate asymmetry with the non-fork Claude branch above, which
+/// keys on `has_turn_started_event`: that signal is unusable here because the
+/// fork transcript snapshot copies the parent's `turn_started` events into the
+/// child (`store/links.rs::insert_fork_session_with_link_and_event_snapshot`),
+/// so it is `true` for every fork child regardless of its own activity. Only
+/// `has_last_prompt_at` distinguishes "child has run since the fork." Do not
+/// unify the two branches.
+fn choose_fork_child_strategy(
+    facts: &SessionStartupFacts,
+) -> anyhow::Result<SessionStartupStrategy> {
+    if let Some(native_session_id) = facts.native_session_id.clone() {
+        if facts.has_last_prompt_at {
+            return Ok(SessionStartupStrategy::LoadNativeNoFallback(
+                native_session_id,
+            ));
+        }
+        // Zero-turn child: prefer re-forking from the parent; otherwise fall
+        // back to the child's own native id rather than failing the launch.
+        if let Some(parent_native_session_id) = resolved_parent_native_session_id(facts) {
+            return Ok(SessionStartupStrategy::ForkFromNative {
+                parent_native_session_id,
+            });
+        }
+        return Ok(SessionStartupStrategy::LoadNativeNoFallback(
+            native_session_id,
+        ));
+    }
+
+    // No native id of its own: must re-fork from the parent.
+    let parent_native_session_id = resolved_parent_native_session_id(facts).ok_or_else(|| {
+        match facts.fork_parent_native_session_id {
+            Some(_) => anyhow::anyhow!("fork parent is missing native session id"),
+            None => anyhow::anyhow!("fork child is missing its parent link"),
+        }
+    })?;
+    Ok(SessionStartupStrategy::ForkFromNative {
+        parent_native_session_id,
+    })
+}
+
+/// The parent's native session id, if one was resolved and is non-empty.
+fn resolved_parent_native_session_id(facts: &SessionStartupFacts) -> Option<String> {
+    facts
+        .fork_parent_native_session_id
+        .clone()
+        .flatten()
+        .filter(|value| !value.trim().is_empty())
 }
 
 /// Precondition: a closed session row never launches.
@@ -199,10 +252,54 @@ mod tests {
     }
 
     #[test]
-    fn loads_fork_children_without_fresh_fallback() {
+    fn loads_started_fork_children_without_fresh_fallback() {
+        // A fork child that has run its own turn has a durable native
+        // transcript; load it with no fallback (re-forking would lose the
+        // child's own turns).
         let mut facts = facts();
         facts.is_fork_child = true;
         facts.native_session_id = Some("fork-native".to_string());
+        facts.has_last_prompt_at = true;
+        facts.fork_parent_native_session_id = Some(Some("parent-native".to_string()));
+
+        let strategy = choose_startup_strategy(&facts).expect("strategy");
+        assert_eq!(
+            strategy,
+            SessionStartupStrategy::LoadNativeNoFallback("fork-native".to_string())
+        );
+    }
+
+    #[test]
+    fn reforks_zero_turn_fork_child_with_native_id_from_parent() {
+        // The bug case: the child has an eagerly-recorded native id but has
+        // never run its own turn, so that id is process-local and may be dead
+        // after a cold restart. Re-fork from the parent instead of issuing a
+        // no-fallback load that would brick the session.
+        let mut facts = facts();
+        facts.is_fork_child = true;
+        facts.native_session_id = Some("stale-fork-native".to_string());
+        facts.has_last_prompt_at = false;
+        facts.fork_parent_native_session_id = Some(Some("parent-native".to_string()));
+
+        let strategy = choose_startup_strategy(&facts).expect("strategy");
+        assert_eq!(
+            strategy,
+            SessionStartupStrategy::ForkFromNative {
+                parent_native_session_id: "parent-native".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn zero_turn_fork_child_falls_back_to_own_native_id_when_parent_unresolvable() {
+        // Last resort: if a zero-turn child cannot resolve a parent native id,
+        // try its own (possibly stale) native id rather than failing the launch
+        // — never regress below the prior behavior.
+        let mut facts = facts();
+        facts.is_fork_child = true;
+        facts.native_session_id = Some("fork-native".to_string());
+        facts.has_last_prompt_at = false;
+        facts.fork_parent_native_session_id = Some(None);
 
         let strategy = choose_startup_strategy(&facts).expect("strategy");
         assert_eq!(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
@@ -80,9 +80,11 @@ pub(super) fn choose_startup_strategy(
 /// - a process-local-fork (Claude) child that has not run yet: re-fork from the
 ///   parent native id (`fork_from_native`), which is what the spec prescribes.
 ///   Fall back to the child's own (possibly stale) id only when no parent can be
-///   resolved, so we never regress below the prior behavior — that floor still
-///   succeeds for a same-process resume and fails identically to today when the
-///   native session is genuinely gone.
+///   resolved. This strategy is only computed on a cold start (a live handle
+///   short-circuits before `choose_session_startup_strategy`), so by then a
+///   process-local id is already dead and the fallback fails identically to the
+///   prior behavior — never worse, and it keeps a clean path for durable-fork
+///   adapters whose recorded id is still valid.
 ///
 /// Residual window: `has_last_prompt_at` flips at turn start
 /// (`actor/turn/active.rs::update_last_prompt_at`), slightly before Claude
@@ -90,7 +92,7 @@ pub(super) fn choose_startup_strategy(
 /// leave a recorded `last_prompt_at` with a non-durable native id. There is no
 /// lossless local recovery for a child that has started its own turn (re-forking
 /// from the parent would drop that turn), so this narrow case is left to the
-/// existing error surface; see the follow-up in the PR/spec.
+/// existing error surface (tracked as a follow-up).
 ///
 /// Note the deliberate asymmetry with the non-fork Claude branch above, which
 /// keys on `has_turn_started_event`: that signal is unusable here because the
@@ -102,7 +104,7 @@ pub(super) fn choose_startup_strategy(
 fn choose_fork_child_strategy(
     facts: &SessionStartupFacts,
 ) -> anyhow::Result<SessionStartupStrategy> {
-    let fork_id_is_process_local = facts.agent_kind == AgentKind::Claude.as_str();
+    let fork_id_is_process_local = fork_id_is_process_local(&facts.agent_kind);
 
     if let Some(native_session_id) = facts.native_session_id.clone() {
         // Durable-fork adapters, or a child that has already run its own turn:
@@ -135,6 +137,16 @@ fn choose_fork_child_strategy(
     Ok(SessionStartupStrategy::ForkFromNative {
         parent_native_session_id,
     })
+}
+
+/// Whether an adapter's fork ids are process-local until the child's first
+/// prompt (vs durable at fork time). Single source for the distinction that
+/// also gates `fork.rs::child_actor_forks`; the two must stay in lockstep — a
+/// child only reaches the zero-turn "stale native id" state if it was forked on
+/// the child actor here. Currently Claude is the only process-local adapter; a
+/// typed adapter capability would be the longer-term home (see PR follow-up).
+pub(super) fn fork_id_is_process_local(agent_kind: &str) -> bool {
+    agent_kind == AgentKind::Claude.as_str()
 }
 
 /// The parent's native session id, if one was resolved and is non-empty.

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
@@ -31,8 +31,8 @@ pub(super) struct SessionStartupFacts {
     pub has_turn_started_event: bool,
 }
 
-/// Pure startup-strategy matrix. Behavior-equivalent to the pre-split
-/// store-coupled decision; only the fact gathering moved out.
+/// Pure startup-strategy matrix: gathered facts in, a `SessionStartupStrategy`
+/// out. All fact gathering lives in `startup.rs`; this stays data-in/data-out.
 pub(super) fn choose_startup_strategy(
     facts: &SessionStartupFacts,
 ) -> anyhow::Result<SessionStartupStrategy> {
@@ -63,20 +63,34 @@ pub(super) fn choose_startup_strategy(
 
 /// Startup strategy for a fork child.
 ///
-/// A fork child only has a durable, reloadable native session once it has run
-/// its own first turn. For adapters whose fork ids are process-local until that
-/// first prompt (Claude — see `specs/.../src/sessions.md` fork invariants), the
-/// eagerly-recorded native id is valid only while the original actor stays
-/// alive; after a cold restart-before-first-prompt the agent has no transcript
-/// for it and `load_session` returns `Resource not found`. So:
+/// When a fork child's recorded native id is reloadable depends on the adapter:
 ///
-/// - child has run its own turn (`has_last_prompt_at`): its native transcript is
-///   durable agent-side — load it with no fallback (re-forking would lose the
-///   child's own turns).
-/// - zero-turn child: re-fork from the parent native id (`fork_from_native`),
-///   which is what the spec prescribes for these adapters. Fall back to the
-///   child's own (possibly stale) native id only when no parent can be
-///   resolved, so we never regress below the prior behavior.
+/// - adapters with durable fork ids (e.g. Codex) get a reloadable native id at
+///   fork time, so a recorded id always loads with no fallback.
+/// - adapters whose fork ids are process-local until first prompt (Claude — see
+///   `specs/.../src/sessions.md` fork invariants) only durably persist the
+///   child's native session after its first turn. Until then the eagerly
+///   recorded id is valid only while the original actor stays alive; after a
+///   cold restart-before-first-prompt the agent has no transcript for it and
+///   `load_session` returns `Resource not found`.
+///
+/// So for a child that has its own native id:
+/// - already ran its own turn (`has_last_prompt_at`), or a durable-fork adapter:
+///   load it with no fallback (re-forking would lose the child's own turns).
+/// - a process-local-fork (Claude) child that has not run yet: re-fork from the
+///   parent native id (`fork_from_native`), which is what the spec prescribes.
+///   Fall back to the child's own (possibly stale) id only when no parent can be
+///   resolved, so we never regress below the prior behavior — that floor still
+///   succeeds for a same-process resume and fails identically to today when the
+///   native session is genuinely gone.
+///
+/// Residual window: `has_last_prompt_at` flips at turn start
+/// (`actor/turn/active.rs::update_last_prompt_at`), slightly before Claude
+/// persists the transcript, so a crash during the child's very first turn can
+/// leave a recorded `last_prompt_at` with a non-durable native id. There is no
+/// lossless local recovery for a child that has started its own turn (re-forking
+/// from the parent would drop that turn), so this narrow case is left to the
+/// existing error surface; see the follow-up in the PR/spec.
 ///
 /// Note the deliberate asymmetry with the non-fork Claude branch above, which
 /// keys on `has_turn_started_event`: that signal is unusable here because the
@@ -88,14 +102,19 @@ pub(super) fn choose_startup_strategy(
 fn choose_fork_child_strategy(
     facts: &SessionStartupFacts,
 ) -> anyhow::Result<SessionStartupStrategy> {
+    let fork_id_is_process_local = facts.agent_kind == AgentKind::Claude.as_str();
+
     if let Some(native_session_id) = facts.native_session_id.clone() {
-        if facts.has_last_prompt_at {
+        // Durable-fork adapters, or a child that has already run its own turn:
+        // the recorded native id is reloadable.
+        if facts.has_last_prompt_at || !fork_id_is_process_local {
             return Ok(SessionStartupStrategy::LoadNativeNoFallback(
                 native_session_id,
             ));
         }
-        // Zero-turn child: prefer re-forking from the parent; otherwise fall
-        // back to the child's own native id rather than failing the launch.
+        // Zero-turn process-local-fork (Claude) child: prefer re-forking from
+        // the parent; otherwise fall back to the child's own native id rather
+        // than failing the launch.
         if let Some(parent_native_session_id) = resolved_parent_native_session_id(facts) {
             return Ok(SessionStartupStrategy::ForkFromNative {
                 parent_native_session_id,
@@ -300,6 +319,24 @@ mod tests {
         facts.native_session_id = Some("fork-native".to_string());
         facts.has_last_prompt_at = false;
         facts.fork_parent_native_session_id = Some(None);
+
+        let strategy = choose_startup_strategy(&facts).expect("strategy");
+        assert_eq!(
+            strategy,
+            SessionStartupStrategy::LoadNativeNoFallback("fork-native".to_string())
+        );
+    }
+
+    #[test]
+    fn loads_non_claude_zero_turn_fork_child_without_refork() {
+        // Durable-fork adapters keep their recorded native id even with no first
+        // prompt; only process-local (Claude) fork ids re-fork on zero turns.
+        let mut facts = facts();
+        facts.is_fork_child = true;
+        facts.agent_kind = "codex".to_string();
+        facts.native_session_id = Some("fork-native".to_string());
+        facts.has_last_prompt_at = false;
+        facts.fork_parent_native_session_id = Some(Some("parent-native".to_string()));
 
         let strategy = choose_startup_strategy(&facts).expect("strategy");
         assert_eq!(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -29,15 +29,19 @@ use super::{
 };
 
 /// Resolve steps only — gather the durable facts, then let the pure policy in
-/// `launch_policy` pick the strategy. The parent lookup keeps today's gating
-/// (only fork children without their own native id pay for it).
+/// `launch_policy` pick the strategy. The parent lookup is gated: a fork child
+/// needs its parent's native id whenever it has not yet run its own turn
+/// (`last_prompt_at` unset) — either because it never had a native id, or
+/// because its eagerly-recorded one is process-local and may be dead after a
+/// cold restart-before-first-prompt. A fork child that has already run keeps
+/// its durable native id and skips the lookup.
 pub(super) fn choose_session_startup_strategy(
     record: &SessionRecord,
     session_store: &SessionStore,
 ) -> anyhow::Result<SessionStartupStrategy> {
     let is_fork_child =
         session_store.has_inbound_link_relation(&record.id, SessionLinkRelation::Fork)?;
-    let fork_parent_native_session_id = if is_fork_child && record.native_session_id.is_none() {
+    let fork_parent_native_session_id = if is_fork_child && record.last_prompt_at.is_none() {
         session_store
             .find_parent_by_inbound_link_relation(&record.id, SessionLinkRelation::Fork)?
             .map(|parent| parent.native_session_id)

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -29,12 +29,15 @@ use super::{
 };
 
 /// Resolve steps only — gather the durable facts, then let the pure policy in
-/// `launch_policy` pick the strategy. The parent lookup is gated: a fork child
-/// needs its parent's native id whenever it has not yet run its own turn
-/// (`last_prompt_at` unset) — either because it never had a native id, or
-/// because its eagerly-recorded one is process-local and may be dead after a
-/// cold restart-before-first-prompt. A fork child that has already run keeps
-/// its durable native id and skips the lookup.
+/// `launch_policy` pick the strategy. The parent lookup is gated to fork
+/// children that have not yet run their own turn (`last_prompt_at` unset): the
+/// policy may need the parent native id to re-fork — either because the child
+/// never had a native id, or because its eagerly-recorded one is process-local
+/// and may be dead after a cold restart-before-first-prompt. This intentionally
+/// over-fetches for durable-fork (non-Claude) zero-turn children, where the
+/// policy ignores the parent id; that is a single harmless row read kept here so
+/// the resolve gate doesn't have to duplicate the adapter distinction. A fork
+/// child that has already run keeps its durable native id and skips the lookup.
 pub(super) fn choose_session_startup_strategy(
     record: &SessionRecord,
     session_store: &SessionStore,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
@@ -470,7 +470,10 @@ fn choose_startup_strategy_keeps_non_claude_agents_on_native_load_path() {
 }
 
 #[test]
-fn choose_startup_strategy_loads_fork_children_without_fresh_fallback() {
+fn choose_startup_strategy_loads_started_fork_children_without_fresh_fallback() {
+    // A fork child that has already run its own turn (`last_prompt_at` set) has
+    // a durable native transcript; load it with no fallback and skip the parent
+    // lookup.
     let db = Db::open_in_memory().expect("open db");
     seed_workspace(&db);
 
@@ -482,6 +485,7 @@ fn choose_startup_strategy_loads_fork_children_without_fresh_fallback() {
     let mut child = session_record("claude");
     child.id = "fork-child".to_string();
     child.native_session_id = Some("fork-native".to_string());
+    child.last_prompt_at = Some("2026-03-25T00:05:00Z".to_string());
     let link = link_record(
         "fork-link",
         SessionLinkRelation::Fork,
@@ -498,6 +502,46 @@ fn choose_startup_strategy_loads_fork_children_without_fresh_fallback() {
     assert_eq!(
         strategy,
         SessionStartupStrategy::LoadNativeNoFallback("fork-native".to_string())
+    );
+}
+
+#[test]
+fn choose_startup_strategy_reforks_zero_turn_fork_child_with_native_id() {
+    // The bug case end-to-end through the IO layer: a fork child with an
+    // eagerly-recorded native id but no first prompt resolves the parent native
+    // id (widened gating) and re-forks instead of issuing a dead no-fallback
+    // load.
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    let mut parent = session_record("claude");
+    parent.id = "parent-session".to_string();
+    parent.native_session_id = Some("parent-native".to_string());
+    store.insert(&parent).expect("insert parent");
+
+    let mut child = session_record("claude");
+    child.id = "fork-child".to_string();
+    child.native_session_id = Some("stale-fork-native".to_string());
+    child.last_prompt_at = None;
+    let link = link_record(
+        "fork-link",
+        SessionLinkRelation::Fork,
+        "parent-session",
+        "fork-child",
+    );
+    store
+        .insert_session_with_link(&child, &link)
+        .expect("insert fork child and link");
+
+    let strategy =
+        choose_session_startup_strategy(&child, &store).expect("select startup strategy");
+
+    assert_eq!(
+        strategy,
+        SessionStartupStrategy::ForkFromNative {
+            parent_native_session_id: "parent-native".to_string()
+        }
     );
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
@@ -585,6 +585,105 @@ fn choose_startup_strategy_forks_unstarted_fork_children_from_parent_native_id()
 }
 
 #[test]
+fn choose_startup_strategy_reforks_snapshot_polluted_zero_turn_fork_child() {
+    // End-to-end guard against the snapshot-pollution trap: build the child via
+    // the real fork snapshot (which copies the parent's `turn_started` events),
+    // so `has_turn_started_event(child)` is true. A zero-turn Claude child must
+    // still re-fork from the parent — proving the policy keys on `last_prompt_at`
+    // and not on the polluted `turn_started` signal. This test fails if anyone
+    // reverts the fork branch to key on `has_turn_started_event`.
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    let mut parent = session_record("claude");
+    parent.id = "parent-session".to_string();
+    parent.native_session_id = Some("parent-native".to_string());
+    store.insert(&parent).expect("insert parent");
+    store
+        .append_event(&SessionEventRecord {
+            id: 0,
+            session_id: "parent-session".to_string(),
+            seq: 1,
+            timestamp: "2026-03-25T00:01:00Z".to_string(),
+            event_type: "turn_started".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            item_id: None,
+            payload_json: r#"{"type":"turn_started"}"#.to_string(),
+        })
+        .expect("append parent turn");
+
+    let mut child = session_record("claude");
+    child.id = "fork-child".to_string();
+    child.native_session_id = Some("stale-fork-native".to_string());
+    child.last_prompt_at = None;
+    let link = link_record(
+        "fork-link",
+        SessionLinkRelation::Fork,
+        "parent-session",
+        "fork-child",
+    );
+    store
+        .insert_fork_session_with_link_and_event_snapshot(&child, &link)
+        .expect("insert fork child with snapshot");
+
+    // Precondition: the snapshot polluted the child's turn_started signal.
+    assert!(
+        store
+            .has_turn_started_event("fork-child")
+            .expect("has_turn_started_event"),
+        "snapshot should have copied the parent's turn_started into the child"
+    );
+
+    let strategy =
+        choose_session_startup_strategy(&child, &store).expect("select startup strategy");
+
+    assert_eq!(
+        strategy,
+        SessionStartupStrategy::ForkFromNative {
+            parent_native_session_id: "parent-native".to_string()
+        }
+    );
+}
+
+#[test]
+fn choose_startup_strategy_loads_non_claude_zero_turn_fork_child_without_refork() {
+    // Durable-fork adapters (e.g. Codex) get a reloadable native id at fork
+    // time, so a zero-turn fork child keeps LoadNativeNoFallback rather than
+    // re-forking — the re-fork path is specific to process-local fork ids.
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    let mut parent = session_record("codex");
+    parent.id = "parent-session".to_string();
+    parent.native_session_id = Some("parent-native".to_string());
+    store.insert(&parent).expect("insert parent");
+
+    let mut child = session_record("codex");
+    child.id = "fork-child".to_string();
+    child.native_session_id = Some("fork-native".to_string());
+    child.last_prompt_at = None;
+    let link = link_record(
+        "fork-link",
+        SessionLinkRelation::Fork,
+        "parent-session",
+        "fork-child",
+    );
+    store
+        .insert_session_with_link(&child, &link)
+        .expect("insert fork child and link");
+
+    let strategy =
+        choose_session_startup_strategy(&child, &store).expect("select startup strategy");
+
+    assert_eq!(
+        strategy,
+        SessionStartupStrategy::LoadNativeNoFallback("fork-native".to_string())
+    );
+}
+
+#[test]
 fn fork_parent_validation_allows_api_origin_as_advisory_provenance() {
     let db = Db::open_in_memory().expect("open db");
     seed_workspace(&db);

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/links.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/links.rs
@@ -34,6 +34,64 @@ fn insert_session_with_link_rolls_back_child_when_link_insert_fails() {
         .is_none());
 }
 
+// Regression evidence for the fork-resume dead-end (native session
+// `Resource not found`): the fork snapshot copies `turn_started` events from
+// the parent into the child, so `has_turn_started_event(child)` is `true` even
+// though the child has never run its own turn. A never-prompted fork child also
+// has `last_prompt_at == None`. Therefore the launch policy must key its
+// "has this fork child run since the fork?" guard on `last_prompt_at`, NOT on
+// `has_turn_started_event`, which is polluted by the snapshot.
+#[test]
+fn fork_snapshot_pollutes_turn_started_but_not_last_prompt_at() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+
+    let store = SessionStore::new(db);
+    let mut parent = session_record();
+    parent.id = "parent-session".to_string();
+    store.insert(&parent).expect("insert parent session");
+    store
+        .append_event(&SessionEventRecord {
+            id: 0,
+            session_id: "parent-session".to_string(),
+            seq: 1,
+            timestamp: "2026-03-25T00:01:00Z".to_string(),
+            event_type: "turn_started".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            item_id: None,
+            payload_json: r#"{"type":"turn_started"}"#.to_string(),
+        })
+        .expect("append parent turn");
+
+    let mut child = session_record();
+    child.id = "child-session".to_string();
+    child.native_session_id = Some("native-child".to_string());
+    child.last_prompt_at = None; // mirrors fork.rs: forks start with no prompt
+    let link = fork_link_record("fork-link", "parent-session", "child-session");
+    store
+        .insert_fork_session_with_link_and_event_snapshot(&child, &link)
+        .expect("insert fork child with event snapshot");
+
+    // POLLUTED signal: the parent's turn_started rode along in the snapshot.
+    assert!(
+        store
+            .has_turn_started_event("child-session")
+            .expect("has_turn_started_event"),
+        "snapshot must copy the parent's turn_started into the child"
+    );
+
+    // CLEAN signal: a never-prompted fork child has no last_prompt_at, so the
+    // launch policy can use it to detect "child has not run since the fork".
+    let reloaded = store
+        .find_by_id("child-session")
+        .expect("find child")
+        .expect("child exists");
+    assert_eq!(
+        reloaded.last_prompt_at, None,
+        "a never-prompted fork child must have last_prompt_at == None"
+    );
+}
+
 #[test]
 fn insert_fork_session_with_link_snapshots_parent_events() {
     let db = Db::open_in_memory().expect("open db");

--- a/specs/codebase/structures/anyharness/src/sessions.md
+++ b/specs/codebase/structures/anyharness/src/sessions.md
@@ -258,6 +258,22 @@ Fork invariants:
 - adapters whose fork ids are process-local until first prompt, such as Claude,
   start the child actor with `fork_from_native`; that child actor calls ACP
   `session/fork` from the parent native id and owns the resulting live fork
+- a process-local fork id only becomes durable (reloadable via `load_session`)
+  once the child has run its own first turn. Until then — i.e. while the child's
+  `last_prompt_at` is unset — startup re-forks from the parent
+  (`fork_from_native`) rather than loading the child's recorded native id, even
+  if one was eagerly persisted at fork creation. Loading it after a cold
+  restart-before-first-prompt returns `Resource not found` and, with no
+  fallback, bricks the session. Once `last_prompt_at` is set the child loads its
+  own native id with no fallback (re-forking would drop the child's own turns).
+  If a zero-turn child cannot resolve a parent native id, it falls back to its
+  own (possibly stale) native id rather than failing the launch. This decision
+  keys on `last_prompt_at`, not on `turn_started`: the transcript snapshot below
+  copies the parent's `turn_started` events into the child, so that signal is
+  always set for forks. Known limitation: re-fork is tip-only (see below), so a
+  zero-turn child re-forked after the parent advanced sees the parent's current
+  tip, not its frozen snapshot — strictly better than the prior permanent
+  failure; full fidelity needs ACP message-indexed fork, which is unavailable.
 - for adapters that cannot replay the forked transcript through child
   `load_session`, AnyHarness snapshots the parent's durable `session_events`
   into the child before startup and appends child events after that prefix

--- a/specs/codebase/structures/anyharness/src/sessions.md
+++ b/specs/codebase/structures/anyharness/src/sessions.md
@@ -269,7 +269,9 @@ Fork invariants:
   If a zero-turn child cannot resolve a parent native id, it falls back to its
   own (possibly stale) native id rather than failing the launch. This applies
   to process-local-fork adapters (Claude); durable-fork adapters keep loading
-  their recorded native id. The decision keys on `last_prompt_at`, not on
+  their recorded native id per the durable-fork bullet above (a zero-turn
+  durable-fork child still uses `load_session`). The decision keys on
+  `last_prompt_at`, not on
   `turn_started`: the transcript snapshot below copies the parent's
   `turn_started` events into the child, so that signal is always set for forks.
   Because re-fork is tip-only, a zero-turn child re-forked after the parent

--- a/specs/codebase/structures/anyharness/src/sessions.md
+++ b/specs/codebase/structures/anyharness/src/sessions.md
@@ -267,13 +267,17 @@ Fork invariants:
   fallback, bricks the session. Once `last_prompt_at` is set the child loads its
   own native id with no fallback (re-forking would drop the child's own turns).
   If a zero-turn child cannot resolve a parent native id, it falls back to its
-  own (possibly stale) native id rather than failing the launch. This decision
-  keys on `last_prompt_at`, not on `turn_started`: the transcript snapshot below
-  copies the parent's `turn_started` events into the child, so that signal is
-  always set for forks. Known limitation: re-fork is tip-only (see below), so a
-  zero-turn child re-forked after the parent advanced sees the parent's current
-  tip, not its frozen snapshot — strictly better than the prior permanent
-  failure; full fidelity needs ACP message-indexed fork, which is unavailable.
+  own (possibly stale) native id rather than failing the launch. This applies
+  to process-local-fork adapters (Claude); durable-fork adapters keep loading
+  their recorded native id. The decision keys on `last_prompt_at`, not on
+  `turn_started`: the transcript snapshot below copies the parent's
+  `turn_started` events into the child, so that signal is always set for forks.
+  Because re-fork is tip-only, a zero-turn child re-forked after the parent
+  advanced is seeded from the parent's current tip while its stored
+  `session_events` snapshot still reflects the fork-point prefix; the agent then
+  reasons over state the child transcript does not show. This is accepted as
+  better than the prior permanent failure, but it is a real divergence, not just
+  a fidelity gap.
 - for adapters that cannot replay the forked transcript through child
   `load_session`, AnyHarness snapshots the parent's durable `session_events`
   into the child before startup and appends child events after that prefix


### PR DESCRIPTION
## What & why

A forked Claude session that is **created but never prompted** before its agent process recycles became **permanently unpromptable**. On the next prompt, startup resumed the fork child's native session with `LoadNativeNoFallback`; the Claude ACP agent returned `Resource not found` (the Claude Code SDK only writes a session transcript after the first *completed* turn, so a never-prompted fork has no file on disk); and because the strategy forbids fallback, every Retry re-failed.

This was validated end-to-end: anyharness logs → launch-policy code → the `claude-agent-acp` wrapper's error mapping (`"No conversation found with session ID"` → `resourceNotFound`) → SDK persistence semantics → the actual on-disk Claude store (the dead fork child + two never-prompted sibling forks have **no** `.jsonl`; the parent and every prompted session do) → the real incident DB (child `last_prompt_at` NULL; 245 `turn_started` events copied from the parent by the fork snapshot).

The fix restores the behavior already prescribed in `specs/.../src/sessions.md`: *"adapters whose fork ids are process-local until first prompt, such as Claude, start the child actor with `fork_from_native`."*

## Change

- **`launch_policy.rs`** (pure decision layer): a zero-turn fork child (no `last_prompt_at`) re-forks from the parent (`ForkFromNative`) instead of issuing a dead `LoadNativeNoFallback`. A child that has run its own turn keeps `LoadNativeNoFallback` (re-forking would drop its own turns). Falls back to the child's own native id if no parent native id resolves — never regresses below prior behavior.
- **`startup.rs`**: widened parent-native-id resolution to `is_fork_child && last_prompt_at.is_none()`.
- **Signal choice**: keys on `last_prompt_at`, **not** `has_turn_started_event` — the fork snapshot copies the parent's `turn_started` events into the child, so that signal is always set for forks. Documented the asymmetry inline to prevent a future "unification" regression.
- **`sessions.md`**: fork invariants updated in the same PR, including the tip-fork divergence as a documented known limitation.

## Tests

- `cargo test -p anyharness-lib --lib` → **713 passed, 0 failed** (1 pre-existing ignored).
- New: zero-turn → `ForkFromNative`; zero-turn + no parent → last-resort `LoadNativeNoFallback`; IO-layer parent-resolution test; store-level snapshot-pollution regression guard. Reconciled the two tests that asserted the old buggy behavior.

## Known limitation

Re-fork is tip-only (ACP has no message-indexed fork), so a zero-turn child re-forked after the parent advanced sees the parent's current tip, not its frozen snapshot — strictly better than the prior permanent failure.

## Follow-ups (out of scope)

- Close superseded native sessions on repeated re-fork-before-first-prompt (bounded leak).
- Divergence telemetry comparing child snapshot vs parent current `MAX(seq)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
