### PR TITLE
fix(desktop): self-heal stale default model + gate new-thread to active auth context

### DIFF
--- a/apps/desktop/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts
+++ b/apps/desktop/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts
@@ -1,9 +1,10 @@
 import {
   resolveRuntimeConnection,
+  useAgentLaunchOptionsQuery,
   useAnyHarnessRuntimeContext,
   useCreateCoworkThreadMutation,
 } from "@anyharness/sdk-react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 import { resolveEffectiveChatDefaults } from "@/lib/domain/chat/composer/preference-resolvers";
@@ -22,6 +23,11 @@ import { useWorkspaceEntryFlow } from "@/hooks/workspaces/workflows/use-workspac
 import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { useCloudLaunchModelRegistries } from "@/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog";
+import { mergeRuntimeLaunchOptionsIntoModelRegistries } from "@/lib/domain/settings/model-registries";
+import {
+  isStoredDefaultModelStale,
+  withClearedDefaultModelIdByAgentKind,
+} from "@/lib/domain/agents/model-options";
 import type { DesktopLaunchModelRegistry as ModelRegistry } from "@/lib/domain/agents/cloud-launch-catalog";
 import { applySessionLaunchDefaults } from "@/lib/workflows/sessions/session-launch-defaults";
 import { mergeLiveDefaultLaunchControls } from "@/lib/domain/sessions/creation/launch-controls";
@@ -54,13 +60,28 @@ export function useCoworkThreadWorkflow() {
   const activateWorkspace = useSessionSelectionStore((state) => state.activateWorkspace);
   const { beginPendingWorkspace } = useWorkspaceEntryFlow();
   const { agents } = useAgentCatalog();
-  const { data: modelRegistries = EMPTY_MODEL_REGISTRIES } = useCloudLaunchModelRegistries();
+  const { data: cloudModelRegistries = EMPTY_MODEL_REGISTRIES } = useCloudLaunchModelRegistries();
+  // Gate the new-thread model set to the runtime's active auth context. The cloud
+  // catalog lists every model across all contexts (incl. bedrock us.anthropic.*),
+  // so resolving a stored default against it alone can pick a model that is not
+  // valid in the live context. The runtime launch-options are pre-filtered to
+  // visible + available for the classified context; merging them (runtime wins)
+  // yields the same context-valid set the composer/model-selector already uses.
+  const runtimeLaunchOptions = useAgentLaunchOptionsQuery();
+  const modelRegistries = useMemo(
+    () => mergeRuntimeLaunchOptionsIntoModelRegistries(
+      cloudModelRegistries,
+      runtimeLaunchOptions.data?.agents ?? null,
+    ),
+    [cloudModelRegistries, runtimeLaunchOptions.data?.agents],
+  );
   const preferences = useUserPreferencesStore(useShallow((state) => ({
     defaultChatAgentKind: state.defaultChatAgentKind,
     defaultChatModelIdByAgentKind: state.defaultChatModelIdByAgentKind,
     defaultLiveSessionControlValuesByAgentKind:
       state.defaultLiveSessionControlValuesByAgentKind,
     coworkWorkspaceDelegationEnabled: state.coworkWorkspaceDelegationEnabled,
+    set: state.set,
   })));
   const showToast = useToastStore((state) => state.show);
   const { selectWorkspace } = useWorkspaceSelection();
@@ -155,8 +176,21 @@ export function useCoworkThreadWorkflow() {
   ]);
 
   const createThread = useCallback(async () => {
+    // Resolve against the runtime's context-gated launch options, not the
+    // ungated cloud catalog. If the query has not resolved yet (e.g. a fast
+    // "New Thread" right after connect), fetch it now — otherwise the merge
+    // falls back to the cloud catalog and could pick a stale default (e.g. a
+    // bedrock id) that the runtime then rejects.
+    let runtimeAgents = runtimeLaunchOptions.data?.agents ?? null;
+    if (!runtimeAgents && runtimeUrl) {
+      runtimeAgents = (await runtimeLaunchOptions.refetch()).data?.agents ?? null;
+    }
+    const gatedRegistries = mergeRuntimeLaunchOptionsIntoModelRegistries(
+      cloudModelRegistries,
+      runtimeAgents,
+    );
     const defaults = resolveEffectiveChatDefaults(
-      modelRegistries,
+      gatedRegistries,
       agents,
       preferences,
       null,
@@ -166,7 +200,33 @@ export function useCoworkThreadWorkflow() {
       throw new Error(defaults.degradedReason ?? "No ready agents are available.");
     }
 
-    if (defaults.degradedReason) {
+    // Self-heal a stale stored default: if the persisted default model for this
+    // agent is not in the runtime's context-gated options (e.g. a bedrock id
+    // left over after switching to oauth), drop it so the warning does not
+    // re-fire on every new thread. Only act when the runtime authoritatively
+    // lists the agent (avoids wiping a valid default while options are loading).
+    const storedDefault = preferences.defaultChatModelIdByAgentKind[defaults.agentKind];
+    const runtimeAgent = runtimeAgents?.find(
+      (agent) => agent.kind === defaults.agentKind,
+    );
+    const healedStaleDefault = isStoredDefaultModelStale(
+      storedDefault,
+      runtimeAgent?.models ?? null,
+    );
+    if (healedStaleDefault) {
+      preferences.set(
+        "defaultChatModelIdByAgentKind",
+        withClearedDefaultModelIdByAgentKind(
+          preferences.defaultChatModelIdByAgentKind,
+          defaults.agentKind,
+        ),
+      );
+    }
+
+    // Surface the degraded reason — but not when we just self-healed a stale
+    // default: a valid model was substituted and the dead pref cleared, so
+    // there is nothing actionable to warn about.
+    if (defaults.degradedReason && !healedStaleDefault) {
       showToast(defaults.degradedReason, "info");
     }
 
@@ -176,9 +236,11 @@ export function useCoworkThreadWorkflow() {
     });
   }, [
     agents,
+    cloudModelRegistries,
     createThreadWithResolvedConfig,
-    modelRegistries,
     preferences,
+    runtimeLaunchOptions,
+    runtimeUrl,
     showToast,
   ]);
 

--- a/apps/desktop/src/lib/domain/agents/model-options.test.ts
+++ b/apps/desktop/src/lib/domain/agents/model-options.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAgentModelGroups,
+  isStoredDefaultModelStale,
   resolveEffectiveAgentModelSelection,
+  withClearedDefaultModelIdByAgentKind,
   type AgentCatalogSummary,
   type AgentModelRegistry,
   type AgentModelRegistryModel,
@@ -234,5 +236,49 @@ describe("resolveEffectiveAgentModelSelection", () => {
       defaultAgentKind: "missing",
       defaultModelIdByAgentKind: {},
     })).toEqual({ kind: "codex", modelId: "first" });
+  });
+});
+
+describe("withClearedDefaultModelIdByAgentKind", () => {
+  it("removes the stored default for the given agent kind", () => {
+    expect(
+      withClearedDefaultModelIdByAgentKind(
+        { claude: "us.anthropic.claude-sonnet-4-6", codex: "gpt-5.5" },
+        "claude",
+      ),
+    ).toEqual({ codex: "gpt-5.5" });
+  });
+
+  it("returns the same reference when there is nothing to clear", () => {
+    const defaults = { codex: "gpt-5.5" };
+    expect(withClearedDefaultModelIdByAgentKind(defaults, "claude")).toBe(defaults);
+    expect(withClearedDefaultModelIdByAgentKind(defaults, "  ")).toBe(defaults);
+  });
+});
+
+describe("isStoredDefaultModelStale", () => {
+  const models = [
+    { id: "sonnet", aliases: ["claude-sonnet-4-6"] },
+    { id: "opus" },
+  ];
+
+  it("is stale when the stored id is absent from the gated runtime models", () => {
+    // e.g. a bedrock id left over after switching to oauth
+    expect(isStoredDefaultModelStale("us.anthropic.claude-sonnet-4-6", models)).toBe(true);
+  });
+
+  it("is not stale when the stored id matches a model id", () => {
+    expect(isStoredDefaultModelStale("opus", models)).toBe(false);
+  });
+
+  it("is not stale when the stored id matches a model alias", () => {
+    expect(isStoredDefaultModelStale("claude-sonnet-4-6", models)).toBe(false);
+  });
+
+  it("never reports stale without a stored id or runtime models (loading/unclassified guard)", () => {
+    expect(isStoredDefaultModelStale(undefined, models)).toBe(false);
+    expect(isStoredDefaultModelStale("", models)).toBe(false);
+    expect(isStoredDefaultModelStale("opus", null)).toBe(false);
+    expect(isStoredDefaultModelStale("opus", undefined)).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/domain/agents/model-options.ts
+++ b/apps/desktop/src/lib/domain/agents/model-options.ts
@@ -209,6 +209,42 @@ export function withUpdatedDefaultModelIdByAgentKind(
   };
 }
 
+// Drop a persisted default model for one agent kind (referentially stable when
+// there is nothing to clear). Used to self-heal a stored default that is no
+// longer valid in the user's active auth context — e.g. a bedrock
+// `us.anthropic.*` id left over after switching to oauth — so the "default no
+// longer available" warning stops re-firing on every new thread.
+export function withClearedDefaultModelIdByAgentKind(
+  defaultsByAgentKind: Record<string, string>,
+  agentKind: string,
+): Record<string, string> {
+  const trimmedAgentKind = agentKind.trim();
+  if (!trimmedAgentKind || !(trimmedAgentKind in defaultsByAgentKind)) {
+    return defaultsByAgentKind;
+  }
+  const { [trimmedAgentKind]: _removed, ...rest } = defaultsByAgentKind;
+  return rest;
+}
+
+// True when a stored default model id is no longer offered by the runtime's
+// context-gated launch options for an agent, so it should be self-healed
+// (cleared). `runtimeModels` must be the agent's launch models for the active
+// auth context, or null/undefined when the runtime does not (yet) list the
+// agent — in which case we never report stale, to avoid clearing a still-valid
+// default while options are loading or the agent is unclassified. A stored id
+// that matches a model's alias is considered valid (not stale).
+export function isStoredDefaultModelStale(
+  storedModelId: string | null | undefined,
+  runtimeModels: ReadonlyArray<{ id: string; aliases?: readonly string[] | null }> | null | undefined,
+): boolean {
+  if (!storedModelId || !runtimeModels) {
+    return false;
+  }
+  return !runtimeModels.some(
+    (model) => model.id === storedModelId || (model.aliases ?? []).includes(storedModelId),
+  );
+}
+
 export function resolveAgentModelInfo(
   groups: AgentModelGroup[],
   modelRegistries: AgentModelRegistry[],


### PR DESCRIPTION
Fixes a customer-facing bug (10+ users): every new chat thread showed *"Stored default model is no longer available"* + *"model 'us.anthropic.…' is not supported for agent 'claude'"*, recurring forever.

## Root cause
The new-thread (cowork) path resolved the stored default against the **cloud catalog alone** — every model across all auth contexts, including bedrock `us.anthropic.*` ids — instead of the runtime's context-gated launch options that every other launch path (composer/home/bootstrap) already merges. A stored default carried over from another context (e.g. a bedrock id after switching to oauth) was sent to the runtime (`not supported`), and the stale pref was never cleared, so the warning re-fired on every new thread.

## Fix
- **Gate** `createThread`'s model set to the runtime launch options (merge, runtime wins) so the resolved default is always valid in the live auth context.
- **Self-heal**: clear the stored default when it's absent from the gated set (`isStoredDefaultModelStale` + `withClearedDefaultModelIdByAgentKind`, unit-tested) so the warning stops recurring.

14 tests pass (6 new), `tsc` clean, desktop build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)