### PR TITLE
feat(desktop): misc UI polish — tab width, markdown headings, codex spinner, default ⌘N

### DIFF
--- a/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
+++ b/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
@@ -72,7 +72,7 @@ export function MarkdownRenderer({
     // GFM task lists: drop the stray disc bullet and align the checkbox inline.
     // Descendant selector (not `>input`) so it also matches loose lists where
     // the checkbox sits inside a <p>; avoid flex so nested blocks still stack.
-    "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
+    "[&_ul.contains-task-list]:list-none [&>ul.contains-task-list]:pl-0",
     "[&_li.task-list-item]:pl-0",
     "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
     className,

--- a/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
+++ b/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
@@ -20,6 +20,9 @@ type MdTag =
   | "h1"
   | "h2"
   | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
   | "p"
   | "ul"
   | "ol"
@@ -66,6 +69,10 @@ export function MarkdownRenderer({
     "[&_li>p]:my-0",
     "[&_li>ol]:mt-2",
     "[&_li>ul]:mt-2",
+    // GFM task lists: drop the stray disc bullet and align the checkbox inline.
+    "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
+    "[&_li.task-list-item]:pl-0 [&_li.task-list-item]:flex [&_li.task-list-item]:items-start [&_li.task-list-item]:gap-2",
+    "[&_li.task-list-item>input]:mt-1 [&_li.task-list-item>input]:size-3.5 [&_li.task-list-item>input]:shrink-0 [&_li.task-list-item>input]:accent-link-foreground",
     className,
   ].filter(Boolean).join(" ");
 
@@ -75,11 +82,17 @@ export function MarkdownRenderer({
         remarkPlugins={[remarkGfm]}
         components={{
           h1: (props) =>
-            mdHtmlElement("h1", "mb-2 mt-3 text-chat leading-[var(--text-chat--line-height)] font-bold text-foreground", props),
+            mdHtmlElement("h1", "mb-3 mt-6 border-b border-border pb-1.5 text-[24px] font-semibold leading-[1.25] text-foreground first:mt-0", props),
           h2: (props) =>
-            mdHtmlElement("h2", "mb-2 mt-3 text-chat leading-[var(--text-chat--line-height)] font-bold text-foreground", props),
+            mdHtmlElement("h2", "mb-2.5 mt-5 border-b border-border pb-1 text-[20px] font-semibold leading-[1.25] text-foreground", props),
           h3: (props) =>
-            mdHtmlElement("h3", "mb-1 mt-2 text-chat leading-[var(--text-chat--line-height)] font-semibold text-foreground", props),
+            mdHtmlElement("h3", "mb-2 mt-5 text-[17px] font-semibold leading-[1.3] text-foreground", props),
+          h4: (props) =>
+            mdHtmlElement("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground", props),
+          h5: (props) =>
+            mdHtmlElement("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground", props),
+          h6: (props) =>
+            mdHtmlElement("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground", props),
           p: (props) =>
             mdHtmlElement("p", "my-2 text-chat leading-[var(--text-chat--line-height)] text-foreground", props),
           ul: (props) =>

--- a/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
+++ b/apps/desktop/src/components/content/ui/MarkdownRenderer.tsx
@@ -70,9 +70,11 @@ export function MarkdownRenderer({
     "[&_li>ol]:mt-2",
     "[&_li>ul]:mt-2",
     // GFM task lists: drop the stray disc bullet and align the checkbox inline.
+    // Descendant selector (not `>input`) so it also matches loose lists where
+    // the checkbox sits inside a <p>; avoid flex so nested blocks still stack.
     "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
-    "[&_li.task-list-item]:pl-0 [&_li.task-list-item]:flex [&_li.task-list-item]:items-start [&_li.task-list-item]:gap-2",
-    "[&_li.task-list-item>input]:mt-1 [&_li.task-list-item>input]:size-3.5 [&_li.task-list-item>input]:shrink-0 [&_li.task-list-item>input]:accent-link-foreground",
+    "[&_li.task-list-item]:pl-0",
+    "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
     className,
   ].filter(Boolean).join(" ");
 

--- a/apps/desktop/src/components/settings/panes/GeneralPane.tsx
+++ b/apps/desktop/src/components/settings/panes/GeneralPane.tsx
@@ -12,7 +12,7 @@ import { APP_ROUTES } from "@/config/app-routes";
 import { useAvailableEditors } from "@/hooks/access/tauri/shell/use-available-editors";
 import { resolvePreferredOpenTarget } from "@/lib/domain/chat/composer/preference-resolvers";
 import { emitTurnEnd } from "@/lib/infra/events/turn-end-events";
-import type { TurnEndSoundId } from "@/lib/domain/preferences/user/model";
+import type { DefaultNewWorkspaceMode, TurnEndSoundId } from "@/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 type SettingsOpenTargetIconId =
@@ -38,6 +38,10 @@ const BRANCH_PREFIX_OPTIONS = [
   { id: "proliferate" as const, label: "Proliferate" },
   { id: "github_username" as const, label: "GitHub username" },
 ];
+const NEW_WORKSPACE_MODE_OPTIONS: { id: DefaultNewWorkspaceMode; label: string }[] = [
+  { id: "worktree", label: "Worktree" },
+  { id: "local", label: "Local" },
+];
 const SOUND_LABELS: Record<TurnEndSoundId, string> = {
   ding: "Ding",
   gong: "Gong",
@@ -53,6 +57,7 @@ export function GeneralPane() {
   const preferences = useUserPreferencesStore(useShallow((state) => ({
     defaultOpenInTargetId: state.defaultOpenInTargetId,
     branchPrefixType: state.branchPrefixType,
+    defaultNewWorkspaceMode: state.defaultNewWorkspaceMode,
     themePreset: state.themePreset,
     turnEndSoundEnabled: state.turnEndSoundEnabled,
     turnEndSoundId: state.turnEndSoundId,
@@ -80,6 +85,9 @@ export function GeneralPane() {
   const currentBranchPrefixLabel = BRANCH_PREFIX_OPTIONS.find(
     (option) => option.id === preferences.branchPrefixType,
   )?.label ?? "None";
+  const currentNewWorkspaceModeLabel = NEW_WORKSPACE_MODE_OPTIONS.find(
+    (option) => option.id === preferences.defaultNewWorkspaceMode,
+  )?.label ?? "Worktree";
 
   return (
     <section className="space-y-5">
@@ -124,6 +132,26 @@ export function GeneralPane() {
                   label: option.label,
                   selected: preferences.branchPrefixType === option.id,
                   onSelect: () => preferences.set("branchPrefixType", option.id),
+                })),
+              }]}
+            />
+          </SettingsCardRow>
+
+          <SettingsCardRow
+            label="New workspace (⌘N)"
+            description="What ⌘N creates by default"
+          >
+            <SettingsMenu
+              label={currentNewWorkspaceModeLabel}
+              className="w-44"
+              menuClassName="w-44"
+              groups={[{
+                id: "new-workspace-mode",
+                options: NEW_WORKSPACE_MODE_OPTIONS.map((option) => ({
+                  id: option.id,
+                  label: option.label,
+                  selected: preferences.defaultNewWorkspaceMode === option.id,
+                  onSelect: () => preferences.set("defaultNewWorkspaceMode", option.id),
                 })),
               }]}
             />

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -77,7 +77,7 @@ export function SidebarStatusIndicatorView({
           {glyph}
         </IconButton>
       ) : (
-        glyph
+        <span role="img" aria-label={indicator.tooltip}>{glyph}</span>
       )}
     </Tooltip>
   );

--- a/apps/desktop/src/config/shortcuts/groups.ts
+++ b/apps/desktop/src/config/shortcuts/groups.ts
@@ -30,6 +30,7 @@ export const SHORTCUT_GROUPS = [
   {
     title: "Workspaces",
     shortcutKeys: [
+      "newDefault",
       "newWorktree",
       "newLocal",
       "newCloud",

--- a/apps/desktop/src/config/shortcuts/workspace-shortcuts.ts
+++ b/apps/desktop/src/config/shortcuts/workspace-shortcuts.ts
@@ -1,6 +1,15 @@
 import type { ShortcutDef } from "./types";
 
 export const WORKSPACE_SHORTCUTS = {
+  newDefault: {
+    id: "workspace.new-default",
+    label: "⌘N",
+    nonMacLabel: "Ctrl+N",
+    description: "New workspace",
+    owner: "js",
+    match: { kind: "fixed-code", code: "KeyN", meta: true, shift: false, alt: false },
+    allowInInputs: true,
+  },
   newWorktree: {
     id: "workspace.new-worktree",
     label: "⌘⌥N",

--- a/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -121,6 +121,15 @@ export function useAppShortcuts(actions: AppCommandActions): void {
     store.setThreadsCollapsed(!store.threadsCollapsed);
   });
 
+  useShortcutHandler("workspace.new-default", () => {
+    const mode = useUserPreferencesStore.getState().defaultNewWorkspaceMode;
+    if (mode === "local") {
+      actions.newLocalWorkspace.execute("shortcut");
+    } else {
+      actions.newWorktreeWorkspace.execute("shortcut");
+    }
+  });
+
   useShortcutHandler("workspace.new-local", () => {
     actions.newLocalWorkspace.execute("shortcut");
   });

--- a/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
+++ b/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
@@ -58,6 +58,7 @@ export function selectPersistedUserPreferencesSlice(
       preferences.defaultLiveSessionControlValuesByAgentKind,
     defaultOpenInTargetId: preferences.defaultOpenInTargetId,
     branchPrefixType: preferences.branchPrefixType,
+    defaultNewWorkspaceMode: preferences.defaultNewWorkspaceMode,
     turnEndSoundEnabled: preferences.turnEndSoundEnabled,
     turnEndSoundId: preferences.turnEndSoundId,
     transparentChromeEnabled: preferences.transparentChromeEnabled,

--- a/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
@@ -143,11 +143,13 @@ describe("user preference migration", () => {
       worktreeAutoDeleteLimit: 8,
       pasteAttachmentsEnabled: "yes" as unknown as boolean,
       defaultOpenInTargetId: "  ",
+      defaultNewWorkspaceMode: "cloud" as unknown as typeof USER_PREFERENCE_DEFAULTS.defaultNewWorkspaceMode,
       uiFontSizeId: "giant" as typeof USER_PREFERENCE_DEFAULTS.uiFontSizeId,
       readableCodeFontSizeId: "tiny" as typeof USER_PREFERENCE_DEFAULTS.readableCodeFontSizeId,
     });
 
     expect(result.changed).toBe(true);
+    expect(result.preferences.defaultNewWorkspaceMode).toBe("worktree");
     expect(result.preferences.subagentsEnabled).toBe(true);
     expect(result.preferences.coworkWorkspaceDelegationEnabled).toBe(true);
     expect(result.preferences.cloudRuntimeInputSyncEnabled).toBe(false);
@@ -157,5 +159,11 @@ describe("user preference migration", () => {
     expect(result.preferences.uiFontSizeId).toBe("default");
     expect(result.preferences.readableCodeFontSizeId).toBe("default");
     expect(USER_PREFERENCE_DEFAULTS.transparentChromeEnabled).toBe(false);
+  });
+
+  it("preserves a valid persisted defaultNewWorkspaceMode", () => {
+    const result = migrateUserPreferences({ defaultNewWorkspaceMode: "local" });
+
+    expect(result.preferences.defaultNewWorkspaceMode).toBe("local");
   });
 });

--- a/apps/desktop/src/lib/domain/preferences/user/migration.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.ts
@@ -82,6 +82,14 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
     changed = true;
   }
 
+  if (
+    next.defaultNewWorkspaceMode !== "worktree"
+    && next.defaultNewWorkspaceMode !== "local"
+  ) {
+    next.defaultNewWorkspaceMode = PERSISTED_RECORD_BACKFILL.defaultNewWorkspaceMode;
+    changed = true;
+  }
+
   const sanitizedDefaultOpenInTargetId = typeof next.defaultOpenInTargetId === "string"
     ? next.defaultOpenInTargetId.trim()
     : "";

--- a/apps/desktop/src/lib/domain/preferences/user/model.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/model.ts
@@ -13,6 +13,7 @@ import { DEFAULT_OPEN_IN_TARGET_ID } from "@/config/open-target-defaults";
 
 export type BranchPrefixType = "none" | "proliferate" | "github_username";
 export type TurnEndSoundId = "ding" | "gong";
+export type DefaultNewWorkspaceMode = "worktree" | "local";
 
 export interface UserPreferences {
   themePreset: ThemePreset;
@@ -26,6 +27,7 @@ export interface UserPreferences {
   defaultLiveSessionControlValuesByAgentKind: DefaultLiveSessionControlValuesByAgentKind;
   defaultOpenInTargetId: string;
   branchPrefixType: BranchPrefixType;
+  defaultNewWorkspaceMode: DefaultNewWorkspaceMode;
   turnEndSoundEnabled: boolean;
   turnEndSoundId: TurnEndSoundId;
   transparentChromeEnabled: boolean;
@@ -50,6 +52,7 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   defaultLiveSessionControlValuesByAgentKind: {},
   defaultOpenInTargetId: DEFAULT_OPEN_IN_TARGET_ID,
   branchPrefixType: "none",
+  defaultNewWorkspaceMode: "worktree",
   turnEndSoundEnabled: false,
   turnEndSoundId: "ding",
   transparentChromeEnabled: false,
@@ -74,6 +77,7 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   defaultLiveSessionControlValuesByAgentKind: {},
   defaultOpenInTargetId: DEFAULT_OPEN_IN_TARGET_ID,
   branchPrefixType: "none",
+  defaultNewWorkspaceMode: "worktree",
   turnEndSoundEnabled: false,
   turnEndSoundId: "ding",
   // Existing persisted records keep the legacy transparent chrome default;

--- a/apps/desktop/src/lib/domain/preferences/user/persisted-keys.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/persisted-keys.test.ts
@@ -26,4 +26,13 @@ describe("persisted user preference keys", () => {
     });
     expect(hasDeprecatedUserPreferenceKeys(persisted)).toBe(true);
   });
+
+  it("treats defaultNewWorkspaceMode as a known key, not a forward-compatible extra", () => {
+    const persisted = { defaultNewWorkspaceMode: "local" };
+
+    expect(pickLegacyUserPreferencesInput(persisted)).toEqual({
+      defaultNewWorkspaceMode: "local",
+    });
+    expect(getForwardCompatibleUserPreferenceExtras(persisted)).toEqual({});
+  });
 });

--- a/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
@@ -12,6 +12,7 @@ const USER_PREFERENCE_KEYS = [
   "defaultLiveSessionControlValuesByAgentKind",
   "defaultOpenInTargetId",
   "branchPrefixType",
+  "defaultNewWorkspaceMode",
   "turnEndSoundEnabled",
   "turnEndSoundId",
   "transparentChromeEnabled",

--- a/apps/desktop/src/lib/domain/workspaces/tabs/chrome-layout.ts
+++ b/apps/desktop/src/lib/domain/workspaces/tabs/chrome-layout.ts
@@ -1,7 +1,7 @@
-export const CHROME_TAB_MIN_WIDTH = 84;
+export const CHROME_TAB_MIN_WIDTH = 136;
 export const CHROME_TAB_COMPACT_WIDTH = 60;
 export const CHROME_TAB_SMALL_WIDTH = 84;
-export const CHROME_TAB_MAX_WIDTH = 160;
+export const CHROME_TAB_MAX_WIDTH = 200;
 export const CHROME_DELEGATED_TAB_MAX_WIDTH = CHROME_TAB_SMALL_WIDTH;
 export const CHROME_TAB_GAP = 3;
 export const CHROME_TAB_CONTENT_MARGIN = 0;

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -1931,7 +1931,7 @@ body {
 }
 
 .proliferate-spinner {
-  animation: proliferate-spinner-rotate 1.1s linear infinite;
+  animation: proliferate-spinner-rotate 1.4s linear infinite;
   transform-origin: center;
   will-change: transform;
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -194,7 +194,7 @@ export const MarkdownBody = memo(function MarkdownBody({
     // GFM task lists: drop the stray disc bullet and align the checkbox inline.
     // Descendant selector (not `>input`) so it also matches loose lists where
     // the checkbox sits inside a <p>; avoid flex so nested blocks still stack.
-    "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
+    "[&_ul.contains-task-list]:list-none [&>ul.contains-task-list]:pl-0",
     "[&_li.task-list-item]:pl-0",
     "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
     className,

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -55,6 +55,9 @@ type MdTag =
   | "h1"
   | "h2"
   | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
   | "li"
   | "ol"
   | "p"
@@ -82,6 +85,12 @@ const STATIC_MARKDOWN_COMPONENTS = {
     mdHtmlElement("h2", "mb-2.5 mt-5 text-[20px] font-semibold leading-[1.25] text-foreground", props),
   h3: (props: MdElementProps) =>
     mdHtmlElement("h3", "mb-2.5 mt-5 text-[17px] font-semibold leading-[22px] text-foreground", props),
+  h4: (props: MdElementProps) =>
+    mdHtmlElement("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground", props),
+  h5: (props: MdElementProps) =>
+    mdHtmlElement("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground", props),
+  h6: (props: MdElementProps) =>
+    mdHtmlElement("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground", props),
   p: (props: MdElementProps) =>
     mdHtmlElement("p", "mb-[0.6875rem] mt-0 text-chat leading-[var(--text-chat--line-height)] text-foreground", props),
   ul: (props: MdElementProps) =>
@@ -182,6 +191,10 @@ export const MarkdownBody = memo(function MarkdownBody({
     "[&_li>ul]:mt-2",
     "[&>ol+p]:mt-4",
     "[&>ul+p]:mt-4",
+    // GFM task lists: drop the stray disc bullet and align the checkbox inline.
+    "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
+    "[&_li.task-list-item]:pl-0 [&_li.task-list-item]:flex [&_li.task-list-item]:items-start [&_li.task-list-item]:gap-2",
+    "[&_li.task-list-item>input]:mt-1 [&_li.task-list-item>input]:size-3.5 [&_li.task-list-item>input]:shrink-0 [&_li.task-list-item>input]:accent-link-foreground",
     className,
   ].filter(Boolean).join(" ");
 

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -192,9 +192,11 @@ export const MarkdownBody = memo(function MarkdownBody({
     "[&>ol+p]:mt-4",
     "[&>ul+p]:mt-4",
     // GFM task lists: drop the stray disc bullet and align the checkbox inline.
+    // Descendant selector (not `>input`) so it also matches loose lists where
+    // the checkbox sits inside a <p>; avoid flex so nested blocks still stack.
     "[&_ul.contains-task-list]:list-none [&_ul.contains-task-list]:pl-0",
-    "[&_li.task-list-item]:pl-0 [&_li.task-list-item]:flex [&_li.task-list-item]:items-start [&_li.task-list-item]:gap-2",
-    "[&_li.task-list-item>input]:mt-1 [&_li.task-list-item>input]:size-3.5 [&_li.task-list-item>input]:shrink-0 [&_li.task-list-item>input]:accent-link-foreground",
+    "[&_li.task-list-item]:pl-0",
+    "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
     className,
   ].filter(Boolean).join(" ");
 

--- a/apps/packages/ui/src/primitives/Spinner.tsx
+++ b/apps/packages/ui/src/primitives/Spinner.tsx
@@ -10,20 +10,21 @@ export function Spinner({ className }: SpinnerProps) {
     >
       <svg
         aria-hidden="true"
-        className="size-full overflow-visible"
-        viewBox="0 0 20 20"
+        className="size-full"
+        viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <circle
-          cx="10"
-          cy="10"
-          r="7.25"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeDasharray="30 18"
-          opacity="0.72"
+        {/* Faint full-ring track. */}
+        <path
+          opacity="0.3"
+          d="M18 12C18 8.68629 15.3137 6 12 6C8.68629 6 6 8.68629 6 12C6 15.3137 8.68629 18 12 18C15.3137 18 18 15.3137 18 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z"
+          fill="currentColor"
+        />
+        {/* Solid quarter arc that rotates over the track. */}
+        <path
+          d="M12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12H6C6 15.3137 8.68629 18 12 18C15.3137 18 18 15.3137 18 12C18 8.68629 15.3137 6 12 6V4Z"
+          fill="currentColor"
         />
       </svg>
     </div>

--- a/apps/packages/ui/src/primitives/Spinner.tsx
+++ b/apps/packages/ui/src/primitives/Spinner.tsx
@@ -21,7 +21,7 @@ export function Spinner({ className }: SpinnerProps) {
           d="M18 12C18 8.68629 15.3137 6 12 6C8.68629 6 6 8.68629 6 12C6 15.3137 8.68629 18 12 18C15.3137 18 18 15.3137 18 12ZM20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12Z"
           fill="currentColor"
         />
-        {/* Solid quarter arc that rotates over the track. */}
+        {/* Solid ~270° arc over the track; the moving 90° gap reads as motion. */}
         <path
           d="M12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12H6C6 15.3137 8.68629 18 12 18C15.3137 18 18 15.3137 18 12C18 8.68629 15.3137 6 12 6V4Z"
           fill="currentColor"


### PR DESCRIPTION
Miscellaneous desktop UI improvements.

## Changes
- **Tabs** — widen min/max tab width so tabs don't over-shrink (`chrome-layout.ts`).
- **Markdown headings** — both the right-panel file view (`MarkdownRenderer`) and the chat transcript (`MarkdownBody`) only styled h1–h3 (and at body size in the file view); h4–h6 fell back to Tailwind preflight (`font-size: inherit`), so `#` looked the same size as `####`. Now a real descending scale (24/20/17/15/13/12), with a document-style h1/h2 underline in the file view.
- **GFM task lists** — `- [ ]` / `- [x]` no longer render a stray disc bullet next to the checkbox; checkbox aligned inline and accent-tinted.
- **Spinner** — replaced the flat dashed-stroke ring with a codex-style faint full-ring track + solid quarter arc, eased to a calmer 1.4s spin. Shared `ui` primitive, so it updates everywhere (sidebar indicators, update pill, etc.).
- **Default ⌘N mode** — new `defaultNewWorkspaceMode` preference (worktree | local) in Settings → General, plus a plain ⌘N shortcut that dispatches the existing worktree/local action per the preference. Existing ⌘⌥N / ⌘⇧N / ⌘⌃N unchanged.

## Verification
- `tsc -p tsconfig.json` passes for `ui`, `product-domain`, `product-ui`; `tsc --noEmit` passes for `desktop`.
- `scripts/check_frontend_boundaries.py` passes.
- Manual: open a README in the right panel (heading levels + checkbox list), send a `#`…`######` block in chat, toggle Settings → General → "New workspace (⌘N)" and press ⌘N, observe sidebar spinner on an iterating row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)