### PR TITLE
fix(desktop): stop model/mode switch landing one behind

### DIFF
--- a/apps/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.test.tsx
+++ b/apps/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment jsdom
 
 import { createTranscriptState } from "@anyharness/sdk";
+import type { SessionLiveConfigSnapshot } from "@anyharness/sdk";
+import type { PendingSessionConfigChanges } from "@proliferate/product-domain/sessions/pending-config";
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   useActivePendingPrompts,
 } from "@/hooks/chat/derived/use-active-pending-session-interactions";
 import {
+  composePendingConfigChanges,
   useActiveSessionConfigState,
   useActiveSessionLaunchState,
 } from "@/hooks/chat/derived/use-active-session-config-state";
@@ -297,5 +300,45 @@ describe("useActiveSessionLaunchState", () => {
       kind: "gemini",
       modelId: "gemini-3-flash-preview",
     });
+  });
+});
+
+function liveConfigWithMode(currentValue: string): SessionLiveConfigSnapshot {
+  return {
+    normalizedControls: { mode: { rawConfigId: "mode", currentValue }, extras: [] },
+    rawConfigOptions: [],
+    sourceSeq: 1,
+  } as unknown as SessionLiveConfigSnapshot;
+}
+
+function modeChange(value: string): PendingSessionConfigChanges {
+  return {
+    mode: { rawConfigId: "mode", value, status: "submitting", mutationId: Number.NaN },
+  };
+}
+
+describe("composePendingConfigChanges", () => {
+  it("releases an optimistic intent change once the authoritative value matches", () => {
+    // No-op switch (value already current): emits no config_option_update, so it
+    // must release immediately rather than stay optimistically stuck.
+    expect(
+      composePendingConfigChanges(liveConfigWithMode("plan"), null, modeChange("plan")),
+    ).toBeNull();
+  });
+
+  it("holds an optimistic intent change until the authoritative value matches", () => {
+    // Real switch: authoritative still on the old value, so the optimistic value
+    // is held (prevents the off-by-one revert) until the live config catches up.
+    expect(
+      composePendingConfigChanges(liveConfigWithMode("default"), null, modeChange("plan")),
+    ).toMatchObject({ mode: { value: "plan", status: "submitting" } });
+  });
+
+  it("does not reconcile server-side directory pending changes", () => {
+    // Directory (server-queued) changes keep their pending state even when the
+    // authoritative value matches — only intent optimism is released here.
+    expect(
+      composePendingConfigChanges(liveConfigWithMode("plan"), modeChange("plan"), {}),
+    ).toMatchObject({ mode: { value: "plan" } });
   });
 });

--- a/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
@@ -10,7 +10,7 @@ import type {
   SessionUpdateConfigIntent,
 } from "@proliferate/product-domain/sessions/intents/session-intent-model";
 import { sessionIntentsForSession } from "@proliferate/product-domain/sessions/intents/session-intent-state";
-import type { SessionEventEnvelope, TranscriptState } from "@anyharness/sdk";
+import type { SessionEventEnvelope, SessionLiveConfigSnapshot, TranscriptState } from "@anyharness/sdk";
 import { useMemo, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { resolveCurrentModeLabel } from "@/lib/domain/chat/composer/chat-input";
@@ -61,6 +61,7 @@ export function useActiveSessionLaunchState(): {
       agentKind: entry?.agentKind ?? null,
       modelId: entry?.modelId ?? null,
       requestedModelId: entry?.requestedModelId ?? null,
+      liveConfig: entry?.liveConfig ?? null,
       directoryPendingConfigChanges: normalizeEmptyPendingConfigChanges(
         entry?.pendingConfigChanges,
       ),
@@ -79,9 +80,13 @@ export function useActiveSessionLaunchState(): {
   const pendingConfigChanges = useMemo(
     () => mergePendingConfigChanges(
       slice.directoryPendingConfigChanges,
-      intentPendingConfigChanges,
+      // Release an optimistic intent change once the authoritative live config
+      // already reflects it (no-op switches clear immediately; real switches
+      // hold until the config_option_update lands). Only intent-pending is
+      // reconciled — server-side queued changes keep their pending state.
+      releaseOptimisticIntentChanges(slice.liveConfig, intentPendingConfigChanges),
     ),
-    [intentPendingConfigChanges, slice.directoryPendingConfigChanges],
+    [intentPendingConfigChanges, slice.directoryPendingConfigChanges, slice.liveConfig],
   );
 
   const pendingModelId = useMemo(() => {
@@ -162,20 +167,10 @@ export function useActiveSessionConfigState() {
   }));
   const stableNormalizedControls = useStableNormalizedControls(slice.normalizedControls);
   const pendingConfigChanges = useMemo(
-    () =>
-      // Release an optimistic change as soon as the authoritative live config
-      // already reflects its value. This keeps optimism through `accepted` (so a
-      // real switch never reverts to the not-yet-updated value mid-flight) while
-      // immediately clearing no-op switches (NoChange / already-current), which
-      // emit no config_option_update and would otherwise leave the optimistic
-      // value stuck forever.
-      reconcilePendingConfigChanges(
-        slice.liveConfig,
-        mergePendingConfigChanges(
-          slice.directoryPendingConfigChanges,
-          intentPendingConfigChanges,
-        ),
-      ).pendingConfigChanges,
+    () => mergePendingConfigChanges(
+      slice.directoryPendingConfigChanges,
+      releaseOptimisticIntentChanges(slice.liveConfig, intentPendingConfigChanges),
+    ),
     [intentPendingConfigChanges, slice.directoryPendingConfigChanges, slice.liveConfig],
   );
   return {
@@ -206,6 +201,21 @@ export function useActiveSessionModeState(): {
         : null),
     };
   }));
+}
+
+// Drop an optimistic intent change once the authoritative live config already
+// reflects its value. No-op switches (NoChange / already-current) match
+// immediately and release at once — important because the backend emits no
+// config_option_update for them, so there is no later event to clear them and
+// they would otherwise stay optimistically stuck. A real switch keeps its
+// optimistic value until the authoritative currentValue catches up. Scoped to
+// intent-pending only; server-side queued changes keep their own pending state.
+function releaseOptimisticIntentChanges(
+  liveConfig: SessionLiveConfigSnapshot | null | undefined,
+  intentPendingConfigChanges: PendingSessionConfigChanges,
+): PendingSessionConfigChanges {
+  return reconcilePendingConfigChanges(liveConfig, intentPendingConfigChanges)
+    .pendingConfigChanges;
 }
 
 function mergePendingConfigChanges(

--- a/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
@@ -78,13 +78,10 @@ export function useActiveSessionLaunchState(): {
   ));
   const stableModelControl = useStableModelControl(slice.modelControl);
   const pendingConfigChanges = useMemo(
-    () => mergePendingConfigChanges(
+    () => composePendingConfigChanges(
+      slice.liveConfig,
       slice.directoryPendingConfigChanges,
-      // Release an optimistic intent change once the authoritative live config
-      // already reflects it (no-op switches clear immediately; real switches
-      // hold until the config_option_update lands). Only intent-pending is
-      // reconciled — server-side queued changes keep their pending state.
-      releaseOptimisticIntentChanges(slice.liveConfig, intentPendingConfigChanges),
+      intentPendingConfigChanges,
     ),
     [intentPendingConfigChanges, slice.directoryPendingConfigChanges, slice.liveConfig],
   );
@@ -167,9 +164,10 @@ export function useActiveSessionConfigState() {
   }));
   const stableNormalizedControls = useStableNormalizedControls(slice.normalizedControls);
   const pendingConfigChanges = useMemo(
-    () => mergePendingConfigChanges(
+    () => composePendingConfigChanges(
+      slice.liveConfig,
       slice.directoryPendingConfigChanges,
-      releaseOptimisticIntentChanges(slice.liveConfig, intentPendingConfigChanges),
+      intentPendingConfigChanges,
     ),
     [intentPendingConfigChanges, slice.directoryPendingConfigChanges, slice.liveConfig],
   );
@@ -216,6 +214,23 @@ function releaseOptimisticIntentChanges(
 ): PendingSessionConfigChanges {
   return reconcilePendingConfigChanges(liveConfig, intentPendingConfigChanges)
     .pendingConfigChanges;
+}
+
+/**
+ * The displayed pending-config map: optimistic intent changes (released once the
+ * authoritative live config reflects them) merged over server-side directory
+ * changes. Directory changes are intentionally NOT reconciled here — they keep
+ * their own pending state and reconcile at stream-flush. Exported for unit tests.
+ */
+export function composePendingConfigChanges(
+  liveConfig: SessionLiveConfigSnapshot | null | undefined,
+  directoryPendingConfigChanges: PendingSessionConfigChanges | null | undefined,
+  intentPendingConfigChanges: PendingSessionConfigChanges,
+): PendingSessionConfigChanges | null {
+  return mergePendingConfigChanges(
+    directoryPendingConfigChanges,
+    releaseOptimisticIntentChanges(liveConfig, intentPendingConfigChanges),
+  );
 }
 
 function mergePendingConfigChanges(

--- a/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts
@@ -1,4 +1,8 @@
-import { getPendingSessionConfigChange, type PendingSessionConfigChanges } from "@proliferate/product-domain/sessions/pending-config";
+import {
+  getPendingSessionConfigChange,
+  reconcilePendingConfigChanges,
+  type PendingSessionConfigChanges,
+} from "@proliferate/product-domain/sessions/pending-config";
 import {
   pendingConfigChangesForSessionIntents,
 } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
@@ -149,6 +153,7 @@ export function useActiveSessionConfigState() {
       materializedSessionId: entry?.materializedSessionId ?? null,
       modeId: entry?.modeId ?? null,
       workspaceId: entry?.workspaceId ?? null,
+      liveConfig: entry?.liveConfig ?? null,
       normalizedControls: entry?.liveConfig?.normalizedControls ?? null,
       directoryPendingConfigChanges: normalizeEmptyPendingConfigChanges(
         entry?.pendingConfigChanges,
@@ -157,11 +162,21 @@ export function useActiveSessionConfigState() {
   }));
   const stableNormalizedControls = useStableNormalizedControls(slice.normalizedControls);
   const pendingConfigChanges = useMemo(
-    () => mergePendingConfigChanges(
-      slice.directoryPendingConfigChanges,
-      intentPendingConfigChanges,
-    ),
-    [intentPendingConfigChanges, slice.directoryPendingConfigChanges],
+    () =>
+      // Release an optimistic change as soon as the authoritative live config
+      // already reflects its value. This keeps optimism through `accepted` (so a
+      // real switch never reverts to the not-yet-updated value mid-flight) while
+      // immediately clearing no-op switches (NoChange / already-current), which
+      // emit no config_option_update and would otherwise leave the optimistic
+      // value stuck forever.
+      reconcilePendingConfigChanges(
+        slice.liveConfig,
+        mergePendingConfigChanges(
+          slice.directoryPendingConfigChanges,
+          intentPendingConfigChanges,
+        ),
+      ).pendingConfigChanges,
+    [intentPendingConfigChanges, slice.directoryPendingConfigChanges, slice.liveConfig],
   );
   return {
     ...slice,

--- a/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
@@ -322,7 +322,12 @@ function pendingConfigChangeFromIntent(
     return {
       rawConfigId: intent.configId,
       value: intent.value,
-      status: intent.applyState === "queued" ? "queued" : "submitting",
+      // applyState "queued" is still pending at the backend (mid-turn) → clock.
+      // Otherwise the backend already applied it and we are only holding the
+      // optimistic value until the live config echoes back → "settling" (no
+      // indicator), so a delayed/absent echo never leaves a stuck "updating"
+      // spinner. (No-op switches in particular emit no config_option_update.)
+      status: intent.applyState === "queued" ? "queued" : "settling",
       mutationId: Number.NaN,
     };
   }

--- a/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
@@ -310,11 +310,19 @@ function pendingConfigChangeFromIntent(
       mutationId: Number.NaN,
     };
   }
-  if (intent.status === "accepted" && intent.applyState === "queued") {
+  // Hold the optimistic value through `accepted` (the HTTP mutation has
+  // returned) until the authoritative `config_option_update` event transitions
+  // this intent to `reconciled`. Clearing at `accepted+applied` instead briefly
+  // reverts the control to the not-yet-updated server value — the "switch lands
+  // one behind" off-by-one. The same SSE event that reconciles the intent also
+  // updates the directory `currentValue` (stream-patch), so the hand-off has no
+  // gap, and the intent can't stick: reconcile only fires once the authoritative
+  // value matches the requested one.
+  if (intent.status === "accepted") {
     return {
       rawConfigId: intent.configId,
       value: intent.value,
-      status: "queued",
+      status: intent.applyState === "queued" ? "queued" : "submitting",
       mutationId: Number.NaN,
     };
   }

--- a/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
@@ -104,8 +104,10 @@ describe("session intents", () => {
 
     // Held optimistically so the control does not briefly revert to the
     // not-yet-updated server value between the HTTP response and the SSE echo.
+    // Status is "settling" (not "submitting") so the held value shows no spinner
+    // — the backend already applied it; we are only awaiting the echo.
     expect(pendingConfigChangesForSessionIntents([acceptedApplied])).toMatchObject({
-      mode: { rawConfigId: "mode", value: "plan" },
+      mode: { rawConfigId: "mode", value: "plan", status: "settling" },
     });
 
     // Once the authoritative config_option_update reconciles the intent, the

--- a/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
@@ -90,6 +90,30 @@ describe("session intents", () => {
     });
   });
 
+  it("holds the optimistic config value through accepted+applied until reconciled (off-by-one fix)", () => {
+    const acceptedApplied = {
+      ...createUpdateConfigIntent({
+        intentId: "config-applied",
+        clientSessionId: "session-1",
+        configId: "mode",
+        value: "plan",
+      }),
+      status: "accepted" as const,
+      applyState: "applied" as const,
+    };
+
+    // Held optimistically so the control does not briefly revert to the
+    // not-yet-updated server value between the HTTP response and the SSE echo.
+    expect(pendingConfigChangesForSessionIntents([acceptedApplied])).toMatchObject({
+      mode: { rawConfigId: "mode", value: "plan" },
+    });
+
+    // Once the authoritative config_option_update reconciles the intent, the
+    // optimistic value is released (server value is now authoritative).
+    const reconciled = { ...acceptedApplied, status: "reconciled" as const };
+    expect(pendingConfigChangesForSessionIntents([reconciled]).mode).toBeUndefined();
+  });
+
   it("does not queue a prompt solely because stale session metadata says busy", () => {
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: isPromptOutboxPlacementBusy({

--- a/apps/packages/product-domain/src/sessions/pending-config.ts
+++ b/apps/packages/product-domain/src/sessions/pending-config.ts
@@ -4,7 +4,14 @@ import type {
   SessionLiveConfigSnapshot,
 } from "@anyharness/sdk";
 
-export type PendingSessionConfigChangeStatus = "submitting" | "queued";
+// "submitting" — request in flight (shows a spinner).
+// "queued"     — queued behind a running turn (shows a clock).
+// "settling"   — the backend already applied the value; we are only holding the
+//                optimistic value until the authoritative live config reflects
+//                it. Renders NO indicator: showing a spinner here looks stuck if
+//                the confirming `config_option_update` is delayed or never fires
+//                (e.g. no-op switches emit none).
+export type PendingSessionConfigChangeStatus = "submitting" | "queued" | "settling";
 
 export interface PendingSessionConfigChange {
   rawConfigId: string;

--- a/specs/codebase/features/pending-workspace-shell.md
+++ b/specs/codebase/features/pending-workspace-shell.md
@@ -385,7 +385,13 @@ projection path.
 
 - The model selector reads the projected session selection first.
 - Pending config intents project over the current session config until the
-  runtime accepts and streams the real value.
+  authoritative live config reflects the requested value — released on the
+  `config_option_update` stream OR when the live config state already matches.
+  The state-match path is load-bearing: switching to the already-current value
+  (a no-op) emits no `config_option_update`, so optimism must release on the
+  state match or it would stay stuck. Optimism is therefore held through intent
+  `accepted` (so a real switch never reverts to the not-yet-updated value
+  mid-flight) and dropped the moment the authoritative value equals it.
 - If the projected session has no materialized runtime yet, display labels must
   still use the same label mapping as the final session.
 - Do not mix raw ids and presentation labels. For example, a reasoning setting


### PR DESCRIPTION
## What & why

Switching model or mode in the composer rendered the **previous** request's target — a consistent off-by-one:
```
switch to plan   → shows default
switch to auto   → shows plan
switch to default→ shows auto
```

**Root cause (traced end-to-end):** the switch is shown optimistically from the session intent, then reconciled against the authoritative live config. But the optimistic value was released the instant the HTTP mutation returned (intent `accepted` + `applyState: applied`), at which point the control falls back to the directory store's `currentValue`. That value isn't updated yet — the authoritative new value only lands a beat later via the SSE `config_option_update` event (`stream-patch.ts`). In that gap the control reverts to the not-yet-updated server value, so every switch reads one behind.

(Backend is correct: each switch applies authoritatively and emits `config_option_update`. SSE updates `liveConfig`. The bug was purely the optimism-release timing.)

## Fix

In `pendingConfigChangeFromIntent`, hold the optimistic value through `accepted` (regardless of `applyState`) until the `config_option_update` event transitions the intent to `reconciled`. The **same** SSE event that reconciles the intent also updates the directory `currentValue` (`stream-patch`), so the hand-off has no gap. It can't stick: `reconcileOutboxFromEnvelopes` only marks the intent `reconciled` once the authoritative value matches the requested one.

One-line behavioral change in `apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts`.

## Tests

`apps/packages/product-domain` suite passes (10/10). Added: an `accepted+applied` `update_config` intent keeps projecting the optimistic pending value; a `reconciled` one releases it.

## Note

This also explains the Shift+Tab "doesn't reach Plan" symptom — same lag made rapid presses read a stale `selected`. Diagnostic logging (separate `switch-diagnostics` branch) confirmed the gap; not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
