### PR TITLE
fix(desktop): GitHub sign-in checking flash + sidebar spinner alignment

### DIFF
--- a/apps/desktop/src/components/auth/AuthScreenLayout.tsx
+++ b/apps/desktop/src/components/auth/AuthScreenLayout.tsx
@@ -110,11 +110,7 @@ export function AuthScreenLayout({
               className="h-11 w-full"
             >
               {!submitting && <GitHub className="h-4 w-4 shrink-0" />}
-              {submitting
-                ? AUTH_LOGIN_LABELS.waiting
-                : githubSignInChecking
-                  ? AUTH_LOGIN_LABELS.checking
-                  : AUTH_LOGIN_LABELS.signIn}
+              {submitting ? AUTH_LOGIN_LABELS.waiting : AUTH_LOGIN_LABELS.signIn}
               {!submitting && <ArrowRight className="h-4 w-4" />}
             </Button>
           </div>
@@ -125,7 +121,7 @@ export function AuthScreenLayout({
           <div className="absolute inset-x-0 top-full mt-3 text-center">
             {showAuth && error
               ? <p className="text-sm text-destructive">{error}</p>
-              : showAuth && (githubSignInChecking || !githubSignInAvailable)
+              : showAuth && !githubSignInChecking && !githubSignInAvailable
                 ? (
                   <p className="text-sm text-muted-foreground">
                     {githubSignInUnavailableDescription}

--- a/apps/desktop/src/components/auth/AuthShell.tsx
+++ b/apps/desktop/src/components/auth/AuthShell.tsx
@@ -20,7 +20,7 @@ export function AuthShell({ mode, markComplete, onMarkResolved }: AuthShellProps
     signInAvailable,
     signInChecking,
     signInUnavailableDescription,
-  } = useGitHubSignIn({ enabled: mode === "auth" });
+  } = useGitHubSignIn();
 
   return (
     <AuthScreenLayout

--- a/apps/desktop/src/components/auth/LoginScreen.tsx
+++ b/apps/desktop/src/components/auth/LoginScreen.tsx
@@ -73,15 +73,11 @@ export function LoginScreen({
             className="h-11 w-full"
           >
             {!submitting && <GitHub className="h-4 w-4 shrink-0" />}
-            {submitting
-              ? AUTH_LOGIN_LABELS.waiting
-              : githubSignInChecking
-                ? AUTH_LOGIN_LABELS.checking
-                : AUTH_LOGIN_LABELS.signIn}
+            {submitting ? AUTH_LOGIN_LABELS.waiting : AUTH_LOGIN_LABELS.signIn}
             {!submitting && <ArrowRight className="h-4 w-4" />}
           </Button>
 
-          {(githubSignInChecking || !githubSignInAvailable) && (
+          {!githubSignInChecking && !githubSignInAvailable && (
             <p className="text-sm text-muted-foreground">
               {githubSignInUnavailableDescription}
             </p>

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -77,7 +77,7 @@ export function SidebarStatusIndicatorView({
           {glyph}
         </IconButton>
       ) : (
-        <span role="img" aria-label={indicator.tooltip}>{glyph}</span>
+        <span role="img" aria-label={indicator.tooltip} className="inline-flex items-center justify-center">{glyph}</span>
       )}
     </Tooltip>
   );

--- a/apps/desktop/src/copy/auth/auth-copy.ts
+++ b/apps/desktop/src/copy/auth/auth-copy.ts
@@ -16,7 +16,6 @@ export const AUTH_LOGIN_LABELS = {
   detail: "Start by signing in with GitHub.",
   detailWithLocalPrefix: "Continue with GitHub, or",
   signIn: "Continue with GitHub",
-  checking: "Checking GitHub sign-in...",
   waiting: "Waiting for GitHub...",
   continueLocally: "Start locally",
   continueLocallyInline: "start locally",

--- a/apps/desktop/src/copy/capabilities/capability-copy.ts
+++ b/apps/desktop/src/copy/capabilities/capability-copy.ts
@@ -22,8 +22,6 @@ export const CAPABILITY_COPY = {
     "This environment can reach the control plane, but desktop GitHub sign-in is not configured.",
   githubLocalDescription:
     "GitHub sign-in is unavailable while the control plane is unreachable.",
-  githubAuthCheckingDescription:
-    "Checking whether GitHub sign-in is configured for this environment.",
   githubAuthUnavailableDescription:
     "GitHub sign-in is not configured for this environment.",
   githubSignedInUnavailableDescription:

--- a/apps/desktop/src/hooks/auth/workflows/use-github-sign-in.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-github-sign-in.ts
@@ -16,26 +16,24 @@ export interface UseGitHubSignInResult {
 }
 
 // Owns GitHub sign-in form state and submit callback. Does not own auth availability access.
-// `enabled` can gate the availability poll for on-demand callers. The auth shell leaves it
-// enabled during the loading phase too, so the availability answer is warm before the sign-in
-// button morphs in — otherwise the first-load pending window flashes a "checking…" state
-// during the loading -> auth transition.
-export function useGitHubSignIn(options?: { enabled?: boolean }): UseGitHubSignInResult {
+// The availability probe runs whenever this hook is mounted — the persistent auth shell mounts
+// it during the loading phase too, so the answer is warm before the sign-in button morphs in,
+// otherwise the first-load pending window flashes a "checking…" state during the loading -> auth
+// transition. The query self-guards on control-plane reachability.
+export function useGitHubSignIn(): UseGitHubSignInResult {
   const { signInWithGitHub } = useAuthActions();
   const { cloudEnabled } = useAppCapabilities();
   const {
     data: githubDesktopAuthAvailable,
     isPending: githubDesktopAuthAvailabilityPending,
-  } = useGitHubDesktopAuthAvailability({ enabled: options?.enabled ?? true });
+  } = useGitHubDesktopAuthAvailability();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const signInChecking = cloudEnabled && githubDesktopAuthAvailabilityPending;
   const signInAvailable = cloudEnabled && githubDesktopAuthAvailable?.enabled === true;
-  const signInUnavailableDescription = signInChecking
-    ? CAPABILITY_COPY.githubAuthCheckingDescription
-    : cloudEnabled
-      ? CAPABILITY_COPY.githubAuthUnavailableDescription
+  const signInUnavailableDescription = cloudEnabled
+    ? CAPABILITY_COPY.githubAuthUnavailableDescription
     : CAPABILITY_COPY.githubLocalDescription;
 
   const signIn = useCallback(async (options?: GitHubDesktopSignInOptions) => {

--- a/apps/desktop/src/hooks/auth/workflows/use-github-sign-in.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-github-sign-in.ts
@@ -16,8 +16,10 @@ export interface UseGitHubSignInResult {
 }
 
 // Owns GitHub sign-in form state and submit callback. Does not own auth availability access.
-// `enabled` gates the availability poll so it only runs when sign-in is actually
-// shown (the persistent auth shell mounts this hook during the loading phase too).
+// `enabled` can gate the availability poll for on-demand callers. The auth shell leaves it
+// enabled during the loading phase too, so the availability answer is warm before the sign-in
+// button morphs in — otherwise the first-load pending window flashes a "checking…" state
+// during the loading -> auth transition.
 export function useGitHubSignIn(options?: { enabled?: boolean }): UseGitHubSignInResult {
   const { signInWithGitHub } = useAuthActions();
   const { cloudEnabled } = useAppCapabilities();


### PR DESCRIPTION
## What
Two small desktop UI cleanups.

### 1. GitHub sign-in "checking" flash during the auth transition
The persistent `AuthShell` morphs a loading skeleton into the GitHub button in place. The availability probe was gated `enabled: mode === "auth"`, so it only *started* the instant the morph began — its first-load pending window overlapped the transition and surfaced *"Checking whether GitHub sign-in is configured for this environment."* (and a "Checking…" button label) for a beat before resolving.

- **Warm the probe** whenever `AuthShell` is mounted (loading phase included), so the answer is normally resolved *before* the button appears. The query already self-guards on `controlPlaneReachable` and caches (`staleTime: 15s`).
- **Stop rendering the transient "checking" copy** in `AuthScreenLayout` + `LoginScreen` — the button just stays disabled until the probe resolves, so the transition is skeleton → sign-in button with no "checking" text. Drops the now-unused `checking` label.

### 2. Sidebar workspace status spinner not vertically centered
The non-action status indicator wrapped its glyph in a plain inline `<span>`, so the `inline-flex` Spinner baseline-aligned and sat high relative to the row. Flex-center the wrapper so the spinner (and every status glyph) is vertically centered.

## Scope / risk
Presentational only; no change to actual sign-in behavior or status logic. `LoginScreen` is playground-only but shares the pattern, so it's fixed for consistency. Verified the dropped `checking` copy has no remaining consumers.

## Verify
- Auth: loading → sign-in morph shows no "checking" flash (replayable via `/playground` → AuthOnboarding).
- Sidebar: a workspace with an iterating/queued status shows its spinner vertically centered in the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
