### PR TITLE
fix(desktop): polish settings and page spacing

### DIFF
--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -15,6 +15,17 @@ pub fn apply_macos_window_chrome(window: tauri::Window) -> Result<(), String> {
     }
 }
 
+#[tauri::command]
+pub fn set_webview_zoom(window: tauri::WebviewWindow, scale_factor: f64) -> Result<(), String> {
+    if !scale_factor.is_finite() {
+        return Err("webview zoom scale must be finite".to_string());
+    }
+
+    window
+        .set_zoom(scale_factor.clamp(0.8, 1.2))
+        .map_err(|error| error.to_string())
+}
+
 #[cfg(target_os = "macos")]
 fn apply_traffic_light_position(
     window: &tauri::Window,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -256,6 +256,7 @@ pub fn run() {
             support::stage_support_report_attachment,
             support::submit_support_report_job,
             window_chrome::apply_macos_window_chrome,
+            window_chrome::set_webview_zoom,
             process::command_exists,
             ssh_tunnel::install_ssh_target_runtime,
             ssh_tunnel::probe_ssh_target_connection,

--- a/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
@@ -223,7 +223,7 @@ export function AgentDefaultsPane() {
             >
               <SettingsMenu
                 label={primaryHarnessLabel}
-                className="w-56"
+                className="w-[240px]"
                 menuClassName="w-64"
                 groups={[{
                   id: "harnesses",

--- a/apps/desktop/src/components/settings/panes/AppearancePane.tsx
+++ b/apps/desktop/src/components/settings/panes/AppearancePane.tsx
@@ -6,14 +6,19 @@ import { SettingsPageHeader } from "@/components/settings/shared/SettingsPageHea
 import { Button } from "@proliferate/ui/primitives/Button";
 import { DiffViewer } from "@/components/content/ui/DiffViewer";
 import { FileDiffCard } from "@/components/content/ui/FileDiffCard";
-import { Monitor, Moon, Sun } from "@proliferate/ui/icons";
+import { Minus, Monitor, Moon, Plus, Sun } from "@proliferate/ui/icons";
 import { Switch } from "@proliferate/ui/primitives/Switch";
 import {
   READABLE_CODE_FONT_SIZE_LABELS,
   READABLE_CODE_FONT_SIZE_OPTIONS,
   UI_FONT_SIZE_LABELS,
   UI_FONT_SIZE_OPTIONS,
+  WINDOW_ZOOM_LABELS,
 } from "@/lib/domain/preferences/appearance-presentation";
+import {
+  stepWindowZoomId,
+  WINDOW_ZOOM_IDS,
+} from "@/lib/domain/preferences/appearance";
 import {
   COLOR_MODES,
   isModeLockedPreset,
@@ -43,6 +48,9 @@ const MODE_ICONS: Record<ColorMode, FC<{ className?: string }>> = {
   system: Monitor,
 };
 
+const SETTINGS_CONTROL_WIDTH_CLASS = "w-[240px]";
+const SETTINGS_CONTROL_MENU_CLASS = "w-[240px]";
+
 const PREVIEW_DIFF = `@@ -1,5 +1,5 @@
  export const environment = {
 -  branch: "develop",
@@ -56,9 +64,12 @@ export function AppearancePane() {
   const transparentChromeEnabled = useUserPreferencesStore((state) => state.transparentChromeEnabled);
   const uiFontSizeId = useUserPreferencesStore((state) => state.uiFontSizeId);
   const readableCodeFontSizeId = useUserPreferencesStore((state) => state.readableCodeFontSizeId);
+  const windowZoomId = useUserPreferencesStore((state) => state.windowZoomId);
   const setPreference = useUserPreferencesStore((state) => state.set);
   const modeLocked = isModeLockedPreset(preset);
   const displayedMode: ColorMode = modeLocked ? "dark" : mode;
+  const canDecreaseZoom = windowZoomId !== WINDOW_ZOOM_IDS[0];
+  const canIncreaseZoom = windowZoomId !== WINDOW_ZOOM_IDS[WINDOW_ZOOM_IDS.length - 1];
 
   return (
     <section className="space-y-5">
@@ -107,8 +118,8 @@ export function AppearancePane() {
           >
             <SettingsMenu
               label={PRESET_LABELS[preset]}
-              className="w-40"
-              menuClassName="w-48"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName={SETTINGS_CONTROL_MENU_CLASS}
               groups={[{
                 id: "theme-presets",
                 options: THEME_PRESETS.map((themePreset) => ({
@@ -122,13 +133,48 @@ export function AppearancePane() {
           </SettingsCardRow>
 
           <SettingsCardRow
+            label="Window zoom"
+            description="Scale the app window without changing saved font sizes"
+          >
+            <div
+              className={`grid h-8 ${SETTINGS_CONTROL_WIDTH_CLASS} grid-cols-[2rem_minmax(0,1fr)_2rem] items-center overflow-hidden rounded-lg border border-transparent bg-foreground/5 text-foreground`}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Zoom out"
+                disabled={!canDecreaseZoom}
+                className="h-8 w-8 rounded-none text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+                onClick={() => setPreference("windowZoomId", stepWindowZoomId(windowZoomId, -1))}
+              >
+                <Minus className="size-3.5" />
+              </Button>
+              <div className="flex h-8 min-w-16 items-center justify-center border-x border-border-light px-3 text-sm font-[430] leading-4 text-foreground">
+                {WINDOW_ZOOM_LABELS[windowZoomId]}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Zoom in"
+                disabled={!canIncreaseZoom}
+                className="h-8 w-8 rounded-none text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+                onClick={() => setPreference("windowZoomId", stepWindowZoomId(windowZoomId, 1))}
+              >
+                <Plus className="size-3.5" />
+              </Button>
+            </div>
+          </SettingsCardRow>
+
+          <SettingsCardRow
             label="UI font size"
             description="Scale app and chat text"
           >
             <SettingsMenu
               label={UI_FONT_SIZE_LABELS[uiFontSizeId]}
-              className="w-40"
-              menuClassName="w-48"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName={SETTINGS_CONTROL_MENU_CLASS}
               groups={[{
                 id: "ui-font-size",
                 options: UI_FONT_SIZE_OPTIONS.map((option) => ({
@@ -147,8 +193,8 @@ export function AppearancePane() {
           >
             <SettingsMenu
               label={READABLE_CODE_FONT_SIZE_LABELS[readableCodeFontSizeId]}
-              className="w-40"
-              menuClassName="w-48"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName={SETTINGS_CONTROL_MENU_CLASS}
               groups={[{
                 id: "readable-code-font-size",
                 options: READABLE_CODE_FONT_SIZE_OPTIONS.map((option) => ({
@@ -189,7 +235,7 @@ function AppearanceSection({
 }) {
   return (
     <div className="space-y-2">
-      <h2 className="text-sm font-medium text-foreground">{title}</h2>
+      <h2 className="text-base font-medium text-foreground">{title}</h2>
       {children}
     </div>
   );

--- a/apps/desktop/src/components/settings/panes/GeneralPane.tsx
+++ b/apps/desktop/src/components/settings/panes/GeneralPane.tsx
@@ -50,6 +50,7 @@ const TURN_END_SOUND_OPTIONS: { id: TurnEndSoundId; label: string }[] = [
   { id: "ding", label: "Ding" },
   { id: "gong", label: "Gong" },
 ];
+const SETTINGS_CONTROL_WIDTH_CLASS = "w-[240px]";
 
 export function GeneralPane() {
   const navigate = useNavigate();
@@ -102,8 +103,8 @@ export function GeneralPane() {
             <SettingsMenu
               label={currentTargetLabel}
               leading={<OpenTargetIcon iconId={currentTarget?.iconId} className="size-4 rounded-sm" />}
-              className="w-44"
-              menuClassName="w-52"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName="w-60"
               groups={[{
                 id: "targets",
                 options: targets.map((target) => ({
@@ -123,8 +124,8 @@ export function GeneralPane() {
           >
             <SettingsMenu
               label={currentBranchPrefixLabel}
-              className="w-44"
-              menuClassName="w-48"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName="w-60"
               groups={[{
                 id: "branch-prefix",
                 options: BRANCH_PREFIX_OPTIONS.map((option) => ({
@@ -143,8 +144,8 @@ export function GeneralPane() {
           >
             <SettingsMenu
               label={currentNewWorkspaceModeLabel}
-              className="w-44"
-              menuClassName="w-44"
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName="w-60"
               groups={[{
                 id: "new-workspace-mode",
                 options: NEW_WORKSPACE_MODE_OPTIONS.map((option) => ({
@@ -189,8 +190,8 @@ export function GeneralPane() {
                   </Button>
                   <SettingsMenu
                     label={SOUND_LABELS[preferences.turnEndSoundId]}
-                    className="w-32"
-                    menuClassName="w-48"
+                    className={SETTINGS_CONTROL_WIDTH_CLASS}
+                    menuClassName="w-60"
                     groups={[{
                       id: "turn-end-sounds",
                       options: TURN_END_SOUND_OPTIONS
@@ -264,7 +265,7 @@ function GeneralSection({
   return (
     <div className="space-y-2">
       <div className="space-y-0.5">
-        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+        <h2 className="text-base font-medium text-foreground">{title}</h2>
         {description ? (
           <p className="text-sm text-muted-foreground">{description}</p>
         ) : null}

--- a/apps/desktop/src/components/settings/panes/agent-authentication/AgentAuthAdminTag.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/AgentAuthAdminTag.tsx
@@ -1,6 +1,6 @@
 export function AgentAuthAdminTag() {
   return (
-    <span className="ml-1 inline-flex rounded border border-border-light bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+    <span className="ml-1 inline-flex rounded border border-border-light bg-foreground/5 px-1.5 py-0.5 text-sm font-medium text-muted-foreground">
       Admin
     </span>
   );

--- a/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodRows.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodRows.tsx
@@ -49,14 +49,14 @@ export function ManagedFreeCreditsMethodRow({
         <div className="truncate text-sm font-medium text-foreground">
           Proliferate Default Free credits
         </div>
-        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+        <div className="mt-0.5 truncate text-sm text-muted-foreground">
           Managed gateway credit
         </div>
       </div>
-      <div className="min-w-0 text-xs text-muted-foreground">
+      <div className="min-w-0 text-sm text-muted-foreground">
         {harnessLabel}
       </div>
-      <div className="min-w-0 truncate text-xs text-muted-foreground">
+      <div className="min-w-0 truncate text-sm text-muted-foreground">
         {agentAuthManagedCreditsCapabilityLabel(capabilities, "personal")}
       </div>
       <div className="flex items-center justify-end gap-2">
@@ -98,10 +98,10 @@ export function LocalMethodRow({
   return (
     <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1.3fr)_11rem] items-center gap-3 border-b border-border-light px-4 py-3">
       <div className="min-w-0 text-sm font-medium text-foreground">Local credential</div>
-      <div className="min-w-0 text-xs text-muted-foreground">
+      <div className="min-w-0 text-sm text-muted-foreground">
         {agentAuthSlotLabel(slot)}
       </div>
-      <div className="min-w-0 truncate text-xs text-muted-foreground">
+      <div className="min-w-0 truncate text-sm text-muted-foreground">
         {provider
           ? detected
             ? `${localSource.authMode} credential detected`
@@ -162,14 +162,14 @@ export function CredentialMethodRow({
         <div className="truncate text-sm font-medium text-foreground">
           {credential.displayName}
         </div>
-        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+        <div className="mt-0.5 truncate text-sm text-muted-foreground">
           {agentAuthCredentialKindLabel(credential)}
         </div>
       </div>
-      <div className="min-w-0 text-xs text-muted-foreground">
+      <div className="min-w-0 text-sm text-muted-foreground">
         {agentAuthCredentialProviderLabel(credential.credentialProviderId)}
       </div>
-      <div className="min-w-0 truncate text-xs text-muted-foreground">
+      <div className="min-w-0 truncate text-sm text-muted-foreground">
         {methodSourceLabel(credential)}
       </div>
       <div className="flex flex-wrap items-center justify-end gap-2">

--- a/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodsSection.tsx
@@ -56,7 +56,7 @@ export function AuthenticationMethodsSection({
     <section className="space-y-3">
       <div className="space-y-1">
         <h2 className="text-sm font-medium text-foreground">Authentication methods</h2>
-        <p className="max-w-2xl text-xs leading-4 text-muted-foreground">
+        <p className="max-w-2xl text-sm leading-5 text-muted-foreground">
           Detected local credentials, synced credentials, cloud API keys, BYOK,
           and managed credits available to your personal sandboxes.
         </p>
@@ -91,7 +91,7 @@ export function AuthenticationMethodsSection({
           onEnsureFreeCredits={onEnsureFreeCredits}
         />
         {userManagedCredentials.length === 0 ? (
-          <div className="border-t border-border-light px-4 py-3 text-xs text-muted-foreground">
+          <div className="border-t border-border-light px-4 py-3 text-sm text-muted-foreground">
             No synced or BYOK credentials have been saved yet.
           </div>
         ) : userManagedCredentials.map((credential) => (
@@ -116,7 +116,7 @@ export function AuthenticationMethodsSection({
           </span>
           <span className="min-w-0 flex-1">
             <span className="block font-medium text-foreground">Add credential</span>
-            <span className="block text-xs leading-4 text-muted-foreground">
+            <span className="block text-sm leading-5 text-muted-foreground">
               Add Anthropic, OpenAI, Gemini, or Bedrock credentials for a harness.
             </span>
           </span>

--- a/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/AuthenticationMethodsSection.tsx
@@ -62,7 +62,7 @@ export function AuthenticationMethodsSection({
         </p>
       </div>
       <SettingsCard>
-        <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1.3fr)_11rem] gap-3 border-b border-border-light bg-foreground/5 px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1.3fr)_11rem] gap-3 border-b border-border-light bg-foreground/5 px-4 py-2 text-base font-semibold uppercase tracking-wide text-muted-foreground">
           <span>Method</span>
           <span>Provider</span>
           <span>Source</span>

--- a/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthCredentialForm.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthCredentialForm.tsx
@@ -204,7 +204,7 @@ export function CloudAgentAuthCredentialForm({
           )}
 
           <div className="flex items-center justify-between gap-3">
-            <p className="min-w-0 text-xs text-muted-foreground">
+            <p className="min-w-0 text-sm text-muted-foreground">
               {feedback ?? "Secrets stay in Cloud and are never injected into hosted sandboxes."}
             </p>
             <Button
@@ -219,7 +219,7 @@ export function CloudAgentAuthCredentialForm({
           </div>
         </div>
       ) : (
-        <div className="border-t border-border-light px-4 py-3 text-xs leading-4 text-muted-foreground">
+        <div className="border-t border-border-light px-4 py-3 text-sm leading-5 text-muted-foreground">
           API key, OpenAI-compatible, and Bedrock credential forms appear here when
           this deployment enables provider BYOK support.
         </div>

--- a/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthLibrary.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/CloudAgentAuthLibrary.tsx
@@ -23,7 +23,7 @@ export function CloudAgentAuthLibrary({ initialAgentKind = null }: CloudAgentAut
           <h2 className="text-sm font-medium text-foreground">
             Personal sandbox authentication
           </h2>
-          <p className="max-w-2xl text-xs leading-4 text-muted-foreground">
+          <p className="max-w-2xl text-sm leading-5 text-muted-foreground">
             Choose what your local sandbox and personal cloud sandboxes use for
             each harness.
           </p>
@@ -31,7 +31,7 @@ export function CloudAgentAuthLibrary({ initialAgentKind = null }: CloudAgentAut
       </section>
 
       {(library.feedback || library.localSourceError || credentialLoadError) && (
-        <p className="text-xs leading-4 text-muted-foreground">
+        <p className="text-sm leading-5 text-muted-foreground">
           {library.feedback
             ?? library.localSourceError
             ?? "Could not load personal cloud credentials. Try again in a moment."}

--- a/apps/desktop/src/components/settings/panes/agent-authentication/PersonalAuthInUseSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/PersonalAuthInUseSection.tsx
@@ -79,7 +79,7 @@ export function PersonalAuthInUseSection({
       <div className="flex items-end justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-sm font-medium text-foreground">In use</h2>
-          <p className="max-w-2xl text-xs leading-4 text-muted-foreground">
+          <p className="max-w-2xl text-sm leading-5 text-muted-foreground">
             Pick the credential each harness uses in local and personal cloud sandboxes.
           </p>
         </div>
@@ -150,7 +150,7 @@ function HarnessIdentity({ slot }: { slot: AgentAuthSlotDefinition }) {
         <span className="block text-sm font-medium text-foreground">
           {agentAuthSlotLabel(slot)}
         </span>
-        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+        <span className="mt-0.5 block truncate text-sm text-muted-foreground">
           {agentAuthHarnessDescription(slot.agentKind)}
         </span>
       </span>

--- a/apps/desktop/src/components/settings/panes/agent-authentication/PersonalAuthInUseSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-authentication/PersonalAuthInUseSection.tsx
@@ -96,7 +96,7 @@ export function PersonalAuthInUseSection({
       </div>
 
       <SettingsCard>
-        <div className="grid grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_minmax(0,1.1fr)] gap-3 border-b border-border-light bg-foreground/5 px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="grid grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_minmax(0,1.1fr)] gap-3 border-b border-border-light bg-foreground/5 px-4 py-2 text-base font-semibold uppercase tracking-wide text-muted-foreground">
           <span>Harness</span>
           <span>Local sandbox</span>
           <span>Personal cloud</span>

--- a/apps/desktop/src/components/settings/panes/agent-defaults/AgentDefaultsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-defaults/AgentDefaultsSection.tsx
@@ -14,7 +14,7 @@ export function AgentDefaultsSection({
       <div className="space-y-1">
         <h2 className="text-base font-semibold leading-6 tracking-normal text-foreground">{title}</h2>
         {description ? (
-          <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+          <p className="text-sm leading-5 text-muted-foreground">{description}</p>
         ) : null}
       </div>
       {children}

--- a/apps/desktop/src/components/settings/panes/compute/AddSshTargetDialog.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/AddSshTargetDialog.tsx
@@ -129,7 +129,7 @@ export function AddSshTargetDialog({
                 {activeOrganization ? `${activeOrganization.name} organization cloud` : "Team cloud"}
               </option>
             </Select>
-            <p className="mt-1 text-xs leading-4 text-muted-foreground">
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">
               Team targets can be used by organization workflows, Slack, and claimed organization workspaces.
             </p>
           </div>
@@ -263,7 +263,7 @@ export function AddSshTargetDialog({
         {phaseState && (
           <div className="rounded-md border border-border/60 bg-foreground/5 p-3 text-sm">
             <div className="font-medium text-foreground">{phaseState.label}</div>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">
               {phaseHelp(phaseState.phase)}
             </p>
           </div>

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetAgentAuthCard.tsx
@@ -195,8 +195,8 @@ export function ComputeTargetAgentAuthCard({ target }: ComputeTargetAgentAuthCar
     <div className="space-y-3 border-t border-border/40 pt-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 space-y-1">
-          <h4 className="text-xs font-medium text-foreground">Agent auth</h4>
-          <p className="text-xs text-muted-foreground">
+          <h4 className="text-sm font-medium text-foreground">Agent auth</h4>
+          <p className="text-sm text-muted-foreground">
             Select launch credentials for agent harnesses on this target.
           </p>
         </div>
@@ -209,7 +209,7 @@ export function ComputeTargetAgentAuthCard({ target }: ComputeTargetAgentAuthCar
 
       {!profile ? (
         <div className="flex items-center justify-between gap-3 rounded-md border border-border/50 p-3">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             {feedback ?? (sharedTarget && !canManageAgentAuth
               ? "Shared target auth can only be configured by an organization admin."
               : "Initialize this target's sandbox profile before selecting auth.")}
@@ -262,7 +262,7 @@ export function ComputeTargetAgentAuthCard({ target }: ComputeTargetAgentAuthCar
               />
             );
           })}
-          {feedback && <p className="px-3 py-2 text-xs text-muted-foreground">{feedback}</p>}
+          {feedback && <p className="px-3 py-2 text-sm text-muted-foreground">{feedback}</p>}
         </div>
       )}
     </div>

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetAppearanceSection.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetAppearanceSection.tsx
@@ -30,7 +30,7 @@ export function ComputeTargetAppearanceSection({
     <section className="space-y-3">
       <div>
         <div className="text-sm font-medium text-foreground">Appearance</div>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           {COMPUTE_COPY.appearanceHelp}
         </p>
       </div>

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetDetails.tsx
@@ -285,12 +285,12 @@ export function ComputeTargetDetails({
         />
 
         {reconnect.phaseState && (
-          <div className="rounded-md border border-border/60 bg-foreground/5 p-3 text-xs text-muted-foreground">
+          <div className="rounded-md border border-border/60 bg-foreground/5 p-3 text-sm text-muted-foreground">
             <span className="font-medium text-foreground">{reconnect.phaseState.label}</span>
           </div>
         )}
 
-        {feedback && <p className="text-xs text-muted-foreground">{feedback}</p>}
+        {feedback && <p className="text-sm text-muted-foreground">{feedback}</p>}
 
         {reconnect.phaseState?.phase === "failed" && reconnect.enrollment && !reconnect.isCreating && (
           <EnrollmentCommandBlock command={reconnect.enrollment.installCommand} />

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetDetailsHeader.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetDetailsHeader.tsx
@@ -47,7 +47,7 @@ export function ComputeTargetDetailsHeader({
             <h3 className="truncate text-sm font-medium text-foreground">
               {appearance.displayName}
             </h3>
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            <p className="mt-0.5 truncate text-sm text-muted-foreground">
               {computeTargetKindLabel(target.kind)}
               {" · "}
               {computeTargetStatusLabel(target.status).toLowerCase()}

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetDirectSshSection.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetDirectSshSection.tsx
@@ -36,7 +36,7 @@ export function ComputeTargetDirectSshSection({
     <section className="space-y-3">
       <div>
         <div className="text-sm font-medium text-foreground">Direct SSH access</div>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           {targetKind === "ssh"
             ? COMPUTE_COPY.directSshHelp
             : COMPUTE_COPY.directSshUnavailable}
@@ -110,7 +110,7 @@ export function ComputeTargetDirectSshSection({
           </div>
         </div>
       ) : (
-        <div className="rounded-md border border-border/50 bg-foreground/5 p-3 text-xs text-muted-foreground">
+        <div className="rounded-md border border-border/50 bg-foreground/5 p-3 text-sm text-muted-foreground">
           {COMPUTE_COPY.directSshNotSshTarget}
         </div>
       )}

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
@@ -51,7 +51,7 @@ export function ComputeTargetList({
                 <Badge tone="neutral">{targetCountLabel(targets.length)}</Badge>
               ) : null}
             </div>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">
               Select an SSH target to inspect setup, readiness, local access, and auth.
             </p>
           </div>
@@ -113,7 +113,7 @@ function TargetGroup({
         <h4 className="text-base font-medium uppercase tracking-normal text-muted-foreground/90">
           {group.label}
         </h4>
-        <p className="text-xs leading-5 text-muted-foreground">{group.description}</p>
+        <p className="text-sm leading-5 text-muted-foreground">{group.description}</p>
       </div>
       <div className="space-y-2">
         {group.targets.map((target) => (

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetList.tsx
@@ -110,7 +110,7 @@ function TargetGroup({
   return (
     <div className="space-y-2">
       <div className="space-y-0.5 px-1">
-        <h4 className="text-[11px] font-medium uppercase tracking-normal text-muted-foreground/90">
+        <h4 className="text-base font-medium uppercase tracking-normal text-muted-foreground/90">
           {group.label}
         </h4>
         <p className="text-xs leading-5 text-muted-foreground">{group.description}</p>
@@ -174,7 +174,7 @@ function TargetRow({
           <span aria-hidden="true">·</span>
           <span>{computeTargetOwnerLabel(target.ownerScope)}</span>
         </span>
-        <span className="mt-1 block truncate font-mono text-[11px] text-muted-foreground">
+        <span className="mt-1 block truncate font-mono text-base text-muted-foreground">
           {target.defaultWorkspaceRoot ?? "Workspace root not set"}
         </span>
       </span>

--- a/apps/desktop/src/components/settings/panes/compute/ComputeTargetReadiness.tsx
+++ b/apps/desktop/src/components/settings/panes/compute/ComputeTargetReadiness.tsx
@@ -41,7 +41,7 @@ export function ComputeTargetReadiness({
     <div className="space-y-2">
       <div>
         <div className="text-sm font-medium text-foreground">Readiness</div>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Tooling and target state required for cloud-dispatched work.
         </p>
       </div>
@@ -52,7 +52,7 @@ export function ComputeTargetReadiness({
             <div key={item.key} className="flex items-center justify-between gap-3 p-3">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-foreground">{item.label}</div>
-                <div className="mt-0.5 text-xs text-muted-foreground">{item.detail}</div>
+                <div className="mt-0.5 text-sm text-muted-foreground">{item.detail}</div>
               </div>
               <Badge tone={READINESS_TONE[item.status]}>{badgeLabel}</Badge>
             </div>

--- a/apps/desktop/src/components/settings/panes/environments/WorktreeStorageSection.tsx
+++ b/apps/desktop/src/components/settings/panes/environments/WorktreeStorageSection.tsx
@@ -1,36 +1,19 @@
-import { useState } from "react";
-import type { WorktreeInventoryRow } from "@anyharness/sdk";
-import { Badge } from "@proliferate/ui/primitives/Badge";
+import { useState, type KeyboardEvent } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
-import { RefreshCw, Trash, Tree } from "@proliferate/ui/icons";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { Label } from "@proliferate/ui/primitives/Label";
-import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import { SettingsCardRow } from "@/components/settings/shared/SettingsCardRow";
 import {
-  EnvironmentField,
-  EnvironmentPanel,
-  EnvironmentPanelRow,
-  EnvironmentSection,
-} from "@proliferate/ui/layout/EnvironmentLayout";
+  RuntimePressureDetailsDialog,
+  RuntimePressureRing,
+} from "@/components/workspace/chat/input/RuntimePressureIndicator";
 import { useWorktreeCleanupPolicy } from "@/hooks/workspaces/facade/use-worktree-cleanup-policy";
 import {
-  useWorktreeSettingsTargets,
-  type WorktreeSettingsTargetState,
-} from "@/hooks/workspaces/facade/use-worktree-settings-targets";
-import {
-  worktreeRetentionRunMessage,
-  worktreeSettingsActionFailureMessage,
-} from "@/lib/domain/workspaces/sidebar/worktree-settings-actions";
-import {
-  formatWorktreeStorage,
-  formatWorktreeStorageDetail,
-  worktreeGitStatusView,
-  worktreeRowLabel,
-} from "@/lib/domain/workspaces/worktrees/worktree-inventory-presentation";
+  type RuntimePressureTargetState,
+  useRuntimePressureControlStateFromSettings,
+} from "@/hooks/workspaces/facade/use-runtime-pressure-control-state";
+import { useWorktreeSettingsTargets } from "@/hooks/workspaces/facade/use-worktree-settings-targets";
 import { useToastStore } from "@/stores/toast/toast-store";
-
-const EMPTY_ROWS: WorktreeInventoryRow[] = [];
 
 export function WorktreeStorageSection() {
   const settings = useWorktreeSettingsTargets();
@@ -38,25 +21,16 @@ export function WorktreeStorageSection() {
     settings.targets,
     settings.syncPolicyToTarget,
   );
+  const pressure = useRuntimePressureControlStateFromSettings(settings);
   const showToast = useToastStore((state) => state.show);
-  const [confirmDelete, setConfirmDelete] = useState<{
-    target: WorktreeSettingsTargetState["target"];
-    workspaceId: string;
-    label: string;
-  } | null>(null);
+  const [selectedTargetKey, setSelectedTargetKey] = useState<string | null>(null);
+  const selectedTarget = selectedTargetKey
+    ? pressure.targets.find((targetState) => targetState.target.key === selectedTargetKey) ?? null
+    : null;
 
-  const runAction = <TResult,>(
-    operation: () => Promise<TResult>,
-    success: string | ((result: TResult) => string),
-  ) => {
-    void operation().then((result) => {
-      const failureMessage = worktreeSettingsActionFailureMessage(result);
-      if (failureMessage) {
-        showToast(failureMessage);
-        return;
-      }
-      const successMessage = typeof success === "function" ? success(result) : success;
-      showToast(successMessage);
+  const applyPolicy = () => {
+    void cleanupPolicy.apply().then(() => {
+      showToast("Worktree preference updated.");
     }).catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
       showToast(message);
@@ -65,84 +39,54 @@ export function WorktreeStorageSection() {
 
   return (
     <>
-      <AutomaticCleanupSection
-        draftValue={cleanupPolicy.draftValue}
-        onDraftValueChange={cleanupPolicy.setDraftValue}
-        canApply={cleanupPolicy.canApply && !cleanupPolicy.isApplying}
-        applyDisabledReason={cleanupPolicy.applyDisabledReason}
-        statusMessage={cleanupPolicy.statusMessage}
-        onApply={() => runAction(
-          cleanupPolicy.apply,
-          "Pruning preference updated.",
-        )}
-      />
+      <section>
+        <SettingsCard className="w-full">
+          <WorktreePolicyRow
+            draftValue={cleanupPolicy.draftValue}
+            currentValue={cleanupPolicy.value}
+            onDraftValueChange={cleanupPolicy.setDraftValue}
+            canApply={cleanupPolicy.canApply && !cleanupPolicy.isApplying}
+            applyDisabledReason={cleanupPolicy.applyDisabledReason}
+            statusMessage={cleanupPolicy.statusMessage}
+            onApply={applyPolicy}
+          />
+          {pressure.isDiscovering && pressure.targets.length === 0 ? (
+            <SettingsCardRow
+              label="Runtime status"
+              description="Looking for runtimes..."
+            />
+          ) : pressure.targets.length === 0 ? (
+            <SettingsCardRow
+              label="Runtime status"
+              description="No runtime roots found."
+            />
+          ) : (
+            pressure.targets.map((targetState) => (
+              <WorktreeRuntimeStatusRow
+                key={targetState.target.key}
+                targetState={targetState}
+                onOpenDetails={() => setSelectedTargetKey(targetState.target.key)}
+              />
+            ))
+          )}
+        </SettingsCard>
+      </section>
 
-      {settings.targets.length === 0 ? (
-        <EnvironmentSection title="Current worktrees">
-          <EnvironmentPanel>
-            <EnvironmentPanelRow>
-              <p className="text-sm text-muted-foreground">No runtime roots found.</p>
-            </EnvironmentPanelRow>
-          </EnvironmentPanel>
-        </EnvironmentSection>
-      ) : settings.targets.map((targetState) => (
-        <RuntimeWorktreesSection
-          key={targetState.target.key}
-          targetState={targetState}
-          onRunCleanup={() => runAction(
-            () => settings.runRetention(targetState.target, cleanupPolicy.value),
-            worktreeRetentionRunMessage,
-          )}
-          onPruneOrphan={(path) => runAction(
-            () => settings.pruneOrphan(targetState.target, { path }),
-            "Worktree checkout removed.",
-          )}
-          onPruneWorkspace={(workspaceId) => runAction(
-            () => settings.pruneWorkspaceCheckout(targetState.target, workspaceId),
-            "Workspace checkout removed.",
-          )}
-          onPurgeWorkspace={(workspaceId) => {
-            const row = (targetState.inventory?.rows ?? EMPTY_ROWS).find((candidate) => (
-              candidate.associatedWorkspaces.some((workspace) => workspace.id === workspaceId)
-            ));
-            setConfirmDelete({
-              target: targetState.target,
-              workspaceId,
-              label: row ? worktreeRowLabel(row) : "this workspace",
-            });
-          }}
-          onRetryPurge={(workspaceId) => runAction(
-            () => settings.retryPurge(targetState.target, workspaceId),
-            "Purge retry finished.",
-          )}
+      {selectedTarget ? (
+        <RuntimePressureDetailsDialog
+          open
+          targetState={selectedTarget}
+          actions={pressure.actions}
+          onClose={() => setSelectedTargetKey(null)}
         />
-      ))}
-
-      <ConfirmationDialog
-        open={confirmDelete !== null}
-        title={`Delete runtime history for ${confirmDelete?.label ?? "this workspace"}?`}
-        description="This removes the AnyHarness runtime workspace record, chats, raw events, normalized events, checkout, and local agent artifacts from the owning runtime. Uncommitted changes in the checkout will be lost. Git commits, branches, pull requests, and Cloud product records are preserved."
-        confirmLabel="Delete"
-        confirmVariant="destructive"
-        onClose={() => setConfirmDelete(null)}
-        onConfirm={() => {
-          const pending = confirmDelete;
-          if (!pending) {
-            return;
-          }
-          setConfirmDelete(null);
-          runAction(
-            () => settings.purgeWorkspace(pending.target, pending.workspaceId),
-            "Runtime workspace history deleted.",
-          );
-        }}
-      />
+      ) : null}
     </>
   );
 }
 
-function AutomaticCleanupSection({
+function WorktreePolicyRow({
   draftValue,
+  currentValue,
   onDraftValueChange,
   canApply,
   applyDisabledReason,
@@ -150,236 +94,100 @@ function AutomaticCleanupSection({
   onApply,
 }: {
   draftValue: string;
+  currentValue: number;
   onDraftValueChange: (value: string) => void;
   canApply: boolean;
   applyDisabledReason: string | null;
   statusMessage: string | null;
   onApply: () => void;
 }) {
+  const helperText = applyDisabledReason ?? statusMessage;
+  const parsedDraft = Number.parseInt(draftValue, 10);
+  const commitIfChanged = () => {
+    if (canApply && parsedDraft !== currentValue) {
+      onApply();
+    }
+  };
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.currentTarget.blur();
+    }
+  };
+
   return (
-    <EnvironmentSection
-      title="Pruning"
-      description="Set the ideal worktree count used by the composer pressure indicator. Cleanup only runs when you explicitly ask for it."
+    <SettingsCardRow
+      label="Ideal worktrees"
+      description="Per-repo target for managed worktrees. Composer pressure warns above this count; cleanup skips dirty checkouts."
     >
-      <EnvironmentPanel>
-        <EnvironmentPanelRow>
-          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <EnvironmentField
-              label="Ideal materialized managed worktrees per repo"
-              description="When a repo exceeds this count, the composer pressure circle moves toward warning or red. Manual cleanup retires the oldest clean managed checkouts first; workspace history stays available unless you explicitly delete the workspace."
-            >
-              <div className="w-full max-w-64 space-y-1.5">
-                <Label htmlFor="worktree-policy-global">Ideal worktrees</Label>
-                <Input
-                  id="worktree-policy-global"
-                  type="number"
-                  min={10}
-                  max={100}
-                  value={draftValue}
-                  onChange={(event) => onDraftValueChange(event.target.value)}
-                />
-                <p className="text-xs leading-4 text-muted-foreground">
-                  Default is 20; minimum is 10. This does not prune automatically.
-                  Commits, branches, and pull requests are preserved by Git; dirty
-                  worktrees are skipped.
-                </p>
-                {statusMessage ? (
-                  <p className="text-xs leading-4 text-muted-foreground">{statusMessage}</p>
-                ) : null}
-                {applyDisabledReason ? (
-                  <p className="text-xs leading-4 text-muted-foreground">
-                    {applyDisabledReason}
-                  </p>
-                ) : null}
-              </div>
-            </EnvironmentField>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={!canApply}
-              onClick={onApply}
-            >
-              Apply
-            </Button>
-          </div>
-        </EnvironmentPanelRow>
-      </EnvironmentPanel>
-    </EnvironmentSection>
-  );
-}
-
-function RuntimeWorktreesSection({
-  targetState,
-  onRunCleanup,
-  onPruneOrphan,
-  onPruneWorkspace,
-  onPurgeWorkspace,
-  onRetryPurge,
-}: {
-  targetState: WorktreeSettingsTargetState;
-  onRunCleanup: () => void;
-  onPruneOrphan: (path: string) => void;
-  onPruneWorkspace: (workspaceId: string) => void;
-  onPurgeWorkspace: (workspaceId: string) => void;
-  onRetryPurge: (workspaceId: string) => void;
-}) {
-  const rows = targetState.inventory?.rows ?? EMPTY_ROWS;
-
-  return (
-    <EnvironmentSection
-      title={targetState.target.label}
-      description={targetState.target.location === "cloud" ? "Cloud runtime" : "Local runtime"}
-    >
-      <EnvironmentPanel>
-        <EnvironmentPanelRow>
-          <div className="flex w-full items-center justify-between gap-3">
-            <div className="space-y-1">
-              <h3 className="text-sm font-medium text-foreground">Current worktrees</h3>
-              <p className="text-sm text-muted-foreground">
-                Review managed checkouts, orphaned paths, git status, storage, and workspace history in this runtime.
-              </p>
-            </div>
-            <Tooltip content={RUN_CLEANUP_TOOLTIP}>
-              <Button type="button" variant="outline" size="sm" onClick={onRunCleanup}>
-                <RefreshCw className="size-4" />
-                Run cleanup
-              </Button>
-            </Tooltip>
-          </div>
-        </EnvironmentPanelRow>
-        {targetState.isLoading ? (
-          <EnvironmentPanelRow>
-            <p className="text-sm text-muted-foreground">Loading worktrees...</p>
-          </EnvironmentPanelRow>
-        ) : targetState.error ? (
-          <EnvironmentPanelRow>
-            <p className="text-sm text-muted-foreground">Runtime is unavailable.</p>
-          </EnvironmentPanelRow>
-        ) : rows.length === 0 ? (
-          <EnvironmentPanelRow>
-            <p className="text-sm text-muted-foreground">No worktrees found.</p>
-          </EnvironmentPanelRow>
-        ) : (
-          rows.map((row) => (
-            <EnvironmentPanelRow key={row.id}>
-              <WorktreeRow
-                row={row}
-                onPruneOrphan={() => onPruneOrphan(row.path)}
-                onPruneWorkspace={onPruneWorkspace}
-                onPurgeWorkspace={onPurgeWorkspace}
-                onRetryPurge={onRetryPurge}
-              />
-            </EnvironmentPanelRow>
-          ))
-        )}
-      </EnvironmentPanel>
-    </EnvironmentSection>
-  );
-}
-
-function WorktreeRow({
-  row,
-  onPruneOrphan,
-  onPruneWorkspace,
-  onPurgeWorkspace,
-  onRetryPurge,
-}: {
-  row: WorktreeInventoryRow;
-  onPruneOrphan: () => void;
-  onPruneWorkspace: (workspaceId: string) => void;
-  onPurgeWorkspace: (workspaceId: string) => void;
-  onRetryPurge: (workspaceId: string) => void;
-}) {
-  const primaryWorkspace = row.associatedWorkspaces[0] ?? null;
-  const label = worktreeRowLabel(row);
-  const stateLabel = row.state.replaceAll("_", " ");
-  const status = worktreeGitStatusView(row.gitStatus);
-  const storageDetail = formatWorktreeStorageDetail(row.storage);
-
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex min-w-0 items-center gap-3">
-        <Tree className="size-5 shrink-0 text-muted-foreground" />
-        <div className="min-w-0 space-y-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium text-foreground">{label}</span>
-            <Badge tone="neutral" className="rounded-sm uppercase">
-              {stateLabel}
-            </Badge>
-            <Badge tone={status.tone} className="rounded-sm">
-              {status.label}
-            </Badge>
-            {row.cleanupOperation ? (
-              <Badge tone="neutral" className="rounded-sm uppercase">
-                {row.cleanupOperation}
-              </Badge>
-            ) : null}
-          </div>
-          <div className="truncate text-xs text-muted-foreground">{row.path}</div>
-          <div className="text-xs text-muted-foreground">
-            {row.totalSessionCount} sessions - {row.materialized ? "checkout present" : "checkout missing"} - {formatWorktreeStorage(row.storage)}
-          </div>
-          {status.detail || storageDetail || primaryWorkspace?.cleanupOperation ? (
-            <div className="text-xs text-muted-foreground">
-              {[status.detail, storageDetail, primaryWorkspace?.cleanupOperation].filter(Boolean).join(" - ")}
-            </div>
-          ) : null}
+      <div className="flex flex-col items-end gap-1">
+        <div className="flex items-center gap-2">
+          <Input
+            id="worktree-policy-global"
+            aria-label="Ideal worktrees per repo"
+            type="number"
+            min={10}
+            max={100}
+            value={draftValue}
+            onChange={(event) => onDraftValueChange(event.target.value)}
+            onBlur={commitIfChanged}
+            onKeyDown={handleKeyDown}
+            className="h-8 w-20 text-right"
+          />
+          <span className="text-sm text-muted-foreground">worktrees</span>
         </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        {row.state === "orphan_checkout" && row.availableActions.includes("delete_orphan_checkout") ? (
-          <Tooltip content={PRUNE_ORPHAN_TOOLTIP}>
-            <Button type="button" variant="outline" size="sm" onClick={onPruneOrphan}>
-              <Trash className="size-4" />
-              Prune
-            </Button>
-          </Tooltip>
+        {helperText ? (
+          <p className="max-w-72 text-right text-sm text-muted-foreground">
+            {helperText}
+          </p>
         ) : null}
-        {row.associatedWorkspaces.map((workspace) => (
-          <div key={workspace.id} className="flex items-center gap-2">
-            {row.state !== "conflict" && row.availableActions.includes("prune_checkout") ? (
-              <Tooltip content={PRUNE_WORKSPACE_TOOLTIP}>
-                <Button type="button" variant="outline" size="sm" onClick={() => onPruneWorkspace(workspace.id)}>
-                  <Trash className="size-4" />
-                  Prune
-                </Button>
-              </Tooltip>
-            ) : null}
-            {workspace.cleanupOperation === "purge"
-              && (workspace.cleanupState === "pending" || workspace.cleanupState === "failed") ? (
-                <Button type="button" variant="outline" size="sm" onClick={() => onRetryPurge(workspace.id)}>
-                  <RefreshCw className="size-4" />
-                  Retry
-                </Button>
-              ) : null}
-            {row.state !== "conflict" && row.availableActions.includes("delete_workspace_history") ? (
-              <Button type="button" variant="outline" size="sm" onClick={() => onPurgeWorkspace(workspace.id)}>
-                <Trash className="size-4" />
-                Delete
-              </Button>
-            ) : null}
-          </div>
-        ))}
       </div>
-    </div>
+    </SettingsCardRow>
   );
 }
 
-const RUN_CLEANUP_TOOLTIP = [
-  "Run cleanup",
-  "Removes only clean managed checkout directories above the ideal per-repo count.",
-  "Skips dirty or conflicted worktrees and keeps workspace history.",
-].join("\n");
+function WorktreeRuntimeStatusRow({
+  targetState,
+  onOpenDetails,
+}: {
+  targetState: RuntimePressureTargetState;
+  onOpenDetails: () => void;
+}) {
+  return (
+    <SettingsCardRow
+      label={targetState.target.label}
+      description={runtimeStatusDescription(targetState)}
+    >
+      <div className="flex items-center gap-3">
+        <RuntimePressureRing
+          tone={targetState.tone}
+          progressPercent={targetState.ringProgressPercent}
+          loading={targetState.isLoading}
+        />
+        <span className="min-w-24 text-right text-sm tabular-nums text-foreground">
+          {targetState.isLoading ? "Loading" : targetState.pressureLabel}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onOpenDetails}
+        >
+          Details
+        </Button>
+      </div>
+    </SettingsCardRow>
+  );
+}
 
-const PRUNE_WORKSPACE_TOOLTIP = [
-  "Prune checkout",
-  "Removes only this checkout directory.",
-  "Keeps the workspace record, chats, raw events, normalized events, and Cloud product records.",
-].join("\n");
-
-const PRUNE_ORPHAN_TOOLTIP = [
-  "Prune orphan checkout",
-  "Deletes this orphan checkout directory.",
-  "No workspace record or chat history is attached to this row.",
-].join("\n");
+function runtimeStatusDescription(targetState: RuntimePressureTargetState): string {
+  if (targetState.error) {
+    return "Runtime inventory is unavailable.";
+  }
+  if (targetState.isLoading) {
+    return "Loading worktree status...";
+  }
+  if (targetState.target.location === "cloud") {
+    return targetState.detailLines.join(" · ");
+  }
+  return targetState.detailLines.slice(0, 2).join(" · ");
+}

--- a/apps/desktop/src/components/settings/panes/slack/ChannelsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/slack/ChannelsSection.tsx
@@ -87,7 +87,7 @@ export function ChannelsSection({
                 <span className="block text-sm font-medium text-foreground">
                   #{channel.name}
                 </span>
-                <span className="block text-xs text-muted-foreground">
+                <span className="block text-sm text-muted-foreground">
                   {channel.isArchived
                     ? "Archived"
                     : channel.isPrivate

--- a/apps/desktop/src/components/settings/panes/slack/RepoRoutingSection.tsx
+++ b/apps/desktop/src/components/settings/panes/slack/RepoRoutingSection.tsx
@@ -135,7 +135,7 @@ export function RepoRoutingSection({
                       <span className="block text-sm font-medium text-foreground">
                         {repoLabel(profile)}
                       </span>
-                      <span className="block text-xs text-muted-foreground">
+                      <span className="block text-sm text-muted-foreground">
                         {profile.languages.length > 0
                           ? profile.languages.join(", ")
                           : "No language metadata cached"}

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -238,8 +238,8 @@ export function SettingsScreen({
           <div className="flex justify-center pb-8">
             <div
               className={`w-full space-y-6 ${
-                effectiveActiveSection === "billing" || effectiveActiveSection === "organization-integrations"
-                  ? "max-w-[76rem]"
+                effectiveActiveSection === "worktrees"
+                  ? "max-w-[58rem]"
                   : "max-w-[50rem]"
               }`}
             >

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -64,7 +64,7 @@ const SETTINGS_GROUPS_CLASS = "flex flex-col";
 const SETTINGS_GROUP_CLASS = "flex flex-col gap-1";
 const SETTINGS_GROUP_SPACING_CLASS = "mt-5";
 const SETTINGS_GROUP_HEADING_CLASS =
-  "px-2.5 pb-1 pt-1.5 text-[11px] font-medium leading-4 tracking-normal text-sidebar-muted-foreground";
+  "px-2.5 pb-1 pt-1.5 text-base font-medium tracking-normal text-sidebar-muted-foreground";
 const SETTINGS_ROW_INACTIVE_CLASS =
   "!text-sidebar-foreground hover:!text-sidebar-foreground";
 const SETTINGS_BACK_ROW_CLASS =
@@ -168,7 +168,7 @@ function TbrPill() {
     <span
       aria-hidden="true"
       title="To be removed"
-      className="rounded-md border border-sidebar-border bg-sidebar-accent px-1.5 py-0.5 text-[10px] font-semibold leading-none tracking-normal text-sidebar-muted-foreground"
+      className="rounded-md border border-sidebar-border bg-sidebar-accent px-1.5 py-0.5 text-sm font-semibold leading-none tracking-normal text-sidebar-muted-foreground"
     >
       tbr
     </span>
@@ -315,7 +315,7 @@ export function SettingsSidebar({
         </div>
       </nav>
       {appVersion ? (
-        <div className="shrink-0 border-t border-sidebar-border px-4 py-3 text-[11px] leading-4 text-sidebar-muted-foreground">
+        <div className="shrink-0 border-t border-sidebar-border px-4 py-3 text-base text-sidebar-muted-foreground">
           Proliferate v{appVersion}
         </div>
       ) : null}

--- a/apps/desktop/src/components/workspace/chat/input/RuntimePressureIndicator.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/RuntimePressureIndicator.tsx
@@ -56,7 +56,7 @@ export function RuntimePressureIndicator() {
           aria-haspopup="dialog"
           aria-expanded={open}
           icon={(
-            <PressureRing
+            <RuntimePressureRing
               tone={indicator.tone}
               progressPercent={indicator.ringProgressPercent}
               loading={pressure.isDiscovering || indicator.isLoading}
@@ -65,7 +65,7 @@ export function RuntimePressureIndicator() {
           onClick={() => setOpen(true)}
         />
       </Tooltip>
-      <RuntimePressureModal
+      <RuntimePressureDetailsDialog
         open={open}
         targetState={indicator}
         actions={pressure.actions}
@@ -75,7 +75,7 @@ export function RuntimePressureIndicator() {
   );
 }
 
-function RuntimePressureModal({
+export function RuntimePressureDetailsDialog({
   open,
   targetState,
   actions,
@@ -679,7 +679,7 @@ function formatByteEstimate(value: number | null | undefined): string {
   return `~${scaled.toFixed(digits)} ${units[unitIndex]}`;
 }
 
-function PressureRing({
+export function RuntimePressureRing({
   tone,
   progressPercent,
   loading = false,

--- a/apps/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -87,14 +87,14 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
       )}
 
       <div
-        className={`flex min-w-0 flex-1 flex-col overflow-hidden ${chromeClasses.contentShell}`}
+        className={`relative flex min-w-0 flex-1 flex-col overflow-hidden ${chromeClasses.contentShell}`}
       >
         <div
-          className={chromeClasses.header}
+          className="absolute left-0 right-0 top-0 z-20 h-10"
           data-tauri-drag-region="true"
         >
           {!sidebarOpen && (
-            <div className="flex items-center gap-2 pl-[82px] pr-2">
+            <div className="flex h-full items-center gap-2 pl-[82px] pr-2">
               <IconButton
                 size="sm"
                 onClick={() => setSidebarOpen(true)}

--- a/apps/desktop/src/config/shortcuts/app-shortcuts.ts
+++ b/apps/desktop/src/config/shortcuts/app-shortcuts.ts
@@ -65,29 +65,29 @@ export const APP_SHORTCUTS = {
     match: { kind: "fixed-code", code: "Slash", meta: true, shift: true, alt: false },
     allowInInputs: true,
   },
-  increaseTextSize: {
-    id: "app.increase-text-size",
+  increaseWindowZoom: {
+    id: "app.increase-window-zoom",
     label: "⌘+",
     nonMacLabel: "Ctrl+Plus",
-    description: "Increase text size",
+    description: "Zoom in",
     owner: "js",
     match: { kind: "fixed-code", code: "Equal", meta: true, shift: true, alt: false },
     allowInInputs: true,
   },
-  increaseTextSizeEqualAlias: {
-    id: "app.increase-text-size",
+  increaseWindowZoomEqualAlias: {
+    id: "app.increase-window-zoom",
     label: "⌘=",
     nonMacLabel: "Ctrl+=",
-    description: "Increase text size",
+    description: "Zoom in",
     owner: "js",
     match: { kind: "fixed-code", code: "Equal", meta: true, shift: false, alt: false },
     allowInInputs: true,
   },
-  decreaseTextSize: {
-    id: "app.decrease-text-size",
+  decreaseWindowZoom: {
+    id: "app.decrease-window-zoom",
     label: "⌘-",
     nonMacLabel: "Ctrl+-",
-    description: "Decrease text size",
+    description: "Zoom out",
     owner: "js",
     match: { kind: "fixed-code", code: "Minus", meta: true, shift: false, alt: false },
     allowInInputs: true,

--- a/apps/desktop/src/config/shortcuts/groups.ts
+++ b/apps/desktop/src/config/shortcuts/groups.ts
@@ -23,8 +23,8 @@ export const SHORTCUT_GROUPS = [
       "openSupport",
       "showKeyboardShortcuts",
       "settingsSectionByIndex",
-      "increaseTextSize",
-      "decreaseTextSize",
+      "increaseWindowZoom",
+      "decreaseWindowZoom",
     ],
   },
   {

--- a/apps/desktop/src/config/theme.ts
+++ b/apps/desktop/src/config/theme.ts
@@ -1,11 +1,15 @@
 import {
   buildUiTextScaleCssVariables,
   DEFAULT_APPEARANCE_SIZE_ID,
+  DEFAULT_WINDOW_ZOOM_ID,
   resolveAppearanceSizeId,
   resolveReadableCodeFontScale,
   resolveUiFontScale,
+  resolveWindowZoomId,
+  resolveWindowZoomScale,
   type ReadableCodeFontSizeId,
   type UiFontSizeId,
+  type WindowZoomId,
 } from "@/lib/domain/preferences/appearance";
 
 // ---------------------------------------------------------------------------
@@ -71,6 +75,7 @@ export interface AppearancePreference {
   colorMode: ColorMode;
   uiFontSizeId: UiFontSizeId;
   readableCodeFontSizeId: ReadableCodeFontSizeId;
+  windowZoomId: WindowZoomId;
 }
 
 export function applyAppearancePreference({
@@ -78,16 +83,20 @@ export function applyAppearancePreference({
   colorMode,
   uiFontSizeId,
   readableCodeFontSizeId,
+  windowZoomId,
 }: AppearancePreference) {
   const root = document.documentElement;
   const resolvedUiFontSizeId = resolveAppearanceSizeId(uiFontSizeId);
   const resolvedReadableCodeFontSizeId = resolveAppearanceSizeId(readableCodeFontSizeId);
+  const resolvedWindowZoomId = resolveWindowZoomId(windowZoomId);
   const uiScale = resolveUiFontScale(resolvedUiFontSizeId);
   const readableCodeScale = resolveReadableCodeFontScale(resolvedReadableCodeFontSizeId);
+  const windowZoomScale = resolveWindowZoomScale(resolvedWindowZoomId);
 
   root.dataset.theme = themePreset;
   root.dataset.uiFontSize = resolvedUiFontSizeId;
   root.dataset.readableCodeFontSize = resolvedReadableCodeFontSizeId;
+  root.dataset.windowZoom = resolvedWindowZoomId;
   applyMode(colorMode, themePreset);
 
   for (const [property, value] of Object.entries(buildUiTextScaleCssVariables(uiScale))) {
@@ -98,6 +107,7 @@ export function applyAppearancePreference({
   root.style.setProperty("--diffs-line-height", readableCodeScale.diffsLineHeight);
   root.style.setProperty("--readable-code-font-size", readableCodeScale.codeFontSize);
   root.style.setProperty("--readable-code-line-height", readableCodeScale.codeLineHeight);
+  root.style.setProperty("--proliferate-window-zoom", windowZoomScale.cssValue);
 
   notify();
 }
@@ -110,6 +120,7 @@ export function initializeTheme(
   applyMode(mode, preset);
   document.documentElement.dataset.uiFontSize = DEFAULT_APPEARANCE_SIZE_ID;
   document.documentElement.dataset.readableCodeFontSize = DEFAULT_APPEARANCE_SIZE_ID;
+  document.documentElement.dataset.windowZoom = DEFAULT_WINDOW_ZOOM_ID;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -69,30 +69,33 @@ describe("useAppShortcuts", () => {
     vi.clearAllMocks();
   });
 
-  it("steps appearance font sizes through the registered app shortcuts", () => {
+  it("steps window zoom through the registered app shortcuts without changing font sizes", () => {
     renderHook(() => useAppShortcuts(commandActions()));
 
     useUserPreferencesStore.setState({
+      windowZoomId: "zoom90",
       uiFontSizeId: "xsmall",
       readableCodeFontSizeId: "xsmall",
     });
 
-    expect(runShortcutHandler("app.decrease-text-size", { source: "keyboard" })).toBe(true);
-    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxsmall");
-    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xxsmall");
+    expect(runShortcutHandler("app.decrease-window-zoom", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().windowZoomId).toBe("zoom80");
+    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xsmall");
+    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xsmall");
 
-    expect(runShortcutHandler("app.decrease-text-size", { source: "keyboard" })).toBe(true);
-    expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxsmall");
-    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xxsmall");
+    expect(runShortcutHandler("app.decrease-window-zoom", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().windowZoomId).toBe("zoom80");
 
     useUserPreferencesStore.setState({
+      windowZoomId: "zoom110",
       uiFontSizeId: "xxxlarge",
       readableCodeFontSizeId: "large",
     });
 
-    expect(runShortcutHandler("app.increase-text-size", { source: "keyboard" })).toBe(true);
+    expect(runShortcutHandler("app.increase-window-zoom", { source: "keyboard" })).toBe(true);
+    expect(useUserPreferencesStore.getState().windowZoomId).toBe("zoom120");
     expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxxlarge");
-    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("xlarge");
+    expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("large");
   });
 
   it("routes option-number shortcuts to the right panel when right-panel focus is active", () => {

--- a/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -11,7 +11,7 @@ import { requestRightPanelTabByIndex } from "@/lib/workflows/workspaces/right-pa
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
-import { stepAppearanceFontSizes } from "@/lib/domain/preferences/appearance";
+import { stepWindowZoomId } from "@/lib/domain/preferences/appearance";
 import {
   runRedoCommand,
   runSelectAllCommand,
@@ -56,12 +56,12 @@ export function useAppShortcuts(actions: AppCommandActions): void {
     actions.showKeyboardShortcuts.execute("shortcut");
   });
 
-  useShortcutHandler("app.increase-text-size", () => {
-    stepTextSizePreference(1);
+  useShortcutHandler("app.increase-window-zoom", () => {
+    stepWindowZoomPreference(1);
   });
 
-  useShortcutHandler("app.decrease-text-size", () => {
-    stepTextSizePreference(-1);
+  useShortcutHandler("app.decrease-window-zoom", () => {
+    stepWindowZoomPreference(-1);
   });
 
   useShortcutHandler("app.select-all", () => {
@@ -155,10 +155,7 @@ export function useAppShortcuts(actions: AppCommandActions): void {
   });
 }
 
-function stepTextSizePreference(delta: -1 | 1): void {
+function stepWindowZoomPreference(delta: -1 | 1): void {
   const preferences = useUserPreferencesStore.getState();
-  preferences.setMultiple(stepAppearanceFontSizes({
-    uiFontSizeId: preferences.uiFontSizeId,
-    readableCodeFontSizeId: preferences.readableCodeFontSizeId,
-  }, delta));
+  preferences.set("windowZoomId", stepWindowZoomId(preferences.windowZoomId, delta));
 }

--- a/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx
+++ b/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx
@@ -21,6 +21,7 @@ function resetAppearanceState() {
   delete root.dataset.mode;
   delete root.dataset.uiFontSize;
   delete root.dataset.readableCodeFontSize;
+  delete root.dataset.windowZoom;
   root.style.cssText = "";
 }
 
@@ -76,7 +77,9 @@ describe("useAppearancePreferenceLifecycle", () => {
       expect(document.documentElement.dataset.mode).toBe("dark");
       expect(document.documentElement.dataset.uiFontSize).toBe("default");
       expect(document.documentElement.dataset.readableCodeFontSize).toBe("default");
+      expect(document.documentElement.dataset.windowZoom).toBe("default");
       expect(document.documentElement.style.getPropertyValue("--text-chat")).toBe("12px");
+      expect(document.documentElement.style.getPropertyValue("--proliferate-window-zoom")).toBe("1");
     });
   });
 
@@ -90,6 +93,7 @@ describe("useAppearancePreferenceLifecycle", () => {
         themePreset: "tbpn",
         uiFontSizeId: "large",
         readableCodeFontSizeId: "xlarge",
+        windowZoomId: "zoom90",
       });
     });
 
@@ -98,8 +102,10 @@ describe("useAppearancePreferenceLifecycle", () => {
       expect(document.documentElement.dataset.mode).toBe("dark");
       expect(document.documentElement.dataset.uiFontSize).toBe("large");
       expect(document.documentElement.dataset.readableCodeFontSize).toBe("xlarge");
+      expect(document.documentElement.dataset.windowZoom).toBe("zoom90");
       expect(document.documentElement.style.getPropertyValue("--text-chat")).toBe("13px");
       expect(document.documentElement.style.getPropertyValue("--readable-code-font-size")).toBe("0.8125rem");
+      expect(document.documentElement.style.getPropertyValue("--proliferate-window-zoom")).toBe("0.9");
     });
   });
 

--- a/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts
+++ b/apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts
@@ -3,6 +3,8 @@ import {
   applyAppearancePreference,
   initializeTheme,
 } from "@/config/theme";
+import { setWebviewZoom } from "@/lib/access/tauri/window";
+import { resolveWindowZoomScale } from "@/lib/domain/preferences/appearance";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 function applyStoredAppearancePreference(): void {
@@ -11,12 +13,22 @@ function applyStoredAppearancePreference(): void {
     colorMode,
     uiFontSizeId,
     readableCodeFontSizeId,
+    windowZoomId,
   } = useUserPreferencesStore.getState();
   applyAppearancePreference({
     themePreset,
     colorMode,
     uiFontSizeId,
     readableCodeFontSizeId,
+    windowZoomId,
+  });
+}
+
+function applyStoredWindowZoomPreference(): void {
+  const { windowZoomId } = useUserPreferencesStore.getState();
+  const { factor } = resolveWindowZoomScale(windowZoomId);
+  void setWebviewZoom(factor).catch(() => {
+    // Non-critical appearance preference; the CSS tokens still update.
   });
 }
 
@@ -25,6 +37,7 @@ export function useAppearancePreferenceLifecycle(): void {
   useEffect(() => {
     initializeTheme();
     applyStoredAppearancePreference();
+    applyStoredWindowZoomPreference();
 
     const unsubscribeAppearance = useUserPreferencesStore.subscribe((state, prev) => {
       if (
@@ -32,8 +45,12 @@ export function useAppearancePreferenceLifecycle(): void {
         || state.colorMode !== prev.colorMode
         || state.uiFontSizeId !== prev.uiFontSizeId
         || state.readableCodeFontSizeId !== prev.readableCodeFontSizeId
+        || state.windowZoomId !== prev.windowZoomId
       ) {
         applyStoredAppearancePreference();
+      }
+      if (state.windowZoomId !== prev.windowZoomId) {
+        applyStoredWindowZoomPreference();
       }
     });
 

--- a/apps/desktop/src/hooks/workspaces/facade/use-runtime-pressure-control-state.ts
+++ b/apps/desktop/src/hooks/workspaces/facade/use-runtime-pressure-control-state.ts
@@ -64,6 +64,14 @@ const EMPTY_ROWS: WorktreeInventoryRow[] = [];
 
 export function useRuntimePressureControlState(): RuntimePressureControlState {
   const settings = useWorktreeSettingsTargets();
+  return useRuntimePressureControlStateFromSettings(settings);
+}
+
+type RuntimePressureSettingsState = ReturnType<typeof useWorktreeSettingsTargets>;
+
+export function useRuntimePressureControlStateFromSettings(
+  settings: RuntimePressureSettingsState,
+): RuntimePressureControlState {
   const selected = useSelectedLogicalWorkspace();
   const idealWorktreeCount = useUserPreferencesStore(
     (state) => state.worktreeAutoDeleteLimit ?? WORKTREE_AUTO_DELETE_LIMIT_DEFAULT,

--- a/apps/desktop/src/lib/access/tauri/window.ts
+++ b/apps/desktop/src/lib/access/tauri/window.ts
@@ -20,3 +20,12 @@ export async function applyMacWindowChrome(): Promise<void> {
   const { invoke } = await import("@tauri-apps/api/core");
   await invoke("apply_macos_window_chrome");
 }
+
+export async function setWebviewZoom(scaleFactor: number): Promise<void> {
+  if (!isTauriWindowApiAvailable()) {
+    return;
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("set_webview_zoom", { scaleFactor });
+}

--- a/apps/desktop/src/lib/domain/preferences/appearance-presentation.ts
+++ b/apps/desktop/src/lib/domain/preferences/appearance-presentation.ts
@@ -2,6 +2,8 @@ import {
   APPEARANCE_SIZE_IDS,
   type ReadableCodeFontSizeId,
   type UiFontSizeId,
+  type WindowZoomId,
+  WINDOW_ZOOM_IDS,
 } from "@/lib/domain/preferences/appearance";
 
 interface AppearanceSizeOption<T extends string> {
@@ -21,6 +23,14 @@ const SIZE_LABELS: Record<UiFontSizeId, string> = {
   xxxlarge: "Largest",
 };
 
+const WINDOW_ZOOM_LABELS_INTERNAL: Record<WindowZoomId, string> = {
+  zoom80: "80%",
+  zoom90: "90%",
+  default: "100%",
+  zoom110: "110%",
+  zoom120: "120%",
+};
+
 export const UI_FONT_SIZE_OPTIONS: AppearanceSizeOption<UiFontSizeId>[] =
   APPEARANCE_SIZE_IDS.map((id) => ({
     id,
@@ -35,5 +45,13 @@ export const READABLE_CODE_FONT_SIZE_OPTIONS: AppearanceSizeOption<ReadableCodeF
     detail: id === "default" ? "Default editor and code text" : "Editor, diffs, and code blocks",
   }));
 
+export const WINDOW_ZOOM_OPTIONS: AppearanceSizeOption<WindowZoomId>[] =
+  WINDOW_ZOOM_IDS.map((id) => ({
+    id,
+    label: WINDOW_ZOOM_LABELS_INTERNAL[id],
+    detail: id === "default" ? "Default app zoom" : "App window zoom",
+  }));
+
 export const UI_FONT_SIZE_LABELS: Record<UiFontSizeId, string> = SIZE_LABELS;
 export const READABLE_CODE_FONT_SIZE_LABELS: Record<ReadableCodeFontSizeId, string> = SIZE_LABELS;
+export const WINDOW_ZOOM_LABELS: Record<WindowZoomId, string> = WINDOW_ZOOM_LABELS_INTERNAL;

--- a/apps/desktop/src/lib/domain/preferences/appearance.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/appearance.test.ts
@@ -5,9 +5,12 @@ import {
   READABLE_CODE_FONT_SCALES,
   type TextTokenScale,
   resolveAppearanceSizeId,
+  resolveWindowZoomId,
   stepAppearanceFontSizes,
   stepAppearanceSizeId,
+  stepWindowZoomId,
   UI_FONT_SCALES,
+  WINDOW_ZOOM_SCALES,
 } from "./appearance";
 
 function cssLengthToPx(value: string): number {
@@ -60,6 +63,22 @@ describe("appearance preferences", () => {
     expect(stepAppearanceSizeId("xxxlarge", 1)).toBe("xxxlarge");
     expect(stepAppearanceSizeId("xsmall", -1)).toBe("xxsmall");
     expect(stepAppearanceSizeId("xxsmall", -1)).toBe("xxsmall");
+  });
+
+  it("resolves invalid window zoom ids to default", () => {
+    expect(resolveWindowZoomId("zoom90")).toBe("zoom90");
+    expect(resolveWindowZoomId("zoom120")).toBe("zoom120");
+    expect(resolveWindowZoomId("unknown")).toBe("default");
+    expect(resolveWindowZoomId(undefined)).toBe("default");
+  });
+
+  it("steps window zoom ids within bounds", () => {
+    expect(stepWindowZoomId("default", 1)).toBe("zoom110");
+    expect(stepWindowZoomId("default", -1)).toBe("zoom90");
+    expect(stepWindowZoomId("zoom110", 1)).toBe("zoom120");
+    expect(stepWindowZoomId("zoom120", 1)).toBe("zoom120");
+    expect(stepWindowZoomId("zoom90", -1)).toBe("zoom80");
+    expect(stepWindowZoomId("zoom80", -1)).toBe("zoom80");
   });
 
   it("steps UI and readable code font sizes independently", () => {
@@ -166,6 +185,16 @@ describe("appearance preferences", () => {
       diffsLineHeight: "calc(var(--diffs-font-size) * 1.8)",
       codeFontSize: "0.6875rem",
       codeLineHeight: "1.625",
+    });
+  });
+
+  it("defines window zoom values separately from font scales", () => {
+    expect(WINDOW_ZOOM_SCALES).toEqual({
+      zoom80: { factor: 0.8, cssValue: "0.8" },
+      zoom90: { factor: 0.9, cssValue: "0.9" },
+      default: { factor: 1, cssValue: "1" },
+      zoom110: { factor: 1.1, cssValue: "1.1" },
+      zoom120: { factor: 1.2, cssValue: "1.2" },
     });
   });
 

--- a/apps/desktop/src/lib/domain/preferences/appearance.ts
+++ b/apps/desktop/src/lib/domain/preferences/appearance.ts
@@ -13,6 +13,16 @@ export type AppearanceSizeId = (typeof APPEARANCE_SIZE_IDS)[number];
 export type UiFontSizeId = AppearanceSizeId;
 export type ReadableCodeFontSizeId = AppearanceSizeId;
 
+export const WINDOW_ZOOM_IDS = [
+  "zoom80",
+  "zoom90",
+  "default",
+  "zoom110",
+  "zoom120",
+] as const;
+
+export type WindowZoomId = (typeof WINDOW_ZOOM_IDS)[number];
+
 export interface TextTokenScale {
   fontSize: string;
   lineHeight: string;
@@ -51,7 +61,13 @@ export interface ReadableCodeFontScale {
   codeLineHeight: string;
 }
 
+export interface WindowZoomScale {
+  factor: number;
+  cssValue: string;
+}
+
 export const DEFAULT_APPEARANCE_SIZE_ID: AppearanceSizeId = "default";
+export const DEFAULT_WINDOW_ZOOM_ID: WindowZoomId = "default";
 export const CHAT_LINE_HEIGHTS: Record<UiFontSizeId, string> = {
   xxsmall: "17.5px",
   xsmall: "18px",
@@ -197,12 +213,28 @@ export const READABLE_CODE_FONT_SCALES: Record<ReadableCodeFontSizeId, ReadableC
   },
 };
 
+export const WINDOW_ZOOM_SCALES: Record<WindowZoomId, WindowZoomScale> = {
+  zoom80: { factor: 0.8, cssValue: "0.8" },
+  zoom90: { factor: 0.9, cssValue: "0.9" },
+  default: { factor: 1, cssValue: "1" },
+  zoom110: { factor: 1.1, cssValue: "1.1" },
+  zoom120: { factor: 1.2, cssValue: "1.2" },
+};
+
 export function isAppearanceSizeId(value: unknown): value is AppearanceSizeId {
   return typeof value === "string" && APPEARANCE_SIZE_IDS.includes(value as AppearanceSizeId);
 }
 
 export function resolveAppearanceSizeId(value: unknown): AppearanceSizeId {
   return isAppearanceSizeId(value) ? value : DEFAULT_APPEARANCE_SIZE_ID;
+}
+
+export function isWindowZoomId(value: unknown): value is WindowZoomId {
+  return typeof value === "string" && WINDOW_ZOOM_IDS.includes(value as WindowZoomId);
+}
+
+export function resolveWindowZoomId(value: unknown): WindowZoomId {
+  return isWindowZoomId(value) ? value : DEFAULT_WINDOW_ZOOM_ID;
 }
 
 export function resolveUiFontScale(value: unknown): UiFontScale {
@@ -234,6 +266,10 @@ export function resolveReadableCodeFontScale(value: unknown): ReadableCodeFontSc
   return READABLE_CODE_FONT_SCALES[resolveAppearanceSizeId(value)];
 }
 
+export function resolveWindowZoomScale(value: unknown): WindowZoomScale {
+  return WINDOW_ZOOM_SCALES[resolveWindowZoomId(value)];
+}
+
 export function stepAppearanceSizeId(
   value: unknown,
   delta: -1 | 1,
@@ -245,6 +281,19 @@ export function stepAppearanceSizeId(
     Math.min(APPEARANCE_SIZE_IDS.length - 1, index + delta),
   );
   return APPEARANCE_SIZE_IDS[nextIndex] ?? DEFAULT_APPEARANCE_SIZE_ID;
+}
+
+export function stepWindowZoomId(
+  value: unknown,
+  delta: -1 | 1,
+): WindowZoomId {
+  const current = resolveWindowZoomId(value);
+  const index = WINDOW_ZOOM_IDS.indexOf(current);
+  const nextIndex = Math.max(
+    0,
+    Math.min(WINDOW_ZOOM_IDS.length - 1, index + delta),
+  );
+  return WINDOW_ZOOM_IDS[nextIndex] ?? DEFAULT_WINDOW_ZOOM_ID;
 }
 
 export function stepAppearanceFontSizes(

--- a/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
+++ b/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
@@ -49,6 +49,7 @@ export function selectPersistedUserPreferencesSlice(
     colorMode: preferences.colorMode,
     uiFontSizeId: preferences.uiFontSizeId,
     readableCodeFontSizeId: preferences.readableCodeFontSizeId,
+    windowZoomId: preferences.windowZoomId,
     defaultChatAgentKind: preferences.defaultChatAgentKind,
     defaultChatModelIdByAgentKind: preferences.defaultChatModelIdByAgentKind,
     chatModelVisibilityOverridesByAgentKind:

--- a/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.test.ts
@@ -146,6 +146,7 @@ describe("user preference migration", () => {
       defaultNewWorkspaceMode: "cloud" as unknown as typeof USER_PREFERENCE_DEFAULTS.defaultNewWorkspaceMode,
       uiFontSizeId: "giant" as typeof USER_PREFERENCE_DEFAULTS.uiFontSizeId,
       readableCodeFontSizeId: "tiny" as typeof USER_PREFERENCE_DEFAULTS.readableCodeFontSizeId,
+      windowZoomId: "zoom200" as typeof USER_PREFERENCE_DEFAULTS.windowZoomId,
     });
 
     expect(result.changed).toBe(true);
@@ -158,6 +159,7 @@ describe("user preference migration", () => {
     expect(result.preferences.defaultOpenInTargetId).toBe("cursor");
     expect(result.preferences.uiFontSizeId).toBe("default");
     expect(result.preferences.readableCodeFontSizeId).toBe("default");
+    expect(result.preferences.windowZoomId).toBe("default");
     expect(USER_PREFERENCE_DEFAULTS.transparentChromeEnabled).toBe(false);
   });
 

--- a/apps/desktop/src/lib/domain/preferences/user/migration.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.ts
@@ -1,4 +1,7 @@
-import { resolveAppearanceSizeId } from "@/lib/domain/preferences/appearance";
+import {
+  resolveAppearanceSizeId,
+  resolveWindowZoomId,
+} from "@/lib/domain/preferences/appearance";
 import {
   sanitizeReviewDefaultsByKind,
   sanitizeReviewPersonalitiesByKind,
@@ -142,6 +145,12 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
   const readableCodeFontSizeId = resolveAppearanceSizeId(next.readableCodeFontSizeId);
   if (readableCodeFontSizeId !== next.readableCodeFontSizeId) {
     next.readableCodeFontSizeId = readableCodeFontSizeId;
+    changed = true;
+  }
+
+  const windowZoomId = resolveWindowZoomId(next.windowZoomId);
+  if (windowZoomId !== next.windowZoomId) {
+    next.windowZoomId = windowZoomId;
     changed = true;
   }
 

--- a/apps/desktop/src/lib/domain/preferences/user/model.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/model.ts
@@ -1,5 +1,9 @@
 import type { ColorMode, ThemePreset } from "@/config/theme";
-import type { ReadableCodeFontSizeId, UiFontSizeId } from "@/lib/domain/preferences/appearance";
+import type {
+  ReadableCodeFontSizeId,
+  UiFontSizeId,
+  WindowZoomId,
+} from "@/lib/domain/preferences/appearance";
 import type {
   ChatModelVisibilityOverridesByAgentKind,
   DefaultLiveSessionControlValuesByAgentKind,
@@ -20,6 +24,7 @@ export interface UserPreferences {
   colorMode: ColorMode;
   uiFontSizeId: UiFontSizeId;
   readableCodeFontSizeId: ReadableCodeFontSizeId;
+  windowZoomId: WindowZoomId;
   defaultChatAgentKind: string;
   defaultChatModelIdByAgentKind: Record<string, string>;
   chatModelVisibilityOverridesByAgentKind: ChatModelVisibilityOverridesByAgentKind;
@@ -45,6 +50,7 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   colorMode: "dark",
   uiFontSizeId: "default",
   readableCodeFontSizeId: "default",
+  windowZoomId: "default",
   defaultChatAgentKind: "claude",
   defaultChatModelIdByAgentKind: {},
   chatModelVisibilityOverridesByAgentKind: {},
@@ -70,6 +76,7 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   colorMode: "dark",
   uiFontSizeId: "default",
   readableCodeFontSizeId: "default",
+  windowZoomId: "default",
   defaultChatAgentKind: "",
   defaultChatModelIdByAgentKind: {},
   chatModelVisibilityOverridesByAgentKind: {},

--- a/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
@@ -5,6 +5,7 @@ const USER_PREFERENCE_KEYS = [
   "colorMode",
   "uiFontSizeId",
   "readableCodeFontSizeId",
+  "windowZoomId",
   "defaultChatAgentKind",
   "defaultChatModelIdByAgentKind",
   "chatModelVisibilityOverridesByAgentKind",

--- a/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/dispatch-policy.ts
@@ -119,7 +119,10 @@ function canBypassDefaultPrevented(
   }
 
   if (
-    (shortcut.id === SHORTCUTS.increaseTextSize.id || shortcut.id === SHORTCUTS.decreaseTextSize.id)
+    (
+      shortcut.id === SHORTCUTS.increaseWindowZoom.id
+      || shortcut.id === SHORTCUTS.decreaseWindowZoom.id
+    )
     && (event.metaKey || event.ctrlKey)
     && !event.altKey
     && (

--- a/apps/desktop/src/lib/domain/shortcuts/native-accelerators.test.ts
+++ b/apps/desktop/src/lib/domain/shortcuts/native-accelerators.test.ts
@@ -22,7 +22,7 @@ describe("getShortcutNativeAccelerator", () => {
 
   it("does not invent accelerators for shortcut ranges or platform-specific matches", () => {
     expect(getShortcutNativeAccelerator(SHORTCUTS.tabByIndex)).toBeNull();
-    expect(getShortcutNativeAccelerator(SHORTCUTS.increaseTextSize)).toBeNull();
+    expect(getShortcutNativeAccelerator(SHORTCUTS.increaseWindowZoom)).toBeNull();
     expect(getShortcutNativeAccelerator(SHORTCUTS.newWorktree)).toBeNull();
     expect(getShortcutNativeAccelerator(SHORTCUTS.newCloud)).toBeNull();
   });

--- a/apps/desktop/src/lib/workflows/preferences/user-preferences-persistence.ts
+++ b/apps/desktop/src/lib/workflows/preferences/user-preferences-persistence.ts
@@ -84,6 +84,7 @@ async function readLegacyUserPreferences(): Promise<LegacyUserPreferencesInput> 
     colorMode: legacyTheme.colorMode ?? defaults.colorMode,
     uiFontSizeId: defaults.uiFontSizeId,
     readableCodeFontSizeId: defaults.readableCodeFontSizeId,
+    windowZoomId: defaults.windowZoomId,
     defaultChatAgentKind: legacyDefaultChatAgentKind ?? defaults.defaultChatAgentKind,
     ...(legacyDefaultChatModelId !== undefined
       ? { defaultChatModelId: legacyDefaultChatModelId }

--- a/apps/desktop/src/stores/preferences/user-preferences-appearance-store.test.ts
+++ b/apps/desktop/src/stores/preferences/user-preferences-appearance-store.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { selectPersistedUserPreferencesSlice } from "@/lib/domain/preferences/persisted-metadata";
+import {
+  markModelVisibilityDefaultsReset,
+  selectPersistedUserPreferencesSlice,
+} from "@/lib/domain/preferences/persisted-metadata";
 import {
   USER_PREFERENCE_DEFAULTS,
   type UserPreferences,
@@ -50,18 +53,21 @@ describe("user appearance preference persistence", () => {
     });
   });
 
-  it("round-trips the appearance font preference bounds", async () => {
+  it("round-trips the appearance preference bounds", async () => {
     storeMocks.values.set("user_preferences", {
       ...USER_PREFERENCE_DEFAULTS,
+      ...markModelVisibilityDefaultsReset({}),
       uiFontSizeId: "xxsmall",
       readableCodeFontSizeId: "xxxlarge",
-    } satisfies UserPreferences);
+      windowZoomId: "zoom120",
+    } as UserPreferences);
 
     await bootstrapUserPreferencesForTest();
 
     const preferences = useUserPreferencesStore.getState();
     expect(preferences.uiFontSizeId).toBe("xxsmall");
     expect(preferences.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(preferences.windowZoomId).toBe("zoom120");
     expect(storeMocks.set).not.toHaveBeenCalled();
 
     preferences.set("turnEndSoundEnabled", true);
@@ -73,6 +79,7 @@ describe("user appearance preference persistence", () => {
     const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
     expect(persisted.uiFontSizeId).toBe("xxsmall");
     expect(persisted.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(persisted.windowZoomId).toBe("zoom120");
     expect(persisted.turnEndSoundEnabled).toBe(true);
   });
 });

--- a/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -79,6 +79,7 @@ describe("user preference migration", () => {
     expect(preferences.colorMode).toBe("dark");
     expect(preferences.uiFontSizeId).toBe("default");
     expect(preferences.readableCodeFontSizeId).toBe("default");
+    expect(preferences.windowZoomId).toBe("default");
     expect(preferences.defaultChatAgentKind).toBe("claude");
     expect(preferences.transparentChromeEnabled).toBe(false);
     expect(preferences.pasteAttachmentsEnabled).toBe(true);
@@ -390,11 +391,13 @@ describe("user preference migration", () => {
     expect(USER_PREFERENCE_DEFAULTS.pasteAttachmentsEnabled).toBe(true);
   });
 
-  it("defaults appearance font preferences to default", () => {
+  it("defaults appearance preferences to default", () => {
     expect(USER_PREFERENCE_DEFAULTS.uiFontSizeId).toBe("default");
     expect(USER_PREFERENCE_DEFAULTS.readableCodeFontSizeId).toBe("default");
+    expect(USER_PREFERENCE_DEFAULTS.windowZoomId).toBe("default");
     expect(PERSISTED_RECORD_BACKFILL.uiFontSizeId).toBe("default");
     expect(PERSISTED_RECORD_BACKFILL.readableCodeFontSizeId).toBe("default");
+    expect(PERSISTED_RECORD_BACKFILL.windowZoomId).toBe("default");
   });
 
   it("migrates missing runtime input sync preference to false", () => {
@@ -433,11 +436,12 @@ describe("user preference migration", () => {
     expect(result.preferences.transparentChromeEnabled).toBe(true);
   });
 
-  it("migrates missing appearance font preferences to default", () => {
+  it("migrates missing appearance preferences to default", () => {
     const legacy = {
       ...USER_PREFERENCE_DEFAULTS,
       uiFontSizeId: undefined,
       readableCodeFontSizeId: undefined,
+      windowZoomId: undefined,
     } as unknown as UserPreferences;
 
     const result = migrateUserPreferences(legacy);
@@ -445,30 +449,35 @@ describe("user preference migration", () => {
     expect(result.changed).toBe(true);
     expect(result.preferences.uiFontSizeId).toBe("default");
     expect(result.preferences.readableCodeFontSizeId).toBe("default");
+    expect(result.preferences.windowZoomId).toBe("default");
   });
 
-  it("sanitizes invalid appearance font preferences", () => {
+  it("sanitizes invalid appearance preferences", () => {
     const result = migrateUserPreferences({
       ...USER_PREFERENCE_DEFAULTS,
       uiFontSizeId: "giant" as unknown as UserPreferences["uiFontSizeId"],
       readableCodeFontSizeId: "tiny" as unknown as UserPreferences["readableCodeFontSizeId"],
+      windowZoomId: "125" as unknown as UserPreferences["windowZoomId"],
     });
 
     expect(result.changed).toBe(true);
     expect(result.preferences.uiFontSizeId).toBe("default");
     expect(result.preferences.readableCodeFontSizeId).toBe("default");
+    expect(result.preferences.windowZoomId).toBe("default");
   });
 
-  it("preserves explicit valid appearance font preferences", () => {
+  it("preserves explicit valid appearance preferences", () => {
     const result = migrateUserPreferences({
       ...USER_PREFERENCE_DEFAULTS,
       uiFontSizeId: "xxsmall",
       readableCodeFontSizeId: "xxxlarge",
+      windowZoomId: "zoom90",
     });
 
     expect(result.changed).toBe(false);
     expect(result.preferences.uiFontSizeId).toBe("xxsmall");
     expect(result.preferences.readableCodeFontSizeId).toBe("xxxlarge");
+    expect(result.preferences.windowZoomId).toBe("zoom90");
   });
 
   it("sanitizes partially present review defaults", () => {

--- a/apps/packages/product-ui/src/settings/SettingsCardRow.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsCardRow.tsx
@@ -17,15 +17,15 @@ export function SettingsCardRow({
   return (
     <div
       className={twMerge(
-        "flex min-h-[4rem] flex-col gap-3 border-b border-border-light px-4 py-3.5 last:border-b-0 sm:flex-row sm:items-center sm:justify-between",
+        "flex min-h-[3.75rem] flex-col gap-2.5 border-b border-border-light px-4 py-3 last:border-b-0 sm:flex-row sm:items-center sm:justify-between",
         className,
       )}
       {...props}
     >
-      <div className="min-w-0 space-y-1.5">
+      <div className="min-w-0 space-y-1">
         <div className="text-sm font-semibold leading-5 tracking-normal text-foreground">{label}</div>
         {description ? (
-          <div className="max-w-2xl text-xs leading-5 text-muted-foreground">{description}</div>
+          <div className="max-w-2xl text-sm leading-5 text-muted-foreground">{description}</div>
         ) : null}
       </div>
       {children ? <div className="flex shrink-0 items-center sm:justify-end">{children}</div> : null}

--- a/apps/packages/product-ui/src/settings/SettingsPageHeader.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsPageHeader.tsx
@@ -12,9 +12,9 @@ export function SettingsPageHeader({
   action,
 }: SettingsPageHeaderProps) {
   return (
-    <header className="flex min-h-[4.25rem] flex-col gap-3 border-b border-border-light pb-4 sm:flex-row sm:items-start sm:justify-between">
-      <div className="min-w-0 space-y-2">
-        <h1 className="text-xl font-semibold leading-7 tracking-normal text-foreground">{title}</h1>
+    <header className="flex min-h-[4.25rem] flex-col gap-2 pb-0 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 space-y-1.5">
+        <h1 className="text-[length:calc(var(--text-xl)_+_0.875rem)] font-semibold leading-[calc(var(--text-xl--line-height)_+_0.5rem)] tracking-normal text-foreground">{title}</h1>
         {description ? (
           <p className="max-w-3xl text-sm leading-5 text-muted-foreground">{description}</p>
         ) : null}

--- a/apps/packages/product-ui/src/settings/SettingsShell.tsx
+++ b/apps/packages/product-ui/src/settings/SettingsShell.tsx
@@ -66,7 +66,7 @@ export function SettingsShell({
           {groups.map((group, groupIndex) => (
             <div key={group.label ?? `settings-group-${groupIndex}`} className="space-y-1">
               {group.label ? (
-                <div className="px-2.5 pb-1 text-[11px] font-medium leading-4 tracking-normal text-sidebar-muted-foreground">
+                <div className="px-2.5 pb-1 text-base font-medium tracking-normal text-sidebar-muted-foreground">
                   {group.label}
                 </div>
               ) : null}

--- a/apps/packages/ui/src/layout/PageContentFrame.tsx
+++ b/apps/packages/ui/src/layout/PageContentFrame.tsx
@@ -67,7 +67,7 @@ export function PageContentFrame({
       )}
       <div
         className={twMerge(
-          "mx-auto flex min-h-full w-full min-w-0 flex-col gap-5 px-4 py-5 sm:px-6 sm:py-6",
+          "mx-auto flex min-h-full w-full min-w-0 flex-col gap-5 px-10 pb-12 pt-14",
           maxWidthClassName,
         )}
       >

--- a/apps/packages/ui/src/layout/PageHeader.tsx
+++ b/apps/packages/ui/src/layout/PageHeader.tsx
@@ -27,7 +27,7 @@ export function PageHeader({
       {...props}
     >
       <div className="min-w-0">
-        <h1 className="truncate text-lg font-semibold text-foreground">{title}</h1>
+        <h1 className="text-[length:calc(var(--text-xl)_+_0.875rem)] font-semibold leading-[calc(var(--text-xl--line-height)_+_0.5rem)] tracking-normal text-foreground">{title}</h1>
         {description && (
           <p className="mt-1 max-w-3xl text-sm leading-5 text-muted-foreground">
             {description}

--- a/apps/packages/ui/src/primitives/SettingsMenu.tsx
+++ b/apps/packages/ui/src/primitives/SettingsMenu.tsx
@@ -32,7 +32,7 @@ export function SettingsMenu({
   label,
   leading,
   groups,
-  className = "w-44",
+  className = "w-[240px]",
   menuClassName = "w-60",
 }: SettingsMenuProps) {
   return (
@@ -44,7 +44,7 @@ export function SettingsMenu({
           type="button"
           variant="outline"
           size="sm"
-          className={`h-8 justify-between rounded-md border-transparent bg-surface-control px-2.5 text-sm font-[430] leading-4 text-foreground shadow-none hover:bg-list-hover data-[state=open]:bg-list-hover ${className}`}
+          className={`h-8 justify-between rounded-lg border-transparent bg-foreground/5 px-2.5 text-sm font-[430] leading-4 text-foreground shadow-none hover:bg-foreground/10 data-[state=open]:bg-foreground/10 ${className}`}
         >
           {leading}
           <span className="min-w-0 flex-1 truncate text-left">{label}</span>


### PR DESCRIPTION
## Summary
- separates window zoom from saved font-size preferences and adds native window zoom control
- refreshes settings typography, card rows, menu sizing, and Pruning runtime status/details
- aligns Workflows/Integrations page title sizing and top padding with Settings

## Verification
- pnpm --dir apps/desktop exec tsc --noEmit
- pnpm --dir apps/desktop exec vitest run src/components/settings/sidebar/SettingsSidebar.test.tsx
- pnpm --filter @proliferate/ui build
- pnpm --filter @proliferate/ui typecheck
- pnpm --filter @proliferate/product-ui build
- pnpm --filter @proliferate/product-ui typecheck
- git diff --check