### PR TITLE
fix(transcript): no session-switch flicker + collapse resume backlog (#2, #6)

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptRows.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptRows.tsx
@@ -1,20 +1,14 @@
 import type { TranscriptRowListBaseProps } from "./TranscriptRowListShared";
 import { VirtualTranscriptRowList } from "./VirtualTranscriptRowList";
 
-interface ChatTranscriptRowsProps extends TranscriptRowListBaseProps {
-  rowListKey: string;
-}
-
-export function ChatTranscriptRows({
-  rowListKey,
-  ...props
-}: ChatTranscriptRowsProps) {
+// Intentionally NOT keyed by session/workspace: remounting on switch threw away
+// the virtualizer's measurement cache, so the new session re-pinned from the
+// 360px estimate and briefly read as blank (virtualized->full flash). The list
+// instead resets stickiness in place via resetForSession on the id change.
+export function ChatTranscriptRows(props: TranscriptRowListBaseProps) {
   return (
     <div className="flex-1 min-h-0" data-telemetry-block>
-      <VirtualTranscriptRowList
-        key={rowListKey}
-        {...props}
-      />
+      <VirtualTranscriptRowList {...props} />
     </div>
   );
 }

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
@@ -65,7 +65,6 @@ export function ChatTranscriptView({
 
   return (
     <ChatTranscriptRows
-      rowListKey={`${model.selectedWorkspaceId ?? "workspace"}:${model.activeSessionId}`}
       rows={model.virtualRows}
       selectionRootRef={selectionRootRef}
       hasOlderHistory={model.hasOlderHistory}

--- a/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
@@ -21,12 +21,18 @@ export const DIRECTION_EPSILON_PX = 1;
 // nothing would re-pin and the scroll-to-bottom button would wrongly show while
 // already at the bottom.
 export const SCROLLABLE_OVERFLOW_EPSILON_PX = 1;
-// Visibility-resume glue loop: hold the viewport at the bottom each frame until
-// measured scrollHeight is stable for this many consecutive frames, capped at
-// GLUE_MAX_FRAMES, so a suspended-then-resumed measurement backlog collapses
+// Glue loops re-apply a scroll write each frame until measured scrollHeight is
+// stable for this many consecutive frames, so a measurement backlog collapses
 // into one jump instead of a visible crawl.
 export const GLUE_STABLE_FRAMES = 3;
-export const GLUE_MAX_FRAMES = 12;
+// Above-change compensation holds an anchored row in place while one freshly
+// inserted row measures in — a small, bounded backlog — so a hard frame cap is
+// a safe ceiling.
+export const GLUE_ABOVE_MAX_FRAMES = 12;
+// The visibility/focus resume path can face an arbitrarily large
+// suspended-then-resumed measurement backlog, so it terminates on stability
+// rather than a hard cap; this is only a runaway safety ceiling.
+export const GLUE_RESUME_MAX_FRAMES = 600;
 export const HISTORY_PREFETCH_TOP_THRESHOLD_PX = 480;
 export const HISTORY_LOADING_ROW_KEY = "history-loader";
 export const DEFAULT_CHAT_COLUMN_CLASSNAME = "mx-auto w-full max-w-3xl";

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -70,6 +70,11 @@ export function VirtualizedTranscriptRowList({
   // resume-measure callback reads it through a ref (set once the virtualizer
   // exists) to force one synchronous measure pass on tab/window resume.
   const virtualizerRef = useRef<{ measure: () => void } | null>(null);
+  // measure() clears the entire itemSizeCache (full re-measure from estimates),
+  // so this momentarily resets scrollHeight to estimates before the resume glue
+  // loop follows the re-measure. That cost is acceptable only because this is
+  // resume-only (one tab/window re-show); do NOT widen its trigger to per-event
+  // paths or it reintroduces the estimate->measure churn during streaming.
   const resumeMeasure = useCallback(() => {
     virtualizerRef.current?.measure();
   }, []);
@@ -215,18 +220,22 @@ export function VirtualizedTranscriptRowList({
   }, [activeSessionId, resetForSession, selectedWorkspaceId]);
 
   // Flip measurement-ready one frame after a session change: by the next frame
-  // the virtualizer has measured the visible rows, so the blank-viewport check
-  // can run without false-positiving on the estimate-only first frame.
+  // the virtualizer has already measured the visible rows (via
+  // useAnimationFrameWithResizeObserver) so the blank-viewport check can run
+  // without false-positiving on the estimate-only first frame. Gate strictly to
+  // session/workspace change: keying off rows.length would re-arm on every
+  // streamed-row append, and an explicit virtualizer.measure() here would clear
+  // the whole itemSizeCache and reintroduce per-event estimate->measure churn.
+  const hasRows = rows.length > 0;
   useEffect(() => {
-    if (rows.length === 0) {
+    if (!hasRows) {
       return;
     }
     const frame = window.requestAnimationFrame(() => {
-      virtualizer.measure();
       setMeasurementReady(true);
     });
     return () => { window.cancelAnimationFrame(frame); };
-  }, [activeSessionId, rows.length, selectedWorkspaceId, virtualizer]);
+  }, [activeSessionId, hasRows, selectedWorkspaceId]);
 
   useLayoutEffect(() => {
     const anchor = pendingPrependAnchorRef.current;

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TranscriptVirtualizationMode } from "@proliferate/product-domain/chats/transcript/transcript-virtualization-config";
@@ -65,6 +66,13 @@ export function VirtualizedTranscriptRowList({
   virtualizationMode,
 }: VirtualizedTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  // The stick-to-bottom engine is created before the virtualizer below, so the
+  // resume-measure callback reads it through a ref (set once the virtualizer
+  // exists) to force one synchronous measure pass on tab/window resume.
+  const virtualizerRef = useRef<{ measure: () => void } | null>(null);
+  const resumeMeasure = useCallback(() => {
+    virtualizerRef.current?.measure();
+  }, []);
   const pendingAnchorRef = useRef<VirtualScrollAnchor | null>(null);
   const pendingPrependAnchorRef = useRef<HistoryPrependScrollAnchor | null>(null);
   const lastOlderHistoryCursorRequestRef = useRef<number | null>(null);
@@ -80,7 +88,11 @@ export function VirtualizedTranscriptRowList({
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
-  } = useTranscriptStickToBottom({ scrollRef, onScrollSample });
+  } = useTranscriptStickToBottom({ scrollRef, onScrollSample, onResumeMeasure: resumeMeasure });
+  // Gates the blank-viewport fallback until the virtualizer has run >=1
+  // measurement pass after mount/session change; the first frame is
+  // estimate-only and would read as blank (the session-switch flicker).
+  const [measurementReady, setMeasurementReady] = useState(false);
   const renderableRows = useMemo(
     () => buildRenderableRows(rows, isLoadingOlderHistory),
     [isLoadingOlderHistory, rows],
@@ -101,6 +113,7 @@ export function VirtualizedTranscriptRowList({
     initialOffset: () => estimatedInitialBottomOffset,
     useAnimationFrameWithResizeObserver: true,
   });
+  virtualizerRef.current = virtualizer;
   const virtualItems = virtualizer.getVirtualItems();
   const totalContentHeight = virtualizer.getTotalSize();
   const firstVirtualItem = virtualItems[0] ?? null;
@@ -189,13 +202,31 @@ export function VirtualizedTranscriptRowList({
     onViewportScroll,
   ]);
 
+  // On mount and every session/workspace switch, reset stickiness (keeping the
+  // virtualizer mounted so its measurement cache survives) and re-gate the
+  // blank-fallback until the next measurement pass lands.
   useLayoutEffect(() => {
     lastBlankReportSignatureRef.current = null;
     pendingPrependAnchorRef.current = null;
     lastOlderHistoryCursorRequestRef.current = null;
     lastPrefetchDecisionLogRef.current = null;
+    setMeasurementReady(false);
     resetForSession();
   }, [activeSessionId, resetForSession, selectedWorkspaceId]);
+
+  // Flip measurement-ready one frame after a session change: by the next frame
+  // the virtualizer has measured the visible rows, so the blank-viewport check
+  // can run without false-positiving on the estimate-only first frame.
+  useEffect(() => {
+    if (rows.length === 0) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      virtualizer.measure();
+      setMeasurementReady(true);
+    });
+    return () => { window.cancelAnimationFrame(frame); };
+  }, [activeSessionId, rows.length, selectedWorkspaceId, virtualizer]);
 
   useLayoutEffect(() => {
     const anchor = pendingPrependAnchorRef.current;
@@ -343,6 +374,7 @@ export function VirtualizedTranscriptRowList({
     firstVirtualItem,
     lastVirtualItem,
     lastBlankReportSignatureRef,
+    measurementReady,
     onFallback,
     rowCount: rows.length,
     scrollRef,

--- a/apps/packages/product-ui/src/chat/transcript/useAboveChangeCompensation.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useAboveChangeCompensation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, type RefObject } from "react";
 import {
-  GLUE_MAX_FRAMES,
+  GLUE_ABOVE_MAX_FRAMES,
   GLUE_STABLE_FRAMES,
   type ContentHeightScrollAnchor,
 } from "./TranscriptRowListShared";
@@ -49,7 +49,7 @@ export function useAboveChangeCompensation({
         lastHeight = height;
       }
       totalFrames += 1;
-      if (stableFrames >= GLUE_STABLE_FRAMES || totalFrames >= GLUE_MAX_FRAMES) {
+      if (stableFrames >= GLUE_STABLE_FRAMES || totalFrames >= GLUE_ABOVE_MAX_FRAMES) {
         compensateFrameRef.current = null;
         return;
       }

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
@@ -41,12 +41,12 @@ interface HarnessHandle {
   viewport: HTMLDivElement;
 }
 
-function renderHarness(onScrollSample = vi.fn()) {
+function renderHarness(onScrollSample = vi.fn(), onResumeMeasure?: () => void) {
   const handle: { current: HarnessHandle | null } = { current: null };
 
   function Harness() {
     const scrollRef = useRef<HTMLDivElement>(null);
-    const api = useTranscriptStickToBottom({ scrollRef, onScrollSample });
+    const api = useTranscriptStickToBottom({ scrollRef, onScrollSample, onResumeMeasure });
     return (
       <div
         ref={(node) => {
@@ -281,6 +281,40 @@ describe("useTranscriptStickToBottom", () => {
       flushRafRound();
     });
     expect(viewport.scrollTop).toBe(1600);
+  });
+
+  it("forces a synchronous measure on resume so the backlog lands in one jump", () => {
+    const onResumeMeasure = vi.fn();
+    const handle = renderHarness(vi.fn(), onResumeMeasure);
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+    expect(onResumeMeasure).toHaveBeenCalledTimes(1);
+  });
+
+  it("resume glue terminates on stability past the old 12-frame cap", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+
+    act(() => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+
+    // Grow the bottom for far more than the old 12-frame cap; the resume loop
+    // must keep following the backlog (it terminates on stability, not a cap).
+    let height = 1000;
+    for (let frame = 0; frame < 20; frame += 1) {
+      height += 200;
+      setMetrics(viewport, { scrollHeight: height, clientHeight: 300, scrollTop: viewport.scrollTop });
+      act(() => {
+        flushRafRound();
+      });
+      expect(viewport.scrollTop).toBe(height);
+    }
   });
 
   it("bails the glue loop if the user scrolls up mid-resume", () => {

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
 import { resolveVirtualBottomDistance } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
 import {
   DIRECTION_EPSILON_PX,
-  GLUE_MAX_FRAMES,
+  GLUE_ABOVE_MAX_FRAMES,
+  GLUE_RESUME_MAX_FRAMES,
   GLUE_STABLE_FRAMES,
   PROGRAMMATIC_MATCH_TOL_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
@@ -27,6 +28,13 @@ export interface UseTranscriptStickToBottomOptions {
   onScrollSample: () => void;
   /** px from the bottom within which a user scroll re-pins. */
   repinThresholdPx?: number;
+  /**
+   * Force a synchronous virtualizer measure pass on tab/window resume so the
+   * suspended-then-resumed measurement backlog lands in one jump (one
+   * synchronous measure, then the glue loop follows any residual growth) rather
+   * than crawling in over many estimate→measure frames.
+   */
+  onResumeMeasure?: () => void;
 }
 
 export interface TranscriptStickToBottom {
@@ -66,12 +74,15 @@ export function useTranscriptStickToBottom({
   scrollRef,
   onScrollSample,
   repinThresholdPx = REPIN_BOTTOM_THRESHOLD_PX,
+  onResumeMeasure,
 }: UseTranscriptStickToBottomOptions): TranscriptStickToBottom {
   const pinnedRef = useRef(true);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
   const lastScrollTopRef = useRef(0);
   const programmaticRef = useRef<{ expectedTop: number; frame: number } | null>(null);
   const glueFrameRef = useRef<number | null>(null);
+  const onResumeMeasureRef = useRef(onResumeMeasure);
+  onResumeMeasureRef.current = onResumeMeasure;
 
   const setPinned = useCallback((next: boolean) => {
     if (pinnedRef.current === next) {
@@ -166,7 +177,7 @@ export function useTranscriptStickToBottom({
     scrollToBottom();
   }, [scrollToBottom, setPinned]);
 
-  const startGlueLoop = useCallback(() => {
+  const startGlueLoop = useCallback((maxFrames: number = GLUE_ABOVE_MAX_FRAMES) => {
     if (typeof window === "undefined") {
       return;
     }
@@ -194,7 +205,9 @@ export function useTranscriptStickToBottom({
         lastHeight = height;
       }
       totalFrames += 1;
-      if (stableFrames >= GLUE_STABLE_FRAMES || totalFrames >= GLUE_MAX_FRAMES) {
+      // The resume path passes GLUE_RESUME_MAX_FRAMES so it effectively
+      // terminates on stability; maxFrames is only a runaway safety ceiling.
+      if (stableFrames >= GLUE_STABLE_FRAMES || totalFrames >= maxFrames) {
         glueFrameRef.current = null;
         return;
       }
@@ -262,7 +275,10 @@ export function useTranscriptStickToBottom({
       if (document.visibilityState !== "visible" || !pinnedRef.current) {
         return;
       }
-      startGlueLoop();
+      // Force one synchronous measure so the backlog lands in a single jump,
+      // then glue (terminating on stability) to follow any residual growth.
+      onResumeMeasureRef.current?.();
+      startGlueLoop(GLUE_RESUME_MAX_FRAMES);
     };
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onVisible);

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptVirtualizerBlankFallback.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptVirtualizerBlankFallback.test.tsx
@@ -1,0 +1,85 @@
+/* @vitest-environment jsdom */
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTranscriptVirtualizerBlankFallback } from "./useTranscriptVirtualizerBlankFallback";
+
+let rafCallbacks: Array<FrameRequestCallback | null>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks[id - 1] = null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function flushRafRound() {
+  const pending = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of pending) {
+    cb?.(0);
+  }
+}
+
+function renderHarness(measurementReady: boolean, onFallback: (reason: string) => void) {
+  function Harness() {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const lastBlankReportSignatureRef = useRef<string | null>(null);
+    useTranscriptVirtualizerBlankFallback({
+      activeSessionId: "session-1",
+      firstVirtualItem: { index: 0 },
+      lastVirtualItem: { index: 0 },
+      lastBlankReportSignatureRef,
+      measurementReady,
+      onFallback,
+      rowCount: 3,
+      scrollRef,
+    });
+    return (
+      <div
+        ref={(node) => {
+          if (node) {
+            // A scrollable viewport with zero rendered rows reads as "blank".
+            Object.defineProperty(node, "scrollHeight", { value: 2000, configurable: true });
+            Object.defineProperty(node, "clientHeight", { value: 300, configurable: true });
+            node.getBoundingClientRect = () =>
+              ({ top: 0, bottom: 300, left: 0, right: 0, width: 0, height: 300, x: 0, y: 0, toJSON() {} }) as DOMRect;
+            scrollRef.current = node;
+          }
+        }}
+      />
+    );
+  }
+  render(<Harness />);
+}
+
+describe("useTranscriptVirtualizerBlankFallback", () => {
+  it("does not report blank until a measurement pass has completed", () => {
+    const onFallback = vi.fn();
+    renderHarness(false, onFallback);
+    act(() => {
+      flushRafRound();
+    });
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  it("reports blank once measurement is ready and the viewport has no visible rows", () => {
+    const onFallback = vi.fn();
+    renderHarness(true, onFallback);
+    act(() => {
+      flushRafRound();
+    });
+    expect(onFallback).toHaveBeenCalledWith("blank_viewport");
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptVirtualizerBlankFallback.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptVirtualizerBlankFallback.ts
@@ -7,6 +7,7 @@ export function useTranscriptVirtualizerBlankFallback({
   firstVirtualItem,
   lastVirtualItem,
   lastBlankReportSignatureRef,
+  measurementReady,
   onFallback,
   rowCount,
   scrollRef,
@@ -15,12 +16,17 @@ export function useTranscriptVirtualizerBlankFallback({
   firstVirtualItem: { index: number } | null;
   lastVirtualItem: { index: number } | null;
   lastBlankReportSignatureRef: RefObject<string | null>;
+  // Suppress the blank-viewport check until >=1 measurement pass has completed
+  // after mount/session change. The first virtualized frame is estimate-only:
+  // rows aren't positioned yet, so the viewport reads "blank" and would
+  // wrongly swap virtualized->full for a frame (the session-switch flicker).
+  measurementReady: boolean;
   onFallback: (reason: string) => void;
   rowCount: number;
   scrollRef: RefObject<HTMLDivElement | null>;
 }): void {
   useEffect(() => {
-    if (rowCount === 0) {
+    if (rowCount === 0 || !measurementReady) {
       return;
     }
 
@@ -70,6 +76,7 @@ export function useTranscriptVirtualizerBlankFallback({
     firstVirtualItem,
     lastBlankReportSignatureRef,
     lastVirtualItem,
+    measurementReady,
     onFallback,
     rowCount,
     scrollRef,


### PR DESCRIPTION
Stack 1/9 on #746. **#2**: stop remounting the list on session switch (drop key={rowListKey}; resetForSession in place, keeping the virtualizer measurement cache); gate the blank-viewport fallback until the first measurement pass. **#6**: resume glue terminates on stability (not a 12-frame cap) + one synchronous virtualizer.measure() so a backgrounded backlog lands in one jump. tsc clean; product-ui transcript suite green. Verified: acceptance met (high).