### PR TITLE
fix(transcript): correct file-path link resolution (#12)

### DIFF
--- a/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -64,6 +64,10 @@ function EditActionRow({
   const fileReferenceActions = useFileReferenceActions({
     rawPath: pathLabel,
     workspacePath,
+    // The path comes from the file_change tool-call metadata, so it is
+    // authoritative — skip the fuzzy backstop (which could re-resolve a
+    // same-basename file), matching FileChangeCall.
+    authoritativePath: true,
   });
   const handleOpen = useCallback(() => {
     void fileReferenceActions.openPrimary();

--- a/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -1,29 +1,44 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileChangeCall } from "./FileChangeCall";
 
-vi.mock("@/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
-    reference: {
-      rawPath,
-      path: rawPath,
-      line: null,
-      column: null,
-      absolutePath: `/repo/${rawPath}`,
-      workspacePath: rawPath,
-    },
-    openTargets: [],
-    canOpenInSidebar: true,
-    canOpenExternal: true,
-    copyPath: vi.fn(),
-    openInSidebar: vi.fn(),
-    openDefault: vi.fn(),
-    openPrimary: vi.fn(),
-    openWithTarget: vi.fn(),
-    reveal: vi.fn(),
-  }),
+const fileReferenceActionsMock = vi.hoisted(() => ({
+  calls: [] as Array<{ rawPath: string; workspacePath?: string | null; authoritativePath?: boolean }>,
 }));
+
+vi.mock("@/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
+  useFileReferenceActions: (input: {
+    rawPath: string;
+    workspacePath?: string | null;
+    authoritativePath?: boolean;
+  }) => {
+    fileReferenceActionsMock.calls.push(input);
+    return {
+      reference: {
+        rawPath: input.rawPath,
+        path: input.rawPath,
+        line: null,
+        column: null,
+        absolutePath: `/repo/${input.rawPath}`,
+        workspacePath: input.rawPath,
+      },
+      openTargets: [],
+      canOpenInSidebar: true,
+      canOpenExternal: true,
+      copyPath: vi.fn(),
+      openInSidebar: vi.fn(),
+      openDefault: vi.fn(),
+      openPrimary: vi.fn(),
+      openWithTarget: vi.fn(),
+      reveal: vi.fn(),
+    };
+  },
+}));
+
+afterEach(() => {
+  fileReferenceActionsMock.calls.length = 0;
+});
 
 describe("FileChangeCall", () => {
   it("renders expanded edit diffs as file cards without an aggregate files-changed header", () => {
@@ -93,5 +108,27 @@ describe("FileChangeCall", () => {
 
     expect(html).toContain("Too large to render inline");
     expect(html).not.toContain("overflow-x-auto overflow-y-auto");
+  });
+
+  it("opens the move destination authoritatively (matches the label's target chip)", () => {
+    renderToStaticMarkup(
+      createElement(FileChangeCall, {
+        operation: "move",
+        path: "src/old/Foo.tsx",
+        workspacePath: "src/old/Foo.tsx",
+        basename: "Foo.tsx",
+        newPath: "src/new/Foo.tsx",
+        newWorkspacePath: "src/new/Foo.tsx",
+        newBasename: "Foo.tsx",
+        status: "completed",
+      }),
+    );
+
+    // The component resolves its own diff-card open target before rendering the
+    // label chips, so calls[0] is the diff card's actions hook.
+    const diffCardCall = fileReferenceActionsMock.calls[0];
+    expect(diffCardCall?.rawPath).toBe("src/new/Foo.tsx");
+    expect(diffCardCall?.workspacePath).toBe("src/new/Foo.tsx");
+    expect(diffCardCall?.authoritativePath).toBe(true);
   });
 });

--- a/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
@@ -53,10 +53,21 @@ export function FileChangeCall({
 }: FileChangeCallProps) {
   const hasDiff = !!patch;
   const actionLabel = getOperationLabel(operation, status);
-  const displayPath = newWorkspacePath || workspacePath || newPath || path;
+  // For a move, the chip the user sees as the diff target is the destination
+  // (the right side of the `old -> new` label). Open exactly that so the diff
+  // card's open action lands on the file the label names, not the pre-move path.
+  const isMove = operation === "move";
+  const resolvedWorkspacePath = isMove
+    ? (newWorkspacePath ?? workspacePath)
+    : (workspacePath ?? newWorkspacePath);
+  const displayPath = resolvedWorkspacePath
+    ?? (isMove ? (newPath ?? path) : (path ?? newPath))
+    ?? path;
   const fileReferenceActions = useFileReferenceActions({
     rawPath: displayPath,
-    workspacePath: newWorkspacePath || workspacePath,
+    workspacePath: resolvedWorkspacePath,
+    // These paths come straight from the tool call — they are authoritative.
+    authoritativePath: true,
   });
   const handleOpenFile = useCallback(() => {
     void fileReferenceActions.openPrimary();

--- a/apps/desktop/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
@@ -28,6 +28,8 @@ export function ToolFileChip({
       basename={basename}
       label={basename}
       workspacePath={workspacePath}
+      // The tool call named this exact file — never fuzzy-correct it.
+      authoritativePath
       variant="chip"
     />
   );

--- a/apps/desktop/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/apps/desktop/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -22,6 +22,9 @@ interface FileReferenceBadgeProps {
   label?: ReactNode;
   basename?: string;
   workspacePath?: string | null;
+  /** See {@link useFileReferenceActions}: skip the fuzzy backstop for paths
+   * that a tool call named authoritatively. */
+  authoritativePath?: boolean;
   variant?: FileReferenceBadgeVariant;
   stopPropagation?: boolean;
   className?: string;
@@ -32,11 +35,12 @@ export function FileReferenceBadge({
   label,
   basename,
   workspacePath,
+  authoritativePath = false,
   variant = "inline",
   stopPropagation = true,
   className = "",
 }: FileReferenceBadgeProps) {
-  const actions = useFileReferenceActions({ rawPath, workspacePath });
+  const actions = useFileReferenceActions({ rawPath, workspacePath, authoritativePath });
   const { onContextMenuCapture } = useFileReferenceNativeContextMenu(actions);
   const resolvedBasename = basename ?? extractBasename(actions.reference.workspacePath ?? actions.reference.path);
   const iconPath = actions.reference.workspacePath ?? actions.reference.path;

--- a/apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -17,6 +17,14 @@ const shellMocks = vi.hoisted(() => ({
   revealInFinder: vi.fn(async () => undefined),
 }));
 
+const fuzzyMocks = vi.hoisted(() => ({
+  resolve: vi.fn(async (_input: unknown): Promise<string | null> => null),
+}));
+
+const viewerStoreMocks = vi.hoisted(() => ({
+  openTarget: vi.fn(),
+}));
+
 vi.mock("@/hooks/editor/workflows/use-open-in-default-editor", () => ({
   useOpenInDefaultEditor: () => ({
     defaultTarget: null,
@@ -39,11 +47,17 @@ vi.mock("@/lib/access/tauri/shell", () => ({
 }));
 
 vi.mock("@/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () => ({
-  useFuzzyFileResolver: () => async () => null,
+  useFuzzyFileResolver: () => fuzzyMocks.resolve,
+}));
+
+vi.mock("@/stores/editor/workspace-viewer-tabs-store", () => ({
+  useWorkspaceViewerTabsStore: (selector: (state: { openTarget: typeof viewerStoreMocks.openTarget }) => unknown) =>
+    selector({ openTarget: viewerStoreMocks.openTarget }),
 }));
 
 afterEach(() => {
   vi.clearAllMocks();
+  fuzzyMocks.resolve.mockResolvedValue(null);
 });
 
 describe("useFileReferenceActions", () => {
@@ -59,6 +73,42 @@ describe("useFileReferenceActions", () => {
 
     expect(shellMocks.revealInFinder).toHaveBeenCalledWith("/Users/pablo/landing");
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+  });
+
+  it("fuzzy-corrects a non-authoritative workspace path and reopens it", async () => {
+    fuzzyMocks.resolve.mockResolvedValue("src/real/App.tsx");
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "App.tsx", workspacePath: "App.tsx" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await act(async () => {
+      await result.current.openInSidebar();
+    });
+
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
+    // Opened optimistically, then reopened on the corrected path.
+    expect(viewerStoreMocks.openTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it("never fuzzy-corrects an authoritative tool-call path", async () => {
+    fuzzyMocks.resolve.mockResolvedValue("src/real/App.tsx");
+    const { result } = renderHook(
+      () => useFileReferenceActions({
+        rawPath: "App.tsx",
+        workspacePath: "App.tsx",
+        authoritativePath: true,
+      }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await act(async () => {
+      await result.current.openInSidebar();
+    });
+
+    expect(fuzzyMocks.resolve).not.toHaveBeenCalled();
+    // Opened exactly once, on the named path — no fuzzy reopen.
+    expect(viewerStoreMocks.openTarget).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -18,11 +18,19 @@ import { useWorkspaceViewerTabsStore } from "@/stores/editor/workspace-viewer-ta
 interface UseFileReferenceActionsInput {
   rawPath: string;
   workspacePath?: string | null;
+  /**
+   * When the path comes from an authoritative source (a tool call that named the
+   * exact file it touched), skip the fuzzy backstop entirely: there is no
+   * ambiguity to correct, and a fuzzy "correction" would only risk opening a
+   * different same-basename file than the one the chip names.
+   */
+  authoritativePath?: boolean;
 }
 
 export function useFileReferenceActions({
   rawPath,
   workspacePath,
+  authoritativePath = false,
 }: UseFileReferenceActionsInput) {
   const openTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
@@ -77,10 +85,15 @@ export function useFileReferenceActions({
       }
     };
     // Open optimistically so the common (correct-path) case has zero latency.
-    // Then, best-effort and non-blocking, correct a partial/abbreviated path
-    // and re-open if it actually pointed elsewhere (the viewer would otherwise
-    // just show "file not found").
     openViewer(reference.workspacePath);
+    // Authoritative tool-call paths name the exact file — never second-guess
+    // them with the fuzzy backstop.
+    if (authoritativePath) {
+      return;
+    }
+    // Otherwise, best-effort and non-blocking, correct a partial/abbreviated
+    // path and re-open if it actually pointed elsewhere (the viewer would
+    // otherwise just show "file not found").
     const corrected = await fuzzyResolveFilePath({
       workspacePath: reference.workspacePath,
       materializedWorkspaceId,
@@ -90,6 +103,7 @@ export function useFileReferenceActions({
     }
   }, [
     activateViewerTarget,
+    authoritativePath,
     fuzzyResolveFilePath,
     openTarget,
     reference.workspacePath,

--- a/apps/desktop/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts
@@ -38,16 +38,19 @@ export function useFuzzyFileResolver() {
         // High limit (server caps at 200): a basename can match many files, and
         // truncating the real one out would defeat the "already exists" guard
         // and risk correcting a valid path to the wrong file.
+        const limit = 200;
         const response = await searchWorkspaceFiles(
           connection,
           connection.anyharnessWorkspaceId,
           basename,
-          200,
+          limit,
         );
-        return pickFuzzyPathMatch(
-          targetPath,
-          (response.results ?? []).map((result) => result.path),
-        );
+        const candidatePaths = (response.results ?? []).map((result) => result.path);
+        // When the result set is capped, the exact file or a second suffix match
+        // may have been dropped — abstain rather than risk a wrong correction.
+        return pickFuzzyPathMatch(targetPath, candidatePaths, {
+          truncated: candidatePaths.length >= limit,
+        });
       } catch {
         return null;
       }

--- a/apps/desktop/src/lib/domain/files/path-references.test.ts
+++ b/apps/desktop/src/lib/domain/files/path-references.test.ts
@@ -30,6 +30,14 @@ describe("pickFuzzyPathMatch", () => {
     expect(pickFuzzyPathMatch("content/ui/markdownrenderer.tsx", tree))
       .toBe("apps/desktop/src/components/content/ui/MarkdownRenderer.tsx");
   });
+
+  it("abstains when the search result set was truncated", () => {
+    // A truncated set can drop the exact file or a second suffix match, so a
+    // would-be unique correction is unsafe — abstain.
+    expect(
+      pickFuzzyPathMatch("content/ui/MarkdownRenderer.tsx", tree, { truncated: true }),
+    ).toBeNull();
+  });
 });
 
 describe("resolveFileReference", () => {

--- a/apps/desktop/src/lib/domain/files/path-references.ts
+++ b/apps/desktop/src/lib/domain/files/path-references.ts
@@ -37,11 +37,20 @@ export function resolveFileReference(args: {
  * from a basename search, return the single candidate whose path equals or ends
  * with the target path. Returns null when the target already appears among the
  * candidates (it exists), or when the suffix match is absent or ambiguous.
+ *
+ * Pass `truncated: true` when the search hit its result cap: a truncated set can
+ * silently drop the exact file (defeating the "already exists" guard) or the
+ * real second suffix match (defeating the uniqueness guard), so we abstain
+ * entirely rather than risk correcting to the wrong file.
  */
 export function pickFuzzyPathMatch(
   targetPath: string,
   candidatePaths: readonly string[],
+  options?: { truncated?: boolean },
 ): string | null {
+  if (options?.truncated) {
+    return null;
+  }
   // Compare case-insensitively (the workspace search is case-insensitive, and
   // a ref may differ in case from the real file) but return the real casing.
   const target = targetPath.toLowerCase();

--- a/apps/packages/product-ui/src/chat/transcript/ProviderLinkMention.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ProviderLinkMention.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   ProviderLinkMention,
   isExternalHttpLink,
+  isSchemelessWebHost,
   linkHost,
   rootDomain,
 } from "./ProviderLinkMention";
@@ -16,18 +17,22 @@ describe("rootDomain", () => {
 });
 
 describe("isExternalHttpLink", () => {
-  it("matches http(s) and www. web URLs", () => {
+  it("matches http(s), www., and scheme-less web hosts", () => {
     for (const value of [
       "https://github.com/x/y",
       "http://example.com",
       "www.example.com",
       "www.example.com/docs",
+      // scheme-less hosts with a well-known web TLD + a path segment
+      "github.com/org/repo/pull/1",
+      "console.aws.amazon.com/ecs/home",
+      "linear.app/team/issue",
     ]) {
       expect(isExternalHttpLink(value)).toBe(true);
     }
   });
 
-  it("rejects file paths, dotted-dir paths, scheme-less hosts, and non-http hrefs", () => {
+  it("rejects file paths, dotted-dir paths, and non-http hrefs", () => {
     for (const value of [
       "src/App.tsx",
       "apps/desktop/src/components/Foo.tsx:12",
@@ -36,9 +41,8 @@ describe("isExternalHttpLink", () => {
       // dotted directory segments must NOT be mistaken for a host.tld
       "v1.2/notes.txt",
       "CHANGELOG.md/x",
-      // scheme-less hosts are left to file detection (rare in practice)
-      "github.com/org/repo/pull/1",
-      "console.aws.amazon.com/ecs/home",
+      // a bare host with no path stays unclaimed (could be a filename)
+      "github.com",
       "#section",
       "mailto:a@b.com",
       "vscode://file/x",
@@ -48,11 +52,37 @@ describe("isExternalHttpLink", () => {
   });
 });
 
+describe("isSchemelessWebHost", () => {
+  it("claims host.tld/path with a well-known web TLD", () => {
+    for (const value of [
+      "github.com/org/repo",
+      "console.aws.amazon.com/ecs/home",
+      "linear.app/team/issue",
+      "vercel.com/docs",
+    ]) {
+      expect(isSchemelessWebHost(value)).toBe(true);
+    }
+  });
+
+  it("leaves file paths and bare hosts to file detection", () => {
+    for (const value of [
+      "v1.2/notes.txt",
+      "CHANGELOG.md/x",
+      "src/App.tsx",
+      "github.com",
+      "github.com/",
+      "https://github.com/x",
+    ]) {
+      expect(isSchemelessWebHost(value)).toBe(false);
+    }
+  });
+});
+
 describe("linkHost", () => {
   it("returns the hostname for web URLs and null otherwise", () => {
     expect(linkHost("https://console.aws.amazon.com/ecs")).toBe("console.aws.amazon.com");
     expect(linkHost("www.example.com/docs")).toBe("www.example.com");
-    expect(linkHost("github.com/x/y")).toBeNull();
+    expect(linkHost("github.com/x/y")).toBe("github.com");
     expect(linkHost("README.md")).toBeNull();
     expect(linkHost("mailto:a@b.com")).toBeNull();
   });

--- a/apps/packages/product-ui/src/chat/transcript/ProviderLinkMention.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ProviderLinkMention.tsx
@@ -132,16 +132,63 @@ export function linkHost(href: string): string | null {
 
 /**
  * Whether an href should be treated as an external web link (vs. a workspace
- * file path). Deliberately conservative: only `http(s)://…` and `www.…`.
+ * file path). Conservative: `http(s)://…`, `www.…`, and a bare `host.tld/path`
+ * form only when the TLD is a well-known web TLD (see {@link isSchemelessWebHost}).
  *
- * A bare `host.tld/path` form (`github.com/x`) is NOT claimed, because it is
- * structurally indistinguishable from a relative file path with a dotted
- * directory (`v1.2/notes.txt`, `CHANGELOG.md/x`) — claiming those would lose
- * the file mention and fire a favicon fetch for a bogus host. Scheme-less URLs
- * are rare in agent output (they almost always emit `https://`), so this trades
- * that edge for never stealing a real file path.
+ * The TLD allow-list is what keeps a relative file path with a dotted directory
+ * (`v1.2/notes.txt`, `CHANGELOG.md/x`) from being mistaken for a host: their
+ * "TLD" (`2`, `md`) is not a web TLD, so they stay file mentions. Without this,
+ * `github.com/org/repo` rendered as a dead FilePathLink (it never resolves to a
+ * workspace file), so we now claim it as an external link.
  */
 export function isExternalHttpLink(href: string): boolean {
   const value = href.trim();
-  return /^https?:\/\//i.test(value) || /^www\.[a-z0-9-]/i.test(value);
+  return (
+    /^https?:\/\//i.test(value) ||
+    /^www\.[a-z0-9-]/i.test(value) ||
+    isSchemelessWebHost(value)
+  );
+}
+
+/**
+ * Web TLDs common enough that they unambiguously signal a host rather than a
+ * file extension. Deliberately small: every entry must be a TLD that is never a
+ * real file extension (so it can't steal `notes.md`, `data.io` would be rare).
+ */
+const WEB_TLDS = new Set([
+  "com",
+  "org",
+  "net",
+  "io",
+  "dev",
+  "app",
+  "ai",
+  "co",
+  "gov",
+  "edu",
+]);
+
+/**
+ * A bare `host.tld/path` link with a well-known web TLD and at least one path
+ * segment (so a bare `foo.com` filename-with-extension is not claimed). The
+ * host's final label must be a {@link WEB_TLDS} entry; this is what lets
+ * `github.com/org/repo` through while leaving `v1.2/notes.txt` to file
+ * detection.
+ */
+export function isSchemelessWebHost(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed) || trimmed.includes("://")) {
+    return false;
+  }
+  const slash = trimmed.indexOf("/");
+  // Require a path segment after the host so a bare token isn't claimed.
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    return false;
+  }
+  const host = trimmed.slice(0, slash).toLowerCase();
+  const labels = host.split(".");
+  if (labels.length < 2 || labels.some((label) => label.length === 0)) {
+    return false;
+  }
+  return WEB_TLDS.has(labels[labels.length - 1]);
 }


### PR DESCRIPTION
Stack 9/9. Scheme-less hosts (github.com/…) render as external links not dead file mentions; fuzzy resolver abstains on a truncated result set and is skipped for authoritative tool-call paths; tool-chip label/open-target aligned on moves. Verified: acceptance met.