### PR TITLE
fix(workspaces): always land on a session when one exists (#14)

### DIFF
--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -53,6 +53,8 @@ import {
 } from "@/lib/domain/workspaces/selection/optimistic-session-shell";
 import { handleEmptyWorkspaceBootstrap } from "@/hooks/workspaces/workflows/workspace-bootstrap-empty-session";
 import { handleRememberedWorkspaceSessionBootstrap } from "@/hooks/workspaces/workflows/workspace-bootstrap-remembered-session";
+import { selectSessionWithShellIntentRollback } from "@/hooks/sessions/workflows/session-shell-selection";
+import { choosePreferredWorkspaceSession } from "@/lib/domain/workspaces/selection/selection";
 
 interface BootstrapWorkspaceInput {
   workspaceId: string;
@@ -323,6 +325,34 @@ export function useWorkspaceBootstrapActions() {
 
     if (isCurrent()) {
       markWorkspaceBootstrappedInSession(workspaceId);
+    }
+
+    // Final guarantee: the bootstrap handlers above can fall through with no
+    // active session (race/staleness holes), stranding the user on the empty
+    // hero even though the workspace has sessions. If we're still current and
+    // nothing got selected, land on the preferred session so a workspace with
+    // >=1 session never shows the empty state.
+    if (
+      isCurrent()
+      && sessions.length > 0
+      && !useSessionSelectionStore.getState().activeSessionId
+    ) {
+      const fallbackSession = choosePreferredWorkspaceSession(sessions, null);
+      if (fallbackSession) {
+        logLatency("workspace.select.session_fallback", {
+          workspaceId,
+          logicalWorkspaceId,
+          sessionId: fallbackSession.id,
+          sessionCount: sessions.length,
+          totalElapsedMs: elapsedMs(startedAt),
+        });
+        await selectSessionWithShellIntentRollback({
+          workspaceId,
+          sessionId: fallbackSession.id,
+          options: { latencyFlowId },
+          selectSession,
+        });
+      }
     }
 
     return { sessions };

--- a/apps/desktop/src/lib/domain/workspaces/selection/selection.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/selection/selection.test.ts
@@ -53,6 +53,22 @@ describe("choosePreferredWorkspaceSession", () => {
 
     expect(choosePreferredWorkspaceSession(sessions, null)?.id).toBe("session-2");
   });
+
+  it("never returns null for a non-empty list (bootstrap fallback guarantee)", () => {
+    // The bootstrap final-guarantee fallback calls this with a null last-viewed
+    // id; it must always resolve to a session so a workspace with >=1 session
+    // never strands the user on the empty hero (#14).
+    const sessions = [
+      { id: "no-timestamps" },
+      { id: "setup-only", updatedAt: "2026-04-07T20:00:00.000Z" },
+    ];
+
+    expect(choosePreferredWorkspaceSession(sessions, null)).not.toBeNull();
+  });
+
+  it("returns null only for an empty list", () => {
+    expect(choosePreferredWorkspaceSession([], null)).toBeNull();
+  });
 });
 
 describe("getLatestWorkspaceInteractionTimestamp", () => {


### PR DESCRIPTION
Stack 8/9. Final fallback in bootstrapWorkspace: if current and the workspace has ≥1 session but no active session was selected (race/staleness), select choosePreferredWorkspaceSession. Verified: acceptance met.