### PR TITLE
fix(transcript): hold unpinned read position on at/below composition changes (#10)

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -23,6 +23,7 @@ import {
   type TranscriptRowListBaseProps,
 } from "./TranscriptRowListShared";
 import { useAboveChangeCompensation } from "./useAboveChangeCompensation";
+import { resolveUnpinnedAnchorRestore } from "./unpinned-anchor-restore";
 import { useTranscriptStickToBottom } from "./useTranscriptStickToBottom";
 import { VirtualTranscriptViewport } from "./VirtualTranscriptViewport";
 import { useTranscriptVirtualizerBlankFallback } from "./useTranscriptVirtualizerBlankFallback";
@@ -283,12 +284,21 @@ export function VirtualizedTranscriptRowList({
     notifyProgrammaticScroll,
   });
 
-  // While unpinned, a completing turn can split one row into completed-history +
-  // content — a new, unmeasured row inserted ABOVE the anchored row. The
-  // getOffsetForIndex + offsetWithinRowPx restore lands against the 360px
-  // estimate and bumps when measurement corrects. When rows were inserted above
-  // the anchor, hold the user's position with the measured scrollHeight delta;
-  // pure shifts and below-the-viewport appends keep the offset reposition / no-op.
+  // While unpinned, a completing turn can split/grow rows around the anchored
+  // (first-visible) row. getOffsetForIndex builds on the 360px estimate for
+  // unmeasured neighbours, so the naive offset restore lands wrong and nudges
+  // the read position. Distinguish the three change shapes relative to the
+  // anchor and pick the restore that holds it at the same viewport y:
+  //   - anchor moved DOWN  (nextIndex > rowIndex): rows inserted ABOVE the
+  //     viewport — hold with the measured scrollHeight delta (estimate-immune).
+  //   - anchor moved UP    (nextIndex < rowIndex): rows removed ABOVE the
+  //     viewport — same measured-delta compensation applies.
+  //   - anchor index UNCHANGED (nextIndex === rowIndex): nothing changed above
+  //     the anchor, so getOffsetForIndex(nextIndex) is the anchor's real top.
+  //     A change strictly BELOW the viewport leaves scrollTop correct (hold it,
+  //     no move); a same-index height change of the anchor row itself needs the
+  //     measured offset — force-measure the anchor row first so the offset is
+  //     real, not the estimate, then restore offset + intra-row position.
   useLayoutEffect(() => {
     const anchor = pendingAnchorRef.current;
     pendingAnchorRef.current = null;
@@ -307,9 +317,31 @@ export function VirtualizedTranscriptRowList({
       return;
     }
 
-    if (nextIndex > anchor.rowIndex) {
+    const restore = resolveUnpinnedAnchorRestore({
+      capturedRowIndex: anchor.rowIndex,
+      nextRowIndex: nextIndex,
+    });
+
+    if (restore.kind === "measured-delta") {
+      // The anchor shifted, so rows were inserted/removed above the viewport.
+      // Measured-delta keeps the anchored row at the same y regardless of
+      // estimate error on the changed (unmeasured) rows.
       startAboveChangeCompensation(anchor);
       return;
+    }
+
+    // measured-offset — index unchanged: the composition change is at the anchor
+    // row or strictly below it. Force-measure the anchor row so its offset is
+    // measured rather than estimated, then re-anchor to (measured top + captured
+    // intra-row offset). When the change is purely below the viewport this
+    // reproduces the captured scrollTop exactly (a no-op hold); when the anchor
+    // row itself grew/shrank it holds the same visible content.
+    const viewport = scrollRef.current;
+    const anchorNode = viewport?.querySelector<HTMLElement>(
+      `[data-index="${nextIndex}"]`,
+    );
+    if (anchorNode) {
+      virtualizer.measureElement(anchorNode);
     }
 
     const offsetInfo = virtualizer.getOffsetForIndex(nextIndex, "start");

--- a/apps/packages/product-ui/src/chat/transcript/unpinned-anchor-restore.test.ts
+++ b/apps/packages/product-ui/src/chat/transcript/unpinned-anchor-restore.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveUnpinnedAnchorRestore } from "./unpinned-anchor-restore";
+
+describe("resolveUnpinnedAnchorRestore", () => {
+  it("uses measured-delta when rows are inserted above the anchor (anchor moves down)", () => {
+    // thinking->command split inserts a completed-history row above the anchored
+    // first-visible row, so its index increases.
+    expect(
+      resolveUnpinnedAnchorRestore({ capturedRowIndex: 4, nextRowIndex: 5 }),
+    ).toEqual({ kind: "measured-delta" });
+  });
+
+  it("uses measured-delta when rows are removed above the anchor (anchor moves up)", () => {
+    expect(
+      resolveUnpinnedAnchorRestore({ capturedRowIndex: 5, nextRowIndex: 3 }),
+    ).toEqual({ kind: "measured-delta" });
+  });
+
+  it("uses measured-offset for a below-the-viewport change (anchor index unchanged)", () => {
+    // A turn growing below the read position must not shift it: the anchor index
+    // is unchanged, so we hold via the measured offset (a no-op for below).
+    expect(
+      resolveUnpinnedAnchorRestore({ capturedRowIndex: 2, nextRowIndex: 2 }),
+    ).toEqual({ kind: "measured-offset" });
+  });
+
+  it("uses measured-offset for a same-index height change of the anchor row", () => {
+    expect(
+      resolveUnpinnedAnchorRestore({ capturedRowIndex: 0, nextRowIndex: 0 }),
+    ).toEqual({ kind: "measured-offset" });
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/unpinned-anchor-restore.ts
+++ b/apps/packages/product-ui/src/chat/transcript/unpinned-anchor-restore.ts
@@ -1,0 +1,35 @@
+// Decides how to restore the user's read position when an unpinned transcript
+// changes composition around the anchored (first-visible) row. The restore math
+// itself lives in VirtualizedTranscriptRowList; this is the pure branch picker so
+// the above/below/same-index distinction can be unit-tested without a layout
+// engine (jsdom does no layout, so the virtualizer surfaces no virtual items).
+
+export interface UnpinnedAnchorChange {
+  // Index of the anchored row when its scroll position was captured.
+  capturedRowIndex: number;
+  // Index of the same anchored row (matched by key) after the change.
+  nextRowIndex: number;
+}
+
+export type UnpinnedAnchorRestoreAction =
+  // Rows were inserted/removed ABOVE the viewport, so the anchor shifted. Hold
+  // it with the measured scrollHeight delta (immune to estimate error on the
+  // changed, still-unmeasured rows).
+  | { kind: "measured-delta" }
+  // The anchor index is unchanged, so nothing changed above it: the change is at
+  // the anchor row itself or strictly below the viewport. Re-anchor to the
+  // (measured) row top plus the captured intra-row offset, which holds the
+  // anchor row at the same viewport y and no-ops for purely-below changes.
+  | { kind: "measured-offset" };
+
+// nextRowIndex < 0 means the anchored row vanished; callers should bail before
+// reaching here. This picker only distinguishes the above-change (shifted index)
+// case from the same-index (at/below) case.
+export function resolveUnpinnedAnchorRestore(
+  change: UnpinnedAnchorChange,
+): UnpinnedAnchorRestoreAction {
+  if (change.nextRowIndex !== change.capturedRowIndex) {
+    return { kind: "measured-delta" };
+  }
+  return { kind: "measured-offset" };
+}


### PR DESCRIPTION
Stack 2/9. The unpinned anchor-restore used estimate-based getOffsetForIndex; now distinguishes above-viewport changes (rows inserted/removed above the read position -> measured-delta) from at/below changes (the anchor's index is unchanged -> force-measure the anchor row and hold the exact pixel offset) so a turn growing at or below the read position no longer nudges it. New pure helper resolveUnpinnedAnchorRestore + tests (pure picker + an integration guard that the same-index path force-measures the anchor node and re-anchors). Verified: acceptance met (high).