### PR TITLE
fix(product): tighten sidebar row density

### DIFF
--- a/apps/packages/product-ui/src/sidebar/ProductSidebarNavigation.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarNavigation.tsx
@@ -49,13 +49,13 @@ export function ProductSidebarNavRow({
       active={item.active}
       disabled={item.disabled}
       onPress={() => onSelect(item.id)}
-      className={`min-h-[calc(1lh+0.5rem)] gap-2 px-2 py-1 text-base leading-5 focus-visible:outline-offset-[-2px] ${className}`}
+      className={`min-h-[calc(1lh+0.5rem)] gap-2 px-2 py-1 text-sm leading-5 focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       <div className="flex size-[1.125em] shrink-0 items-center justify-center [&>svg]:size-full [&>svg]:shrink-0">
         {item.icon}
       </div>
-      <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-current">
+      <div className="flex min-w-0 flex-1 items-center text-sm leading-5 text-current">
         <span className="truncate">{item.label}</span>
       </div>
       {item.status ? (

--- a/apps/packages/ui/src/layout/SidebarNavRow.tsx
+++ b/apps/packages/ui/src/layout/SidebarNavRow.tsx
@@ -32,13 +32,13 @@ export function SidebarNavRow({
       active={active}
       disabled={disabled}
       onPress={onPress}
-      className={`min-h-[calc(1lh+0.5rem)] gap-2 px-2 py-1 text-base leading-5 focus-visible:outline-offset-[-2px] ${className}`}
+      className={`min-h-[calc(1lh+0.5rem)] gap-2 px-2 py-1 text-sm leading-5 focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       <div className="flex size-[1.125em] shrink-0 items-center justify-center [&>svg]:size-full [&>svg]:shrink-0">
         {icon}
       </div>
-      <div className="flex min-w-0 flex-1 items-center text-base leading-5 text-current">
+      <div className="flex min-w-0 flex-1 items-center text-sm leading-5 text-current">
         <span className="truncate">{label}</span>
       </div>
       {status ? (


### PR DESCRIPTION
## Summary
- Tighten shared sidebar row typography from text-base to text-sm.
- Keep icon sizing tied to row text size so icons and labels scale together.

## Verification
- pnpm --filter @proliferate/ui build
- pnpm --filter @proliferate/product-ui build