### PR TITLE
feat(desktop): polish scratch markdown editing

### DIFF
--- a/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
+++ b/apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx
@@ -18,9 +18,21 @@ function collectStyleText() {
   return rules.join("\n");
 }
 
+function installRangeMeasurementStub() {
+  if (!window.Range || typeof window.Range.prototype.getClientRects === "function") {
+    return;
+  }
+  Object.defineProperty(window.Range.prototype, "getClientRects", {
+    configurable: true,
+    value: () => [],
+  });
+}
+
 describe("ScratchCodeMirrorEditor", () => {
 
-  it("keeps empty-state typography and caret sizing independent from diff styling", () => {
+  it("keeps empty-state typography and uses CodeMirror cursor geometry", () => {
+    installRangeMeasurementStub();
+
     render(
       <ScratchCodeMirrorEditor
         value=""
@@ -38,7 +50,9 @@ describe("ScratchCodeMirrorEditor", () => {
     expect(styleText).toContain("font-size: var(--scratch-font-size)");
     expect(styleText).toContain("line-height: var(--scratch-line-height)");
     expect(styleText).toContain("white-space: normal");
-    expect(styleText).toContain("height: 1em !important");
+    expect(styleText).toContain("border-left-color: var(--color-foreground)");
+    expect(styleText).not.toContain("height: 1em !important");
+    expect(styleText).not.toContain("margin-top: 0.33em");
     expect(styleText).not.toContain("min-height: 1.1em");
   });
 });

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  scratchEditorTheme,
+  scratchListDecorations,
+  scratchMarkdownLanguage,
+} from "@/hooks/workspaces/lifecycle/scratch-codemirror-extensions";
+
+let view: EditorView | null = null;
+
+function createView(doc: string) {
+  view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc,
+      extensions: [scratchMarkdownLanguage(), scratchEditorTheme, scratchListDecorations],
+    }),
+  });
+  return view;
+}
+
+function collectStyleText() {
+  const rules: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        rules.push(rule.cssText);
+      }
+    } catch {
+      // Ignore opaque sheets; CodeMirror injects a readable local sheet.
+    }
+  }
+  return rules.join("\n");
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+describe("scratchListDecorations", () => {
+  it("renders ordered markdown markers as ordered markers", () => {
+    const editor = createView("1. first");
+
+    const marker = editor.contentDOM.querySelector(".scratch-list-marker--ordered");
+    expect(marker?.textContent).toBe("1. ");
+    expect(editor.contentDOM.textContent).not.toContain("•");
+
+    const styleText = collectStyleText();
+    expect(styleText).toContain("font-variant-numeric: tabular-nums");
+    expect(styleText).toContain("justify-content: flex-start");
+  });
+
+  it("renders parenthesized ordered markdown markers as ordered markers", () => {
+    const editor = createView("1) first");
+
+    const marker = editor.contentDOM.querySelector(".scratch-list-marker--ordered");
+    expect(marker?.textContent).toBe("1) ");
+    expect(editor.contentDOM.textContent).not.toContain("•");
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts
@@ -42,23 +42,47 @@ afterEach(() => {
 });
 
 describe("scratchListDecorations", () => {
+  it("renders unordered markdown markers with shared marker spacing", () => {
+    const editor = createView("- first");
+
+    const marker = editor.contentDOM.querySelector(".scratch-list-marker");
+    expect(marker?.textContent).toBe("•");
+    expect(editor.contentDOM.textContent).toContain("• first");
+
+    const styleText = collectStyleText();
+    expect(styleText).toContain("padding-left: var(--scratch-list-marker-leading-space)");
+  });
+
   it("renders ordered markdown markers as ordered markers", () => {
     const editor = createView("1. first");
 
     const marker = editor.contentDOM.querySelector(".scratch-list-marker--ordered");
-    expect(marker?.textContent).toBe("1. ");
+    expect(marker?.textContent).toBe("1.");
+    expect(editor.contentDOM.textContent).toContain("1. first");
     expect(editor.contentDOM.textContent).not.toContain("•");
 
     const styleText = collectStyleText();
     expect(styleText).toContain("font-variant-numeric: tabular-nums");
-    expect(styleText).toContain("justify-content: flex-start");
+    expect(styleText).toContain("padding-left: var(--scratch-list-marker-leading-space)");
   });
 
   it("renders parenthesized ordered markdown markers as ordered markers", () => {
     const editor = createView("1) first");
 
     const marker = editor.contentDOM.querySelector(".scratch-list-marker--ordered");
-    expect(marker?.textContent).toBe("1) ");
+    expect(marker?.textContent).toBe("1)");
     expect(editor.contentDOM.textContent).not.toContain("•");
+  });
+
+  it("renders task markers with shared marker spacing", () => {
+    const editor = createView("- [ ] first");
+
+    const marker = editor.contentDOM.querySelector(".scratch-task-checkbox");
+    expect(marker).not.toBeNull();
+    expect(editor.contentDOM.textContent).toContain(" first");
+
+    const styleText = collectStyleText();
+    expect(styleText).toContain("margin: 0");
+    expect(styleText).toContain("padding-left: var(--scratch-list-marker-leading-space)");
   });
 });

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -121,6 +121,11 @@ export const scratchEditorTheme = EditorView.theme({
     justifyContent: "center",
     color: "var(--color-sidebar-muted-foreground)",
   },
+  ".scratch-list-marker--ordered": {
+    width: "auto",
+    justifyContent: "flex-start",
+    fontVariantNumeric: "tabular-nums",
+  },
   ".scratch-task-checkbox": {
     display: "inline-block",
     width: "var(--scratch-list-marker-width)",
@@ -199,12 +204,7 @@ function buildScratchListDecorations(view: EditorView) {
       if (prefix) {
         const markerFrom = line.from + prefix.indent.length;
         const markerTo = line.from + prefix.prefixLength;
-        const widget = prefix.kind === "task"
-          ? new ScratchTaskWidget({
-            checked: prefix.checked,
-            checkboxPosition: line.from + (prefix.checkboxOffset ?? 0),
-          })
-          : new ScratchBulletWidget();
+        const widget = listMarkerWidget(prefix, line.from);
         decorations.push(Decoration.replace({
           widget,
           inclusive: false,
@@ -219,6 +219,22 @@ function buildScratchListDecorations(view: EditorView) {
   return Decoration.set(decorations, true);
 }
 
+function listMarkerWidget(
+  prefix: NonNullable<ReturnType<typeof parseScratchMarkdownListPrefix>>,
+  lineFrom: number,
+) {
+  if (prefix.kind === "task") {
+    return new ScratchTaskWidget({
+      checked: prefix.checked,
+      checkboxPosition: lineFrom + (prefix.checkboxOffset ?? 0),
+    });
+  }
+  if (prefix.kind === "ordered") {
+    return new ScratchOrderedListWidget(prefix.marker);
+  }
+  return new ScratchBulletWidget();
+}
+
 class ScratchBulletWidget extends WidgetType {
   eq() {
     return true;
@@ -228,6 +244,23 @@ class ScratchBulletWidget extends WidgetType {
     const marker = document.createElement("span");
     marker.className = "scratch-list-marker";
     marker.textContent = "•";
+    return marker;
+  }
+}
+
+class ScratchOrderedListWidget extends WidgetType {
+  constructor(private readonly markerText: string) {
+    super();
+  }
+
+  eq(other: ScratchOrderedListWidget) {
+    return this.markerText === other.markerText;
+  }
+
+  toDOM() {
+    const marker = document.createElement("span");
+    marker.className = "scratch-list-marker scratch-list-marker--ordered";
+    marker.textContent = `${this.markerText} `;
     return marker;
   }
 }

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -94,10 +94,6 @@ export const scratchEditorTheme = EditorView.theme({
   ".cm-cursor": {
     borderLeftColor: "var(--color-foreground)",
     borderLeftWidth: "1px",
-    // Match the caret to the text's own height (ascender→baseline), centred in
-    // the line box, instead of the full line-height. Scales with headings.
-    height: "1em !important",
-    marginTop: "0.33em",
   },
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
     backgroundColor: "color-mix(in oklab, var(--color-foreground) 18%, transparent)",

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -28,6 +28,7 @@ export const scratchHighlightStyle = HighlightStyle.define([
   // Heading scale/spacing lives on the line (see scratchEditorTheme) so it
   // survives the caret revealing the raw "#"; here we only carry weight/colour.
   { tag: tags.heading, color: "var(--color-foreground)", fontWeight: "600" },
+  { tag: tags.processingInstruction, color: "var(--color-sidebar-muted-foreground)" },
   { tag: tags.emphasis, fontStyle: "italic" },
   { tag: tags.strong, fontWeight: "600" },
   { tag: tags.strikethrough, textDecoration: "line-through", color: "var(--color-muted-foreground)" },

--- a/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts
@@ -117,21 +117,23 @@ export const scratchEditorTheme = EditorView.theme({
   },
   ".scratch-list-marker": {
     display: "inline-flex",
-    width: "var(--scratch-list-marker-width)",
-    justifyContent: "center",
+    boxSizing: "border-box",
+    paddingLeft: "var(--scratch-list-marker-leading-space)",
+    justifyContent: "flex-start",
     color: "var(--color-sidebar-muted-foreground)",
   },
   ".scratch-list-marker--ordered": {
     width: "auto",
-    justifyContent: "flex-start",
     fontVariantNumeric: "tabular-nums",
   },
   ".scratch-task-checkbox": {
-    display: "inline-block",
-    width: "var(--scratch-list-marker-width)",
+    display: "inline-flex",
     height: "1em",
-    margin: "0 0.1em 0 0",
+    margin: "0",
+    paddingLeft: "var(--scratch-list-marker-leading-space)",
     boxSizing: "border-box",
+    alignItems: "center",
+    justifyContent: "flex-start",
     lineHeight: "1",
     position: "relative",
     verticalAlign: "-0.1em",
@@ -141,14 +143,11 @@ export const scratchEditorTheme = EditorView.theme({
     width: "var(--scratch-task-box-size)",
     height: "var(--scratch-task-box-size)",
     boxSizing: "border-box",
-    position: "absolute",
-    left: "50%",
-    top: "50%",
+    position: "relative",
     border: "1px solid color-mix(in oklab, var(--color-sidebar-muted-foreground) 72%, transparent)",
     borderRadius: "0.18em",
     background: "transparent",
     color: "transparent",
-    transform: "translate(-50%, -50%)",
   },
   ".scratch-task-checkbox[data-checked=\"true\"] .scratch-task-box": {
     borderColor: "color-mix(in oklab, var(--color-foreground) 68%, transparent)",
@@ -203,7 +202,7 @@ function buildScratchListDecorations(view: EditorView) {
       const prefix = parseScratchMarkdownListPrefix(line.text);
       if (prefix) {
         const markerFrom = line.from + prefix.indent.length;
-        const markerTo = line.from + prefix.prefixLength;
+        const markerTo = line.from + prefix.indent.length + markerReplacementLength(prefix);
         const widget = listMarkerWidget(prefix, line.from);
         decorations.push(Decoration.replace({
           widget,
@@ -217,6 +216,13 @@ function buildScratchListDecorations(view: EditorView) {
     }
   }
   return Decoration.set(decorations, true);
+}
+
+function markerReplacementLength(prefix: NonNullable<ReturnType<typeof parseScratchMarkdownListPrefix>>) {
+  if (prefix.kind === "task") {
+    return prefix.marker.length + 1 + 3;
+  }
+  return prefix.marker.length;
 }
 
 function listMarkerWidget(
@@ -260,7 +266,7 @@ class ScratchOrderedListWidget extends WidgetType {
   toDOM() {
     const marker = document.createElement("span");
     marker.className = "scratch-list-marker scratch-list-marker--ordered";
-    marker.textContent = `${this.markerText} `;
+    marker.textContent = this.markerText;
     return marker;
   }
 }

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -87,8 +87,8 @@ export function useScratchCodeMirrorEditor({
   // Owns the imperative CodeMirror editor lifecycle and keeps React as the source of saved text.
   const extensions = useMemo(() => [
     history(),
-    // Replaces the native contentEditable caret (whose height we can't control
-    // and which spans the full line box) with a styleable .cm-cursor element.
+    // Keeps cursor and selection rendering in CodeMirror's measured overlay so
+    // heading line geometry can drive caret placement.
     drawSelection(),
     scratchMarkdownLanguage(),
     syntaxHighlighting(scratchHighlightStyle),

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts
@@ -9,7 +9,10 @@ import {
 } from "@codemirror/view";
 import { useCallback, useEffect, useMemo, useRef, type RefObject } from "react";
 import {
+  applyScratchListIndentFormatting,
   applyScratchListEnterFormatting,
+  applyScratchListOutdentFormatting,
+  shouldScratchBackspaceOutdent,
 } from "@/lib/domain/workspaces/scratch/scratch-list-formatting";
 import {
   disabledExtensions,
@@ -112,6 +115,89 @@ export function useScratchCodeMirrorEditor({
       onChangeRef.current(next);
     }),
     keymap.of([
+      {
+        key: "Backspace",
+        run: (view) => {
+          if (disabledRef.current) {
+            return false;
+          }
+          const selection = view.state.selection.main;
+          const value = view.state.doc.toString();
+          const input = {
+            value,
+            selectionStart: selection.from,
+            selectionEnd: selection.to,
+          };
+          if (!shouldScratchBackspaceOutdent(input)) {
+            return false;
+          }
+          const result = applyScratchListOutdentFormatting(input);
+          if (!result) {
+            return false;
+          }
+          view.dispatch({
+            changes: result.changes,
+            selection: {
+              anchor: result.selectionStart,
+              head: result.selectionEnd,
+            },
+            scrollIntoView: true,
+          });
+          return true;
+        },
+      },
+      {
+        key: "Tab",
+        run: (view) => {
+          if (disabledRef.current) {
+            return false;
+          }
+          const selection = view.state.selection.main;
+          const result = applyScratchListIndentFormatting({
+            value: view.state.doc.toString(),
+            selectionStart: selection.from,
+            selectionEnd: selection.to,
+          });
+          if (!result) {
+            return false;
+          }
+          view.dispatch({
+            changes: result.changes,
+            selection: {
+              anchor: result.selectionStart,
+              head: result.selectionEnd,
+            },
+            scrollIntoView: true,
+          });
+          return true;
+        },
+      },
+      {
+        key: "Shift-Tab",
+        run: (view) => {
+          if (disabledRef.current) {
+            return false;
+          }
+          const selection = view.state.selection.main;
+          const result = applyScratchListOutdentFormatting({
+            value: view.state.doc.toString(),
+            selectionStart: selection.from,
+            selectionEnd: selection.to,
+          });
+          if (!result) {
+            return false;
+          }
+          view.dispatch({
+            changes: result.changes,
+            selection: {
+              anchor: result.selectionStart,
+              head: result.selectionEnd,
+            },
+            scrollIntoView: true,
+          });
+          return true;
+        },
+      },
       {
         key: "Enter",
         run: (view) => {

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
@@ -40,6 +40,18 @@ describe("parseScratchMarkdownListPrefix", () => {
       body: "done",
     });
   });
+
+  it("does not parse markdown task prefixes until the trailing space is typed", () => {
+    expect(parseScratchMarkdownListPrefix("- [ ]")).toEqual({
+      kind: "bullet",
+      checked: false,
+      indent: "",
+      marker: "-",
+      prefixLength: 2,
+      checkboxOffset: null,
+      body: "[ ]",
+    });
+  });
 });
 
 describe("applyScratchListEnterFormatting", () => {

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
@@ -17,6 +17,18 @@ describe("parseScratchMarkdownListPrefix", () => {
     });
   });
 
+  it("parses markdown ordered prefixes", () => {
+    expect(parseScratchMarkdownListPrefix("  12) nested")).toEqual({
+      kind: "ordered",
+      checked: false,
+      indent: "  ",
+      marker: "12)",
+      prefixLength: 6,
+      checkboxOffset: null,
+      body: "nested",
+    });
+  });
+
   it("parses markdown task prefixes", () => {
     expect(parseScratchMarkdownListPrefix("- [x] done")).toEqual({
       kind: "task",
@@ -44,6 +56,38 @@ describe("applyScratchListEnterFormatting", () => {
         from: 7,
         to: 7,
         insert: "\n- ",
+      },
+    });
+  });
+
+  it("continues markdown ordered lists while preserving delimiter style", () => {
+    expect(applyScratchListEnterFormatting({
+      value: "1. first",
+      selectionStart: 8,
+      selectionEnd: 8,
+    })).toEqual({
+      value: "1. first\n2. ",
+      selectionStart: 12,
+      selectionEnd: 12,
+      changes: {
+        from: 8,
+        to: 8,
+        insert: "\n2. ",
+      },
+    });
+
+    expect(applyScratchListEnterFormatting({
+      value: "1) first",
+      selectionStart: 8,
+      selectionEnd: 8,
+    })).toEqual({
+      value: "1) first\n2) ",
+      selectionStart: 12,
+      selectionEnd: 12,
+      changes: {
+        from: 8,
+        to: 8,
+        insert: "\n2) ",
       },
     });
   });
@@ -99,6 +143,23 @@ describe("applyScratchListEnterFormatting", () => {
     });
   });
 
+  it("preserves indentation for continued markdown ordered lists", () => {
+    expect(applyScratchListEnterFormatting({
+      value: "  9. nested",
+      selectionStart: 11,
+      selectionEnd: 11,
+    })).toEqual({
+      value: "  9. nested\n  10. ",
+      selectionStart: 18,
+      selectionEnd: 18,
+      changes: {
+        from: 11,
+        to: 11,
+        insert: "\n  10. ",
+      },
+    });
+  });
+
   it("removes an empty markdown bullet marker to exit the list", () => {
     expect(applyScratchListEnterFormatting({
       value: "- first\n- ",
@@ -111,6 +172,23 @@ describe("applyScratchListEnterFormatting", () => {
       changes: {
         from: 8,
         to: 10,
+        insert: "",
+      },
+    });
+  });
+
+  it("removes an empty markdown ordered marker to exit the list", () => {
+    expect(applyScratchListEnterFormatting({
+      value: "1. first\n2. ",
+      selectionStart: 12,
+      selectionEnd: 12,
+    })).toEqual({
+      value: "1. first\n",
+      selectionStart: 9,
+      selectionEnd: 9,
+      changes: {
+        from: 9,
+        to: 12,
         insert: "",
       },
     });

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyScratchListIndentFormatting,
   applyScratchListEnterFormatting,
+  applyScratchListOutdentFormatting,
   parseScratchMarkdownListPrefix,
+  shouldScratchBackspaceOutdent,
 } from "./scratch-list-formatting";
 
 describe("parseScratchMarkdownListPrefix", () => {
@@ -279,5 +282,245 @@ describe("applyScratchListEnterFormatting", () => {
       selectionStart: 10,
       selectionEnd: 10,
     })).toBeNull();
+  });
+});
+
+describe("applyScratchListIndentFormatting", () => {
+  it("indents markdown bullet lines with real spaces", () => {
+    expect(applyScratchListIndentFormatting({
+      value: "- first",
+      selectionStart: 7,
+      selectionEnd: 7,
+    })).toEqual({
+      value: "    - first",
+      selectionStart: 11,
+      selectionEnd: 11,
+      changes: [{
+        from: 0,
+        to: 0,
+        insert: "    ",
+      }],
+    });
+  });
+
+  it("indents ordered and task list lines", () => {
+    expect(applyScratchListIndentFormatting({
+      value: "1. first\n- [ ] task",
+      selectionStart: 0,
+      selectionEnd: 19,
+    })).toEqual({
+      value: "    1. first\n    - [ ] task",
+      selectionStart: 4,
+      selectionEnd: 27,
+      changes: [
+        {
+          from: 0,
+          to: 0,
+          insert: "    ",
+        },
+        {
+          from: 9,
+          to: 9,
+          insert: "    ",
+        },
+      ],
+    });
+  });
+
+  it("indents literal list lines", () => {
+    expect(applyScratchListIndentFormatting({
+      value: "☐ task",
+      selectionStart: 6,
+      selectionEnd: 6,
+    })).toEqual({
+      value: "    ☐ task",
+      selectionStart: 10,
+      selectionEnd: 10,
+      changes: [{
+        from: 0,
+        to: 0,
+        insert: "    ",
+      }],
+    });
+  });
+
+  it("indents every selected line", () => {
+    expect(applyScratchListIndentFormatting({
+      value: "- first\nplain\n1. third",
+      selectionStart: 0,
+      selectionEnd: 22,
+    })).toEqual({
+      value: "    - first\n    plain\n    1. third",
+      selectionStart: 4,
+      selectionEnd: 34,
+      changes: [
+        {
+          from: 0,
+          to: 0,
+          insert: "    ",
+        },
+        {
+          from: 8,
+          to: 8,
+          insert: "    ",
+        },
+        {
+          from: 14,
+          to: 14,
+          insert: "    ",
+        },
+      ],
+    });
+  });
+
+  it("indents plain text lines", () => {
+    expect(applyScratchListIndentFormatting({
+      value: "plain text",
+      selectionStart: 0,
+      selectionEnd: 10,
+    })).toEqual({
+      value: "    plain text",
+      selectionStart: 4,
+      selectionEnd: 14,
+      changes: [{
+        from: 0,
+        to: 0,
+        insert: "    ",
+      }],
+    });
+  });
+});
+
+describe("applyScratchListOutdentFormatting", () => {
+  it("outdents markdown bullet lines by one indent unit", () => {
+    expect(applyScratchListOutdentFormatting({
+      value: "    - first",
+      selectionStart: 11,
+      selectionEnd: 11,
+    })).toEqual({
+      value: "- first",
+      selectionStart: 7,
+      selectionEnd: 7,
+      changes: [{
+        from: 0,
+        to: 4,
+        insert: "",
+      }],
+    });
+  });
+
+  it("outdents ordered and task list selections", () => {
+    expect(applyScratchListOutdentFormatting({
+      value: "    1. first\n    - [ ] task",
+      selectionStart: 4,
+      selectionEnd: 27,
+    })).toEqual({
+      value: "1. first\n- [ ] task",
+      selectionStart: 0,
+      selectionEnd: 19,
+      changes: [
+        {
+          from: 0,
+          to: 4,
+          insert: "",
+        },
+        {
+          from: 13,
+          to: 17,
+          insert: "",
+        },
+      ],
+    });
+  });
+
+  it("outdents a single leading space when that is the current indent", () => {
+    expect(applyScratchListOutdentFormatting({
+      value: " - first",
+      selectionStart: 8,
+      selectionEnd: 8,
+    })).toEqual({
+      value: "- first",
+      selectionStart: 7,
+      selectionEnd: 7,
+      changes: [{
+        from: 0,
+        to: 1,
+        insert: "",
+      }],
+    });
+  });
+
+  it("outdents plain text lines", () => {
+    expect(applyScratchListOutdentFormatting({
+      value: "    plain\n - second",
+      selectionStart: 0,
+      selectionEnd: 19,
+    })).toEqual({
+      value: "plain\n- second",
+      selectionStart: 0,
+      selectionEnd: 14,
+      changes: [
+        {
+          from: 0,
+          to: 4,
+          insert: "",
+        },
+        {
+          from: 10,
+          to: 11,
+          insert: "",
+        },
+      ],
+    });
+  });
+
+  it("returns null when selected lines are already flush", () => {
+    expect(applyScratchListOutdentFormatting({
+      value: "plain\n- first",
+      selectionStart: 0,
+      selectionEnd: 13,
+    })).toBeNull();
+  });
+});
+
+describe("shouldScratchBackspaceOutdent", () => {
+  it("returns true when backspacing at an indent boundary", () => {
+    expect(shouldScratchBackspaceOutdent({
+      value: "    - first",
+      selectionStart: 4,
+      selectionEnd: 4,
+    })).toBe(true);
+  });
+
+  it("returns true when backspacing at a nested indent boundary", () => {
+    expect(shouldScratchBackspaceOutdent({
+      value: "        plain",
+      selectionStart: 8,
+      selectionEnd: 8,
+    })).toBe(true);
+  });
+
+  it("returns false outside leading indentation", () => {
+    expect(shouldScratchBackspaceOutdent({
+      value: "    plain",
+      selectionStart: 6,
+      selectionEnd: 6,
+    })).toBe(false);
+  });
+
+  it("returns false between indent boundaries", () => {
+    expect(shouldScratchBackspaceOutdent({
+      value: "    plain",
+      selectionStart: 3,
+      selectionEnd: 3,
+    })).toBe(false);
+  });
+
+  it("returns false for ranged deletions", () => {
+    expect(shouldScratchBackspaceOutdent({
+      value: "    plain",
+      selectionStart: 0,
+      selectionEnd: 4,
+    })).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts
@@ -35,7 +35,7 @@ describe("parseScratchMarkdownListPrefix", () => {
       checked: true,
       indent: "",
       marker: "-",
-      prefixLength: 5,
+      prefixLength: 6,
       checkboxOffset: 3,
       body: "done",
     });

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
@@ -27,6 +27,18 @@ export interface ScratchListEnterResult {
   };
 }
 
+export interface ScratchListIndentResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  changes: Array<{
+    from: number;
+    to: number;
+    insert: string;
+  }>;
+}
+
+const SCRATCH_LIST_INDENT = "    ";
 const MARKDOWN_LIST_LINE_PATTERN = /^(\s*)(?:(\d+[.)])|([-*]))\s+(?:(\[([ xX])\]\s+)(.*)|(.*))$/;
 const LITERAL_LIST_LINE_PATTERN = /^(\s*)(?:([•◦])\s+|([☐☑])\s+)(.*)$/;
 
@@ -117,6 +129,77 @@ export function applyScratchListEnterFormatting({
   return null;
 }
 
+export function applyScratchListIndentFormatting({
+  value,
+  selectionStart,
+  selectionEnd,
+}: ScratchListEnterInput): ScratchListIndentResult | null {
+  const start = clampOffset(selectionStart, value.length);
+  const end = clampOffset(selectionEnd, value.length);
+  const changes = selectedLines(value, start, end).map((line) => ({
+    from: line.from,
+    to: line.from,
+    insert: SCRATCH_LIST_INDENT,
+  }));
+  return applyListLineChanges(value, start, end, changes);
+}
+
+export function applyScratchListOutdentFormatting({
+  value,
+  selectionStart,
+  selectionEnd,
+}: ScratchListEnterInput): ScratchListIndentResult | null {
+  const start = clampOffset(selectionStart, value.length);
+  const end = clampOffset(selectionEnd, value.length);
+  const changes = selectedLines(value, start, end)
+    .map((line) => {
+      const indentLength = leadingWhitespaceLength(line.text);
+      if (indentLength === 0) {
+        return null;
+      }
+      const removeCount = line.text.startsWith(SCRATCH_LIST_INDENT)
+        ? SCRATCH_LIST_INDENT.length
+        : 1;
+      return {
+        from: line.from,
+        to: line.from + removeCount,
+        insert: "",
+      };
+    })
+    .filter((change): change is {
+      from: number;
+      to: number;
+      insert: string;
+    } => change !== null);
+  return applyListLineChanges(value, start, end, changes);
+}
+
+export function shouldScratchBackspaceOutdent({
+  value,
+  selectionStart,
+  selectionEnd,
+}: ScratchListEnterInput): boolean {
+  const start = clampOffset(selectionStart, value.length);
+  const end = clampOffset(selectionEnd, value.length);
+  if (start !== end) {
+    return false;
+  }
+
+  const lineStart = lineStartAt(value, start);
+  const column = start - lineStart;
+  if (column === 0 || column % SCRATCH_LIST_INDENT.length !== 0) {
+    return false;
+  }
+
+  const beforeCaret = value.slice(lineStart, start);
+  if (!/^\s+$/.test(beforeCaret)) {
+    return false;
+  }
+
+  const from = start - SCRATCH_LIST_INDENT.length;
+  return from >= lineStart;
+}
+
 function markerForNextMarkdownListItem(prefix: ScratchListPrefix) {
   if (prefix.kind === "task") {
     return `${prefix.marker} [ ] `;
@@ -127,6 +210,26 @@ function markerForNextMarkdownListItem(prefix: ScratchListPrefix) {
     return `${number + 1}${delimiter} `;
   }
   return `${prefix.marker} `;
+}
+
+function selectedLines(value: string, selectionStart: number, selectionEnd: number) {
+  const from = Math.min(selectionStart, selectionEnd);
+  const to = Math.max(selectionStart, selectionEnd);
+  const lastOffset = to > from && isLineStart(value, to) ? to - 1 : to;
+  const lines: Array<{ from: number; to: number; text: string }> = [];
+  let lineStart = lineStartAt(value, from);
+
+  while (lineStart <= lastOffset) {
+    const lineEnd = lineEndAt(value, lineStart);
+    const text = value.slice(lineStart, lineEnd);
+    lines.push({ from: lineStart, to: lineEnd, text });
+    if (lineEnd >= value.length) {
+      break;
+    }
+    lineStart = lineEnd + 1;
+  }
+
+  return lines;
 }
 
 function parseLiteralListPrefix(line: string) {
@@ -147,6 +250,71 @@ function parseLiteralListPrefix(line: string) {
     body,
     prefixLength: indent.length + marker.length,
   };
+}
+
+function leadingWhitespaceLength(value: string) {
+  return /^\s*/.exec(value)?.[0].length ?? 0;
+}
+
+function applyListLineChanges(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  changes: ScratchListIndentResult["changes"],
+): ScratchListIndentResult | null {
+  if (changes.length === 0) {
+    return null;
+  }
+
+  const next = changes
+    .slice()
+    .sort((a, b) => b.from - a.from)
+    .reduce((current, change) => (
+      `${current.slice(0, change.from)}${change.insert}${current.slice(change.to)}`
+    ), value);
+
+  return {
+    value: next,
+    selectionStart: mapOffsetThroughChanges(selectionStart, changes),
+    selectionEnd: mapOffsetThroughChanges(selectionEnd, changes),
+    changes,
+  };
+}
+
+function mapOffsetThroughChanges(
+  offset: number,
+  changes: ScratchListIndentResult["changes"],
+) {
+  return changes
+    .slice()
+    .sort((a, b) => a.from - b.from)
+    .reduce((current, change) => mapOffsetThroughChange(current, change), offset);
+}
+
+function mapOffsetThroughChange(
+  offset: number,
+  change: ScratchListIndentResult["changes"][number],
+) {
+  if (offset < change.from) {
+    return offset;
+  }
+  if (offset > change.to) {
+    return offset + change.insert.length - (change.to - change.from);
+  }
+  return change.from + change.insert.length;
+}
+
+function lineStartAt(value: string, offset: number) {
+  return value.lastIndexOf("\n", Math.max(0, offset - 1)) + 1;
+}
+
+function lineEndAt(value: string, lineStart: number) {
+  const lineEnd = value.indexOf("\n", lineStart);
+  return lineEnd === -1 ? value.length : lineEnd;
+}
+
+function isLineStart(value: string, offset: number) {
+  return offset === 0 || value[offset - 1] === "\n";
 }
 
 function applyListEnter(

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
@@ -27,7 +27,7 @@ export interface ScratchListEnterResult {
   };
 }
 
-const MARKDOWN_LIST_LINE_PATTERN = /^(\s*)(?:(\d+[.)])|([-*]))\s+(?:(\[([ xX])\])(?:\s+(.*))?|(.*))$/;
+const MARKDOWN_LIST_LINE_PATTERN = /^(\s*)(?:(\d+[.)])|([-*]))\s+(?:(\[([ xX])\]\s+)(.*)|(.*))$/;
 const LITERAL_LIST_LINE_PATTERN = /^(\s*)(?:([•◦])\s+|([☐☑])\s+)(.*)$/;
 
 export function parseScratchMarkdownListPrefix(line: string): ScratchListPrefix | null {

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
@@ -40,6 +40,7 @@ export function parseScratchMarkdownListPrefix(line: string): ScratchListPrefix 
   const orderedMarker = match[2];
   const unorderedMarker = match[3];
   const marker = orderedMarker ?? unorderedMarker ?? "-";
+  const checkboxToken = match[4];
   const taskState = match[5];
   const body = match[6] ?? match[7] ?? "";
 
@@ -73,7 +74,7 @@ export function parseScratchMarkdownListPrefix(line: string): ScratchListPrefix 
     checked: taskState !== " ",
     indent,
     marker,
-    prefixLength: indent.length + marker.length + 1 + 3,
+    prefixLength: indent.length + marker.length + 1 + (checkboxToken?.length ?? 3),
     checkboxOffset,
     body,
   };

--- a/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
+++ b/apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts
@@ -1,4 +1,4 @@
-export type ScratchListKind = "bullet" | "task";
+export type ScratchListKind = "bullet" | "ordered" | "task";
 
 export interface ScratchListPrefix {
   kind: ScratchListKind;
@@ -27,7 +27,7 @@ export interface ScratchListEnterResult {
   };
 }
 
-const MARKDOWN_LIST_LINE_PATTERN = /^(\s*)([-*])\s+(?:(\[([ xX])\])(?:\s+(.*))?|(.*))$/;
+const MARKDOWN_LIST_LINE_PATTERN = /^(\s*)(?:(\d+[.)])|([-*]))\s+(?:(\[([ xX])\])(?:\s+(.*))?|(.*))$/;
 const LITERAL_LIST_LINE_PATTERN = /^(\s*)(?:([•◦])\s+|([☐☑])\s+)(.*)$/;
 
 export function parseScratchMarkdownListPrefix(line: string): ScratchListPrefix | null {
@@ -37,9 +37,23 @@ export function parseScratchMarkdownListPrefix(line: string): ScratchListPrefix 
   }
 
   const indent = match[1] ?? "";
-  const marker = match[2] ?? "-";
-  const taskState = match[4];
-  const body = match[5] ?? match[6] ?? "";
+  const orderedMarker = match[2];
+  const unorderedMarker = match[3];
+  const marker = orderedMarker ?? unorderedMarker ?? "-";
+  const taskState = match[5];
+  const body = match[6] ?? match[7] ?? "";
+
+  if (orderedMarker !== undefined) {
+    return {
+      kind: "ordered",
+      checked: false,
+      indent,
+      marker,
+      prefixLength: indent.length + marker.length + 1,
+      checkboxOffset: null,
+      body,
+    };
+  }
 
   if (taskState === undefined) {
     return {
@@ -86,7 +100,7 @@ export function applyScratchListEnterFormatting({
     }
     return applyListEnter(value, start, end, lineStart, lineEnd, {
       indent: markdownPrefix.indent,
-      marker: markdownPrefix.kind === "task" ? `${markdownPrefix.marker} [ ] ` : `${markdownPrefix.marker} `,
+      marker: markerForNextMarkdownListItem(markdownPrefix),
       body: markdownPrefix.body,
       prefixLength: markdownPrefix.prefixLength,
     });
@@ -100,6 +114,18 @@ export function applyScratchListEnterFormatting({
   }
 
   return null;
+}
+
+function markerForNextMarkdownListItem(prefix: ScratchListPrefix) {
+  if (prefix.kind === "task") {
+    return `${prefix.marker} [ ] `;
+  }
+  if (prefix.kind === "ordered") {
+    const number = Number(prefix.marker.slice(0, -1));
+    const delimiter = prefix.marker.slice(-1);
+    return `${number + 1}${delimiter} `;
+  }
+  return `${prefix.marker} `;
 }
 
 function parseLiteralListPrefix(line: string) {

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -325,7 +325,7 @@
   --scratch-code-font-family: var(--font-mono);
   --scratch-font-size: var(--text-chat, 12px);
   --scratch-line-height: var(--text-chat--line-height, 20px);
-  --scratch-list-marker-width: 1.35em;
+  --scratch-list-marker-leading-space: 0.48em;
   --scratch-task-box-size: 0.82em;
   --readable-code-font-size: 0.6875rem;
   --readable-code-line-height: 1.625;


### PR DESCRIPTION
## What

Polishes scratch Markdown editing behavior in the desktop app.

- Supports ordered-list live preview and continuation for `1. ` and `1) `.
- Adds four-space indentation/outdentation shortcuts with Tab, Shift-Tab, and leading-indent Backspace.
- Fixes list marker rendering details for ordered markers, task markers, spacing, and raw markdown marker color.
- Lets CodeMirror own scratch cursor geometry so caret height follows the current line layout.

## How

- Extends scratch list parsing/formatting to recognize ordered markers, continue ordered lists on Enter, and apply indentation edits across selected lines.
- Keeps rendered list markers as scratch widgets while styling raw markdown syntax markers through CodeMirror’s `tags.processingInstruction`.
- Removes the fixed cursor-height override so CodeMirror can measure caret placement from the actual rendered line.
- Adds focused unit coverage for list parsing, list widgets, indentation behavior, cursor geometry expectations, and live-preview marker behavior.

## Verification

- `pnpm --dir apps/desktop exec vitest run src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts`
- Automated review round 1 approved by integration and correctness reviewers.