### PR TITLE
feat(desktop): refresh settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Move running sessions between your machine and the cloud. Works solo or across a
 
 <br />
 
-Proliferate is a desktop and web app for running coding agents in parallel, locally or in cloud sandboxes. Each agent runs through its own native harness.
+Proliferate is a desktop and web app for running coding agents in parallel, locally or in cloud sandboxes.
 
 - **Run any mix of agents in parallel**, each in its own isolated worktree or sandbox, with native tools, auth, and config intact
 - **Let your agents manage each other**, like having Codex hand design work to Claude Code
@@ -95,7 +95,7 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
 
 ## Open Source
 
-Proliferate is AGPL-3.0. The desktop and web apps are fully open today.
+Proliferate is AGPL-3.0. The desktop and web apps are open today.
 Self-hosting the full cloud control plane is in beta — see
 [Self-hosting](#self-hosting) below.
 
@@ -135,8 +135,8 @@ Requirements:
 - `uv`
 - Docker, for the local control plane database
 
-Use named dev profiles for full-stack development, especially when multiple
-worktrees run at the same time.
+Use named dev profiles for full-stack development when multiple worktrees run at
+the same time.
 
 ```bash
 make server-install
@@ -167,8 +167,7 @@ on the way.
   documents every required and optional setting
 
 Point the desktop app at your control plane by setting `apiBaseUrl` in
-`~/.proliferate/config.json`. Since this is beta, expect rough edges — please
-[open an issue](../../issues/new/choose) or ask in
+`~/.proliferate/config.json`. Expect rough edges — [open an issue](../../issues/new/choose) or ask in
 [Discord](https://discord.gg/wCEgUnEuF) if you hit problems, and see
 [SECURITY.md](./SECURITY.md) for reporting vulnerabilities.
 
@@ -177,8 +176,8 @@ Point the desktop app at your control plane by setting `apiBaseUrl` in
 ## Proliferate Cloud (Beta)
 
 > Proliferate Cloud is in beta and rolling out in waves - request access at
-> [proliferate.com](https://proliferate.com). Everything local above is fully
-> open and available today.
+> [proliferate.com](https://proliferate.com). Everything local above is open
+> today.
 
 - ☁️ **Cloud sandboxes** - isolated cloud environments that keep working after you close your laptop
 - 🔁 **Workspace mobility** - move a running workspace between your machine and the cloud, mid-task, with changes and history intact
@@ -193,16 +192,15 @@ Point the desktop app at your control plane by setting `apiBaseUrl` in
 - 🏗️ **Self-hosted Proliferate Cloud** - beta: run the full cloud control plane yourself ([docs](#self-hosting))
 
 Proliferate Cloud is open source (AGPL-3.0) and self-hostable today in beta; the
-self-host experience will be fully polished as Cloud moves toward GA.
+self-host experience will be polished as Cloud moves toward GA.
 
 ## Community
 
-Join our open source community on [Discord](https://discord.gg/wCEgUnEuF)!
+Join our community on [Discord](https://discord.gg/wCEgUnEuF)!
 
 ## Contributing
 
-Looking to contribute? Please check out the [Contribution Guide](./CONTRIBUTING.md)
-for more details.
+Contributing? See the [Contribution Guide](./CONTRIBUTING.md).
 
 ## License
 

--- a/apps/desktop/src/components/settings/panes/AppearancePane.tsx
+++ b/apps/desktop/src/components/settings/panes/AppearancePane.tsx
@@ -128,13 +128,12 @@ export function AppearancePane() {
             <SettingsMenu
               label={UI_FONT_SIZE_LABELS[uiFontSizeId]}
               className="w-40"
-              menuClassName="w-60"
+              menuClassName="w-48"
               groups={[{
                 id: "ui-font-size",
                 options: UI_FONT_SIZE_OPTIONS.map((option) => ({
                   id: option.id,
                   label: option.label,
-                  detail: option.detail,
                   selected: option.id === uiFontSizeId,
                   onSelect: () => setPreference("uiFontSizeId", option.id),
                 })),
@@ -149,13 +148,12 @@ export function AppearancePane() {
             <SettingsMenu
               label={READABLE_CODE_FONT_SIZE_LABELS[readableCodeFontSizeId]}
               className="w-40"
-              menuClassName="w-60"
+              menuClassName="w-48"
               groups={[{
                 id: "readable-code-font-size",
                 options: READABLE_CODE_FONT_SIZE_OPTIONS.map((option) => ({
                   id: option.id,
                   label: option.label,
-                  detail: option.detail,
                   selected: option.id === readableCodeFontSizeId,
                   onSelect: () => setPreference("readableCodeFontSizeId", option.id),
                 })),

--- a/apps/desktop/src/components/settings/panes/agent-defaults/AgentDefaultsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-defaults/AgentDefaultsSection.tsx
@@ -10,11 +10,11 @@ export function AgentDefaultsSection({
   children: ReactNode;
 }) {
   return (
-    <div className="space-y-2">
-      <div className="space-y-0.5">
-        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+    <div className="space-y-2.5">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold leading-6 tracking-normal text-foreground">{title}</h2>
         {description ? (
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="text-xs leading-5 text-muted-foreground">{description}</p>
         ) : null}
       </div>
       {children}

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -232,15 +232,15 @@ export function SettingsScreen({
         }}
       />
 
-      <div className="relative flex-1 bg-background">
+      <div className="relative min-w-0 flex-1 bg-background">
         <div className="absolute left-0 right-0 top-0 h-10" data-tauri-drag-region="true" />
-        <AutoHideScrollArea className="h-full" viewportClassName="px-8 pt-12">
-          <div className="flex justify-center pb-16">
+        <AutoHideScrollArea className="h-full" viewportClassName="px-10 pb-12 pt-14">
+          <div className="flex justify-center pb-8">
             <div
-              className={`w-full space-y-7 ${
+              className={`w-full space-y-6 ${
                 effectiveActiveSection === "billing" || effectiveActiveSection === "organization-integrations"
-                  ? "max-w-[72rem]"
-                  : "max-w-[46rem]"
+                  ? "max-w-[76rem]"
+                  : "max-w-[50rem]"
               }`}
             >
               <SettingsContentBoundary section={effectiveActiveSection}>

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -58,19 +58,19 @@ interface SettingsSidebarProps {
 }
 
 const SETTINGS_SIDEBAR_ROOT_CLASS =
-  "flex h-full w-[280px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar";
-const SETTINGS_NAV_CLASS = "flex-1 overflow-y-auto px-2.5 pb-4";
+  "flex h-full w-[280px] shrink-0 select-none flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground";
+const SETTINGS_NAV_CLASS = "flex-1 overflow-y-auto px-3 pb-5";
 const SETTINGS_GROUPS_CLASS = "flex flex-col";
-const SETTINGS_GROUP_CLASS = "flex flex-col gap-0.5";
-const SETTINGS_GROUP_SPACING_CLASS = "mt-4";
+const SETTINGS_GROUP_CLASS = "flex flex-col gap-1";
+const SETTINGS_GROUP_SPACING_CLASS = "mt-5";
 const SETTINGS_GROUP_HEADING_CLASS =
-  "px-2 pb-1 pt-1.5 text-[11px] font-medium leading-4 tracking-normal text-sidebar-muted-foreground";
+  "px-2.5 pb-1 pt-1.5 text-[11px] font-medium leading-4 tracking-normal text-sidebar-muted-foreground";
 const SETTINGS_ROW_INACTIVE_CLASS =
   "!text-sidebar-foreground hover:!text-sidebar-foreground";
 const SETTINGS_BACK_ROW_CLASS =
   "!text-sidebar-muted-foreground hover:!text-sidebar-foreground";
 const SETTINGS_ROW_ACTIVE_CLASS =
-  "!font-medium !text-sidebar-foreground";
+  "!font-semibold !text-sidebar-foreground";
 const SETTINGS_ROW_DISABLED_CLASS =
   "!text-sidebar-muted-foreground hover:!text-sidebar-muted-foreground";
 
@@ -168,7 +168,7 @@ function TbrPill() {
     <span
       aria-hidden="true"
       title="To be removed"
-      className="rounded-sm border border-sidebar-border px-1.5 py-0.5 text-[10px] font-semibold leading-none tracking-normal text-sidebar-muted-foreground"
+      className="rounded-md border border-sidebar-border bg-sidebar-accent px-1.5 py-0.5 text-[10px] font-semibold leading-none tracking-normal text-sidebar-muted-foreground"
     >
       tbr
     </span>
@@ -255,7 +255,7 @@ export function SettingsSidebar({
     <div className={SETTINGS_SIDEBAR_ROOT_CLASS}>
       <div className="h-10 pl-[82px]" data-tauri-drag-region="true" />
 
-      <div className="mb-4 px-2.5">
+      <div className="mb-5 px-3">
         <SidebarNavRow
           icon={<ArrowLeft className="size-4" />}
           label={SETTINGS_COPY.back}
@@ -315,7 +315,7 @@ export function SettingsSidebar({
         </div>
       </nav>
       {appVersion ? (
-        <div className="shrink-0 border-t border-sidebar-border px-3 py-2 text-xs text-sidebar-muted-foreground">
+        <div className="shrink-0 border-t border-sidebar-border px-4 py-3 text-[11px] leading-4 text-sidebar-muted-foreground">
           Proliferate v{appVersion}
         </div>
       ) : null}

--- a/apps/packages/product-ui/src/settings/SettingsCard.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsCard.tsx
@@ -8,7 +8,7 @@ export function SettingsCard({
   return (
     <div
       className={twMerge(
-        "flex flex-col overflow-hidden rounded-lg border border-border-light bg-foreground/5 text-card-foreground shadow-none",
+        "flex flex-col overflow-hidden rounded-lg border border-border-light bg-surface-elevated text-card-foreground shadow-none",
         className,
       )}
       {...props}

--- a/apps/packages/product-ui/src/settings/SettingsCard.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsCard.tsx
@@ -8,7 +8,7 @@ export function SettingsCard({
   return (
     <div
       className={twMerge(
-        "flex flex-col overflow-hidden rounded-lg border border-border-light bg-surface-elevated text-card-foreground shadow-subtle",
+        "flex flex-col overflow-hidden rounded-lg border border-border-light bg-foreground/5 text-card-foreground shadow-none",
         className,
       )}
       {...props}

--- a/apps/packages/product-ui/src/settings/SettingsCardRow.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsCardRow.tsx
@@ -17,18 +17,18 @@ export function SettingsCardRow({
   return (
     <div
       className={twMerge(
-        "flex min-h-[3.75rem] flex-col gap-3 border-b border-border-light px-4 py-3 last:border-b-0 sm:flex-row sm:items-center sm:justify-between",
+        "flex min-h-[4rem] flex-col gap-3 border-b border-border-light px-4 py-3.5 last:border-b-0 sm:flex-row sm:items-center sm:justify-between",
         className,
       )}
       {...props}
     >
-      <div className="min-w-0 space-y-1">
-        <div className="text-sm font-medium text-foreground">{label}</div>
+      <div className="min-w-0 space-y-1.5">
+        <div className="text-sm font-semibold leading-5 tracking-normal text-foreground">{label}</div>
         {description ? (
-          <div className="max-w-xl text-xs leading-4 text-muted-foreground">{description}</div>
+          <div className="max-w-2xl text-xs leading-5 text-muted-foreground">{description}</div>
         ) : null}
       </div>
-      {children ? <div className="shrink-0">{children}</div> : null}
+      {children ? <div className="flex shrink-0 items-center sm:justify-end">{children}</div> : null}
     </div>
   );
 }

--- a/apps/packages/product-ui/src/settings/SettingsPageHeader.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsPageHeader.tsx
@@ -12,14 +12,14 @@ export function SettingsPageHeader({
   action,
 }: SettingsPageHeaderProps) {
   return (
-    <header className="flex min-h-[3.75rem] flex-col gap-2 border-b border-border-light pb-3 sm:flex-row sm:items-start sm:justify-between">
-      <div className="min-w-0 space-y-1.5">
-        <h1 className="text-lg font-normal text-foreground">{title}</h1>
+    <header className="flex min-h-[4.25rem] flex-col gap-3 border-b border-border-light pb-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 space-y-2">
+        <h1 className="text-xl font-semibold leading-7 tracking-normal text-foreground">{title}</h1>
         {description ? (
-          <p className="max-w-2xl text-xs leading-5 text-muted-foreground">{description}</p>
+          <p className="max-w-3xl text-sm leading-5 text-muted-foreground">{description}</p>
         ) : null}
       </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
+      {action ? <div className="flex shrink-0 items-center">{action}</div> : null}
     </header>
   );
 }

--- a/apps/packages/product-ui/src/settings/SettingsShell.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsShell.tsx
@@ -45,28 +45,28 @@ export function SettingsShell({
         className,
       )}
     >
-      <aside className="flex h-full w-[210px] shrink-0 flex-col border-r border-border bg-sidebar px-2.5 py-3 text-sidebar-foreground">
-        <div className="mb-3 flex items-center gap-2 px-2">
-          <div className="text-sm font-medium text-sidebar-foreground">Settings</div>
+      <aside className="flex h-full w-[240px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar px-3 py-4 text-sidebar-foreground">
+        <div className="mb-4 flex items-center gap-2 px-2">
+          <div className="text-base font-semibold leading-6 tracking-normal text-sidebar-foreground">Settings</div>
         </div>
 
         {onNavigateHome ? (
-          <div className="mb-3">
+          <div className="mb-4">
             <SidebarRowSurface
               as="button"
               onPress={onNavigateHome}
-              className="h-7 px-2 text-[13px] leading-4"
+              className="h-8 px-2.5 text-sm leading-4"
             >
               <span className="truncate">Back to app</span>
             </SidebarRowSurface>
           </div>
         ) : null}
 
-        <nav className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+        <nav className="min-h-0 flex-1 space-y-5 overflow-y-auto pb-2">
           {groups.map((group, groupIndex) => (
             <div key={group.label ?? `settings-group-${groupIndex}`} className="space-y-1">
               {group.label ? (
-                <div className="px-2 pb-1 text-[10.5px] font-semibold uppercase text-sidebar-muted-foreground">
+                <div className="px-2.5 pb-1 text-[11px] font-medium leading-4 tracking-normal text-sidebar-muted-foreground">
                   {group.label}
                 </div>
               ) : null}
@@ -77,7 +77,7 @@ export function SettingsShell({
                   active={item.id === activeSectionId}
                   disabled={item.disabled}
                   onPress={() => onSelectSection(item.id)}
-                  className="h-9 gap-2 px-2.5 text-sm leading-5"
+                  className="h-8 gap-2 px-2.5 text-sm leading-5"
                 >
                   <span className="flex size-3.5 shrink-0 items-center justify-center text-sidebar-muted-foreground transition-colors group-data-[active=true]:text-sidebar-foreground">
                     {item.icon}
@@ -91,13 +91,13 @@ export function SettingsShell({
         </nav>
 
         {updateAction ? (
-          <div className="mt-3 border-t border-sidebar-border pt-3">{updateAction}</div>
+          <div className="mt-4 border-t border-sidebar-border pt-3">{updateAction}</div>
         ) : null}
       </aside>
 
-      <main className="min-w-0 flex-1">
+      <main className="min-w-0 flex-1 bg-background">
         <AutoHideScrollArea className="h-full">
-          <div className={twMerge("mx-auto w-full max-w-[680px] px-4 py-5", contentClassName)}>
+          <div className={twMerge("mx-auto w-full max-w-[760px] px-6 py-8", contentClassName)}>
             {children}
           </div>
         </AutoHideScrollArea>


### PR DESCRIPTION
## Summary

- Refresh shared settings shell, cards, rows, and page headers with stronger hierarchy, wider sidebars, and theme-token colors.
- Update the desktop settings screen/sidebar and agent defaults sections to match the new spacing and typography.
- Remove secondary description lines from the appearance font-size popovers.
- Tighten README product copy included on this branch.

## Verification

- `pnpm --filter @proliferate/product-ui test -- SettingsShell.test.tsx`
- `pnpm --filter @proliferate/product-ui typecheck`
- `pnpm --dir apps/desktop exec vitest run src/components/settings/sidebar/SettingsSidebar.test.tsx`
- `pnpm -C apps/desktop exec tsc --noEmit`
- `pnpm --dir apps/desktop test -- src/components/settings/sidebar/SettingsSidebar.test.tsx` failed because the full desktop suite ran and hit unrelated existing failures in AutomationRunLocationSelector, MarkdownRenderer favicon expectations, highlighting color expectations, keyboard conflict checks, workspace bootstrap empty-session, chrome layout, and user preferences appearance persistence.
