### PR TITLE
feat(web): gate browser auth for beta access

### DIFF
--- a/apps/desktop/src/components/feedback/UpdateDialogContent.tsx
+++ b/apps/desktop/src/components/feedback/UpdateDialogContent.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
+import { Label } from "@proliferate/ui/primitives/Label";
 import { ProliferateIcon } from "@proliferate/ui/proliferate-icons";
 
 export interface UpdateDialogContentProps {
@@ -45,14 +46,14 @@ export function UpdateDialogContent({
         </div>
       </div>
 
-      <label className="flex select-none items-center gap-2 pl-[4.5rem] text-[13px] text-muted-foreground">
+      <Label className="mb-0 flex select-none items-center gap-2 pl-[4.5rem] text-[13px]">
         <Checkbox
           checked={autoUpdate}
           onChange={(event) => onToggleAutoUpdate(event.target.checked)}
           className="size-4"
         />
         Automatically download and install updates in the future
-      </label>
+      </Label>
 
       <div className="mt-auto flex items-center justify-between gap-3">
         <Button variant="ghost" size="sm" onClick={onSkip}>

--- a/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
+++ b/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
@@ -1,19 +1,12 @@
-import { useEffect, useState, type ComponentType } from "react";
-import { Badge, type BadgeTone } from "@proliferate/ui/primitives/Badge";
+import { useEffect, useState, type ReactNode } from "react";
+import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { ProgressBar } from "@proliferate/ui/primitives/ProgressBar";
-import {
-  ArrowUp,
-  Check,
-  CircleAlert,
-  Spinner,
-} from "@proliferate/ui/icons";
-import {
-  UPDATE_PREVIEW_STATES,
-  type UpdatePreviewPhase,
-  type UpdatePreviewState,
-} from "@/config/update-playground";
+import { UPDATE_PREVIEW_STATES } from "@/config/update-playground";
 import { UpdateDialogContent } from "@/components/feedback/UpdateDialogContent";
+import {
+  UpdateSettingsStatusCard,
+  UpdateWorkspaceBanner,
+} from "@/components/playground/UpdateUiPlaygroundSections";
 import { SidebarUpdatePill } from "@/components/workspace/shell/sidebar/SidebarUpdatePill";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { setDevRunningAgentCount } from "@/hooks/app/lifecycle/use-running-agent-count";
@@ -45,38 +38,6 @@ const PRODUCTION_SURFACE_PREVIEWS: {
   { id: "ready-reminder", label: "Ready reminder" },
   { id: "restart-dialog", label: "Restart dialog" },
 ];
-
-const PHASE_LABELS: Record<UpdatePreviewPhase, string> = {
-  checking: "Checking",
-  available: "Available",
-  downloading: "Downloading",
-  ready: "Ready",
-  error: "Error",
-};
-
-const PHASE_ICONS: Record<UpdatePreviewPhase, ComponentType<{ className?: string }>> = {
-  checking: Spinner,
-  available: ArrowUp,
-  downloading: Spinner,
-  ready: Check,
-  error: CircleAlert,
-};
-
-const PHASE_ICON_CLASSNAMES: Record<UpdatePreviewPhase, string> = {
-  checking: "text-muted-foreground",
-  available: "text-foreground",
-  downloading: "text-muted-foreground",
-  ready: "text-success",
-  error: "text-destructive",
-};
-
-const PHASE_BADGE_TONES: Record<UpdatePreviewPhase, BadgeTone> = {
-  checking: "neutral",
-  available: "accent",
-  downloading: "neutral",
-  ready: "success",
-  error: "destructive",
-};
 
 export function UpdateUiPlayground() {
   const [productionSurfacePreview, setProductionSurfacePreview] =
@@ -324,7 +285,7 @@ function PreviewSection({
 }: {
   title: string;
   description: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <section className="grid gap-3">
@@ -334,129 +295,5 @@ function PreviewSection({
       </div>
       {children}
     </section>
-  );
-}
-
-function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
-  const Icon = PHASE_ICONS[state.phase];
-  const isBusy = state.phase === "checking" || state.phase === "downloading";
-  const primaryDisabled = isBusy;
-
-  return (
-    <div className="overflow-hidden rounded-lg border border-border bg-card/70 shadow-sm">
-      <div className="flex items-center gap-3 px-3 py-2.5">
-        <div
-          className={`flex size-8 shrink-0 items-center justify-center rounded-md bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
-        >
-          <Icon className="size-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <p className="truncate text-sm font-medium">{state.title}</p>
-            <Badge tone={PHASE_BADGE_TONES[state.phase]}>
-              {PHASE_LABELS[state.phase]}
-            </Badge>
-          </div>
-          <p className="truncate text-xs text-muted-foreground">
-            {state.description}
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {state.secondaryAction && (
-            <Button variant="ghost" size="sm" className="px-2.5">
-              {state.secondaryAction}
-            </Button>
-          )}
-          <Button
-            variant={state.phase === "ready" ? "primary" : "secondary"}
-            size="sm"
-            disabled={primaryDisabled}
-            className="px-2.5"
-          >
-            {state.primaryAction}
-          </Button>
-        </div>
-      </div>
-      {state.phase === "downloading" && state.progress !== null && (
-        <ProgressBar
-          value={state.progress}
-          className="h-1 bg-muted"
-          indicatorClassName="h-full bg-foreground transition-[width]"
-        />
-      )}
-    </div>
-  );
-}
-
-function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
-  const Icon = PHASE_ICONS[state.phase];
-  const isBusy = state.phase === "checking" || state.phase === "downloading";
-  const primaryDisabled = isBusy;
-
-  return (
-    <article className="flex min-h-48 flex-col justify-between gap-5 rounded-lg border border-border bg-card/60 p-4">
-      <div className="space-y-4">
-        <div className="flex items-start justify-between gap-3">
-          <div
-            className={`flex size-10 shrink-0 items-center justify-center rounded-lg bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
-          >
-            <Icon className="size-5" />
-          </div>
-          <Badge tone={PHASE_BADGE_TONES[state.phase]}>
-            {PHASE_LABELS[state.phase]}
-          </Badge>
-        </div>
-
-        <div className="space-y-1">
-          <h3 className="text-base font-medium">{state.title}</h3>
-          <p className="text-sm text-muted-foreground">{state.description}</p>
-          <p className="text-xs text-muted-foreground/80">{state.detail}</p>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 text-xs">
-          <StatusDatum label="Current" value={`v${state.currentVersion}`} />
-          <StatusDatum label="Latest" value={state.version ? `v${state.version}` : "Unknown"} />
-          <StatusDatum label="Last check" value={state.checkedAt ?? "In progress"} />
-          <StatusDatum
-            label="State"
-            value={state.phase === "downloading" && state.progress !== null
-              ? `${state.progress}%`
-              : PHASE_LABELS[state.phase]}
-          />
-        </div>
-
-        {state.phase === "downloading" && state.progress !== null && (
-          <ProgressBar
-            value={state.progress}
-            className="h-1.5 overflow-hidden rounded-full bg-muted"
-            indicatorClassName="h-full rounded-full bg-foreground transition-[width]"
-          />
-        )}
-      </div>
-
-      <div className="flex justify-end gap-2">
-        {state.secondaryAction && (
-          <Button variant="ghost" size="sm">
-            {state.secondaryAction}
-          </Button>
-        )}
-        <Button
-          variant={state.phase === "ready" ? "primary" : "secondary"}
-          size="sm"
-          disabled={primaryDisabled}
-        >
-          {state.primaryAction}
-        </Button>
-      </div>
-    </article>
-  );
-}
-
-function StatusDatum({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-md bg-foreground/5 px-2.5 py-2">
-      <div className="text-muted-foreground">{label}</div>
-      <div className="mt-0.5 truncate font-medium text-foreground">{value}</div>
-    </div>
   );
 }

--- a/apps/desktop/src/components/playground/UpdateUiPlaygroundSections.tsx
+++ b/apps/desktop/src/components/playground/UpdateUiPlaygroundSections.tsx
@@ -1,0 +1,168 @@
+import { type ComponentType } from "react";
+import { Badge, type BadgeTone } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ProgressBar } from "@proliferate/ui/primitives/ProgressBar";
+import {
+  ArrowUp,
+  Check,
+  CircleAlert,
+  Spinner,
+} from "@proliferate/ui/icons";
+import {
+  type UpdatePreviewPhase,
+  type UpdatePreviewState,
+} from "@/config/update-playground";
+
+const PHASE_LABELS: Record<UpdatePreviewPhase, string> = {
+  checking: "Checking",
+  available: "Available",
+  downloading: "Downloading",
+  ready: "Ready",
+  error: "Error",
+};
+
+const PHASE_ICONS: Record<UpdatePreviewPhase, ComponentType<{ className?: string }>> = {
+  checking: Spinner,
+  available: ArrowUp,
+  downloading: Spinner,
+  ready: Check,
+  error: CircleAlert,
+};
+
+const PHASE_ICON_CLASSNAMES: Record<UpdatePreviewPhase, string> = {
+  checking: "text-muted-foreground",
+  available: "text-foreground",
+  downloading: "text-muted-foreground",
+  ready: "text-success",
+  error: "text-destructive",
+};
+
+const PHASE_BADGE_TONES: Record<UpdatePreviewPhase, BadgeTone> = {
+  checking: "neutral",
+  available: "accent",
+  downloading: "neutral",
+  ready: "success",
+  error: "destructive",
+};
+
+export function UpdateWorkspaceBanner({ state }: { state: UpdatePreviewState }) {
+  const Icon = PHASE_ICONS[state.phase];
+  const primaryDisabled = state.phase === "checking" || state.phase === "downloading";
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card/70 shadow-sm">
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <div
+          className={`flex size-8 shrink-0 items-center justify-center rounded-md bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
+        >
+          <Icon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate text-sm font-medium">{state.title}</p>
+            <Badge tone={PHASE_BADGE_TONES[state.phase]}>
+              {PHASE_LABELS[state.phase]}
+            </Badge>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {state.description}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {state.secondaryAction && (
+            <Button variant="ghost" size="sm" className="px-2.5">
+              {state.secondaryAction}
+            </Button>
+          )}
+          <Button
+            variant={state.phase === "ready" ? "primary" : "secondary"}
+            size="sm"
+            disabled={primaryDisabled}
+            className="px-2.5"
+          >
+            {state.primaryAction}
+          </Button>
+        </div>
+      </div>
+      {state.phase === "downloading" && state.progress !== null && (
+        <ProgressBar
+          value={state.progress}
+          className="h-1 bg-muted"
+          indicatorClassName="h-full bg-foreground transition-[width]"
+        />
+      )}
+    </div>
+  );
+}
+
+export function UpdateSettingsStatusCard({ state }: { state: UpdatePreviewState }) {
+  const Icon = PHASE_ICONS[state.phase];
+  const primaryDisabled = state.phase === "checking" || state.phase === "downloading";
+
+  return (
+    <article className="flex min-h-48 flex-col justify-between gap-5 rounded-lg border border-border bg-card/60 p-4">
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div
+            className={`flex size-10 shrink-0 items-center justify-center rounded-lg bg-foreground/5 ${PHASE_ICON_CLASSNAMES[state.phase]}`}
+          >
+            <Icon className="size-5" />
+          </div>
+          <Badge tone={PHASE_BADGE_TONES[state.phase]}>
+            {PHASE_LABELS[state.phase]}
+          </Badge>
+        </div>
+
+        <div className="space-y-1">
+          <h3 className="text-base font-medium">{state.title}</h3>
+          <p className="text-sm text-muted-foreground">{state.description}</p>
+          <p className="text-xs text-muted-foreground/80">{state.detail}</p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <StatusDatum label="Current" value={`v${state.currentVersion}`} />
+          <StatusDatum label="Latest" value={state.version ? `v${state.version}` : "Unknown"} />
+          <StatusDatum label="Last check" value={state.checkedAt ?? "In progress"} />
+          <StatusDatum
+            label="State"
+            value={state.phase === "downloading" && state.progress !== null
+              ? `${state.progress}%`
+              : PHASE_LABELS[state.phase]}
+          />
+        </div>
+
+        {state.phase === "downloading" && state.progress !== null && (
+          <ProgressBar
+            value={state.progress}
+            className="h-1.5 overflow-hidden rounded-full bg-muted"
+            indicatorClassName="h-full rounded-full bg-foreground transition-[width]"
+          />
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {state.secondaryAction && (
+          <Button variant="ghost" size="sm">
+            {state.secondaryAction}
+          </Button>
+        )}
+        <Button
+          variant={state.phase === "ready" ? "primary" : "secondary"}
+          size="sm"
+          disabled={primaryDisabled}
+        >
+          {state.primaryAction}
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+function StatusDatum({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-foreground/5 px-2.5 py-2">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="mt-0.5 truncate font-medium text-foreground">{value}</div>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -14,9 +14,7 @@ import {
   buildRemoteLogicalWorkspaceId,
   normalizeLogicalWorkspaceBranchKey,
 } from "@/lib/domain/workspaces/cloud/logical-workspace-id";
-import {
-  resolvePreferredLogicalWorkspaceMaterialization,
-} from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import { resolvePreferredLogicalWorkspaceMaterialization } from "@/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   buildBaseLogicalWorkspaceIdForLocalWorkspace,
@@ -95,10 +93,7 @@ interface CollapsedLocalWorkspace {
 }
 
 function localWorkspaceIdentityIds(workspace: Workspace): string[] {
-  return [
-    workspace.id,
-    buildLocalSlotLogicalWorkspaceId(workspace.id),
-  ];
+  return [workspace.id, buildLocalSlotLogicalWorkspaceId(workspace.id)];
 }
 
 function localWorkspaceMatchesSelection(
@@ -141,19 +136,9 @@ function collapseExactLocalWorkspaceDuplicates(
     }
   }
 
-  // Distinct local workspaces for the same folder+branch are kept separate so
-  // each "project/feature thread" gets its own sidebar entry. Within a bucket,
-  // a workspace is surfaced as its own distinct entry when it has its own chats
-  // OR it is the current selection (covers a just-created workspace that has no
-  // chats yet — `createLocalWorkspaceAndEnter` selects it immediately). Only
-  // genuinely-empty, unselected (setup-only / stale) duplicates are folded onto
-  // the top distinct entry so they don't show as junk rows but stay selectable.
   return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
     if (bucket.length === 1) {
-      return [{
-        workspace: bucket[0]!,
-        aliasIds: [],
-      }];
+      return [{ workspace: bucket[0]!, aliasIds: [] }];
     }
 
     const distinct = bucket.filter(
@@ -168,8 +153,6 @@ function collapseExactLocalWorkspaceDuplicates(
     );
 
     if (distinct.length === 0) {
-      // No chats and nothing selected in this folder+branch yet: keep a single
-      // representative (preferring history/selection), aliasing the rest.
       const representative = [...foldable]
         .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
       return [{

--- a/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
+++ b/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
@@ -1,7 +1,5 @@
-import { useState, type ReactNode } from "react";
-import { ChevronDown } from "@proliferate/ui/icons";
+import { type ReactNode } from "react";
 import { AuthProviderButton } from "@proliferate/ui/primitives/AuthProviderButton";
-import { Button } from "@proliferate/ui/primitives/Button";
 import { AuthLayout } from "./AuthLayout";
 
 export interface AuthProviderActionView {
@@ -21,9 +19,6 @@ interface AuthStartPanelProps {
   footer: ReactNode;
   providers: AuthProviderActionView[];
   credentialForm?: ReactNode;
-  secondaryActions?: AuthProviderActionView[];
-  secondaryLabel?: ReactNode;
-  secondaryContent?: ReactNode;
   note?: ReactNode;
   error?: ReactNode;
   devAccess?: ReactNode;
@@ -36,20 +31,14 @@ export function AuthStartPanel({
   footer,
   providers,
   credentialForm,
-  secondaryActions,
-  secondaryLabel = "More",
-  secondaryContent,
   note,
   error,
   devAccess,
 }: AuthStartPanelProps) {
-  const hasSecondaryOptions =
-    Boolean(secondaryActions?.length) || secondaryContent !== undefined;
-
   return (
     <AuthLayout mark={mark} title={title} subtitle={subtitle} footer={footer}>
-      {!hasSecondaryOptions ? credentialForm : null}
-      {!hasSecondaryOptions && credentialForm ? <AuthDivider /> : null}
+      {credentialForm}
+      {credentialForm ? <AuthDivider /> : null}
       {providers.map((provider) => (
         <AuthProviderButton
           key={provider.id}
@@ -62,13 +51,6 @@ export function AuthStartPanel({
           {provider.label}
         </AuthProviderButton>
       ))}
-      {hasSecondaryOptions ? (
-        <AuthSecondaryOptions
-          label={secondaryLabel}
-          actions={secondaryActions ?? []}
-          content={secondaryContent}
-        />
-      ) : null}
       {note ? <p className="mt-2 text-xs leading-5 text-muted-foreground">{note}</p> : null}
       {error ? (
         <div
@@ -80,60 +62,6 @@ export function AuthStartPanel({
       ) : null}
       {devAccess}
     </AuthLayout>
-  );
-}
-
-function AuthSecondaryOptions({
-  label,
-  actions,
-  content,
-}: {
-  label: ReactNode;
-  actions: AuthProviderActionView[];
-  content?: ReactNode;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <div className="space-y-3">
-      <Button
-        type="button"
-        variant="secondary"
-        size="md"
-        aria-expanded={expanded}
-        className="h-11 w-full justify-center gap-2.5"
-        onClick={() => setExpanded((current) => !current)}
-      >
-        <span>{label}</span>
-        <ChevronDown
-          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
-            expanded ? "rotate-180" : ""
-          }`}
-        />
-      </Button>
-      {expanded ? (
-        <div className="space-y-3">
-          {actions.map((action) => (
-            <AuthProviderButton
-              key={action.id}
-              icon={action.icon}
-              loading={action.loading}
-              disabled={action.disabled}
-              variant={action.primary ? "primary" : "secondary"}
-              onClick={action.onClick}
-            >
-              {action.label}
-            </AuthProviderButton>
-          ))}
-          {content ? (
-            <>
-              {actions.length > 0 ? <AuthDivider /> : null}
-              {content}
-            </>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
   );
 }
 

--- a/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
+++ b/apps/packages/product-ui/src/auth/AuthStartPanel.tsx
@@ -1,5 +1,7 @@
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "@proliferate/ui/icons";
 import { AuthProviderButton } from "@proliferate/ui/primitives/AuthProviderButton";
+import { Button } from "@proliferate/ui/primitives/Button";
 import { AuthLayout } from "./AuthLayout";
 
 export interface AuthProviderActionView {
@@ -19,6 +21,9 @@ interface AuthStartPanelProps {
   footer: ReactNode;
   providers: AuthProviderActionView[];
   credentialForm?: ReactNode;
+  secondaryActions?: AuthProviderActionView[];
+  secondaryLabel?: ReactNode;
+  secondaryContent?: ReactNode;
   note?: ReactNode;
   error?: ReactNode;
   devAccess?: ReactNode;
@@ -31,14 +36,20 @@ export function AuthStartPanel({
   footer,
   providers,
   credentialForm,
+  secondaryActions,
+  secondaryLabel = "More",
+  secondaryContent,
   note,
   error,
   devAccess,
 }: AuthStartPanelProps) {
+  const hasSecondaryOptions =
+    Boolean(secondaryActions?.length) || secondaryContent !== undefined;
+
   return (
     <AuthLayout mark={mark} title={title} subtitle={subtitle} footer={footer}>
-      {credentialForm}
-      {credentialForm ? <AuthDivider /> : null}
+      {!hasSecondaryOptions ? credentialForm : null}
+      {!hasSecondaryOptions && credentialForm ? <AuthDivider /> : null}
       {providers.map((provider) => (
         <AuthProviderButton
           key={provider.id}
@@ -51,7 +62,14 @@ export function AuthStartPanel({
           {provider.label}
         </AuthProviderButton>
       ))}
-      {note ? <p className="mt-2 text-center text-xs leading-5 text-muted-foreground">{note}</p> : null}
+      {hasSecondaryOptions ? (
+        <AuthSecondaryOptions
+          label={secondaryLabel}
+          actions={secondaryActions ?? []}
+          content={secondaryContent}
+        />
+      ) : null}
+      {note ? <p className="mt-2 text-xs leading-5 text-muted-foreground">{note}</p> : null}
       {error ? (
         <div
           className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm leading-5 text-destructive"
@@ -62,6 +80,60 @@ export function AuthStartPanel({
       ) : null}
       {devAccess}
     </AuthLayout>
+  );
+}
+
+function AuthSecondaryOptions({
+  label,
+  actions,
+  content,
+}: {
+  label: ReactNode;
+  actions: AuthProviderActionView[];
+  content?: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      <Button
+        type="button"
+        variant="secondary"
+        size="md"
+        aria-expanded={expanded}
+        className="h-11 w-full justify-center gap-2.5"
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span>{label}</span>
+        <ChevronDown
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            expanded ? "rotate-180" : ""
+          }`}
+        />
+      </Button>
+      {expanded ? (
+        <div className="space-y-3">
+          {actions.map((action) => (
+            <AuthProviderButton
+              key={action.id}
+              icon={action.icon}
+              loading={action.loading}
+              disabled={action.disabled}
+              variant={action.primary ? "primary" : "secondary"}
+              onClick={action.onClick}
+            >
+              {action.label}
+            </AuthProviderButton>
+          ))}
+          {content ? (
+            <>
+              {actions.length > 0 ? <AuthDivider /> : null}
+              {content}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/packages/product-ui/test/AuthPanels.test.tsx
+++ b/apps/packages/product-ui/test/AuthPanels.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -55,60 +55,6 @@ describe("auth product panels", () => {
       "Continue with Google",
     ]);
     expect(providerButtons[0].className).toContain("bg-foreground");
-  });
-
-  it("renders secondary providers behind the more menu", () => {
-    const githubClick = vi.fn();
-    const appleClick = vi.fn();
-    const googleClick = vi.fn();
-
-    render(
-      <AuthStartPanel
-        title={AUTH_SIGN_IN_COPY.title}
-        subtitle={AUTH_SIGN_IN_COPY.subtitle}
-        footer={AUTH_SIGN_IN_COPY.footer}
-        providers={[
-          {
-            id: "github",
-            label: "Continue with GitHub",
-            primary: true,
-            onClick: githubClick,
-          },
-        ]}
-        secondaryLabel="More"
-        secondaryActions={[
-          {
-            id: "apple",
-            label: "Continue with Apple",
-            onClick: appleClick,
-          },
-          {
-            id: "google",
-            label: "Continue with Google",
-            onClick: googleClick,
-          },
-        ]}
-        secondaryContent={<div>Email sign-in</div>}
-      />,
-    );
-
-    expect(screen.getByRole("button", { name: "Continue with GitHub" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "More" })).toBeTruthy();
-    expect(screen.queryByText("Continue with Apple")).toBeNull();
-    expect(screen.queryByText("Email sign-in")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "More" }));
-
-    expect(screen.getByRole("button", { name: "Continue with Apple" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Continue with Google" })).toBeTruthy();
-    expect(screen.getByText("Email sign-in")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Continue with Apple" }));
-
-    expect(appleClick).toHaveBeenCalledTimes(1);
-    expect(githubClick).not.toHaveBeenCalled();
-    expect(googleClick).not.toHaveBeenCalled();
-    expect(screen.getByText("Email sign-in")).toBeTruthy();
   });
 
   it("renders the email credential form slot", () => {

--- a/apps/packages/product-ui/test/AuthPanels.test.tsx
+++ b/apps/packages/product-ui/test/AuthPanels.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -55,6 +55,60 @@ describe("auth product panels", () => {
       "Continue with Google",
     ]);
     expect(providerButtons[0].className).toContain("bg-foreground");
+  });
+
+  it("renders secondary providers behind the more menu", () => {
+    const githubClick = vi.fn();
+    const appleClick = vi.fn();
+    const googleClick = vi.fn();
+
+    render(
+      <AuthStartPanel
+        title={AUTH_SIGN_IN_COPY.title}
+        subtitle={AUTH_SIGN_IN_COPY.subtitle}
+        footer={AUTH_SIGN_IN_COPY.footer}
+        providers={[
+          {
+            id: "github",
+            label: "Continue with GitHub",
+            primary: true,
+            onClick: githubClick,
+          },
+        ]}
+        secondaryLabel="More"
+        secondaryActions={[
+          {
+            id: "apple",
+            label: "Continue with Apple",
+            onClick: appleClick,
+          },
+          {
+            id: "google",
+            label: "Continue with Google",
+            onClick: googleClick,
+          },
+        ]}
+        secondaryContent={<div>Email sign-in</div>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Continue with GitHub" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "More" })).toBeTruthy();
+    expect(screen.queryByText("Continue with Apple")).toBeNull();
+    expect(screen.queryByText("Email sign-in")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(screen.getByRole("button", { name: "Continue with Apple" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue with Google" })).toBeTruthy();
+    expect(screen.getByText("Email sign-in")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue with Apple" }));
+
+    expect(appleClick).toHaveBeenCalledTimes(1);
+    expect(githubClick).not.toHaveBeenCalled();
+    expect(googleClick).not.toHaveBeenCalled();
+    expect(screen.getByText("Email sign-in")).toBeTruthy();
   });
 
   it("renders the email credential form slot", () => {

--- a/apps/web/src/components/auth/AuthGate.tsx
+++ b/apps/web/src/components/auth/AuthGate.tsx
@@ -14,13 +14,20 @@ export function AuthGate({ children }: { children: ReactNode }) {
   const viewer = useAuthViewer(!bootstrapping && Boolean(token));
   const authError = viewer.error instanceof ProliferateClientError ? viewer.error : null;
   const invalidToken = authError?.status === 401;
-  const betaDenied = isWebBetaAuthErrorCode(authError?.code ?? null);
+  const betaDeniedCode = isWebBetaAuthErrorCode(authError?.code ?? null)
+    ? authError?.code ?? null
+    : null;
+  const betaDenied = betaDeniedCode !== null;
 
   useEffect(() => {
-    if (invalidToken || betaDenied) {
+    if (betaDeniedCode) {
+      void clearToken({ authRejectionCode: betaDeniedCode });
+      return;
+    }
+    if (invalidToken) {
       void clearToken();
     }
-  }, [betaDenied, clearToken, invalidToken]);
+  }, [betaDeniedCode, clearToken, invalidToken]);
 
   if (bootstrapping) {
     return <AuthLoadingScreen />;

--- a/apps/web/src/components/auth/AuthGate.tsx
+++ b/apps/web/src/components/auth/AuthGate.tsx
@@ -3,27 +3,33 @@ import { ProliferateClientError } from "@proliferate/cloud-sdk";
 import { useAuthViewer } from "@proliferate/cloud-sdk-react";
 
 import { useAuthToken } from "../../providers/WebCloudProvider";
+import { isWebBetaAuthErrorCode } from "../../lib/domain/auth/web-auth-errors";
+import { AuthErrorScreen } from "./screen/AuthErrorScreen";
 import { AuthLoadingScreen } from "./screen/AuthLoadingScreen";
 import { AuthScreen } from "./screen/AuthScreen";
 import { ConnectGitHubScreen } from "./screen/ConnectGitHubScreen";
 
 export function AuthGate({ children }: { children: ReactNode }) {
-  const { token, bootstrapping, clearToken } = useAuthToken();
+  const { token, bootstrapping, authRejectionCode, clearToken } = useAuthToken();
   const viewer = useAuthViewer(!bootstrapping && Boolean(token));
   const authError = viewer.error instanceof ProliferateClientError ? viewer.error : null;
   const invalidToken = authError?.status === 401;
+  const betaDenied = isWebBetaAuthErrorCode(authError?.code ?? null);
 
   useEffect(() => {
-    if (invalidToken) {
+    if (invalidToken || betaDenied) {
       void clearToken();
     }
-  }, [clearToken, invalidToken]);
+  }, [betaDenied, clearToken, invalidToken]);
 
   if (bootstrapping) {
     return <AuthLoadingScreen />;
   }
 
   if (!token) {
+    if (authRejectionCode) {
+      return <AuthErrorScreen code={authRejectionCode} />;
+    }
     return <AuthScreen />;
   }
 
@@ -32,6 +38,10 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }
 
   if (invalidToken) {
+    return <AuthLoadingScreen />;
+  }
+
+  if (betaDenied) {
     return <AuthLoadingScreen />;
   }
 

--- a/apps/web/src/components/auth/screen/AuthErrorScreen.tsx
+++ b/apps/web/src/components/auth/screen/AuthErrorScreen.tsx
@@ -1,0 +1,70 @@
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useNavigate, type NavigateFunction } from "react-router-dom";
+
+import {
+  RedirectCallbackScreen,
+  type RedirectCallbackAction,
+} from "@proliferate/product-ui/auth/RedirectCallbackScreen";
+import { ProliferateMark } from "@proliferate/product-ui/brand/ProliferateMark";
+
+import { routes } from "../../../config/routes";
+import {
+  type WebAuthErrorAction,
+  webAuthErrorPresentation,
+} from "../../../lib/domain/auth/web-auth-errors";
+
+const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+export function AuthErrorScreen({ code }: { code: string | null }) {
+  const navigate = useNavigate();
+  const presentation = webAuthErrorPresentation(code);
+
+  return (
+    <RedirectCallbackScreen
+      tone="error"
+      title={presentation.title}
+      description={presentation.description}
+      statusLabel={presentation.statusLabel}
+      brandMark={<ProliferateMark size={32} />}
+      brandLabel={null}
+      primaryAction={authErrorActionProps(presentation.primaryAction, navigate)}
+      secondaryAction={
+        presentation.secondaryAction
+          ? authErrorActionProps(presentation.secondaryAction, navigate)
+          : undefined
+      }
+    />
+  );
+}
+
+function authErrorActionProps(
+  action: WebAuthErrorAction,
+  navigate: NavigateFunction,
+): RedirectCallbackAction {
+  switch (action.kind) {
+    case "open_desktop":
+      return {
+        label: action.label,
+        icon: <ExternalLink size={15} />,
+        onClick: () => window.location.assign(desktopRootDeepLink()),
+      };
+    case "try_again":
+      return {
+        label: action.label,
+        icon: <RefreshCw size={15} />,
+        onClick: () => navigate(routes.auth),
+      };
+    case "go_home":
+      return {
+        label: action.label,
+        onClick: () => navigate(routes.home),
+      };
+  }
+}
+
+function desktopRootDeepLink(): string {
+  const scheme = LOCALHOST_NAMES.has(window.location.hostname)
+    ? "proliferate-local"
+    : "proliferate";
+  return `${scheme}://`;
+}

--- a/apps/web/src/components/auth/screen/AuthScreen.tsx
+++ b/apps/web/src/components/auth/screen/AuthScreen.tsx
@@ -1,42 +1,49 @@
 import { KeyRound } from "lucide-react";
 import { useState } from "react";
 
-import { loginWebWithPassword, type AuthProviderName } from "@proliferate/cloud-sdk";
+import { type AuthProviderName } from "@proliferate/cloud-sdk";
 import {
   AUTH_PROVIDER_ORDER,
   AUTH_SIGN_IN_COPY,
   authProviderPresentation,
 } from "@proliferate/product-domain/auth/presentation";
 import { AuthStartPanel } from "@proliferate/product-ui/auth/AuthStartPanel";
-import { PasswordCredentialForm } from "@proliferate/product-ui/auth/PasswordCredentialForm";
 import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
 import { ProliferateMark } from "@proliferate/product-ui/brand/ProliferateMark";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 
 import { webEnv } from "../../../config/env";
+import { WEB_AUTH_COPY } from "../../../copy/auth/web-auth-copy";
 import { startWebAuthFlow } from "../../../lib/access/cloud/auth/web-auth-flow";
-import { createWebCloudClient } from "../../../lib/access/cloud/client";
 import { useAuthToken } from "../../../providers/WebCloudProvider";
 
+const WEB_SIGN_IN_PROVIDERS = new Set<AuthProviderName>(["github", "google"]);
+
 export function AuthScreen() {
-  const { setToken, setSession, bootstrapUnreachable } = useAuthToken();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const { setToken, bootstrapUnreachable } = useAuthToken();
   const [manualToken, setManualToken] = useState("");
   const [showDevAccess, setShowDevAccess] = useState(false);
   const [loadingProvider, setLoadingProvider] = useState<AuthProviderName | null>(null);
-  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
   const [providerError, setProviderError] = useState<string | null>(null);
-  const [passwordError, setPasswordError] = useState<string | null>(null);
-  const busy = Boolean(loadingProvider) || passwordSubmitting;
+  const busy = Boolean(loadingProvider);
+  const providerActions = AUTH_PROVIDER_ORDER
+    .filter((provider) => WEB_SIGN_IN_PROVIDERS.has(provider))
+    .map((provider) => ({
+      id: provider,
+      label: authProviderPresentation(provider).actionLabel,
+      icon: providerIcon(provider),
+      loading: loadingProvider === provider,
+      disabled: busy,
+      primary: provider === "github",
+      onClick: () => void signIn(provider),
+    }));
 
   async function signIn(provider: AuthProviderName) {
     if (busy) {
       return;
     }
     setProviderError(null);
-    setPasswordError(null);
     setLoadingProvider(provider);
     try {
       await startWebAuthFlow({ provider });
@@ -46,58 +53,18 @@ export function AuthScreen() {
     }
   }
 
-  async function signInWithPassword() {
-    if (busy) {
-      return;
-    }
-    setProviderError(null);
-    setPasswordError(null);
-    setPasswordSubmitting(true);
-    try {
-      const client = createWebCloudClient(webEnv.apiBaseUrl, null);
-      const session = await loginWebWithPassword(
-        {
-          email: email.trim(),
-          password,
-        },
-        client,
-      );
-      setSession(session);
-    } catch (authError) {
-      setPasswordError(authError instanceof Error ? authError.message : "Email sign in failed.");
-    } finally {
-      setPasswordSubmitting(false);
-    }
-  }
-
   return (
     <AuthStartPanel
       mark={<ProliferateMark size={36} />}
       title={AUTH_SIGN_IN_COPY.title}
-      subtitle={AUTH_SIGN_IN_COPY.subtitle}
-      footer={<span className="block text-faint">{AUTH_SIGN_IN_COPY.footer}</span>}
-      credentialForm={(
-        <PasswordCredentialForm
-          email={email}
-          password={password}
-          submitting={passwordSubmitting}
-          disabled={Boolean(loadingProvider)}
-          error={passwordError}
-          onEmailChange={setEmail}
-          onPasswordChange={setPassword}
-          onSubmit={() => { void signInWithPassword(); }}
-        />
+      subtitle={(
+        <span>
+          <span className="font-medium text-foreground/80">{WEB_AUTH_COPY.betaLabel}.</span>{" "}
+          {WEB_AUTH_COPY.subtitle}
+        </span>
       )}
-      providers={AUTH_PROVIDER_ORDER.map((provider) => ({
-        id: provider,
-        label: authProviderPresentation(provider).actionLabel,
-        icon: providerIcon(provider),
-        loading: loadingProvider === provider,
-        disabled: busy,
-        primary: provider === "github",
-        onClick: () => void signIn(provider),
-      }))}
-      note={AUTH_SIGN_IN_COPY.note}
+      footer={<span className="block text-faint">{AUTH_SIGN_IN_COPY.footer}</span>}
+      providers={providerActions}
       error={providerError ?? (bootstrapUnreachable ? localApiUnreachableNotice() : null)}
       devAccess={webEnv.devAccessTokenLogin ? (
         <div className="mt-2 border-t border-border pt-4">

--- a/apps/web/src/copy/auth/web-auth-copy.ts
+++ b/apps/web/src/copy/auth/web-auth-copy.ts
@@ -1,0 +1,4 @@
+export const WEB_AUTH_COPY = {
+  betaLabel: "Beta only",
+  subtitle: "Sign in to run cloud workspaces, workflows, and coding agents across devices.",
+} as const;

--- a/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
+++ b/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
@@ -13,6 +13,16 @@ import { createWebCloudClient } from "../client";
 
 const PENDING_WEB_AUTH_KEY = "proliferate.web.pendingAuth";
 
+export class WebAuthFlowError extends Error {
+  code: string | null;
+
+  constructor(message: string, code: string | null) {
+    super(message);
+    this.name = "WebAuthFlowError";
+    this.code = code;
+  }
+}
+
 interface PendingWebAuth {
   provider: AuthProviderName;
   purpose: AuthPurpose;
@@ -63,7 +73,7 @@ export async function completeWebAuthFlow(
 ): Promise<AuthSessionResponse> {
   const error = searchParams.get("error");
   if (error) {
-    throw new Error(error);
+    throw new WebAuthFlowError(authCallbackErrorMessage(error), error);
   }
   const code = searchParams.get("code");
   const state = searchParams.get("state");
@@ -84,6 +94,31 @@ export async function completeWebAuthFlow(
     },
     client,
   );
+}
+
+export function webAuthFlowErrorCode(error: unknown): string | null {
+  if (error instanceof WebAuthFlowError) {
+    return error.code;
+  }
+  if (
+    error
+    && typeof error === "object"
+    && "code" in error
+    && typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return null;
+}
+
+function authCallbackErrorMessage(code: string): string {
+  switch (code) {
+    case "web_beta_email_missing":
+    case "web_beta_email_not_allowed":
+      return "Hosted web access is currently limited to beta users.";
+    default:
+      return code;
+  }
 }
 
 function writePendingWebAuth(pending: PendingWebAuth): void {

--- a/apps/web/src/lib/domain/auth/web-auth-errors.test.ts
+++ b/apps/web/src/lib/domain/auth/web-auth-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isWebBetaAuthErrorCode,
+  webAuthErrorPresentation,
+  webBetaAuthErrorCode,
+} from "./web-auth-errors";
+
+describe("web auth errors", () => {
+  it("presents beta denials as no cloud account errors", () => {
+    const presentation = webAuthErrorPresentation("web_beta_email_not_allowed");
+
+    expect(isWebBetaAuthErrorCode("web_beta_email_not_allowed")).toBe(true);
+    expect(presentation.title).toBe("No cloud account");
+    expect(presentation.statusLabel).toBe("Beta only");
+    expect(presentation.primaryAction.kind).toBe("open_desktop");
+    expect(presentation.secondaryAction?.kind).toBe("try_again");
+  });
+
+  it("extracts only beta auth error codes from thrown errors", () => {
+    expect(webBetaAuthErrorCode({ code: "web_beta_email_missing" })).toBe(
+      "web_beta_email_missing",
+    );
+    expect(webBetaAuthErrorCode({ code: "github_link_required" })).toBeNull();
+    expect(webBetaAuthErrorCode(new Error("failed"))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/domain/auth/web-auth-errors.ts
+++ b/apps/web/src/lib/domain/auth/web-auth-errors.ts
@@ -1,0 +1,57 @@
+export type WebAuthErrorActionKind = "open_desktop" | "try_again" | "go_home";
+
+export interface WebAuthErrorAction {
+  kind: WebAuthErrorActionKind;
+  label: string;
+}
+
+export interface WebAuthErrorPresentation {
+  title: string;
+  description: string;
+  statusLabel: string;
+  primaryAction: WebAuthErrorAction;
+  secondaryAction: WebAuthErrorAction | null;
+}
+
+const WEB_BETA_ERROR_CODES = new Set([
+  "web_beta_email_missing",
+  "web_beta_email_not_allowed",
+]);
+
+export function isWebBetaAuthErrorCode(code: string | null): boolean {
+  return code !== null && WEB_BETA_ERROR_CODES.has(code);
+}
+
+export function webBetaAuthErrorCode(error: unknown): string | null {
+  const code =
+    error
+    && typeof error === "object"
+    && "code" in error
+    && typeof error.code === "string"
+      ? error.code
+      : null;
+  return isWebBetaAuthErrorCode(code) ? code : null;
+}
+
+export function webAuthErrorPresentation(code: string | null): WebAuthErrorPresentation {
+  if (isWebBetaAuthErrorCode(code)) {
+    return {
+      title: "No cloud account",
+      description:
+        "Hosted web access is currently limited to beta users. You can still use Proliferate from the desktop app.",
+      statusLabel: "Beta only",
+      primaryAction: { kind: "open_desktop", label: "Open Desktop" },
+      secondaryAction: { kind: "try_again", label: "Try another account" },
+    };
+  }
+
+  return {
+    title: "Sign in needs attention",
+    description: code
+      ? `The sign-in attempt could not be completed: ${code}`
+      : "The sign-in attempt could not be completed. Return to the app and try again.",
+    statusLabel: "Auth error",
+    primaryAction: { kind: "try_again", label: "Try again" },
+    secondaryAction: { kind: "go_home", label: "Go to dashboard" },
+  };
+}

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -5,7 +5,10 @@ import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCal
 import { ProliferateMark } from "@proliferate/product-ui/brand/ProliferateMark";
 
 import { routes } from "../config/routes";
-import { completeWebAuthFlow } from "../lib/access/cloud/auth/web-auth-flow";
+import {
+  completeWebAuthFlow,
+  webAuthFlowErrorCode,
+} from "../lib/access/cloud/auth/web-auth-flow";
 import { useAuthToken } from "../providers/WebCloudProvider";
 
 export function AuthCallbackPage() {
@@ -26,12 +29,13 @@ export function AuthCallbackPage() {
         navigate(routes.home, { replace: true });
       })
       .catch((callbackError) => {
+        const code = webAuthFlowErrorCode(callbackError);
         const message =
           callbackError instanceof Error
             ? callbackError.message
             : "The sign-in callback could not be completed.";
         setError(message);
-        navigate(`${routes.authError}?code=${encodeURIComponent(message)}`, {
+        navigate(`${routes.authError}?code=${encodeURIComponent(code ?? message)}`, {
           replace: true,
         });
       });

--- a/apps/web/src/pages/AuthErrorPage.tsx
+++ b/apps/web/src/pages/AuthErrorPage.tsx
@@ -1,37 +1,9 @@
-import { RefreshCw } from "lucide-react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
-import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
-import { ProliferateMark } from "@proliferate/product-ui/brand/ProliferateMark";
-
-import { routes } from "../config/routes";
+import { AuthErrorScreen } from "../components/auth/screen/AuthErrorScreen";
 
 export function AuthErrorPage() {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code");
-
-  return (
-    <RedirectCallbackScreen
-      tone="error"
-      title="Sign in needs attention"
-      description={
-        code
-          ? `The sign-in attempt could not be completed: ${code}`
-          : "The sign-in attempt could not be completed. Return to the app and try again."
-      }
-      statusLabel="Auth error"
-      brandMark={<ProliferateMark size={32} />}
-      brandLabel={null}
-      primaryAction={{
-        label: "Try again",
-        icon: <RefreshCw size={15} />,
-        onClick: () => navigate(routes.auth),
-      }}
-      secondaryAction={{
-        label: "Go to dashboard",
-        onClick: () => navigate(routes.home),
-      }}
-    />
-  );
+  return <AuthErrorScreen code={code} />;
 }

--- a/apps/web/src/providers/WebCloudProvider.tsx
+++ b/apps/web/src/providers/WebCloudProvider.tsx
@@ -36,7 +36,7 @@ interface AuthTokenContextValue {
   authRejectionCode: string | null;
   setToken: (token: string) => void;
   setSession: (session: AuthSessionResponse) => void;
-  clearToken: () => Promise<void>;
+  clearToken: (options?: { authRejectionCode?: string | null }) => Promise<void>;
 }
 
 const AuthTokenContext = createContext<AuthTokenContextValue | null>(null);
@@ -131,7 +131,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         setTokenState(session.accessToken);
         setUserState(session.user);
       },
-      async clearToken() {
+      async clearToken(options) {
         authEpochRef.current += 1;
         const csrfToken = readCookie("proliferate_web_csrf");
         if (csrfToken) {
@@ -146,7 +146,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         clearStoredAuthToken();
         setBootstrapping(false);
         setBootstrapUnreachable(false);
-        setAuthRejectionCode(null);
+        setAuthRejectionCode(options?.authRejectionCode ?? null);
         setTokenState(null);
         setUserState(null);
       },

--- a/apps/web/src/providers/WebCloudProvider.tsx
+++ b/apps/web/src/providers/WebCloudProvider.tsx
@@ -24,6 +24,7 @@ import {
   writeStoredAuthToken,
 } from "../lib/access/cloud/auth-token-store";
 import { isApiUnreachableError } from "../lib/access/cloud/session-bootstrap-failure";
+import { webBetaAuthErrorCode } from "../lib/domain/auth/web-auth-errors";
 
 const SESSION_BOOTSTRAP_TIMEOUT_MS = 5_000;
 
@@ -32,6 +33,7 @@ interface AuthTokenContextValue {
   user: AuthUser | null;
   bootstrapping: boolean;
   bootstrapUnreachable: boolean;
+  authRejectionCode: string | null;
   setToken: (token: string) => void;
   setSession: (session: AuthSessionResponse) => void;
   clearToken: () => Promise<void>;
@@ -49,6 +51,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
   const [user, setUserState] = useState<AuthUser | null>(null);
   const [bootstrapping, setBootstrapping] = useState(initialTokenRef.current === null);
   const [bootstrapUnreachable, setBootstrapUnreachable] = useState(false);
+  const [authRejectionCode, setAuthRejectionCode] = useState<string | null>(null);
   const authEpochRef = useRef(0);
   const client = useMemo(() => createWebCloudClient(webEnv.apiBaseUrl, token), [token]);
 
@@ -73,13 +76,18 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
           queryClient.clear();
           setTokenState(session.accessToken);
           setUserState(session.user);
+          setAuthRejectionCode(null);
         }
       })
       .catch((error: unknown) => {
         if (!cancelled && authEpochRef.current === bootstrapEpoch) {
+          const rejectionCode = webBetaAuthErrorCode(error);
           setTokenState(null);
           setUserState(null);
-          setBootstrapUnreachable(import.meta.env.DEV && isApiUnreachableError(error));
+          setAuthRejectionCode(rejectionCode);
+          setBootstrapUnreachable(
+            !rejectionCode && import.meta.env.DEV && isApiUnreachableError(error),
+          );
         }
       })
       .finally(() => {
@@ -102,12 +110,14 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
       user,
       bootstrapping,
       bootstrapUnreachable,
+      authRejectionCode,
       setToken(nextToken) {
         authEpochRef.current += 1;
         queryClient.clear();
         writeStoredAuthToken(nextToken);
         setBootstrapping(false);
         setBootstrapUnreachable(false);
+        setAuthRejectionCode(null);
         setTokenState(nextToken);
         setUserState(null);
       },
@@ -117,6 +127,7 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         clearStoredAuthToken();
         setBootstrapping(false);
         setBootstrapUnreachable(false);
+        setAuthRejectionCode(null);
         setTokenState(session.accessToken);
         setUserState(session.user);
       },
@@ -134,11 +145,13 @@ export function WebCloudProvider({ children }: { children: ReactNode }) {
         queryClient.clear();
         clearStoredAuthToken();
         setBootstrapping(false);
+        setBootstrapUnreachable(false);
+        setAuthRejectionCode(null);
         setTokenState(null);
         setUserState(null);
       },
     }),
-    [bootstrapping, bootstrapUnreachable, token, user],
+    [authRejectionCode, bootstrapping, bootstrapUnreachable, token, user],
   );
 
   return (

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -27,7 +27,6 @@ anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1880 existing SDK oversi
 anyharness/sdk/src/reducer/transcript.ts 1575 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/keychain.rs 760 existing desktop native oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
-apps/desktop/src/components/workspace/shell/right-panel/RightPanel.test.tsx 733 existing desktop component oversized test file
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 662 existing desktop oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 632 existing desktop oversized test file
 apps/desktop/src/lib/workflows/mcp/connector-persistence.test.ts 704 existing desktop oversized test file

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -38,7 +38,7 @@ server/proliferate/constants/cloud.py 614 existing cloud constants module with c
 server/tests/integration/schema_migration_assertions.py 885 existing server oversized test helper
 server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
-server/tests/integration/test_billing_api.py 2054 existing server oversized integration test
+server/tests/integration/test_billing_api.py 2040 existing server oversized integration test
 server/tests/integration/test_cloud_agent_auth_api.py 1897 existing server oversized integration test
 server/tests/integration/test_cloud_api.py 2346 existing server oversized integration test
 server/tests/integration/test_cloud_commands_api.py 4889 existing server oversized integration test

--- a/server/proliferate/auth/identity/api.py
+++ b/server/proliferate/auth/identity/api.py
@@ -54,6 +54,10 @@ from proliferate.auth.identity.sessions import (
     refresh_auth_session,
 )
 from proliferate.auth.identity.types import AuthProviderName
+from proliferate.auth.identity.web_beta import (
+    WebBetaAccessDenied,
+    ensure_web_beta_email_allowed,
+)
 from proliferate.config import settings
 from proliferate.constants.auth import REFRESH_TOKEN_LIFETIME_SECONDS
 from proliferate.db.engine import get_async_session
@@ -188,14 +192,18 @@ async def oauth_callback(
         return RedirectResponse(_auth_error_url(error), status_code=status.HTTP_302_FOUND)
     if state is None or code is None:
         return RedirectResponse(_auth_error_url("missing_callback_params"), status_code=302)
-    redirect_url = await complete_oauth_provider_callback(
-        db,
-        request,
-        provider=provider,
-        surface=surface,
-        state=state,
-        code=code,
-    )
+    try:
+        redirect_url = await complete_oauth_provider_callback(
+            db,
+            request,
+            provider=provider,
+            surface=surface,
+            state=state,
+            code=code,
+        )
+    except WebBetaAccessDenied as exc:
+        await db.rollback()
+        return RedirectResponse(_auth_error_url(exc.code), status_code=status.HTTP_302_FOUND)
     await db.commit()
     return RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
 
@@ -228,14 +236,18 @@ async def oauth_shared_provider_callback(
         return RedirectResponse(_auth_error_url(error), status_code=status.HTTP_302_FOUND)
     if state is None or code is None:
         return RedirectResponse(_auth_error_url("missing_callback_params"), status_code=302)
-    redirect_url = await complete_oauth_provider_callback(
-        db,
-        request,
-        provider=provider,
-        surface=None,
-        state=state,
-        code=code,
-    )
+    try:
+        redirect_url = await complete_oauth_provider_callback(
+            db,
+            request,
+            provider=provider,
+            surface=None,
+            state=state,
+            code=code,
+        )
+    except WebBetaAccessDenied as exc:
+        await db.rollback()
+        return RedirectResponse(_auth_error_url(exc.code), status_code=status.HTTP_302_FOUND)
     await db.commit()
     return RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
 
@@ -263,13 +275,17 @@ async def apple_web_callback(
                     display_name = " ".join(part for part in parts if part) or None
         except json.JSONDecodeError:
             pass
-    redirect_url = await complete_apple_web_callback(
-        db,
-        state=state,
-        identity_token=id_token,
-        email=email,
-        display_name=display_name,
-    )
+    try:
+        redirect_url = await complete_apple_web_callback(
+            db,
+            state=state,
+            identity_token=id_token,
+            email=email,
+            display_name=display_name,
+        )
+    except WebBetaAccessDenied as exc:
+        await db.rollback()
+        return RedirectResponse(_auth_error_url(exc.code), status_code=status.HTTP_302_FOUND)
     await db.commit()
     return RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
 
@@ -304,6 +320,7 @@ async def web_password_login(
             password=body.password,
             client_ip=_request_client_ip(request),
         )
+        ensure_web_beta_email_allowed(session.email)
     except HTTPException:
         await db.commit()
         raise
@@ -355,6 +372,7 @@ async def web_token(
     db: AsyncSession = Depends(get_async_session),
 ) -> AuthSessionResponse:
     session = await exchange_auth_code(db, code=body.code, code_verifier=body.code_verifier)
+    ensure_web_beta_email_allowed(session.email)
     await db.commit()
     _set_web_session_cookies(response, session.refresh_token)
     return auth_session_response(session, include_refresh_token=False)
@@ -379,6 +397,7 @@ async def web_session_bootstrap(
     if not refresh_token:
         raise HTTPException(status_code=401, detail="No web session.")
     session = await refresh_auth_session(db, refresh_token=refresh_token)
+    ensure_web_beta_email_allowed(session.email)
     _set_web_session_cookies(response, session.refresh_token)
     return auth_session_response(session, include_refresh_token=False)
 
@@ -395,6 +414,7 @@ async def web_session_refresh(
     if not refresh_token:
         raise HTTPException(status_code=401, detail="No web session.")
     session = await refresh_auth_session(db, refresh_token=refresh_token)
+    ensure_web_beta_email_allowed(session.email)
     _set_web_session_cookies(response, session.refresh_token)
     return auth_session_response(session, include_refresh_token=False)
 

--- a/server/proliferate/auth/identity/api.py
+++ b/server/proliferate/auth/identity/api.py
@@ -321,6 +321,9 @@ async def web_password_login(
             client_ip=_request_client_ip(request),
         )
         ensure_web_beta_email_allowed(session.email)
+    except WebBetaAccessDenied:
+        await db.rollback()
+        raise
     except HTTPException:
         await db.commit()
         raise

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -30,6 +30,7 @@ from proliferate.auth.identity.types import (
     AuthSession,
     VerifiedProviderIdentity,
 )
+from proliferate.auth.identity.web_beta import ensure_web_beta_email_allowed
 from proliferate.config import settings
 from proliferate.constants.auth import (
     DESKTOP_REDIRECT_SCHEMES,
@@ -199,6 +200,8 @@ async def complete_oauth_provider_callback(
             request, provider=provider, surface=callback_surface
         ),
     )
+    if callback_surface == "web" and challenge.purpose == "login":
+        ensure_web_beta_email_allowed(verified.email)
     desktop_github_account_or_email_exists = True
     if callback_surface == "desktop" and provider == "github":
         desktop_github_account_or_email_exists = await _desktop_github_account_or_email_exists(
@@ -336,6 +339,8 @@ async def complete_apple_web_callback(
         email_hint=email,
         display_name_hint=display_name,
     )
+    if challenge.purpose == "login":
+        ensure_web_beta_email_allowed(verified.email)
     user = await resolve_provider_user(db, verified=verified, challenge=challenge)
     auth_code = await create_auth_code(
         db,

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -201,7 +201,8 @@ async def complete_oauth_provider_callback(
         ),
     )
     if callback_surface == "web" and challenge.purpose == "login":
-        ensure_web_beta_email_allowed(verified.email)
+        beta_email = await _beta_email_for_provider_login(db, verified=verified)
+        ensure_web_beta_email_allowed(beta_email)
     desktop_github_account_or_email_exists = True
     if callback_surface == "desktop" and provider == "github":
         desktop_github_account_or_email_exists = await _desktop_github_account_or_email_exists(
@@ -340,7 +341,8 @@ async def complete_apple_web_callback(
         display_name_hint=display_name,
     )
     if challenge.purpose == "login":
-        ensure_web_beta_email_allowed(verified.email)
+        beta_email = await _beta_email_for_provider_login(db, verified=verified)
+        ensure_web_beta_email_allowed(beta_email)
     user = await resolve_provider_user(db, verified=verified, challenge=challenge)
     auth_code = await create_auth_code(
         db,
@@ -351,6 +353,28 @@ async def complete_apple_web_callback(
         redirect_uri=challenge.redirect_uri,
     )
     return append_query(challenge.redirect_uri, code=auth_code.code, state=challenge.client_state)
+
+
+async def _beta_email_for_provider_login(
+    db: AsyncSession,
+    *,
+    verified: VerifiedProviderIdentity,
+) -> str | None:
+    existing_identity = await get_identity_by_provider_subject(
+        db,
+        provider=verified.provider,
+        provider_subject=verified.provider_subject,
+    )
+    if existing_identity is not None:
+        user = await get_user_by_id(db, existing_identity.user_id)
+        return user.email if user is not None else None
+
+    if verified.provider == "github" and verified.email:
+        existing_email_user = await get_user_by_email(db, verified.email)
+        if existing_email_user is not None:
+            return existing_email_user.email
+
+    return verified.email
 
 
 def _nonce_unavailable_marker(challenge: AuthChallengeSnapshot) -> str:

--- a/server/proliferate/auth/identity/web_beta.py
+++ b/server/proliferate/auth/identity/web_beta.py
@@ -14,11 +14,13 @@ class WebBetaAccessDenied(PermissionDenied):
 
 
 def web_beta_gate_configured() -> bool:
-    return bool(_allowed_emails() or _allowed_domains())
+    allowed_emails, allowed_domains = _allowed_beta_config()
+    return bool(allowed_emails or allowed_domains)
 
 
 def ensure_web_beta_email_allowed(email: str | None) -> None:
-    if not web_beta_gate_configured():
+    allowed_emails, allowed_domains = _allowed_beta_config()
+    if not allowed_emails and not allowed_domains:
         return
 
     normalized_email = _normalize_email(email)
@@ -29,11 +31,11 @@ def ensure_web_beta_email_allowed(email: str | None) -> None:
             code=WEB_BETA_EMAIL_MISSING_CODE,
         )
 
-    if normalized_email in _allowed_emails():
+    if normalized_email in allowed_emails:
         return
 
     domain = normalized_email.rsplit("@", 1)[1]
-    if domain in _allowed_domains():
+    if domain in allowed_domains:
         return
 
     raise WebBetaAccessDenied(
@@ -70,3 +72,7 @@ def _allowed_domains() -> set[str]:
         if normalized and "@" not in normalized:
             domains.add(normalized)
     return domains
+
+
+def _allowed_beta_config() -> tuple[set[str], set[str]]:
+    return _allowed_emails(), _allowed_domains()

--- a/server/proliferate/auth/identity/web_beta.py
+++ b/server/proliferate/auth/identity/web_beta.py
@@ -1,0 +1,72 @@
+"""Web beta allowlist policy for hosted browser sessions."""
+
+from __future__ import annotations
+
+from proliferate.config import settings
+from proliferate.errors import PermissionDenied
+
+WEB_BETA_EMAIL_MISSING_CODE = "web_beta_email_missing"
+WEB_BETA_EMAIL_NOT_ALLOWED_CODE = "web_beta_email_not_allowed"
+
+
+class WebBetaAccessDenied(PermissionDenied):
+    """Raised when an authenticated identity is not eligible for hosted web."""
+
+
+def web_beta_gate_configured() -> bool:
+    return bool(_allowed_emails() or _allowed_domains())
+
+
+def ensure_web_beta_email_allowed(email: str | None) -> None:
+    if not web_beta_gate_configured():
+        return
+
+    normalized_email = _normalize_email(email)
+    if normalized_email is None:
+        raise WebBetaAccessDenied(
+            "Web access is currently limited to beta users. "
+            "Sign in with a beta-approved email address.",
+            code=WEB_BETA_EMAIL_MISSING_CODE,
+        )
+
+    if normalized_email in _allowed_emails():
+        return
+
+    domain = normalized_email.rsplit("@", 1)[1]
+    if domain in _allowed_domains():
+        return
+
+    raise WebBetaAccessDenied(
+        "Web access is currently limited to beta users. "
+        "This email is not enrolled in the web beta.",
+        code=WEB_BETA_EMAIL_NOT_ALLOWED_CODE,
+    )
+
+
+def _normalize_email(email: str | None) -> str | None:
+    if email is None:
+        return None
+    normalized = email.strip().lower()
+    if not normalized or "@" not in normalized:
+        return None
+    local, domain = normalized.rsplit("@", 1)
+    if not local or not domain:
+        return None
+    return normalized
+
+
+def _allowed_emails() -> set[str]:
+    return {
+        normalized
+        for raw in settings.web_beta_allowed_emails.split(",")
+        if (normalized := _normalize_email(raw)) is not None
+    }
+
+
+def _allowed_domains() -> set[str]:
+    domains: set[str] = set()
+    for raw in settings.web_beta_allowed_domains.split(","):
+        normalized = raw.strip().lower().removeprefix("@")
+        if normalized and "@" not in normalized:
+            domains.add(normalized)
+    return domains

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -61,6 +61,8 @@ class Settings(BaseSettings):
     jwt_secret: str = "CHANGE-ME-IN-PRODUCTION"
     password_auth_enabled: bool = True
     password_auth_trusted_proxy_hosts: str = ""
+    web_beta_allowed_emails: str = ""
+    web_beta_allowed_domains: str = ""
 
     # GitHub OAuth
     github_oauth_client_id: str = ""

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -18,7 +18,6 @@ from proliferate.auth.desktop.models import AuthorizeParams
 from proliferate.auth.desktop import service as desktop_service
 from proliferate.auth.identity import providers as identity_providers
 from proliferate.auth.identity.sessions import WEB_CSRF_COOKIE
-from proliferate.auth.identity.web_beta import WEB_BETA_EMAIL_NOT_ALLOWED_CODE
 from proliferate.auth.oauth import github_oauth_client, google_oauth_client
 from proliferate.auth.passwords import hash_password
 from proliferate.config import settings
@@ -280,75 +279,6 @@ class TestPasswordAuthFlow:
         )
         assert ai_magic.status_code == 403
         assert ai_magic.json()["detail"]["code"] == "github_link_required"
-
-    @pytest.mark.asyncio
-    async def test_web_password_login_rejects_non_beta_email(
-        self,
-        client: AsyncClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(settings, "password_auth_enabled", True)
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
-        await _create_password_user("not-beta@example.com", self.password)
-
-        response = await client.post(
-            "/auth/web/password/login",
-            json={"email": "not-beta@example.com", "password": self.password},
-        )
-
-        assert response.status_code == 403
-        assert response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
-        assert "proliferate_web_refresh" not in response.headers.get("set-cookie", "")
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("email", "allowed_emails", "allowed_domains"),
-        [
-            ("exact-beta@example.com", " exact-beta@example.com ", ""),
-            ("domain-beta@team.example.com", "", " @team.example.com "),
-        ],
-    )
-    async def test_web_password_login_accepts_beta_email_or_domain(
-        self,
-        client: AsyncClient,
-        monkeypatch: pytest.MonkeyPatch,
-        email: str,
-        allowed_emails: str,
-        allowed_domains: str,
-    ) -> None:
-        monkeypatch.setattr(settings, "password_auth_enabled", True)
-        monkeypatch.setattr(settings, "web_beta_allowed_emails", allowed_emails)
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", allowed_domains)
-        await _create_password_user(email, self.password)
-
-        response = await client.post(
-            "/auth/web/password/login",
-            json={"email": email, "password": self.password},
-        )
-
-        assert response.status_code == 200
-        assert "proliferate_web_refresh" in response.headers["set-cookie"]
-
-    @pytest.mark.asyncio
-    async def test_web_session_bootstrap_rechecks_beta_allowlist_for_existing_cookie(
-        self,
-        client: AsyncClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(settings, "password_auth_enabled", True)
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "example.com")
-        await _create_password_user("existing-cookie@example.com", self.password)
-        response = await client.post(
-            "/auth/web/password/login",
-            json={"email": "existing-cookie@example.com", "password": self.password},
-        )
-        assert response.status_code == 200
-
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
-        bootstrap = await client.post("/auth/web/session/bootstrap")
-
-        assert bootstrap.status_code == 403
-        assert bootstrap.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
 
     @pytest.mark.asyncio
     async def test_mobile_password_login_returns_refresh_token_for_ready_user(
@@ -700,51 +630,6 @@ class TestWebMobileSessionGuards:
 
         assert response.status_code == 403
         assert response.json()["detail"] == "User is inactive."
-
-    @pytest.mark.asyncio
-    async def test_web_beta_allowlist_applies_to_web_token_not_desktop_token(
-        self,
-        client: AsyncClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        user_id = await _create_user_via_manager("token-non-beta@example.com")
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
-
-        web_verifier, web_challenge = _make_pkce_pair()
-        web_code = await _create_desktop_auth_code_for_user(
-            user_id=user_id,
-            state="web-beta-denied-state",
-            code_challenge=web_challenge,
-        )
-        web_response = await client.post(
-            "/auth/web/token",
-            json={
-                "code": web_code,
-                "codeVerifier": web_verifier,
-                "grantType": "authorization_code",
-            },
-        )
-
-        assert web_response.status_code == 403
-        assert web_response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
-
-        desktop_verifier, desktop_challenge = _make_pkce_pair()
-        desktop_code = await _create_desktop_auth_code_for_user(
-            user_id=user_id,
-            state="desktop-beta-bypass-state",
-            code_challenge=desktop_challenge,
-        )
-        desktop_response = await client.post(
-            "/auth/desktop/token",
-            json={
-                "code": desktop_code,
-                "code_verifier": desktop_verifier,
-                "grant_type": "authorization_code",
-            },
-        )
-
-        assert desktop_response.status_code == 200
-        assert desktop_response.json()["user"]["email"] == "token-non-beta@example.com"
 
     @pytest.mark.asyncio
     async def test_mobile_refresh_rejects_inactive_user(self, client: AsyncClient) -> None:
@@ -1100,7 +985,6 @@ class TestWebMobileProductAuthFlow:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         verifier, challenge = _make_pkce_pair()
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
         self._enable_identity_github(monkeypatch, "desktop-shared-github@example.com")
         schedule_mock = Mock()
         monkeypatch.setattr(
@@ -1332,40 +1216,6 @@ class TestWebMobileProductAuthFlow:
             headers={"Authorization": f"Bearer {payload['accessToken']}"},
         )
         assert protected.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_web_github_login_redirects_to_beta_error_when_email_denied(
-        self,
-        client: AsyncClient,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _, challenge = _make_pkce_pair()
-        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
-        self._enable_identity_github(monkeypatch, "not-beta-github@example.com")
-
-        started = await client.post(
-            "/auth/web/github/start",
-            json={
-                "purpose": "login",
-                "clientState": "web-beta-denied-state",
-                "codeChallenge": challenge,
-                "codeChallengeMethod": "S256",
-                "redirectUri": "http://localhost:5174/auth/callback",
-            },
-        )
-        assert started.status_code == 200
-        oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
-
-        callback = await client.get(
-            "/auth/github/callback",
-            params={"code": "github-code", "state": oauth_state},
-            follow_redirects=False,
-        )
-
-        assert callback.status_code == 302
-        redirect = urlparse(callback.headers["location"])
-        assert redirect.path == "/auth/error"
-        assert parse_qs(redirect.query)["code"] == [WEB_BETA_EMAIL_NOT_ALLOWED_CODE]
 
     @pytest.mark.asyncio
     async def test_web_google_login_requires_github_then_links_github(

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -18,6 +18,7 @@ from proliferate.auth.desktop.models import AuthorizeParams
 from proliferate.auth.desktop import service as desktop_service
 from proliferate.auth.identity import providers as identity_providers
 from proliferate.auth.identity.sessions import WEB_CSRF_COOKIE
+from proliferate.auth.identity.web_beta import WEB_BETA_EMAIL_NOT_ALLOWED_CODE
 from proliferate.auth.oauth import github_oauth_client, google_oauth_client
 from proliferate.auth.passwords import hash_password
 from proliferate.config import settings
@@ -279,6 +280,75 @@ class TestPasswordAuthFlow:
         )
         assert ai_magic.status_code == 403
         assert ai_magic.json()["detail"]["code"] == "github_link_required"
+
+    @pytest.mark.asyncio
+    async def test_web_password_login_rejects_non_beta_email(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+        await _create_password_user("not-beta@example.com", self.password)
+
+        response = await client.post(
+            "/auth/web/password/login",
+            json={"email": "not-beta@example.com", "password": self.password},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+        assert "proliferate_web_refresh" not in response.headers.get("set-cookie", "")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("email", "allowed_emails", "allowed_domains"),
+        [
+            ("exact-beta@example.com", " exact-beta@example.com ", ""),
+            ("domain-beta@team.example.com", "", " @team.example.com "),
+        ],
+    )
+    async def test_web_password_login_accepts_beta_email_or_domain(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        email: str,
+        allowed_emails: str,
+        allowed_domains: str,
+    ) -> None:
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "web_beta_allowed_emails", allowed_emails)
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", allowed_domains)
+        await _create_password_user(email, self.password)
+
+        response = await client.post(
+            "/auth/web/password/login",
+            json={"email": email, "password": self.password},
+        )
+
+        assert response.status_code == 200
+        assert "proliferate_web_refresh" in response.headers["set-cookie"]
+
+    @pytest.mark.asyncio
+    async def test_web_session_bootstrap_rechecks_beta_allowlist_for_existing_cookie(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "example.com")
+        await _create_password_user("existing-cookie@example.com", self.password)
+        response = await client.post(
+            "/auth/web/password/login",
+            json={"email": "existing-cookie@example.com", "password": self.password},
+        )
+        assert response.status_code == 200
+
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+        bootstrap = await client.post("/auth/web/session/bootstrap")
+
+        assert bootstrap.status_code == 403
+        assert bootstrap.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
 
     @pytest.mark.asyncio
     async def test_mobile_password_login_returns_refresh_token_for_ready_user(
@@ -630,6 +700,51 @@ class TestWebMobileSessionGuards:
 
         assert response.status_code == 403
         assert response.json()["detail"] == "User is inactive."
+
+    @pytest.mark.asyncio
+    async def test_web_beta_allowlist_applies_to_web_token_not_desktop_token(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user_id = await _create_user_via_manager("token-non-beta@example.com")
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+
+        web_verifier, web_challenge = _make_pkce_pair()
+        web_code = await _create_desktop_auth_code_for_user(
+            user_id=user_id,
+            state="web-beta-denied-state",
+            code_challenge=web_challenge,
+        )
+        web_response = await client.post(
+            "/auth/web/token",
+            json={
+                "code": web_code,
+                "codeVerifier": web_verifier,
+                "grantType": "authorization_code",
+            },
+        )
+
+        assert web_response.status_code == 403
+        assert web_response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+
+        desktop_verifier, desktop_challenge = _make_pkce_pair()
+        desktop_code = await _create_desktop_auth_code_for_user(
+            user_id=user_id,
+            state="desktop-beta-bypass-state",
+            code_challenge=desktop_challenge,
+        )
+        desktop_response = await client.post(
+            "/auth/desktop/token",
+            json={
+                "code": desktop_code,
+                "code_verifier": desktop_verifier,
+                "grant_type": "authorization_code",
+            },
+        )
+
+        assert desktop_response.status_code == 200
+        assert desktop_response.json()["user"]["email"] == "token-non-beta@example.com"
 
     @pytest.mark.asyncio
     async def test_mobile_refresh_rejects_inactive_user(self, client: AsyncClient) -> None:
@@ -985,6 +1100,7 @@ class TestWebMobileProductAuthFlow:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         verifier, challenge = _make_pkce_pair()
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
         self._enable_identity_github(monkeypatch, "desktop-shared-github@example.com")
         schedule_mock = Mock()
         monkeypatch.setattr(
@@ -1216,6 +1332,40 @@ class TestWebMobileProductAuthFlow:
             headers={"Authorization": f"Bearer {payload['accessToken']}"},
         )
         assert protected.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_web_github_login_redirects_to_beta_error_when_email_denied(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _, challenge = _make_pkce_pair()
+        monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+        self._enable_identity_github(monkeypatch, "not-beta-github@example.com")
+
+        started = await client.post(
+            "/auth/web/github/start",
+            json={
+                "purpose": "login",
+                "clientState": "web-beta-denied-state",
+                "codeChallenge": challenge,
+                "codeChallengeMethod": "S256",
+                "redirectUri": "http://localhost:5174/auth/callback",
+            },
+        )
+        assert started.status_code == 200
+        oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+        callback = await client.get(
+            "/auth/github/callback",
+            params={"code": "github-code", "state": oauth_state},
+            follow_redirects=False,
+        )
+
+        assert callback.status_code == 302
+        redirect = urlparse(callback.headers["location"])
+        assert redirect.path == "/auth/error"
+        assert parse_qs(redirect.query)["code"] == [WEB_BETA_EMAIL_NOT_ALLOWED_CODE]
 
     @pytest.mark.asyncio
     async def test_web_google_login_requires_github_then_links_github(

--- a/server/tests/integration/test_web_beta_auth.py
+++ b/server/tests/integration/test_web_beta_auth.py
@@ -118,8 +118,7 @@ def _enable_identity_github(monkeypatch: pytest.MonkeyPatch, email: str) -> None
         assert code_challenge_method is None
         assert state is not None
         return (
-            "https://github.com/login/oauth/authorize"
-            f"?state={state}&redirect_uri={redirect_uri}"
+            f"https://github.com/login/oauth/authorize?state={state}&redirect_uri={redirect_uri}"
         )
 
     async def fake_get_access_token(code: str, redirect_uri: str) -> dict[str, object]:

--- a/server/tests/integration/test_web_beta_auth.py
+++ b/server/tests/integration/test_web_beta_auth.py
@@ -1,0 +1,425 @@
+"""Integration tests for beta-gated web auth entry points."""
+
+import base64
+import hashlib
+from datetime import UTC, datetime
+from urllib.parse import parse_qs, urlparse
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from proliferate.auth.desktop.models import AuthorizeParams
+from proliferate.auth.desktop import service as desktop_service
+from proliferate.auth.identity import providers as identity_providers
+from proliferate.auth.identity.web_beta import WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+from proliferate.auth.oauth import github_oauth_client
+from proliferate.auth.passwords import hash_password
+from proliferate.config import settings
+from proliferate.db.models.auth import AuthIdentity, User
+from proliferate.integrations.github import GitHubUserProfile
+
+
+def _make_pkce_pair() -> tuple[str, str]:
+    verifier = "test-code-verifier-that-is-long-enough-for-pkce"
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+async def _create_user(email: str) -> str:
+    from proliferate.db import engine as engine_module
+
+    async with engine_module.async_session_factory() as session:
+        user = User(
+            email=email,
+            hashed_password="unused-oauth-only",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            display_name="Beta Tester",
+        )
+        session.add(user)
+        await session.commit()
+    return str(user.id)
+
+
+async def _create_password_user(email: str, password: str) -> str:
+    from proliferate.db import engine as engine_module
+
+    async with engine_module.async_session_factory() as session:
+        user = User(
+            email=email,
+            hashed_password=hash_password(password),
+            password_set_at=datetime.now(UTC),
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            display_name="Beta Password Tester",
+        )
+        session.add(user)
+        await session.commit()
+    return str(user.id)
+
+
+async def _link_github_identity(user_id: str, *, provider_email: str) -> None:
+    from proliferate.db import engine as engine_module
+
+    async with engine_module.async_session_factory() as session:
+        identity = AuthIdentity(
+            user_id=UUID(user_id),
+            provider="github",
+            provider_subject=f"github-account-{provider_email}",
+            email=provider_email,
+            email_verified=True,
+        )
+        session.add(identity)
+        await session.commit()
+
+
+async def _create_desktop_auth_code_for_user(
+    *,
+    user_id: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    from proliferate.db import engine as engine_module
+
+    async with engine_module.async_session_factory() as session:
+        auth_code = await desktop_service.create_desktop_auth_code(
+            session,
+            AuthorizeParams(
+                state=state,
+                code_challenge=code_challenge,
+                code_challenge_method="S256",
+                redirect_uri="proliferate://auth/callback",
+            ),
+            UUID(user_id),
+        )
+        await session.commit()
+        return auth_code.code
+
+
+def _enable_identity_github(monkeypatch: pytest.MonkeyPatch, email: str) -> None:
+    monkeypatch.setattr(settings, "github_oauth_client_id", "github-client-id")
+    monkeypatch.setattr(settings, "github_oauth_client_secret", "github-client-secret")
+
+    async def fake_get_authorization_url(
+        redirect_uri: str,
+        state: str | None = None,
+        scope: list[str] | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+        extras_params: dict[str, str] | None = None,
+    ) -> str:
+        assert redirect_uri.endswith("/auth/github/callback")
+        assert scope == ["repo", "user", "user:email"]
+        assert code_challenge is None
+        assert code_challenge_method is None
+        assert state is not None
+        return (
+            "https://github.com/login/oauth/authorize"
+            f"?state={state}&redirect_uri={redirect_uri}"
+        )
+
+    async def fake_get_access_token(code: str, redirect_uri: str) -> dict[str, object]:
+        assert code == "github-code"
+        assert "/auth/" in redirect_uri
+        return {"access_token": "github-access-token", "scope": "repo,user"}
+
+    async def fake_get_id_email(token: str) -> tuple[str, str]:
+        assert token == "github-access-token"
+        return (f"github-account-{email}", email)
+
+    async def fake_get_github_user_profile(token: str) -> GitHubUserProfile:
+        assert token == "github-access-token"
+        return GitHubUserProfile(
+            login=f"github-{email.split('@')[0]}",
+            avatar_url="https://avatars.githubusercontent.com/u/583231?v=4",
+            display_name="GitHub Tester",
+        )
+
+    monkeypatch.setattr(
+        github_oauth_client,
+        "get_authorization_url",
+        fake_get_authorization_url,
+    )
+    monkeypatch.setattr(github_oauth_client, "get_access_token", fake_get_access_token)
+    monkeypatch.setattr(github_oauth_client, "get_id_email", fake_get_id_email)
+    monkeypatch.setattr(
+        identity_providers,
+        "get_github_user_profile",
+        fake_get_github_user_profile,
+    )
+
+
+@pytest.mark.asyncio
+async def test_web_password_login_rejects_non_beta_email(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", True)
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    await _create_password_user("not-beta@example.com", "password1234")
+
+    response = await client.post(
+        "/auth/web/password/login",
+        json={"email": "not-beta@example.com", "password": "password1234"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+    assert "proliferate_web_refresh" not in response.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("email", "allowed_emails", "allowed_domains"),
+    [
+        ("exact-beta@example.com", " exact-beta@example.com ", ""),
+        ("domain-beta@team.example.com", "", " @team.example.com "),
+    ],
+)
+async def test_web_password_login_accepts_beta_email_or_domain(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    email: str,
+    allowed_emails: str,
+    allowed_domains: str,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", True)
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", allowed_emails)
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", allowed_domains)
+    await _create_password_user(email, "password1234")
+
+    response = await client.post(
+        "/auth/web/password/login",
+        json={"email": email, "password": "password1234"},
+    )
+
+    assert response.status_code == 200
+    assert "proliferate_web_refresh" in response.headers["set-cookie"]
+
+
+@pytest.mark.asyncio
+async def test_web_session_bootstrap_rechecks_beta_allowlist_for_existing_cookie(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", True)
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "example.com")
+    await _create_password_user("existing-cookie@example.com", "password1234")
+    response = await client.post(
+        "/auth/web/password/login",
+        json={"email": "existing-cookie@example.com", "password": "password1234"},
+    )
+    assert response.status_code == 200
+
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    bootstrap = await client.post("/auth/web/session/bootstrap")
+
+    assert bootstrap.status_code == 403
+    assert bootstrap.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+
+
+@pytest.mark.asyncio
+async def test_web_beta_allowlist_applies_to_web_token_not_desktop_token(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = await _create_user("token-non-beta@example.com")
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+
+    web_verifier, web_challenge = _make_pkce_pair()
+    web_code = await _create_desktop_auth_code_for_user(
+        user_id=user_id,
+        state="web-beta-denied-state",
+        code_challenge=web_challenge,
+    )
+    web_response = await client.post(
+        "/auth/web/token",
+        json={
+            "code": web_code,
+            "codeVerifier": web_verifier,
+            "grantType": "authorization_code",
+        },
+    )
+
+    assert web_response.status_code == 403
+    assert web_response.json()["detail"]["code"] == WEB_BETA_EMAIL_NOT_ALLOWED_CODE
+
+    desktop_verifier, desktop_challenge = _make_pkce_pair()
+    desktop_code = await _create_desktop_auth_code_for_user(
+        user_id=user_id,
+        state="desktop-beta-bypass-state",
+        code_challenge=desktop_challenge,
+    )
+    desktop_response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": desktop_code,
+            "code_verifier": desktop_verifier,
+            "grant_type": "authorization_code",
+        },
+    )
+
+    assert desktop_response.status_code == 200
+    assert desktop_response.json()["user"]["email"] == "token-non-beta@example.com"
+
+
+@pytest.mark.asyncio
+async def test_web_github_login_redirects_to_beta_error_when_email_denied(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, challenge = _make_pkce_pair()
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    _enable_identity_github(monkeypatch, "not-beta-github@example.com")
+
+    started = await client.post(
+        "/auth/web/github/start",
+        json={
+            "purpose": "login",
+            "clientState": "web-beta-denied-state",
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+            "redirectUri": "http://localhost:5174/auth/callback",
+        },
+    )
+    assert started.status_code == 200
+    oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+    callback = await client.get(
+        "/auth/github/callback",
+        params={"code": "github-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 302
+    redirect = urlparse(callback.headers["location"])
+    assert redirect.path == "/auth/error"
+    assert parse_qs(redirect.query)["code"] == [WEB_BETA_EMAIL_NOT_ALLOWED_CODE]
+
+
+@pytest.mark.asyncio
+async def test_web_github_login_uses_existing_account_email_for_beta_gate(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier, challenge = _make_pkce_pair()
+    user_id = await _create_user("linked-account@beta.example.com")
+    await _link_github_identity(user_id, provider_email="provider-email@example.com")
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    _enable_identity_github(monkeypatch, "provider-email@example.com")
+
+    started = await client.post(
+        "/auth/web/github/start",
+        json={
+            "purpose": "login",
+            "clientState": "web-linked-account-state",
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+            "redirectUri": "http://localhost:5174/auth/callback",
+        },
+    )
+    assert started.status_code == 200
+    oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+    callback = await client.get(
+        "/auth/github/callback",
+        params={"code": "github-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+    assert callback.status_code == 302
+    callback_query = parse_qs(urlparse(callback.headers["location"]).query)
+
+    token = await client.post(
+        "/auth/web/token",
+        json={
+            "code": callback_query["code"][0],
+            "codeVerifier": verifier,
+            "grantType": "authorization_code",
+        },
+    )
+
+    assert token.status_code == 200
+    assert token.json()["user"]["email"] == "linked-account@beta.example.com"
+
+
+@pytest.mark.asyncio
+async def test_web_github_login_rejects_denied_existing_account_email(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, challenge = _make_pkce_pair()
+    user_id = await _create_user("linked-account@example.com")
+    await _link_github_identity(user_id, provider_email="provider-email@beta.example.com")
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    _enable_identity_github(monkeypatch, "provider-email@beta.example.com")
+
+    started = await client.post(
+        "/auth/web/github/start",
+        json={
+            "purpose": "login",
+            "clientState": "web-linked-account-denied-state",
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+            "redirectUri": "http://localhost:5174/auth/callback",
+        },
+    )
+    assert started.status_code == 200
+    oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+    callback = await client.get(
+        "/auth/github/callback",
+        params={"code": "github-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 302
+    redirect = urlparse(callback.headers["location"])
+    assert redirect.path == "/auth/error"
+    assert parse_qs(redirect.query)["code"] == [WEB_BETA_EMAIL_NOT_ALLOWED_CODE]
+
+
+@pytest.mark.asyncio
+async def test_desktop_github_login_is_not_beta_gated(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, challenge = _make_pkce_pair()
+    monkeypatch.setattr(settings, "web_beta_allowed_emails", "")
+    monkeypatch.setattr(settings, "web_beta_allowed_domains", "beta.example.com")
+    _enable_identity_github(monkeypatch, "desktop-non-beta@example.com")
+
+    started = await client.post(
+        "/auth/desktop/github/start",
+        json={
+            "purpose": "login",
+            "clientState": "desktop-beta-bypass-state",
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+            "redirectUri": "proliferate://auth/callback",
+        },
+    )
+    assert started.status_code == 200
+    oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+    callback = await client.get(
+        "/auth/github/callback",
+        params={"code": "github-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 302
+    redirect = urlparse(callback.headers["location"])
+    assert f"{redirect.scheme}://{redirect.netloc}{redirect.path}" == (
+        "proliferate://auth/callback"
+    )
+    assert parse_qs(redirect.query)["state"] == ["desktop-beta-bypass-state"]

--- a/specs/codebase/features/product-auth.md
+++ b/specs/codebase/features/product-auth.md
@@ -27,6 +27,27 @@ GitHub remains the product-readiness provider. A password-only user is signed in
 but limited until the existing GitHub readiness check succeeds. Do not add a
 hidden bypass for normal users.
 
+## Web Beta Access
+
+Hosted web access is beta-gated. The server enforces the gate when issuing or
+refreshing a web session; Desktop and Mobile OAuth/token flows are not blocked
+by this web-only policy.
+
+Beta membership is configured with:
+
+- `WEB_BETA_ALLOWED_EMAILS` for exact email addresses
+- `WEB_BETA_ALLOWED_DOMAINS` for all emails at an exact domain
+
+Both lists are comma-separated and normalized case-insensitively. A user is
+eligible when their account email matches either an exact email or the domain
+after `@`. Existing users do not bypass the web beta gate. If the beta allowlist
+is not configured, the server does not apply the web beta restriction for local
+and unconfigured deployments.
+
+Denied web sessions return a stable `403` error code. OAuth callback denials
+redirect back to the web auth error route with the same stable code so the web
+app can render beta-specific copy and point the user to Desktop.
+
 ## Email/Password
 
 Email/password auth is a controlled sign-in method for accounts that already
@@ -85,11 +106,13 @@ CIDRs listed in `PASSWORD_AUTH_TRUSTED_PROXY_HOSTS`.
 
 Web signed out:
 
-- Shows email/password as a default sign-in option.
-- Keeps `Continue with GitHub` as the primary provider action because GitHub is
-  still required for full product readiness.
-- On password success, adopts the web session through `setSession`.
+- Shows `Continue with GitHub` as the primary provider action.
+- Shows `Continue with Google` as the secondary visible provider action.
+- Shows web beta copy before sign-in.
+- Does not currently show Apple or email/password sign-in on the web auth page.
 - If readiness is missing, the existing Connect GitHub gate is shown.
+- If web beta access is denied, shows a beta-only rejection state with Desktop
+  app handoff and alternate-account actions.
 
 Mobile signed out:
 

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -171,6 +171,18 @@
   description: Comma-separated proxy IPs or CIDRs allowed to supply x-forwarded-for for password login throttling
   tags: [self-hosted, production]
 
+- name: WEB_BETA_ALLOWED_EMAILS
+  secret: false
+  default: ""
+  description: Comma-separated exact email addresses allowed to create or refresh hosted web sessions
+  tags: [local-dev, self-hosted, production]
+
+- name: WEB_BETA_ALLOWED_DOMAINS
+  secret: false
+  default: ""
+  description: Comma-separated exact email domains allowed to create or refresh hosted web sessions
+  tags: [local-dev, self-hosted, production]
+
 - name: MOBILE_REDIRECT_URI
   secret: false
   default: "proliferate://auth/callback"


### PR DESCRIPTION
## Summary
- Gate hosted web session creation and refresh behind WEB_BETA_ALLOWED_EMAILS / WEB_BETA_ALLOWED_DOMAINS while leaving desktop and mobile auth flows available.
- Update web auth UI to show only GitHub and Google, with beta copy and a beta-denied No cloud account handoff state.
- Document the beta gate env vars and add focused server/UI tests.

## Verification
- DEBUG=true uv run --extra dev pytest -q tests/integration/test_auth_flow.py -k "web_beta or beta_allowlist or beta_error or desktop_github_login_uses_shared_identity_callback or web_password_login"
- DEBUG=true uv run --extra dev ruff check proliferate/auth/identity/web_beta.py proliferate/auth/identity/api.py proliferate/auth/identity/service.py proliferate/config.py tests/integration/test_auth_flow.py
- pnpm --filter @proliferate/product-ui test -- AuthPanels.test.tsx
- pnpm --filter @proliferate/web build
- cd apps/web && pnpm exec vitest run src/lib/domain/auth/web-auth-errors.test.ts

## Screenshots
Captured locally under artifacts/screenshots/ and left out of the commit.
