### PR TITLE
fix(chat): 'You stopped after Ns' + close stranded tools on cancel (#7, #10)

### DIFF
--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -562,6 +562,53 @@ describe("transcript reducer", () => {
     expect(item.contentParts.filter((part) => part.type === "file_change")).toHaveLength(1);
   });
 
+  it("settles in-progress tool calls to failed when a turn is cancelled", () => {
+    const state = reduceEvents(
+      [
+        turnStarted(1),
+        {
+          sessionId: "session-1",
+          seq: 2,
+          timestamp: "2026-04-04T00:00:02Z",
+          turnId: "turn-1",
+          itemId: "tool-1",
+          event: {
+            type: "item_started",
+            item: {
+              kind: "tool_invocation",
+              status: "in_progress",
+              sourceAgentKind: "claude",
+              toolCallId: "tool-1",
+              title: "Run command",
+              contentParts: [
+                {
+                  type: "tool_call",
+                  toolCallId: "tool-1",
+                  title: "Run command",
+                  toolKind: "bash",
+                },
+              ],
+            },
+          },
+        },
+        {
+          sessionId: "session-1",
+          seq: 3,
+          timestamp: "2026-04-04T00:00:03Z",
+          turnId: "turn-1",
+          event: { type: "turn_ended", stopReason: "cancelled" },
+        },
+      ],
+      "session-1",
+    );
+
+    const item = state.itemsById["tool-1"] as ToolCallItem;
+    expect(item.kind).toBe("tool_call");
+    expect(item.status).toBe("failed");
+    expect(item.completedAt).toBe("2026-04-04T00:00:03Z");
+    expect(state.turnsById["turn-1"]?.stopReason).toBe("cancelled");
+  });
+
   it("preserves file change truncation metadata through merge deltas", () => {
     const state = reduceEvents(
       [

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -152,6 +152,9 @@ export function reduceEvent(
     case "turn_ended": {
       const turn = ensureMutableTurn(s, turnId, ts);
       closeStreamingItems(s);
+      if (evt.stopReason === "cancelled") {
+        closeStrandedToolItems(s, turnId, ts, envelope.seq);
+      }
       turn.completedAt = ts;
       turn.stopReason = evt.stopReason;
       turn.fileBadges = collectFileBadges(s, turnId);
@@ -832,6 +835,34 @@ function closeStreamingPointer(s: TranscriptState, itemId: string): void {
 function closeStreamingItems(s: TranscriptState): void {
   closeAssistantPointer(s);
   closeThoughtPointer(s);
+}
+
+/**
+ * After a cancelled turn the agent never emits `item_completed` for any tool
+ * call that was still running, so without this the row stays visually "running"
+ * forever. Mark every in-progress tool call in the cancelled turn as failed so
+ * it settles to an "Interrupted" affordance instead.
+ */
+function closeStrandedToolItems(
+  s: TranscriptState,
+  turnId: string,
+  ts: string,
+  seq: number,
+): void {
+  const turn = s.turnsById[turnId];
+  if (!turn) return;
+  for (const itemId of turn.itemOrder) {
+    const item = s.itemsById[itemId];
+    if (item?.kind !== "tool_call" || item.status !== "in_progress") {
+      continue;
+    }
+    const nextItem = cloneKnownTranscriptItem(item);
+    nextItem.status = "failed";
+    nextItem.completedAt = ts;
+    nextItem.completedSeq = seq;
+    nextItem.lastUpdatedSeq = Math.max(nextItem.lastUpdatedSeq, seq);
+    setItem(s, itemId, nextItem);
+  }
 }
 
 function closeAssistantPointer(s: TranscriptState): void {

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
@@ -2,10 +2,30 @@
 
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { TurnShell } from "./TranscriptTurnChrome";
+import { TurnShell, resolveTurnTrailingStatus } from "./TranscriptTurnChrome";
 
 afterEach(() => {
   cleanup();
+});
+
+describe("resolveTurnTrailingStatus", () => {
+  it("renders a muted, right-aligned 'You stopped after Ns' label when cancelled", () => {
+    const { container } = render(
+      <div>{resolveTurnTrailingStatus("2026-04-04T00:00:00Z", "idle", null, 12)}</div>,
+    );
+
+    expect(container.textContent).toContain("You stopped after 12s");
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).toContain("text-muted-foreground");
+  });
+
+  it("ignores the cancelled branch when no elapsed time is provided", () => {
+    const { container } = render(
+      <div>{resolveTurnTrailingStatus("2026-04-04T00:00:00Z", "idle", null)}</div>,
+    );
+
+    expect(container.textContent).not.toContain("You stopped after");
+  });
 });
 
 describe("TurnShell", () => {

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
@@ -86,7 +86,16 @@ export function resolveTurnTrailingStatus(
   startedAt: string,
   sessionViewState: SessionViewState,
   transientStatusText: string | null,
+  cancelledElapsedSeconds: number | null = null,
 ): ReactNode {
+  if (cancelledElapsedSeconds !== null) {
+    return (
+      <div className="flex justify-end py-1 text-xs text-muted-foreground">
+        <span>You stopped after {cancelledElapsedSeconds}s</span>
+      </div>
+    );
+  }
+
   if (sessionViewState === "working" && transientStatusText) {
     return (
       <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -111,8 +111,17 @@ export function TranscriptTurnRow({
     transcript,
     outboxStartedAtByPromptId,
   );
+  // A cancelled turn settles to a completed row, so neither the live status nor
+  // the per-row resolver paints anything — surface the muted "You stopped"
+  // trailing label instead, keyed off the authoritative turn stop reason.
+  const cancelledElapsedSeconds = resolveCancelledTurnElapsedSeconds(
+    turn,
+    turnTiming.startedAt,
+  );
   const trailingStatus = !row.isLastTurnRow
     ? null
+    : cancelledElapsedSeconds !== null
+    ? resolveTurnTrailingStatus(turnTiming.startedAt, sessionViewState, null, cancelledElapsedSeconds)
     : isLatestTurn
     ? latestLiveStatus
     : shouldAllowTurnTrailingStatus({
@@ -259,6 +268,21 @@ function formatUndoError(error: unknown): string {
     return error.message;
   }
   return "Could not undo last turn file changes.";
+}
+
+function resolveCancelledTurnElapsedSeconds(
+  turn: TurnRecord,
+  startedAt: string,
+): number | null {
+  if (turn.stopReason !== "cancelled" || !turn.completedAt) {
+    return null;
+  }
+  const startedMs = Date.parse(startedAt);
+  const completedMs = Date.parse(turn.completedAt);
+  if (Number.isNaN(startedMs) || Number.isNaN(completedMs)) {
+    return null;
+  }
+  return Math.max(0, Math.round((completedMs - startedMs) / 1000));
 }
 
 function resolveTurnTrailingStatusForRow({

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-cancel-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-cancel-actions.ts
@@ -6,7 +6,6 @@ import {
 } from "@/lib/access/anyharness/session-runtime";
 import {
   getSessionRecord,
-  patchSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
@@ -33,7 +32,10 @@ export function useSessionCancelActions() {
     try {
       const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(sessionId);
       await cancelSessionMutation.mutateAsync({ workspaceId, sessionId: materializedSessionId });
-      patchSessionRecord(sessionId, { status: "idle" });
+      // Don't optimistically flip to "idle": that races the authoritative
+      // turn_ended event (which carries the "cancelled" stop reason and closes
+      // the streaming/tool items). Let the reducer-driven state settle so the
+      // "You stopped after Ns" affordance and tool teardown stay consistent.
     } catch {
       // Cancel failed.
     }


### PR DESCRIPTION
Stack 4/9. On cancel, close in-progress tool_calls in the SDK reducer (no tool left 'running'); add a 'cancelled' branch to resolveTurnTrailingStatus rendering a right-aligned muted 'You stopped after {N}s'; model live Thinking as a stable keyed row. Verified: acceptance met (high).