### PR TITLE
fix(transcript): stable scroll — no per-message jump, snappier composer reflow

### DIFF
--- a/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -5,8 +5,6 @@ import {
   computeChatSurfaceBottomInsetPx,
 } from "@/config/chat-layout";
 
-const CHAT_DOCK_RESIZE_SETTLE_MS = 90;
-
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   const [metrics, setMetrics] = useState({
@@ -54,21 +52,18 @@ export function useChatDockInset() {
       return;
     }
 
-    let settleTimer: number | null = null;
+    // Coalesce resize bursts onto the next animation frame only. The composer
+    // autosizes discretely (per line), so the transcript inset must follow on
+    // the next frame — a debounce here made the transcript lag the textarea
+    // visibly when adding/removing lines.
     const scheduleMeasure = () => {
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
       }
-      settleTimer = window.setTimeout(() => {
-        settleTimer = null;
-        if (frameId !== null) {
-          window.cancelAnimationFrame(frameId);
-        }
-        frameId = window.requestAnimationFrame(() => {
-          frameId = null;
-          measure();
-        });
-      }, CHAT_DOCK_RESIZE_SETTLE_MS);
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        measure();
+      });
     };
 
     const observer = new ResizeObserver(() => {
@@ -87,9 +82,6 @@ export function useChatDockInset() {
 
     return () => {
       observer.disconnect();
-      if (settleTimer !== null) {
-        window.clearTimeout(settleTimer);
-      }
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -75,6 +75,7 @@ export function VirtualizedTranscriptRowList({
     pinnedRef,
     onViewportScroll,
     scrollToBottom,
+    glueToBottom,
     handleScrollToBottomClick,
     notifyProgrammaticScroll,
     setPinned,
@@ -289,9 +290,15 @@ export function VirtualizedTranscriptRowList({
     if (!pinnedRef.current) {
       return;
     }
+    // Synchronous snap (pre-paint, no flash) + a glue loop that re-snaps until
+    // the measured height settles. A freshly appended/streamed row enters at its
+    // estimated height and corrects a frame later; the one-shot snap alone lands
+    // against the estimate and leaves a visible jump as the measurement lands.
     scrollToBottom();
+    glueToBottom();
   }, [
     bottomInsetPx,
+    glueToBottom,
     isSessionBusy,
     pendingPromptText,
     pinnedRef,

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
@@ -261,6 +261,28 @@ describe("useTranscriptStickToBottom", () => {
     expect(viewport.scrollTop).toBe(2200);
   });
 
+  it("glueToBottom re-snaps to the bottom as a row measures taller a frame later", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    // A new row entered at its estimate; the engine is pinned and snapping.
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 0 });
+
+    act(() => {
+      handle.current.api.glueToBottom();
+    });
+    act(() => {
+      flushRafRound();
+    });
+    expect(viewport.scrollTop).toBe(1000);
+
+    // The row's real (taller) height lands a frame later; glue follows it.
+    setMetrics(viewport, { scrollHeight: 1600, clientHeight: 300, scrollTop: 1000 });
+    act(() => {
+      flushRafRound();
+    });
+    expect(viewport.scrollTop).toBe(1600);
+  });
+
   it("bails the glue loop if the user scrolls up mid-resume", () => {
     const handle = renderHarness();
     const { viewport } = handle.current;

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -38,6 +38,13 @@ export interface TranscriptStickToBottom {
   onViewportScroll: (viewport: HTMLDivElement) => void;
   /** Imperative snap to the true bottom (always snaps; callers gate on pinnedRef). */
   scrollToBottom: () => void;
+  /**
+   * Re-snap to the bottom each frame until measured scrollHeight stabilizes.
+   * Use after a content change while pinned: a row enters at its estimated
+   * height and corrects a frame later, so the single-shot scrollToBottom leaves
+   * a momentary gap/jump at the bottom. Bails the instant the user unpins.
+   */
+  glueToBottom: () => void;
   /** Snap + re-pin, for the scroll-to-bottom button. */
   handleScrollToBottomClick: () => void;
   /** Wrap ANY external scrollTop/scrollToOffset write so its scroll event is excluded from pin/direction. */
@@ -283,6 +290,7 @@ export function useTranscriptStickToBottom({
     pinnedRef,
     onViewportScroll,
     scrollToBottom,
+    glueToBottom: startGlueLoop,
     handleScrollToBottomClick,
     notifyProgrammaticScroll,
     setPinned,


### PR DESCRIPTION
PR 2 of the live-chat scroll/layout cleanup. Two focused, low-risk fixes that reuse mechanisms already proven in the transcript code.

## 1. Glue the pinned snap (commit 1)
The virtualized transcript's pinned snap was a **one-shot** `scrollToBottom` on content-change deps. A new/streamed row enters at the flat `ESTIMATED_TURN_HEIGHT_PX = 360` estimate → the effect snaps once → the virtualizer's ResizeObserver corrects the height a frame later → a **second snap against a different height**. That double-snap is the visible jump on every message and at session start.

Fix: expose the existing snap-until-stable glue loop (`startGlueLoop` → `glueToBottom`) and run it alongside the synchronous snap:
- synchronous `scrollToBottom()` keeps the **no-flash, pre-paint** guarantee,
- `glueToBottom()` re-snaps each frame until measured `scrollHeight` settles.

The glue already bails the instant the user scrolls up (`pinnedRef`), so scroll-up-during-stream is unchanged. The full (non-virtualized) list already re-sticks via a content `ResizeObserver`, so it needs no change.

**Fixes:** per-message shift (#9), estimate half of start-of-session shift (#8), and the **common pinned case** of the thinking→command nudge (#10).

## 2. Track dock inset on the next frame (commit 2)
The composer textarea autosizes synchronously per line, but the transcript bottom inset was recomputed behind a **90ms settle timer** (`CHAT_DOCK_RESIZE_SETTLE_MS`), so the transcript lagged the textarea when adding/removing lines. Coalesce resize bursts onto the next animation frame only — the autosize is discrete, so one rAF is enough and immediate. No loop risk (inset is a pure function of dock geometry; transcript reflow doesn't resize the dock).

**Fixes:** slow composer reflow (#5); tightens start-of-session inset settle (#8).

## Explicitly deferred
The **unpinned-history** half of #10 (the anchor-restore `getOffsetForIndex` estimate branch). A blanket measured-delta swap would mis-shift below-the-anchor inserts — measured-delta is only correct for above-the-viewport changes (which the code already routes through `startAboveChangeCompensation`). Needs a more careful design; tracked as a follow-up.

## Testing
- `useTranscriptStickToBottom.test.tsx` — added an explicit `glueToBottom` test (re-snaps as a row measures taller a frame later); 14 tests pass.
- `VirtualizedTranscriptRowList` + `FullTranscriptRowList` tests pass (19 total in the transcript suite).
- `tsc --noEmit` clean for both `@proliferate/product-ui` and `apps/desktop`.
- Visual pass in `/playground` (ChatPlaygroundPage) recommended before merge — start of session, per-message streaming, composer grow/shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)