### PR TITLE
fix(catalog): drop sourceless native pins + update catalog tests for the refresh

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -357,14 +357,14 @@ mod tests {
 
         let claude = &catalog.agents[0];
         assert_eq!(claude.kind, "claude");
-        assert_eq!(claude.harness.agent_process.version, "0.29.0");
+        assert_eq!(claude.harness.agent_process.version, "0.44.0");
         assert_eq!(
             claude
                 .harness
                 .native
                 .as_ref()
                 .map(|pin| pin.version.as_str()),
-            Some("2.1.170 (Claude Code)")
+            Some("2.1.181")
         );
         assert_eq!(
             claude
@@ -374,13 +374,19 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["bedrock", "anthropic-api", "anthropic-oauth"]
         );
-        let sonnet = &claude.session.models[0];
-        assert_eq!(sonnet.id, "sonnet");
-        assert_eq!(sonnet.availability.any_of, vec!["anthropic-api"]);
-        assert!(sonnet.default_visible);
-        let effort = sonnet.controls.get("effort").expect("effort control");
-        assert_eq!(effort.values, vec!["low", "medium", "high"]);
-        assert_eq!(effort.observed_value.as_deref(), Some("high"));
+        let first = &claude.session.models[0];
+        assert_eq!(first.id, "default");
+        assert_eq!(
+            first.availability.any_of,
+            vec!["anthropic-api", "anthropic-oauth", "bedrock"]
+        );
+        assert!(first.default_visible);
+        let effort = first.controls.get("effort").expect("effort control");
+        assert_eq!(
+            effort.values,
+            vec!["default", "low", "medium", "high", "xhigh", "max"]
+        );
+        assert_eq!(effort.observed_value.as_deref(), Some("default"));
         assert_eq!(effort.default, None);
 
         let codex = &catalog.agents[1];
@@ -391,11 +397,31 @@ mod tests {
             .find(|control| control.key == "model")
             .expect("model control");
         let mapping = model_control.mapping.as_ref().expect("model mapping");
-        assert_eq!(mapping.switch_via.as_deref(), Some("setSessionModel"));
-        assert_eq!(mapping.variant_syntax.as_deref(), Some("slash-effort"));
+        assert_eq!(mapping.switch_via.as_deref(), Some("configOption"));
+        assert_eq!(mapping.variant_syntax.as_deref(), None);
+
+        let cursor = &catalog.agents[2];
+        assert!(cursor.provenance.attestation.is_none());
+        assert!(cursor.harness.native.is_none());
+        // Cursor is the variant-carrying agent: its model control declares the
+        // bracket-params syntax and its models carry probe-observed variant ids.
+        let cursor_model_control = cursor
+            .session
+            .controls
+            .iter()
+            .find(|control| control.key == "model")
+            .expect("cursor model control");
+        let cursor_mapping = cursor_model_control
+            .mapping
+            .as_ref()
+            .expect("cursor model mapping");
+        assert_eq!(
+            cursor_mapping.variant_syntax.as_deref(),
+            Some("bracket-params")
+        );
         // Variant families are draft data — anchor on the stable shape, not a
         // fixed model id (the probed model list moves between catalog runs).
-        let with_variants = codex
+        let with_variants = cursor
             .session
             .models
             .iter()
@@ -405,16 +431,12 @@ mod tests {
                     .as_ref()
                     .is_some_and(|provenance| !provenance.variant_ids.is_empty())
             })
-            .expect("some codex model carries variant ids");
+            .expect("some cursor model carries variant ids");
         let provenance = with_variants.provenance.as_ref().expect("provenance");
         assert!(provenance
             .variant_ids
             .iter()
-            .any(|variant| variant.starts_with(&format!("{}/", with_variants.id))));
-
-        let cursor = &catalog.agents[2];
-        assert!(cursor.provenance.attestation.is_none());
-        assert!(cursor.harness.native.is_none());
+            .any(|variant| variant.starts_with(&format!("{}[", with_variants.id))));
 
         let opencode = &catalog.agents[5];
         assert!(opencode

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -36,10 +36,10 @@ fn pins_surface_catalog_harness_versions() {
     let catalog = draft_catalog();
 
     let claude = catalog.pins("claude").expect("claude pins");
-    assert_eq!(claude.agent_process.version, "0.29.0");
+    assert_eq!(claude.agent_process.version, "0.44.0");
     assert_eq!(
         claude.native.as_ref().map(|pin| pin.version.as_str()),
-        Some("2.1.170 (Claude Code)")
+        Some("2.1.181")
     );
 
     // Cursor has no native pin; unknown kinds have no pins at all.
@@ -99,16 +99,26 @@ fn models_intersect_availability_with_active_contexts() {
     assert_eq!(
         model_ids(catalog.models("claude", &contexts(&["anthropic-api"]))),
         vec![
+            "default",
+            "opus[1m]",
             "sonnet",
             "sonnet[1m]",
             "haiku",
+            "opus",
             "claude-fable-5",
             "claude-opus-4-8"
         ]
     );
     assert_eq!(
         model_ids(catalog.models("claude", &contexts(&["anthropic-oauth"]))),
-        vec!["haiku", "claude-fable-5", "claude-opus-4-8", "opus"]
+        vec![
+            "default",
+            "sonnet",
+            "haiku",
+            "opus",
+            "claude-fable-5",
+            "claude-opus-4-8"
+        ]
     );
     // No matching context, no models; unknown kind, no models.
     assert!(catalog
@@ -130,8 +140,8 @@ fn baseline_counts_as_a_context_when_active() {
             "opencode/big-pickle",
             "opencode/deepseek-v4-flash-free",
             "opencode/mimo-v2.5-free",
-            "opencode/minimax-m3-free",
-            "opencode/nemotron-3-ultra-free"
+            "opencode/nemotron-3-ultra-free",
+            "opencode/north-mini-code-free"
         ]
     );
 }
@@ -147,7 +157,7 @@ fn visible_models_are_the_default_visible_subset_of_available() {
     assert!(available.contains(&"claude-opus-4-8"));
     assert_eq!(
         model_ids(catalog.visible_models("claude", &contexts(&["anthropic-oauth"]))),
-        vec!["haiku", "claude-fable-5", "opus"]
+        vec!["default", "sonnet", "haiku", "opus", "claude-fable-5"]
     );
 }
 
@@ -158,7 +168,7 @@ fn controls_return_the_per_model_matrix() {
     let opus = catalog.controls("claude", "opus").expect("opus controls");
     assert_eq!(
         opus.get("effort").expect("effort control").values,
-        vec!["low", "medium", "high", "xhigh"]
+        vec!["default", "low", "medium", "high", "xhigh", "max"]
     );
     assert!(opus.contains_key("mode"));
     assert!(catalog.controls("claude", "not-a-model").is_none());
@@ -209,19 +219,19 @@ fn validate_launch_availability_beats_visibility() {
 fn validate_launch_rejects_gated_and_unknown_models() {
     let catalog = draft_catalog();
 
-    // sonnet is api-only: gated under oauth, with the unlock condition.
+    // sonnet[1m] is api-only: gated under oauth, with the unlock condition.
     let gated = catalog
         .validate_launch(
             "claude",
             &contexts(&["anthropic-oauth"]),
-            Some("sonnet"),
+            Some("sonnet[1m]"),
             None,
         )
         .expect_err("api-only model must be gated under oauth");
     assert_eq!(
         gated,
         SelectionUnsupported::ModelGated {
-            model_id: "sonnet".into(),
+            model_id: "sonnet[1m]".into(),
             required_contexts: vec!["anthropic-api".into()],
         }
     );
@@ -262,8 +272,8 @@ fn validate_launch_defaults_to_the_first_visible_available_model() {
     let selection = catalog
         .validate_launch("claude", &contexts(&["anthropic-oauth"]), None, None)
         .expect("default resolution never hard-fails");
-    assert_eq!(selection.model_id.as_deref(), Some("haiku"));
-    assert_eq!(selection.launch_model_id.as_deref(), Some("haiku"));
+    assert_eq!(selection.model_id.as_deref(), Some("default"));
+    assert_eq!(selection.launch_model_id.as_deref(), Some("default"));
 
     // No model available at all (claude has no baseline-available models):
     // selection stays empty — the harness default applies, never a block.
@@ -293,17 +303,22 @@ fn validate_launch_honors_curation_defaults_per_context() {
 fn validate_launch_resolves_probe_observed_variant_ids() {
     let catalog = draft_catalog();
 
-    // "gpt-5.5/xhigh" is a probe-observed variant id of gpt-5.5.
+    // The fully-qualified bracket id is a probe-observed variant id of
+    // cursor's claude-fable-5: resolution matches it against the model's
+    // recorded variantIds and preserves it as the launch id.
     let selection = catalog
         .validate_launch(
-            "codex",
-            &contexts(&["openai-api"]),
-            Some("gpt-5.5/xhigh"),
+            "cursor",
+            &contexts(&["cursor-login"]),
+            Some("claude-fable-5[thinking=true,context=300k,effort=high]"),
             None,
         )
         .expect("observed variant id must resolve");
-    assert_eq!(selection.model_id.as_deref(), Some("gpt-5.5"));
-    assert_eq!(selection.launch_model_id.as_deref(), Some("gpt-5.5/xhigh"));
+    assert_eq!(selection.model_id.as_deref(), Some("claude-fable-5"));
+    assert_eq!(
+        selection.launch_model_id.as_deref(),
+        Some("claude-fable-5[thinking=true,context=300k,effort=high]")
+    );
 }
 
 #[test]
@@ -341,7 +356,24 @@ fn validate_launch_composes_variants_by_declared_syntax() {
     ));
 
     // slash-effort composition validates effort against the base model.
-    let slash = catalog
+    // No probed agent currently declares slash-effort (codex's fresh probe
+    // dropped its variant syntax), so declare it on codex's model control to
+    // exercise the composition path: gpt-5.4 carries reasoning_effort
+    // ["low","medium","high","xhigh"], so "/medium" composes.
+    let mut raw: serde_json::Value =
+        serde_json::from_str(draft_catalog_json()).expect("draft must parse");
+    raw["agents"][1]["session"]["controls"]
+        .as_array_mut()
+        .expect("codex controls")
+        .iter_mut()
+        .find(|control| control["key"] == "model")
+        .expect("codex model control")["mapping"]["variantSyntax"] =
+        serde_json::json!("slash-effort");
+    let slash_document =
+        parse_agent_catalog_json(&serde_json::to_string(&raw).expect("serialize"))
+            .expect("doctored draft must load");
+    let slash_catalog = ActiveCatalog::new(Arc::new(slash_document));
+    let slash = slash_catalog
         .validate_launch(
             "codex",
             &contexts(&["openai-oauth"]),
@@ -349,6 +381,7 @@ fn validate_launch_composes_variants_by_declared_syntax() {
             None,
         )
         .expect("slash-effort variant must resolve");
+    assert_eq!(slash.model_id.as_deref(), Some("gpt-5.4"));
     assert_eq!(slash.launch_model_id.as_deref(), Some("gpt-5.4/medium"));
 
     // claude declares no variantSyntax: composition never applies.

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
@@ -331,7 +331,7 @@ mod tests {
         let claude = &mut catalog.agents[0];
         let duplicate = claude.session.models[0].clone();
         claude.session.models.push(duplicate);
-        expect_invalid(&catalog, "model 'sonnet' is duplicated");
+        expect_invalid(&catalog, "model 'default' is duplicated");
     }
 
     #[test]
@@ -424,9 +424,9 @@ mod tests {
     #[test]
     fn rejects_model_control_default_outside_values() {
         let mut catalog = draft_catalog();
-        let sonnet = &mut catalog.agents[0].session.models[0];
-        let effort = sonnet.controls.get_mut("effort").expect("effort control");
-        effort.default = Some("xhigh".to_string());
-        expect_invalid(&catalog, "default 'xhigh' is not a value");
+        let model = &mut catalog.agents[0].session.models[0];
+        let effort = model.controls.get_mut("effort").expect("effort control");
+        effort.default = Some("ultra".to_string());
+        expect_invalid(&catalog, "default 'ultra' is not a value");
     }
 }

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-06-18.4",
+  "catalogVersion": "2026-06-18.5",
   "probedAgainst": {
     "registryVersion": "2026-06-10.1"
   },
-  "generatedAt": "2026-06-18T05:27:42.106Z",
+  "generatedAt": "2026-06-18T06:23:46.960Z",
   "agents": [
     {
       "kind": "claude",
@@ -1470,9 +1470,6 @@
               "acp"
             ]
           }
-        },
-        "native": {
-          "version": "2.1.177 (Claude Code)"
         }
       },
       "authContexts": [
@@ -3249,9 +3246,6 @@
               "acp"
             ]
           }
-        },
-        "native": {
-          "version": "2.1.177 (Claude Code)"
         }
       },
       "authContexts": [

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-06-18.4",
+  "catalogVersion": "2026-06-18.5",
   "probedAgainst": {
     "registryVersion": "2026-06-10.1"
   },
-  "generatedAt": "2026-06-18T05:27:42.106Z",
+  "generatedAt": "2026-06-18T06:23:46.960Z",
   "agents": [
     {
       "kind": "claude",
@@ -1470,9 +1470,6 @@
               "acp"
             ]
           }
-        },
-        "native": {
-          "version": "2.1.177 (Claude Code)"
         }
       },
       "authContexts": [
@@ -3249,9 +3246,6 @@
               "acp"
             ]
           }
-        },
-        "native": {
-          "version": "2.1.177 (Claude Code)"
         }
       },
       "authContexts": [

--- a/scripts/agent-catalog/resolve-pins.mjs
+++ b/scripts/agent-catalog/resolve-pins.mjs
@@ -90,6 +90,14 @@ for (const agent of catalog.agents) {
     agent.harness.native.version = version;
     agent.harness.native.source = source;
     console.log(`   native        ${version}  (${source.kind})`);
+  } else if (agent.harness.native) {
+    // The probe's nativeCli attestation can leak a foreign launcher (e.g. the
+    // bundled `claude` binary reported as the nativeCli for cursor/opencode)
+    // onto agents that have no native artifact in the registry. Such a pin can
+    // never be sourced, so drop it — otherwise the bundled catalog ships a
+    // sourceless native entry and stops being a complete lockfile.
+    delete agent.harness.native;
+    console.log(`   native        (dropped — no registry native artifact)`);
   }
 
   const ap = await resolveAgentProcess(


### PR DESCRIPTION
Fixes two Cargo-test regressions from #738 (the catalog refresh), which slipped through because #738 was merged before its Cargo job finished. **Main's Cargo is currently red; this greens it.**

## 1. Real catalog bug — sourceless native pins
`resolve-pins` minted `native` pins for **cursor** and **opencode** from the probe's red-herring `nativeCli` (the bundled `claude` launcher, reported as `"2.1.177 (Claude Code)"`). Those agents have **no native artifact in the registry**, so the pin could never be sourced — failing `bundled_catalog_is_a_complete_lockfile` and the runtime install path (`NoPinForPlatform`). Pre-#738 they correctly had no native pin.

Fix: `resolve-pins` now **drops** a native pin when the registry declares no native artifact (claude/codex keep their real, sourced native pins).

## 2. Test drift — Rust catalog tests
The catalog tests hardcoded pre-refresh values. Updated to the refreshed catalog, **preserving each test's intent**:
- versions: claude `0.29→0.44`, native `2.1.170→2.1.181`
- opus effort set, per-context model lists, `models[0]` `sonnet→default`
- api-only-gated case → `sonnet[1m]` (sonnet is now oauth-available)
- variant tests repointed to cursor's bracket-params; slash-effort compose path exercised via a doctored fixture (no live agent declares slash-effort after the refresh)

## Verification
`cargo test -p anyharness-lib`: **718 passed / 0 failed**. `validate-agent-catalog`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)