### PR TITLE
feat(desktop): publish Homebrew cask on release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -688,3 +688,57 @@ jobs:
           aws cloudfront create-invalidation \
             --distribution-id "${{ vars.DESKTOP_CLOUDFRONT_DISTRIBUTION_ID }}" \
             --paths "/desktop/stable/latest.json" "/desktop/stable/installers.json"
+
+      - name: Bump Homebrew cask
+        env:
+          # contents:write PAT/App token scoped to the tap repo only. When unset
+          # (e.g. before the tap exists) this step no-ops instead of failing.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO || 'proliferate-ai/homebrew-tap' }}
+          INPUT_VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not set; skipping Homebrew cask bump."
+            exit 0
+          fi
+
+          version="$INPUT_VERSION"
+          if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
+            version="${GITHUB_REF_NAME#desktop-v}"
+          fi
+          : "${version:?Missing desktop release version.}"
+
+          # Compute sha256 from the build artifacts we just shipped (not the CDN,
+          # to avoid propagation races and verify the exact bytes published).
+          dmg_aarch64=$(find all-artifacts -type f -name "Proliferate_${version}_aarch64.dmg" | head -n 1)
+          dmg_x64=$(find all-artifacts -type f -name "Proliferate_${version}_x64.dmg" | head -n 1)
+          [[ -n "$dmg_aarch64" ]] || { echo "::error::Missing aarch64 DMG for cask bump"; exit 1; }
+          [[ -n "$dmg_x64" ]] || { echo "::error::Missing x64 DMG for cask bump"; exit 1; }
+          sha_aarch64=$(shasum -a 256 "$dmg_aarch64" | awk '{print $1}')
+          sha_x64=$(shasum -a 256 "$dmg_x64" | awk '{print $1}')
+
+          tap_dir="$(mktemp -d)"
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${HOMEBREW_TAP_REPO}.git" \
+            "$tap_dir"
+
+          mkdir -p "$tap_dir/Casks"
+          node scripts/generate-homebrew-cask.mjs \
+            --version "$version" \
+            --sha-aarch64 "$sha_aarch64" \
+            --sha-x64 "$sha_x64" \
+            --base-url "${{ vars.DESKTOP_DOWNLOADS_BASE_URL }}/desktop/stable" \
+            --desc "Open-source AI IDE for running coding agents in parallel" \
+            --output "$tap_dir/Casks/proliferate.rb"
+
+          cd "$tap_dir"
+          if git diff --quiet -- Casks/proliferate.rb; then
+            echo "Cask already up to date at version $version; nothing to push."
+            exit 0
+          fi
+          git config user.name "proliferate-release-bot"
+          git config user.email "release-bot@proliferate.com"
+          git add Casks/proliferate.rb
+          git commit -m "proliferate ${version}"
+          git push origin HEAD

--- a/scripts/generate-homebrew-cask.mjs
+++ b/scripts/generate-homebrew-cask.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { writeFileSync } from "fs";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {};
+  for (let i = 0; i < args.length; i += 2) {
+    parsed[args[i].replace(/^--/, "")] = args[i + 1];
+  }
+  return parsed;
+}
+
+const args = parseArgs();
+const version = args.version;
+const shaAarch64 = args["sha-aarch64"];
+const shaX64 = args["sha-x64"];
+const baseUrl = args["base-url"];
+const output = args.output;
+const minMacos = args["min-macos"] || "sonoma";
+const homepage = args.homepage || "https://proliferate.com/";
+const desc = args.desc || "Open-source AI IDE for running coding agents in parallel";
+
+if (!version || !shaAarch64 || !shaX64 || !baseUrl || !output) {
+  console.error(
+    "Usage: generate-homebrew-cask.mjs --version <ver> --sha-aarch64 <sha> --sha-x64 <sha> --base-url <url> --output <file> [--min-macos <name>] [--homepage <url>] [--desc <text>]",
+  );
+  process.exit(1);
+}
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+for (const [label, sha] of [
+  ["aarch64", shaAarch64],
+  ["x64", shaX64],
+]) {
+  if (!SHA256_RE.test(sha)) {
+    console.error(`Invalid sha256 for ${label}: ${sha}`);
+    process.exit(1);
+  }
+}
+
+// `#{version}` / `#{arch}` are Ruby interpolations resolved by Homebrew at
+// install time — they must remain literal in the emitted cask, so they are NOT
+// interpolated here (JS only expands ${...}).
+const cask = `cask "proliferate" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "${version}"
+  sha256 arm:   "${shaAarch64}",
+         intel: "${shaX64}"
+
+  url "${baseUrl}/Proliferate_#{version}_#{arch}.dmg"
+  name "Proliferate"
+  desc "${desc}"
+  homepage "${homepage}"
+
+  livecheck do
+    url "${baseUrl}/installers.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :${minMacos}
+
+  app "Proliferate.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.proliferate.app",
+    "~/Library/Caches/com.proliferate.app",
+    "~/Library/Preferences/com.proliferate.app.plist",
+    "~/Library/Saved Application State/com.proliferate.app.savedState",
+  ]
+end
+`;
+
+writeFileSync(output, cask);
+console.log(`Generated ${output} for version ${version}`);


### PR DESCRIPTION
## What

Adds a Homebrew **cask** so the desktop app installs with one command:

```sh
brew install --cask proliferate-ai/tap/proliferate
```

`brew install --cask` does the whole DMG flow (download → verify sha → mount → copy to `/Applications`) — no manual drag, no Gatekeeper prompt (notarization carries through).

## How

- **`scripts/generate-homebrew-cask.mjs`** — renders `Casks/proliferate.rb` from version + per-arch sha256s. `auto_updates true` (the Tauri in-app updater owns upgrades), `livecheck` against `installers.json`, `zap` cleanup.
- **`release-desktop.yml`** — a "Bump Homebrew cask" step in the `publish-updater` job computes sha256 from the shipped DMGs (not the CDN, to avoid propagation races), regenerates the cask, and pushes it to [`proliferate-ai/homebrew-tap`](https://github.com/proliferate-ai/homebrew-tap). Inherits the job's dry-run gating; **no-ops when `HOMEBREW_TAP_TOKEN` is unset**.

## Before this works in CI

- Add repo secret **`HOMEBREW_TAP_TOKEN`** — fine-grained PAT, `homebrew-tap` only, Contents: read/write.
- (Optional) confirm `depends_on macos:` floor — defaults to `:sonoma`.

## Validation

Tested against the live 0.2.18 artifacts: `brew audit --new` → exit 0, and a real `brew install --cask` → "successfully installed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)