### PR TITLE
chore(dev): split local dev setup and run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,18 +32,20 @@ uv run pytest -q
 
 ## Local Full-Stack Profiles
 
-Use `make dev PROFILE=<name>` for full-stack local development, especially when
-multiple worktrees need to run at the same time. Do not use the default-port
+Use `make setup PROFILE=<name>` and `make run PROFILE=<name>` for full-stack
+local development, especially when multiple worktrees need to run at the same
+time. Do not use the default-port
 `make dev-runtime`, `make dev-server`, or `make dev-desktop` shortcuts for
 multi-worktree testing.
 
 Useful commands:
 
 ```bash
-make dev-init PROFILE=<name>
+make setup PROFILE=<name>
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
 make dev-list
-make dev PROFILE=<name>
-make dev PROFILE=<name> STRIPE=1
+make run PROFILE=<name>
+make run PROFILE=<name> STRIPE=1
 ```
 
 Profile state lives under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,10 @@ For full-stack local development, use named profiles:
 
 ```bash
 make server-install
-make dev-init PROFILE=main
+make setup PROFILE=main
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
 make dev-list
-make dev PROFILE=main
+make run PROFILE=main
 ```
 
 ## Pull Requests

--- a/Makefile
+++ b/Makefile
@@ -55,18 +55,34 @@ STRIPE_LOCAL_SECRET_ENV = if [ -z "$${STRIPE_SECRET_KEY:-}" ] && command -v stri
 		echo "Using Stripe CLI test key for local billing API calls."; \
 	fi; \
 fi;
+DEV_FRONTEND_ARTIFACTS := \
+	anyharness/sdk/dist \
+	anyharness/sdk-react/dist \
+	cloud/sdk/dist \
+	cloud/sdk-react/dist \
+	apps/packages/design/dist \
+	apps/packages/product-domain/dist \
+	apps/packages/ui/dist \
+	apps/packages/product-ui/dist \
+	apps/packages/product-surfaces/dist
+PROFILE_DB_READY_COMMAND = make server-db-ready;
+PROFILE_DB_ENSURE_COMMAND = LOCAL_PGHOST="$(LOCAL_PGHOST)" LOCAL_PGPORT="$(LOCAL_PGPORT)" LOCAL_PGUSER="$(LOCAL_PGUSER)" LOCAL_PGPASSWORD="$(LOCAL_PGPASSWORD)" USE_EXISTING_POSTGRES="$(USE_EXISTING_POSTGRES)" node scripts/dev.mjs ensure-db --db-name "$$PROLIFERATE_DEV_DB_NAME";
+ifneq ($(origin DATABASE_URL), undefined)
+PROFILE_DB_READY_COMMAND = :;
+PROFILE_DB_ENSURE_COMMAND = :;
+endif
 
-ifneq ($(filter dev dev-init,$(MAKECMDGOALS)),)
+ifneq ($(filter dev dev-init setup run,$(MAKECMDGOALS)),)
 ifeq ($(strip $(PROFILE)),)
 $(error PROFILE is required. Example: make dev PROFILE=main)
 endif
 endif
 
-.PHONY: catalog-view catalog-pin catalog-update dev dev-init dev-list dev-local dev-desktop dev-runtime dev-server dev-mobile-auth dev-mobile-tunnel dev-web-auth server-db-up server-db-wait \
+.PHONY: catalog-view catalog-pin catalog-update setup run dev dev-init dev-list dev-local dev-desktop dev-runtime dev-server dev-mobile-auth dev-mobile-tunnel dev-web-auth server-db-up server-db-wait \
         server-db-down server-db-ready db db-local db-ah server-migrate serve install \
         check check-max-lines check-server-boundaries test test-server fmt clippy \
         dev-automation-worker \
-        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build runtime-build desktop-build rebuild \
+        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build rebuild \
         release-desktop-dry-run release-desktop-draft \
         test-agent-spec test-agent-runtime-local test-agent-local-fast test-agent-local \
         test-agent-runtime-cloud-e2b test-agent-runtime-cloud-daytona \
@@ -81,12 +97,39 @@ endif
         db-migrate-up db-migrate-down \
         all clean
 
-# --- Dev (builds SDK, starts runtime + desktop together) ---
+# --- Profile dev (setup, build, and run are separate) ---
 
-dev: sdk-build server-db-ready
+dev: setup run
+
+dev-artifacts-ready:
+	@runtime_bin="$${CARGO_TARGET_DIR:-target}/debug/anyharness"; \
+	missing_rust=0; \
+	missing_frontend=0; \
+	if [ ! -x "$$runtime_bin" ]; then \
+		echo "Missing AnyHarness runtime binary: $$runtime_bin"; \
+		missing_rust=1; \
+	fi; \
+	for artifact in $(DEV_FRONTEND_ARTIFACTS); do \
+		if [ ! -d "$$artifact" ]; then \
+			echo "Missing frontend build artifact: $$artifact"; \
+			missing_frontend=1; \
+		fi; \
+	done; \
+	if [ "$$missing_rust" = "1" ] || [ "$$missing_frontend" = "1" ]; then \
+		if [ "$$missing_rust" = "1" ] && [ "$$missing_frontend" = "1" ]; then \
+			echo "Run: make build"; \
+		elif [ "$$missing_rust" = "1" ]; then \
+			echo "Run: make build-rust"; \
+		else \
+			echo "Run: make build-frontend"; \
+		fi; \
+		exit 1; \
+	fi
+
+run: dev-artifacts-ready
 	@set -e; \
 	if [ -z "$(PROFILE)" ]; then \
-		echo "PROFILE is required. Example: make dev PROFILE=main"; \
+		echo "PROFILE is required. Example: make run PROFILE=main"; \
 		exit 1; \
 	fi; \
 	launch_env=$$( \
@@ -122,6 +165,7 @@ dev: sdk-build server-db-ready
 		export DATABASE_URL="$$database_url_override_value"; \
 		use_profile_db=0; \
 	else \
+		$(PROFILE_DB_READY_COMMAND) \
 		export DATABASE_URL="$$( \
 			LOCAL_PGHOST="$(LOCAL_PGHOST)" \
 			LOCAL_PGPORT="$(LOCAL_PGPORT)" \
@@ -198,12 +242,7 @@ dev: sdk-build server-db-ready
 		exit 1; \
 	fi; \
 	if [ "$$use_profile_db" = "1" ]; then \
-		LOCAL_PGHOST="$(LOCAL_PGHOST)" \
-		LOCAL_PGPORT="$(LOCAL_PGPORT)" \
-		LOCAL_PGUSER="$(LOCAL_PGUSER)" \
-		LOCAL_PGPASSWORD="$(LOCAL_PGPASSWORD)" \
-		USE_EXISTING_POSTGRES="$(USE_EXISTING_POSTGRES)" \
-		node scripts/dev.mjs ensure-db --db-name "$$PROLIFERATE_DEV_DB_NAME"; \
+		$(PROFILE_DB_ENSURE_COMMAND) \
 	fi; \
 	if [ "$$agent_gateway_mode" = "1" ] || [ "$$agent_gateway_mode" = "bifrost" ]; then \
 		export AGENT_GATEWAY_ENABLED=true; \
@@ -292,8 +331,9 @@ dev: sdk-build server-db-ready
 		fi; \
 		stripe listen --events "$(STRIPE_SNAPSHOT_EVENTS)" --forward-to "$$STRIPE_FORWARD_TO" & \
 	fi; \
+	runtime_bin="$${CARGO_TARGET_DIR:-target}/debug/anyharness"; \
 	echo "Starting profile $$PROLIFERATE_DEV_PROFILE: runtime :$$ANYHARNESS_PORT, backend :$$PROLIFERATE_API_PORT, desktop :$$PROLIFERATE_WEB_PORT, web :$$PROLIFERATE_HOSTED_WEB_PORT, mobile web :$$PROLIFERATE_MOBILE_WEB_PORT"; \
-	RUST_LOG=info ANYHARNESS_DEV_CORS=1 $(CARGO) run --bin anyharness -- serve --port "$$ANYHARNESS_PORT" --runtime-home "$$ANYHARNESS_RUNTIME_HOME" & \
+	RUST_LOG=info ANYHARNESS_DEV_CORS=1 "$$runtime_bin" serve --port "$$ANYHARNESS_PORT" --runtime-home "$$ANYHARNESS_RUNTIME_HOME" & \
 	(cd server && .venv/bin/uvicorn proliferate.main:app --reload --host 127.0.0.1 --port "$$PROLIFERATE_API_PORT") & \
 	echo "Starting hosted web app..."; \
 	(cd apps/web && VITE_PROLIFERATE_API_BASE_URL="$$API_BASE_URL" VITE_PROLIFERATE_DEV_TOKEN_LOGIN="$${VITE_PROLIFERATE_DEV_TOKEN_LOGIN:-true}" pnpm dev --host 127.0.0.1 --port "$$PROLIFERATE_HOSTED_WEB_PORT" --strictPort) & \
@@ -302,22 +342,34 @@ dev: sdk-build server-db-ready
 	sleep 2; \
 	(cd apps/desktop && pnpm tauri dev --runner "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri-runner.sh" --config "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri.dev.json")
 
-dev-init:
+setup:
 	@if [ -z "$(PROFILE)" ]; then \
-		echo "PROFILE is required. Example: make dev-init PROFILE=main"; \
+		echo "PROFILE is required. Example: make setup PROFILE=main"; \
 		exit 1; \
+	fi; \
+	database_url_override_set="$${DATABASE_URL+x}"; \
+	launch_env=$$( \
+		PROLIFERATE_API_PORT="$(PROLIFERATE_API_PORT)" \
+		PROLIFERATE_WEB_PORT="$(PROLIFERATE_WEB_PORT)" \
+		PROLIFERATE_WEB_HMR_PORT="$(PROLIFERATE_WEB_HMR_PORT)" \
+		PROLIFERATE_HOSTED_WEB_PORT="$(PROLIFERATE_HOSTED_WEB_PORT)" \
+		PROLIFERATE_MOBILE_WEB_PORT="$(PROLIFERATE_MOBILE_WEB_PORT)" \
+		PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE="$(PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE)" \
+		ANYHARNESS_PORT="$(ANYHARNESS_PORT)" \
+		ANYHARNESS_RUNTIME_HOME="$(ANYHARNESS_RUNTIME_HOME)" \
+		PROLIFERATE_DEV_HOME="$(PROLIFERATE_DEV_HOME)" \
+		PROLIFERATE_DEV_DB_NAME="$(PROLIFERATE_DEV_DB_NAME)" \
+		node scripts/dev.mjs ensure --profile "$(PROFILE)" \
+	); \
+	if [ "$$database_url_override_set" = "x" ]; then \
+		echo "Skipping profile database creation because DATABASE_URL is set."; \
+	else \
+		. "$$launch_env"; \
+		$(PROFILE_DB_READY_COMMAND) \
+		$(PROFILE_DB_ENSURE_COMMAND) \
 	fi
-	@PROLIFERATE_API_PORT="$(PROLIFERATE_API_PORT)" \
-	PROLIFERATE_WEB_PORT="$(PROLIFERATE_WEB_PORT)" \
-	PROLIFERATE_WEB_HMR_PORT="$(PROLIFERATE_WEB_HMR_PORT)" \
-	PROLIFERATE_HOSTED_WEB_PORT="$(PROLIFERATE_HOSTED_WEB_PORT)" \
-	PROLIFERATE_MOBILE_WEB_PORT="$(PROLIFERATE_MOBILE_WEB_PORT)" \
-	PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE="$(PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE)" \
-	ANYHARNESS_PORT="$(ANYHARNESS_PORT)" \
-	ANYHARNESS_RUNTIME_HOME="$(ANYHARNESS_RUNTIME_HOME)" \
-	PROLIFERATE_DEV_HOME="$(PROLIFERATE_DEV_HOME)" \
-	PROLIFERATE_DEV_DB_NAME="$(PROLIFERATE_DEV_DB_NAME)" \
-	node scripts/dev.mjs ensure --profile "$(PROFILE)"
+
+dev-init: setup
 
 dev-list:
 	@node scripts/dev.mjs list
@@ -775,11 +827,20 @@ shared-build:
 	pnpm --filter @proliferate/product-ui build
 	pnpm --filter @proliferate/product-surfaces build
 
-runtime-build:
+build-rust:
 	$(CARGO) build --workspace
+
+runtime-build: build-rust
 
 desktop-build: cloud-sdk-build cloud-sdk-react-build sdk-build sdk-react-build shared-build
 	cd apps/desktop && pnpm exec tsc && pnpm exec vite build
+
+web-build: cloud-sdk-build cloud-sdk-react-build sdk-build shared-build
+	cd apps/web && pnpm exec tsc -p tsconfig.json && pnpm exec vite build
+
+build-frontend: desktop-build web-build
+
+build: build-rust build-frontend
 
 test-agent-runtime-cloud-e2b: sdk-generate
 	cd anyharness/tests && pnpm run test:cloud:e2b
@@ -804,7 +865,7 @@ stage-sidecar:
 
 all: check check-max-lines check-server-boundaries sdk-build
 
-rebuild: sdk-build runtime-build desktop-build
+rebuild: build
 
 clean:
 	$(CARGO) clean

--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ the same time.
 
 ```bash
 make server-install
-make dev-init PROFILE=main
+make setup PROFILE=main
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
 make dev-list
-make dev PROFILE=main
+make run PROFILE=main
 ```
 
 See [dev profiles](./specs/developing/local/dev-profiles.md) for profile state, ports,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,8 @@
   "version": "0.2.22",
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
+    "dev": "vite",
+    "dev:built": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
     "build": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
+    "dev": "vite",
+    "dev:built": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
     "build": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -525,6 +525,7 @@ function generatedTauriConfig(profile, env) {
     productName: displayName,
     identifier: `com.proliferate.app.local.${identifierSlug}`,
     build: {
+      beforeDevCommand: "pnpm dev",
       devUrl: `http://127.0.0.1:${env.PROLIFERATE_WEB_PORT}`,
     },
     app: {

--- a/specs/developing/local/README.md
+++ b/specs/developing/local/README.md
@@ -62,8 +62,9 @@ deployment variable ownership.
 From a repo worktree:
 
 ```bash
-make dev-init PROFILE=<name>
-make dev PROFILE=<name>
+make setup PROFILE=<name>
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
+make run PROFILE=<name>
 ```
 
 On Pablo's machine, the shell helper is:
@@ -72,13 +73,27 @@ On Pablo's machine, the shell helper is:
 pdev <name>
 ```
 
-`pdev` initializes the profile, ensures the profile database exists, rebuilds
-the repo, and starts the same profile-aware dev stack. It is a local shell
-convenience, not a repo contract.
+`pdev` should initialize the profile, ensure the profile database exists, and
+start the same profile-aware dev stack without rebuilding the repo. It is a
+local shell convenience, not a repo contract.
+
+Use explicit build targets when generated artifacts or binaries need refreshing:
+
+```bash
+make build-rust
+make build-frontend
+make build
+```
+
+`make run PROFILE=<name>` never invokes these build targets. It checks for the
+existing AnyHarness debug binary and frontend package build artifacts and tells
+you which explicit build target to run when they are missing.
+
+`make dev PROFILE=<name>` remains a compatibility alias for `setup` plus `run`.
 
 ## What Starts
 
-`make dev PROFILE=<name>` starts:
+`make run PROFILE=<name>` starts:
 
 - AnyHarness runtime on the profile's `ANYHARNESS_PORT`
 - Proliferate server on the profile's `PROLIFERATE_API_PORT`
@@ -162,7 +177,7 @@ It does not write Stripe API keys or webhook secrets.
 Start the full stack with Stripe webhook forwarding:
 
 ```bash
-make dev PROFILE=<name> STRIPE=1
+make run PROFILE=<name> STRIPE=1
 ```
 
 This does three useful things:
@@ -186,7 +201,7 @@ The billing-specific runbook is
 ## Web
 
 The hosted web app starts automatically with the full profile. Open the profile
-hosted web URL printed by `make dev` or inspect it with:
+hosted web URL printed by `make run` or inspect it with:
 
 ```bash
 source ~/.proliferate-local/dev/profiles/<name>/launch.env
@@ -224,7 +239,7 @@ add or change an email/password credential from Account settings.
 
 ## Desktop
 
-The desktop app starts automatically at the end of `make dev PROFILE=<name>`.
+The desktop app starts automatically at the end of `make run PROFILE=<name>`.
 The generated app identity makes the macOS app bar show the profile name, such
 as:
 
@@ -311,14 +326,14 @@ paths are:
 For local Bifrost/managed-credit work:
 
 ```bash
-make dev PROFILE=<name> AGENT_GATEWAY=bifrost
+make run PROFILE=<name> AGENT_GATEWAY=bifrost
 ```
 
 For E2B or public sandbox tests that need to call back into the local profile:
 
 ```bash
-make dev PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
-make dev PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
+make run PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
+make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
 ```
 
 The first command exposes both API callbacks and Bifrost through ngrok. The

--- a/specs/developing/local/dev-profiles.md
+++ b/specs/developing/local/dev-profiles.md
@@ -7,17 +7,18 @@ home, desktop file-backed home, and the macOS dev app label.
 ## Commands
 
 ```bash
-make dev-init PROFILE=<name>       # create or update profile state
+make setup PROFILE=<name>          # create/update profile state and database
+make build                         # first clean worktree or artifact refresh
 make dev-list                      # list profiles and TCP-probed status
-make dev PROFILE=<name>            # full stack for this profile
-make dev PROFILE=<name> STRIPE=1   # also run Stripe webhook forwarding
-make dev PROFILE=<name> AGENT_GATEWAY=1
+make run PROFILE=<name>            # full stack for this profile, no rebuild
+make run PROFILE=<name> STRIPE=1   # also run Stripe webhook forwarding
+make run PROFILE=<name> AGENT_GATEWAY=1
                                     # also run/reuse local Bifrost for gateway work
-make dev PROFILE=<name> AGENT_GATEWAY=bifrost
+make run PROFILE=<name> AGENT_GATEWAY=bifrost
                                     # also run/reuse local Bifrost for gateway work
-make dev PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
+make run PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
                                     # expose Bifrost and API worker callbacks through ngrok for E2B/public sandbox tests
-make dev PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
+make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
                                     # expose only API worker callbacks through ngrok
 make dev-web-auth                  # standalone web auth helper with ngrok callbacks
 ```
@@ -57,9 +58,11 @@ but they are excluded from automatic per-repo retention and orphan pruning.
 The default database is `proliferate_dev_<name>` on the local Docker Postgres
 server. On macOS, profile database URLs default to `::1` so Docker Desktop's
 Postgres listener is not confused with a Homebrew Postgres bound to
-`127.0.0.1:5432`. Use `DATABASE_URL=... make dev PROFILE=<name>` when you
+`127.0.0.1:5432`. Use `DATABASE_URL=... make run PROFILE=<name>` when you
 intentionally want to bypass the profile database for a one-off run, or
 `LOCAL_PGHOST=127.0.0.1` when you intentionally want a separate local Postgres.
+When `DATABASE_URL` is set, profile setup and run skip profile database
+creation/readiness checks and migrate the provided database URL.
 
 Desktop auth sessions, pending-auth entries, and stored provider API keys are
 profile-scoped `0600` files under the dev app home, so per-profile databases do
@@ -69,8 +72,8 @@ state. (See the sidecar spec's Local Secrets for the storage model.)
 
 ## Agent Gateway Local Dev
 
-`make dev PROFILE=<name> AGENT_GATEWAY=1` and
-`make dev PROFILE=<name> AGENT_GATEWAY=bifrost` start or reuse a local Bifrost
+`make run PROFILE=<name> AGENT_GATEWAY=1` and
+`make run PROFILE=<name> AGENT_GATEWAY=bifrost` start or reuse a local Bifrost
 gateway and export the API env needed for Bifrost-backed managed credits and
 personal BYOK development:
 
@@ -124,7 +127,7 @@ types at the same time.
 
 The Google Workspace MCP value is the base of a 64-port loopback pool used for
 local Gmail OAuth callbacks. The generated Tauri config points the desktop at
-`PROLIFERATE_WEB_PORT`, while `make dev PROFILE=<name>` also starts the hosted
+`PROLIFERATE_WEB_PORT`, while `make run PROFILE=<name>` also starts the hosted
 web app on `PROLIFERATE_HOSTED_WEB_PORT` and sets `FRONTEND_BASE_URL` to that
 hosted web origin. Server CORS includes the desktop renderer, hosted web, Expo
 mobile web, and Tauri origins. For browser-based mobile smoke tests, run Expo
@@ -142,7 +145,9 @@ appearing as `proliferate`.
 
 ## Scope Notes
 
-`make dev PROFILE=<name>` is the profile-aware workflow. The individual
+`make setup PROFILE=<name>` and `make run PROFILE=<name>` are the
+profile-aware workflow. `make dev PROFILE=<name>` remains a compatibility alias
+for setup plus run. The individual
 `make dev-runtime`, `make dev-server`, and `make dev-desktop` shortcuts remain
 default-port shortcuts.
 
@@ -185,7 +190,7 @@ pass the resolved seed directory to the AnyHarness sidecar. Local development ca
 exercise the same hydration path by setting:
 
 ```bash
-ANYHARNESS_AGENT_SEED_DIR=/absolute/path/to/agent-seeds make dev PROFILE=<name>
+ANYHARNESS_AGENT_SEED_DIR=/absolute/path/to/agent-seeds make run PROFILE=<name>
 ```
 
 The directory should contain the generated target archive and checksum:

--- a/specs/developing/local/mobile.md
+++ b/specs/developing/local/mobile.md
@@ -30,8 +30,9 @@ Use the narrowest mobile mode that proves the change:
 Start the full profile first:
 
 ```bash
-make dev-init PROFILE=<name>
-make dev PROFILE=<name>
+make setup PROFILE=<name>
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
+make run PROFILE=<name>
 ```
 
 Then run Expo web using the profile environment:

--- a/specs/developing/local/stripe-local-testing.md
+++ b/specs/developing/local/stripe-local-testing.md
@@ -36,12 +36,12 @@ The script is idempotent. It creates these test-mode resources if missing:
 With `--write-env-local`, non-secret IDs are written to `server/.env.local`.
 The script never writes `STRIPE_SECRET_KEY` or `STRIPE_WEBHOOK_SECRET`.
 
-Profile-based `make dev PROFILE=<name>` does not run this setup automatically.
+Profile-based `make run PROFILE=<name>` does not run this setup automatically.
 Run `make stripe-setup-test` when you need durable local Stripe price and meter
 IDs in `server/.env.local`. Profile dev overrides port-specific Stripe redirect
 URLs in the backend process environment at launch time.
 
-When launched through `make dev` or `make dev-server`, the backend process reads
+When launched through `make run` or `make dev-server`, the backend process reads
 the Stripe CLI test-mode key from `stripe config --list` if `STRIPE_SECRET_KEY`
 is otherwise unset. The key is exported only into that process environment and
 is not written to `server/.env.local`.
@@ -54,13 +54,13 @@ or run through `make dev-server`.
 1. Start the full local app with Stripe forwarding enabled:
 
    ```bash
-   make dev PROFILE=billing STRIPE=1
+   make run PROFILE=billing STRIPE=1
    ```
 
    This runs migrations for the selected profile database, injects the Stripe
    CLI test key into the backend process, starts a Stripe webhook listener,
    starts the backend, and opens the desktop app.
-   `make dev` and `make dev-server` export `DEBUG=true` for the backend process
+   `make run` and `make dev-server` export `DEBUG=true` for the backend process
    so a fresh local worktree does not need a committed production secret file.
 
 2. In the desktop app, open Cloud settings and use the Cloud checkout action.
@@ -94,7 +94,7 @@ use:
 CLOUD_BILLING_MODE=enforce
 ```
 
-Then restart `make dev PROFILE=<name>`.
+Then restart `make run PROFILE=<name>`.
 
 ## Send A Meter Hit
 
@@ -127,10 +127,10 @@ quantity to Stripe.
 
 ## Local Webhook Delivery
 
-`make dev PROFILE=<name>` starts a Stripe snapshot-event listener only when
+`make run PROFILE=<name>` starts a Stripe snapshot-event listener only when
 `STRIPE=1` is set. If Stripe is unavailable, dev continues without the listener.
 
-When the listener starts, `make dev` exports `STRIPE_WEBHOOK_SECRET` into the
+When the listener starts, `make run` exports `STRIPE_WEBHOOK_SECRET` into the
 backend process from `stripe listen --print-secret`. The secret is not written
 to `server/.env.local`.
 
@@ -146,7 +146,7 @@ stripe listen \
 The endpoint verifies the Stripe signature before parsing the event and returns
 a small acknowledgement with the Stripe event id and event type.
 
-If you are not using profile-based `make dev`, start the listener manually:
+If you are not using profile-based `make run`, start the listener manually:
 
 ```bash
 stripe listen --forward-to http://127.0.0.1:8000/v1/billing/webhooks/stripe

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -250,12 +250,12 @@ docs need to change.
 | `stripe-local-testing.md` | Webhook forwarding, checkout, portal, refill, meter events |
 | `mobile.md` | Native mobile OAuth, Expo overrides, dev refresh-token path |
 
-Quick start: `make dev-init PROFILE=<name>` + `make dev PROFILE=<name>` (Pablo's alias: `pdev <name>`).
+Quick start: `make setup PROFILE=<name>` + `make build` for a clean worktree + `make run PROFILE=<name>` (Pablo's alias: `pdev <name>`).
 
-Stripe: `make stripe-setup-test` then `make dev PROFILE=<name> STRIPE=1`.
+Stripe: `make stripe-setup-test` then `make run PROFILE=<name> STRIPE=1`.
 Mobile web: `pnpm --dir apps/mobile web:profile`.
 Native mobile: `make dev-mobile-auth` (starts server + ngrok + Expo).
-Tunnels: `make dev PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok` or `CLOUD_WORKER_TUNNEL=ngrok`.
+Tunnels: `make run PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok` or `CLOUD_WORKER_TUNNEL=ngrok`.
 
 MCPs + permissions: local shell, Browser/Chrome for local/OAuth/provider
 surfaces, GitHub MCP/`gh` when reproducing from issue or artifact context,


### PR DESCRIPTION
## Summary
- Add profile-centered `make setup PROFILE=...` and `make run PROFILE=...` commands.
- Keep compatibility aliases for `dev`, `dev-init`, and existing build target names.
- Make desktop/web `pnpm dev` start Vite directly and move build-before-dev behavior to `dev:built`.
- Update local development docs to prefer the setup/run split.

## Validation
- `make -n run PROFILE=devsplit-test` has no build/codegen commands
- `make -n setup PROFILE=devsplit-test` has no build/codegen commands
- `make -n dev PROFILE=devsplit-test` has no build/codegen commands
- `make -n build-rust`, `make -n build-frontend`, `make -n build`
- `git diff --cached --check`
- Parsed `apps/desktop/package.json` and `apps/web/package.json` with Node

## Notes
- Opened from a fresh worktree based on `origin/main` so the existing `chimp` branch PR remains untouched.