### PR TITLE
perf(chat): reflow transcript immediately on composer resize

### DIFF
--- a/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -5,8 +5,6 @@ import {
   computeChatSurfaceBottomInsetPx,
 } from "@/config/chat-layout";
 
-const CHAT_DOCK_RESIZE_SETTLE_MS = 90;
-
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   const [metrics, setMetrics] = useState({
@@ -54,21 +52,20 @@ export function useChatDockInset() {
       return;
     }
 
-    let settleTimer: number | null = null;
+    // Re-measure on the next frame after any observed resize. The composer
+    // textarea autosizes synchronously in a layout effect, so coalescing to a
+    // single rAF keeps the transcript's bottom inset in lockstep with the dock
+    // (no perceptible lag when a line is added/removed). A frame is enough to
+    // dedupe bursts; the inset only affects the scroll area above the dock, so
+    // re-measuring can't feed back into the observed elements.
     const scheduleMeasure = () => {
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
+      if (frameId !== null) {
+        return;
       }
-      settleTimer = window.setTimeout(() => {
-        settleTimer = null;
-        if (frameId !== null) {
-          window.cancelAnimationFrame(frameId);
-        }
-        frameId = window.requestAnimationFrame(() => {
-          frameId = null;
-          measure();
-        });
-      }, CHAT_DOCK_RESIZE_SETTLE_MS);
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        measure();
+      });
     };
 
     const observer = new ResizeObserver(() => {
@@ -87,9 +84,6 @@ export function useChatDockInset() {
 
     return () => {
       observer.disconnect();
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
-      }
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }


### PR DESCRIPTION
## Problem (#5 from the live-chat audit)
Adding/removing a line in the chat input is slow to reflow the transcript above it — the chat view visibly "takes time to process" before it shifts up/down.

## Root cause
The composer textarea autosizes **synchronously** in a layout effect ([use-composer-textarea-autosize.ts](apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts):73-75), so the dock grows/shrinks instantly. But the transcript's bottom inset is recomputed by `useChatDockInset`'s ResizeObserver through a **90ms settle `setTimeout`** before its rAF ([use-chat-dock-inset.ts](apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts), former `CHAT_DOCK_RESIZE_SETTLE_MS = 90`). The inset feeds the virtualizer's `paddingEnd` and pin target, so it lagged the composer by ~90ms + 1 frame.

## Fix
Coalesce re-measurement to a **single `requestAnimationFrame`** instead of the 90ms settle. Now the transcript inset updates in lockstep with the composer.

**Why it's safe (no thrash loop):** the inset only affects the scroll area *above* the dock, never the observed elements (dock / composer surface / footer), so re-measuring can't feed back into the ResizeObserver. The existing changed-value compare in `setMetrics` still suppresses redundant renders, and the rAF dedupes bursts within a frame.

## Scope
Deliberately narrow — **#5 only**. The remaining start-of-session shift (#8) is the virtualizer's row-height estimate, which is a separate follow-up.

## Testing
- `tsc --noEmit` clean.
- Existing composer autosize + sizing tests pass (6/6).
- No unit test added: the change is ResizeObserver/rAF + layout timing, not meaningfully testable in jsdom (no layout, no ResizeObserver). Verified by reasoning + manual reflow check in the chat surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)