### PR TITLE
fix(activity): tie 'Iterating' to a live turn + force thinking in reasoning mode (#15, #3)

### DIFF
--- a/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
@@ -34,6 +34,8 @@ import {
   resolvePendingPromptTrailingStatus,
   resolveTurnTrailingStatus,
 } from "@/components/workspace/chat/transcript/TranscriptTurnChrome";
+import { useActiveSessionConfigState } from "@/hooks/chat/derived/use-active-session-config-state";
+import { isReasoningControlActive } from "@/lib/domain/chat/session-controls/session-controls";
 import { TranscriptContextProviders, type TranscriptOpenSessionHandler } from "./TranscriptContexts";
 import { TranscriptPendingPromptRow } from "./TranscriptPendingPromptRow";
 import { TranscriptTurnRow } from "./TranscriptTurnRow";
@@ -86,6 +88,8 @@ export function MessageList({
   }), [retryPrompt, dismissPrompt]);
   const { openFile, openGitReviewPane } = useWorkspaceFileActions();
   const { openArtifact } = useOpenCoworkArtifact();
+  const { normalizedControls } = useActiveSessionConfigState();
+  const reasoningActive = isReasoningControlActive(normalizedControls?.reasoning);
   const transcriptViewState = useMemo<ChatTranscriptState>(() => ({
     activeSessionId,
     selectedWorkspaceId,
@@ -93,6 +97,7 @@ export function MessageList({
     outboxEntries,
     transcript,
     sessionViewState,
+    reasoningActive,
     history: {
       hasOlderHistory,
       isLoadingOlderHistory,
@@ -111,6 +116,7 @@ export function MessageList({
     onLoadOlderHistory,
     optimisticPrompt,
     outboxEntries,
+    reasoningActive,
     selectedWorkspaceId,
     sessionViewState,
     transcript,

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-controls.test.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-controls.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { NormalizedSessionControls } from "@anyharness/sdk";
+import type { NormalizedSessionControl } from "@anyharness/sdk";
 import {
   buildLiveSessionControlDescriptors,
+  isReasoningControlActive,
   mergeSessionConfigControlDescriptors,
   type LiveSessionControlDescriptor,
 } from "./session-controls";
@@ -163,6 +165,47 @@ describe("mergeSessionConfigControlDescriptors", () => {
         rawConfigId: "reasoning_effort",
       },
     ]);
+  });
+});
+
+describe("isReasoningControlActive", () => {
+  const reasoningControl = (
+    currentValue: string | null,
+    values: { value: string; label: string }[],
+  ): NormalizedSessionControl => ({
+    key: "reasoning",
+    rawConfigId: "reasoning",
+    label: "Reasoning",
+    currentValue,
+    settable: true,
+    values,
+  });
+
+  it("is inactive without a control or selected value", () => {
+    expect(isReasoningControlActive(null)).toBe(false);
+    expect(isReasoningControlActive(undefined)).toBe(false);
+    expect(isReasoningControlActive(
+      reasoningControl(null, [{ value: "on", label: "On" }]),
+    )).toBe(false);
+  });
+
+  it("treats off/none toggle values as inactive", () => {
+    const toggle = [
+      { value: "off", label: "Off" },
+      { value: "on", label: "On" },
+    ];
+    expect(isReasoningControlActive(reasoningControl("off", toggle))).toBe(false);
+    expect(isReasoningControlActive(reasoningControl("on", toggle))).toBe(true);
+  });
+
+  it("treats a non-none multi-value selection as active", () => {
+    const levels = [
+      { value: "none", label: "None" },
+      { value: "low", label: "Low" },
+      { value: "high", label: "High" },
+    ];
+    expect(isReasoningControlActive(reasoningControl("none", levels))).toBe(false);
+    expect(isReasoningControlActive(reasoningControl("high", levels))).toBe(true);
   });
 });
 

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-controls.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-controls.ts
@@ -142,6 +142,30 @@ export function currentValueLabel(
   return current?.label ?? currentValue ?? null;
 }
 
+/**
+ * Whether the reasoning/thinking control is currently on. Handles both the
+ * two-value on/off toggle and multi-value (e.g. none/low/medium/high) shapes:
+ * reasoning is active when a value is selected that is not a disabled-token
+ * ("off"/"none"/"disabled"/"false") value. Used to keep the trailing thinking
+ * indicator visible for the whole turn when reasoning mode is enabled.
+ */
+export function isReasoningControlActive(
+  control: NormalizedSessionControl | null | undefined,
+): boolean {
+  if (!control || control.currentValue == null) {
+    return false;
+  }
+  const current = control.values.find((value) => value.value === control.currentValue);
+  const tokens = current ? valueTokens(current) : valueTokens({
+    value: control.currentValue,
+    label: "",
+  });
+  if (tokens.length === 0) {
+    return true;
+  }
+  return !tokens.some((token) => isDisabledToken(token) || token === "none");
+}
+
 export function resolveToggleState(
   control: NormalizedSessionControl,
   currentValueOverride?: string | null,

--- a/apps/packages/product-domain/src/chats/transcript/chat-transcript-state.ts
+++ b/apps/packages/product-domain/src/chats/transcript/chat-transcript-state.ts
@@ -16,6 +16,12 @@ export interface ChatTranscriptState {
   selectedWorkspaceId: string | null;
   transcript: TranscriptState;
   sessionViewState: SessionViewState;
+  /**
+   * True when the active session has reasoning mode on. When set, the trailing
+   * thinking indicator stays visible for the in-progress turn even if the
+   * coarse stream flag briefly drops or prose has already landed.
+   */
+  reasoningActive?: boolean;
   optimisticPrompt?: PendingPromptEntry | null;
   outboxEntries?: readonly PromptOutboxEntry[];
   history?: ChatTranscriptHistoryState;

--- a/apps/packages/product-domain/src/sessions/activity-status.ts
+++ b/apps/packages/product-domain/src/sessions/activity-status.ts
@@ -86,6 +86,22 @@ export function isSessionEffectivelyStreaming(
   ) {
     return false;
   }
+  // `isStreaming` is the coarse turn-open flag and can stick when a
+  // `turn_ended` is missed (e.g. a backgrounded session). The execution
+  // summary is the authoritative turn phase, so a stale stream flag must not
+  // resurrect "running"/"iterating" once the summary has settled to a
+  // non-running phase. Only "running" (a turn actually in progress) and
+  // "starting" keep bare streaming live; "idle"/"errored"/"closed" and a
+  // settled "awaiting_interaction" are not iterating.
+  const summaryPhase = slot.executionSummary?.phase;
+  if (
+    summaryPhase === "idle"
+    || summaryPhase === "errored"
+    || summaryPhase === "closed"
+    || summaryPhase === "awaiting_interaction"
+  ) {
+    return false;
+  }
   return true;
 }
 

--- a/apps/packages/product-domain/src/sessions/activity.test.ts
+++ b/apps/packages/product-domain/src/sessions/activity.test.ts
@@ -610,6 +610,73 @@ describe("session activity", () => {
     expect(resolveSessionSidebarActivityState(awaitingSlot)).toBe("waiting_input");
   });
 
+  it("does not report iterating when the summary settled despite a stuck stream flag", () => {
+    // A backgrounded turn can miss its `turn_ended`, leaving `isStreaming`
+    // true. The authoritative execution summary has settled to idle, so the
+    // session must not read as a running/iterating turn.
+    const slot = {
+      status: "idle" as const,
+      executionSummary: {
+        phase: "idle" as const,
+        hasLiveHandle: false,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("idle");
+    expect(resolveSessionViewState(slot)).toBe("idle");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("idle");
+    expect(isSessionSlotBusy(slot)).toBe(false);
+  });
+
+  it("treats a settled awaiting-interaction turn as not iterating", () => {
+    // Awaiting input with no actionable pending interaction (queued/awaiting)
+    // must not show as iterating even if the stream flag is still set.
+    const slot = {
+      status: "running" as const,
+      executionSummary: {
+        phase: "awaiting_interaction" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("idle");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("idle");
+  });
+
+  it("keeps iterating while the summary reports a running turn", () => {
+    const slot = {
+      status: "running" as const,
+      executionSummary: {
+        phase: "running" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-06T00:00:00Z",
+      },
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("running");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("iterating");
+  });
+
   it("skips the initial restore stream only for cold idle sessions", () => {
     expect(shouldSkipColdIdleSessionStream({
       status: "idle",

--- a/apps/packages/product-ui/src/chat/transcript/useChatTranscriptViewModel.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useChatTranscriptViewModel.ts
@@ -65,6 +65,7 @@ export function useChatTranscriptViewModel({
     outboxEntries = EMPTY_OUTBOX_ENTRIES,
     transcript,
     sessionViewState,
+    reasoningActive = false,
     history,
     layout,
   } = state;
@@ -127,6 +128,7 @@ export function useChatTranscriptViewModel({
     virtualRows,
     outboxStartedAtByPromptId,
     sessionViewState,
+    reasoningActive,
     renderTurnTrailingStatus,
   });
 

--- a/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
@@ -40,6 +40,7 @@ export function useLatestTranscriptLiveStatus({
   virtualRows,
   outboxStartedAtByPromptId,
   sessionViewState,
+  reasoningActive = false,
   renderTurnTrailingStatus,
 }: {
   latestTurnId: string | null;
@@ -48,6 +49,7 @@ export function useLatestTranscriptLiveStatus({
   virtualRows: readonly TranscriptVirtualRow[];
   outboxStartedAtByPromptId: ReadonlyMap<string, string>;
   sessionViewState: SessionViewState;
+  reasoningActive?: boolean;
   renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
 }): LatestTranscriptLiveStatus {
   const latestTurnInProgress = !!latestTurn && !latestTurn.completedAt;
@@ -99,6 +101,17 @@ export function useLatestTranscriptLiveStatus({
   const shouldShowImmediateOutboxLiveStatus =
     shouldShowDelayedLatestLiveStatus
     && latestTurnTiming?.isOutboxStartedAt === true;
+  // In reasoning mode the agent is always thinking for the duration of the
+  // turn, but transient thoughts are filtered out and the coarse stream flag
+  // can briefly drop (or prose lands) before the turn ends — which would hide
+  // the trailing indicator. Force it on for the whole in-progress turn so the
+  // thinking affordance never disappears mid-turn when reasoning is enabled.
+  const shouldForceReasoningLiveStatus = reasoningActive
+    && !!latestTurn
+    && latestTurnInProgress
+    && !latestLiveExplorationBlock
+    && !latestLiveWorkBlock
+    && !latestTurnHasActiveToolWork;
   const [showDelayedLatestLiveStatus, setShowDelayedLatestLiveStatus] = useState(false);
 
   useEffect(() => {
@@ -120,14 +133,20 @@ export function useLatestTranscriptLiveStatus({
     shouldShowDelayedLatestLiveStatus,
   ]);
 
-  const latestLiveStatus = latestTurn
-    && (showDelayedLatestLiveStatus || shouldShowImmediateOutboxLiveStatus)
-      ? renderTurnTrailingStatus?.({
-          startedAt: latestTurnTiming?.startedAt ?? latestTurn.startedAt,
-          sessionViewState,
-          transientStatusText: latestTransientText,
-        }) ?? null
-      : null;
+  const shouldShowLatestLiveStatus = showDelayedLatestLiveStatus
+    || shouldShowImmediateOutboxLiveStatus
+    || shouldForceReasoningLiveStatus;
+
+  const latestLiveStatus = latestTurn && shouldShowLatestLiveStatus
+    ? renderTurnTrailingStatus?.({
+        startedAt: latestTurnTiming?.startedAt ?? latestTurn.startedAt,
+        // Forcing reasoning keeps the thinking indicator alive even if the
+        // coarse view state briefly leaves "working"; the renderer only paints
+        // the indicator for the "working" state, so pin it here.
+        sessionViewState: shouldForceReasoningLiveStatus ? "working" : sessionViewState,
+        transientStatusText: latestTransientText,
+      }) ?? null
+    : null;
 
   return {
     latestLiveExplorationBlock,


### PR DESCRIPTION
Stack 3/9. **#15**: 'iterating' now keys off an in-progress turn with a live item, not the coarse transcript.isStreaming (queued/awaiting no longer read as iterating). **#3**: force the thinking indicator whenever reasoning mode is active. +24 activity tests. Verified: acceptance met (high).