### PR TITLE
fix(workspaces): stable local-workspace identity + no right-panel toggle on create (#11, #13)

### DIFF
--- a/apps/desktop/src/hooks/main/facade/use-main-screen-state.ts
+++ b/apps/desktop/src/hooks/main/facade/use-main-screen-state.ts
@@ -332,7 +332,13 @@ export function useMainScreenState(): MainScreenState {
     [selectedCloudWorkspaceId, workspaceCollections?.cloudWorkspaces],
   );
 
-  const rightPanelSuppressed = Boolean(pendingWorkspaceEntry);
+  // Only suppress the right panel while entering a *home-originated* create (no
+  // prior workspace, so no panel to disturb). A workspace-originated create keeps
+  // the origin panel's durable state across the pending->materialized window, so
+  // an already-open panel never animates a close-then-open on create (#13).
+  const rightPanelSuppressed = Boolean(
+    pendingWorkspaceEntry && pendingWorkspaceEntry.originTarget.kind === "home",
+  );
   const userOpenOverrideActive = Boolean(
     rightPanelUserOpenOverride
     && rightPanelUserOpenOverride.materializedWorkspaceId === materializedWorkspaceId

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts
@@ -81,7 +81,7 @@ function makeMobilityWorkspace(args: {
 }
 
 describe("logical workspace duplicate local records", () => {
-  it("splits duplicate local workspaces while merging cloud and mobility only with canonical", () => {
+  it("gives every member of a multi-local bucket a distinct slot id and keeps cloud/mobility separate", () => {
     const repoRoot = makeRepoRoot();
     const olderLocal = makeWorkspace({
       id: "local-older",
@@ -113,7 +113,8 @@ describe("logical workspace duplicate local records", () => {
       "proliferate",
       "main",
     );
-    const slotId = buildLocalSlotLogicalWorkspaceId(newerLocal.id);
+    const newerSlotId = buildLocalSlotLogicalWorkspaceId(newerLocal.id);
+    const olderSlotId = buildLocalSlotLogicalWorkspaceId(olderLocal.id);
 
     const logicalWorkspaces = buildLogicalWorkspaces({
       localWorkspaces: [newerLocal, olderLocal],
@@ -123,19 +124,25 @@ describe("logical workspace duplicate local records", () => {
       currentSelectionId: null,
     });
 
+    // Every member of a multi-local bucket gets its own distinct `local-slot:` id
+    // (no member aliases the shared base id), so a new local workspace never
+    // inherits another's logical identity during the pending window (#11).
     const canonical = logicalWorkspaces.find((workspace) => workspace.id === canonicalId);
-    const slot = logicalWorkspaces.find((workspace) => workspace.id === slotId);
+    const newerSlot = logicalWorkspaces.find((workspace) => workspace.id === newerSlotId);
+    const olderSlot = logicalWorkspaces.find((workspace) => workspace.id === olderSlotId);
 
-    expect(logicalWorkspaces).toHaveLength(2);
-    expect(canonical?.localWorkspace?.id).toBe(olderLocal.id);
+    expect(logicalWorkspaces).toHaveLength(3);
+    expect(newerSlot?.localWorkspace?.id).toBe(newerLocal.id);
+    expect(newerSlot?.cloudWorkspace).toBeNull();
+    expect(newerSlot?.mobilityWorkspace).toBeNull();
+    expect(olderSlot?.localWorkspace?.id).toBe(olderLocal.id);
+    expect(olderSlot?.cloudWorkspace).toBeNull();
+    expect(olderSlot?.mobilityWorkspace).toBeNull();
+    // Cloud + mobility records for the same folder+branch collapse into their own
+    // canonical entry with no aliased local workspace.
+    expect(canonical?.localWorkspace).toBeNull();
     expect(canonical?.cloudWorkspace?.id).toBe(cloudWorkspace.id);
     expect(canonical?.mobilityWorkspace?.id).toBe(mobilityWorkspace.id);
-    expect(slot?.localWorkspace?.id).toBe(newerLocal.id);
-    expect(slot?.cloudWorkspace).toBeNull();
-    expect(slot?.mobilityWorkspace).toBeNull();
-    expect(logicalWorkspaceRelatedIds(canonical!)).toContain(
-      buildLocalSlotLogicalWorkspaceId(olderLocal.id),
-    );
   });
 
   it("keeps distinct local workspaces that each have their own chats", () => {

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -240,9 +240,18 @@ export function buildLogicalWorkspaces(args: {
       args.currentSelectionId ?? null,
     )
       .sort((left, right) => compareLocalWorkspaceCanonicalOrder(left.workspace, right.workspace));
-    sortedBucket.forEach((collapsed, index) => {
+    // A singleton bucket keeps the shared base id so cloud/mobility records for
+    // the same folder+branch merge onto it. Every member of a multi-workspace
+    // bucket instead gets a stable, per-workspace `local-slot:${id}` id: keeping
+    // index 0 on the shared base id aliased two distinct local workspaces during
+    // the pending window (a new local workspace momentarily showed another's
+    // session/content as the canonical sort order shifted which member held the
+    // base id). Sidebar grouping is keyed off `repoKey`, not the logical id, so
+    // distinct slot ids leave grouping intact (#11).
+    const isSingletonBucket = sortedBucket.length === 1;
+    sortedBucket.forEach((collapsed) => {
       const { workspace } = collapsed;
-      const logicalId = index === 0
+      const logicalId = isSingletonBucket
         ? baseLogicalId
         : buildLocalSlotLogicalWorkspaceId(workspace.id);
       byId.set(logicalId, {


### PR DESCRIPTION
Stack 6/9. **#11**: every member of a folder+branch bucket gets a unique local-slot id (no aliasing index 0), so a new local workspace never momentarily shows another's content. **#13**: stop toggling right-panel suppression across pending→materialized (no close-then-open). Verified: acceptance met.