### PR TITLE
refactor(server): enforce integration policy org RLS

### DIFF
--- a/server/alembic/versions/b8e1f5a6c9d2_org_integration_policy_rls.py
+++ b/server/alembic/versions/b8e1f5a6c9d2_org_integration_policy_rls.py
@@ -1,0 +1,57 @@
+"""enforce organization integration policy RLS
+
+Revision ID: b8e1f5a6c9d2
+Revises: b4c5d6e7f8a9
+Create Date: 2026-06-23 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b8e1f5a6c9d2"
+down_revision: str | Sequence[str] | None = "b4c5d6e7f8a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "cloud_organization_integration_policy"
+_POLICY_NAME = "cloud_org_integration_policy_org_rls"
+_ORG_ISOLATION_EXPR = """
+current_setting('app.owner_scope', true) = 'organization'
+AND organization_id = nullif(current_setting('app.organization_id', true), '')::uuid
+"""
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if not _has_table(_TABLE_NAME):
+        return
+
+    op.execute(f"ALTER TABLE {_TABLE_NAME} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {_TABLE_NAME} FORCE ROW LEVEL SECURITY")
+    op.execute(f"DROP POLICY IF EXISTS {_POLICY_NAME} ON {_TABLE_NAME}")
+    op.execute(
+        f"""
+        CREATE POLICY {_POLICY_NAME}
+        ON {_TABLE_NAME}
+        FOR ALL
+        USING ({_ORG_ISOLATION_EXPR})
+        WITH CHECK ({_ORG_ISOLATION_EXPR})
+        """
+    )
+
+
+def downgrade() -> None:
+    if not _has_table(_TABLE_NAME):
+        return
+
+    op.execute(f"DROP POLICY IF EXISTS {_POLICY_NAME} ON {_TABLE_NAME}")
+    op.execute(f"ALTER TABLE {_TABLE_NAME} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE {_TABLE_NAME} DISABLE ROW LEVEL SECURITY")

--- a/server/proliferate/server/cloud/integration_policy/api.py
+++ b/server/proliferate/server/cloud/integration_policy/api.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from uuid import UUID
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
-from proliferate.db.models.auth import User
+from proliferate.permissions import (
+    CurrentOrgUser,
+    current_path_org_admin,
+    current_path_org_member,
+)
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.integration_policy.models import (
     CloudOrganizationIntegrationPolicyResponse,
@@ -26,15 +27,13 @@ router = APIRouter(prefix="/organizations/{organization_id}/integration-policy")
 
 @router.get("", response_model=CloudOrganizationIntegrationPolicyResponse)
 async def get_organization_integration_policy_endpoint(
-    organization_id: UUID,
-    user: User = Depends(current_product_user),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudOrganizationIntegrationPolicyResponse:
     try:
         snapshot = await get_organization_integration_policy(
             db,
-            actor_user_id=user.id,
-            organization_id=organization_id,
+            org_user=org_user,
         )
     except CloudApiError as error:
         return raise_cloud_error(error)
@@ -43,16 +42,14 @@ async def get_organization_integration_policy_endpoint(
 
 @router.patch("", response_model=CloudOrganizationIntegrationPolicyResponse)
 async def patch_organization_integration_policy_endpoint(
-    organization_id: UUID,
     body: PatchCloudOrganizationIntegrationPolicyRequest,
-    user: User = Depends(current_product_user),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudOrganizationIntegrationPolicyResponse:
     try:
         snapshot = await patch_organization_integration_policy(
             db,
-            actor_user_id=user.id,
-            organization_id=organization_id,
+            org_admin=org_admin,
             body=body,
         )
     except CloudApiError as error:

--- a/server/proliferate/server/cloud/integration_policy/service.py
+++ b/server/proliferate/server/cloud/integration_policy/service.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from uuid import UUID
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
 from proliferate.db.store import cloud_integration_policy as policy_store
-from proliferate.db.store import organizations as organizations_store
-from proliferate.db.store.organization_records import MembershipRecord
+from proliferate.permissions import CurrentOrgUser
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integration_policy.domain.types import (
     OrganizationIntegrationPolicyEntry,
@@ -20,39 +16,6 @@ from proliferate.server.cloud.integration_policy.models import (
 )
 from proliferate.server.cloud.mcp_catalog.availability import catalog_entry_is_configured
 from proliferate.server.cloud.mcp_catalog.catalog import build_connector_catalog
-
-
-def _require_org_member(membership: MembershipRecord | None) -> MembershipRecord:
-    if membership is None:
-        raise CloudApiError(
-            "organization_not_found",
-            "Organization not found.",
-            status_code=404,
-        )
-    return membership
-
-
-def _require_org_admin(membership: MembershipRecord | None) -> None:
-    membership = _require_org_member(membership)
-    if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
-        raise CloudApiError(
-            "organization_permission_denied",
-            "You do not have permission to manage this organization.",
-            status_code=403,
-        )
-
-
-async def _active_membership(
-    db: AsyncSession,
-    *,
-    actor_user_id: UUID,
-    organization_id: UUID,
-) -> MembershipRecord | None:
-    return await organizations_store.get_active_membership(
-        db,
-        organization_id=organization_id,
-        user_id=actor_user_id,
-    )
 
 
 def _configured_catalog_entry_ids() -> tuple[str, ...]:
@@ -66,51 +29,36 @@ def _configured_catalog_entry_ids() -> tuple[str, ...]:
 async def get_organization_integration_policy(
     db: AsyncSession,
     *,
-    actor_user_id: UUID,
-    organization_id: UUID,
+    org_user: CurrentOrgUser,
 ) -> OrganizationIntegrationPolicySnapshot:
-    membership = await _active_membership(
+    records = await policy_store.list_organization_integration_policy(
         db,
-        actor_user_id=actor_user_id,
-        organization_id=organization_id,
+        org_user.organization_id,
     )
-    _require_org_member(membership)
-    records = await policy_store.list_organization_integration_policy(db, organization_id)
     records_by_entry_id = {record.catalog_entry_id: record for record in records}
-    entries = tuple(
-        OrganizationIntegrationPolicyEntry(
-            catalog_entry_id=catalog_entry_id,
-            enabled=records_by_entry_id.get(catalog_entry_id).enabled
-            if catalog_entry_id in records_by_entry_id
-            else True,
-            updated_at=records_by_entry_id.get(catalog_entry_id).updated_at
-            if catalog_entry_id in records_by_entry_id
-            else None,
-            updated_by_user_id=records_by_entry_id.get(catalog_entry_id).updated_by_user_id
-            if catalog_entry_id in records_by_entry_id
-            else None,
+    entries = []
+    for catalog_entry_id in _configured_catalog_entry_ids():
+        record = records_by_entry_id.get(catalog_entry_id)
+        entries.append(
+            OrganizationIntegrationPolicyEntry(
+                catalog_entry_id=catalog_entry_id,
+                enabled=record.enabled if record is not None else True,
+                updated_at=record.updated_at if record is not None else None,
+                updated_by_user_id=record.updated_by_user_id if record is not None else None,
+            )
         )
-        for catalog_entry_id in _configured_catalog_entry_ids()
-    )
     return OrganizationIntegrationPolicySnapshot(
-        organization_id=organization_id,
-        entries=entries,
+        organization_id=org_user.organization_id,
+        entries=tuple(entries),
     )
 
 
 async def patch_organization_integration_policy(
     db: AsyncSession,
     *,
-    actor_user_id: UUID,
-    organization_id: UUID,
+    org_admin: CurrentOrgUser,
     body: PatchCloudOrganizationIntegrationPolicyRequest,
 ) -> OrganizationIntegrationPolicySnapshot:
-    membership = await _active_membership(
-        db,
-        actor_user_id=actor_user_id,
-        organization_id=organization_id,
-    )
-    _require_org_admin(membership)
     catalog_entry_id = body.catalog_entry_id.strip()
     catalog_entry_ids = set(_configured_catalog_entry_ids())
     if catalog_entry_id not in catalog_entry_ids:
@@ -121,13 +69,12 @@ async def patch_organization_integration_policy(
         )
     await policy_store.upsert_organization_integration_policy(
         db,
-        organization_id=organization_id,
+        organization_id=org_admin.organization_id,
         catalog_entry_id=catalog_entry_id,
         enabled=body.enabled,
-        updated_by_user_id=actor_user_id,
+        updated_by_user_id=org_admin.actor_user_id,
     )
     return await get_organization_integration_policy(
         db,
-        actor_user_id=actor_user_id,
-        organization_id=organization_id,
+        org_user=org_admin,
     )

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -7,7 +7,7 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
@@ -24,10 +24,12 @@ from proliferate.db.models.cloud.mcp import (
     CloudMcpConnectionAuth,
     CloudMcpOAuthFlow,
 )
+from proliferate.db.models.cloud.integrations import CloudOrganizationIntegrationPolicy
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.models.cloud.worktree_policy import CloudWorktreeRetentionPolicy
+from proliferate.db.engine import apply_rls_context_to_session
 from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store.cloud_mcp.auth import (
     update_connection_auth_if_version,
@@ -50,6 +52,7 @@ from proliferate.integrations.mcp_oauth import (
     RegisteredOAuthClient,
     TokenResponse,
 )
+from proliferate.middleware.request_context import with_rls_context
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.repo_config import service as repo_config_service
 from proliferate.server.cloud.repos import service as repos_service
@@ -225,6 +228,76 @@ async def _add_organization_member(
         )
     )
     await db_session.commit()
+
+
+async def _insert_organization_integration_policy(
+    db_session: AsyncSession,
+    *,
+    actor_user_id: str,
+    organization_id: str,
+    catalog_entry_id: str,
+    enabled: bool,
+) -> None:
+    actor_uuid = uuid.UUID(actor_user_id)
+    organization_uuid = uuid.UUID(organization_id)
+    with with_rls_context(
+        actor_user_id=actor_uuid,
+        owner_scope="organization",
+        organization_id=organization_uuid,
+    ):
+        await apply_rls_context_to_session(db_session)
+        db_session.add(
+            CloudOrganizationIntegrationPolicy(
+                organization_id=organization_uuid,
+                catalog_entry_id=catalog_entry_id,
+                enabled=enabled,
+                updated_by_user_id=actor_uuid,
+            )
+        )
+        await db_session.commit()
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+async def _create_rls_test_role(db_session: AsyncSession, role_name: str) -> None:
+    quoted_role = _quote_identifier(role_name)
+    await db_session.execute(text(f"CREATE ROLE {quoted_role} NOLOGIN"))
+    await db_session.execute(text(f"GRANT USAGE ON SCHEMA public TO {quoted_role}"))
+    await db_session.execute(
+        text(f"GRANT SELECT ON cloud_organization_integration_policy TO {quoted_role}")
+    )
+    await db_session.commit()
+
+
+async def _drop_rls_test_role(db_session: AsyncSession, role_name: str) -> None:
+    quoted_role = _quote_identifier(role_name)
+    await db_session.rollback()
+    await db_session.execute(text("RESET ROLE"))
+    await db_session.execute(text(f"DROP OWNED BY {quoted_role}"))
+    await db_session.execute(text(f"DROP ROLE IF EXISTS {quoted_role}"))
+    await db_session.commit()
+
+
+async def _list_integration_policy_as_role(
+    db_session: AsyncSession,
+    *,
+    role_name: str,
+) -> list[tuple[uuid.UUID, str]]:
+    quoted_role = _quote_identifier(role_name)
+    await db_session.rollback()
+    await db_session.execute(text(f"SET LOCAL ROLE {quoted_role}"))
+    rows = (
+        await db_session.execute(
+            select(
+                CloudOrganizationIntegrationPolicy.organization_id,
+                CloudOrganizationIntegrationPolicy.catalog_entry_id,
+            ).order_by(CloudOrganizationIntegrationPolicy.catalog_entry_id)
+        )
+    ).all()
+    await db_session.rollback()
+    return [(row.organization_id, row.catalog_entry_id) for row in rows]
 
 
 async def _list_mcp_connections(
@@ -493,6 +566,60 @@ class TestCloudOrganizationIntegrationPolicy:
 
         assert response.status_code == 404
         assert response.json()["detail"]["code"] == "catalog_entry_not_found"
+
+    @pytest.mark.asyncio
+    async def test_rls_filters_policy_rows_without_org_filter(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        owner_a = await _register_and_login(
+            client,
+            f"integration-policy-rls-a-{uuid.uuid4().hex[:8]}@example.com",
+        )
+        owner_b = await _register_and_login(
+            client,
+            f"integration-policy-rls-b-{uuid.uuid4().hex[:8]}@example.com",
+        )
+        organization_a = await _create_organization_for_user(db_session, owner_a["user_id"])
+        organization_b = await _create_organization_for_user(db_session, owner_b["user_id"])
+        await _insert_organization_integration_policy(
+            db_session,
+            actor_user_id=owner_a["user_id"],
+            organization_id=organization_a,
+            catalog_entry_id="linear",
+            enabled=False,
+        )
+        await _insert_organization_integration_policy(
+            db_session,
+            actor_user_id=owner_b["user_id"],
+            organization_id=organization_b,
+            catalog_entry_id="github",
+            enabled=True,
+        )
+
+        role_name = f"rls_policy_{uuid.uuid4().hex}"
+        await _create_rls_test_role(db_session, role_name)
+        try:
+            unscoped_rows = await _list_integration_policy_as_role(
+                db_session,
+                role_name=role_name,
+            )
+            assert unscoped_rows == []
+
+            with with_rls_context(
+                actor_user_id=uuid.UUID(owner_a["user_id"]),
+                owner_scope="organization",
+                organization_id=uuid.UUID(organization_a),
+            ):
+                scoped_rows = await _list_integration_policy_as_role(
+                    db_session,
+                    role_name=role_name,
+                )
+        finally:
+            await _drop_rls_test_role(db_session, role_name)
+
+        assert scoped_rows == [(uuid.UUID(organization_a), "linear")]
 
 
 class TestCloudMcpConnections:


### PR DESCRIPTION
## Summary
- migrate organization integration-policy routes to the path org dependency model
- remove hidden service-layer membership checks for that surface
- enable/FORCE RLS on cloud_organization_integration_policy with org-context GUC isolation
- add integration coverage proving unfiltered selects fail closed for non-bypass app roles

## Verification
- DEBUG=1 uv run python -m alembic heads
- DEBUG=1 uv run --extra dev python -m ruff check proliferate/server/cloud/integration_policy/api.py proliferate/server/cloud/integration_policy/service.py alembic/versions/b8e1f5a6c9d2_org_integration_policy_rls.py tests/integration/test_cloud_api.py
- DEBUG=1 uv run --extra dev python -m ruff format --check proliferate/server/cloud/integration_policy/api.py proliferate/server/cloud/integration_policy/service.py alembic/versions/b8e1f5a6c9d2_org_integration_policy_rls.py tests/integration/test_cloud_api.py
- DEBUG=1 uv run --extra dev python -m mypy proliferate/server/cloud/integration_policy/api.py proliferate/server/cloud/integration_policy/service.py
- DEBUG=1 uv run --extra dev python -m pytest tests/integration/test_cloud_api.py::TestCloudOrganizationIntegrationPolicy -q