### PR TITLE
fix(product-ui): don't show scroll-to-bottom button when transcript isn't scrollable

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
@@ -15,6 +15,12 @@ export const REPIN_BOTTOM_THRESHOLD_PX = 24;
 export const PROGRAMMATIC_MATCH_TOL_PX = 2;
 // Ignore subpixel scroll jitter when classifying user scroll direction.
 export const DIRECTION_EPSILON_PX = 1;
+// Minimum overflow (scrollHeight - clientHeight) for the viewport to count as
+// scrollable. The pre-emptive intent-to-leave listeners must not unpin when the
+// content fits in the viewport: such a gesture produces no scroll event, so
+// nothing would re-pin and the scroll-to-bottom button would wrongly show while
+// already at the bottom.
+export const SCROLLABLE_OVERFLOW_EPSILON_PX = 1;
 // Visibility-resume glue loop: hold the viewport at the bottom each frame until
 // measured scrollHeight is stable for this many consecutive frames, capped at
 // GLUE_MAX_FRAMES, so a suspended-then-resumed measurement backlog collapses

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
@@ -93,6 +93,7 @@ describe("useTranscriptStickToBottom", () => {
 
   it("unpins immediately on an upward wheel (pre-empts the snap race)", () => {
     const handle = renderHarness();
+    setMetrics(handle.current.viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
     act(() => {
       fireEvent.wheel(handle.current.viewport, { deltaY: -20 });
     });
@@ -103,6 +104,7 @@ describe("useTranscriptStickToBottom", () => {
   it("unpins on ArrowUp / PageUp / Home keydown", () => {
     for (const key of ["ArrowUp", "PageUp", "Home"]) {
       const handle = renderHarness();
+      setMetrics(handle.current.viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
       act(() => {
         fireEvent.keyDown(handle.current.viewport, { key });
       });
@@ -113,10 +115,35 @@ describe("useTranscriptStickToBottom", () => {
 
   it("does not unpin on a downward wheel", () => {
     const handle = renderHarness();
+    setMetrics(handle.current.viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
     act(() => {
       fireEvent.wheel(handle.current.viewport, { deltaY: 20 });
     });
     expect(handle.current.api.isPinnedToBottom).toBe(true);
+  });
+
+  it("stays pinned on an upward wheel when the content is not scrollable", () => {
+    // Regression: with content that fits the viewport there is nowhere to
+    // scroll, so the wheel fires no scroll event. Unpinning here would strand
+    // the engine and show the scroll-to-bottom button while already at bottom.
+    const handle = renderHarness();
+    setMetrics(handle.current.viewport, { scrollHeight: 300, clientHeight: 300, scrollTop: 0 });
+    act(() => {
+      fireEvent.wheel(handle.current.viewport, { deltaY: -50 });
+    });
+    expect(handle.current.api.isPinnedToBottom).toBe(true);
+  });
+
+  it("stays pinned on ArrowUp/PageUp/Home when the content is not scrollable", () => {
+    for (const key of ["ArrowUp", "PageUp", "Home"]) {
+      const handle = renderHarness();
+      setMetrics(handle.current.viewport, { scrollHeight: 300, clientHeight: 300, scrollTop: 0 });
+      act(() => {
+        fireEvent.keyDown(handle.current.viewport, { key });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      cleanup();
+    }
   });
 
   it("ignores its own programmatic snap, then unpins on a real user scroll", () => {

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -6,7 +6,19 @@ import {
   GLUE_STABLE_FRAMES,
   PROGRAMMATIC_MATCH_TOL_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
+  SCROLLABLE_OVERFLOW_EPSILON_PX,
 } from "./TranscriptRowListShared";
+
+/**
+ * Whether the viewport actually has room to scroll. The pre-emptive
+ * intent-to-leave listeners must not unpin when the content fits entirely in the
+ * viewport: that gesture produces no scroll event, so `onViewportScroll` never
+ * runs to re-pin, leaving the engine stuck unpinned and the scroll-to-bottom
+ * button wrongly visible while already at the bottom.
+ */
+function viewportCanScroll(viewport: HTMLDivElement): boolean {
+  return viewport.scrollHeight - viewport.clientHeight > SCROLLABLE_OVERFLOW_EPSILON_PX;
+}
 
 export interface UseTranscriptStickToBottomOptions {
   /** The real scroll element ref (AutoHideScrollArea forwards its viewport here). */
@@ -194,13 +206,19 @@ export function useTranscriptStickToBottom({
       return;
     }
     let touchStartY = 0;
+    // All three listeners gate on `viewportCanScroll`: an intent to leave the
+    // bottom is meaningless when there is nowhere to scroll, and acting on it
+    // would strand the engine unpinned (no scroll event follows to re-pin).
     const onWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0) {
+      if (event.deltaY < 0 && viewportCanScroll(viewport)) {
         setPinned(false);
       }
     };
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") {
+      if (
+        (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") &&
+        viewportCanScroll(viewport)
+      ) {
         setPinned(false);
       }
     };
@@ -210,7 +228,7 @@ export function useTranscriptStickToBottom({
     const onTouchMove = (event: TouchEvent) => {
       const y = event.touches[0]?.clientY ?? touchStartY;
       // Finger dragging down reveals content above (scrolls toward history).
-      if (y - touchStartY > DIRECTION_EPSILON_PX) {
+      if (y - touchStartY > DIRECTION_EPSILON_PX && viewportCanScroll(viewport)) {
         setPinned(false);
       }
     };


### PR DESCRIPTION
## What & why

The scroll-to-bottom button appeared even when already at the bottom of the transcript.

The stick-to-bottom engine has pre-emptive "intent to leave" listeners (wheel-up, ArrowUp/PageUp/Home, touch drag-down) that flip `pinned = false` the instant you gesture, to win a race against streaming auto-scroll. They fired **unconditionally**. When the transcript fits the viewport (nothing to scroll), the gesture produces **no scroll event**, so `onViewportScroll` never runs to re-pin — the engine stays stuck unpinned and the button shows with nothing to scroll to.

## Fix

Gate all three listeners on a new `viewportCanScroll(viewport)` helper (`scrollHeight - clientHeight > SCROLLABLE_OVERFLOW_EPSILON_PX`): an intent to leave the bottom is meaningless when there's nowhere to scroll. Scrollable behavior is unchanged — scrolling up still shows the button, settling at the bottom still hides it via the scroll-event path.

## Tests

The two existing wheel/key tests were actually exercising the buggy path (firing a gesture on a 0×0, non-scrollable viewport and expecting it to unpin), so they now set scrollable metrics. Added two regression tests asserting the pin **stays** on wheel-up / arrow-up when content isn't scrollable. All 18 transcript tests pass.

## Not included

A separate resize-driven edge: if content is scrollable, you scroll up, then the viewport grows / content shrinks so it all fits, the ResizeObserver in `FullTranscriptRowList` bails when unpinned and the button can linger. No input event fires, so it's out of scope for this interactive fix — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
