### PR TITLE
fix(home): navigate before painting the first message (#1)

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
@@ -289,7 +289,10 @@ describe("HomeNextScreen model availability notices", () => {
     expect(screen.queryByText("start cowork")).toBeNull();
   });
 
-  it("keeps the submitted preview for repository launches", () => {
+  it("does not render a submitted preview below the composer for repository launches", () => {
+    // Navigate-first (#1): the optimistic message now appears on the destination
+    // session shell, not on home — so no preview should paint here even for
+    // worktree/repository launches.
     screenMocks.homeNext.launchTarget = {
       kind: "worktree",
       repoRootId: "repo-root-1",
@@ -302,7 +305,10 @@ describe("HomeNextScreen model availability notices", () => {
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "start worktree" } });
     fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-    expect(screen.getByText("start worktree")).toBeTruthy();
+    expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
+      text: "start worktree",
+    }));
+    expect(screen.queryByText("start worktree")).toBeNull();
   });
 
   it("renders onboarding cards as the only home onboarding actions", () => {

--- a/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
@@ -11,7 +11,6 @@ import { ChatComposerActions } from "@/components/workspace/chat/input/ChatCompo
 import { SessionConfigControls } from "@/components/workspace/chat/input/SessionConfigControls";
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
 import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
-import { UserMessage } from "@/components/workspace/chat/transcript/UserMessage";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { useHomeNextLaunchControls } from "@/hooks/home/derived/use-home-next-launch-controls";
 import { useHomeCloudRepoSettingsNavigation } from "@/hooks/home/workflows/use-home-cloud-repo-settings-navigation";
@@ -213,20 +212,6 @@ export function HomeNextScreen() {
               onConfigureCloud={configureCloud}
             />
           </div>
-
-          {composer.submittedPreview ? (
-            <div
-              key={composer.submittedPreview.id}
-              className="mt-5"
-              data-home-submit-preview
-            >
-              <UserMessage
-                sessionId={null}
-                content={composer.submittedPreview.text}
-                contentParts={[{ type: "text", text: composer.submittedPreview.text }]}
-              />
-            </div>
-          ) : null}
 
           {modelAvailabilityNotice ? (
             <div className="mx-auto mt-2 flex max-w-2xl items-center justify-center gap-2 px-2 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.test.tsx
+++ b/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  HomeLaunchTarget,
+  HomeNextModelSelection,
+} from "@/lib/domain/home/home-next-launch";
+import { useHomeNextComposerState } from "./use-home-next-composer-state";
+
+const launchMock = vi.fn();
+
+vi.mock("@/hooks/home/workflows/use-home-next-launch", () => ({
+  useHomeNextLaunch: () => ({ isLaunching: false, launch: launchMock }),
+}));
+
+vi.mock("@/stores/home/home-draft-handoff-store", () => ({
+  useHomeDraftHandoffStore: (selector: (state: unknown) => unknown) =>
+    selector({ draftText: null, clearDraftText: vi.fn() }),
+}));
+
+const modelSelection: HomeNextModelSelection = {
+  kind: "codex",
+  modelId: "gpt-5.4",
+} as HomeNextModelSelection;
+
+const launchTarget: HomeLaunchTarget = {
+  kind: "local",
+  sourceRoot: "/repo",
+} as HomeLaunchTarget;
+
+function renderComposer() {
+  return renderHook(() =>
+    useHomeNextComposerState({
+      targetDisabledReason: null,
+      modelAvailabilityState: "launchable",
+      canLaunchTarget: true,
+      modelSelection,
+      modeId: null,
+      launchControlValues: {},
+      launchTarget,
+    }),
+  );
+}
+
+describe("useHomeNextComposerState (navigate-first)", () => {
+  beforeEach(() => {
+    launchMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not expose a home-side submitted preview", () => {
+    const { result } = renderComposer();
+    expect("submittedPreview" in result.current).toBe(false);
+  });
+
+  it("clears the draft and launches without painting an optimistic preview on home", async () => {
+    launchMock.mockResolvedValue(true);
+    const { result } = renderComposer();
+
+    act(() => {
+      result.current.setDraft("hello world");
+    });
+    expect(result.current.canSubmit).toBe(true);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(launchMock).toHaveBeenCalledTimes(1);
+    expect(launchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello world", target: launchTarget }),
+    );
+    // The draft is cleared; the destination pending session owns the preview.
+    expect(result.current.draft).toBe("");
+  });
+
+  it("restores the draft when the launch fails", async () => {
+    launchMock.mockResolvedValue(false);
+    const { result } = renderComposer();
+
+    act(() => {
+      result.current.setDraft("retry me");
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(launchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.draft).toBe("retry me");
+  });
+});

--- a/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
-import { flushSync } from "react-dom";
 import { HOME_CHAT_COMPOSER_INPUT } from "@/config/chat";
 import { useHomeNextLaunch } from "@/hooks/home/workflows/use-home-next-launch";
 import { useHomeDraftHandoffStore } from "@/stores/home/home-draft-handoff-store";
@@ -9,13 +8,6 @@ import type {
   HomeNextModelSelection,
   ModelAvailabilityState,
 } from "@/lib/domain/home/home-next-launch";
-import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
-
-function waitForNextPaint(): Promise<void> {
-  return new Promise((resolve) => {
-    scheduleAfterNextPaint(resolve);
-  });
-}
 
 interface UseHomeNextComposerStateArgs {
   targetDisabledReason: string | null;
@@ -38,10 +30,6 @@ export function useHomeNextComposerState({
 }: UseHomeNextComposerStateArgs) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState("");
-  const [submittedPreview, setSubmittedPreview] = useState<{
-    id: string;
-    text: string;
-  } | null>(null);
   const restoredDraftText = useHomeDraftHandoffStore((state) => state.draftText);
   const clearRestoredDraftText = useHomeDraftHandoffStore((state) => state.clearDraftText);
   const { isLaunching, launch } = useHomeNextLaunch();
@@ -62,7 +50,6 @@ export function useHomeNextComposerState({
     && canLaunchTarget
     && !!modelSelection
     && !!launchTarget
-    && submittedPreview === null
     && !isLaunching;
 
   useLayoutEffect(() => {
@@ -89,20 +76,11 @@ export function useHomeNextComposerState({
     if (!canSubmit || !modelSelection || !launchTarget) return;
 
     const submittedDraft = draft;
-    const submittedText = submittedDraft.trim();
-    const shouldShowHomeSubmittedPreview = launchTarget.kind !== "cowork";
-    flushSync(() => {
-      if (shouldShowHomeSubmittedPreview) {
-        setSubmittedPreview({
-          id: crypto.randomUUID(),
-          text: submittedText,
-        });
-      }
-      setDraft("");
-    });
-    if (shouldShowHomeSubmittedPreview) {
-      await waitForNextPaint();
-    }
+    // Navigate-first: launch() enters the pending-workspace shell and navigates
+    // before any optimistic paint, so the user's message renders on the
+    // destination session shell rather than flashing on home. We only clear the
+    // draft here; the projected pending session owns the optimistic preview.
+    setDraft("");
     const succeeded = await launch({
       text: submittedDraft,
       modelSelection,
@@ -111,7 +89,6 @@ export function useHomeNextComposerState({
       target: launchTarget,
     });
     if (!succeeded) {
-      setSubmittedPreview(null);
       setDraft(submittedDraft);
     }
   }, [
@@ -126,7 +103,6 @@ export function useHomeNextComposerState({
 
   const cancel = useCallback(() => {
     if (!isLaunching) {
-      setSubmittedPreview(null);
       setDraft("");
     }
   }, [isLaunching]);
@@ -159,7 +135,6 @@ export function useHomeNextComposerState({
     textareaRef,
     draft,
     setDraft,
-    submittedPreview,
     submitDisabledReason,
     canSubmit,
     isLaunching,


### PR DESCRIPTION
Stack 7/9. Enter the pending session shell before the optimistic paint so the first message appears on the destination, not flashing on home; the projected pending session owns the preview. Verified: acceptance met (message not dropped — destination shell owns it).