### PR TITLE
fix(desktop): keep distinct local workspaces per folder+branch instead of collapsing

### DIFF
--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
@@ -230,6 +230,48 @@ describe("logical workspace duplicate local records", () => {
     )?.id).toBe(logicalWorkspaces[0]?.id);
   });
 
+  it("keeps a just-created (selected, zero-session) duplicate visible next to a used sibling", () => {
+    // Regression: clicking "New local workspace" on an already-used folder makes
+    // a 0-session row that is immediately selected. It must show as its own entry
+    // (not fold into the used sibling) so selection resolves to the new workspace.
+    const checkoutPath = "/tmp/proliferate";
+    const usedLocal = {
+      ...makeWorkspace({
+        id: "local-used",
+        branch: "main",
+        updatedAt: "2026-06-02T09:10:00.000Z",
+        executionSummary: makeExecutionSummary({
+          totalSessionCount: 3,
+          liveSessionCount: 0,
+          updatedAt: "2026-06-02T09:15:00.000Z",
+        }),
+      }),
+      path: checkoutPath,
+    };
+    const justCreated = {
+      ...makeWorkspace({
+        id: "local-just-created",
+        branch: "main",
+        updatedAt: "2026-06-02T09:50:00.000Z",
+      }),
+      path: checkoutPath,
+    };
+
+    const logicalWorkspaces = buildLogicalWorkspaces({
+      localWorkspaces: [usedLocal, justCreated],
+      repoRoots: [],
+      cloudWorkspaces: [],
+      currentSelectionId: justCreated.id,
+    });
+
+    expect(logicalWorkspaces).toHaveLength(2);
+    const createdEntry = findLogicalWorkspace(logicalWorkspaces, justCreated.id);
+    const usedEntry = findLogicalWorkspace(logicalWorkspaces, usedLocal.id);
+    expect(createdEntry?.localWorkspace?.id).toBe(justCreated.id);
+    expect(usedEntry?.localWorkspace?.id).toBe(usedLocal.id);
+    expect(createdEntry?.id).not.toBe(usedEntry?.id);
+  });
+
   it("promotes a prior local-slot workspace to canonical and preserves alias lookup", () => {
     const olderLocal = makeWorkspace({
       id: "local-older",

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
@@ -138,69 +138,96 @@ describe("logical workspace duplicate local records", () => {
     );
   });
 
-  it("collapses exact duplicate local records and prefers transcript history over setup-only slots", () => {
+  it("keeps distinct local workspaces that each have their own chats", () => {
+    // Same folder+branch, but each record has its own sessions: they are
+    // separate "project/feature threads" and must stay as distinct entries.
     const checkoutPath = "/tmp/proliferate";
-    const setupOnlyLocal = {
+    const firstLocal = {
       ...makeWorkspace({
-        id: "local-setup-only",
-        branch: "main",
-        updatedAt: "2026-06-02T09:50:00.000Z",
-        executionSummary: makeExecutionSummary({
-          phase: "running",
-          totalSessionCount: 4,
-          liveSessionCount: 4,
-          updatedAt: "2026-06-02T09:50:00.000Z",
-        }),
-      }),
-      path: checkoutPath,
-    };
-    const historicalLocal = {
-      ...makeWorkspace({
-        id: "local-with-transcript",
+        id: "local-first",
         branch: "main",
         updatedAt: "2026-06-02T09:10:00.000Z",
         executionSummary: makeExecutionSummary({
-          totalSessionCount: 4,
+          totalSessionCount: 2,
           liveSessionCount: 0,
           updatedAt: "2026-06-02T09:15:00.000Z",
         }),
       }),
       path: checkoutPath,
     };
+    const secondLocal = {
+      ...makeWorkspace({
+        id: "local-second",
+        branch: "main",
+        updatedAt: "2026-06-02T09:50:00.000Z",
+        executionSummary: makeExecutionSummary({
+          phase: "running",
+          totalSessionCount: 1,
+          liveSessionCount: 1,
+          updatedAt: "2026-06-02T09:50:00.000Z",
+        }),
+      }),
+      path: checkoutPath,
+    };
 
     const logicalWorkspaces = buildLogicalWorkspaces({
-      localWorkspaces: [setupOnlyLocal, historicalLocal],
+      localWorkspaces: [secondLocal, firstLocal],
+      repoRoots: [],
+      cloudWorkspaces: [],
+      currentSelectionId: null,
+    });
+
+    expect(logicalWorkspaces).toHaveLength(2);
+    const firstEntry = findLogicalWorkspace(logicalWorkspaces, firstLocal.id);
+    const secondEntry = findLogicalWorkspace(logicalWorkspaces, secondLocal.id);
+    expect(firstEntry?.localWorkspace?.id).toBe(firstLocal.id);
+    expect(secondEntry?.localWorkspace?.id).toBe(secondLocal.id);
+    expect(firstEntry?.id).not.toBe(secondEntry?.id);
+  });
+
+  it("folds a zero-session duplicate onto the local workspace that has chats", () => {
+    // A genuinely-empty (setup-only / stale) duplicate of the same folder+branch
+    // is hidden behind the used record rather than shown as a junk row, but stays
+    // selectable via alias lookup.
+    const checkoutPath = "/tmp/proliferate";
+    const usedLocal = {
+      ...makeWorkspace({
+        id: "local-used",
+        branch: "main",
+        updatedAt: "2026-06-02T09:10:00.000Z",
+        executionSummary: makeExecutionSummary({
+          totalSessionCount: 3,
+          liveSessionCount: 0,
+          updatedAt: "2026-06-02T09:15:00.000Z",
+        }),
+      }),
+      path: checkoutPath,
+    };
+    const emptyLocal = {
+      ...makeWorkspace({
+        id: "local-empty",
+        branch: "main",
+        updatedAt: "2026-06-02T09:50:00.000Z",
+      }),
+      path: checkoutPath,
+    };
+
+    const logicalWorkspaces = buildLogicalWorkspaces({
+      localWorkspaces: [emptyLocal, usedLocal],
       repoRoots: [],
       cloudWorkspaces: [],
       currentSelectionId: null,
     });
 
     expect(logicalWorkspaces).toHaveLength(1);
-    expect(logicalWorkspaces[0]?.localWorkspace?.id).toBe(historicalLocal.id);
-    expect(logicalWorkspaceRelatedIds(logicalWorkspaces[0]!)).toContain(setupOnlyLocal.id);
-    expect(logicalWorkspaceRelatedIds(logicalWorkspaces[0]!)).toContain(
-      buildLocalSlotLogicalWorkspaceId(setupOnlyLocal.id),
-    );
-    expect(findLogicalWorkspace(logicalWorkspaces, setupOnlyLocal.id)?.id)
+    expect(logicalWorkspaces[0]?.localWorkspace?.id).toBe(usedLocal.id);
+    expect(logicalWorkspaceRelatedIds(logicalWorkspaces[0]!)).toContain(emptyLocal.id);
+    expect(findLogicalWorkspace(logicalWorkspaces, emptyLocal.id)?.id)
       .toBe(logicalWorkspaces[0]?.id);
     expect(findLogicalWorkspace(
       logicalWorkspaces,
-      buildLocalSlotLogicalWorkspaceId(setupOnlyLocal.id),
+      buildLocalSlotLogicalWorkspaceId(emptyLocal.id),
     )?.id).toBe(logicalWorkspaces[0]?.id);
-
-    const selectedDuplicateWorkspaces = buildLogicalWorkspaces({
-      localWorkspaces: [setupOnlyLocal, historicalLocal],
-      repoRoots: [],
-      cloudWorkspaces: [],
-      currentSelectionId: setupOnlyLocal.id,
-    });
-
-    expect(selectedDuplicateWorkspaces).toHaveLength(1);
-    expect(selectedDuplicateWorkspaces[0]?.localWorkspace?.id).toBe(setupOnlyLocal.id);
-    expect(selectedDuplicateWorkspaces[0]?.preferredMaterializationId).toBe(setupOnlyLocal.id);
-    expect(logicalWorkspaceRelatedIds(selectedDuplicateWorkspaces[0]!)).toContain(
-      historicalLocal.id,
-    );
   });
 
   it("promotes a prior local-slot workspace to canonical and preserves alias lookup", () => {

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -143,11 +143,11 @@ function collapseExactLocalWorkspaceDuplicates(
 
   // Distinct local workspaces for the same folder+branch are kept separate so
   // each "project/feature thread" gets its own sidebar entry. Within a bucket,
-  // every workspace that has its own chats is surfaced as a distinct entry; only
-  // genuinely-empty (setup-only / stale) duplicates are folded onto the top used
-  // entry so they don't show as junk rows but stay selectable. A brand-new empty
-  // workspace is still shown immediately via the pending-workspace projection
-  // until its first turn makes it "used".
+  // a workspace is surfaced as its own distinct entry when it has its own chats
+  // OR it is the current selection (covers a just-created workspace that has no
+  // chats yet — `createLocalWorkspaceAndEnter` selects it immediately). Only
+  // genuinely-empty, unselected (setup-only / stale) duplicates are folded onto
+  // the top distinct entry so they don't show as junk rows but stay selectable.
   return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
     if (bucket.length === 1) {
       return [{
@@ -156,29 +156,37 @@ function collapseExactLocalWorkspaceDuplicates(
       }];
     }
 
-    const used = bucket.filter(workspaceHasOwnSessions);
-    const empty = bucket.filter((candidate) => !workspaceHasOwnSessions(candidate));
+    const distinct = bucket.filter(
+      (candidate) =>
+        workspaceHasOwnSessions(candidate)
+        || localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
+    const foldable = bucket.filter(
+      (candidate) =>
+        !workspaceHasOwnSessions(candidate)
+        && !localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
 
-    if (used.length === 0) {
-      // No chats anywhere in this folder+branch yet: keep a single
+    if (distinct.length === 0) {
+      // No chats and nothing selected in this folder+branch yet: keep a single
       // representative (preferring history/selection), aliasing the rest.
-      const representative = [...empty]
+      const representative = [...foldable]
         .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
       return [{
         workspace: representative,
-        aliasIds: empty
+        aliasIds: foldable
           .filter((candidate) => candidate.id !== representative.id)
           .flatMap(localWorkspaceIdentityIds),
       }];
     }
 
-    const sortedUsed = [...used]
+    const sortedDistinct = [...distinct]
       .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
-    const foldedEmptyAliasIds = empty.flatMap(localWorkspaceIdentityIds);
-    return sortedUsed.map((workspace, index) => ({
+    const foldedAliasIds = foldable.flatMap(localWorkspaceIdentityIds);
+    return sortedDistinct.map((workspace, index) => ({
       workspace,
-      // Fold stale empty duplicates onto the top used entry.
-      aliasIds: index === 0 ? foldedEmptyAliasIds : [],
+      // Fold stale empty duplicates onto the first distinct entry.
+      aliasIds: index === 0 ? foldedAliasIds : [],
     }));
   });
 }

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -122,6 +122,10 @@ function compareExactLocalWorkspaceDuplicateOrderForSelection(
   };
 }
 
+function workspaceHasOwnSessions(workspace: Workspace): boolean {
+  return (workspace.executionSummary?.totalSessionCount ?? 0) > 0;
+}
+
 function collapseExactLocalWorkspaceDuplicates(
   workspaces: readonly Workspace[],
   currentSelectionId: string | null,
@@ -137,23 +141,45 @@ function collapseExactLocalWorkspaceDuplicates(
     }
   }
 
-  return Array.from(byMaterialization.values()).map((bucket) => {
+  // Distinct local workspaces for the same folder+branch are kept separate so
+  // each "project/feature thread" gets its own sidebar entry. Within a bucket,
+  // every workspace that has its own chats is surfaced as a distinct entry; only
+  // genuinely-empty (setup-only / stale) duplicates are folded onto the top used
+  // entry so they don't show as junk rows but stay selectable. A brand-new empty
+  // workspace is still shown immediately via the pending-workspace projection
+  // until its first turn makes it "used".
+  return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
     if (bucket.length === 1) {
-      return {
+      return [{
         workspace: bucket[0]!,
         aliasIds: [],
-      };
+      }];
     }
 
-    const workspace = [...bucket]
-      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
-    const aliasIds = bucket
-      .filter((candidate) => candidate.id !== workspace.id)
-      .flatMap(localWorkspaceIdentityIds);
-    return {
+    const used = bucket.filter(workspaceHasOwnSessions);
+    const empty = bucket.filter((candidate) => !workspaceHasOwnSessions(candidate));
+
+    if (used.length === 0) {
+      // No chats anywhere in this folder+branch yet: keep a single
+      // representative (preferring history/selection), aliasing the rest.
+      const representative = [...empty]
+        .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
+      return [{
+        workspace: representative,
+        aliasIds: empty
+          .filter((candidate) => candidate.id !== representative.id)
+          .flatMap(localWorkspaceIdentityIds),
+      }];
+    }
+
+    const sortedUsed = [...used]
+      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
+    const foldedEmptyAliasIds = empty.flatMap(localWorkspaceIdentityIds);
+    return sortedUsed.map((workspace, index) => ({
       workspace,
-      aliasIds,
-    };
+      // Fold stale empty duplicates onto the top used entry.
+      aliasIds: index === 0 ? foldedEmptyAliasIds : [],
+    }));
   });
 }
 

--- a/specs/codebase/structures/anyharness/src/workspaces.md
+++ b/specs/codebase/structures/anyharness/src/workspaces.md
@@ -110,6 +110,17 @@ for that path. The runtime does not expose a canonical-vs-sibling concept for
 these duplicates; desktop reconstructs that projection from the returned local
 workspace rows.
 
+Desktop projection rule (sidebar logical workspaces): duplicate local rows
+sharing the same `path + branch` each become their own sidebar entry when they
+have their own chats (sessions) or are the current selection — so a user can keep
+multiple distinct "project/feature threads" over the same checkout, and a newly
+created local workspace (selected immediately, no chats yet) shows right away.
+Only genuinely-empty, unselected (setup-only / stale) duplicate rows are folded
+behind the first distinct entry — hidden as a junk row but still resolvable via
+alias lookup. This lives in `collapseExactLocalWorkspaceDuplicates`
+(`apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts`); distinct
+entries get `local-slot` logical ids and `#2`/`#3` sidebar name suffixes.
+
 ### Create Workspace
 
 `create_workspace(...)`


### PR DESCRIPTION
## What & why

"New local workspace" for an already-open folder collapsed into the existing workspace — *"local workspaces all the same workspace."*

Root cause: the **backend** creates a distinct workspace row per "New local workspace" (`resolve_or_create_workspace(..., allow_existing=false)`, [identity.rs:70](anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/identity.rs:70) — only *worktrees* bail-on-existing), but the **desktop** logical-workspace projection collapsed every local record sharing the same `path+branch` into one sidebar entry (`collapseExactLocalWorkspaceDuplicates`, [logical-workspaces.ts](apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts)). So the new row was swallowed and its sessions appeared under the existing workspace.

A local workspace is meant to be a "project/feature thread" holding many chat tabs; starting a new feature should give a separate entry.

## Change

Relax the collapse: within a `path+branch` bucket, **every workspace that has its own chats** (`executionSummary.totalSessionCount > 0`) is surfaced as its own distinct logical workspace; only **genuinely-empty** (setup-only/stale) duplicates fold onto the top used entry (all-empty buckets still keep one representative). This keeps the sidebar clean of junk empty rows while honoring real, distinct workspaces.

Downstream is unchanged — distinct entries already get slot ids (`buildLocalSlotLogicalWorkspaceId` / `"local-slot"`) and `#2`/`#3` name suffixes (`applyDuplicateLocalNameSuffixes`). Backend unchanged.

## Tests

The old "collapses exact duplicate … prefers transcript history" test actually had **both** fixtures with sessions, so under the new rule they split — replaced it with:
- distinct-when-both-have-chats → two logical entries
- zero-session-duplicate folds onto the used record (still selectable via alias)

Ran `logical-workspaces` + full `sidebar/` + `cloud/` workspace suites: **196 pass** (via main-tree deps; fresh worktree has no node_modules).

## Notes / follow-ups

- A brand-new local workspace shows via the **pending-workspace projection** until its first turn marks it "used"; worth a manual pass in-app.
- Sanity-check no non-create flow (mobility "bring local", restart re-resolution) emits a *used* same-path+branch row that should still merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
