### PR TITLE
refactor(server): add ownership dependency substrate

### DIFF
--- a/server/proliferate/auth/dependencies.py
+++ b/server/proliferate/auth/dependencies.py
@@ -13,7 +13,10 @@ from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.errors import PermissionDenied
 from proliferate.integrations.sentry import set_server_sentry_user
-from proliferate.middleware.request_context import set_authenticated_user_context
+from proliferate.middleware.request_context import (
+    set_authenticated_user_context,
+    set_rls_actor_context,
+)
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](
     get_user_manager,
@@ -28,6 +31,7 @@ async def current_active_user(
     user: User = Depends(_current_active_user),
 ) -> User:
     set_authenticated_user_context(str(user.id))
+    set_rls_actor_context(user.id)
     set_server_sentry_user(user_id=str(user.id))
     return user
 
@@ -56,5 +60,6 @@ async def optional_current_active_user(
 ) -> User | None:
     if user is not None:
         set_authenticated_user_context(str(user.id))
+        set_rls_actor_context(user.id)
         set_server_sentry_user(user_id=str(user.id))
     return user

--- a/server/proliferate/auth/dependencies.py
+++ b/server/proliferate/auth/dependencies.py
@@ -13,10 +13,8 @@ from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.errors import PermissionDenied
 from proliferate.integrations.sentry import set_server_sentry_user
-from proliferate.middleware.request_context import (
-    set_authenticated_user_context,
-    set_rls_actor_context,
-)
+from proliferate.middleware.request_context import set_authenticated_user_context
+from proliferate.rls_context import set_rls_actor_context
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](
     get_user_manager,

--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -5,11 +5,13 @@ from typing import Annotated, cast
 
 from anyio import CancelScope
 from fastapi import Depends
-from sqlalchemy import event
+from sqlalchemy import event, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session
 
 from proliferate.config import settings
+from proliferate.middleware.request_context import get_rls_context
 
 engine = create_async_engine(
     settings.database_url,
@@ -37,6 +39,38 @@ _AFTER_COMMIT_LISTENERS_KEY = "proliferate_after_commit_listeners"
 _logger = logging.getLogger(__name__)
 
 type AfterCommitCallback = Callable[[], Awaitable[None]]
+
+_RLS_CONTEXT_SQL = text(
+    """
+    SELECT
+      set_config('app.actor_user_id', :actor_user_id, true),
+      set_config('app.owner_scope', :owner_scope, true),
+      set_config('app.organization_id', :organization_id, true)
+    """
+)
+
+
+def _rls_context_params() -> dict[str, str]:
+    actor_user_id, owner_scope, organization_id = get_rls_context()
+    return {
+        "actor_user_id": actor_user_id or "",
+        "owner_scope": owner_scope or "",
+        "organization_id": organization_id or "",
+    }
+
+
+@event.listens_for(Session, "after_begin")
+def _apply_rls_context_after_begin(
+    session: Session,
+    transaction: object,
+    connection: Connection,
+) -> None:
+    del session, transaction
+    connection.execute(_RLS_CONTEXT_SQL, _rls_context_params())
+
+
+async def apply_rls_context_to_session(db: AsyncSession) -> None:
+    await db.execute(_RLS_CONTEXT_SQL, _rls_context_params())
 
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:

--- a/server/proliferate/db/engine.py
+++ b/server/proliferate/db/engine.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Session
 
 from proliferate.config import settings
-from proliferate.middleware.request_context import get_rls_context
+from proliferate.rls_context import get_rls_context
 
 engine = create_async_engine(
     settings.database_url,

--- a/server/proliferate/middleware/request_context.py
+++ b/server/proliferate/middleware/request_context.py
@@ -9,6 +9,8 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
+from proliferate.rls_context import with_cleared_rls_context
+
 _request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 _user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
 _organization_id_var: ContextVar[str | None] = ContextVar("organization_id", default=None)
@@ -27,18 +29,6 @@ _session_id_var: ContextVar[str | None] = ContextVar("session_id", default=None)
 _interaction_id_var: ContextVar[str | None] = ContextVar("interaction_id", default=None)
 _command_id_var: ContextVar[str | None] = ContextVar("command_id", default=None)
 _worker_id_var: ContextVar[str | None] = ContextVar("worker_id", default=None)
-_rls_actor_user_id_var: ContextVar[str | None] = ContextVar(
-    "rls_actor_user_id",
-    default=None,
-)
-_rls_owner_scope_var: ContextVar[str | None] = ContextVar(
-    "rls_owner_scope",
-    default=None,
-)
-_rls_organization_id_var: ContextVar[str | None] = ContextVar(
-    "rls_organization_id",
-    default=None,
-)
 
 _CORRELATION_VARS: dict[str, ContextVar[str | None]] = {
     "request_id": _request_id_var,
@@ -57,12 +47,6 @@ _CORRELATION_VARS: dict[str, ContextVar[str | None]] = {
     "command_id": _command_id_var,
     "worker_id": _worker_id_var,
 }
-
-_RLS_CONTEXT_VARS: tuple[ContextVar[str | None], ...] = (
-    _rls_actor_user_id_var,
-    _rls_owner_scope_var,
-    _rls_organization_id_var,
-)
 
 
 def get_request_id() -> str | None:
@@ -85,27 +69,6 @@ def set_authenticated_user_context(user_id: str | None) -> None:
     _user_id_var.set(str(user_id) if user_id else None)
 
 
-def set_rls_actor_context(user_id: object | None) -> None:
-    _rls_actor_user_id_var.set(str(user_id) if user_id else None)
-
-
-def set_rls_owner_context(
-    *,
-    owner_scope: str,
-    organization_id: object | None,
-) -> None:
-    _rls_owner_scope_var.set(owner_scope)
-    _rls_organization_id_var.set(str(organization_id) if organization_id else None)
-
-
-def get_rls_context() -> tuple[str | None, str | None, str | None]:
-    return (
-        _rls_actor_user_id_var.get(),
-        _rls_owner_scope_var.get(),
-        _rls_organization_id_var.get(),
-    )
-
-
 def set_resource_tenant_context(
     *,
     organization_id: str | None = None,
@@ -117,28 +80,6 @@ def set_resource_tenant_context(
 
 def set_support_report_context(report_id: str | None) -> None:
     _support_report_id_var.set(str(report_id) if report_id else None)
-
-
-@contextmanager
-def with_rls_context(
-    *,
-    actor_user_id: object,
-    owner_scope: str,
-    organization_id: object | None,
-) -> Iterator[None]:
-    tokens: list[tuple[ContextVar[str | None], Token[str | None]]] = [
-        (_rls_actor_user_id_var, _rls_actor_user_id_var.set(str(actor_user_id))),
-        (_rls_owner_scope_var, _rls_owner_scope_var.set(owner_scope)),
-        (
-            _rls_organization_id_var,
-            _rls_organization_id_var.set(str(organization_id) if organization_id else None),
-        ),
-    ]
-    try:
-        yield
-    finally:
-        for context_var, token in reversed(tokens):
-            context_var.reset(token)
 
 
 @contextmanager
@@ -170,12 +111,11 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
             tokens.append(
                 (context_var, context_var.set(request_id if key == "request_id" else None))
             )
-        for context_var in _RLS_CONTEXT_VARS:
-            tokens.append((context_var, context_var.set(None)))
         request.state.request_id = request_id
 
         try:
-            response = await call_next(request)
+            with with_cleared_rls_context():
+                response = await call_next(request)
         finally:
             for context_var, token in reversed(tokens):
                 context_var.reset(token)

--- a/server/proliferate/middleware/request_context.py
+++ b/server/proliferate/middleware/request_context.py
@@ -27,6 +27,18 @@ _session_id_var: ContextVar[str | None] = ContextVar("session_id", default=None)
 _interaction_id_var: ContextVar[str | None] = ContextVar("interaction_id", default=None)
 _command_id_var: ContextVar[str | None] = ContextVar("command_id", default=None)
 _worker_id_var: ContextVar[str | None] = ContextVar("worker_id", default=None)
+_rls_actor_user_id_var: ContextVar[str | None] = ContextVar(
+    "rls_actor_user_id",
+    default=None,
+)
+_rls_owner_scope_var: ContextVar[str | None] = ContextVar(
+    "rls_owner_scope",
+    default=None,
+)
+_rls_organization_id_var: ContextVar[str | None] = ContextVar(
+    "rls_organization_id",
+    default=None,
+)
 
 _CORRELATION_VARS: dict[str, ContextVar[str | None]] = {
     "request_id": _request_id_var,
@@ -45,6 +57,12 @@ _CORRELATION_VARS: dict[str, ContextVar[str | None]] = {
     "command_id": _command_id_var,
     "worker_id": _worker_id_var,
 }
+
+_RLS_CONTEXT_VARS: tuple[ContextVar[str | None], ...] = (
+    _rls_actor_user_id_var,
+    _rls_owner_scope_var,
+    _rls_organization_id_var,
+)
 
 
 def get_request_id() -> str | None:
@@ -67,6 +85,27 @@ def set_authenticated_user_context(user_id: str | None) -> None:
     _user_id_var.set(str(user_id) if user_id else None)
 
 
+def set_rls_actor_context(user_id: object | None) -> None:
+    _rls_actor_user_id_var.set(str(user_id) if user_id else None)
+
+
+def set_rls_owner_context(
+    *,
+    owner_scope: str,
+    organization_id: object | None,
+) -> None:
+    _rls_owner_scope_var.set(owner_scope)
+    _rls_organization_id_var.set(str(organization_id) if organization_id else None)
+
+
+def get_rls_context() -> tuple[str | None, str | None, str | None]:
+    return (
+        _rls_actor_user_id_var.get(),
+        _rls_owner_scope_var.get(),
+        _rls_organization_id_var.get(),
+    )
+
+
 def set_resource_tenant_context(
     *,
     organization_id: str | None = None,
@@ -78,6 +117,28 @@ def set_resource_tenant_context(
 
 def set_support_report_context(report_id: str | None) -> None:
     _support_report_id_var.set(str(report_id) if report_id else None)
+
+
+@contextmanager
+def with_rls_context(
+    *,
+    actor_user_id: object,
+    owner_scope: str,
+    organization_id: object | None,
+) -> Iterator[None]:
+    tokens: list[tuple[ContextVar[str | None], Token[str | None]]] = [
+        (_rls_actor_user_id_var, _rls_actor_user_id_var.set(str(actor_user_id))),
+        (_rls_owner_scope_var, _rls_owner_scope_var.set(owner_scope)),
+        (
+            _rls_organization_id_var,
+            _rls_organization_id_var.set(str(organization_id) if organization_id else None),
+        ),
+    ]
+    try:
+        yield
+    finally:
+        for context_var, token in reversed(tokens):
+            context_var.reset(token)
 
 
 @contextmanager
@@ -109,6 +170,8 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
             tokens.append(
                 (context_var, context_var.set(request_id if key == "request_id" else None))
             )
+        for context_var in _RLS_CONTEXT_VARS:
+            tokens.append((context_var, context_var.set(None)))
         request.state.request_id = request_id
 
         try:

--- a/server/proliferate/permissions.py
+++ b/server/proliferate/permissions.py
@@ -26,10 +26,8 @@ from proliferate.db.engine import apply_rls_context_to_session, get_async_sessio
 from proliferate.db.models.auth import User
 from proliferate.db.store import organizations as organization_store
 from proliferate.errors import InvalidRequest, NotFoundError, PermissionDenied
-from proliferate.middleware.request_context import (
-    set_resource_tenant_context,
-    set_rls_owner_context,
-)
+from proliferate.middleware.request_context import set_resource_tenant_context
+from proliferate.rls_context import set_rls_owner_context
 from proliferate.server.billing.subjects import (
     ensure_organization_billing_subject_state,
     ensure_personal_billing_subject_state,

--- a/server/proliferate/permissions.py
+++ b/server/proliferate/permissions.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from typing import Literal, cast
+from uuid import UUID
+
+from fastapi import Cookie, Depends, Header, Path, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.authorization import (
+    ActorIdentity,
+    AuthenticatedUser,
+    OwnerContext,
+    OwnerScope,
+    OwnerSelection,
+    PolicyAllowed,
+    PolicyDenied,
+    PolicyVerdict,
+    require_org_role,
+)
+from proliferate.auth.dependencies import current_product_user
+from proliferate.constants.billing import BILLING_SUBJECT_KIND_PERSONAL
+from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
+from proliferate.db.engine import apply_rls_context_to_session, get_async_session
+from proliferate.db.models.auth import User
+from proliferate.db.store import organizations as organization_store
+from proliferate.errors import InvalidRequest, NotFoundError, PermissionDenied
+from proliferate.middleware.request_context import (
+    set_resource_tenant_context,
+    set_rls_owner_context,
+)
+from proliferate.server.billing.subjects import (
+    ensure_organization_billing_subject_state,
+    ensure_personal_billing_subject_state,
+)
+
+OrganizationRole = Literal["owner", "admin", "member"]
+
+__all__ = [
+    "ActorIdentity",
+    "AuthenticatedUser",
+    "CurrentOrgUser",
+    "OwnerContext",
+    "OwnerScope",
+    "OwnerSelection",
+    "PolicyAllowed",
+    "PolicyDenied",
+    "PolicyVerdict",
+    "current_org_admin",
+    "current_org_member",
+    "current_org_owner",
+    "current_owner_context",
+    "current_path_org_admin",
+    "current_path_org_member",
+    "current_path_org_owner",
+    "require_org_role",
+    "require_owner_role",
+]
+
+
+@dataclass(frozen=True)
+class CurrentOrgUser:
+    actor_user_id: UUID
+    organization_id: UUID
+    membership_id: UUID
+    role: OrganizationRole
+
+
+async def current_owner_context(
+    owner_scope: OwnerScope | None = Query(default=None, alias="ownerScope"),
+    organization_id: UUID | None = Query(default=None, alias="organizationId"),
+    header_owner_scope: OwnerScope | None = Header(
+        default=None,
+        alias="X-Proliferate-Owner-Scope",
+    ),
+    header_org_id: UUID | None = Header(default=None, alias="X-Proliferate-Org-Id"),
+    cookie_org_id: UUID | None = Cookie(default=None, alias="proliferate_org_id"),
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> OwnerContext:
+    selection = _owner_selection_from_request(
+        owner_scope=owner_scope,
+        organization_id=organization_id,
+        header_owner_scope=header_owner_scope,
+        header_org_id=header_org_id,
+        cookie_org_id=cookie_org_id,
+    )
+    return await _resolve_owner_context_for_selection(db, user, selection)
+
+
+def require_owner_role(*roles: str) -> Callable[[OwnerContext], Awaitable[OwnerContext]]:
+    async def dependency(
+        context: OwnerContext = Depends(current_owner_context),
+    ) -> OwnerContext:
+        require_org_role(context, roles)
+        return context
+
+    return dependency
+
+
+async def current_path_org_member(
+    organization_id: UUID = Path(...),
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> CurrentOrgUser:
+    return await _resolve_current_org_user(db, user=user, organization_id=organization_id)
+
+
+async def current_path_org_admin(
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
+) -> CurrentOrgUser:
+    _require_current_org_role(org_user, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
+    return org_user
+
+
+async def current_path_org_owner(
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
+) -> CurrentOrgUser:
+    _require_current_org_role(org_user, {ORGANIZATION_ROLE_OWNER})
+    return org_user
+
+
+async def current_org_member(
+    context: OwnerContext = Depends(current_owner_context),
+) -> CurrentOrgUser:
+    return _current_org_user_from_owner_context(context)
+
+
+async def current_org_admin(
+    org_user: CurrentOrgUser = Depends(current_org_member),
+) -> CurrentOrgUser:
+    _require_current_org_role(org_user, {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN})
+    return org_user
+
+
+async def current_org_owner(
+    org_user: CurrentOrgUser = Depends(current_org_member),
+) -> CurrentOrgUser:
+    _require_current_org_role(org_user, {ORGANIZATION_ROLE_OWNER})
+    return org_user
+
+
+def _owner_selection_from_request(
+    *,
+    owner_scope: OwnerScope | None,
+    organization_id: UUID | None,
+    header_owner_scope: OwnerScope | None,
+    header_org_id: UUID | None,
+    cookie_org_id: UUID | None,
+) -> OwnerSelection:
+    if owner_scope == "personal":
+        return OwnerSelection(owner_scope="personal", organization_id=None)
+
+    selected_org_id = organization_id or header_org_id or cookie_org_id
+    selected_scope = owner_scope or header_owner_scope
+    if selected_scope == "personal":
+        return OwnerSelection(owner_scope="personal", organization_id=None)
+    if selected_scope == "organization":
+        if selected_org_id is None:
+            raise InvalidRequest(
+                "organizationId is required for organization scope.",
+                code="missing_organization_id",
+            )
+        return OwnerSelection(owner_scope="organization", organization_id=selected_org_id)
+    if selected_org_id is not None:
+        return OwnerSelection(owner_scope="organization", organization_id=selected_org_id)
+    return OwnerSelection(owner_scope="personal", organization_id=None)
+
+
+async def _resolve_owner_context_for_selection(
+    db: AsyncSession,
+    user: User,
+    selection: OwnerSelection,
+) -> OwnerContext:
+    if selection.owner_scope == "personal":
+        set_resource_tenant_context(organization_id=None)
+        set_rls_owner_context(owner_scope="personal", organization_id=None)
+        await apply_rls_context_to_session(db)
+        state = await ensure_personal_billing_subject_state(db, user.id)
+        if state.kind != BILLING_SUBJECT_KIND_PERSONAL:
+            raise InvalidRequest(
+                "Personal billing subject could not be resolved.",
+                code="invalid_owner_selection",
+                status_code=500,
+            )
+        return OwnerContext(
+            owner_scope="personal",
+            actor_user_id=user.id,
+            owner_user_id=user.id,
+            organization_id=None,
+            membership_id=None,
+            membership_role=None,
+            billing_subject_id=state.billing_subject_id,
+        )
+
+    if selection.organization_id is None:
+        raise InvalidRequest(
+            "organizationId is required for organization scope.",
+            code="missing_organization_id",
+        )
+    record = await organization_store.get_organization_with_membership(
+        db,
+        organization_id=selection.organization_id,
+        user_id=user.id,
+    )
+    if record is None:
+        raise NotFoundError(
+            "Organization not found.",
+            code="organization_not_found",
+        )
+    set_resource_tenant_context(organization_id=str(selection.organization_id))
+    set_rls_owner_context(
+        owner_scope="organization",
+        organization_id=selection.organization_id,
+    )
+    await apply_rls_context_to_session(db)
+    state = await ensure_organization_billing_subject_state(db, selection.organization_id)
+    return OwnerContext(
+        owner_scope="organization",
+        actor_user_id=user.id,
+        owner_user_id=None,
+        organization_id=selection.organization_id,
+        membership_id=record.membership.id,
+        membership_role=record.membership.role,
+        billing_subject_id=state.billing_subject_id,
+    )
+
+
+async def _resolve_current_org_user(
+    db: AsyncSession,
+    *,
+    user: User,
+    organization_id: UUID,
+) -> CurrentOrgUser:
+    record = await organization_store.get_organization_with_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user.id,
+    )
+    if record is None:
+        raise NotFoundError(
+            "Organization not found.",
+            code="organization_not_found",
+        )
+    set_resource_tenant_context(organization_id=str(organization_id))
+    set_rls_owner_context(owner_scope="organization", organization_id=organization_id)
+    await apply_rls_context_to_session(db)
+    return CurrentOrgUser(
+        actor_user_id=user.id,
+        organization_id=organization_id,
+        membership_id=record.membership.id,
+        role=_coerce_org_role(record.membership.role),
+    )
+
+
+def _current_org_user_from_owner_context(context: OwnerContext) -> CurrentOrgUser:
+    if (
+        context.owner_scope != "organization"
+        or context.organization_id is None
+        or context.membership_id is None
+        or context.membership_role is None
+    ):
+        raise NotFoundError(
+            "Organization not found.",
+            code="organization_not_found",
+        )
+    return CurrentOrgUser(
+        actor_user_id=context.actor_user_id,
+        organization_id=context.organization_id,
+        membership_id=context.membership_id,
+        role=_coerce_org_role(context.membership_role),
+    )
+
+
+def _coerce_org_role(role: str) -> OrganizationRole:
+    if role in {"owner", "admin", "member"}:
+        return cast(OrganizationRole, role)
+    raise PermissionDenied(
+        "Invalid organization membership role.",
+        code="invalid_organization_role",
+    )
+
+
+def _require_current_org_role(org_user: CurrentOrgUser, roles: Iterable[str]) -> None:
+    if org_user.role not in set(roles):
+        raise PermissionDenied(
+            "You do not have permission to manage this organization.",
+            code="organization_permission_denied",
+        )

--- a/server/proliferate/rls_context.py
+++ b/server/proliferate/rls_context.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+
+_rls_actor_user_id_var: ContextVar[str | None] = ContextVar(
+    "rls_actor_user_id",
+    default=None,
+)
+_rls_owner_scope_var: ContextVar[str | None] = ContextVar(
+    "rls_owner_scope",
+    default=None,
+)
+_rls_organization_id_var: ContextVar[str | None] = ContextVar(
+    "rls_organization_id",
+    default=None,
+)
+
+_RLS_CONTEXT_VARS: tuple[ContextVar[str | None], ...] = (
+    _rls_actor_user_id_var,
+    _rls_owner_scope_var,
+    _rls_organization_id_var,
+)
+
+
+def set_rls_actor_context(user_id: object | None) -> None:
+    _rls_actor_user_id_var.set(str(user_id) if user_id else None)
+
+
+def set_rls_owner_context(
+    *,
+    owner_scope: str,
+    organization_id: object | None,
+) -> None:
+    _rls_owner_scope_var.set(owner_scope)
+    _rls_organization_id_var.set(str(organization_id) if organization_id else None)
+
+
+def get_rls_context() -> tuple[str | None, str | None, str | None]:
+    return (
+        _rls_actor_user_id_var.get(),
+        _rls_owner_scope_var.get(),
+        _rls_organization_id_var.get(),
+    )
+
+
+@contextmanager
+def with_rls_context(
+    *,
+    actor_user_id: object,
+    owner_scope: str,
+    organization_id: object | None,
+) -> Iterator[None]:
+    tokens: list[tuple[ContextVar[str | None], Token[str | None]]] = [
+        (_rls_actor_user_id_var, _rls_actor_user_id_var.set(str(actor_user_id))),
+        (_rls_owner_scope_var, _rls_owner_scope_var.set(owner_scope)),
+        (
+            _rls_organization_id_var,
+            _rls_organization_id_var.set(str(organization_id) if organization_id else None),
+        ),
+    ]
+    try:
+        yield
+    finally:
+        for context_var, token in reversed(tokens):
+            context_var.reset(token)
+
+
+@contextmanager
+def with_cleared_rls_context() -> Iterator[None]:
+    tokens: list[tuple[ContextVar[str | None], Token[str | None]]] = [
+        (context_var, context_var.set(None)) for context_var in _RLS_CONTEXT_VARS
+    ]
+    try:
+        yield
+    finally:
+        for context_var, token in reversed(tokens):
+            context_var.reset(token)

--- a/server/proliferate/server/billing/api.py
+++ b/server/proliferate/server/billing/api.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import Literal
-from uuid import UUID
-
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import OwnerSelection
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.permissions import OwnerContext, current_owner_context
 from proliferate.server.billing.checkout import (
     create_cloud_checkout_session,
     create_customer_portal_session,
@@ -28,10 +26,8 @@ from proliferate.server.billing.models import (
     StripeWebhookAck,
 )
 from proliferate.server.billing.overview import (
-    get_billing_overview,
-    get_billing_overview_for_owner,
-    get_cloud_plan,
-    get_cloud_plan_for_owner,
+    get_billing_overview_for_context,
+    get_cloud_plan_for_context,
     get_current_plan,
 )
 from proliferate.server.billing.stripe_webhooks import handle_stripe_webhook
@@ -57,19 +53,11 @@ async def get_plan(
 
 @router.get("/cloud-plan", response_model=CloudPlanInfo)
 async def get_cloud_plan_endpoint(
-    owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
-    organization_id: UUID | None = Query(default=None, alias="organizationId"),
-    user: User = Depends(current_product_user),
+    owner_context: OwnerContext = Depends(current_owner_context),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudPlanInfo:
     try:
-        if owner_scope == "personal" and organization_id is None:
-            return await get_cloud_plan(db, user.id)
-        return await get_cloud_plan_for_owner(
-            db,
-            user,
-            OwnerSelection(owner_scope=owner_scope, organization_id=organization_id),
-        )
+        return await get_cloud_plan_for_context(db, owner_context)
     except BillingServiceError as error:
         raise HTTPException(
             status_code=error.status_code,
@@ -79,19 +67,11 @@ async def get_cloud_plan_endpoint(
 
 @router.get("/overview", response_model=BillingOverview)
 async def get_overview(
-    owner_scope: Literal["personal", "organization"] = Query("personal", alias="ownerScope"),
-    organization_id: UUID | None = Query(default=None, alias="organizationId"),
-    user: User = Depends(current_product_user),
+    owner_context: OwnerContext = Depends(current_owner_context),
     db: AsyncSession = Depends(get_async_session),
 ) -> BillingOverview:
     try:
-        if owner_scope == "personal" and organization_id is None:
-            return await get_billing_overview(db, user.id)
-        return await get_billing_overview_for_owner(
-            db,
-            user,
-            OwnerSelection(owner_scope=owner_scope, organization_id=organization_id),
-        )
+        return await get_billing_overview_for_context(db, owner_context)
     except BillingServiceError as error:
         raise HTTPException(
             status_code=error.status_code,

--- a/server/proliferate/server/billing/overview.py
+++ b/server/proliferate/server/billing/overview.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.authorization import AuthenticatedUser, OwnerSelection
+from proliferate.auth.authorization import AuthenticatedUser, OwnerContext, OwnerSelection
 from proliferate.server.billing import snapshots as billing_snapshots
 from proliferate.server.billing.checkout import resolve_billing_owner_context
 from proliferate.server.billing.models import (
@@ -30,6 +30,13 @@ async def get_billing_overview_for_owner(
     owner_selection: OwnerSelection,
 ) -> BillingOverview:
     context = await resolve_billing_owner_context(db, user, owner_selection)
+    return await get_billing_overview_for_context(db, context)
+
+
+async def get_billing_overview_for_context(
+    db: AsyncSession,
+    context: OwnerContext,
+) -> BillingOverview:
     snapshot = await billing_snapshots.get_billing_snapshot_for_subject_in_session(
         db,
         context.billing_subject_id,
@@ -57,6 +64,13 @@ async def get_cloud_plan_for_owner(
     owner_selection: OwnerSelection,
 ) -> CloudPlanInfo:
     context = await resolve_billing_owner_context(db, user, owner_selection)
+    return await get_cloud_plan_for_context(db, context)
+
+
+async def get_cloud_plan_for_context(
+    db: AsyncSession,
+    context: OwnerContext,
+) -> CloudPlanInfo:
     snapshot = await billing_snapshots.get_billing_snapshot_for_subject_in_session(
         db,
         context.billing_subject_id,

--- a/server/proliferate/server/organizations/api.py
+++ b/server/proliferate/server/organizations/api.py
@@ -9,6 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.permissions import (
+    CurrentOrgUser,
+    current_path_org_admin,
+    current_path_org_member,
+)
 from proliferate.server.organizations.models import (
     OrganizationInvitationAcceptRequest,
     OrganizationInvitationAcceptResponse,
@@ -94,25 +99,22 @@ async def list_organizations_endpoint(
 
 @router.get("/{organization_id}", response_model=OrganizationResponse)
 async def get_organization_endpoint(
-    organization_id: UUID,
-    user: User = Depends(current_product_user),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationResponse:
-    record = await get_organization(db, user, organization_id)
+    record = await get_organization(db, org_user)
     return organization_with_membership_response(record)
 
 
 @router.patch("/{organization_id}", response_model=OrganizationResponse)
 async def update_organization_endpoint(
-    organization_id: UUID,
     body: OrganizationUpdateRequest,
-    user: User = Depends(current_product_user),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationResponse:
     record = await update_organization(
         db,
-        user,
-        organization_id,
+        org_admin,
         name=body.name,
         logo_image=body.logo_image,
         update_logo_image="logo_image" in body.model_fields_set,
@@ -122,11 +124,10 @@ async def update_organization_endpoint(
 
 @router.get("/{organization_id}/members", response_model=OrganizationMembersResponse)
 async def list_organization_members_endpoint(
-    organization_id: UUID,
-    user: User = Depends(current_product_user),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembersResponse:
-    members = await list_members(db, user, organization_id)
+    members = await list_members(db, org_user)
     return OrganizationMembersResponse(members=[member_response(member) for member in members])
 
 
@@ -135,16 +136,14 @@ async def list_organization_members_endpoint(
     response_model=OrganizationMembershipResponse,
 )
 async def update_organization_membership_endpoint(
-    organization_id: UUID,
     membership_id: UUID,
     body: OrganizationMembershipUpdateRequest,
-    user: User = Depends(current_product_user),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembershipResponse:
     membership = await update_membership(
         db,
-        user,
-        organization_id,
+        org_admin,
         membership_id,
         role=body.role,
         status=body.status,
@@ -157,22 +156,20 @@ async def update_organization_membership_endpoint(
     response_model=OrganizationMembershipResponse,
 )
 async def remove_organization_membership_endpoint(
-    organization_id: UUID,
     membership_id: UUID,
-    user: User = Depends(current_product_user),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationMembershipResponse:
-    membership = await remove_membership(db, user, organization_id, membership_id)
+    membership = await remove_membership(db, org_admin, membership_id)
     return membership_response(membership)
 
 
 @router.get("/{organization_id}/invitations", response_model=OrganizationInvitationsResponse)
 async def list_organization_invitations_endpoint(
-    organization_id: UUID,
-    user: User = Depends(current_product_user),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationsResponse:
-    invitations = await list_invitations(db, user, organization_id)
+    invitations = await list_invitations(db, org_user)
     return OrganizationInvitationsResponse(
         invitations=[invitation_response(invitation) for invitation in invitations],
     )
@@ -184,15 +181,15 @@ async def list_organization_invitations_endpoint(
     status_code=201,
 )
 async def create_organization_invitation_endpoint(
-    organization_id: UUID,
     body: OrganizationInviteRequest,
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     user: User = Depends(current_product_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
     result = await create_invitation(
         db,
-        user,
-        organization_id,
+        org_admin,
+        inviter_email=user.email,
         email=str(body.email),
         role=body.role,
     )
@@ -204,12 +201,17 @@ async def create_organization_invitation_endpoint(
     response_model=OrganizationInvitationResponse,
 )
 async def resend_organization_invitation_endpoint(
-    organization_id: UUID,
     invitation_id: UUID,
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     user: User = Depends(current_product_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
-    result = await resend_invitation(db, user, organization_id, invitation_id)
+    result = await resend_invitation(
+        db,
+        org_admin,
+        invitation_id,
+        inviter_email=user.email,
+    )
     return invitation_response(result.invitation)
 
 
@@ -218,10 +220,9 @@ async def resend_organization_invitation_endpoint(
     response_model=OrganizationInvitationResponse,
 )
 async def revoke_organization_invitation_endpoint(
-    organization_id: UUID,
     invitation_id: UUID,
-    user: User = Depends(current_product_user),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationResponse:
-    invitation = await revoke_invitation(db, user, organization_id, invitation_id)
+    invitation = await revoke_invitation(db, org_admin, invitation_id)
     return invitation_response(invitation)

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -12,13 +12,6 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.authorization import (
-    OwnerContext,
-    OwnerSelection,
-    PolicyDenied,
-    PolicyVerdict,
-    require_org_role,
-)
 from proliferate.config import settings
 from proliferate.constants.billing import BILLING_SUBJECT_KIND_PERSONAL
 from proliferate.constants.organizations import (
@@ -27,6 +20,7 @@ from proliferate.constants.organizations import (
     ORGANIZATION_INVITE_HANDOFF_TOKEN_DOMAIN,
     ORGANIZATION_INVITE_TOKEN_DOMAIN,
     ORGANIZATION_MEMBERSHIP_STATUS_REMOVED,
+    ORGANIZATION_ROLE_OWNER,
 )
 from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import organizations as organization_store
@@ -37,6 +31,11 @@ from proliferate.db.store.organization_records import (
     OrganizationWithMembershipRecord,
     normalize_invitation_email,
 )
+from proliferate.permissions import (
+    CurrentOrgUser,
+    OwnerContext,
+    OwnerSelection,
+)
 from proliferate.server.billing.seat_reconciliation import (
     maybe_create_organization_seat_adjustment,
 )
@@ -46,8 +45,6 @@ from proliferate.server.billing.subjects import (
 )
 from proliferate.server.organizations import invitation_delivery
 from proliferate.server.organizations.domain.policy import (
-    can_modify_membership,
-    can_modify_owner_memberships,
     is_membership_update_status,
     is_organization_role,
     organization_admin_roles,
@@ -95,12 +92,12 @@ def _raise_organization_issue(issue: OrganizationProfileIssue | None) -> None:
         )
 
 
-def _raise_if_denied(verdict: PolicyVerdict) -> None:
-    if isinstance(verdict, PolicyDenied):
+def _require_current_org_role(org_user: CurrentOrgUser, roles: frozenset[str]) -> None:
+    if org_user.role not in roles:
         raise OrganizationServiceError(
-            verdict.code,
-            verdict.message,
-            status_code=verdict.status_code,
+            "organization_permission_denied",
+            "You do not have permission to manage this organization.",
+            status_code=403,
         )
 
 
@@ -217,30 +214,6 @@ async def resolve_owner_context(
     )
 
 
-async def _resolve_organization_owner_context(
-    db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
-) -> OwnerContext:
-    record = await organization_store.get_organization_with_membership(
-        db,
-        organization_id=organization_id,
-        user_id=actor_user.id,
-    )
-    if record is None:
-        raise _org_not_found()
-    subject = await ensure_organization_billing_subject_state(db, organization_id)
-    return OwnerContext(
-        owner_scope="organization",
-        actor_user_id=actor_user.id,
-        owner_user_id=None,
-        organization_id=organization_id,
-        membership_id=record.membership.id,
-        membership_role=record.membership.role,
-        billing_subject_id=subject.billing_subject_id,
-    )
-
-
 async def list_organizations(
     db: AsyncSession,
     actor_user: OrganizationActor,
@@ -264,13 +237,12 @@ async def list_organizations(
 
 async def get_organization(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
 ) -> OrganizationWithMembershipRecord:
     record = await organization_store.get_organization_with_membership(
         db,
-        organization_id=organization_id,
-        user_id=actor_user.id,
+        organization_id=org_user.organization_id,
+        user_id=org_user.actor_user_id,
     )
     if record is None:
         raise _org_not_found()
@@ -279,22 +251,16 @@ async def get_organization(
 
 async def update_organization(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     *,
     name: str | None,
     logo_image: str | None,
     update_logo_image: bool,
 ) -> OrganizationWithMembershipRecord:
-    context = await _resolve_organization_owner_context(
-        db,
-        actor_user,
-        organization_id,
-    )
-    require_org_role(context, organization_admin_roles())
+    _require_current_org_role(org_user, organization_admin_roles())
     updated = await organization_store.update_organization_settings(
         db,
-        organization_id=organization_id,
+        organization_id=org_user.organization_id,
         name=_clean_organization_name(name) if name is not None else None,
         logo_image=_sanitize_logo_image(logo_image) if update_logo_image else None,
         update_logo_image=update_logo_image,
@@ -303,32 +269,33 @@ async def update_organization(
         raise _org_not_found()
     return OrganizationWithMembershipRecord(
         organization=updated,
-        membership=(await get_organization(db, actor_user, organization_id)).membership,
+        membership=(await get_organization(db, org_user)).membership,
     )
 
 
 async def list_members(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
 ) -> list[MemberRecord]:
-    await _resolve_organization_owner_context(db, actor_user, organization_id)
-    return await organization_store.list_organization_members(db, organization_id)
+    return await organization_store.list_organization_members(db, org_user.organization_id)
 
 
 async def update_membership(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     membership_id: UUID,
     *,
     role: str | None,
     status: str | None,
 ) -> MembershipRecord:
-    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
-    require_org_role(context, organization_admin_roles())
-    _raise_if_denied(can_modify_membership(context, membership_id))
-    can_modify_owner = can_modify_owner_memberships(context)
+    _require_current_org_role(org_user, organization_admin_roles())
+    if org_user.membership_id == membership_id:
+        raise OrganizationServiceError(
+            "cannot_modify_own_membership",
+            "You cannot modify your own organization membership.",
+            status_code=403,
+        )
+    can_modify_owner = org_user.role == ORGANIZATION_ROLE_OWNER
     if role is not None:
         _require_role(role)
     if status is not None and not is_membership_update_status(status):
@@ -339,7 +306,7 @@ async def update_membership(
         )
     membership, error = await organization_store.update_organization_membership(
         db,
-        organization_id=organization_id,
+        organization_id=org_user.organization_id,
         membership_id=membership_id,
         role=role,
         status=status,
@@ -368,7 +335,7 @@ async def update_membership(
     if status is not None:
         await maybe_create_organization_seat_adjustment(
             db,
-            organization_id=organization_id,
+            organization_id=org_user.organization_id,
             membership_id=membership.id,
         )
     return membership
@@ -376,14 +343,12 @@ async def update_membership(
 
 async def remove_membership(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     membership_id: UUID,
 ) -> MembershipRecord:
     return await update_membership(
         db,
-        actor_user,
-        organization_id,
+        org_user,
         membership_id,
         role=None,
         status=ORGANIZATION_MEMBERSHIP_STATUS_REMOVED,
@@ -392,25 +357,24 @@ async def remove_membership(
 
 async def create_invitation(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     *,
+    inviter_email: str,
     email: str,
     role: str,
 ) -> OrganizationInvitationEmailResult:
-    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
-    require_org_role(context, required_roles_for_invitation_role(role))
+    _require_current_org_role(org_user, required_roles_for_invitation_role(role))
     normalized_email = normalize_invitation_email(email)
     token = _new_token()
     result = await invitation_delivery.create_and_send_invitation(
-        organization_id=organization_id,
+        organization_id=org_user.organization_id,
         email=normalized_email,
         role=_require_role(role),
         token_hash=_hash_token(token, ORGANIZATION_INVITE_TOKEN_DOMAIN),
-        invited_by_user_id=actor_user.id,
+        invited_by_user_id=org_user.actor_user_id,
         expires_at=utcnow() + timedelta(days=ORGANIZATION_INVITE_EXPIRES_DAYS),
         token=token,
-        inviter_email=actor_user.email,
+        inviter_email=inviter_email,
     )
     if result is None:
         raise _org_not_found()
@@ -422,20 +386,20 @@ async def create_invitation(
 
 async def resend_invitation(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     invitation_id: UUID,
+    *,
+    inviter_email: str,
 ) -> OrganizationInvitationEmailResult:
-    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
-    require_org_role(context, organization_admin_roles())
+    _require_current_org_role(org_user, organization_admin_roles())
     token = _new_token()
     result = await invitation_delivery.rotate_and_send_invitation(
-        organization_id=organization_id,
+        organization_id=org_user.organization_id,
         invitation_id=invitation_id,
         token_hash=_hash_token(token, ORGANIZATION_INVITE_TOKEN_DOMAIN),
         expires_at=utcnow() + timedelta(days=ORGANIZATION_INVITE_EXPIRES_DAYS),
         token=token,
-        inviter_email=actor_user.email,
+        inviter_email=inviter_email,
     )
     if result is None:
         raise OrganizationServiceError(
@@ -451,11 +415,9 @@ async def resend_invitation(
 
 async def list_invitations(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
 ) -> list[InvitationRecord]:
-    await _resolve_organization_owner_context(db, actor_user, organization_id)
-    return await invitation_store.list_organization_invitations(db, organization_id)
+    return await invitation_store.list_organization_invitations(db, org_user.organization_id)
 
 
 async def list_current_user_invitations(
@@ -467,15 +429,13 @@ async def list_current_user_invitations(
 
 async def revoke_invitation(
     db: AsyncSession,
-    actor_user: OrganizationActor,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
     invitation_id: UUID,
 ) -> InvitationRecord:
-    context = await _resolve_organization_owner_context(db, actor_user, organization_id)
-    require_org_role(context, organization_admin_roles())
+    _require_current_org_role(org_user, organization_admin_roles())
     invitation = await invitation_store.revoke_organization_invitation(
         db,
-        organization_id=organization_id,
+        organization_id=org_user.organization_id,
         invitation_id=invitation_id,
     )
     if invitation is None:

--- a/server/tests/integration/test_organizations_api.py
+++ b/server/tests/integration/test_organizations_api.py
@@ -23,6 +23,7 @@ from proliferate.db.models.organizations import (
     OrganizationMembership,
 )
 from proliferate.integrations import resend
+from proliferate.permissions import CurrentOrgUser
 from proliferate.server.organizations import service as organization_service
 from tests.helpers.desktop_auth import mint_desktop_token_payload
 
@@ -275,10 +276,16 @@ async def test_invitation_is_durable_before_email_delivery(
     async with engine_module.async_session_factory() as session:
         actor = await session.get(User, uuid.UUID(owner["user_id"]))
         assert actor is not None
+        org_user = CurrentOrgUser(
+            actor_user_id=actor.id,
+            organization_id=organization_id,
+            membership_id=uuid.UUID(organization["membership_id"]),
+            role=ORGANIZATION_ROLE_OWNER,
+        )
         result = await organization_service.create_invitation(
             session,
-            actor,
-            organization_id,
+            org_user,
+            inviter_email=actor.email,
             email="durable-member@acme.dev",
             role=ORGANIZATION_ROLE_MEMBER,
         )

--- a/server/tests/unit/test_rls_context.py
+++ b/server/tests/unit/test_rls_context.py
@@ -1,0 +1,41 @@
+from proliferate.rls_context import (
+    get_rls_context,
+    set_rls_actor_context,
+    set_rls_owner_context,
+    with_cleared_rls_context,
+    with_rls_context,
+)
+
+
+def test_rls_context_can_be_scoped_and_restored() -> None:
+    with with_cleared_rls_context():
+        set_rls_actor_context("user-1")
+        set_rls_owner_context(owner_scope="personal", organization_id=None)
+
+        assert get_rls_context() == ("user-1", "personal", None)
+
+        with with_rls_context(
+            actor_user_id="user-2",
+            owner_scope="organization",
+            organization_id="org-1",
+        ):
+            assert get_rls_context() == ("user-2", "organization", "org-1")
+
+        assert get_rls_context() == ("user-1", "personal", None)
+
+
+def test_cleared_rls_context_restores_previous_values() -> None:
+    with (
+        with_cleared_rls_context(),
+        with_rls_context(
+            actor_user_id="user-1",
+            owner_scope="organization",
+            organization_id="org-1",
+        ),
+    ):
+        assert get_rls_context() == ("user-1", "organization", "org-1")
+
+        with with_cleared_rls_context():
+            assert get_rls_context() == (None, None, None)
+
+        assert get_rls_context() == ("user-1", "organization", "org-1")


### PR DESCRIPTION
## Summary

- add canonical server ownership dependencies for personal/org owner context and path-scoped org member/admin/owner checks
- wire RLS request contextvars, actor context, SQLAlchemy GUC application, and explicit session re-apply after owner validation
- migrate representative organization endpoints and billing read endpoints to the new dependency substrate

## PR Metadata

- Title format: `refactor(server): add ownership dependency substrate`
- Release label: `release:maintenance`
- Area label: `area:server`

## Verification

- `uv run python -m compileall -q proliferate`
- `uv run --extra dev python -m ruff check proliferate/auth/dependencies.py proliferate/db/engine.py proliferate/middleware/request_context.py proliferate/permissions.py proliferate/server/billing/api.py proliferate/server/billing/overview.py proliferate/server/organizations/api.py proliferate/server/organizations/service.py tests/integration/test_organizations_api.py`
- `uv run --extra dev python -m ruff format --check proliferate/auth/dependencies.py proliferate/db/engine.py proliferate/middleware/request_context.py proliferate/permissions.py proliferate/server/billing/api.py proliferate/server/billing/overview.py proliferate/server/organizations/api.py proliferate/server/organizations/service.py tests/integration/test_organizations_api.py`
- `DEBUG=1 uv run --extra dev python -m mypy proliferate/permissions.py proliferate/auth/dependencies.py proliferate/db/engine.py proliferate/middleware/request_context.py proliferate/server/organizations/api.py proliferate/server/organizations/service.py proliferate/server/billing/api.py proliferate/server/billing/overview.py`
- `DEBUG=1 uv run --extra dev python -m pytest tests/unit/auth/test_authorization.py tests/unit/test_organization_domain.py -q`
- `DEBUG=1 uv run --extra dev python -m pytest tests/integration/test_organizations_api.py tests/integration/test_billing_api.py -q`
