### PR TITLE
fix(desktop): push Homebrew cask on the tap's first release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -733,12 +733,15 @@ jobs:
             --output "$tap_dir/Casks/proliferate.rb"
 
           cd "$tap_dir"
-          if git diff --quiet -- Casks/proliferate.rb; then
+          git config user.name "proliferate-release-bot"
+          git config user.email "release-bot@proliferate.com"
+          # Stage first, then diff the index: `git diff` alone ignores untracked
+          # files, so on the tap's first-ever cask it would wrongly report "no
+          # change" and skip the push.
+          git add Casks/proliferate.rb
+          if git diff --cached --quiet; then
             echo "Cask already up to date at version $version; nothing to push."
             exit 0
           fi
-          git config user.name "proliferate-release-bot"
-          git config user.email "release-bot@proliferate.com"
-          git add Casks/proliferate.rb
           git commit -m "proliferate ${version}"
           git push origin HEAD


### PR DESCRIPTION
## Problem

On the 0.2.19 release, the "Bump Homebrew cask" step ran and generated the cask but logged *"Cask already up to date … nothing to push"* and pushed nothing. The tap's `Casks/proliferate.rb` was never created.

Root cause: the guard used `git diff --quiet -- Casks/proliferate.rb`. `git diff` (without `--cached`) **ignores untracked files**, so on the tap's first-ever cask the freshly generated file is untracked → diff sees no change → the step exits early and skips the push. It would self-heal on the *second* release, but the first cask never lands.

## Fix

Stage the file first, then diff the index (`git diff --cached --quiet`).

## Note

The 0.2.19 cask was pushed to `proliferate-ai/homebrew-tap` manually so `brew install --cask proliferate-ai/tap/proliferate` works now; this fix makes every future release self-publish correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)