### PR TITLE
fix(codex): agent-aware current-mode for plan/default (#4)

### DIFF
--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -203,11 +203,17 @@ export function reduceEvent(
       s.currentModeId = evt.currentModeId;
       break;
 
-    case "config_option_update":
+    case "config_option_update": {
       s.liveConfig = evt.liveConfig;
-      s.currentModeId =
-        evt.liveConfig.normalizedControls.mode?.currentValue ?? s.currentModeId;
+      // Codex exposes two mode-like controls: collaborationMode (default/plan)
+      // and mode (permissions). Prefer collaborationMode when present so the
+      // current mode tracks plan<->default, mirroring useChatSessionControls.
+      const modeControl =
+        evt.liveConfig.normalizedControls.collaborationMode
+        ?? evt.liveConfig.normalizedControls.mode;
+      s.currentModeId = modeControl?.currentValue ?? s.currentModeId;
       break;
+    }
 
     case "session_state_update":
       break;

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -122,14 +122,17 @@ export async function dispatchConfigIntent(
         patchSessionRecord(intent.clientSessionId, nextPatch);
       }
       if (response.applyState === "applied" && intent.persistDefaultPreference) {
-        // Persist against whichever mode-like control the intent actually
-        // targeted: collaborationMode (default/plan) or mode (permissions).
-        // The preference guard requires this rawConfigId to match intent.configId.
+        // Only the permission `mode` control persists into the create-session
+        // mode_id store (defaultSessionModeByAgentKind). collaboration_mode
+        // (default/plan) is a live control whose default lives in a separate
+        // store (defaultLiveSessionControlValuesByAgentKind), so it must NOT
+        // pass this guard — otherwise toggling Plan/Default would write
+        // "plan"/"default" as an invalid permission mode_id.
         const normalizedControls = effectiveLiveConfig?.normalizedControls;
         const intentModeRawConfigId =
-          [normalizedControls?.collaborationMode, normalizedControls?.mode]
-            .find((control) => control?.rawConfigId === intent.configId)
-            ?.rawConfigId ?? null;
+          normalizedControls?.mode?.rawConfigId === intent.configId
+            ? normalizedControls.mode.rawConfigId
+            : null;
         persistDefaultSessionModePreference({
           agentKind: response.session.agentKind ?? latestSlot.agentKind,
           liveConfigRawConfigId: intentModeRawConfigId,

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -91,6 +91,12 @@ export async function dispatchConfigIntent(
           ?? null,
       } as const;
       if (effectiveLiveConfig) {
+        // Codex exposes two mode-like controls: collaborationMode (default/plan)
+        // and mode (permissions). Prefer collaborationMode when present so the
+        // current mode tracks plan<->default, mirroring useChatSessionControls.
+        const modeControl =
+          effectiveLiveConfig.normalizedControls.collaborationMode
+          ?? effectiveLiveConfig.normalizedControls.mode;
         patchSessionRecord(intent.clientSessionId, {
           ...nextPatch,
           liveConfig: effectiveLiveConfig,
@@ -100,14 +106,14 @@ export async function dispatchConfigIntent(
             ?? latestSlot.modelId
             ?? null,
           modeId:
-            effectiveLiveConfig.normalizedControls.mode?.currentValue
+            modeControl?.currentValue
             ?? response.session.modeId
             ?? latestSlot.modeId
             ?? null,
           transcript: {
             ...latestSlot.transcript,
             currentModeId:
-              effectiveLiveConfig.normalizedControls.mode?.currentValue
+              modeControl?.currentValue
               ?? response.session.modeId
               ?? latestSlot.transcript.currentModeId,
           },
@@ -116,9 +122,17 @@ export async function dispatchConfigIntent(
         patchSessionRecord(intent.clientSessionId, nextPatch);
       }
       if (response.applyState === "applied" && intent.persistDefaultPreference) {
+        // Persist against whichever mode-like control the intent actually
+        // targeted: collaborationMode (default/plan) or mode (permissions).
+        // The preference guard requires this rawConfigId to match intent.configId.
+        const normalizedControls = effectiveLiveConfig?.normalizedControls;
+        const intentModeRawConfigId =
+          [normalizedControls?.collaborationMode, normalizedControls?.mode]
+            .find((control) => control?.rawConfigId === intent.configId)
+            ?.rawConfigId ?? null;
         persistDefaultSessionModePreference({
           agentKind: response.session.agentKind ?? latestSlot.agentKind,
-          liveConfigRawConfigId: effectiveLiveConfig?.normalizedControls.mode?.rawConfigId ?? null,
+          liveConfigRawConfigId: intentModeRawConfigId,
           rawConfigId: intent.configId,
           modeId: getAuthoritativeConfigValue(effectiveLiveConfig, intent.configId) ?? intent.value,
           workspaceSurface: deps.getWorkspaceSurface(workspaceId),

--- a/apps/desktop/src/lib/domain/chat/composer/chat-input.test.ts
+++ b/apps/desktop/src/lib/domain/chat/composer/chat-input.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveChatDraftWorkspaceId,
   resolveChatInputAvailability,
+  resolveCurrentModeLabel,
 } from "./chat-input";
 
 describe("resolveChatDraftWorkspaceId", () => {
@@ -15,6 +16,52 @@ describe("resolveChatDraftWorkspaceId", () => {
 
   it("returns null when no workspace is selected", () => {
     expect(resolveChatDraftWorkspaceId(null, null)).toBeNull();
+  });
+});
+
+describe("resolveCurrentModeLabel", () => {
+  const planControl = {
+    currentValue: "plan",
+    values: [
+      { value: "default", label: "Default" },
+      { value: "plan", label: "Plan" },
+    ],
+  };
+  const permissionControl = {
+    currentValue: "acceptEdits",
+    values: [
+      { value: "acceptEdits", label: "Accept edits" },
+      { value: "readOnly", label: "Read only" },
+    ],
+  };
+
+  it("prefers the collaboration mode control over the permission mode control", () => {
+    expect(resolveCurrentModeLabel({
+      liveConfig: {
+        normalizedControls: {
+          collaborationMode: planControl,
+          mode: permissionControl,
+        },
+      },
+    })).toBe("Plan");
+  });
+
+  it("falls back to the permission mode control when no collaboration mode exists", () => {
+    expect(resolveCurrentModeLabel({
+      liveConfig: {
+        normalizedControls: {
+          mode: permissionControl,
+        },
+      },
+    })).toBe("Accept edits");
+  });
+
+  it("falls back to the slot mode id when no live config is present", () => {
+    expect(resolveCurrentModeLabel({ modeId: "plan" })).toBe("plan");
+  });
+
+  it("returns null when no mode is resolvable", () => {
+    expect(resolveCurrentModeLabel(null)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/lib/domain/chat/composer/chat-input.ts
+++ b/apps/desktop/src/lib/domain/chat/composer/chat-input.ts
@@ -47,6 +47,7 @@ interface ChatInputActiveSlotLike {
   } | null;
   liveConfig?: {
     normalizedControls?: {
+      collaborationMode?: NormalizedModeControlLike | null;
       mode?: NormalizedModeControlLike | null;
     } | null;
   } | null;
@@ -216,8 +217,16 @@ function pendingInteractionDisabledReason(kind: ChatInputPendingInteractionKind)
 export function resolveCurrentModeLabel(
   activeSlot: ChatInputActiveSlotLike | null,
 ): string | null {
+  const normalizedControls = activeSlot?.liveConfig?.normalizedControls;
+  // Codex exposes two mode-like controls: collaborationMode (default/plan) and
+  // mode (permissions). Prefer collaborationMode when present so the label
+  // tracks plan<->default, mirroring useChatSessionControls.
+  const modeControl =
+    normalizedControls?.collaborationMode
+    ?? normalizedControls?.mode
+    ?? null;
   const currentModeId =
-    activeSlot?.liveConfig?.normalizedControls?.mode?.currentValue
+    modeControl?.currentValue
     ?? activeSlot?.modeId
     ?? activeSlot?.transcript?.currentModeId
     ?? null;
@@ -225,6 +234,5 @@ export function resolveCurrentModeLabel(
     return null;
   }
 
-  const modeControl = activeSlot?.liveConfig?.normalizedControls?.mode ?? null;
   return modeControl?.values.find((value) => value.value === currentModeId)?.label ?? currentModeId;
 }

--- a/apps/desktop/src/lib/domain/sessions/stream-patch.ts
+++ b/apps/desktop/src/lib/domain/sessions/stream-patch.ts
@@ -69,13 +69,17 @@ export function buildSessionStreamPatch({
     patch.liveConfig = event.liveConfig;
     patch.modelId =
       event.liveConfig.normalizedControls.model?.currentValue ?? slot.modelId;
-    patch.modeId =
-      event.liveConfig.normalizedControls.mode?.currentValue ?? slot.modeId;
+    // Codex exposes two mode-like controls: collaborationMode (default/plan) and
+    // mode (permissions). Prefer collaborationMode so plan<->default reflects in
+    // the badge/persistence on the stream-flush path too (matches the reducer +
+    // session-intent dispatch).
+    const nextModeId =
+      event.liveConfig.normalizedControls.collaborationMode?.currentValue
+      ?? event.liveConfig.normalizedControls.mode?.currentValue;
+    patch.modeId = nextModeId ?? slot.modeId;
     patch.transcript = {
       ...nextTranscript,
-      currentModeId:
-        event.liveConfig.normalizedControls.mode?.currentValue
-        ?? nextTranscript.currentModeId,
+      currentModeId: nextModeId ?? nextTranscript.currentModeId,
     };
   }
 

--- a/apps/desktop/src/stores/sessions/session-records.ts
+++ b/apps/desktop/src/stores/sessions/session-records.ts
@@ -49,7 +49,10 @@ export function createEmptySessionRecord(
   },
 ): SessionRuntimeRecord {
   const resolvedModeId =
-    config?.liveConfig?.normalizedControls.mode?.currentValue ?? config?.modeId ?? null;
+    config?.liveConfig?.normalizedControls.collaborationMode?.currentValue
+    ?? config?.liveConfig?.normalizedControls.mode?.currentValue
+    ?? config?.modeId
+    ?? null;
   const title = config?.title?.trim() || null;
   const transcript = {
     ...createTranscriptState(sessionId),
@@ -100,7 +103,8 @@ export function createSessionRecordFromSummary(
   },
 ): SessionRuntimeRecord {
   const modeId =
-    session.liveConfig?.normalizedControls.mode?.currentValue
+    session.liveConfig?.normalizedControls.collaborationMode?.currentValue
+    ?? session.liveConfig?.normalizedControls.mode?.currentValue
     ?? session.modeId
     ?? null;
   const title = session.title?.trim() || options?.titleFallback?.trim() || null;


### PR DESCRIPTION
Stack 5/9. Codex has two controls (collaboration_mode default/plan + mode permissions). Made current-mode/label/persistence prefer collaborationMode across ALL paths: session-intent dispatch, SDK reducer, chat-input label, **and** the stream-flush patch (stream-patch.ts) + hydration (session-records.ts) — the last two were caught by adversarial review as same-bug sites that clobbered the fix on the live path. 124 session tests green.