### PR TITLE
feat(product): add organization integration controls

### DIFF
--- a/apps/desktop/src/components/settings/panes/OrganizationIntegrationsPane.tsx
+++ b/apps/desktop/src/components/settings/panes/OrganizationIntegrationsPane.tsx
@@ -1,0 +1,11 @@
+import { CloudOrganizationIntegrationsPolicySurface } from "@proliferate/product-surfaces/settings/CloudOrganizationIntegrationsPolicySurface";
+import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
+
+export function OrganizationIntegrationsPane() {
+  const { activeOrganizationId } = useActiveOrganization();
+  return (
+    <CloudOrganizationIntegrationsPolicySurface
+      organizationId={activeOrganizationId}
+    />
+  );
+}

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
 import { SETTINGS_DEFAULT_SECTION, type SettingsSection } from "@/config/settings";
 import { SettingsContentBoundary } from "./SettingsContentBoundary";
@@ -192,12 +192,19 @@ export function SettingsScreen({
     activeSectionIsAdminOnly && admin.isAdmin !== true
       ? SETTINGS_DEFAULT_SECTION
       : activeSection;
+  const redirectedAdminSectionRef = useRef<SettingsSection | null>(null);
 
   useEffect(() => {
-    if (shouldRedirectAdminSection) {
-      onSelectSection(SETTINGS_DEFAULT_SECTION);
+    if (!shouldRedirectAdminSection) {
+      redirectedAdminSectionRef.current = null;
+      return;
     }
-  }, [onSelectSection, shouldRedirectAdminSection]);
+    if (redirectedAdminSectionRef.current === activeSection) {
+      return;
+    }
+    redirectedAdminSectionRef.current = activeSection;
+    onSelectSection(SETTINGS_DEFAULT_SECTION);
+  }, [activeSection, onSelectSection, shouldRedirectAdminSection]);
 
   return (
     <div className="flex h-screen bg-surface-under text-foreground" data-telemetry-block>

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
-import { type SettingsSection } from "@/config/settings";
+import { SETTINGS_DEFAULT_SECTION, type SettingsSection } from "@/config/settings";
 import { SettingsContentBoundary } from "./SettingsContentBoundary";
 import { AccountPane } from "@/components/settings/panes/AccountPane";
 import { AgentAuthenticationPane } from "@/components/settings/panes/AgentAuthenticationPane";
@@ -9,6 +9,7 @@ import { ArchivedChatsPane } from "@/components/settings/panes/ArchivedChatsPane
 import { AppearancePane } from "@/components/settings/panes/AppearancePane";
 import { GeneralPane } from "@/components/settings/panes/GeneralPane";
 import { KeyboardShortcutsPane } from "@/components/settings/panes/KeyboardShortcutsPane";
+import { OrganizationIntegrationsPane } from "@/components/settings/panes/OrganizationIntegrationsPane";
 import { OrganizationPane } from "@/components/settings/panes/OrganizationPane";
 import { SettingsScaffoldPane } from "@/components/settings/panes/SettingsScaffoldPane";
 // SLACK BOT PARKED: pane implementation is preserved but not rendered while disabled.
@@ -24,6 +25,7 @@ import {
   type SettingsRepositoryEntry,
 } from "@/lib/domain/settings/repositories";
 import { type SettingsFocus } from "@/lib/domain/settings/navigation";
+import { isSettingsAdminOnlySection } from "@/lib/domain/settings/navigation-presentation";
 import { SettingsSidebar } from "@/components/settings/sidebar/SettingsSidebar";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { useUpdater } from "@/hooks/access/tauri/use-updater";
@@ -75,6 +77,21 @@ function renderSettingsSection(
   }
   if (activeSection === "organization") {
     return <OrganizationPane />;
+  }
+  if (activeSection === "organization-integrations") {
+    if (!cloudEnabled) {
+      return <CloudUnavailablePane />;
+    }
+
+    if (cloudActive) {
+      return <OrganizationIntegrationsPane />;
+    }
+
+    if (cloudSignInChecking) {
+      return <CloudSignInRequiredPane />;
+    }
+
+    return cloudSignInAvailable ? <CloudSignInRequiredPane /> : <CloudAuthUnavailablePane />;
   }
   if (isSettingsScaffoldPageId(activeSection)) {
     return <SettingsScaffoldPane pageId={activeSection} />;
@@ -168,11 +185,24 @@ export function SettingsScreen({
   const activeRepository = repositories.find(
     (repository) => repository.sourceRoot === activeRepoSourceRoot,
   ) ?? null;
+  const activeSectionIsAdminOnly = isSettingsAdminOnlySection(activeSection);
+  const shouldRedirectAdminSection =
+    activeSectionIsAdminOnly && !admin.isLoading && admin.isAdmin !== true;
+  const effectiveActiveSection =
+    activeSectionIsAdminOnly && admin.isAdmin !== true
+      ? SETTINGS_DEFAULT_SECTION
+      : activeSection;
+
+  useEffect(() => {
+    if (shouldRedirectAdminSection) {
+      onSelectSection(SETTINGS_DEFAULT_SECTION);
+    }
+  }, [onSelectSection, shouldRedirectAdminSection]);
 
   return (
     <div className="flex h-screen bg-surface-under text-foreground" data-telemetry-block>
       <SettingsSidebar
-        activeSection={activeSection}
+        activeSection={effectiveActiveSection}
         adminAccess={{
           isAdmin: admin.isAdmin,
           isLoading: admin.isLoading,
@@ -181,6 +211,7 @@ export function SettingsScreen({
         onSelectSection={onSelectSection}
         disabledSections={{
           "agent-authentication": !cloudEnabled,
+          "organization-integrations": !cloudEnabled,
           compute: !cloudEnabled,
           // SLACK BOT PARKED: section is not registered while the flow is disabled.
           // "slack-bot": !cloudEnabled,
@@ -200,12 +231,14 @@ export function SettingsScreen({
           <div className="flex justify-center pb-16">
             <div
               className={`w-full space-y-7 ${
-                activeSection === "billing" ? "max-w-[72rem]" : "max-w-[46rem]"
+                effectiveActiveSection === "billing" || effectiveActiveSection === "organization-integrations"
+                  ? "max-w-[72rem]"
+                  : "max-w-[46rem]"
               }`}
             >
-              <SettingsContentBoundary section={activeSection}>
+              <SettingsContentBoundary section={effectiveActiveSection}>
                 {renderSettingsSection(
-                  activeSection,
+                  effectiveActiveSection,
                   activeRepository,
                   repositories,
                   cloudEnabled,

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
@@ -154,11 +154,11 @@ describe("SettingsSidebar layout and shortcuts", () => {
     expect(screen.queryByRole("button", { name: "Cloud" })).toBeNull();
   });
 
-  it("renders admin tags for admin-only settings rows", () => {
+  it("does not render admin tags for admin-only settings rows", () => {
     renderSettingsSidebar();
 
     const adminPills = screen.getAllByText("Admin").filter((element) => element.tagName === "SPAN");
-    expect(adminPills).toHaveLength(5);
+    expect(adminPills).toHaveLength(0);
     expect(screen.queryByRole("button", { name: /Slack bot/ })).toBeNull();
   });
 
@@ -168,19 +168,43 @@ describe("SettingsSidebar layout and shortcuts", () => {
     expect(screen.getAllByText("tbr")).toHaveLength(1);
   });
 
-  it("disables admin-only rows for non-admins", () => {
+  it("hides admin-only rows for non-admins", () => {
     const onSelectSection = vi.fn();
     renderSettingsSidebar({
       adminAccess: { isAdmin: false, isLoading: false },
       onSelectSection,
     });
 
-    const organizationIntegrations = screen.getByRole("button", { name: /Integrations/ }) as HTMLButtonElement;
-    expect(organizationIntegrations.disabled).toBe(true);
-    expect(organizationIntegrations.getAttribute("title")).toBe("Admin access required");
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Organization settings/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Plan \+ billing/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Integrations/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Model policy/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Limits/ })).toBeNull();
+  });
 
-    fireEvent.click(organizationIntegrations);
-    expect(onSelectSection).not.toHaveBeenCalledWith("organization-integrations");
+  it("uses visible settings rows for non-admin shortcut numbering", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    const onSelectSection = vi.fn();
+    renderSettingsSidebar({
+      adminAccess: { isAdmin: false, isLoading: false },
+      onSelectSection,
+    });
+
+    await waitFor(() => {
+      expect(getShortcutHandler("settings.section-by-index")).not.toBeNull();
+    });
+
+    expect(screen.getByText("⌘1")).toBeTruthy();
+    expect(runShortcutHandler("settings.section-by-index", {
+      source: "keyboard",
+      digit: 1,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("general");
   });
 
   it("keeps the back row full width", () => {

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/config/settings";
 import {
   SETTINGS_NAV_GROUPS,
+  isSettingsAdminOnlySection,
   type SettingsNavIconId,
   type SettingsNavItem,
 } from "@/lib/domain/settings/navigation-presentation";
@@ -108,11 +109,9 @@ function isSettingsItemDisabled(
   item: SettingsNavItem,
   disabledSections: Partial<Record<SettingsSection, boolean>> | undefined,
   updateActionState: SettingsSidebarProps["updateActionState"],
-  adminAccess: SettingsSidebarProps["adminAccess"],
 ) {
   return (
     (item.kind === "section" && !!disabledSections?.[item.id])
-    || (item.kind === "section" && item.adminOnly === true && adminAccess?.isAdmin !== true)
     || (item.kind === "action"
       && item.id === "checkForUpdates"
       && !updateActionState.updatesSupported)
@@ -124,9 +123,6 @@ function settingsItemStatus(
   updateActionState: SettingsSidebarProps["updateActionState"],
 ) {
   const statusItems: ReactNode[] = [];
-  if (item.kind === "section" && item.adminOnly === true) {
-    statusItems.push(<AdminPill key="admin" />);
-  }
   if (item.tbr === true) {
     statusItems.push(<TbrPill key="tbr" />);
   }
@@ -157,26 +153,14 @@ function settingsItemDisabledReason(
   item: SettingsNavItem,
   disabled: boolean,
   updateActionState: SettingsSidebarProps["updateActionState"],
-  adminAccess: SettingsSidebarProps["adminAccess"],
 ) {
   if (!disabled) {
     return undefined;
-  }
-  if (item.kind === "section" && item.adminOnly === true && adminAccess?.isAdmin !== true) {
-    return adminAccess?.isLoading ? "Checking admin access" : "Admin access required";
   }
   if (item.kind === "action" && item.id === "checkForUpdates" && !updateActionState.updatesSupported) {
     return "Desktop updates are available in packaged builds.";
   }
   return undefined;
-}
-
-function AdminPill() {
-  return (
-    <span className="rounded-sm border border-sidebar-border px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-sidebar-muted-foreground">
-      Admin
-    </span>
-  );
 }
 
 function TbrPill() {
@@ -203,23 +187,35 @@ export function SettingsSidebar({
   const appVersion = useAppVersion().data?.trim();
   const handleOpenSupport = useOpenSupportReportWindow({ source: "settings" });
   const shortcutRevealVisible = useShortcutRevealVisible();
+  const visibleNavGroups = useMemo(() =>
+    SETTINGS_NAV_GROUPS.map((group) => ({
+      ...group,
+      items: group.items.filter((item) =>
+        item.kind !== "section"
+        || !isSettingsAdminOnlySection(item.id)
+        || adminAccess?.isAdmin === true
+      ),
+    })).filter((group) => group.items.length > 0),
+  [adminAccess?.isAdmin]);
+  const visibleShortcutSections = useMemo(() => {
+    const visibleSections = new Set(
+      visibleNavGroups.flatMap((group) =>
+        group.items.flatMap((item) => item.kind === "section" ? [item.id] : [])
+      ),
+    );
+    return SETTINGS_SHORTCUT_SECTION_ORDER.filter((section) =>
+      visibleSections.has(section)
+    );
+  }, [visibleNavGroups]);
   const effectiveDisabledSections = useMemo(() => {
-    const next: Partial<Record<SettingsSection, boolean>> = { ...disabledSections };
-    for (const group of SETTINGS_NAV_GROUPS) {
-      for (const item of group.items) {
-        if (item.kind === "section" && item.adminOnly === true && adminAccess?.isAdmin !== true) {
-          next[item.id] = true;
-        }
-      }
-    }
-    return next;
-  }, [adminAccess?.isAdmin, disabledSections]);
+    return { ...disabledSections };
+  }, [disabledSections]);
   const shortcutTargets = useMemo(
     () => buildSettingsShortcutSectionTargets(
-      SETTINGS_SHORTCUT_SECTION_ORDER,
+      visibleShortcutSections,
       effectiveDisabledSections,
     ),
-    [effectiveDisabledSections],
+    [effectiveDisabledSections, visibleShortcutSections],
   );
   const shortcutLabelBySection = useMemo(
     () => buildShortcutRangeLabelById(
@@ -233,7 +229,7 @@ export function SettingsSidebar({
     onSelectSection,
   });
   function handleItemClick(item: SettingsNavItem) {
-    if (isSettingsItemDisabled(item, effectiveDisabledSections, updateActionState, adminAccess)) {
+    if (isSettingsItemDisabled(item, effectiveDisabledSections, updateActionState)) {
       return;
     }
 
@@ -270,7 +266,7 @@ export function SettingsSidebar({
 
       <nav className={SETTINGS_NAV_CLASS} aria-label="Settings">
         <div className={SETTINGS_GROUPS_CLASS}>
-          {SETTINGS_NAV_GROUPS.map((group, index) => (
+          {visibleNavGroups.map((group, index) => (
             <div
               key={group.id}
               className={`${SETTINGS_GROUP_CLASS} ${index > 0 ? SETTINGS_GROUP_SPACING_CLASS : ""}`}
@@ -286,7 +282,6 @@ export function SettingsSidebar({
                   item,
                   effectiveDisabledSections,
                   updateActionState,
-                  adminAccess,
                 );
                 const Icon = SETTINGS_NAV_ICONS[item.iconId];
                 return (
@@ -304,7 +299,6 @@ export function SettingsSidebar({
                         item,
                         disabled,
                         updateActionState,
-                        adminAccess,
                       )}
                       onPress={() => handleItemClick(item)}
                       active={active}

--- a/apps/desktop/src/copy/settings/settings-scaffold-copy.ts
+++ b/apps/desktop/src/copy/settings/settings-scaffold-copy.ts
@@ -1,5 +1,4 @@
 export const SETTINGS_SCAFFOLD_PAGE_IDS = [
-  "organization-integrations",
   "organization-model-policy",
   "organization-limits",
 ] as const;
@@ -18,24 +17,6 @@ export interface SettingsScaffoldPageCopy {
 }
 
 export const SETTINGS_SCAFFOLD_COPY: Record<SettingsScaffoldPageId, SettingsScaffoldPageCopy> = {
-  "organization-integrations": {
-    title: "Organization integrations",
-    description: "Team-wide connections used by organization cloud work, workflows, Slack, and API-dispatched sessions.",
-    rows: [
-      {
-        label: "Connected services",
-        description: "Organization-owned GitHub, Slack, MCP, integration, and provider connections for shared work.",
-      },
-      {
-        label: "Access and visibility",
-        description: "Admin-managed availability for organization work and member access.",
-      },
-      {
-        label: "Audit surface",
-        description: "Connection status, last validation time, and usage references for each integration.",
-      },
-    ],
-  },
   "organization-model-policy": {
     title: "Model policy",
     description: "Organization-wide model availability and default model choices for shared work.",

--- a/apps/desktop/src/lib/domain/settings/navigation-presentation.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation-presentation.ts
@@ -150,3 +150,15 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
     ],
   },
 ];
+
+const SETTINGS_ADMIN_ONLY_SECTIONS = new Set<SettingsSection>(
+  SETTINGS_NAV_GROUPS.flatMap((group) =>
+    group.items.flatMap((item) =>
+      item.kind === "section" && item.adminOnly === true ? [item.id] : []
+    )
+  ),
+);
+
+export function isSettingsAdminOnlySection(section: SettingsSection): boolean {
+  return SETTINGS_ADMIN_ONLY_SECTIONS.has(section);
+}

--- a/apps/packages/product-domain/package.json
+++ b/apps/packages/product-domain/package.json
@@ -199,6 +199,10 @@
       "types": "./dist/plugins/cloud-plugin-inventory.d.ts",
       "import": "./dist/plugins/cloud-plugin-inventory.js"
     },
+    "./plugins/organization-integration-policy": {
+      "types": "./dist/plugins/organization-integration-policy.d.ts",
+      "import": "./dist/plugins/organization-integration-policy.js"
+    },
     "./workspaces/model": {
       "types": "./dist/workspaces/model.d.ts",
       "import": "./dist/workspaces/model.js"

--- a/apps/packages/product-domain/src/plugins/cloud-plugin-inventory-types.ts
+++ b/apps/packages/product-domain/src/plugins/cloud-plugin-inventory-types.ts
@@ -1,6 +1,7 @@
 import type {
   CloudMcpCatalogResponse,
   CloudMcpConnection,
+  CloudOrganizationIntegrationPolicyResponse,
   CloudPluginConfiguredItem,
   CloudSkillConfiguredItem,
 } from "@proliferate/cloud-sdk";
@@ -122,6 +123,7 @@ export interface PluginInventoryItem {
 
 export interface BuildCloudPluginInventoryInput {
   catalog: CloudMcpCatalogResponse;
+  integrationPolicy?: CloudOrganizationIntegrationPolicyResponse | null;
   connections: readonly CloudMcpConnection[];
   configuredPlugins: readonly CloudPluginConfiguredItem[];
   configuredSkills: readonly CloudSkillConfiguredItem[];

--- a/apps/packages/product-domain/src/plugins/cloud-plugin-inventory.test.ts
+++ b/apps/packages/product-domain/src/plugins/cloud-plugin-inventory.test.ts
@@ -3,6 +3,7 @@ import type {
   CloudMcpCatalogEntry,
   CloudMcpCatalogResponse,
   CloudMcpConnection,
+  CloudOrganizationIntegrationPolicyResponse,
   CloudPluginConfiguredItem,
   CloudSkillConfiguredItem,
 } from "@proliferate/cloud-sdk";
@@ -56,6 +57,19 @@ describe("cloud plugin inventory", () => {
     });
   });
 
+  it("hides integrations disabled by organization policy", () => {
+    const inventory = buildCloudPluginInventory({
+      catalog: catalog([githubEntry(), posthogEntry()], []),
+      integrationPolicy: integrationPolicy([{ catalogEntryId: "github", enabled: false }]),
+      connections: [],
+      configuredPlugins: [],
+      configuredSkills: [],
+      surface: "desktop",
+    });
+
+    expect(inventory.map((item) => item.entry.id)).toEqual(["posthog"]);
+  });
+
   it("marks broken browser auth as reconnectable", () => {
     const inventory = buildCloudPluginInventory({
       catalog: catalog([githubEntry()], []),
@@ -104,6 +118,19 @@ function catalog(
     catalogVersion: "test",
     entries,
     pluginPackages,
+  };
+}
+
+function integrationPolicy(
+  entries: Array<{ catalogEntryId: string; enabled: boolean }>,
+): CloudOrganizationIntegrationPolicyResponse {
+  return {
+    organizationId: "org_1",
+    entries: entries.map((entry) => ({
+      ...entry,
+      updatedAt: null,
+      updatedByUserId: null,
+    })),
   };
 }
 

--- a/apps/packages/product-domain/src/plugins/cloud-plugin-inventory.ts
+++ b/apps/packages/product-domain/src/plugins/cloud-plugin-inventory.ts
@@ -1,3 +1,5 @@
+import type { CloudOrganizationIntegrationPolicyResponse } from "@proliferate/cloud-sdk";
+
 import {
   catalogEntryView,
   isActiveCatalogEntry,
@@ -42,6 +44,7 @@ export {
 
 export function buildCloudPluginInventory({
   catalog,
+  integrationPolicy = null,
   connections,
   configuredPlugins,
   configuredSkills,
@@ -57,7 +60,10 @@ export function buildCloudPluginInventory({
   );
   const entries = catalog.entries
     .map((entry) => catalogEntryView(entry, packagesByCatalogEntryId.get(entry.id)))
-    .filter(isActiveCatalogEntry);
+    .filter(isActiveCatalogEntry)
+    .filter((entry) =>
+      catalogEntryAllowedByOrganizationPolicy(entry.id, integrationPolicy)
+    );
   const entriesById = new Map(entries.map((entry) => [entry.id, entry]));
   const pluginsByPluginId = new Map(configuredPlugins.map((item) => [item.pluginId, item]));
   const skillsByPluginId = groupSkillsByPluginId(configuredSkills);
@@ -88,4 +94,16 @@ export function buildCloudPluginInventory({
   return [...installed, ...available].filter((item) =>
     matchesInventoryQuery(item, normalizedQuery)
   );
+}
+
+export function catalogEntryAllowedByOrganizationPolicy(
+  catalogEntryId: string,
+  integrationPolicy: CloudOrganizationIntegrationPolicyResponse | null | undefined,
+): boolean {
+  if (!integrationPolicy) {
+    return true;
+  }
+  return integrationPolicy.entries.find((entry) =>
+    entry.catalogEntryId === catalogEntryId
+  )?.enabled ?? true;
 }

--- a/apps/packages/product-domain/src/plugins/organization-integration-policy.test.ts
+++ b/apps/packages/product-domain/src/plugins/organization-integration-policy.test.ts
@@ -22,22 +22,23 @@ describe("organization integration policy", () => {
         catalogEntryId: "github",
         enabled: true,
         name: "GitHub",
-        tags: ["OAuth", "MCP"],
+        tags: ["Source control", "MCP"],
       }),
     ]);
   });
 
-  it("applies policy and filters disabled entries", () => {
+  it("applies policy and filters by category", () => {
     const items = buildOrganizationIntegrationPolicyItems({
       catalog: catalog([
         entry({ id: "github", name: "GitHub" }),
-        entry({ id: "linear", name: "Linear" }),
+        entry({ id: "posthog", name: "PostHog", oneLiner: "Product analytics" }),
       ]),
-      policy: policy([{ catalogEntryId: "linear", enabled: false }]),
-      statusFilter: "disabled",
+      policy: policy([{ catalogEntryId: "posthog", enabled: false }]),
+      categoryFilter: "observability",
     });
 
-    expect(items.map((item) => item.catalogEntryId)).toEqual(["linear"]);
+    expect(items.map((item) => item.catalogEntryId)).toEqual(["posthog"]);
+    expect(items[0]?.enabled).toBe(false);
     expect(organizationIntegrationPolicyEnabled("github", policy([]))).toBe(true);
   });
 
@@ -52,7 +53,7 @@ describe("organization integration policy", () => {
           oneLiner: "Product analytics",
         }),
       ]),
-      query: "api key",
+      query: "observability",
     });
 
     expect(items.map((item) => item.catalogEntryId)).toEqual(["posthog"]);

--- a/apps/packages/product-domain/src/plugins/organization-integration-policy.test.ts
+++ b/apps/packages/product-domain/src/plugins/organization-integration-policy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CloudMcpCatalogEntry,
+  CloudMcpCatalogResponse,
+  CloudOrganizationIntegrationPolicyResponse,
+} from "@proliferate/cloud-sdk";
+
+import {
+  buildOrganizationIntegrationPolicyItems,
+  organizationIntegrationPolicyEnabled,
+} from "./organization-integration-policy";
+
+describe("organization integration policy", () => {
+  it("defaults catalog entries to enabled", () => {
+    const items = buildOrganizationIntegrationPolicyItems({
+      catalog: catalog([entry({ id: "github", name: "GitHub" })]),
+      policy: null,
+    });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        catalogEntryId: "github",
+        enabled: true,
+        name: "GitHub",
+        tags: ["OAuth", "MCP"],
+      }),
+    ]);
+  });
+
+  it("applies policy and filters disabled entries", () => {
+    const items = buildOrganizationIntegrationPolicyItems({
+      catalog: catalog([
+        entry({ id: "github", name: "GitHub" }),
+        entry({ id: "linear", name: "Linear" }),
+      ]),
+      policy: policy([{ catalogEntryId: "linear", enabled: false }]),
+      statusFilter: "disabled",
+    });
+
+    expect(items.map((item) => item.catalogEntryId)).toEqual(["linear"]);
+    expect(organizationIntegrationPolicyEnabled("github", policy([]))).toBe(true);
+  });
+
+  it("matches search against names, descriptions, and tags", () => {
+    const items = buildOrganizationIntegrationPolicyItems({
+      catalog: catalog([
+        entry({ id: "github", name: "GitHub", oneLiner: "Source control" }),
+        entry({
+          id: "posthog",
+          name: "PostHog",
+          authKind: "secret",
+          oneLiner: "Product analytics",
+        }),
+      ]),
+      query: "api key",
+    });
+
+    expect(items.map((item) => item.catalogEntryId)).toEqual(["posthog"]);
+  });
+});
+
+function catalog(entries: CloudMcpCatalogEntry[]): CloudMcpCatalogResponse {
+  return {
+    catalogVersion: "test",
+    entries,
+    pluginPackages: [],
+  };
+}
+
+function policy(
+  entries: Array<{ catalogEntryId: string; enabled: boolean }>,
+): CloudOrganizationIntegrationPolicyResponse {
+  return {
+    organizationId: "org_1",
+    entries: entries.map((entry) => ({
+      ...entry,
+      updatedAt: null,
+      updatedByUserId: null,
+    })),
+  };
+}
+
+function entry(
+  overrides: Partial<CloudMcpCatalogEntry> = {},
+): CloudMcpCatalogEntry {
+  return {
+    id: "github",
+    version: 1,
+    name: "GitHub",
+    oneLiner: "Work with issues and pull requests.",
+    description: "GitHub tools.",
+    docsUrl: "https://docs.example/github",
+    availability: "universal",
+    cloudSecretSync: true,
+    setupKind: "none",
+    transport: "http",
+    authKind: "oauth",
+    url: "https://github.example/mcp",
+    displayUrl: "github.example",
+    serverNameBase: "github",
+    iconId: "github",
+    secretFields: [],
+    requiredFields: [],
+    settingsSchema: [],
+    capabilities: ["issues"],
+    ...overrides,
+  };
+}

--- a/apps/packages/product-domain/src/plugins/organization-integration-policy.ts
+++ b/apps/packages/product-domain/src/plugins/organization-integration-policy.ts
@@ -1,0 +1,128 @@
+import type {
+  CloudMcpCatalogResponse,
+  CloudOrganizationIntegrationPolicyResponse,
+} from "@proliferate/cloud-sdk";
+
+import {
+  catalogEntryView,
+  isActiveCatalogEntry,
+} from "./cloud-plugin-catalog";
+import { normalizeQuery } from "./cloud-plugin-inventory-items";
+import type { PluginCatalogEntryView } from "./cloud-plugin-inventory-types";
+
+export type OrganizationIntegrationPolicyStatusFilter =
+  | "all"
+  | "disabled"
+  | "enabled";
+
+export interface OrganizationIntegrationPolicyItem {
+  catalogEntryId: string;
+  name: string;
+  description: string;
+  iconId: string;
+  enabled: boolean;
+  tags: readonly string[];
+}
+
+export interface BuildOrganizationIntegrationPolicyItemsInput {
+  catalog: CloudMcpCatalogResponse;
+  policy?: CloudOrganizationIntegrationPolicyResponse | null;
+  query?: string;
+  statusFilter?: OrganizationIntegrationPolicyStatusFilter;
+}
+
+export function buildOrganizationIntegrationPolicyItems({
+  catalog,
+  policy = null,
+  query,
+  statusFilter = "all",
+}: BuildOrganizationIntegrationPolicyItemsInput): OrganizationIntegrationPolicyItem[] {
+  const normalizedQuery = normalizeQuery(query);
+  const packagesByCatalogEntryId = new Map(
+    (catalog.pluginPackages ?? []).map((pluginPackage) => [
+      pluginPackage.catalogEntryId,
+      pluginPackage,
+    ]),
+  );
+
+  return catalog.entries
+    .map((entry) => catalogEntryView(entry, packagesByCatalogEntryId.get(entry.id)))
+    .filter(isActiveCatalogEntry)
+    .map((entry) => policyItem(entry, policy))
+    .filter((item) => matchesStatusFilter(item, statusFilter))
+    .filter((item) => matchesQuery(item, normalizedQuery));
+}
+
+export function organizationIntegrationPolicyEnabled(
+  catalogEntryId: string,
+  policy: CloudOrganizationIntegrationPolicyResponse | null | undefined,
+): boolean {
+  if (!policy) {
+    return true;
+  }
+  return policy.entries.find((entry) =>
+    entry.catalogEntryId === catalogEntryId
+  )?.enabled ?? true;
+}
+
+function policyItem(
+  entry: PluginCatalogEntryView,
+  policy: CloudOrganizationIntegrationPolicyResponse | null,
+): OrganizationIntegrationPolicyItem {
+  return {
+    catalogEntryId: entry.id,
+    name: entry.name,
+    description: entry.oneLiner || entry.description,
+    iconId: entry.iconId,
+    enabled: organizationIntegrationPolicyEnabled(entry.id, policy),
+    tags: integrationTags(entry),
+  };
+}
+
+function integrationTags(entry: PluginCatalogEntryView): string[] {
+  return [
+    authTag(entry),
+    entry.availability === "local_only" ? "Desktop only" : null,
+    "MCP",
+  ].filter((tag): tag is string => Boolean(tag));
+}
+
+function authTag(entry: PluginCatalogEntryView): string {
+  if (entry.setupKind === "local_oauth") {
+    return "Local auth";
+  }
+  if (entry.authKind === "oauth") {
+    return "OAuth";
+  }
+  if (entry.authKind === "secret" || entry.requiredFields.length > 0) {
+    return "API key";
+  }
+  return "No setup";
+}
+
+function matchesStatusFilter(
+  item: OrganizationIntegrationPolicyItem,
+  statusFilter: OrganizationIntegrationPolicyStatusFilter,
+): boolean {
+  if (statusFilter === "enabled") {
+    return item.enabled;
+  }
+  if (statusFilter === "disabled") {
+    return !item.enabled;
+  }
+  return true;
+}
+
+function matchesQuery(
+  item: OrganizationIntegrationPolicyItem,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) {
+    return true;
+  }
+  return (
+    item.name.toLowerCase().includes(normalizedQuery)
+    || item.description.toLowerCase().includes(normalizedQuery)
+    || item.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery))
+  );
+}

--- a/apps/packages/product-domain/src/plugins/organization-integration-policy.ts
+++ b/apps/packages/product-domain/src/plugins/organization-integration-policy.ts
@@ -10,10 +10,27 @@ import {
 import { normalizeQuery } from "./cloud-plugin-inventory-items";
 import type { PluginCatalogEntryView } from "./cloud-plugin-inventory-types";
 
-export type OrganizationIntegrationPolicyStatusFilter =
+export type OrganizationIntegrationPolicyCategoryFilter =
   | "all"
-  | "disabled"
-  | "enabled";
+  | "knowledge"
+  | "mcp"
+  | "observability"
+  | "project_management"
+  | "source_control";
+
+export interface OrganizationIntegrationPolicyFilterOption {
+  id: OrganizationIntegrationPolicyCategoryFilter;
+  label: string;
+}
+
+export const ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS: readonly OrganizationIntegrationPolicyFilterOption[] = [
+  { id: "all", label: "All" },
+  { id: "source_control", label: "Source control" },
+  { id: "project_management", label: "Project management" },
+  { id: "observability", label: "Observability" },
+  { id: "knowledge", label: "Knowledge" },
+  { id: "mcp", label: "MCP" },
+];
 
 export interface OrganizationIntegrationPolicyItem {
   catalogEntryId: string;
@@ -21,6 +38,7 @@ export interface OrganizationIntegrationPolicyItem {
   description: string;
   iconId: string;
   enabled: boolean;
+  categories: readonly OrganizationIntegrationPolicyCategoryFilter[];
   tags: readonly string[];
 }
 
@@ -28,14 +46,14 @@ export interface BuildOrganizationIntegrationPolicyItemsInput {
   catalog: CloudMcpCatalogResponse;
   policy?: CloudOrganizationIntegrationPolicyResponse | null;
   query?: string;
-  statusFilter?: OrganizationIntegrationPolicyStatusFilter;
+  categoryFilter?: OrganizationIntegrationPolicyCategoryFilter;
 }
 
 export function buildOrganizationIntegrationPolicyItems({
   catalog,
   policy = null,
   query,
-  statusFilter = "all",
+  categoryFilter = "all",
 }: BuildOrganizationIntegrationPolicyItemsInput): OrganizationIntegrationPolicyItem[] {
   const normalizedQuery = normalizeQuery(query);
   const packagesByCatalogEntryId = new Map(
@@ -49,7 +67,7 @@ export function buildOrganizationIntegrationPolicyItems({
     .map((entry) => catalogEntryView(entry, packagesByCatalogEntryId.get(entry.id)))
     .filter(isActiveCatalogEntry)
     .map((entry) => policyItem(entry, policy))
-    .filter((item) => matchesStatusFilter(item, statusFilter))
+    .filter((item) => matchesCategoryFilter(item, categoryFilter))
     .filter((item) => matchesQuery(item, normalizedQuery));
 }
 
@@ -69,48 +87,69 @@ function policyItem(
   entry: PluginCatalogEntryView,
   policy: CloudOrganizationIntegrationPolicyResponse | null,
 ): OrganizationIntegrationPolicyItem {
+  const categories = integrationCategories(entry);
   return {
     catalogEntryId: entry.id,
     name: entry.name,
     description: entry.oneLiner || entry.description,
     iconId: entry.iconId,
     enabled: organizationIntegrationPolicyEnabled(entry.id, policy),
-    tags: integrationTags(entry),
+    categories,
+    tags: integrationTags(categories),
   };
 }
 
-function integrationTags(entry: PluginCatalogEntryView): string[] {
-  return [
-    authTag(entry),
-    entry.availability === "local_only" ? "Desktop only" : null,
-    "MCP",
-  ].filter((tag): tag is string => Boolean(tag));
+function integrationCategories(
+  entry: PluginCatalogEntryView,
+): OrganizationIntegrationPolicyCategoryFilter[] {
+  const categories = new Set<OrganizationIntegrationPolicyCategoryFilter>(["mcp"]);
+  switch (entry.id) {
+    case "github":
+    case "gitlab":
+      categories.add("source_control");
+      break;
+    case "linear":
+      categories.add("project_management");
+      break;
+    case "axiom":
+    case "posthog":
+    case "render":
+    case "sentry":
+      categories.add("observability");
+      break;
+    case "cloudflare_docs":
+    case "context7":
+    case "exa":
+    case "gmail":
+    case "notion":
+    case "slack":
+    case "tavily":
+      categories.add("knowledge");
+      break;
+  }
+  return [...categories];
 }
 
-function authTag(entry: PluginCatalogEntryView): string {
-  if (entry.setupKind === "local_oauth") {
-    return "Local auth";
-  }
-  if (entry.authKind === "oauth") {
-    return "OAuth";
-  }
-  if (entry.authKind === "secret" || entry.requiredFields.length > 0) {
-    return "API key";
-  }
-  return "No setup";
+function integrationTags(
+  categories: readonly OrganizationIntegrationPolicyCategoryFilter[],
+): string[] {
+  const categoryLabels = new Map(
+    ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS.map((option) => [option.id, option.label]),
+  );
+  const ordered = ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS
+    .map((option) => option.id)
+    .filter((category) => category !== "all" && categories.includes(category));
+  return ordered.map((category) => categoryLabels.get(category) ?? category);
 }
 
-function matchesStatusFilter(
+function matchesCategoryFilter(
   item: OrganizationIntegrationPolicyItem,
-  statusFilter: OrganizationIntegrationPolicyStatusFilter,
+  categoryFilter: OrganizationIntegrationPolicyCategoryFilter,
 ): boolean {
-  if (statusFilter === "enabled") {
-    return item.enabled;
+  if (categoryFilter === "all") {
+    return true;
   }
-  if (statusFilter === "disabled") {
-    return !item.enabled;
-  }
-  return true;
+  return item.categories.includes(categoryFilter);
 }
 
 function matchesQuery(

--- a/apps/packages/product-surfaces/package.json
+++ b/apps/packages/product-surfaces/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/settings/CloudEnvironmentsSettingsSurface.d.ts",
       "import": "./dist/settings/CloudEnvironmentsSettingsSurface.js"
     },
+    "./settings/CloudOrganizationIntegrationsPolicySurface": {
+      "types": "./dist/settings/CloudOrganizationIntegrationsPolicySurface.d.ts",
+      "import": "./dist/settings/CloudOrganizationIntegrationsPolicySurface.js"
+    },
     "./settings/cloud-environments/AddCloudEnvironmentDialogController": {
       "types": "./dist/settings/cloud-environments/AddCloudEnvironmentDialogController.d.ts",
       "import": "./dist/settings/cloud-environments/AddCloudEnvironmentDialogController.js"

--- a/apps/packages/product-surfaces/src/plugins/CloudPluginsSurface.tsx
+++ b/apps/packages/product-surfaces/src/plugins/CloudPluginsSurface.tsx
@@ -16,7 +16,7 @@ export function CloudPluginsSurface(props: CloudPluginsSurfaceProps) {
   return (
     <ProductPageShell
       title="Integrations"
-      description="Apps, MCP tools, and skills agents can use in sessions."
+      description="Connect your personal accounts to integrations enabled by your organization."
       maxWidthClassName="max-w-6xl"
       telemetryBlocked
     >

--- a/apps/packages/product-surfaces/src/plugins/useCloudPluginsSurfaceController.ts
+++ b/apps/packages/product-surfaces/src/plugins/useCloudPluginsSurfaceController.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   useCloudMcpCatalog,
   useCloudMcpConnections,
+  useCloudOrganizationIntegrationPolicy,
   useConfiguredPlugins,
   useConfiguredSkills,
   useCurrentTeam,
@@ -42,6 +43,11 @@ export function useCloudPluginsSurfaceController({
   const configuredPlugins = useConfiguredPlugins(enabled);
   const configuredSkills = useConfiguredSkills(enabled);
   const currentTeam = useCurrentTeam(enabled);
+  const team = currentTeam.data ?? null;
+  const integrationPolicy = useCloudOrganizationIntegrationPolicy(
+    team?.id ?? null,
+    enabled && team !== null,
+  );
   const [query, setQuery] = useState("");
   const [selection, setSelection] = useState<{ id: string; mode: PluginModalMode } | null>(null);
   const [draft, setDraft] = useState<PluginConnectionDraft | null>(null);
@@ -49,11 +55,19 @@ export function useCloudPluginsSurfaceController({
   const [completionNotice, setCompletionNotice] = useState<PluginCompletionNotice | null>(null);
 
   const baseItems = useMemo(() => {
-    if (!catalog.data || !connections.data || !configuredPlugins.data || !configuredSkills.data) {
+    if (
+      !catalog.data
+      || !connections.data
+      || !configuredPlugins.data
+      || !configuredSkills.data
+      || currentTeam.isLoading
+      || (team !== null && !integrationPolicy.data)
+    ) {
       return [];
     }
     return buildCloudPluginInventory({
       catalog: catalog.data,
+      integrationPolicy: integrationPolicy.data ?? null,
       connections: connections.data.connections,
       configuredPlugins: configuredPlugins.data.plugins,
       configuredSkills: configuredSkills.data.skills,
@@ -65,8 +79,11 @@ export function useCloudPluginsSurfaceController({
     configuredPlugins.data,
     configuredSkills.data,
     connections.data,
+    currentTeam.isLoading,
+    integrationPolicy.data,
     query,
     surface,
+    team,
   ]);
   const localOAuthStatuses = useCloudPluginLocalOAuthStatuses(baseItems, localOAuthAdapter);
   const items = useMemo(
@@ -77,7 +94,6 @@ export function useCloudPluginsSurfaceController({
   const selectedItem = selection
     ? items.find((item) => item.id === selection.id || item.entry.id === selection.id) ?? null
     : null;
-  const team = currentTeam.data ?? null;
   const teamRole = team?.membership?.role ?? null;
   const canShare = Boolean(
     team?.membership?.status === "active" && (teamRole === "owner" || teamRole === "admin"),
@@ -85,12 +101,16 @@ export function useCloudPluginsSurfaceController({
   const loading = catalog.isLoading
     || connections.isLoading
     || configuredPlugins.isLoading
-    || configuredSkills.isLoading;
+    || configuredSkills.isLoading
+    || currentTeam.isLoading
+    || (team !== null && integrationPolicy.isLoading);
   const error = firstErrorMessage(
     catalog.error,
     connections.error,
     configuredPlugins.error,
     configuredSkills.error,
+    currentTeam.error,
+    integrationPolicy.error,
   );
   const actions = useCloudPluginsSurfaceActions({
     catalog,

--- a/apps/packages/product-surfaces/src/settings/CloudOrganizationIntegrationsPolicySurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudOrganizationIntegrationsPolicySurface.tsx
@@ -6,7 +6,7 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import {
   buildOrganizationIntegrationPolicyItems,
-  type OrganizationIntegrationPolicyStatusFilter,
+  type OrganizationIntegrationPolicyCategoryFilter,
 } from "@proliferate/product-domain/plugins/organization-integration-policy";
 import { OrganizationIntegrationsPolicySurface } from "@proliferate/product-ui/plugins/OrganizationIntegrationsPolicySurface";
 
@@ -27,8 +27,8 @@ export function CloudOrganizationIntegrationsPolicySurface({
   );
   const actions = useCloudOrganizationIntegrationPolicyActions(organizationId);
   const [query, setQuery] = useState("");
-  const [statusFilter, setStatusFilter] =
-    useState<OrganizationIntegrationPolicyStatusFilter>("all");
+  const [categoryFilter, setCategoryFilter] =
+    useState<OrganizationIntegrationPolicyCategoryFilter>("all");
   const [pendingCatalogEntryIds, setPendingCatalogEntryIds] = useState<string[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -40,9 +40,9 @@ export function CloudOrganizationIntegrationsPolicySurface({
       catalog: catalog.data,
       policy: policy.data,
       query,
-      statusFilter,
+      categoryFilter,
     });
-  }, [catalog.data, policy.data, query, statusFilter]);
+  }, [catalog.data, policy.data, query, categoryFilter]);
 
   const loadError = organizationId
     ? firstErrorMessage(catalog.error, policy.error)
@@ -72,12 +72,12 @@ export function CloudOrganizationIntegrationsPolicySurface({
     <OrganizationIntegrationsPolicySurface
       items={items}
       query={query}
-      statusFilter={statusFilter}
+      categoryFilter={categoryFilter}
       loading={loading}
       error={error}
       pendingCatalogEntryIds={pendingCatalogEntryIds}
       onQueryChange={setQuery}
-      onStatusFilterChange={setStatusFilter}
+      onCategoryFilterChange={setCategoryFilter}
       onToggleIntegration={(catalogEntryId, value) => {
         void toggleIntegration(catalogEntryId, value);
       }}

--- a/apps/packages/product-surfaces/src/settings/CloudOrganizationIntegrationsPolicySurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudOrganizationIntegrationsPolicySurface.tsx
@@ -1,0 +1,107 @@
+import { useMemo, useState } from "react";
+import {
+  useCloudMcpCatalog,
+  useCloudOrganizationIntegrationPolicy,
+  useCloudOrganizationIntegrationPolicyActions,
+} from "@proliferate/cloud-sdk-react";
+import {
+  buildOrganizationIntegrationPolicyItems,
+  type OrganizationIntegrationPolicyStatusFilter,
+} from "@proliferate/product-domain/plugins/organization-integration-policy";
+import { OrganizationIntegrationsPolicySurface } from "@proliferate/product-ui/plugins/OrganizationIntegrationsPolicySurface";
+
+interface CloudOrganizationIntegrationsPolicySurfaceProps {
+  organizationId: string | null;
+  enabled?: boolean;
+}
+
+export function CloudOrganizationIntegrationsPolicySurface({
+  organizationId,
+  enabled = true,
+}: CloudOrganizationIntegrationsPolicySurfaceProps) {
+  const queriesEnabled = enabled && organizationId !== null;
+  const catalog = useCloudMcpCatalog(queriesEnabled);
+  const policy = useCloudOrganizationIntegrationPolicy(
+    organizationId,
+    queriesEnabled,
+  );
+  const actions = useCloudOrganizationIntegrationPolicyActions(organizationId);
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<OrganizationIntegrationPolicyStatusFilter>("all");
+  const [pendingCatalogEntryIds, setPendingCatalogEntryIds] = useState<string[]>([]);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const items = useMemo(() => {
+    if (!catalog.data || !policy.data) {
+      return [];
+    }
+    return buildOrganizationIntegrationPolicyItems({
+      catalog: catalog.data,
+      policy: policy.data,
+      query,
+      statusFilter,
+    });
+  }, [catalog.data, policy.data, query, statusFilter]);
+
+  const loadError = organizationId
+    ? firstErrorMessage(catalog.error, policy.error)
+    : "No active organization is selected.";
+  const error = actionError ?? loadError;
+  const loading = queriesEnabled && (catalog.isLoading || policy.isLoading);
+
+  async function toggleIntegration(catalogEntryId: string, value: boolean) {
+    if (!organizationId) {
+      setActionError("No active organization is selected.");
+      return;
+    }
+    setActionError(null);
+    setPendingCatalogEntryIds((current) => [...new Set([...current, catalogEntryId])]);
+    try {
+      await actions.patchPolicy({ catalogEntryId, enabled: value });
+    } catch (error_) {
+      setActionError(errorMessage(error_));
+    } finally {
+      setPendingCatalogEntryIds((current) =>
+        current.filter((entryId) => entryId !== catalogEntryId)
+      );
+    }
+  }
+
+  return (
+    <OrganizationIntegrationsPolicySurface
+      items={items}
+      query={query}
+      statusFilter={statusFilter}
+      loading={loading}
+      error={error}
+      pendingCatalogEntryIds={pendingCatalogEntryIds}
+      onQueryChange={setQuery}
+      onStatusFilterChange={setStatusFilter}
+      onToggleIntegration={(catalogEntryId, value) => {
+        void toggleIntegration(catalogEntryId, value);
+      }}
+      onRetry={() => {
+        setActionError(null);
+        void catalog.refetch();
+        void policy.refetch();
+      }}
+    />
+  );
+}
+
+function firstErrorMessage(...errors: unknown[]): string | null {
+  for (const error of errors) {
+    if (error) {
+      return errorMessage(error);
+    }
+  }
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Integration policy could not be updated.";
+}

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -183,6 +183,10 @@
       "types": "./dist/plugins/PluginsSurface.d.ts",
       "import": "./dist/plugins/PluginsSurface.js"
     },
+    "./plugins/OrganizationIntegrationsPolicySurface": {
+      "types": "./dist/plugins/OrganizationIntegrationsPolicySurface.d.ts",
+      "import": "./dist/plugins/OrganizationIntegrationsPolicySurface.js"
+    },
     "./settings/SettingsCard": {
       "types": "./dist/settings/SettingsCard.d.ts",
       "import": "./dist/settings/SettingsCard.js"

--- a/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
+++ b/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState, type ComponentType } from "react";
 import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
+import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type {
   CloudChatComposerControlView,
   CloudChatComposerFooterControlView,
@@ -95,7 +96,8 @@ export function CloudChatComposerFooter({
         {controls.map((control) => {
           const Icon = iconForComposerFooterControl(control.icon);
           const copied = copiedFeedbackKey === footerControlFeedbackKey(control);
-          return (
+          const tooltip = copied ? "Copied" : control.title ?? null;
+          const button = (
             <ComposerControlButton
               key={control.id}
               type="button"
@@ -109,12 +111,20 @@ export function CloudChatComposerFooter({
                 <Loader2 size={12} className="shrink-0 animate-spin text-muted-foreground/70" />
               ) : undefined}
               aria-label={copied ? copiedFeedbackLabel(control) : undefined}
-              title={copied ? "Copied" : control.title ?? undefined}
-              className="max-w-full shrink-0 sm:max-w-[18rem]"
+              className={tooltip ? "w-full max-w-full" : "max-w-full shrink-0 sm:max-w-[18rem]"}
               data-telemetry-mask
               onClick={() => handleFooterControlClick(control)}
             />
           );
+          return tooltip ? (
+            <Tooltip
+              key={control.id}
+              content={tooltip}
+              className="inline-flex min-w-0 max-w-full shrink-0 sm:max-w-[18rem]"
+            >
+              {button}
+            </Tooltip>
+          ) : button;
         })}
       </div>
     </div>

--- a/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
+++ b/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
@@ -1,0 +1,196 @@
+import type { ReactNode } from "react";
+import type {
+  OrganizationIntegrationPolicyItem,
+  OrganizationIntegrationPolicyStatusFilter,
+} from "@proliferate/product-domain/plugins/organization-integration-policy";
+import { Plus, Search } from "@proliferate/ui/icons";
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Select } from "@proliferate/ui/primitives/Select";
+import { Switch } from "@proliferate/ui/primitives/Switch";
+import { SettingsPageHeader } from "../settings/SettingsPageHeader";
+import { PluginIconTile } from "./PluginGlyph";
+
+export type {
+  OrganizationIntegrationPolicyItem,
+  OrganizationIntegrationPolicyStatusFilter,
+};
+
+export interface OrganizationIntegrationsPolicySurfaceProps {
+  items: readonly OrganizationIntegrationPolicyItem[];
+  query: string;
+  statusFilter: OrganizationIntegrationPolicyStatusFilter;
+  loading: boolean;
+  error: string | null;
+  pendingCatalogEntryIds: readonly string[];
+  onQueryChange: (query: string) => void;
+  onStatusFilterChange: (statusFilter: OrganizationIntegrationPolicyStatusFilter) => void;
+  onToggleIntegration: (catalogEntryId: string, enabled: boolean) => void;
+  onRetry: () => void;
+  onAddMcpIntegration?: () => void;
+}
+
+export function OrganizationIntegrationsPolicySurface({
+  items,
+  query,
+  statusFilter,
+  loading,
+  error,
+  pendingCatalogEntryIds,
+  onQueryChange,
+  onStatusFilterChange,
+  onToggleIntegration,
+  onRetry,
+  onAddMcpIntegration,
+}: OrganizationIntegrationsPolicySurfaceProps) {
+  const pendingIds = new Set(pendingCatalogEntryIds);
+  const searchEmpty = !loading && !error && query.trim().length > 0 && items.length === 0;
+  const empty = !loading && !error && query.trim().length === 0 && items.length === 0;
+
+  return (
+    <section className="space-y-6">
+      <SettingsPageHeader
+        title="Integrations"
+        description={(
+          <>
+            Manage integrations available to your organization members. Members connect
+            personal accounts from User Settings &gt; Integrations.
+          </>
+        )}
+        action={onAddMcpIntegration ? (
+          <Button type="button" variant="outline" onClick={onAddMcpIntegration}>
+            <Plus className="size-4" />
+            Add MCP integration
+          </Button>
+        ) : null}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_12rem]">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search integrations..."
+            className="pl-9"
+            aria-label="Search integrations"
+          />
+        </div>
+        <Select
+          value={statusFilter}
+          onChange={(event) =>
+            onStatusFilterChange(event.target.value as OrganizationIntegrationPolicyStatusFilter)
+          }
+          aria-label="Filter integrations"
+        >
+          <option value="all">All</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Disabled</option>
+        </Select>
+      </div>
+
+      {error && items.length > 0 ? (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <span className="min-w-0">{error}</span>
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="overflow-hidden rounded-lg border border-border-light bg-surface-elevated">
+        {loading && items.length === 0 ? (
+          <PolicyListMessage title="Loading integrations" />
+        ) : null}
+
+        {error && items.length === 0 ? (
+          <PolicyListMessage
+            title="Couldn't load integrations"
+            description={error}
+            action={<Button variant="outline" onClick={onRetry}>Retry</Button>}
+          />
+        ) : null}
+
+        {searchEmpty ? (
+          <PolicyListMessage
+            title={`No integrations match "${query}"`}
+            description="Try a different search term."
+          />
+        ) : null}
+
+        {empty ? (
+          <PolicyListMessage title="No integrations are available right now." />
+        ) : null}
+
+        {items.map((item) => (
+          <PolicyRow
+            key={item.catalogEntryId}
+            item={item}
+            pending={pendingIds.has(item.catalogEntryId)}
+            onToggle={(enabled) => {
+              onToggleIntegration(item.catalogEntryId, enabled);
+            }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PolicyRow({
+  item,
+  pending,
+  onToggle,
+}: {
+  item: OrganizationIntegrationPolicyItem;
+  pending: boolean;
+  onToggle: (enabled: boolean) => void;
+}) {
+  return (
+    <article className="grid min-h-[5.5rem] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border-light px-4 py-4 last:border-b-0 sm:px-6">
+      <div className="flex min-w-0 items-center gap-4">
+        <PluginIconTile iconId={item.iconId} size="md" />
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h2 className="min-w-0 text-sm font-medium leading-5 text-foreground">
+              {item.name}
+            </h2>
+            {item.tags.map((tag) => (
+              <Badge key={tag} tone={tag === "MCP" ? "neutral" : "accent"}>
+                {tag}
+              </Badge>
+            ))}
+          </div>
+          <p className="line-clamp-2 max-w-3xl text-sm leading-5 text-muted-foreground">
+            {item.description}
+          </p>
+        </div>
+      </div>
+      <Switch
+        checked={item.enabled}
+        disabled={pending}
+        onChange={onToggle}
+        aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.name}`}
+      />
+    </article>
+  );
+}
+
+function PolicyListMessage({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="px-4 py-10 text-center">
+      <div className="text-sm font-medium text-foreground">{title}</div>
+      {description ? <p className="mt-1 text-xs text-muted-foreground">{description}</p> : null}
+      {action ? <div className="mt-4 flex justify-center">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
+++ b/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
@@ -53,11 +53,12 @@ export function OrganizationIntegrationsPolicySurface({
   onAddMcpIntegration,
 }: OrganizationIntegrationsPolicySurfaceProps) {
   const pendingIds = new Set(pendingCatalogEntryIds);
-  const hasActiveFilter = query.trim().length > 0 || categoryFilter !== "all";
+  const trimmedQuery = query.trim();
+  const hasActiveFilter = trimmedQuery.length > 0 || categoryFilter !== "all";
   const filteredEmpty = !loading && !error && hasActiveFilter && items.length === 0;
   const empty = !loading && !error && !hasActiveFilter && items.length === 0;
-  const filteredEmptyTitle = query.trim().length > 0
-    ? `No integrations match "${query}"`
+  const filteredEmptyTitle = trimmedQuery.length > 0
+    ? `No integrations match "${trimmedQuery}"`
     : "No integrations match these filters";
 
   return (

--- a/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
+++ b/apps/packages/product-ui/src/plugins/OrganizationIntegrationsPolicySurface.tsx
@@ -1,31 +1,39 @@
-import type { ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import type {
+  OrganizationIntegrationPolicyCategoryFilter,
   OrganizationIntegrationPolicyItem,
-  OrganizationIntegrationPolicyStatusFilter,
 } from "@proliferate/product-domain/plugins/organization-integration-policy";
-import { Plus, Search } from "@proliferate/ui/icons";
+import {
+  ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS,
+} from "@proliferate/product-domain/plugins/organization-integration-policy";
+import { Check, ChevronDown, Plus, Search } from "@proliferate/ui/icons";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { Select } from "@proliferate/ui/primitives/Select";
+import {
+  PickerEmptyRow,
+  PickerPopoverContent,
+} from "@proliferate/ui/primitives/PickerPopoverContent";
+import { PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { Switch } from "@proliferate/ui/primitives/Switch";
 import { SettingsPageHeader } from "../settings/SettingsPageHeader";
 import { PluginIconTile } from "./PluginGlyph";
 
 export type {
+  OrganizationIntegrationPolicyCategoryFilter,
   OrganizationIntegrationPolicyItem,
-  OrganizationIntegrationPolicyStatusFilter,
 };
 
 export interface OrganizationIntegrationsPolicySurfaceProps {
   items: readonly OrganizationIntegrationPolicyItem[];
   query: string;
-  statusFilter: OrganizationIntegrationPolicyStatusFilter;
+  categoryFilter: OrganizationIntegrationPolicyCategoryFilter;
   loading: boolean;
   error: string | null;
   pendingCatalogEntryIds: readonly string[];
   onQueryChange: (query: string) => void;
-  onStatusFilterChange: (statusFilter: OrganizationIntegrationPolicyStatusFilter) => void;
+  onCategoryFilterChange: (categoryFilter: OrganizationIntegrationPolicyCategoryFilter) => void;
   onToggleIntegration: (catalogEntryId: string, enabled: boolean) => void;
   onRetry: () => void;
   onAddMcpIntegration?: () => void;
@@ -34,19 +42,23 @@ export interface OrganizationIntegrationsPolicySurfaceProps {
 export function OrganizationIntegrationsPolicySurface({
   items,
   query,
-  statusFilter,
+  categoryFilter,
   loading,
   error,
   pendingCatalogEntryIds,
   onQueryChange,
-  onStatusFilterChange,
+  onCategoryFilterChange,
   onToggleIntegration,
   onRetry,
   onAddMcpIntegration,
 }: OrganizationIntegrationsPolicySurfaceProps) {
   const pendingIds = new Set(pendingCatalogEntryIds);
-  const searchEmpty = !loading && !error && query.trim().length > 0 && items.length === 0;
-  const empty = !loading && !error && query.trim().length === 0 && items.length === 0;
+  const hasActiveFilter = query.trim().length > 0 || categoryFilter !== "all";
+  const filteredEmpty = !loading && !error && hasActiveFilter && items.length === 0;
+  const empty = !loading && !error && !hasActiveFilter && items.length === 0;
+  const filteredEmptyTitle = query.trim().length > 0
+    ? `No integrations match "${query}"`
+    : "No integrations match these filters";
 
   return (
     <section className="space-y-6">
@@ -77,17 +89,10 @@ export function OrganizationIntegrationsPolicySurface({
             aria-label="Search integrations"
           />
         </div>
-        <Select
-          value={statusFilter}
-          onChange={(event) =>
-            onStatusFilterChange(event.target.value as OrganizationIntegrationPolicyStatusFilter)
-          }
-          aria-label="Filter integrations"
-        >
-          <option value="all">All</option>
-          <option value="enabled">Enabled</option>
-          <option value="disabled">Disabled</option>
-        </Select>
+        <IntegrationCategoryFilterDropdown
+          value={categoryFilter}
+          onChange={onCategoryFilterChange}
+        />
       </div>
 
       {error && items.length > 0 ? (
@@ -112,10 +117,10 @@ export function OrganizationIntegrationsPolicySurface({
           />
         ) : null}
 
-        {searchEmpty ? (
+        {filteredEmpty ? (
           <PolicyListMessage
-            title={`No integrations match "${query}"`}
-            description="Try a different search term."
+            title={filteredEmptyTitle}
+            description="Try a different search term or filter."
           />
         ) : null}
 
@@ -135,6 +140,82 @@ export function OrganizationIntegrationsPolicySurface({
         ))}
       </div>
     </section>
+  );
+}
+
+function IntegrationCategoryFilterDropdown({
+  value,
+  onChange,
+}: {
+  value: OrganizationIntegrationPolicyCategoryFilter;
+  onChange: (value: OrganizationIntegrationPolicyCategoryFilter) => void;
+}) {
+  const [filterQuery, setFilterQuery] = useState("");
+  const selectedOption =
+    ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS.find((option) => option.id === value)
+    ?? { id: "all", label: "All" };
+  const visibleOptions = useMemo(() => {
+    const normalizedQuery = filterQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS;
+    }
+    return ORGANIZATION_INTEGRATION_POLICY_FILTER_OPTIONS.filter((option) =>
+      option.label.toLowerCase().includes(normalizedQuery)
+    );
+  }, [filterQuery]);
+
+  return (
+    <PopoverButton
+      trigger={(
+        <button
+          type="button"
+          className="flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-surface-control px-3 text-left text-sm text-foreground shadow-none outline-none transition-colors hover:bg-list-hover focus:outline-none focus:ring-1 focus:ring-ring data-[state=open]:bg-list-hover data-[state=open]:ring-1 data-[state=open]:ring-ring"
+          aria-label={`Filter integrations: ${selectedOption.label}`}
+        >
+          <span className="min-w-0 truncate">{selectedOption.label}</span>
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+        </button>
+      )}
+      align="end"
+      side="bottom"
+      className="w-56 rounded-xl border border-border bg-popover p-1 text-popover-foreground shadow-floating"
+      onOpenChange={(open) => {
+        if (!open) {
+          setFilterQuery("");
+        }
+      }}
+    >
+      {(close) => (
+        <PickerPopoverContent
+          searchValue={filterQuery}
+          searchPlaceholder="Search"
+          onSearchChange={setFilterQuery}
+          bodyClassName="py-1"
+        >
+          {visibleOptions.length > 0 ? (
+            visibleOptions.map((option) => {
+              const selected = option.id === value;
+              return (
+                <PopoverMenuItem
+                  key={option.id}
+                  label={option.label}
+                  trailing={selected ? <Check className="size-3.5" /> : null}
+                  className={selected ? "bg-list-hover" : ""}
+                  aria-selected={selected}
+                  onClick={() => {
+                    onChange(option.id);
+                    setFilterQuery("");
+                    close();
+                  }}
+                />
+              );
+            })
+          ) : (
+            <PickerEmptyRow label="No filters found" />
+          )}
+        </PickerPopoverContent>
+      )}
+    </PopoverButton>
   );
 }
 

--- a/apps/packages/product-ui/src/plugins/PluginCards.tsx
+++ b/apps/packages/product-ui/src/plugins/PluginCards.tsx
@@ -1,132 +1,156 @@
-
 import type { ReactNode } from "react";
 import type { PluginInventoryItem } from "@proliferate/product-domain/plugins/cloud-plugin-inventory";
-import { Plus } from "@proliferate/ui/icons";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Switch } from "@proliferate/ui/primitives/Switch";
 import { PluginGlyph } from "./PluginGlyph";
 import { badgeTone } from "./plugin-presentation";
 import type { PluginIconRenderer } from "./plugin-types";
 
-export function PluginSection({
-  title,
+export function PluginList({
   children,
 }: {
-  title: string;
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-3">
-      <div className="border-b border-border/60 pb-2">
-        <h2 className="text-xs font-medium uppercase text-muted-foreground">{title}</h2>
-      </div>
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-        {children}
-      </div>
-    </section>
+    <div className="overflow-hidden rounded-lg border border-border-light bg-surface-elevated">
+      {children}
+    </div>
   );
 }
 
-export function PluginCard({
+export function PluginRow({
   item,
   pending,
   renderIcon,
   onOpen,
-  onToggle,
-  onConfigure,
+  onConnect,
+  onDisconnect,
   onOpenDesktop,
 }: {
   item: PluginInventoryItem;
   pending: boolean;
   renderIcon?: PluginIconRenderer;
   onOpen: () => void;
-  onToggle: (enabled: boolean) => void;
-  onConfigure: () => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
   onOpenDesktop: () => void;
 }) {
   const disabledOnSurface = Boolean(item.unavailableReason);
   const statusTone = badgeTone(item.statusTone);
-  const icon = renderIcon?.(item, "sm") ?? <PluginGlyph item={item} size="sm" />;
+  const icon = renderIcon?.(item, "md") ?? <PluginGlyph item={item} size="md" />;
+  const showStatus = item.state === "installed" && (item.broken || !item.enabled);
 
   return (
-    <article className="group/plugin flex min-h-[96px] flex-col gap-2 rounded-lg border border-border/60 bg-foreground/5 p-3 transition-colors hover:bg-foreground/[0.075]">
-      <div className="flex min-w-0 items-start gap-3">
+    <article className="grid min-h-[5.5rem] grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b border-border-light px-4 py-4 last:border-b-0 sm:px-6">
+      <div className="flex min-w-0 items-center gap-4">
         <Button
           type="button"
           variant="unstyled"
           size="unstyled"
           onClick={onOpen}
-          className="flex min-w-0 flex-1 items-start gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-w-0 flex-1 items-center justify-start gap-4 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {icon}
-          <span className="flex min-w-0 flex-1 flex-col gap-1">
-            <span className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-sm font-medium text-foreground">{item.entry.name}</span>
-              <Badge tone={statusTone} className="shrink-0">
-                {item.statusLabel}
-              </Badge>
+          <span className="min-w-0 space-y-1">
+            <span className="flex min-w-0 flex-wrap items-center gap-2">
+              <span className="min-w-0 text-sm font-medium leading-5 text-foreground">
+                {item.entry.name}
+              </span>
+              {showStatus ? (
+                <Badge tone={statusTone} className="shrink-0">
+                  {item.statusLabel}
+                </Badge>
+              ) : null}
             </span>
-            <span className="line-clamp-1 text-xs leading-5 text-muted-foreground">
+            <span className="line-clamp-2 max-w-3xl text-sm leading-5 text-muted-foreground">
               {item.entry.oneLiner}
             </span>
           </span>
         </Button>
       </div>
 
-      <div className="flex min-w-0 items-center gap-2 pl-11">
-        <div className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground/80">
-          {item.capabilitySummary}
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {item.state === "installed" ? (
-            item.statusActionLabel ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                loading={pending}
-                onClick={onConfigure}
-                className="h-7 px-2 text-[11px]"
-              >
-                {item.statusActionLabel}
-              </Button>
-            ) : (
-              <Switch
-                checked={item.enabled}
-                disabled={pending}
-                onChange={onToggle}
-                size="compact"
-                aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.entry.name}`}
-              />
-            )
-          ) : disabledOnSurface ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={onOpenDesktop}
-              className="h-7 px-2 text-[11px]"
-            >
-              Open Desktop
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              loading={pending}
-              onClick={onConfigure}
-              className="size-7 shrink-0 rounded-md"
-              aria-label={`Install ${item.entry.name}`}
-              title={`Install ${item.entry.name}`}
-            >
-              <Plus className="size-3.5" />
-            </Button>
-          )}
-        </div>
-      </div>
+      <PluginRowAction
+        item={item}
+        pending={pending}
+        disabledOnSurface={disabledOnSurface}
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+        onOpenDesktop={onOpenDesktop}
+      />
     </article>
+  );
+}
+
+function PluginRowAction({
+  item,
+  pending,
+  disabledOnSurface,
+  onConnect,
+  onDisconnect,
+  onOpenDesktop,
+}: {
+  item: PluginInventoryItem;
+  pending: boolean;
+  disabledOnSurface: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onOpenDesktop: () => void;
+}) {
+  if (item.state === "installed" && item.statusActionLabel) {
+    return (
+      <Button
+        type="button"
+        variant="inverted"
+        size="sm"
+        loading={pending}
+        onClick={onConnect}
+        className="h-9 min-w-24 rounded-md px-4 text-sm"
+      >
+        {item.statusActionLabel}
+      </Button>
+    );
+  }
+
+  if (item.state === "installed") {
+    return (
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        loading={pending}
+        onClick={onDisconnect}
+        className="h-9 min-w-24 rounded-md px-4 text-sm"
+      >
+        Disconnect
+      </Button>
+    );
+  }
+
+  if (disabledOnSurface) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onOpenDesktop}
+        className="h-9 min-w-24 rounded-md px-4 text-sm"
+      >
+        Open Desktop
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="inverted"
+      size="sm"
+      loading={pending}
+      onClick={onConnect}
+      className="h-9 min-w-24 rounded-md px-4 text-sm"
+    >
+      Connect
+    </Button>
   );
 }
 

--- a/apps/packages/product-ui/src/plugins/PluginGlyph.tsx
+++ b/apps/packages/product-ui/src/plugins/PluginGlyph.tsx
@@ -80,7 +80,17 @@ export function PluginGlyph({
   item: PluginInventoryItem;
   size?: PluginIconSize;
 }) {
-  const brandAsset = PLUGIN_BRAND_ASSETS[item.entry.iconId];
+  return <PluginIconTile iconId={item.entry.iconId} size={size} />;
+}
+
+export function PluginIconTile({
+  iconId,
+  size = "sm",
+}: {
+  iconId: string;
+  size?: PluginIconSize;
+}) {
+  const brandAsset = PLUGIN_BRAND_ASSETS[iconId];
   if (brandAsset) {
     return (
       <span
@@ -92,7 +102,7 @@ export function PluginGlyph({
     );
   }
 
-  const Icon = PLUGIN_GLYPH_ICONS[item.entry.iconId] ?? Globe;
+  const Icon = PLUGIN_GLYPH_ICONS[iconId] ?? Globe;
   return (
     <span
       aria-hidden="true"

--- a/apps/packages/product-ui/src/plugins/PluginsSurface.tsx
+++ b/apps/packages/product-ui/src/plugins/PluginsSurface.tsx
@@ -1,7 +1,8 @@
-import { AlertCircle, Check } from "lucide-react";
+import { AlertCircle, Check, Search } from "lucide-react";
 import { useMemo } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
+import { Input } from "@proliferate/ui/primitives/Input";
 import { ProductNotice } from "../layout/ProductNotice";
 import { PluginList, PluginListMessage, PluginRow } from "./PluginCards";
 import { PluginConnectionModal } from "./PluginConnectionModal";
@@ -18,6 +19,7 @@ export type {
 
 export function PluginsSurface({
   items,
+  query,
   loading,
   error,
   surface,
@@ -35,6 +37,7 @@ export function PluginsSurface({
   deleteTarget,
   deletePending,
   renderIcon,
+  onQueryChange,
   onRetry,
   onOpenItem,
   onCloseItem,
@@ -51,11 +54,25 @@ export function PluginsSurface({
   onConfirmDelete,
 }: PluginsSurfaceProps) {
   const pendingIds = useMemo(() => new Set(pendingItemIds), [pendingItemIds]);
-  const empty = !loading && !error && items.length === 0;
+  const trimmedQuery = query.trim();
+  const hasQuery = trimmedQuery.length > 0;
+  const searchEmpty = !loading && !error && items.length === 0 && hasQuery;
+  const empty = !loading && !error && items.length === 0 && !hasQuery;
 
   return (
     <>
       <section className="space-y-6">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search integrations..."
+            className="pl-9"
+            aria-label="Search integrations"
+          />
+        </div>
+
         {completionNotice ? (
           <ProductNotice
             tone={completionNotice.tone}
@@ -77,6 +94,13 @@ export function PluginsSurface({
 
         {empty ? (
           <PluginListMessage title="No integrations are available right now." />
+        ) : null}
+
+        {searchEmpty ? (
+          <PluginListMessage
+            title={`No integrations match "${trimmedQuery}"`}
+            description="Try a different search term."
+          />
         ) : null}
 
         {items.length > 0 ? (

--- a/apps/packages/product-ui/src/plugins/PluginsSurface.tsx
+++ b/apps/packages/product-ui/src/plugins/PluginsSurface.tsx
@@ -1,11 +1,9 @@
-
-import { AlertCircle, Check, Search } from "lucide-react";
+import { AlertCircle, Check } from "lucide-react";
 import { useMemo } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
-import { Input } from "@proliferate/ui/primitives/Input";
 import { ProductNotice } from "../layout/ProductNotice";
-import { PluginCard, PluginListMessage, PluginSection } from "./PluginCards";
+import { PluginList, PluginListMessage, PluginRow } from "./PluginCards";
 import { PluginConnectionModal } from "./PluginConnectionModal";
 import type { PluginsSurfaceProps } from "./plugin-types";
 
@@ -20,7 +18,6 @@ export type {
 
 export function PluginsSurface({
   items,
-  query,
   loading,
   error,
   surface,
@@ -38,7 +35,6 @@ export function PluginsSurface({
   deleteTarget,
   deletePending,
   renderIcon,
-  onQueryChange,
   onRetry,
   onOpenItem,
   onCloseItem,
@@ -55,27 +51,11 @@ export function PluginsSurface({
   onConfirmDelete,
 }: PluginsSurfaceProps) {
   const pendingIds = useMemo(() => new Set(pendingItemIds), [pendingItemIds]);
-  const installed = items.filter((item) => item.state === "installed");
-  const available = items.filter((item) => item.state === "available");
-  const firstRunEmpty = !loading && !error && installed.length === 0 && !query.trim();
-  const searchEmpty = !loading && !error && items.length === 0 && query.trim().length > 0;
+  const empty = !loading && !error && items.length === 0;
 
   return (
     <>
-      <section className="space-y-5">
-        <div className="sticky top-10 z-10 bg-background/95 pb-2 pt-1 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={query}
-              onChange={(event) => onQueryChange(event.target.value)}
-              placeholder="Search integrations..."
-              className="pl-9"
-              aria-label="Search integrations"
-            />
-          </div>
-        </div>
-
+      <section className="space-y-6">
         {completionNotice ? (
           <ProductNotice
             tone={completionNotice.tone}
@@ -95,58 +75,28 @@ export function PluginsSurface({
           />
         ) : null}
 
-        {searchEmpty ? (
-          <PluginListMessage
-            title={`No integrations match "${query}"`}
-            description="Try a different search term."
-          />
+        {empty ? (
+          <PluginListMessage title="No integrations are available right now." />
         ) : null}
 
-        {!loading && !error && firstRunEmpty && available.length > 0 ? (
-          <div className="rounded-lg border border-border/50 bg-foreground/5 px-4 py-3">
-            <div className="text-sm font-medium text-foreground">No integrations installed</div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Install a package below. Enabled packages add MCP tools and skills to your sessions.
-            </p>
-          </div>
-        ) : null}
-
-        {installed.length > 0 ? (
-          <PluginSection title="Installed">
-            {installed.map((item) => (
-              <PluginCard
-                key={item.id}
-                item={item}
-                pending={pendingIds.has(item.id)}
-                renderIcon={renderIcon}
-                onOpen={() => onOpenItem(item, "manage")}
-                onToggle={(enabled) => onToggleEnabled(item, enabled)}
-                onConfigure={() => onOpenItem(item, "manage")}
-                onOpenDesktop={onOpenDesktop}
-              />
-            ))}
-          </PluginSection>
-        ) : null}
-
-        {available.length > 0 ? (
-          <PluginSection title="Available">
-            {available.map((item) => (
-              <PluginCard
-                key={item.id}
-                item={item}
-                pending={pendingIds.has(item.id)}
-                renderIcon={renderIcon}
-                onOpen={() => onOpenItem(item, "connect")}
-                onToggle={(enabled) => onToggleEnabled(item, enabled)}
-                onConfigure={() => onOpenItem(item, "connect")}
-                onOpenDesktop={onOpenDesktop}
-              />
-            ))}
-          </PluginSection>
-        ) : !loading && !error && !searchEmpty ? (
-          <p className="text-sm text-muted-foreground">
-            {installed.length > 0 ? "All available integrations are installed." : "No integrations are available right now."}
-          </p>
+        {items.length > 0 ? (
+          <PluginList>
+            {items.map((item) => {
+              const mode = item.state === "installed" ? "manage" : "connect";
+              return (
+                <PluginRow
+                  key={item.id}
+                  item={item}
+                  pending={pendingIds.has(item.id)}
+                  renderIcon={renderIcon}
+                  onOpen={() => onOpenItem(item, mode)}
+                  onConnect={() => onOpenItem(item, mode)}
+                  onDisconnect={() => onRequestDelete(item)}
+                  onOpenDesktop={onOpenDesktop}
+                />
+              );
+            })}
+          </PluginList>
         ) : null}
       </section>
 
@@ -176,9 +126,9 @@ export function PluginsSurface({
 
       <ConfirmationDialog
         open={deleteTarget !== null}
-        title={deleteTarget ? `Delete ${deleteTarget.entry.name}?` : "Delete integration?"}
-        description="This removes the MCP connection from personal cloud access. Existing sessions keep their transcript history."
-        confirmLabel="Delete"
+        title={deleteTarget ? `Disconnect ${deleteTarget.entry.name}?` : "Disconnect integration?"}
+        description="This removes the integration connection from personal cloud access. Existing sessions keep their transcript history."
+        confirmLabel="Disconnect"
         confirmVariant="destructive"
         loading={deletePending}
         disableClose={deletePending}

--- a/apps/packages/product-ui/test/CloudChatComposer.test.tsx
+++ b/apps/packages/product-ui/test/CloudChatComposer.test.tsx
@@ -158,8 +158,16 @@ describe("CloudChatComposer", () => {
       />,
     );
 
-    const copyButton = screen.getByTitle("Copy branch name");
+    const copyButton = screen.getByRole("button", { name: /feature\/loading/i });
+    const tooltipTrigger = copyButton.parentElement;
+    expect(tooltipTrigger).toBeTruthy();
+    expect(copyButton.getAttribute("title")).toBeNull();
     expect(copyButton.querySelector(".lucide-git-branch")).toBeTruthy();
+
+    fireEvent.mouseEnter(tooltipTrigger!);
+    expect(screen.getByRole("tooltip").textContent).toBe("Copy branch name");
+    fireEvent.mouseLeave(tooltipTrigger!);
+
     fireEvent.click(copyButton);
 
     await act(async () => {
@@ -167,17 +175,22 @@ describe("CloudChatComposer", () => {
     });
 
     expect(onCopy).toHaveBeenCalledTimes(1);
-    expect(copyButton.title).toBe("Copied");
+    expect(copyButton.getAttribute("title")).toBeNull();
     expect(screen.getByRole("button", { name: "Copied branch name" })).toBe(copyButton);
     expect(screen.getByText("Copied branch name")).toBeTruthy();
     expect(copyButton.querySelector(".lucide-check")).toBeTruthy();
     expect(copyButton.querySelector(".lucide-git-branch")).toBeNull();
 
+    fireEvent.mouseEnter(tooltipTrigger!);
+    expect(screen.getByRole("tooltip").textContent).toBe("Copied");
+    fireEvent.mouseLeave(tooltipTrigger!);
+
     act(() => {
       vi.advanceTimersByTime(1400);
     });
 
-    expect(copyButton.title).toBe("Copy branch name");
+    expect(copyButton.getAttribute("title")).toBeNull();
+    expect(screen.getByRole("button", { name: /feature\/loading/i })).toBe(copyButton);
     expect(copyButton.querySelector(".lucide-git-branch")).toBeTruthy();
   });
 
@@ -209,7 +222,15 @@ describe("CloudChatComposer", () => {
       />,
     );
 
-    const copyButton = screen.getByTitle("Copy repository name");
+    const copyButton = screen.getByRole("button", { name: /proliferate-ai\/proliferate/i });
+    const tooltipTrigger = copyButton.parentElement;
+    expect(tooltipTrigger).toBeTruthy();
+    expect(copyButton.getAttribute("title")).toBeNull();
+
+    fireEvent.mouseEnter(tooltipTrigger!);
+    expect(screen.getByRole("tooltip").textContent).toBe("Copy repository name");
+    fireEvent.mouseLeave(tooltipTrigger!);
+
     fireEvent.click(copyButton);
 
     await act(async () => {
@@ -217,7 +238,7 @@ describe("CloudChatComposer", () => {
     });
 
     expect(onCopy).toHaveBeenCalledTimes(1);
-    expect(copyButton.title).toBe("Copy repository name");
+    expect(copyButton.getAttribute("title")).toBeNull();
     expect(copyButton.querySelector(".lucide-check")).toBeNull();
     expect(screen.queryByText("Copied repository name")).toBeNull();
   });

--- a/apps/packages/product-ui/test/OrganizationIntegrationsPolicySurface.test.tsx
+++ b/apps/packages/product-ui/test/OrganizationIntegrationsPolicySurface.test.tsx
@@ -61,6 +61,31 @@ describe("OrganizationIntegrationsPolicySurface", () => {
     expect(screen.getByText("Source control")).toBeTruthy();
     expect(screen.getByText("MCP")).toBeTruthy();
   });
+
+  it("emits search query changes", () => {
+    const onQueryChange = vi.fn();
+
+    render(
+      <OrganizationIntegrationsPolicySurface
+        items={[policyItem()]}
+        query=""
+        categoryFilter="all"
+        loading={false}
+        error={null}
+        pendingCatalogEntryIds={[]}
+        onQueryChange={onQueryChange}
+        onCategoryFilterChange={vi.fn()}
+        onToggleIntegration={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Search integrations"), {
+      target: { value: "github" },
+    });
+
+    expect(onQueryChange).toHaveBeenCalledWith("github");
+  });
 });
 
 function policyItem(): OrganizationIntegrationPolicyItem {

--- a/apps/packages/product-ui/test/OrganizationIntegrationsPolicySurface.test.tsx
+++ b/apps/packages/product-ui/test/OrganizationIntegrationsPolicySurface.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OrganizationIntegrationsPolicySurface } from "../src/plugins/OrganizationIntegrationsPolicySurface";
+import type { OrganizationIntegrationPolicyItem } from "../src/plugins/OrganizationIntegrationsPolicySurface";
+
+describe("OrganizationIntegrationsPolicySurface", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the integration category picker style for filters", () => {
+    const onCategoryFilterChange = vi.fn();
+
+    render(
+      <OrganizationIntegrationsPolicySurface
+        items={[policyItem()]}
+        query=""
+        categoryFilter="all"
+        loading={false}
+        error={null}
+        pendingCatalogEntryIds={[]}
+        onQueryChange={vi.fn()}
+        onCategoryFilterChange={onCategoryFilterChange}
+        onToggleIntegration={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter integrations: All" }));
+
+    expect(screen.getByPlaceholderText("Search")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "All" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.change(screen.getByPlaceholderText("Search"), { target: { value: "obs" } });
+    expect(screen.getByRole("button", { name: "Observability" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Knowledge" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Observability" }));
+
+    expect(onCategoryFilterChange).toHaveBeenCalledWith("observability");
+  });
+
+  it("renders category and MCP tags on policy rows", () => {
+    render(
+      <OrganizationIntegrationsPolicySurface
+        items={[policyItem()]}
+        query=""
+        categoryFilter="all"
+        loading={false}
+        error={null}
+        pendingCatalogEntryIds={[]}
+        onQueryChange={vi.fn()}
+        onCategoryFilterChange={vi.fn()}
+        onToggleIntegration={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Source control")).toBeTruthy();
+    expect(screen.getByText("MCP")).toBeTruthy();
+  });
+});
+
+function policyItem(): OrganizationIntegrationPolicyItem {
+  return {
+    catalogEntryId: "github",
+    name: "GitHub",
+    description: "GitHub integration",
+    iconId: "github",
+    enabled: true,
+    categories: ["source_control", "mcp"],
+    tags: ["Source control", "MCP"],
+  };
+}

--- a/apps/packages/product-ui/test/PluginsSurface.test.tsx
+++ b/apps/packages/product-ui/test/PluginsSurface.test.tsx
@@ -32,6 +32,24 @@ describe("PluginsSurface", () => {
 
     expect(onRequestDelete).toHaveBeenCalledWith(item);
   });
+
+  it("emits search query changes", () => {
+    const onQueryChange = vi.fn();
+
+    renderSurface({ onQueryChange });
+
+    fireEvent.change(screen.getByLabelText("Search integrations"), {
+      target: { value: "notion" },
+    });
+
+    expect(onQueryChange).toHaveBeenCalledWith("notion");
+  });
+
+  it("shows a searched-empty state", () => {
+    renderSurface({ query: "missing" });
+
+    expect(screen.getByText('No integrations match "missing"')).toBeTruthy();
+  });
 });
 
 function renderSurface(overrides: Partial<PluginsSurfaceProps> = {}) {

--- a/apps/packages/product-ui/test/PluginsSurface.test.tsx
+++ b/apps/packages/product-ui/test/PluginsSurface.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginInventoryItem } from "@proliferate/product-domain/plugins/cloud-plugin-inventory";
+
+import { PluginsSurface } from "../src/plugins/PluginsSurface";
+import type { PluginsSurfaceProps } from "../src/plugins/PluginsSurface";
+
+describe("PluginsSurface", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens available integrations in connect mode", () => {
+    const item = pluginItem({ state: "available" });
+    const onOpenItem = vi.fn();
+
+    renderSurface({ items: [item], onOpenItem });
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(onOpenItem).toHaveBeenCalledWith(item, "connect");
+  });
+
+  it("requests disconnect for installed integrations", () => {
+    const item = pluginItem({ state: "installed" });
+    const onRequestDelete = vi.fn();
+
+    renderSurface({ items: [item], onRequestDelete });
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(onRequestDelete).toHaveBeenCalledWith(item);
+  });
+});
+
+function renderSurface(overrides: Partial<PluginsSurfaceProps> = {}) {
+  const props: PluginsSurfaceProps = {
+    items: [],
+    query: "",
+    loading: false,
+    error: null,
+    surface: "desktop",
+    selectedItem: null,
+    modalMode: "connect",
+    draft: null,
+    submitting: false,
+    pendingItemIds: [],
+    modalError: null,
+    completionNotice: null,
+    canShare: false,
+    canCancelSubmission: false,
+    cancelingSubmission: false,
+    shareOrganizationName: null,
+    deleteTarget: null,
+    deletePending: false,
+    onQueryChange: vi.fn(),
+    onRetry: vi.fn(),
+    onOpenItem: vi.fn(),
+    onCloseItem: vi.fn(),
+    onCancelSubmission: vi.fn(),
+    onDraftSettingsChange: vi.fn(),
+    onDraftSecretChange: vi.fn(),
+    onSubmitSelected: vi.fn(),
+    onToggleEnabled: vi.fn(),
+    onShareChange: vi.fn(),
+    onOpenDocs: vi.fn(),
+    onOpenDesktop: vi.fn(),
+    onRequestDelete: vi.fn(),
+    onCloseDelete: vi.fn(),
+    onConfirmDelete: vi.fn(),
+    ...overrides,
+  };
+
+  render(<PluginsSurface {...props} />);
+}
+
+function pluginItem({
+  state,
+}: {
+  state: PluginInventoryItem["state"];
+}): PluginInventoryItem {
+  return {
+    id: state === "installed" ? "conn_granola" : "granola",
+    state,
+    entry: {
+      id: "granola",
+      version: 1,
+      name: "Granola",
+      oneLiner: "Granola takes your raw meeting notes and makes them awesome.",
+      description: "Granola tools.",
+      docsUrl: "https://docs.example/granola",
+      availability: "universal",
+      cloudSecretSync: true,
+      setupKind: "none",
+      transport: "http",
+      authKind: "oauth",
+      url: "https://granola.example/mcp",
+      displayUrl: "granola.example",
+      serverNameBase: "granola",
+      iconId: "granola",
+      capabilities: [],
+      secretFields: [],
+      requiredFields: [],
+      settingsSchema: [],
+    },
+    setupVariant: "oauth",
+    configuredPlugin: null,
+    configuredSkills: [],
+    enabled: true,
+    broken: false,
+    statusLabel: state === "installed" ? "Connected" : "Available",
+    statusTone: "neutral",
+    statusActionLabel: null,
+    unavailableReason: null,
+    capabilitySummary: "MCP",
+    includesLabel: "MCP",
+    sharedLabel: "Private",
+    sharedTone: "muted",
+    isFullyPublic: false,
+    hasPublicItems: false,
+  };
+}

--- a/apps/packages/ui/src/primitives/Tooltip.tsx
+++ b/apps/packages/ui/src/primitives/Tooltip.tsx
@@ -128,7 +128,7 @@ export function Tooltip({
           className={`pointer-events-none fixed z-[70] -translate-x-1/2 -translate-y-full border border-border/60 bg-popover/96 px-2.5 py-1 text-[11px] font-medium leading-tight text-popover-foreground shadow-floating backdrop-blur-lg ${
             singleLine
               ? "max-w-[min(18rem,calc(100vw-1.5rem))] overflow-hidden text-ellipsis whitespace-nowrap rounded-full"
-              : "overflow-hidden rounded-md text-left"
+              : "overflow-hidden rounded-lg text-left"
           } ${
             measured ? "opacity-100" : "opacity-0"
           }`}

--- a/cloud/sdk-react/src/hooks/integration-policy.ts
+++ b/cloud/sdk-react/src/hooks/integration-policy.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getCloudOrganizationIntegrationPolicy,
+  patchCloudOrganizationIntegrationPolicy,
+  type CloudOrganizationIntegrationPolicyResponse,
+  type PatchCloudOrganizationIntegrationPolicyRequest,
+} from "@proliferate/cloud-sdk";
+
+import { useCloudClient } from "../context/CloudClientProvider.js";
+import {
+  cloudOrganizationIntegrationPolicyKey,
+  cloudPluginInventoryRootKey,
+} from "../lib/query-keys.js";
+
+export function useCloudOrganizationIntegrationPolicy(
+  organizationId: string | null,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<CloudOrganizationIntegrationPolicyResponse>({
+    queryKey: cloudOrganizationIntegrationPolicyKey(organizationId),
+    queryFn: () => getCloudOrganizationIntegrationPolicy(organizationId!, client),
+    enabled: enabled && organizationId !== null,
+  });
+}
+
+export function useCloudOrganizationIntegrationPolicyActions(
+  organizationId: string | null,
+) {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: cloudOrganizationIntegrationPolicyKey(organizationId),
+      }),
+      queryClient.invalidateQueries({ queryKey: cloudPluginInventoryRootKey() }),
+    ]);
+  };
+  const patchPolicy = useMutation<
+    CloudOrganizationIntegrationPolicyResponse,
+    Error,
+    PatchCloudOrganizationIntegrationPolicyRequest
+  >({
+    mutationFn: (body) =>
+      patchCloudOrganizationIntegrationPolicy(organizationId!, body, client),
+    onSuccess: async (policy) => {
+      queryClient.setQueryData(
+        cloudOrganizationIntegrationPolicyKey(organizationId),
+        policy,
+      );
+      await invalidate();
+    },
+  });
+
+  return {
+    patchPolicy: patchPolicy.mutateAsync,
+    isPatchingPolicy: patchPolicy.isPending,
+  };
+}

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -9,6 +9,7 @@ export * from "./hooks/commands.js";
 export * from "./hooks/config.js";
 export * from "./hooks/claims.js";
 export * from "./hooks/events.js";
+export * from "./hooks/integration-policy.js";
 export * from "./hooks/live.js";
 export * from "./hooks/mcp.js";
 export * from "./hooks/organizations.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -34,6 +34,16 @@ export function cloudMcpCatalogKey() {
   return [...cloudPluginInventoryRootKey(), "mcp-catalog", "v1"] as const;
 }
 
+export function cloudOrganizationIntegrationPolicyKey(
+  organizationId: string | null,
+) {
+  return [
+    ...cloudPluginInventoryRootKey(),
+    "organization-integration-policy",
+    organizationId,
+  ] as const;
+}
+
 export function cloudMcpConnectionsKey() {
   return [...cloudPluginInventoryRootKey(), "mcp-connections"] as const;
 }

--- a/cloud/sdk/src/client/integration_policy.ts
+++ b/cloud/sdk/src/client/integration_policy.ts
@@ -1,0 +1,25 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type {
+  CloudOrganizationIntegrationPolicyResponse,
+  PatchCloudOrganizationIntegrationPolicyRequest,
+} from "../types/index.js";
+
+export async function getCloudOrganizationIntegrationPolicy(
+  organizationId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<CloudOrganizationIntegrationPolicyResponse> {
+  return (await client.GET("/v1/cloud/organizations/{organization_id}/integration-policy", {
+    params: { path: { organization_id: organizationId } },
+  })).data!;
+}
+
+export async function patchCloudOrganizationIntegrationPolicy(
+  organizationId: string,
+  body: PatchCloudOrganizationIntegrationPolicyRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<CloudOrganizationIntegrationPolicyResponse> {
+  return (await client.PATCH("/v1/cloud/organizations/{organization_id}/integration-policy", {
+    params: { path: { organization_id: organizationId } },
+    body,
+  })).data!;
+}

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1595,6 +1595,24 @@ export interface paths {
         patch: operations["update_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__patch"];
         trace?: never;
     };
+    "/v1/cloud/organizations/{organization_id}/integration-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Organization Integration Policy Endpoint */
+        get: operations["get_organization_integration_policy_endpoint_v1_cloud_organizations__organization_id__integration_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Patch Organization Integration Policy Endpoint */
+        patch: operations["patch_organization_integration_policy_endpoint_v1_cloud_organizations__organization_id__integration_policy_patch"];
+        trace?: never;
+    };
     "/v1/cloud/mcp/catalog": {
         parameters: {
             query?: never;
@@ -4863,6 +4881,24 @@ export interface components {
             /** Finalsurface */
             finalSurface: string;
         };
+        /** CloudOrganizationIntegrationPolicyItem */
+        CloudOrganizationIntegrationPolicyItem: {
+            /** Catalogentryid */
+            catalogEntryId: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Updatedat */
+            updatedAt?: string | null;
+            /** Updatedbyuserid */
+            updatedByUserId?: string | null;
+        };
+        /** CloudOrganizationIntegrationPolicyResponse */
+        CloudOrganizationIntegrationPolicyResponse: {
+            /** Organizationid */
+            organizationId: string;
+            /** Entries */
+            entries: components["schemas"]["CloudOrganizationIntegrationPolicyItem"][];
+        };
         /** CloudPendingInteractionResponse */
         CloudPendingInteractionResponse: {
             /** Requestid */
@@ -6586,6 +6622,13 @@ export interface components {
             publicToOrg?: boolean | null;
             /** Publicorganizationid */
             publicOrganizationId?: string | null;
+        };
+        /** PatchCloudOrganizationIntegrationPolicyRequest */
+        PatchCloudOrganizationIntegrationPolicyRequest: {
+            /** Catalogentryid */
+            catalogEntryId: string;
+            /** Enabled */
+            enabled: boolean;
         };
         /** PatchPluginConfiguredItemRequest */
         PatchPluginConfiguredItemRequest: {
@@ -12562,6 +12605,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_organization_integration_policy_endpoint_v1_cloud_organizations__organization_id__integration_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudOrganizationIntegrationPolicyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_organization_integration_policy_endpoint_v1_cloud_organizations__organization_id__integration_policy_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PatchCloudOrganizationIntegrationPolicyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudOrganizationIntegrationPolicyResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -12,6 +12,7 @@ export * from "./client/commands.js";
 export * from "./client/compute.js";
 export * from "./client/config.js";
 export * from "./client/events.js";
+export * from "./client/integration_policy.js";
 export * from "./client/deep-links.js";
 export * from "./client/live.js";
 export * from "./client/mcp_catalog.js";

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -406,6 +406,12 @@ export type CloudMcpCatalogResponse = components["schemas"]["ConnectorCatalogRes
 export type CloudMcpCatalogEntry = components["schemas"]["ConnectorCatalogEntryModel"];
 export type CloudPluginPackage = components["schemas"]["PluginPackageModel"];
 export type CloudPluginPackageSkill = components["schemas"]["PluginPackageSkillModel"];
+export type CloudOrganizationIntegrationPolicyItem =
+  components["schemas"]["CloudOrganizationIntegrationPolicyItem"];
+export type CloudOrganizationIntegrationPolicyResponse =
+  components["schemas"]["CloudOrganizationIntegrationPolicyResponse"];
+export type PatchCloudOrganizationIntegrationPolicyRequest =
+  components["schemas"]["PatchCloudOrganizationIntegrationPolicyRequest"];
 export type CloudMcpConnection = components["schemas"]["CloudMcpConnectionResponse"];
 export type CloudMcpConnectionsResponse = components["schemas"]["CloudMcpConnectionsResponse"];
 export type CreateCloudMcpConnectionRequest =

--- a/server/alembic/versions/b4c5d6e7f8a9_org_integration_policy.py
+++ b/server/alembic/versions/b4c5d6e7f8a9_org_integration_policy.py
@@ -1,0 +1,84 @@
+"""organization integration catalog policy
+
+Revision ID: b4c5d6e7f8a9
+Revises: a3f9c7e21b40
+Create Date: 2026-06-23 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b4c5d6e7f8a9"
+down_revision: str | Sequence[str] | None = "a3f9c7e21b40"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {
+        index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    }
+
+
+def upgrade() -> None:
+    if not _has_table("cloud_organization_integration_policy"):
+        op.create_table(
+            "cloud_organization_integration_policy",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("organization_id", sa.Uuid(), nullable=False),
+            sa.Column("catalog_entry_id", sa.String(length=255), nullable=False),
+            sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("updated_by_user_id", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["organization_id"],
+                ["organization.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["updated_by_user_id"],
+                ["user.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "organization_id",
+                "catalog_entry_id",
+                name="uq_cloud_org_integration_policy_entry",
+            ),
+        )
+    if not _has_index(
+        "cloud_organization_integration_policy",
+        "ix_cloud_org_integration_policy_organization_id",
+    ):
+        op.create_index(
+            "ix_cloud_org_integration_policy_organization_id",
+            "cloud_organization_integration_policy",
+            ["organization_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    if _has_index(
+        "cloud_organization_integration_policy",
+        "ix_cloud_org_integration_policy_organization_id",
+    ):
+        op.drop_index(
+            "ix_cloud_org_integration_policy_organization_id",
+            table_name="cloud_organization_integration_policy",
+        )
+    if _has_table("cloud_organization_integration_policy"):
+        op.drop_table("cloud_organization_integration_policy")

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -10,6 +10,7 @@ from . import claims as claims  # noqa: F401
 from . import cloud_target_runtime_access as cloud_target_runtime_access  # noqa: F401
 from . import commands as commands  # noqa: F401
 from . import exposures as exposures  # noqa: F401
+from . import integrations as integrations  # noqa: F401
 from . import mcp as mcp  # noqa: F401
 from . import mobility as mobility  # noqa: F401
 from . import plugins as plugins  # noqa: F401

--- a/server/proliferate/db/models/cloud/integrations.py
+++ b/server/proliferate/db/models/cloud/integrations.py
@@ -1,0 +1,41 @@
+"""Cloud integration catalog policy ORM models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.db.models.base import Base, utcnow
+
+
+class CloudOrganizationIntegrationPolicy(Base):
+    __tablename__ = "cloud_organization_integration_policy"
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "catalog_entry_id",
+            name="uq_cloud_org_integration_policy_entry",
+        ),
+        Index("ix_cloud_org_integration_policy_organization_id", "organization_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    catalog_entry_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    updated_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/cloud_integration_policy.py
+++ b/server/proliferate/db/store/cloud_integration_policy.py
@@ -1,0 +1,96 @@
+"""Persistence for organization integration catalog policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.integrations import CloudOrganizationIntegrationPolicy
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class CloudOrganizationIntegrationPolicyRecord:
+    id: UUID
+    organization_id: UUID
+    catalog_entry_id: str
+    enabled: bool
+    updated_by_user_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _record(
+    row: CloudOrganizationIntegrationPolicy,
+) -> CloudOrganizationIntegrationPolicyRecord:
+    return CloudOrganizationIntegrationPolicyRecord(
+        id=row.id,
+        organization_id=row.organization_id,
+        catalog_entry_id=row.catalog_entry_id,
+        enabled=row.enabled,
+        updated_by_user_id=row.updated_by_user_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def list_organization_integration_policy(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> tuple[CloudOrganizationIntegrationPolicyRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(CloudOrganizationIntegrationPolicy)
+                .where(CloudOrganizationIntegrationPolicy.organization_id == organization_id)
+                .order_by(CloudOrganizationIntegrationPolicy.updated_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_record(row) for row in rows)
+
+
+async def upsert_organization_integration_policy(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    catalog_entry_id: str,
+    enabled: bool,
+    updated_by_user_id: UUID,
+) -> CloudOrganizationIntegrationPolicyRecord:
+    now = utcnow()
+    await db.execute(
+        pg_insert(CloudOrganizationIntegrationPolicy)
+        .values(
+            organization_id=organization_id,
+            catalog_entry_id=catalog_entry_id,
+            enabled=enabled,
+            updated_by_user_id=updated_by_user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            constraint="uq_cloud_org_integration_policy_entry",
+            set_={
+                "enabled": enabled,
+                "updated_by_user_id": updated_by_user_id,
+                "updated_at": now,
+            },
+        )
+    )
+    row = (
+        await db.execute(
+            select(CloudOrganizationIntegrationPolicy).where(
+                CloudOrganizationIntegrationPolicy.organization_id == organization_id,
+                CloudOrganizationIntegrationPolicy.catalog_entry_id == catalog_entry_id,
+            )
+        )
+    ).scalar_one()
+    return _record(row)

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -11,6 +11,7 @@ from proliferate.server.cloud.claims.api import router as claims_router
 from proliferate.server.cloud.commands.api import router as commands_router
 from proliferate.server.cloud.compute.api import router as compute_router
 from proliferate.server.cloud.events.api import router as events_router
+from proliferate.server.cloud.integration_policy.api import router as integration_policy_router
 from proliferate.server.cloud.live.api import router as live_router
 from proliferate.server.cloud.mcp_catalog.api import router as mcp_catalog_router
 from proliferate.server.cloud.mcp_connections.api import router as mcp_connections_router
@@ -50,6 +51,7 @@ router.include_router(mobility_router)
 router.include_router(sandbox_profiles_router)
 router.include_router(agent_auth_router)
 router.include_router(agent_run_config_router)
+router.include_router(integration_policy_router)
 router.include_router(mcp_catalog_router)
 router.include_router(mcp_connections_router)
 router.include_router(mcp_oauth_router)

--- a/server/proliferate/server/cloud/integration_policy/__init__.py
+++ b/server/proliferate/server/cloud/integration_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Organization integration policy domain package."""

--- a/server/proliferate/server/cloud/integration_policy/api.py
+++ b/server/proliferate/server/cloud/integration_policy/api.py
@@ -1,0 +1,60 @@
+"""HTTP routes for organization integration catalog policy."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.integration_policy.models import (
+    CloudOrganizationIntegrationPolicyResponse,
+    PatchCloudOrganizationIntegrationPolicyRequest,
+    organization_integration_policy_payload,
+)
+from proliferate.server.cloud.integration_policy.service import (
+    get_organization_integration_policy,
+    patch_organization_integration_policy,
+)
+
+router = APIRouter(prefix="/organizations/{organization_id}/integration-policy")
+
+
+@router.get("", response_model=CloudOrganizationIntegrationPolicyResponse)
+async def get_organization_integration_policy_endpoint(
+    organization_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> CloudOrganizationIntegrationPolicyResponse:
+    try:
+        snapshot = await get_organization_integration_policy(
+            db,
+            actor_user_id=user.id,
+            organization_id=organization_id,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return organization_integration_policy_payload(snapshot)
+
+
+@router.patch("", response_model=CloudOrganizationIntegrationPolicyResponse)
+async def patch_organization_integration_policy_endpoint(
+    organization_id: UUID,
+    body: PatchCloudOrganizationIntegrationPolicyRequest,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> CloudOrganizationIntegrationPolicyResponse:
+    try:
+        snapshot = await patch_organization_integration_policy(
+            db,
+            actor_user_id=user.id,
+            organization_id=organization_id,
+            body=body,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return organization_integration_policy_payload(snapshot)

--- a/server/proliferate/server/cloud/integration_policy/api.py
+++ b/server/proliferate/server/cloud/integration_policy/api.py
@@ -37,7 +37,7 @@ async def get_organization_integration_policy_endpoint(
             organization_id=organization_id,
         )
     except CloudApiError as error:
-        raise_cloud_error(error)
+        return raise_cloud_error(error)
     return organization_integration_policy_payload(snapshot)
 
 
@@ -56,5 +56,5 @@ async def patch_organization_integration_policy_endpoint(
             body=body,
         )
     except CloudApiError as error:
-        raise_cloud_error(error)
+        return raise_cloud_error(error)
     return organization_integration_policy_payload(snapshot)

--- a/server/proliferate/server/cloud/integration_policy/domain/__init__.py
+++ b/server/proliferate/server/cloud/integration_policy/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Organization integration policy internal models."""

--- a/server/proliferate/server/cloud/integration_policy/domain/types.py
+++ b/server/proliferate/server/cloud/integration_policy/domain/types.py
@@ -1,0 +1,21 @@
+"""Internal models for organization integration catalog policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class OrganizationIntegrationPolicyEntry:
+    catalog_entry_id: str
+    enabled: bool
+    updated_at: datetime | None
+    updated_by_user_id: UUID | None
+
+
+@dataclass(frozen=True)
+class OrganizationIntegrationPolicySnapshot:
+    organization_id: UUID
+    entries: tuple[OrganizationIntegrationPolicyEntry, ...]

--- a/server/proliferate/server/cloud/integration_policy/models.py
+++ b/server/proliferate/server/cloud/integration_policy/models.py
@@ -1,0 +1,52 @@
+"""HTTP schemas for organization integration catalog policy."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from proliferate.server.cloud.integration_policy.domain.types import (
+    OrganizationIntegrationPolicyEntry,
+    OrganizationIntegrationPolicySnapshot,
+)
+
+
+class PatchCloudOrganizationIntegrationPolicyRequest(BaseModel):
+    catalog_entry_id: str = Field(alias="catalogEntryId")
+    enabled: bool
+
+
+class CloudOrganizationIntegrationPolicyItem(BaseModel):
+    catalog_entry_id: str = Field(serialization_alias="catalogEntryId")
+    enabled: bool
+    updated_at: str | None = Field(default=None, serialization_alias="updatedAt")
+    updated_by_user_id: str | None = Field(
+        default=None,
+        serialization_alias="updatedByUserId",
+    )
+
+
+class CloudOrganizationIntegrationPolicyResponse(BaseModel):
+    organization_id: str = Field(serialization_alias="organizationId")
+    entries: list[CloudOrganizationIntegrationPolicyItem]
+
+
+def _entry_payload(
+    entry: OrganizationIntegrationPolicyEntry,
+) -> CloudOrganizationIntegrationPolicyItem:
+    return CloudOrganizationIntegrationPolicyItem(
+        catalog_entry_id=entry.catalog_entry_id,
+        enabled=entry.enabled,
+        updated_at=entry.updated_at.isoformat() if entry.updated_at else None,
+        updated_by_user_id=(
+            str(entry.updated_by_user_id) if entry.updated_by_user_id else None
+        ),
+    )
+
+
+def organization_integration_policy_payload(
+    snapshot: OrganizationIntegrationPolicySnapshot,
+) -> CloudOrganizationIntegrationPolicyResponse:
+    return CloudOrganizationIntegrationPolicyResponse(
+        organization_id=str(snapshot.organization_id),
+        entries=[_entry_payload(entry) for entry in snapshot.entries],
+    )

--- a/server/proliferate/server/cloud/integration_policy/service.py
+++ b/server/proliferate/server/cloud/integration_policy/service.py
@@ -22,19 +22,18 @@ from proliferate.server.cloud.mcp_catalog.availability import catalog_entry_is_c
 from proliferate.server.cloud.mcp_catalog.catalog import build_connector_catalog
 
 
-def _require_org_member(membership: MembershipRecord | None) -> None:
+def _require_org_member(membership: MembershipRecord | None) -> MembershipRecord:
     if membership is None:
         raise CloudApiError(
             "organization_not_found",
             "Organization not found.",
             status_code=404,
         )
+    return membership
 
 
 def _require_org_admin(membership: MembershipRecord | None) -> None:
-    _require_org_member(membership)
-    if membership is None:
-        return
+    membership = _require_org_member(membership)
     if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
         raise CloudApiError(
             "organization_permission_denied",

--- a/server/proliferate/server/cloud/integration_policy/service.py
+++ b/server/proliferate/server/cloud/integration_policy/service.py
@@ -1,0 +1,134 @@
+"""Organization integration catalog policy orchestration."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
+from proliferate.db.store import cloud_integration_policy as policy_store
+from proliferate.db.store import organizations as organizations_store
+from proliferate.db.store.organization_records import MembershipRecord
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integration_policy.domain.types import (
+    OrganizationIntegrationPolicyEntry,
+    OrganizationIntegrationPolicySnapshot,
+)
+from proliferate.server.cloud.integration_policy.models import (
+    PatchCloudOrganizationIntegrationPolicyRequest,
+)
+from proliferate.server.cloud.mcp_catalog.availability import catalog_entry_is_configured
+from proliferate.server.cloud.mcp_catalog.catalog import build_connector_catalog
+
+
+def _require_org_member(membership: MembershipRecord | None) -> None:
+    if membership is None:
+        raise CloudApiError(
+            "organization_not_found",
+            "Organization not found.",
+            status_code=404,
+        )
+
+
+def _require_org_admin(membership: MembershipRecord | None) -> None:
+    _require_org_member(membership)
+    if membership is None:
+        return
+    if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
+        raise CloudApiError(
+            "organization_permission_denied",
+            "You do not have permission to manage this organization.",
+            status_code=403,
+        )
+
+
+async def _active_membership(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID,
+) -> MembershipRecord | None:
+    return await organizations_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=actor_user_id,
+    )
+
+
+def _configured_catalog_entry_ids() -> tuple[str, ...]:
+    return tuple(
+        entry.id
+        for entry in build_connector_catalog()
+        if catalog_entry_is_configured(entry)
+    )
+
+
+async def get_organization_integration_policy(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID,
+) -> OrganizationIntegrationPolicySnapshot:
+    membership = await _active_membership(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+    )
+    _require_org_member(membership)
+    records = await policy_store.list_organization_integration_policy(db, organization_id)
+    records_by_entry_id = {record.catalog_entry_id: record for record in records}
+    entries = tuple(
+        OrganizationIntegrationPolicyEntry(
+            catalog_entry_id=catalog_entry_id,
+            enabled=records_by_entry_id.get(catalog_entry_id).enabled
+            if catalog_entry_id in records_by_entry_id
+            else True,
+            updated_at=records_by_entry_id.get(catalog_entry_id).updated_at
+            if catalog_entry_id in records_by_entry_id
+            else None,
+            updated_by_user_id=records_by_entry_id.get(catalog_entry_id).updated_by_user_id
+            if catalog_entry_id in records_by_entry_id
+            else None,
+        )
+        for catalog_entry_id in _configured_catalog_entry_ids()
+    )
+    return OrganizationIntegrationPolicySnapshot(
+        organization_id=organization_id,
+        entries=entries,
+    )
+
+
+async def patch_organization_integration_policy(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    organization_id: UUID,
+    body: PatchCloudOrganizationIntegrationPolicyRequest,
+) -> OrganizationIntegrationPolicySnapshot:
+    membership = await _active_membership(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+    )
+    _require_org_admin(membership)
+    catalog_entry_id = body.catalog_entry_id.strip()
+    catalog_entry_ids = set(_configured_catalog_entry_ids())
+    if catalog_entry_id not in catalog_entry_ids:
+        raise CloudApiError(
+            "catalog_entry_not_found",
+            "Integration catalog entry was not found.",
+            status_code=404,
+        )
+    await policy_store.upsert_organization_integration_policy(
+        db,
+        organization_id=organization_id,
+        catalog_entry_id=catalog_entry_id,
+        enabled=body.enabled,
+        updated_by_user_id=actor_user_id,
+    )
+    return await get_organization_integration_policy(
+        db,
+        actor_user_id=actor_user_id,
+        organization_id=organization_id,
+    )

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -205,6 +205,28 @@ async def _create_organization_for_user(db_session: AsyncSession, user_id: str) 
     return str(organization.id)
 
 
+async def _add_organization_member(
+    db_session: AsyncSession,
+    *,
+    organization_id: str,
+    user_id: str,
+    role: str = ORGANIZATION_ROLE_MEMBER,
+) -> None:
+    now = datetime.now(UTC)
+    db_session.add(
+        OrganizationMembership(
+            organization_id=uuid.UUID(organization_id),
+            user_id=uuid.UUID(user_id),
+            role=role,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()
+
+
 async def _list_mcp_connections(
     db_session: AsyncSession,
     user_id: str,
@@ -386,6 +408,91 @@ class TestCloudWorktreeRetentionPolicy:
 
         assert response.status_code == 400
         assert response.json()["detail"]["code"] == "invalid_worktree_retention_policy"
+
+
+class TestCloudOrganizationIntegrationPolicy:
+    @pytest.mark.asyncio
+    async def test_owner_can_patch_policy_and_member_can_read_only(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        owner = await _register_and_login(
+            client,
+            f"integration-policy-owner-{uuid.uuid4().hex[:8]}@example.com",
+        )
+        member = await _register_and_login(
+            client,
+            f"integration-policy-member-{uuid.uuid4().hex[:8]}@example.com",
+        )
+        organization_id = await _create_organization_for_user(db_session, owner["user_id"])
+        await _add_organization_member(
+            db_session,
+            organization_id=organization_id,
+            user_id=member["user_id"],
+        )
+        owner_headers = {"Authorization": f"Bearer {owner['access_token']}"}
+        member_headers = {"Authorization": f"Bearer {member['access_token']}"}
+        url = f"/v1/cloud/organizations/{organization_id}/integration-policy"
+
+        defaults = await client.get(url, headers=owner_headers)
+
+        assert defaults.status_code == 200
+        default_entries = {
+            entry["catalogEntryId"]: entry for entry in defaults.json()["entries"]
+        }
+        assert default_entries["linear"]["enabled"] is True
+        assert default_entries["linear"]["updatedAt"] is None
+
+        patched = await client.patch(
+            url,
+            headers=owner_headers,
+            json={"catalogEntryId": "linear", "enabled": False},
+        )
+
+        assert patched.status_code == 200
+        patched_entries = {
+            entry["catalogEntryId"]: entry for entry in patched.json()["entries"]
+        }
+        assert patched_entries["linear"]["enabled"] is False
+        assert patched_entries["linear"]["updatedAt"] is not None
+        assert patched_entries["linear"]["updatedByUserId"] == owner["user_id"]
+
+        member_read = await client.get(url, headers=member_headers)
+        member_write = await client.patch(
+            url,
+            headers=member_headers,
+            json={"catalogEntryId": "linear", "enabled": True},
+        )
+
+        assert member_read.status_code == 200
+        member_entries = {
+            entry["catalogEntryId"]: entry for entry in member_read.json()["entries"]
+        }
+        assert member_entries["linear"]["enabled"] is False
+        assert member_write.status_code == 403
+        assert member_write.json()["detail"]["code"] == "organization_permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_unknown_catalog_entry(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        owner = await _register_and_login(
+            client,
+            f"integration-policy-missing-{uuid.uuid4().hex[:8]}@example.com",
+        )
+        organization_id = await _create_organization_for_user(db_session, owner["user_id"])
+
+        response = await client.patch(
+            f"/v1/cloud/organizations/{organization_id}/integration-policy",
+            headers={"Authorization": f"Bearer {owner['access_token']}"},
+            json={"catalogEntryId": "not-real", "enabled": False},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "catalog_entry_not_found"
 
 
 class TestCloudMcpConnections:


### PR DESCRIPTION
## Summary
- add organization-level integration catalog policy storage and cloud API
- add SDK/hooks and shared product-domain filtering so disabled org integrations disappear from the main integrations page
- replace the Admin > Integrations scaffold with a searchable toggle surface and hide admin settings from non-admins

## Verification
- pnpm --filter @proliferate/product-domain test -- --runInBand
- pnpm --filter @proliferate/cloud-sdk build
- pnpm --filter @proliferate/cloud-sdk-react build
- pnpm --filter @proliferate/product-ui build
- pnpm --filter @proliferate/product-surfaces build
- pnpm exec vitest run src/components/settings/sidebar/SettingsSidebar.test.tsx
- pnpm --filter proliferate build
- DEBUG=1 JWT_SECRET=local-test-secret CLOUD_SECRET_KEY=local-test-cloud-secret uv run --extra dev pytest -q tests/integration/test_cloud_api.py::TestCloudOrganizationIntegrationPolicy
- DEBUG=1 JWT_SECRET=local-test-secret CLOUD_SECRET_KEY=local-test-cloud-secret uv run --extra dev ruff check proliferate/db/models/cloud/integrations.py proliferate/db/store/cloud_integration_policy.py proliferate/server/cloud/integration_policy tests/integration/test_cloud_api.py