### PR TITLE
feat(cloud): add repo environments

### DIFF
--- a/apps/desktop/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
+++ b/apps/desktop/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
@@ -1,0 +1,49 @@
+import type { AgentLaunchOptionsResponse } from "@anyharness/sdk";
+import {
+  anyHarnessAgentLaunchOptionsKey,
+  useAgentLaunchOptionsQuery,
+} from "@anyharness/sdk-react";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getAgentLaunchOptions } from "@/lib/access/anyharness/agents";
+import type { CloudConnectionInfo } from "@/lib/access/cloud/client";
+import { withFreshManagedSandboxGatewayAccessToken } from "@/lib/access/cloud/managed-sandbox-gateway";
+
+export function useWorkspaceAgentLaunchOptionsQuery({
+  workspaceId,
+  cloudConnectionInfo,
+}: {
+  workspaceId: string | null;
+  cloudConnectionInfo?: CloudConnectionInfo | null;
+}): UseQueryResult<AgentLaunchOptionsResponse> {
+  const localQuery = useAgentLaunchOptionsQuery({
+    workspaceId,
+    enabled: !cloudConnectionInfo,
+  });
+  const gatewayRuntimeUrl = cloudConnectionInfo?.runtimeUrl ?? "";
+  const gatewayWorkspaceId = cloudConnectionInfo?.anyharnessWorkspaceId ?? null;
+  const gatewayQuery = useQuery({
+    queryKey: anyHarnessAgentLaunchOptionsKey(
+      gatewayRuntimeUrl,
+      gatewayWorkspaceId,
+    ),
+    enabled: Boolean(cloudConnectionInfo && gatewayRuntimeUrl && gatewayWorkspaceId),
+    queryFn: async ({ signal }) => {
+      if (!cloudConnectionInfo) {
+        throw new Error("Cloud workspace connection is unavailable.");
+      }
+      const freshConnection = await withFreshManagedSandboxGatewayAccessToken(
+        cloudConnectionInfo,
+      );
+      return getAgentLaunchOptions(
+        {
+          runtimeUrl: freshConnection.runtimeUrl,
+          authToken: freshConnection.accessToken ?? undefined,
+        },
+        freshConnection.anyharnessWorkspaceId,
+        { signal },
+      );
+    },
+  });
+
+  return cloudConnectionInfo ? gatewayQuery : localQuery;
+}

--- a/apps/desktop/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts
@@ -66,13 +66,15 @@ export function useWorkspaceSessionCache() {
   const upsertWorkspaceSessionRecord = useCallback((
     workspaceId: string,
     session: Session,
+    options?: WorkspaceSessionCacheOptions,
   ) => {
+    const targetRuntimeUrl = options?.runtimeUrl ?? runtimeUrl;
     queryClient.setQueryData(
-      anyHarnessSessionKey(runtimeUrl, workspaceId, session.id),
+      anyHarnessSessionKey(targetRuntimeUrl, workspaceId, session.id),
       session,
     );
     queryClient.setQueryData<WorkspaceSession[]>(
-      anyHarnessSessionsKey(runtimeUrl, workspaceId),
+      anyHarnessSessionsKey(targetRuntimeUrl, workspaceId),
       (sessions) => upsertWorkspaceSession(sessions, {
         ...session,
         workspaceId,

--- a/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
+++ b/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
@@ -13,7 +13,7 @@ import type {
 const mocks = vi.hoisted(() => ({
   useCloudAgentCatalog: vi.fn(),
   useAgentCatalog: vi.fn(),
-  useAgentLaunchOptionsQuery: vi.fn(),
+  useWorkspaceAgentLaunchOptionsQuery: vi.fn(),
   useSelectedCloudRuntimeState: vi.fn(),
 }));
 
@@ -25,8 +25,8 @@ vi.mock("@/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: mocks.useAgentCatalog,
 }));
 
-vi.mock("@anyharness/sdk-react", () => ({
-  useAgentLaunchOptionsQuery: mocks.useAgentLaunchOptionsQuery,
+vi.mock("@/hooks/access/anyharness/agents/use-workspace-agent-launch-options", () => ({
+  useWorkspaceAgentLaunchOptionsQuery: mocks.useWorkspaceAgentLaunchOptionsQuery,
 }));
 
 vi.mock("@/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
@@ -83,7 +83,7 @@ describe("useChatLaunchCatalog", () => {
         ["claude", { readiness: "ready" }],
       ]),
     });
-    mocks.useAgentLaunchOptionsQuery.mockReturnValue({
+    mocks.useWorkspaceAgentLaunchOptionsQuery.mockReturnValue({
       data: null,
       isLoading: false,
       isError: false,
@@ -112,8 +112,9 @@ describe("useChatLaunchCatalog", () => {
     const { result } = renderHook(() => useChatLaunchCatalog({ activeSelection: null }));
 
     expect(mocks.useCloudAgentCatalog).toHaveBeenCalledWith(true);
-    expect(mocks.useAgentLaunchOptionsQuery).toHaveBeenCalledWith({
+    expect(mocks.useWorkspaceAgentLaunchOptionsQuery).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
+      cloudConnectionInfo: null,
     });
     expect(result.current.launchAgents.map((agent) => agent.kind)).toEqual([
       "claude",
@@ -143,7 +144,9 @@ describe("useChatLaunchCatalog", () => {
       refetch: vi.fn(),
     });
 
-    const { result } = renderHook(() => useChatLaunchCatalog({ activeSelection: null }));
+    const { result } = renderHook(() => useChatLaunchCatalog({
+      activeSelection: { kind: "claude", modelId: "opus[1m]" },
+    }));
 
     expect(result.current.error).toBe(error);
     expect(result.current.cloudCatalogError).toBe(error);
@@ -190,7 +193,7 @@ describe("useChatLaunchCatalog", () => {
       error: null,
       agentsByKind: new Map([["cursor", { readiness: "ready" }]]),
     });
-    mocks.useAgentLaunchOptionsQuery.mockReturnValue({
+    mocks.useWorkspaceAgentLaunchOptionsQuery.mockReturnValue({
       data: {
         workspaceId: "workspace-1",
         agents: [{
@@ -225,7 +228,16 @@ describe("useChatLaunchCatalog", () => {
     });
   });
 
-  it("uses cloud connection ready agents instead of local runtime readiness for cloud targets", () => {
+  it("uses managed cloud runtime launch options instead of stale cloud catalog models", () => {
+    mocks.useCloudAgentCatalog.mockReturnValue({
+      data: catalog([
+        launchAgent("codex", "gpt-5.5", "Codex"),
+        launchAgent("claude", "opus[1m]", "Claude"),
+      ]),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
     mocks.useAgentCatalog.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -235,21 +247,25 @@ describe("useChatLaunchCatalog", () => {
         ["claude", { readiness: "ready" }],
       ]),
     });
+    const cloudConnectionInfo = {
+      runtimeUrl: "https://api.local/v1/gateway/managed-sandbox/anyharness",
+      accessToken: "product-token",
+      anyharnessWorkspaceId: "cloud-workspace-1",
+      readyAgentKinds: ["codex"],
+    };
     mocks.useSelectedCloudRuntimeState.mockReturnValue({
-      connectionInfo: {
-        readyAgentKinds: ["codex"],
-      },
+      connectionInfo: cloudConnectionInfo,
     });
-    mocks.useAgentLaunchOptionsQuery.mockReturnValue({
+    mocks.useWorkspaceAgentLaunchOptionsQuery.mockReturnValue({
       data: {
-        workspaceId: "workspace-1",
+        workspaceId: "cloud-workspace-1",
         agents: [{
           kind: "claude",
           displayName: "Claude",
-          defaultModelId: "local-sonnet",
+          defaultModelId: "opus",
           models: [{
-            id: "local-sonnet",
-            displayName: "Local Sonnet",
+            id: "opus",
+            displayName: "Opus",
             isDefault: true,
             defaultOptIn: true,
           }],
@@ -259,13 +275,28 @@ describe("useChatLaunchCatalog", () => {
       isError: false,
       error: null,
     });
+    useUserPreferencesStore.setState({
+      defaultChatAgentKind: "claude",
+      defaultChatModelIdByAgentKind: { claude: "opus[1m]" },
+    });
 
-    const { result } = renderHook(() => useChatLaunchCatalog({ activeSelection: null }));
+    const { result } = renderHook(() => useChatLaunchCatalog({
+      activeSelection: { kind: "claude", modelId: "opus[1m]" },
+    }));
 
-    expect(result.current.launchAgents.map((agent) => agent.kind)).toEqual(["codex"]);
+    expect(mocks.useWorkspaceAgentLaunchOptionsQuery).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      cloudConnectionInfo,
+    });
+    expect(result.current.launchAgents.map((agent) => agent.kind)).toEqual(["claude"]);
+    expect(result.current.launchAgents[0]?.models.map((model) => model.id)).toEqual(["opus"]);
     expect(result.current.defaultLaunchSelection).toEqual({
-      kind: "codex",
-      modelId: "gpt-5.5",
+      kind: "claude",
+      modelId: "opus",
+    });
+    expect(result.current.selectedLaunchSelection).toEqual({
+      kind: "claude",
+      modelId: "opus",
     });
   });
 

--- a/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.ts
@@ -11,7 +11,10 @@ import type {
   ModelSelectorGroup,
   ModelSelectorSelection,
 } from "@/lib/domain/chat/models/model-selector-types";
-import { resolveEffectiveLaunchSelection } from "@/lib/domain/chat/models/launch-selection-defaults";
+import {
+  resolveAvailableLaunchSelection,
+  resolveEffectiveLaunchSelection,
+} from "@/lib/domain/chat/models/launch-selection-defaults";
 import type { LaunchCatalogSnapshot } from "@/lib/domain/chat/launch/launch-intent";
 import { useCloudAgentCatalog } from "@/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog";
 import {
@@ -20,8 +23,8 @@ import {
 } from "@/lib/domain/agents/cloud-launch-catalog";
 import { filterTargetReadyLaunchAgents } from "@/lib/domain/agents/target-ready-launch-agents";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
-import { useAgentLaunchOptionsQuery } from "@anyharness/sdk-react";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/facade/use-selected-cloud-runtime-state";
+import { useWorkspaceAgentLaunchOptionsQuery } from "@/hooks/access/anyharness/agents/use-workspace-agent-launch-options";
 
 const EMPTY_AGENTS: DesktopAgentLaunchAgent[] = [];
 
@@ -44,20 +47,22 @@ export function useChatLaunchCatalog({
   const query = useCloudAgentCatalog(true);
   const agentCatalog = useAgentCatalog();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
-  const runtimeLaunchOptions = useAgentLaunchOptionsQuery({
+  const runtimeLaunchOptions = useWorkspaceAgentLaunchOptionsQuery({
     workspaceId: selectedWorkspaceId,
+    cloudConnectionInfo: selectedCloudRuntime.connectionInfo,
   });
   const hasCloudTargetReadiness = Boolean(selectedCloudRuntime.connectionInfo);
   const catalogData = query.data ?? null;
   const catalogLoading = query.isLoading
-    || (!hasCloudTargetReadiness && (agentCatalog.isLoading || runtimeLaunchOptions.isLoading));
+    || runtimeLaunchOptions.isLoading
+    || (!hasCloudTargetReadiness && agentCatalog.isLoading);
   const cloudCatalogError = query.error ?? null;
-  const targetReadinessError = hasCloudTargetReadiness
-    ? null
-    : agentCatalog.isError
-      ? agentCatalog.error
-      : runtimeLaunchOptions.isError
-        ? runtimeLaunchOptions.error
+  const targetReadinessError = runtimeLaunchOptions.isError
+    ? runtimeLaunchOptions.error
+    : hasCloudTargetReadiness
+      ? null
+      : agentCatalog.isError
+        ? agentCatalog.error
         : null;
   const launchCatalogError = cloudCatalogError ?? targetReadinessError;
 
@@ -65,12 +70,11 @@ export function useChatLaunchCatalog({
     () => orderLaunchAgents(
       mergeRuntimeLaunchOptionsIntoDesktopLaunchAgents(
         catalogData?.agents ?? EMPTY_AGENTS,
-        selectedCloudRuntime.connectionInfo
-          ? null
-          : runtimeLaunchOptions.data?.agents ?? null,
+        runtimeLaunchOptions.data?.agents ?? null,
       ),
       agentCatalog.agentsByKind,
       selectedCloudRuntime.connectionInfo?.readyAgentKinds ?? null,
+      Boolean(selectedCloudRuntime.connectionInfo && runtimeLaunchOptions.data?.agents.length),
     ),
     [
       agentCatalog.agentsByKind,
@@ -105,7 +109,14 @@ export function useChatLaunchCatalog({
     [launchAgents, preferences],
   );
 
-  const selectedLaunchSelection = activeSelection ?? defaultLaunchSelection;
+  const selectedLaunchSelection = useMemo(
+    () => resolveAvailableLaunchSelection(
+      launchAgents,
+      activeSelection,
+      defaultLaunchSelection,
+    ),
+    [activeSelection, defaultLaunchSelection, launchAgents],
+  );
 
   const groups = useMemo<ModelSelectorGroup[]>(
     () => buildModelSelectorGroups(
@@ -145,8 +156,11 @@ function orderLaunchAgents(
   agents: readonly DesktopAgentLaunchAgent[],
   agentsByKind: ReadonlyMap<string, { readiness: string }>,
   cloudReadyAgentKinds: readonly string[] | null,
+  runtimeOptionsAreAuthoritative = false,
 ): DesktopAgentLaunchAgent[] {
-  const targetReadyAgents = cloudReadyAgentKinds
+  const targetReadyAgents = runtimeOptionsAreAuthoritative
+    ? agents.filter((agent) => agent.models.length > 0)
+    : cloudReadyAgentKinds
     ? filterCloudReadyLaunchAgents(agents, cloudReadyAgentKinds)
     : filterTargetReadyLaunchAgents(agents, agentsByKind);
 

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -30,7 +30,11 @@ export interface ConfigIntentDispatchDeps {
     workspaceId: string | null | undefined,
   ) => Parameters<typeof persistDefaultSessionModePreference>[0]["workspaceSurface"];
   setSessionConfigOptionMutation: SetSessionConfigOptionMutation;
-  upsertWorkspaceSessionRecord: (workspaceId: string, session: Session) => void;
+  upsertWorkspaceSessionRecord: (
+    workspaceId: string,
+    session: Session,
+    options?: { runtimeUrl?: string },
+  ) => void;
 }
 
 export async function dispatchConfigIntent(
@@ -47,7 +51,9 @@ export async function dispatchConfigIntent(
     dispatchedAt: new Date().toISOString(),
   });
   try {
-    const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(intent.clientSessionId);
+    const { connection, workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(
+      intent.clientSessionId,
+    );
     useSessionIntentStore.getState().bindMaterializedSession(
       intent.clientSessionId,
       materializedSessionId,
@@ -58,7 +64,9 @@ export async function dispatchConfigIntent(
       request: { configId: intent.configId, value: intent.value },
     });
     if (workspaceId) {
-      deps.upsertWorkspaceSessionRecord(workspaceId, response.session);
+      deps.upsertWorkspaceSessionRecord(workspaceId, response.session, {
+        runtimeUrl: connection.runtimeUrl,
+      });
     }
     const latestSlot = getSessionRecord(intent.clientSessionId);
     const responseLiveConfig = response.liveConfig ?? response.session.liveConfig ?? null;

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
@@ -66,7 +66,11 @@ export interface PromptIntentDispatchDeps {
       timeoutMs?: number;
     },
   ) => Promise<boolean>;
-  upsertWorkspaceSessionRecord: (workspaceId: string, session: Session) => void;
+  upsertWorkspaceSessionRecord: (
+    workspaceId: string,
+    session: Session,
+    options?: { runtimeUrl?: string },
+  ) => void;
 }
 
 export async function dispatchPromptIntent(
@@ -177,7 +181,9 @@ export async function dispatchPromptIntent(
     }
 
     deps.applySessionSummary(entry.clientSessionId, response.session, workspaceId);
-    deps.upsertWorkspaceSessionRecord(workspaceId, response.session);
+    deps.upsertWorkspaceSessionRecord(workspaceId, response.session, {
+      runtimeUrl: connection.runtimeUrl,
+    });
     useSessionIntentStore.getState().patchIntent(entry.intentId, {
       status: "accepted",
       deliveryState: response.status === "queued" ? "accepted_queued" : "accepted_running",

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
@@ -29,6 +29,7 @@ export function materializeExistingSession({
   launchIntentId,
   pendingSessionId,
   resolvedModeId,
+  runtimeUrl,
   upsertWorkspaceSessionRecord,
   workspaceId,
 }: {
@@ -39,7 +40,12 @@ export function materializeExistingSession({
   launchIntentId?: string | null;
   pendingSessionId: string;
   resolvedModeId: string | null;
-  upsertWorkspaceSessionRecord: (workspaceId: string, session: Session) => void;
+  upsertWorkspaceSessionRecord: (
+    workspaceId: string,
+    session: Session,
+    options?: { runtimeUrl?: string },
+  ) => void;
+  runtimeUrl?: string;
   workspaceId: string;
 }): string {
   annotateLatencyFlow(latencyFlowId, {
@@ -67,7 +73,7 @@ export function materializeExistingSession({
   if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
     rememberLastViewedSession(workspaceId, existingSession.id);
   }
-  upsertWorkspaceSessionRecord(workspaceId, existingSession);
+  upsertWorkspaceSessionRecord(workspaceId, existingSession, { runtimeUrl });
   if (launchIntentId) {
     useChatLaunchIntentStore.getState().markMaterializedIfActive(
       launchIntentId,

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -61,7 +61,11 @@ interface MaterializeSessionCreationInput {
   options: CreateSessionWithResolvedConfigOptions;
   pendingSessionId: string;
   resolvedModeId: string | null;
-  upsertWorkspaceSessionRecord: (workspaceId: string, session: Session) => void;
+  upsertWorkspaceSessionRecord: (
+    workspaceId: string,
+    session: Session,
+    options?: { runtimeUrl?: string },
+  ) => void;
   workspaceId: string;
 }
 
@@ -132,6 +136,7 @@ export async function materializeSessionCreation({
         latencyFlowId: options.latencyFlowId,
         pendingSessionId,
         resolvedModeId,
+        runtimeUrl: target.baseUrl,
         upsertWorkspaceSessionRecord,
         workspaceId,
         launchIntentId: options.launchIntentId,
@@ -260,7 +265,9 @@ export async function materializeSessionCreation({
   if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
     rememberLastViewedSession(workspaceId, launchedSession.id);
   }
-  upsertWorkspaceSessionRecord(workspaceId, launchedSession);
+  upsertWorkspaceSessionRecord(workspaceId, launchedSession, {
+    runtimeUrl: target.baseUrl,
+  });
   trackProductEvent("chat_session_created", {
     workspace_kind: cloudWorkspaceId ? "cloud" : "local",
     agent_kind: options.agentKind,

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-model-fallback-action.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-model-fallback-action.ts
@@ -14,7 +14,7 @@ export function useSessionModelFallbackAction() {
   const setSessionConfigOptionMutation = useSetSessionConfigOptionMutation();
 
   return useCallback(async (sessionId: string, fallbackModelId: string) => {
-    const { workspaceId, materializedSessionId } =
+    const { connection, workspaceId, materializedSessionId } =
       await getSessionClientAndWorkspace(sessionId);
     const response = await setSessionConfigOptionMutation.mutateAsync({
       workspaceId,
@@ -25,7 +25,9 @@ export function useSessionModelFallbackAction() {
       },
     });
 
-    upsertWorkspaceSessionRecord(workspaceId, response.session);
+    upsertWorkspaceSessionRecord(workspaceId, response.session, {
+      runtimeUrl: connection.runtimeUrl,
+    });
 
     const latestSlot = getSessionRecord(sessionId);
     if (!latestSlot) {

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
@@ -110,7 +110,9 @@ export function useSessionRestoreActions() {
         targetSessionId: restored.id,
       });
 
-      upsertWorkspaceSessionRecord(workspaceId, restored);
+      upsertWorkspaceSessionRecord(workspaceId, restored, {
+        runtimeUrl: target.baseUrl,
+      });
       logLatency("session.restore.cache_upserted", {
         workspaceId,
         sessionId: restored.id,

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-title-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-title-actions.ts
@@ -43,7 +43,7 @@ export function useSessionTitleActions() {
       throw new Error("Chat title cannot be empty.");
     }
 
-    const { workspaceId, materializedSessionId } =
+    const { connection, workspaceId, materializedSessionId } =
       await getSessionClientAndWorkspace(sessionId);
     const operationId = startMeasurementOperation({
       kind: "session_rename",
@@ -62,7 +62,9 @@ export function useSessionTitleActions() {
 
     const storeStartedAt = performance.now();
     applySessionSummary(sessionId, session, workspaceId);
-    upsertWorkspaceSessionRecord(workspaceId, session);
+    upsertWorkspaceSessionRecord(workspaceId, session, {
+      runtimeUrl: connection.runtimeUrl,
+    });
     if (operationId) {
       recordMeasurementMetric({
         type: "store",

--- a/apps/desktop/src/hooks/settings/derived/use-settings-repositories.ts
+++ b/apps/desktop/src/hooks/settings/derived/use-settings-repositories.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
+import { useRepoConfigs } from "@proliferate/cloud-sdk-react";
 import {
   buildSettingsRepositoryEntries,
 } from "@/lib/domain/settings/repositories";
-import { useCloudRepoConfigs } from "@/hooks/access/cloud/use-cloud-repo-configs";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { useStandardRepoProjection } from "@/hooks/workspaces/derived/use-standard-repo-projection";
 import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
@@ -11,7 +11,26 @@ export function useSettingsRepositories() {
   const { localWorkspaces, repoRoots } = useStandardRepoProjection();
   const hiddenRepoRootIds = useWorkspaceUiStore((state) => state.hiddenRepoRootIds);
   const { cloudActive } = useCloudAvailabilityState();
-  const cloudRepoConfigsQuery = useCloudRepoConfigs(cloudActive);
+  const repoConfigsQuery = useRepoConfigs(cloudActive);
+  const cloudRepoConfigs = useMemo(
+    () => (repoConfigsQuery.data?.repositories ?? []).flatMap((repo) => {
+      const cloudEnvironment = repo.environments.find((environment) =>
+        environment.kind === "cloud"
+      );
+      if (!cloudEnvironment) {
+        return [];
+      }
+      return [{
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        configured: cloudEnvironment.configured,
+        configuredAt: cloudEnvironment.configuredAt,
+        defaultBranch: cloudEnvironment.defaultBranch,
+        filesVersion: 0,
+      }];
+    }),
+    [repoConfigsQuery.data?.repositories],
+  );
 
   const repositories = useMemo(() => {
     const hiddenRepoRootIdSet = new Set(hiddenRepoRootIds);
@@ -20,12 +39,12 @@ export function useSettingsRepositories() {
         workspace.repoRootId ? !hiddenRepoRootIdSet.has(workspace.repoRootId) : true
       ),
       repoRoots.filter((repoRoot) => !hiddenRepoRootIdSet.has(repoRoot.id)),
-      cloudRepoConfigsQuery.data?.configs ?? [],
+      cloudRepoConfigs,
     );
-  }, [cloudRepoConfigsQuery.data?.configs, hiddenRepoRootIds, localWorkspaces, repoRoots]);
+  }, [cloudRepoConfigs, hiddenRepoRootIds, localWorkspaces, repoRoots]);
 
   return {
     repositories,
-    isLoadingCloudRepositories: cloudRepoConfigsQuery.isPending,
+    isLoadingCloudRepositories: repoConfigsQuery.isPending,
   };
 }

--- a/apps/desktop/src/hooks/settings/workflows/use-repository-settings.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-repository-settings.ts
@@ -3,7 +3,7 @@ import type { GitBranchRef } from "@anyharness/sdk";
 import {
   useRepoRootGitBranchesQuery,
 } from "@anyharness/sdk-react";
-import { useSaveLocalRepoEnvironment } from "@proliferate/cloud-sdk-react";
+import { useRepoConfigs, useSaveLocalRepoEnvironment } from "@proliferate/cloud-sdk-react";
 import {
   buildLocalEnvironmentSavePatch,
   isLocalEnvironmentDraftDirty,
@@ -26,6 +26,8 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
   );
   const setRepoConfig = useRepoPreferencesStore((state) => state.setRepoConfig);
   const saveLocalEnvironment = useSaveLocalRepoEnvironment();
+  const repoConfigs = useRepoConfigs(Boolean(repository?.gitOwner && repository.gitRepoName));
+  const [desktopInstallId, setDesktopInstallId] = useState<string | null>(null);
   const { data: branchRefs = EMPTY_BRANCHES } = useRepoRootGitBranchesQuery({
     repoRootId: repository?.repoRootId ?? null,
     enabled: !!repository,
@@ -43,9 +45,56 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
     [branchRefs],
   );
 
+  useEffect(() => {
+    let cancelled = false;
+    void loadAnonymousTelemetryBootstrap()
+      .then(({ installId }) => {
+        if (!cancelled) {
+          setDesktopInstallId(installId);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDesktopInstallId(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persistedCloudLocalDraft = useMemo(() => {
+    if (!repository?.gitOwner || !repository.gitRepoName || !sourceRoot || !desktopInstallId) {
+      return null;
+    }
+    const gitProvider = repository.gitProvider ?? "github";
+    const repo = repoConfigs.data?.repositories.find((item) =>
+      item.gitProvider === gitProvider
+      && item.gitOwner === repository.gitOwner
+      && item.gitRepoName === repository.gitRepoName,
+    );
+    const environment = repo?.environments.find((item) =>
+      item.kind === "local"
+      && item.desktopInstallId === desktopInstallId
+      && item.localPath === sourceRoot,
+    );
+    return environment
+      ? normalizeLocalEnvironmentDraft({
+          defaultBranch: environment.defaultBranch,
+          setupScript: environment.setupScript,
+          runCommand: environment.runCommand,
+        })
+      : null;
+  }, [
+    desktopInstallId,
+    repoConfigs.data?.repositories,
+    repository,
+    sourceRoot,
+  ]);
+
   const persistedDraft = useMemo(
-    () => normalizeLocalEnvironmentDraft(repoConfig),
-    [repoConfig],
+    () => normalizeLocalEnvironmentDraft(repoConfig ?? persistedCloudLocalDraft),
+    [persistedCloudLocalDraft, repoConfig],
   );
   const [state, setState] = useState<{
     sourceRoot: string | null;
@@ -96,7 +145,8 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
     if (repository?.gitOwner && repository.gitRepoName) {
       const { gitOwner, gitRepoName, gitProvider } = repository;
       void (async () => {
-        const { installId } = await loadAnonymousTelemetryBootstrap();
+        const installId = desktopInstallId
+          ?? (await loadAnonymousTelemetryBootstrap()).installId;
         await saveLocalEnvironment.mutateAsync({
           gitOwner,
           gitRepoName,
@@ -118,7 +168,14 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
       baseline: nextConfig,
       draft: nextConfig,
     }));
-  }, [repository, saveLocalEnvironment, setRepoConfig, sourceRoot, state.draft]);
+  }, [
+    desktopInstallId,
+    repository,
+    saveLocalEnvironment,
+    setRepoConfig,
+    sourceRoot,
+    state.draft,
+  ]);
 
   const revert = useCallback(() => {
     setState((current) => ({

--- a/apps/desktop/src/hooks/settings/workflows/use-repository-settings.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-repository-settings.ts
@@ -3,6 +3,7 @@ import type { GitBranchRef } from "@anyharness/sdk";
 import {
   useRepoRootGitBranchesQuery,
 } from "@anyharness/sdk-react";
+import { useSaveLocalRepoEnvironment } from "@proliferate/cloud-sdk-react";
 import {
   buildLocalEnvironmentSavePatch,
   isLocalEnvironmentDraftDirty,
@@ -11,6 +12,7 @@ import {
 } from "@/lib/domain/settings/environment-draft";
 import { resolveAutoDetectedBranch } from "@/lib/domain/settings/branch-selection";
 import type { SettingsRepositoryEntry } from "@/lib/domain/settings/repositories";
+import { loadAnonymousTelemetryBootstrap } from "@/lib/integrations/telemetry/anonymous-storage";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 
 const EMPTY_BRANCHES: GitBranchRef[] = [];
@@ -23,6 +25,7 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
     sourceRoot ? state.repoConfigs[sourceRoot] : undefined,
   );
   const setRepoConfig = useRepoPreferencesStore((state) => state.setRepoConfig);
+  const saveLocalEnvironment = useSaveLocalRepoEnvironment();
   const { data: branchRefs = EMPTY_BRANCHES } = useRepoRootGitBranchesQuery({
     repoRootId: repository?.repoRootId ?? null,
     enabled: !!repository,
@@ -90,12 +93,32 @@ export function useRepositorySettings(repository: SettingsRepositoryEntry | null
     }
     const nextConfig = buildLocalEnvironmentSavePatch(state.draft);
     setRepoConfig(sourceRoot, nextConfig);
+    if (repository?.gitOwner && repository.gitRepoName) {
+      const { gitOwner, gitRepoName, gitProvider } = repository;
+      void (async () => {
+        const { installId } = await loadAnonymousTelemetryBootstrap();
+        await saveLocalEnvironment.mutateAsync({
+          gitOwner,
+          gitRepoName,
+          body: {
+            gitProvider: gitProvider ?? "github",
+            desktopInstallId: installId,
+            localPath: sourceRoot,
+            defaultBranch: nextConfig.defaultBranch,
+            setupScript: nextConfig.setupScript,
+            runCommand: nextConfig.runCommand,
+          },
+        });
+      })().catch(() => {
+        // Local preferences remain authoritative when Cloud is unavailable.
+      });
+    }
     setState((current) => ({
       ...current,
       baseline: nextConfig,
       draft: nextConfig,
     }));
-  }, [setRepoConfig, sourceRoot, state.draft]);
+  }, [repository, saveLocalEnvironment, setRepoConfig, sourceRoot, state.draft]);
 
   const revert = useCallback(() => {
     setState((current) => ({

--- a/apps/desktop/src/lib/access/anyharness/agents.ts
+++ b/apps/desktop/src/lib/access/anyharness/agents.ts
@@ -1,8 +1,10 @@
+import type { AnyHarnessRequestOptions } from "@anyharness/sdk";
 import { getAnyHarnessClient, type AnyHarnessClientConnection } from "@anyharness/sdk-react";
 
 export function getAgentLaunchOptions(
   connection: AnyHarnessClientConnection,
   workspaceId?: string | null,
+  options?: AnyHarnessRequestOptions,
 ) {
-  return getAnyHarnessClient(connection).agents.getLaunchOptions(workspaceId);
+  return getAnyHarnessClient(connection).agents.getLaunchOptions(workspaceId, options);
 }

--- a/apps/desktop/src/lib/workflows/cowork/create-cowork-thread.ts
+++ b/apps/desktop/src/lib/workflows/cowork/create-cowork-thread.ts
@@ -57,7 +57,11 @@ export interface CreateCoworkThreadWorkflowDeps {
     launchControlValues?: Record<string, string>;
   }): Promise<Session>;
   upsertLocalWorkspace(workspace: CreateCoworkThreadResponse["workspace"]): void;
-  upsertWorkspaceSessionRecord(workspaceId: string, session: Session): void;
+  upsertWorkspaceSessionRecord(
+    workspaceId: string,
+    session: Session,
+    options?: { runtimeUrl?: string },
+  ): void;
   recordCreatedSession(input: {
     projectedSessionId: string | null;
     launchedSession: Session;
@@ -190,7 +194,9 @@ export async function createCoworkThreadWorkflow(
     }
 
     deps.upsertLocalWorkspace(result.workspace);
-    deps.upsertWorkspaceSessionRecord(result.workspace.id, launchedSession);
+    deps.upsertWorkspaceSessionRecord(result.workspace.id, launchedSession, {
+      runtimeUrl: input.runtimeUrl,
+    });
     const activeSessionId = projectedSessionId ?? launchedSession.id;
     deps.recordCreatedSession({
       projectedSessionId,

--- a/apps/mobile/src/components/onboarding/MobileOnboardingRepoStep.tsx
+++ b/apps/mobile/src/components/onboarding/MobileOnboardingRepoStep.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import {
   useCloudGitRepositories,
-  useCloudRepoConfigs,
+  useRepoConfigs,
   useSaveCloudRepoConfig,
 } from "@proliferate/cloud-sdk-react";
 
@@ -23,7 +23,7 @@ import {
 
 export function MobileOnboardingRepoStep({ onDone }: { onDone: () => void }) {
   const repos = useCloudGitRepositories({}, true);
-  const configured = useCloudRepoConfigs();
+  const configured = useRepoConfigs();
   const save = useSaveCloudRepoConfig();
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -31,11 +31,17 @@ export function MobileOnboardingRepoStep({ onDone }: { onDone: () => void }) {
 
   const configuredKeys = useMemo(
     () => new Set(
-      (configured.data?.configs ?? [])
-        .filter((config) => config.configured)
-        .map((config) => `${config.gitOwner}/${config.gitRepoName}`),
+      (configured.data?.repositories ?? [])
+        .flatMap((config) => {
+          const cloudEnvironment = config.environments.find((environment) =>
+            environment.kind === "cloud"
+          );
+          return cloudEnvironment?.configured
+            ? [`${config.gitOwner}/${config.gitRepoName}`]
+            : [];
+        }),
     ),
-    [configured.data],
+    [configured.data?.repositories],
   );
 
   const available = useMemo(() => {

--- a/apps/mobile/src/hooks/home/derived/use-mobile-home-launch-model.ts
+++ b/apps/mobile/src/hooks/home/derived/use-mobile-home-launch-model.ts
@@ -3,7 +3,7 @@ import {
   useCloudAgentCatalog,
   useCloudCapabilities,
   useCloudRepoBranches,
-  useCloudRepoConfigs,
+  useRepoConfigs,
   useCloudTargets,
   useAgentAuthCredentials,
   useTargetLive,
@@ -36,16 +36,32 @@ export function useMobileHomeLaunchModel() {
     modeId: null,
     controlValues: {},
   });
-  const repoConfigs = useCloudRepoConfigs();
+  const repoConfigs = useRepoConfigs();
   const targets = useCloudTargets();
   const agentAuthCredentials = useAgentAuthCredentials();
   const liveTargetId = runtimeId === "cloud" ? null : runtimeId;
   const targetLive = useTargetLive(liveTargetId, { enabled: Boolean(liveTargetId) });
   const agentCatalog = useCloudAgentCatalog();
   const cloudCapabilities = useCloudCapabilities();
+  const configuredCloudRepos = useMemo(
+    () => (repoConfigs.data?.repositories ?? []).flatMap((repo) => {
+      const cloudEnvironment = repo.environments.find((environment) =>
+        environment.kind === "cloud"
+      );
+      if (!cloudEnvironment) {
+        return [];
+      }
+      return [{
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        configured: cloudEnvironment.configured,
+      }];
+    }),
+    [repoConfigs.data?.repositories],
+  );
   const repoOptions = useMemo(
-    () => buildMobileRepoOptions(repoConfigs.data?.configs ?? []),
-    [repoConfigs.data?.configs],
+    () => buildMobileRepoOptions(configuredCloudRepos),
+    [configuredCloudRepos],
   );
   const liveTargets = useMemo(() => {
     const liveTarget = targetLive.snapshot?.target;

--- a/apps/mobile/src/hooks/settings/facade/use-mobile-settings-model.ts
+++ b/apps/mobile/src/hooks/settings/facade/use-mobile-settings-model.ts
@@ -1,7 +1,8 @@
+import { useMemo } from "react";
 import {
   useAuthViewer,
   useCloudBilling,
-  useCloudRepoConfigs,
+  useRepoConfigs,
   useOrganizations,
 } from "@proliferate/cloud-sdk-react";
 
@@ -11,7 +12,7 @@ export function useMobileSettingsModel(account: MobileSettingsAccountSummary) {
   const viewer = useAuthViewer();
   const organizations = useOrganizations();
   const billing = useCloudBilling({ ownerScope: "personal" });
-  const repoConfigs = useCloudRepoConfigs();
+  const repoConfigs = useRepoConfigs();
 
   const displayName =
     viewer.data?.user.display_name?.trim()
@@ -41,7 +42,22 @@ export function useMobileSettingsModel(account: MobileSettingsAccountSummary) {
       : viewer.data?.onboardingState === "active"
         ? "Active"
         : "Setup";
-  const configuredRepos = (repoConfigs.data?.configs ?? []).filter((repo) => repo.configured);
+  const configuredRepos = useMemo(
+    () => (repoConfigs.data?.repositories ?? []).flatMap((repo) => {
+      const cloudEnvironment = repo.environments.find((environment) =>
+        environment.kind === "cloud"
+      );
+      if (!cloudEnvironment?.configured) {
+        return [];
+      }
+      return [{
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        configured: true,
+      }];
+    }),
+    [repoConfigs.data?.repositories],
+  );
   const organizationRows = organizations.data?.organizations ?? [];
 
   return {

--- a/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudEnvironmentsSettingsSurface } from "./CloudEnvironmentsSettingsSurface";
 
 const cloudHooks = vi.hoisted(() => ({
-  useCloudRepoConfigs: vi.fn(),
+  useRepoConfigs: vi.fn(),
   useCloudRepoConfig: vi.fn(),
   useCloudRepoBranches: vi.fn(),
   useSaveCloudRepoConfig: vi.fn(),
@@ -21,7 +21,7 @@ const cloudHooks = vi.hoisted(() => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudRepoConfigs: cloudHooks.useCloudRepoConfigs,
+  useRepoConfigs: cloudHooks.useRepoConfigs,
   useCloudRepoConfig: cloudHooks.useCloudRepoConfig,
   useCloudRepoBranches: cloudHooks.useCloudRepoBranches,
   useSaveCloudRepoConfig: cloudHooks.useSaveCloudRepoConfig,
@@ -35,20 +35,50 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   useDeleteCloudSecretFile: cloudHooks.useDeleteCloudSecretFile,
 }));
 
-const cloudConfigs = [
+const repoConfigs = [
   {
+    id: "repo-desktop-cloud",
+    ownerScope: "personal",
+    gitProvider: "github",
     gitOwner: "octo",
     gitRepoName: "desktop-cloud",
-    configured: true,
-    configuredAt: "2026-05-24T09:00:00.000Z",
-    filesVersion: 0,
+    environments: [{
+      id: "env-desktop-cloud",
+      repoConfigId: "repo-desktop-cloud",
+      kind: "cloud",
+      desktopInstallId: null,
+      localPath: null,
+      configured: true,
+      configuredAt: "2026-05-24T09:00:00.000Z",
+      defaultBranch: "main",
+      setupScript: "",
+      setupScriptVersion: 0,
+      runCommand: "",
+      configVersion: 1,
+      legacyCloudRepoConfigId: "repo-desktop-cloud",
+    }],
   },
   {
+    id: "repo-web-only",
+    ownerScope: "personal",
+    gitProvider: "github",
     gitOwner: "octo",
     gitRepoName: "web-only",
-    configured: false,
-    configuredAt: "2026-05-23T09:00:00.000Z",
-    filesVersion: 1,
+    environments: [{
+      id: "env-web-only",
+      repoConfigId: "repo-web-only",
+      kind: "cloud",
+      desktopInstallId: null,
+      localPath: null,
+      configured: false,
+      configuredAt: "2026-05-23T09:00:00.000Z",
+      defaultBranch: "main",
+      setupScript: "",
+      setupScriptVersion: 0,
+      runCommand: "",
+      configVersion: 1,
+      legacyCloudRepoConfigId: "repo-web-only",
+    }],
   },
 ];
 
@@ -68,8 +98,8 @@ function repoConfig(overrides: Record<string, unknown> = {}) {
 
 describe("CloudEnvironmentsSettingsSurface", () => {
   beforeEach(() => {
-    cloudHooks.useCloudRepoConfigs.mockReturnValue({
-      data: { configs: cloudConfigs },
+    cloudHooks.useRepoConfigs.mockReturnValue({
+      data: { repositories: repoConfigs },
       isLoading: false,
       isError: false,
       refetch: vi.fn(),

--- a/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
@@ -12,6 +12,11 @@ const cloudHooks = vi.hoisted(() => ({
   useCloudGitRepositories: vi.fn(),
   useValidateCloudRepoBranches: vi.fn(),
   useLoadCloudRepoConfig: vi.fn(),
+  useCloudSecrets: vi.fn(),
+  usePutCloudSecretEnvVar: vi.fn(),
+  useDeleteCloudSecretEnvVar: vi.fn(),
+  usePutCloudSecretFile: vi.fn(),
+  useDeleteCloudSecretFile: vi.fn(),
   saveMutateAsync: vi.fn(),
 }));
 
@@ -23,6 +28,11 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   useCloudGitRepositories: cloudHooks.useCloudGitRepositories,
   useValidateCloudRepoBranches: cloudHooks.useValidateCloudRepoBranches,
   useLoadCloudRepoConfig: cloudHooks.useLoadCloudRepoConfig,
+  useCloudSecrets: cloudHooks.useCloudSecrets,
+  usePutCloudSecretEnvVar: cloudHooks.usePutCloudSecretEnvVar,
+  useDeleteCloudSecretEnvVar: cloudHooks.useDeleteCloudSecretEnvVar,
+  usePutCloudSecretFile: cloudHooks.usePutCloudSecretFile,
+  useDeleteCloudSecretFile: cloudHooks.useDeleteCloudSecretFile,
 }));
 
 const cloudConfigs = [
@@ -91,6 +101,41 @@ describe("CloudEnvironmentsSettingsSurface", () => {
     });
     cloudHooks.useValidateCloudRepoBranches.mockReturnValue({ mutateAsync: vi.fn() });
     cloudHooks.useLoadCloudRepoConfig.mockReturnValue({ mutateAsync: vi.fn() });
+    cloudHooks.useCloudSecrets.mockReturnValue({
+      data: {
+        scopeKind: "workspace",
+        version: 0,
+        envVars: [],
+        files: [],
+        materialization: {
+          status: "pending",
+          lastError: null,
+          materializedAt: null,
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+    cloudHooks.usePutCloudSecretEnvVar.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    });
+    cloudHooks.useDeleteCloudSecretEnvVar.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    });
+    cloudHooks.usePutCloudSecretFile.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    });
+    cloudHooks.useDeleteCloudSecretFile.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -141,7 +186,7 @@ describe("CloudEnvironmentsSettingsSurface", () => {
     expect(screen.queryByText("Cloud enabled")).not.toBeNull();
   });
 
-  it("saves cloud-only detail edits with the existing core request body", async () => {
+  it("saves cloud-only detail edits without legacy secret fields", async () => {
     render(
       <CloudEnvironmentsSettingsSurface
         mode="cloud-only"
@@ -165,7 +210,6 @@ describe("CloudEnvironmentsSettingsSurface", () => {
       body: {
         configured: true,
         defaultBranch: "main",
-        envVars: { FEATURE_FLAG: "1" },
         setupScript: "npm ci",
         runCommand: "",
       },

--- a/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useCloudRepoConfigs } from "@proliferate/cloud-sdk-react";
+import { useRepoConfigs } from "@proliferate/cloud-sdk-react";
 import {
   buildCloudEnvironmentListItems,
 } from "@proliferate/product-domain/environments/cloud-environments";
@@ -43,7 +43,7 @@ export function CloudEnvironmentsSettingsSurface({
   onBackToList,
 }: CloudEnvironmentsSettingsSurfaceProps) {
   const [addOpen, setAddOpen] = useState(false);
-  const repoConfigs = useCloudRepoConfigs(enabled);
+  const repoConfigs = useRepoConfigs(enabled);
   const localCheckoutsForDomain = useMemo(
     () => localCheckouts
       .map((checkout) => ({
@@ -55,10 +55,28 @@ export function CloudEnvironmentsSettingsSurface({
       })),
     [localCheckouts],
   );
+  const cloudEnvironmentConfigs = useMemo(
+    () => (repoConfigs.data?.repositories ?? []).flatMap((repository) => {
+      const cloudEnvironment = repository.environments.find((environment) =>
+        environment.kind === "cloud"
+      );
+      if (!cloudEnvironment) {
+        return [];
+      }
+      return [{
+        gitOwner: repository.gitOwner,
+        gitRepoName: repository.gitRepoName,
+        configured: cloudEnvironment.configured,
+        configuredAt: cloudEnvironment.configuredAt,
+        filesVersion: null,
+      }];
+    }),
+    [repoConfigs.data?.repositories],
+  );
   const cloudEnvironmentItems = useMemo(() => buildCloudEnvironmentListItems({
-    configs: repoConfigs.data?.configs ?? [],
+    configs: cloudEnvironmentConfigs,
     localCheckouts: mode === "hybrid" ? localCheckoutsForDomain : [],
-  }), [localCheckoutsForDomain, mode, repoConfigs.data?.configs]);
+  }), [cloudEnvironmentConfigs, localCheckoutsForDomain, mode]);
 
   if (selectedCloudRepo && enabled) {
     return (

--- a/apps/web/src/hooks/home/facade/use-web-home-screen.ts
+++ b/apps/web/src/hooks/home/facade/use-web-home-screen.ts
@@ -5,7 +5,7 @@ import {
   useCloudAgentCatalog,
   useCloudCapabilities,
   useCloudRepoBranches,
-  useCloudRepoConfigs,
+  useRepoConfigs,
   useCloudTargets,
   useTargetLive,
   useVisibleCloudWorkspaces,
@@ -62,7 +62,7 @@ export function useWebHomeScreen() {
   });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<HomePendingPrompt | null>(null);
-  const repoConfigs = useCloudRepoConfigs();
+  const repoConfigs = useRepoConfigs();
   const agentCatalog = useCloudAgentCatalog();
   const cloudCapabilities = useCloudCapabilities();
   const agentAuthCredentials = useAgentAuthCredentials();
@@ -70,9 +70,25 @@ export function useWebHomeScreen() {
   const targets = useCloudTargets();
   const liveTargetId = runtimeId === "cloud" ? null : runtimeId;
   const targetLive = useTargetLive(liveTargetId, { enabled: Boolean(liveTargetId) });
+  const configuredCloudRepos = useMemo(
+    () => (repoConfigs.data?.repositories ?? []).flatMap((repo) => {
+      const cloudEnvironment = repo.environments.find((environment) =>
+        environment.kind === "cloud"
+      );
+      if (!cloudEnvironment) {
+        return [];
+      }
+      return [{
+        gitOwner: repo.gitOwner,
+        gitRepoName: repo.gitRepoName,
+        configured: cloudEnvironment.configured,
+      }];
+    }),
+    [repoConfigs.data?.repositories],
+  );
   const repoOptions = useMemo(
-    () => buildRepoOptions(repoConfigs.data?.configs ?? [], webEnv.defaultCloudRepo),
-    [repoConfigs.data?.configs],
+    () => buildRepoOptions(configuredCloudRepos, webEnv.defaultCloudRepo),
+    [configuredCloudRepos],
   );
   const selectedRepo = useMemo(
     () => repoOptions.find((repo) => repo.id === repoId) ?? repoOptions[0] ?? null,

--- a/cloud/sdk-react/src/hooks/repo-configs.ts
+++ b/cloud/sdk-react/src/hooks/repo-configs.ts
@@ -13,6 +13,7 @@ import {
   cloudRepoConfigKey,
   cloudRepoConfigsKey,
   organizationCloudRepoConfigsKey,
+  repoConfigsKey,
 } from "../lib/query-keys.js";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 
@@ -71,6 +72,7 @@ export function useSaveCloudRepoConfig() {
       saveCloudRepoConfig(gitOwner, gitRepoName, body, client),
     onSuccess: (response, { gitOwner, gitRepoName }) => {
       queryClient.setQueryData(cloudRepoConfigKey(gitOwner, gitRepoName), response);
+      void queryClient.invalidateQueries({ queryKey: repoConfigsKey() });
       void queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() });
       void queryClient.invalidateQueries({ queryKey: cloudGitRepositoriesRootKey() });
     },

--- a/cloud/sdk-react/src/hooks/repositories.ts
+++ b/cloud/sdk-react/src/hooks/repositories.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  listRepositories,
+  saveCloudRepoEnvironment,
+  saveLocalRepoEnvironment,
+  type RepoConfigsListResponse,
+  type RepoEnvironmentResponse,
+  type SaveCloudRepoEnvironmentRequest,
+  type SaveLocalRepoEnvironmentRequest,
+} from "@proliferate/cloud-sdk";
+import {
+  cloudGitRepositoriesRootKey,
+  cloudRepoConfigKey,
+  cloudRepoConfigsKey,
+  repoConfigsKey,
+  repoEnvironmentKey,
+} from "../lib/query-keys.js";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+
+export function useRepoConfigs(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<RepoConfigsListResponse>({
+    queryKey: repoConfigsKey(),
+    queryFn: () => listRepositories(client),
+    enabled,
+  });
+}
+
+export interface SaveCloudRepoEnvironmentInput {
+  gitOwner: string;
+  gitRepoName: string;
+  body: SaveCloudRepoEnvironmentRequest;
+}
+
+export function useSaveCloudRepoEnvironment() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<RepoEnvironmentResponse, Error, SaveCloudRepoEnvironmentInput>({
+    mutationFn: ({ gitOwner, gitRepoName, body }) =>
+      saveCloudRepoEnvironment(gitOwner, gitRepoName, body, client),
+    onSuccess: (response, { gitOwner, gitRepoName }) => {
+      queryClient.setQueryData(
+        repoEnvironmentKey(gitOwner, gitRepoName, "cloud"),
+        response,
+      );
+      void queryClient.invalidateQueries({ queryKey: repoConfigsKey() });
+      void queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() });
+      void queryClient.invalidateQueries({ queryKey: cloudRepoConfigKey(gitOwner, gitRepoName) });
+      void queryClient.invalidateQueries({ queryKey: cloudGitRepositoriesRootKey() });
+    },
+  });
+}
+
+export interface SaveLocalRepoEnvironmentInput {
+  gitOwner: string;
+  gitRepoName: string;
+  body: SaveLocalRepoEnvironmentRequest;
+}
+
+export function useSaveLocalRepoEnvironment() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<RepoEnvironmentResponse, Error, SaveLocalRepoEnvironmentInput>({
+    mutationFn: ({ gitOwner, gitRepoName, body }) =>
+      saveLocalRepoEnvironment(gitOwner, gitRepoName, body, client),
+    onSuccess: (response, { gitOwner, gitRepoName }) => {
+      queryClient.setQueryData(
+        repoEnvironmentKey(
+          gitOwner,
+          gitRepoName,
+          "local",
+          response.desktopInstallId,
+          response.localPath,
+        ),
+        response,
+      );
+      void queryClient.invalidateQueries({ queryKey: repoConfigsKey() });
+      void queryClient.invalidateQueries({ queryKey: cloudRepoConfigsKey() });
+    },
+  });
+}

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -18,6 +18,7 @@ export * from "./hooks/mcp.js";
 export * from "./hooks/organizations.js";
 export * from "./hooks/runtime-config.js";
 export * from "./hooks/repo-configs.js";
+export * from "./hooks/repositories.js";
 export * from "./hooks/repos.js";
 export * from "./hooks/sessions.js";
 export * from "./hooks/sso.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -150,6 +150,28 @@ export function cloudRepoConfigsKey() {
   return [...cloudRootKey(), "repo-configs"] as const;
 }
 
+export function repoConfigsKey() {
+  return [...cloudRootKey(), "repositories"] as const;
+}
+
+export function repoEnvironmentKey(
+  gitOwner: string,
+  gitRepoName: string,
+  environmentKind: "local" | "cloud",
+  desktopInstallId: string | null = null,
+  localPath: string | null = null,
+) {
+  return [
+    ...repoConfigsKey(),
+    gitOwner,
+    gitRepoName,
+    "environments",
+    environmentKind,
+    desktopInstallId,
+    localPath,
+  ] as const;
+}
+
 export function cloudSecretsRootKey() {
   return [...cloudRootKey(), "secrets"] as const;
 }

--- a/cloud/sdk/src/client/repo-configs.ts
+++ b/cloud/sdk/src/client/repo-configs.ts
@@ -10,7 +10,9 @@ import type {
 export async function listCloudRepoConfigs(
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<CloudRepoConfigsListResponse> {
-  return (await client.GET("/v1/cloud/repos/configs")).data!;
+  return (
+    await client.GET("/v1/cloud/repos/configs")
+  ).data!;
 }
 
 export async function listOrganizationCloudRepoConfigs(

--- a/cloud/sdk/src/client/repositories.ts
+++ b/cloud/sdk/src/client/repositories.ts
@@ -1,0 +1,50 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type {
+  RepoConfigsListResponse,
+  RepoEnvironmentResponse,
+  SaveCloudRepoEnvironmentRequest,
+  SaveLocalRepoEnvironmentRequest,
+} from "../types/index.js";
+
+export async function listRepositories(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<RepoConfigsListResponse> {
+  return client.requestJson<RepoConfigsListResponse>({
+    method: "GET",
+    path: "/v1/cloud/repositories",
+  });
+}
+
+export async function saveLocalRepoEnvironment(
+  gitOwner: string,
+  gitRepoName: string,
+  body: SaveLocalRepoEnvironmentRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<RepoEnvironmentResponse> {
+  return client.requestJson<RepoEnvironmentResponse>({
+    method: "PUT",
+    path: "/v1/cloud/repositories/{git_owner}/{git_repo_name}/environments/local",
+    pathParams: {
+      git_owner: gitOwner,
+      git_repo_name: gitRepoName,
+    },
+    body,
+  });
+}
+
+export async function saveCloudRepoEnvironment(
+  gitOwner: string,
+  gitRepoName: string,
+  body: SaveCloudRepoEnvironmentRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<RepoEnvironmentResponse> {
+  return client.requestJson<RepoEnvironmentResponse>({
+    method: "PUT",
+    path: "/v1/cloud/repositories/{git_owner}/{git_repo_name}/environments/cloud",
+    pathParams: {
+      git_owner: gitOwner,
+      git_repo_name: gitRepoName,
+    },
+    body,
+  });
+}

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -583,6 +583,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Repositories Endpoint */
+        get: operations["list_repositories_endpoint_v1_cloud_repositories_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/repositories/{git_owner}/{git_repo_name}/environments/local": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Save Local Repo Environment Endpoint */
+        put: operations["save_local_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environments_local_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/repositories/{git_owner}/{git_repo_name}/environments/cloud": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Save Cloud Repo Environment Endpoint */
+        put: operations["save_cloud_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environments_cloud_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/repos/configs": {
         parameters: {
             query?: never;
@@ -7878,6 +7929,64 @@ export interface components {
             /** Disabled */
             disabled?: boolean | null;
         };
+        /** RepoConfigResponse */
+        RepoConfigResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Gitprovider */
+            gitProvider: string;
+            /** Gitowner */
+            gitOwner: string;
+            /** Gitreponame */
+            gitRepoName: string;
+            /** Environments */
+            environments: components["schemas"]["RepoEnvironmentResponse"][];
+        };
+        /** RepoConfigsListResponse */
+        RepoConfigsListResponse: {
+            /** Repositories */
+            repositories: components["schemas"]["RepoConfigResponse"][];
+        };
+        /** RepoEnvironmentResponse */
+        RepoEnvironmentResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Repoconfigid
+             * Format: uuid
+             */
+            repoConfigId: string;
+            /** Kind */
+            kind: string;
+            /** Desktopinstallid */
+            desktopInstallId: string | null;
+            /** Localpath */
+            localPath: string | null;
+            /** Configured */
+            configured: boolean;
+            /** Configuredat */
+            configuredAt: string | null;
+            /** Defaultbranch */
+            defaultBranch: string | null;
+            /** Setupscript */
+            setupScript: string;
+            /** Setupscriptversion */
+            setupScriptVersion: number;
+            /** Runcommand */
+            runCommand: string;
+            /** Configversion */
+            configVersion: number;
+            /** Legacycloudrepoconfigid */
+            legacyCloudRepoConfigId: string | null;
+        };
         /** RepoRef */
         RepoRef: {
             /** Provider */
@@ -8188,6 +8297,50 @@ export interface components {
             runCommand: string;
             /** Files */
             files?: components["schemas"]["SaveCloudRepoConfigFile"][] | null;
+        };
+        /** SaveCloudRepoEnvironmentRequest */
+        SaveCloudRepoEnvironmentRequest: {
+            /**
+             * Configured
+             * @default true
+             */
+            configured: boolean;
+            /** Defaultbranch */
+            defaultBranch?: string | null;
+            /**
+             * Setupscript
+             * @default
+             */
+            setupScript: string;
+            /**
+             * Runcommand
+             * @default
+             */
+            runCommand: string;
+        };
+        /** SaveLocalRepoEnvironmentRequest */
+        SaveLocalRepoEnvironmentRequest: {
+            /**
+             * Gitprovider
+             * @default github
+             */
+            gitProvider: string;
+            /** Desktopinstallid */
+            desktopInstallId: string;
+            /** Localpath */
+            localPath: string;
+            /** Defaultbranch */
+            defaultBranch?: string | null;
+            /**
+             * Setupscript
+             * @default
+             */
+            setupScript: string;
+            /**
+             * Runcommand
+             * @default
+             */
+            runCommand: string;
         };
         /** SaveOrganizationCloudRepoConfigRequest */
         SaveOrganizationCloudRepoConfigRequest: {
@@ -11465,6 +11618,98 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RepoBranchesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_repositories_endpoint_v1_cloud_repositories_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoConfigsListResponse"];
+                };
+            };
+        };
+    };
+    save_local_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environments_local_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                git_owner: string;
+                git_repo_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveLocalRepoEnvironmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoEnvironmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_cloud_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environments_cloud_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                git_owner: string;
+                git_repo_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveCloudRepoEnvironmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoEnvironmentResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -26,6 +26,7 @@ export * from "./client/mobility.js";
 export * from "./client/organizations.js";
 export * from "./client/plugins.js";
 export * from "./client/repo-configs.js";
+export * from "./client/repositories.js";
 export * from "./client/repos.js";
 export * from "./client/runtime-config.js";
 export * from "./client/sessions.js";

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -299,6 +299,13 @@ export type CloudRepoConfigResponse   = components["schemas"]["CloudRepoConfigRe
 export type SaveCloudRepoConfigRequest = components["schemas"]["SaveCloudRepoConfigRequest"];
 export type SaveOrganizationCloudRepoConfigRequest =
   components["schemas"]["SaveOrganizationCloudRepoConfigRequest"];
+export type RepoConfigResponse = components["schemas"]["RepoConfigResponse"];
+export type RepoConfigsListResponse = components["schemas"]["RepoConfigsListResponse"];
+export type RepoEnvironmentResponse = components["schemas"]["RepoEnvironmentResponse"];
+export type SaveCloudRepoEnvironmentRequest =
+  components["schemas"]["SaveCloudRepoEnvironmentRequest"];
+export type SaveLocalRepoEnvironmentRequest =
+  components["schemas"]["SaveLocalRepoEnvironmentRequest"];
 export type AutomationOwnerScope = "personal" | "organization";
 export type AutomationTargetMode = "local" | "personal_cloud" | "shared_cloud";
 export type AutomationRunStatus =

--- a/server/alembic/versions/c3f6a9b2d4e8_github_app_authorization.py
+++ b/server/alembic/versions/c3f6a9b2d4e8_github_app_authorization.py
@@ -17,102 +17,142 @@ branch_labels: str | None = None
 depends_on: str | None = None
 
 
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+    postgresql_where: sa.TextClause | None = None,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(
+            index_name,
+            table_name,
+            columns,
+            unique=unique,
+            postgresql_where=postgresql_where,
+        )
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
 def upgrade() -> None:
-    op.create_table(
-        "github_app_authorizations",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("github_user_id", sa.String(length=64), nullable=False),
-        sa.Column("github_login", sa.String(length=255), nullable=False),
-        sa.Column("access_token_ciphertext", sa.Text(), nullable=True),
-        sa.Column("refresh_token_ciphertext", sa.Text(), nullable=True),
-        sa.Column("token_expires_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("refresh_token_expires_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("status", sa.String(length=32), nullable=False),
-        sa.Column("permissions_json", sa.Text(), nullable=True),
-        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.CheckConstraint(
-            "status IN ('ready', 'expired', 'revoked', 'needs_reauth')",
-            name="ck_github_app_authorizations_status",
-        ),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+    if not _has_table("github_app_authorizations"):
+        op.create_table(
+            "github_app_authorizations",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("github_user_id", sa.String(length=64), nullable=False),
+            sa.Column("github_login", sa.String(length=255), nullable=False),
+            sa.Column("access_token_ciphertext", sa.Text(), nullable=True),
+            sa.Column("refresh_token_ciphertext", sa.Text(), nullable=True),
+            sa.Column("token_expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("refresh_token_expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("permissions_json", sa.Text(), nullable=True),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('ready', 'expired', 'revoked', 'needs_reauth')",
+                name="ck_github_app_authorizations_status",
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "ux_github_app_authorizations_user_active",
         "github_app_authorizations",
         ["user_id"],
         unique=True,
         postgresql_where=sa.text("status != 'revoked'"),
     )
-    op.create_index(
+    _create_index_once(
         "ix_github_app_authorizations_github_user",
         "github_app_authorizations",
         ["github_user_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_github_app_authorizations_user_id",
         "github_app_authorizations",
         ["user_id"],
     )
 
-    op.create_table(
-        "github_app_installations",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("github_installation_id", sa.String(length=64), nullable=False),
-        sa.Column("account_login", sa.String(length=255), nullable=False),
-        sa.Column("account_type", sa.String(length=32), nullable=False),
-        sa.Column("repository_selection", sa.String(length=32), nullable=False),
-        sa.Column("permissions_json", sa.Text(), nullable=True),
-        sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+    if not _has_table("github_app_installations"):
+        op.create_table(
+            "github_app_installations",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("github_installation_id", sa.String(length=64), nullable=False),
+            sa.Column("account_login", sa.String(length=255), nullable=False),
+            sa.Column("account_type", sa.String(length=32), nullable=False),
+            sa.Column("repository_selection", sa.String(length=32), nullable=False),
+            sa.Column("permissions_json", sa.Text(), nullable=True),
+            sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "ux_github_app_installations_external",
         "github_app_installations",
         ["github_installation_id"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_github_app_installations_account",
         "github_app_installations",
         ["account_login", "account_type"],
     )
 
-    op.create_table(
-        "github_app_installation_repositories",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("github_app_installation_id", sa.Uuid(), nullable=False),
-        sa.Column("owner", sa.String(length=255), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=False),
-        sa.Column("github_repository_id", sa.String(length=64), nullable=False),
-        sa.Column("private", sa.Boolean(), nullable=False),
-        sa.Column("default_branch", sa.String(length=255), nullable=True),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["github_app_installation_id"],
-            ["github_app_installations.id"],
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+    if not _has_table("github_app_installation_repositories"):
+        op.create_table(
+            "github_app_installation_repositories",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("github_app_installation_id", sa.Uuid(), nullable=False),
+            sa.Column("owner", sa.String(length=255), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("github_repository_id", sa.String(length=64), nullable=False),
+            sa.Column("private", sa.Boolean(), nullable=False),
+            sa.Column("default_branch", sa.String(length=255), nullable=True),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["github_app_installation_id"],
+                ["github_app_installations.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "ux_github_app_installation_repositories_repo",
         "github_app_installation_repositories",
         ["github_app_installation_id", "owner", "name"],
         unique=True,
     )
-    op.create_index(
+    _create_index_once(
         "ix_github_app_installation_repositories_owner_name",
         "github_app_installation_repositories",
         ["owner", "name"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_github_app_installation_repositories_installation",
         "github_app_installation_repositories",
         ["github_app_installation_id"],
@@ -120,29 +160,32 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_github_app_installation_repositories_installation",
-        table_name="github_app_installation_repositories",
-    )
-    op.drop_index(
-        "ix_github_app_installation_repositories_owner_name",
-        table_name="github_app_installation_repositories",
-    )
-    op.drop_index(
-        "ux_github_app_installation_repositories_repo",
-        table_name="github_app_installation_repositories",
-    )
-    op.drop_table("github_app_installation_repositories")
-    op.drop_index("ix_github_app_installations_account", table_name="github_app_installations")
-    op.drop_index("ux_github_app_installations_external", table_name="github_app_installations")
-    op.drop_table("github_app_installations")
-    op.drop_index("ix_github_app_authorizations_user_id", table_name="github_app_authorizations")
-    op.drop_index(
-        "ix_github_app_authorizations_github_user",
-        table_name="github_app_authorizations",
-    )
-    op.drop_index(
-        "ux_github_app_authorizations_user_active",
-        table_name="github_app_authorizations",
-    )
-    op.drop_table("github_app_authorizations")
+    if _has_table("github_app_installation_repositories"):
+        _drop_index_once(
+            "ix_github_app_installation_repositories_installation",
+            "github_app_installation_repositories",
+        )
+        _drop_index_once(
+            "ix_github_app_installation_repositories_owner_name",
+            "github_app_installation_repositories",
+        )
+        _drop_index_once(
+            "ux_github_app_installation_repositories_repo",
+            "github_app_installation_repositories",
+        )
+        op.drop_table("github_app_installation_repositories")
+    if _has_table("github_app_installations"):
+        _drop_index_once("ix_github_app_installations_account", "github_app_installations")
+        _drop_index_once("ux_github_app_installations_external", "github_app_installations")
+        op.drop_table("github_app_installations")
+    if _has_table("github_app_authorizations"):
+        _drop_index_once("ix_github_app_authorizations_user_id", "github_app_authorizations")
+        _drop_index_once(
+            "ix_github_app_authorizations_github_user",
+            "github_app_authorizations",
+        )
+        _drop_index_once(
+            "ux_github_app_authorizations_user_active",
+            "github_app_authorizations",
+        )
+        op.drop_table("github_app_authorizations")

--- a/server/alembic/versions/c3f6a9b2d5e8_cloud_secrets.py
+++ b/server/alembic/versions/c3f6a9b2d5e8_cloud_secrets.py
@@ -19,70 +19,108 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+    postgresql_where: sa.TextClause | None = None,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(
+            index_name,
+            table_name,
+            columns,
+            unique=unique,
+            postgresql_where=postgresql_where,
+        )
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
 def upgrade() -> None:
-    op.create_table(
-        "cloud_secret_set",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("scope_kind", sa.String(length=32), nullable=False),
-        sa.Column("user_id", sa.Uuid(), nullable=True),
-        sa.Column("organization_id", sa.Uuid(), nullable=True),
-        sa.Column("cloud_repo_config_id", sa.Uuid(), nullable=True),
-        sa.Column("version", sa.Integer(), nullable=False),
-        sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
-        sa.Column("updated_by_user_id", sa.Uuid(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.CheckConstraint(
-            "scope_kind IN ('personal', 'organization', 'workspace')",
-            name="ck_cloud_secret_set_scope_kind",
-        ),
-        sa.CheckConstraint(
-            "((scope_kind = 'personal' AND user_id IS NOT NULL "
-            "AND organization_id IS NULL AND cloud_repo_config_id IS NULL) OR "
-            "(scope_kind = 'organization' AND organization_id IS NOT NULL "
-            "AND user_id IS NULL AND cloud_repo_config_id IS NULL) OR "
-            "(scope_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL "
-            "AND user_id IS NULL AND organization_id IS NULL))",
-            name="ck_cloud_secret_set_scope_fields",
-        ),
-        sa.ForeignKeyConstraint(
-            ["cloud_repo_config_id"],
-            ["cloud_repo_config.id"],
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["updated_by_user_id"], ["user.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("ix_cloud_secret_set_scope_kind", "cloud_secret_set", ["scope_kind"])
-    op.create_index("ix_cloud_secret_set_user_id", "cloud_secret_set", ["user_id"])
-    op.create_index(
+    if not _has_table("cloud_secret_set"):
+        op.create_table(
+            "cloud_secret_set",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("scope_kind", sa.String(length=32), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=True),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("cloud_repo_config_id", sa.Uuid(), nullable=True),
+            sa.Column("version", sa.Integer(), nullable=False),
+            sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
+            sa.Column("updated_by_user_id", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "scope_kind IN ('personal', 'organization', 'workspace')",
+                name="ck_cloud_secret_set_scope_kind",
+            ),
+            sa.CheckConstraint(
+                "((scope_kind = 'personal' AND user_id IS NOT NULL "
+                "AND organization_id IS NULL AND cloud_repo_config_id IS NULL) OR "
+                "(scope_kind = 'organization' AND organization_id IS NOT NULL "
+                "AND user_id IS NULL AND cloud_repo_config_id IS NULL) OR "
+                "(scope_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL "
+                "AND user_id IS NULL AND organization_id IS NULL))",
+                name="ck_cloud_secret_set_scope_fields",
+            ),
+            sa.ForeignKeyConstraint(
+                ["cloud_repo_config_id"],
+                ["cloud_repo_config.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["updated_by_user_id"], ["user.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once("ix_cloud_secret_set_scope_kind", "cloud_secret_set", ["scope_kind"])
+    _create_index_once("ix_cloud_secret_set_user_id", "cloud_secret_set", ["user_id"])
+    _create_index_once(
         "ix_cloud_secret_set_organization_id",
         "cloud_secret_set",
         ["organization_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_cloud_secret_set_cloud_repo_config_id",
         "cloud_secret_set",
         ["cloud_repo_config_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ux_cloud_secret_set_personal",
         "cloud_secret_set",
         ["user_id"],
         unique=True,
         postgresql_where=sa.text("scope_kind = 'personal'"),
     )
-    op.create_index(
+    _create_index_once(
         "ux_cloud_secret_set_organization",
         "cloud_secret_set",
         ["organization_id"],
         unique=True,
         postgresql_where=sa.text("scope_kind = 'organization'"),
     )
-    op.create_index(
+    _create_index_once(
         "ux_cloud_secret_set_workspace",
         "cloud_secret_set",
         ["cloud_repo_config_id"],
@@ -90,121 +128,136 @@ def upgrade() -> None:
         postgresql_where=sa.text("scope_kind = 'workspace'"),
     )
 
-    op.create_table(
-        "cloud_secret_env_var",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("secret_set_id", sa.Uuid(), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=False),
-        sa.Column("value_ciphertext", sa.Text(), nullable=False),
-        sa.Column("value_sha256", sa.String(length=64), nullable=False),
-        sa.Column("byte_size", sa.BigInteger(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["secret_set_id"], ["cloud_secret_set.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("secret_set_id", "name"),
-    )
-    op.create_index(
+    if not _has_table("cloud_secret_env_var"):
+        op.create_table(
+            "cloud_secret_env_var",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("secret_set_id", sa.Uuid(), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("value_ciphertext", sa.Text(), nullable=False),
+            sa.Column("value_sha256", sa.String(length=64), nullable=False),
+            sa.Column("byte_size", sa.BigInteger(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["secret_set_id"],
+                ["cloud_secret_set.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("secret_set_id", "name"),
+        )
+    _create_index_once(
         "ix_cloud_secret_env_var_secret_set_id",
         "cloud_secret_env_var",
         ["secret_set_id"],
     )
 
-    op.create_table(
+    if not _has_table("cloud_secret_file"):
+        op.create_table(
+            "cloud_secret_file",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("secret_set_id", sa.Uuid(), nullable=False),
+            sa.Column("path", sa.Text(), nullable=False),
+            sa.Column("content_ciphertext", sa.Text(), nullable=False),
+            sa.Column("content_sha256", sa.String(length=64), nullable=False),
+            sa.Column("byte_size", sa.BigInteger(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["secret_set_id"],
+                ["cloud_secret_set.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("secret_set_id", "path"),
+        )
+    _create_index_once(
+        "ix_cloud_secret_file_secret_set_id",
         "cloud_secret_file",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("secret_set_id", sa.Uuid(), nullable=False),
-        sa.Column("path", sa.Text(), nullable=False),
-        sa.Column("content_ciphertext", sa.Text(), nullable=False),
-        sa.Column("content_sha256", sa.String(length=64), nullable=False),
-        sa.Column("byte_size", sa.BigInteger(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["secret_set_id"], ["cloud_secret_set.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("secret_set_id", "path"),
+        ["secret_set_id"],
     )
-    op.create_index("ix_cloud_secret_file_secret_set_id", "cloud_secret_file", ["secret_set_id"])
 
-    op.create_table(
-        "managed_sandbox_secret_materialization",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("managed_sandbox_id", sa.Uuid(), nullable=False),
-        sa.Column("materialization_kind", sa.String(length=32), nullable=False),
-        sa.Column("cloud_secret_set_id", sa.Uuid(), nullable=True),
-        sa.Column("cloud_repo_config_id", sa.Uuid(), nullable=True),
-        sa.Column("sandbox_generation", sa.Integer(), nullable=False),
-        sa.Column("applied_version", sa.Integer(), nullable=False),
-        sa.Column("applied_versions_json", sa.Text(), nullable=True),
-        sa.Column("applied_manifest_json", sa.Text(), nullable=True),
-        sa.Column("status", sa.String(length=32), nullable=False),
-        sa.Column("last_error", sa.Text(), nullable=True),
-        sa.Column("materialized_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.CheckConstraint(
-            "materialization_kind IN ('global', 'workspace')",
-            name="ck_managed_sandbox_secret_materialization_kind",
-        ),
-        sa.CheckConstraint(
-            "status IN ('pending', 'running', 'ready', 'error')",
-            name="ck_managed_sandbox_secret_materialization_status",
-        ),
-        sa.CheckConstraint(
-            "((materialization_kind = 'global' AND cloud_repo_config_id IS NULL) OR "
-            "(materialization_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL))",
-            name="ck_managed_sandbox_secret_materialization_scope",
-        ),
-        sa.ForeignKeyConstraint(
-            ["cloud_repo_config_id"],
-            ["cloud_repo_config.id"],
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(
-            ["cloud_secret_set_id"],
-            ["cloud_secret_set.id"],
-            ondelete="SET NULL",
-        ),
-        sa.ForeignKeyConstraint(
-            ["managed_sandbox_id"],
-            ["managed_sandbox.id"],
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
+    if not _has_table("managed_sandbox_secret_materialization"):
+        op.create_table(
+            "managed_sandbox_secret_materialization",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("managed_sandbox_id", sa.Uuid(), nullable=False),
+            sa.Column("materialization_kind", sa.String(length=32), nullable=False),
+            sa.Column("cloud_secret_set_id", sa.Uuid(), nullable=True),
+            sa.Column("cloud_repo_config_id", sa.Uuid(), nullable=True),
+            sa.Column("sandbox_generation", sa.Integer(), nullable=False),
+            sa.Column("applied_version", sa.Integer(), nullable=False),
+            sa.Column("applied_versions_json", sa.Text(), nullable=True),
+            sa.Column("applied_manifest_json", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("materialized_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "materialization_kind IN ('global', 'workspace')",
+                name="ck_managed_sandbox_secret_materialization_kind",
+            ),
+            sa.CheckConstraint(
+                "status IN ('pending', 'running', 'ready', 'error')",
+                name="ck_managed_sandbox_secret_materialization_status",
+            ),
+            sa.CheckConstraint(
+                "((materialization_kind = 'global' AND cloud_repo_config_id IS NULL) OR "
+                "(materialization_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL))",
+                name="ck_managed_sandbox_secret_materialization_scope",
+            ),
+            sa.ForeignKeyConstraint(
+                ["cloud_repo_config_id"],
+                ["cloud_repo_config.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["cloud_secret_set_id"],
+                ["cloud_secret_set.id"],
+                ondelete="SET NULL",
+            ),
+            sa.ForeignKeyConstraint(
+                ["managed_sandbox_id"],
+                ["managed_sandbox.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_once(
         "ix_managed_sandbox_secret_materialization_cloud_repo_config_id",
         "managed_sandbox_secret_materialization",
         ["cloud_repo_config_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_managed_sandbox_secret_materialization_cloud_secret_set_id",
         "managed_sandbox_secret_materialization",
         ["cloud_secret_set_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_managed_sandbox_secret_materialization_managed_sandbox_id",
         "managed_sandbox_secret_materialization",
         ["managed_sandbox_id"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_managed_sandbox_secret_materialization_materialization_kind",
         "managed_sandbox_secret_materialization",
         ["materialization_kind"],
     )
-    op.create_index(
+    _create_index_once(
         "ix_managed_sandbox_secret_materialization_status",
         "managed_sandbox_secret_materialization",
         ["managed_sandbox_id", "status"],
     )
-    op.create_index(
+    _create_index_once(
         "ux_managed_sandbox_secret_materialization_global",
         "managed_sandbox_secret_materialization",
         ["managed_sandbox_id"],
         unique=True,
         postgresql_where=sa.text("materialization_kind = 'global'"),
     )
-    op.create_index(
+    _create_index_once(
         "ux_managed_sandbox_secret_materialization_workspace",
         "managed_sandbox_secret_materialization",
         ["managed_sandbox_id", "cloud_repo_config_id"],
@@ -214,44 +267,48 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ux_managed_sandbox_secret_materialization_workspace",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ux_managed_sandbox_secret_materialization_global",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ix_managed_sandbox_secret_materialization_status",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ix_managed_sandbox_secret_materialization_materialization_kind",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ix_managed_sandbox_secret_materialization_managed_sandbox_id",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ix_managed_sandbox_secret_materialization_cloud_secret_set_id",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_index(
-        "ix_managed_sandbox_secret_materialization_cloud_repo_config_id",
-        table_name="managed_sandbox_secret_materialization",
-    )
-    op.drop_table("managed_sandbox_secret_materialization")
-    op.drop_index("ix_cloud_secret_file_secret_set_id", table_name="cloud_secret_file")
-    op.drop_table("cloud_secret_file")
-    op.drop_index("ix_cloud_secret_env_var_secret_set_id", table_name="cloud_secret_env_var")
-    op.drop_table("cloud_secret_env_var")
-    op.drop_index("ux_cloud_secret_set_workspace", table_name="cloud_secret_set")
-    op.drop_index("ux_cloud_secret_set_organization", table_name="cloud_secret_set")
-    op.drop_index("ux_cloud_secret_set_personal", table_name="cloud_secret_set")
-    op.drop_index("ix_cloud_secret_set_cloud_repo_config_id", table_name="cloud_secret_set")
-    op.drop_index("ix_cloud_secret_set_organization_id", table_name="cloud_secret_set")
-    op.drop_index("ix_cloud_secret_set_user_id", table_name="cloud_secret_set")
-    op.drop_index("ix_cloud_secret_set_scope_kind", table_name="cloud_secret_set")
-    op.drop_table("cloud_secret_set")
+    if _has_table("managed_sandbox_secret_materialization"):
+        _drop_index_once(
+            "ux_managed_sandbox_secret_materialization_workspace",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ux_managed_sandbox_secret_materialization_global",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_status",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_materialization_kind",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_managed_sandbox_id",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_cloud_secret_set_id",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_cloud_repo_config_id",
+            "managed_sandbox_secret_materialization",
+        )
+        op.drop_table("managed_sandbox_secret_materialization")
+    if _has_table("cloud_secret_file"):
+        _drop_index_once("ix_cloud_secret_file_secret_set_id", "cloud_secret_file")
+        op.drop_table("cloud_secret_file")
+    if _has_table("cloud_secret_env_var"):
+        _drop_index_once("ix_cloud_secret_env_var_secret_set_id", "cloud_secret_env_var")
+        op.drop_table("cloud_secret_env_var")
+    if _has_table("cloud_secret_set"):
+        _drop_index_once("ux_cloud_secret_set_workspace", "cloud_secret_set")
+        _drop_index_once("ux_cloud_secret_set_organization", "cloud_secret_set")
+        _drop_index_once("ux_cloud_secret_set_personal", "cloud_secret_set")
+        _drop_index_once("ix_cloud_secret_set_cloud_repo_config_id", "cloud_secret_set")
+        _drop_index_once("ix_cloud_secret_set_organization_id", "cloud_secret_set")
+        _drop_index_once("ix_cloud_secret_set_user_id", "cloud_secret_set")
+        _drop_index_once("ix_cloud_secret_set_scope_kind", "cloud_secret_set")
+        op.drop_table("cloud_secret_set")

--- a/server/alembic/versions/d4e7f8a9b2c3_repo_environments.py
+++ b/server/alembic/versions/d4e7f8a9b2c3_repo_environments.py
@@ -230,7 +230,7 @@ def upgrade() -> None:
                     id, id, 'cloud', NULL, NULL,
                     configured, configured_at, default_branch, setup_script,
                     setup_script_version, run_command,
-                    GREATEST(files_version, env_vars_version, setup_script_version),
+                    GREATEST(files_version, env_vars_version, setup_script_version, CASE WHEN configured THEN 1 ELSE 0 END),
                     id, created_at, updated_at, NULL
                 FROM cloud_repo_config
                 ON CONFLICT DO NOTHING

--- a/server/alembic/versions/d4e7f8a9b2c3_repo_environments.py
+++ b/server/alembic/versions/d4e7f8a9b2c3_repo_environments.py
@@ -1,0 +1,494 @@
+"""repo environments
+
+Revision ID: d4e7f8a9b2c3
+Revises: c3f6a9b2d5e8
+Create Date: 2026-06-27 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4e7f8a9b2c3"
+down_revision: str | Sequence[str] | None = "c3f6a9b2d5e8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name)}
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return column_name in {column["name"] for column in _inspector().get_columns(table_name)}
+
+
+def _has_foreign_key(table_name: str, constraint_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return constraint_name in {fk["name"] for fk in _inspector().get_foreign_keys(table_name)}
+
+
+def _create_index_once(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+    postgresql_where: sa.TextClause | None = None,
+) -> None:
+    if not _has_index(table_name, index_name):
+        op.create_index(
+            index_name,
+            table_name,
+            columns,
+            unique=unique,
+            postgresql_where=postgresql_where,
+        )
+
+
+def _drop_index_once(index_name: str, table_name: str) -> None:
+    if _has_index(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+
+
+def _drop_foreign_key_once(table_name: str, constraint_name: str) -> None:
+    if _has_foreign_key(table_name, constraint_name):
+        op.drop_constraint(constraint_name, table_name, type_="foreignkey")
+
+
+def _replace_check_constraint(table_name: str, constraint_name: str, expression: str) -> None:
+    op.execute(sa.text(f"ALTER TABLE {table_name} DROP CONSTRAINT IF EXISTS {constraint_name}"))
+    op.create_check_constraint(constraint_name, table_name, expression)
+
+
+def upgrade() -> None:
+    if not _has_table("repo_config"):
+        op.create_table(
+            "repo_config",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("owner_scope", sa.String(length=32), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=True),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("git_provider", sa.String(length=32), nullable=False),
+            sa.Column("git_owner", sa.String(length=255), nullable=False),
+            sa.Column("git_repo_name", sa.String(length=255), nullable=False),
+            sa.Column("legacy_cloud_repo_config_id", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "owner_scope IN ('personal', 'organization')",
+                name="ck_repo_config_owner_scope",
+            ),
+            sa.CheckConstraint(
+                "((owner_scope = 'personal' AND user_id IS NOT NULL "
+                "AND organization_id IS NULL) OR "
+                "(owner_scope = 'organization' AND organization_id IS NOT NULL "
+                "AND user_id IS NULL))",
+                name="ck_repo_config_owner_fields",
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["legacy_cloud_repo_config_id"],
+                ["cloud_repo_config.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "legacy_cloud_repo_config_id",
+                name="uq_repo_config_legacy_cloud_repo_config_id",
+            ),
+        )
+
+    _create_index_once("ix_repo_config_owner_scope", "repo_config", ["owner_scope"])
+    _create_index_once("ix_repo_config_user_id", "repo_config", ["user_id"])
+    _create_index_once("ix_repo_config_organization_id", "repo_config", ["organization_id"])
+    _create_index_once(
+        "ux_repo_config_personal_repo",
+        "repo_config",
+        ["user_id", "git_provider", "git_owner", "git_repo_name"],
+        unique=True,
+        postgresql_where=sa.text("owner_scope = 'personal' AND deleted_at IS NULL"),
+    )
+    _create_index_once(
+        "ux_repo_config_organization_repo",
+        "repo_config",
+        ["organization_id", "git_provider", "git_owner", "git_repo_name"],
+        unique=True,
+        postgresql_where=sa.text("owner_scope = 'organization' AND deleted_at IS NULL"),
+    )
+
+    if not _has_table("repo_environment"):
+        op.create_table(
+            "repo_environment",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("repo_config_id", sa.Uuid(), nullable=False),
+            sa.Column("environment_kind", sa.String(length=32), nullable=False),
+            sa.Column("desktop_install_id", sa.String(length=255), nullable=True),
+            sa.Column("local_path", sa.Text(), nullable=True),
+            sa.Column("configured", sa.Boolean(), nullable=False),
+            sa.Column("configured_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("default_branch", sa.String(length=255), nullable=True),
+            sa.Column("setup_script", sa.Text(), nullable=False),
+            sa.Column("setup_script_version", sa.Integer(), nullable=False),
+            sa.Column("run_command", sa.Text(), nullable=False),
+            sa.Column("config_version", sa.Integer(), nullable=False),
+            sa.Column("legacy_cloud_repo_config_id", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "environment_kind IN ('local', 'cloud')",
+                name="ck_repo_environment_kind",
+            ),
+            sa.CheckConstraint(
+                "((environment_kind = 'local' AND local_path IS NOT NULL "
+                "AND desktop_install_id IS NOT NULL) OR "
+                "(environment_kind = 'cloud' AND local_path IS NULL))",
+                name="ck_repo_environment_kind_fields",
+            ),
+            sa.ForeignKeyConstraint(["repo_config_id"], ["repo_config.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["legacy_cloud_repo_config_id"],
+                ["cloud_repo_config.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "legacy_cloud_repo_config_id",
+                name="uq_repo_environment_legacy_cloud_repo_config_id",
+            ),
+        )
+
+    _create_index_once("ix_repo_environment_repo_config_id", "repo_environment", ["repo_config_id"])
+    _create_index_once(
+        "ix_repo_environment_environment_kind",
+        "repo_environment",
+        ["environment_kind"],
+    )
+    _create_index_once(
+        "ux_repo_environment_cloud",
+        "repo_environment",
+        ["repo_config_id"],
+        unique=True,
+        postgresql_where=sa.text("environment_kind = 'cloud' AND deleted_at IS NULL"),
+    )
+    _create_index_once(
+        "ux_repo_environment_local_path",
+        "repo_environment",
+        ["repo_config_id", "desktop_install_id", "local_path"],
+        unique=True,
+        postgresql_where=sa.text("environment_kind = 'local' AND deleted_at IS NULL"),
+    )
+
+    if _has_table("cloud_repo_config"):
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO repo_config (
+                    id, owner_scope, user_id, organization_id, git_provider,
+                    git_owner, git_repo_name, legacy_cloud_repo_config_id,
+                    created_at, updated_at, deleted_at
+                )
+                SELECT
+                    id, owner_scope, user_id, organization_id, 'github',
+                    git_owner, git_repo_name, id,
+                    created_at, updated_at, NULL
+                FROM cloud_repo_config
+                ON CONFLICT DO NOTHING
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO repo_environment (
+                    id, repo_config_id, environment_kind, desktop_install_id, local_path,
+                    configured, configured_at, default_branch, setup_script,
+                    setup_script_version, run_command, config_version,
+                    legacy_cloud_repo_config_id, created_at, updated_at, deleted_at
+                )
+                SELECT
+                    id, id, 'cloud', NULL, NULL,
+                    configured, configured_at, default_branch, setup_script,
+                    setup_script_version, run_command,
+                    GREATEST(files_version, env_vars_version, setup_script_version),
+                    id, created_at, updated_at, NULL
+                FROM cloud_repo_config
+                ON CONFLICT DO NOTHING
+                """
+            )
+        )
+
+    if _has_table("managed_sandbox_repo_materialization"):
+        if not _has_column("managed_sandbox_repo_materialization", "repo_environment_id"):
+            op.add_column(
+                "managed_sandbox_repo_materialization",
+                sa.Column("repo_environment_id", sa.Uuid(), nullable=True),
+            )
+        if not _has_foreign_key(
+            "managed_sandbox_repo_materialization",
+            "fk_managed_sandbox_repo_materialization_repo_environment_id",
+        ):
+            op.create_foreign_key(
+                "fk_managed_sandbox_repo_materialization_repo_environment_id",
+                "managed_sandbox_repo_materialization",
+                "repo_environment",
+                ["repo_environment_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+        op.execute(
+            sa.text(
+                """
+                UPDATE managed_sandbox_repo_materialization
+                SET repo_environment_id = cloud_repo_config_id
+                WHERE repo_environment_id IS NULL
+                  AND cloud_repo_config_id IS NOT NULL
+                """
+            )
+        )
+        _create_index_once(
+            "ix_managed_sandbox_repo_materialization_repo_environment_id",
+            "managed_sandbox_repo_materialization",
+            ["repo_environment_id"],
+        )
+
+    if _has_table("cloud_secret_set"):
+        if not _has_column("cloud_secret_set", "repo_environment_id"):
+            op.add_column(
+                "cloud_secret_set",
+                sa.Column("repo_environment_id", sa.Uuid(), nullable=True),
+            )
+        if not _has_foreign_key(
+            "cloud_secret_set",
+            "fk_cloud_secret_set_repo_environment_id",
+        ):
+            op.create_foreign_key(
+                "fk_cloud_secret_set_repo_environment_id",
+                "cloud_secret_set",
+                "repo_environment",
+                ["repo_environment_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+        op.execute(
+            sa.text(
+                """
+                UPDATE cloud_secret_set
+                SET repo_environment_id = cloud_repo_config_id
+                WHERE repo_environment_id IS NULL
+                  AND cloud_repo_config_id IS NOT NULL
+                """
+            )
+        )
+        _create_index_once(
+            "ix_cloud_secret_set_repo_environment_id",
+            "cloud_secret_set",
+            ["repo_environment_id"],
+        )
+        _create_index_once(
+            "ux_cloud_secret_set_workspace_environment",
+            "cloud_secret_set",
+            ["repo_environment_id"],
+            unique=True,
+            postgresql_where=sa.text("scope_kind = 'workspace'"),
+        )
+        _drop_index_once("ux_cloud_secret_set_workspace", "cloud_secret_set")
+        _replace_check_constraint(
+            "cloud_secret_set",
+            "ck_cloud_secret_set_scope_fields",
+            "((scope_kind = 'personal' AND user_id IS NOT NULL "
+            "AND organization_id IS NULL AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
+            "(scope_kind = 'organization' AND organization_id IS NOT NULL "
+            "AND user_id IS NULL AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
+            "(scope_kind = 'workspace' AND repo_environment_id IS NOT NULL "
+            "AND user_id IS NULL AND organization_id IS NULL))",
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE cloud_secret_set
+                SET cloud_repo_config_id = NULL
+                WHERE scope_kind = 'workspace'
+                  AND repo_environment_id IS NOT NULL
+                """
+            )
+        )
+
+    if _has_table("managed_sandbox_secret_materialization"):
+        if not _has_column("managed_sandbox_secret_materialization", "repo_environment_id"):
+            op.add_column(
+                "managed_sandbox_secret_materialization",
+                sa.Column("repo_environment_id", sa.Uuid(), nullable=True),
+            )
+        if not _has_foreign_key(
+            "managed_sandbox_secret_materialization",
+            "fk_managed_sandbox_secret_materialization_repo_environment_id",
+        ):
+            op.create_foreign_key(
+                "fk_managed_sandbox_secret_materialization_repo_environment_id",
+                "managed_sandbox_secret_materialization",
+                "repo_environment",
+                ["repo_environment_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+        op.execute(
+            sa.text(
+                """
+                UPDATE managed_sandbox_secret_materialization
+                SET repo_environment_id = cloud_repo_config_id
+                WHERE repo_environment_id IS NULL
+                  AND cloud_repo_config_id IS NOT NULL
+                """
+            )
+        )
+        _create_index_once(
+            "ix_managed_sandbox_secret_materialization_repo_environment_id",
+            "managed_sandbox_secret_materialization",
+            ["repo_environment_id"],
+        )
+        _create_index_once(
+            "ux_managed_sandbox_secret_materialization_workspace_environment",
+            "managed_sandbox_secret_materialization",
+            ["managed_sandbox_id", "repo_environment_id"],
+            unique=True,
+            postgresql_where=sa.text("materialization_kind = 'workspace'"),
+        )
+        _drop_index_once(
+            "ux_managed_sandbox_secret_materialization_workspace",
+            "managed_sandbox_secret_materialization",
+        )
+        _replace_check_constraint(
+            "managed_sandbox_secret_materialization",
+            "ck_managed_sandbox_secret_materialization_scope",
+            "((materialization_kind = 'global' "
+            "AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
+            "(materialization_kind = 'workspace' AND repo_environment_id IS NOT NULL))",
+        )
+        op.execute(
+            sa.text(
+                """
+                UPDATE managed_sandbox_secret_materialization
+                SET cloud_repo_config_id = NULL
+                WHERE materialization_kind = 'workspace'
+                  AND repo_environment_id IS NOT NULL
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    if _has_table("managed_sandbox_secret_materialization") and _has_column(
+        "managed_sandbox_secret_materialization",
+        "repo_environment_id",
+    ):
+        op.execute(
+            sa.text(
+                """
+                UPDATE managed_sandbox_secret_materialization
+                SET cloud_repo_config_id = repo_environment_id
+                WHERE materialization_kind = 'workspace'
+                  AND cloud_repo_config_id IS NULL
+                  AND repo_environment_id IS NOT NULL
+                """
+            )
+        )
+        _replace_check_constraint(
+            "managed_sandbox_secret_materialization",
+            "ck_managed_sandbox_secret_materialization_scope",
+            "((materialization_kind = 'global' AND cloud_repo_config_id IS NULL) OR "
+            "(materialization_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL))",
+        )
+        _create_index_once(
+            "ux_managed_sandbox_secret_materialization_workspace",
+            "managed_sandbox_secret_materialization",
+            ["managed_sandbox_id", "cloud_repo_config_id"],
+            unique=True,
+            postgresql_where=sa.text("materialization_kind = 'workspace'"),
+        )
+        _drop_index_once(
+            "ux_managed_sandbox_secret_materialization_workspace_environment",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_index_once(
+            "ix_managed_sandbox_secret_materialization_repo_environment_id",
+            "managed_sandbox_secret_materialization",
+        )
+        _drop_foreign_key_once(
+            "managed_sandbox_secret_materialization",
+            "fk_managed_sandbox_secret_materialization_repo_environment_id",
+        )
+        op.drop_column("managed_sandbox_secret_materialization", "repo_environment_id")
+    if _has_table("cloud_secret_set") and _has_column("cloud_secret_set", "repo_environment_id"):
+        op.execute(
+            sa.text(
+                """
+                UPDATE cloud_secret_set
+                SET cloud_repo_config_id = repo_environment_id
+                WHERE scope_kind = 'workspace'
+                  AND cloud_repo_config_id IS NULL
+                  AND repo_environment_id IS NOT NULL
+                """
+            )
+        )
+        _replace_check_constraint(
+            "cloud_secret_set",
+            "ck_cloud_secret_set_scope_fields",
+            "((scope_kind = 'personal' AND user_id IS NOT NULL "
+            "AND organization_id IS NULL AND cloud_repo_config_id IS NULL) OR "
+            "(scope_kind = 'organization' AND organization_id IS NOT NULL "
+            "AND user_id IS NULL AND cloud_repo_config_id IS NULL) OR "
+            "(scope_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL "
+            "AND user_id IS NULL AND organization_id IS NULL))",
+        )
+        _create_index_once(
+            "ux_cloud_secret_set_workspace",
+            "cloud_secret_set",
+            ["cloud_repo_config_id"],
+            unique=True,
+            postgresql_where=sa.text("scope_kind = 'workspace'"),
+        )
+        _drop_index_once("ux_cloud_secret_set_workspace_environment", "cloud_secret_set")
+        _drop_index_once("ix_cloud_secret_set_repo_environment_id", "cloud_secret_set")
+        _drop_foreign_key_once("cloud_secret_set", "fk_cloud_secret_set_repo_environment_id")
+        op.drop_column("cloud_secret_set", "repo_environment_id")
+    if _has_table("managed_sandbox_repo_materialization") and _has_column(
+        "managed_sandbox_repo_materialization",
+        "repo_environment_id",
+    ):
+        _drop_index_once(
+            "ix_managed_sandbox_repo_materialization_repo_environment_id",
+            "managed_sandbox_repo_materialization",
+        )
+        _drop_foreign_key_once(
+            "managed_sandbox_repo_materialization",
+            "fk_managed_sandbox_repo_materialization_repo_environment_id",
+        )
+        op.drop_column("managed_sandbox_repo_materialization", "repo_environment_id")
+    if _has_table("repo_environment"):
+        op.drop_table("repo_environment")
+    if _has_table("repo_config"):
+        op.drop_table("repo_config")

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -17,6 +17,7 @@ from . import mcp as mcp  # noqa: F401
 from . import mobility as mobility  # noqa: F401
 from . import plugins as plugins  # noqa: F401
 from . import repo_config as repo_config  # noqa: F401
+from . import repositories as repositories  # noqa: F401
 from . import runtime_config as runtime_config  # noqa: F401
 from . import runtime_environments as runtime_environments  # noqa: F401
 from . import sandboxes as sandboxes  # noqa: F401

--- a/server/proliferate/db/models/cloud/managed_sandboxes.py
+++ b/server/proliferate/db/models/cloud/managed_sandboxes.py
@@ -121,9 +121,14 @@ class ManagedSandboxRepoMaterialization(Base):
         ForeignKey("cloud_repo_config.id", ondelete="CASCADE"),
         index=True,
     )
+    repo_environment_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("repo_environment.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
     sandbox_generation: Mapped[int] = mapped_column(Integer, default=0)
 
-    status: Mapped[str] = mapped_column(String(32), index=True)
+    status: Mapped[str] = mapped_column(String(32))
     repo_path: Mapped[str] = mapped_column(Text)
     anyharness_repo_root_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     anyharness_workspace_id: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/server/proliferate/db/models/cloud/repositories.py
+++ b/server/proliferate/db/models/cloud/repositories.py
@@ -1,0 +1,130 @@
+"""Repository and environment ORM models."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.db.models.base import Base, utcnow
+
+
+class RepoConfig(Base):
+    __tablename__ = "repo_config"
+    __table_args__ = (
+        CheckConstraint(
+            "owner_scope IN ('personal', 'organization')",
+            name="ck_repo_config_owner_scope",
+        ),
+        CheckConstraint(
+            "((owner_scope = 'personal' AND user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND organization_id IS NOT NULL "
+            "AND user_id IS NULL))",
+            name="ck_repo_config_owner_fields",
+        ),
+        Index(
+            "ux_repo_config_personal_repo",
+            "user_id",
+            "git_provider",
+            "git_owner",
+            "git_repo_name",
+            unique=True,
+            postgresql_where=text("owner_scope = 'personal' AND deleted_at IS NULL"),
+        ),
+        Index(
+            "ux_repo_config_organization_repo",
+            "organization_id",
+            "git_provider",
+            "git_owner",
+            "git_repo_name",
+            unique=True,
+            postgresql_where=text("owner_scope = 'organization' AND deleted_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    owner_scope: Mapped[str] = mapped_column(String(32), index=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    git_provider: Mapped[str] = mapped_column(String(32), default="github")
+    git_owner: Mapped[str] = mapped_column(String(255))
+    git_repo_name: Mapped[str] = mapped_column(String(255))
+    legacy_cloud_repo_config_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_repo_config.id", ondelete="SET NULL"),
+        unique=True,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class RepoEnvironment(Base):
+    __tablename__ = "repo_environment"
+    __table_args__ = (
+        CheckConstraint(
+            "environment_kind IN ('local', 'cloud')",
+            name="ck_repo_environment_kind",
+        ),
+        CheckConstraint(
+            "((environment_kind = 'local' AND local_path IS NOT NULL "
+            "AND desktop_install_id IS NOT NULL) OR "
+            "(environment_kind = 'cloud' AND local_path IS NULL))",
+            name="ck_repo_environment_kind_fields",
+        ),
+        Index(
+            "ux_repo_environment_cloud",
+            "repo_config_id",
+            unique=True,
+            postgresql_where=text("environment_kind = 'cloud' AND deleted_at IS NULL"),
+        ),
+        Index(
+            "ux_repo_environment_local_path",
+            "repo_config_id",
+            "desktop_install_id",
+            "local_path",
+            unique=True,
+            postgresql_where=text("environment_kind = 'local' AND deleted_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    repo_config_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("repo_config.id", ondelete="CASCADE"),
+        index=True,
+    )
+    environment_kind: Mapped[str] = mapped_column(String(32), index=True)
+    desktop_install_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    local_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    configured: Mapped[bool] = mapped_column(default=False)
+    configured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    default_branch: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    setup_script: Mapped[str] = mapped_column(Text, default="")
+    setup_script_version: Mapped[int] = mapped_column(default=0)
+    run_command: Mapped[str] = mapped_column(Text, default="")
+    config_version: Mapped[int] = mapped_column(default=0)
+    legacy_cloud_repo_config_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_repo_config.id", ondelete="SET NULL"),
+        unique=True,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/server/proliferate/db/models/cloud/secrets.py
+++ b/server/proliferate/db/models/cloud/secrets.py
@@ -29,10 +29,12 @@ class CloudSecretSet(Base):
         ),
         CheckConstraint(
             "((scope_kind = 'personal' AND user_id IS NOT NULL "
-            "AND organization_id IS NULL AND cloud_repo_config_id IS NULL) OR "
+            "AND organization_id IS NULL AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
             "(scope_kind = 'organization' AND organization_id IS NOT NULL "
-            "AND user_id IS NULL AND cloud_repo_config_id IS NULL) OR "
-            "(scope_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL "
+            "AND user_id IS NULL AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
+            "(scope_kind = 'workspace' AND repo_environment_id IS NOT NULL "
             "AND user_id IS NULL AND organization_id IS NULL))",
             name="ck_cloud_secret_set_scope_fields",
         ),
@@ -49,8 +51,8 @@ class CloudSecretSet(Base):
             postgresql_where=text("scope_kind = 'organization'"),
         ),
         Index(
-            "ux_cloud_secret_set_workspace",
-            "cloud_repo_config_id",
+            "ux_cloud_secret_set_workspace_environment",
+            "repo_environment_id",
             unique=True,
             postgresql_where=text("scope_kind = 'workspace'"),
         ),
@@ -70,6 +72,11 @@ class CloudSecretSet(Base):
     )
     cloud_repo_config_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("cloud_repo_config.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    repo_environment_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("repo_environment.id", ondelete="CASCADE"),
         index=True,
         nullable=True,
     )
@@ -144,8 +151,10 @@ class ManagedSandboxSecretMaterialization(Base):
             name="ck_managed_sandbox_secret_materialization_status",
         ),
         CheckConstraint(
-            "((materialization_kind = 'global' AND cloud_repo_config_id IS NULL) OR "
-            "(materialization_kind = 'workspace' AND cloud_repo_config_id IS NOT NULL))",
+            "((materialization_kind = 'global' "
+            "AND cloud_repo_config_id IS NULL "
+            "AND repo_environment_id IS NULL) OR "
+            "(materialization_kind = 'workspace' AND repo_environment_id IS NOT NULL))",
             name="ck_managed_sandbox_secret_materialization_scope",
         ),
         Index(
@@ -155,9 +164,9 @@ class ManagedSandboxSecretMaterialization(Base):
             postgresql_where=text("materialization_kind = 'global'"),
         ),
         Index(
-            "ux_managed_sandbox_secret_materialization_workspace",
+            "ux_managed_sandbox_secret_materialization_workspace_environment",
             "managed_sandbox_id",
-            "cloud_repo_config_id",
+            "repo_environment_id",
             unique=True,
             postgresql_where=text("materialization_kind = 'workspace'"),
         ),
@@ -184,11 +193,16 @@ class ManagedSandboxSecretMaterialization(Base):
         index=True,
         nullable=True,
     )
+    repo_environment_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("repo_environment.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
     sandbox_generation: Mapped[int] = mapped_column(Integer, default=0)
     applied_version: Mapped[int] = mapped_column(Integer, default=0)
     applied_versions_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     applied_manifest_json: Mapped[str | None] = mapped_column(Text, nullable=True)
-    status: Mapped[str] = mapped_column(String(32), index=True)
+    status: Mapped[str] = mapped_column(String(32))
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     materialized_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/server/proliferate/db/store/cloud_secrets.py
+++ b/server/proliferate/db/store/cloud_secrets.py
@@ -49,6 +49,7 @@ class CloudSecretSetValue:
     user_id: UUID | None
     organization_id: UUID | None
     cloud_repo_config_id: UUID | None
+    repo_environment_id: UUID | None
     version: int
     created_by_user_id: UUID | None
     updated_by_user_id: UUID | None
@@ -81,6 +82,7 @@ class CloudSecretSetPayload:
     user_id: UUID | None
     organization_id: UUID | None
     cloud_repo_config_id: UUID | None
+    repo_environment_id: UUID | None
     version: int
     env_vars: tuple[CloudSecretEnvVarPayload, ...]
     files: tuple[CloudSecretFilePayload, ...]
@@ -178,6 +180,7 @@ async def _secret_set_value(
         user_id=row.user_id,
         organization_id=row.organization_id,
         cloud_repo_config_id=row.cloud_repo_config_id,
+        repo_environment_id=row.repo_environment_id,
         version=row.version,
         created_by_user_id=row.created_by_user_id,
         updated_by_user_id=row.updated_by_user_id,
@@ -195,6 +198,7 @@ async def _get_or_create_secret_set(
     user_id: UUID | None,
     organization_id: UUID | None,
     cloud_repo_config_id: UUID | None,
+    repo_environment_id: UUID | None,
     actor_user_id: UUID,
 ) -> CloudSecretSet:
     now = utcnow()
@@ -203,6 +207,7 @@ async def _get_or_create_secret_set(
         "user_id": user_id,
         "organization_id": organization_id,
         "cloud_repo_config_id": cloud_repo_config_id,
+        "repo_environment_id": repo_environment_id,
         "version": 0,
         "created_by_user_id": actor_user_id,
         "updated_by_user_id": actor_user_id,
@@ -230,12 +235,12 @@ async def _get_or_create_secret_set(
         )
     elif scope_kind == "workspace":
         insert_stmt = insert_stmt.on_conflict_do_nothing(
-            index_elements=[CloudSecretSet.cloud_repo_config_id],
+            index_elements=[CloudSecretSet.repo_environment_id],
             index_where=CloudSecretSet.scope_kind == "workspace",
         )
         where = (
             CloudSecretSet.scope_kind == "workspace",
-            CloudSecretSet.cloud_repo_config_id == cloud_repo_config_id,
+            CloudSecretSet.repo_environment_id == repo_environment_id,
         )
     else:
         raise ValueError(f"Unsupported cloud secret scope: {scope_kind}")
@@ -256,6 +261,7 @@ async def get_or_create_personal_secret_set(
         user_id=user_id,
         organization_id=None,
         cloud_repo_config_id=None,
+        repo_environment_id=None,
         actor_user_id=actor_user_id,
     )
     return await _secret_set_value(db, row)
@@ -273,6 +279,7 @@ async def get_or_create_organization_secret_set(
         user_id=None,
         organization_id=organization_id,
         cloud_repo_config_id=None,
+        repo_environment_id=None,
         actor_user_id=actor_user_id,
     )
     return await _secret_set_value(db, row)
@@ -281,8 +288,9 @@ async def get_or_create_organization_secret_set(
 async def get_or_create_workspace_secret_set(
     db: AsyncSession,
     *,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
     actor_user_id: UUID,
+    cloud_repo_config_id: UUID | None = None,
 ) -> CloudSecretSetValue:
     row = await _get_or_create_secret_set(
         db,
@@ -290,6 +298,7 @@ async def get_or_create_workspace_secret_set(
         user_id=None,
         organization_id=None,
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=actor_user_id,
     )
     return await _secret_set_value(db, row)
@@ -330,13 +339,13 @@ async def load_organization_secret_set(
 async def load_workspace_secret_set(
     db: AsyncSession,
     *,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
 ) -> CloudSecretSetValue | None:
     row = (
         await db.execute(
             select(CloudSecretSet).where(
                 CloudSecretSet.scope_kind == "workspace",
-                CloudSecretSet.cloud_repo_config_id == cloud_repo_config_id,
+                CloudSecretSet.repo_environment_id == repo_environment_id,
             )
         )
     ).scalar_one_or_none()
@@ -359,6 +368,7 @@ async def load_secret_set_payload(
         user_id=row.user_id,
         organization_id=row.organization_id,
         cloud_repo_config_id=row.cloud_repo_config_id,
+        repo_environment_id=row.repo_environment_id,
         version=row.version,
         env_vars=tuple(_env_payload(item) for item in env_rows),
         files=tuple(_file_payload(item) for item in file_rows),
@@ -386,9 +396,9 @@ async def load_organization_secret_payload(
 async def load_workspace_secret_payload(
     db: AsyncSession,
     *,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
 ) -> CloudSecretSetPayload | None:
-    value = await load_workspace_secret_set(db, cloud_repo_config_id=cloud_repo_config_id)
+    value = await load_workspace_secret_set(db, repo_environment_id=repo_environment_id)
     return None if value is None else await load_secret_set_payload(db, secret_set_id=value.id)
 
 

--- a/server/proliferate/db/store/managed_sandbox_repo_materializations.py
+++ b/server/proliferate/db/store/managed_sandbox_repo_materializations.py
@@ -19,6 +19,7 @@ class ManagedSandboxRepoMaterializationValue:
     id: UUID
     managed_sandbox_id: UUID
     cloud_repo_config_id: UUID
+    repo_environment_id: UUID | None
     sandbox_generation: int
     status: str
     repo_path: str
@@ -41,6 +42,7 @@ def materialization_value(
         id=row.id,
         managed_sandbox_id=row.managed_sandbox_id,
         cloud_repo_config_id=row.cloud_repo_config_id,
+        repo_environment_id=row.repo_environment_id,
         sandbox_generation=row.sandbox_generation,
         status=row.status,
         repo_path=row.repo_path,
@@ -98,6 +100,7 @@ async def begin_repo_materialization(
     *,
     managed_sandbox_id: UUID,
     cloud_repo_config_id: UUID,
+    repo_environment_id: UUID | None = None,
     sandbox_generation: int,
     repo_path: str,
 ) -> ManagedSandboxRepoMaterializationValue:
@@ -109,6 +112,7 @@ async def begin_repo_materialization(
             .values(
                 managed_sandbox_id=managed_sandbox_id,
                 cloud_repo_config_id=cloud_repo_config_id,
+                repo_environment_id=repo_environment_id,
                 sandbox_generation=sandbox_generation,
                 status="running",
                 repo_path=repo_path,
@@ -127,6 +131,7 @@ async def begin_repo_materialization(
                 index_elements=["managed_sandbox_id", "cloud_repo_config_id"],
                 set_={
                     "sandbox_generation": sandbox_generation,
+                    "repo_environment_id": repo_environment_id,
                     "status": "running",
                     "repo_path": repo_path,
                     "anyharness_repo_root_id": case(

--- a/server/proliferate/db/store/managed_sandbox_secrets.py
+++ b/server/proliferate/db/store/managed_sandbox_secrets.py
@@ -22,6 +22,7 @@ class ManagedSandboxSecretMaterializationValue:
     materialization_kind: str
     cloud_secret_set_id: UUID | None
     cloud_repo_config_id: UUID | None
+    repo_environment_id: UUID | None
     sandbox_generation: int
     applied_version: int
     applied_versions: dict[str, int]
@@ -66,6 +67,7 @@ def materialization_value(
         materialization_kind=row.materialization_kind,
         cloud_secret_set_id=row.cloud_secret_set_id,
         cloud_repo_config_id=row.cloud_repo_config_id,
+        repo_environment_id=row.repo_environment_id,
         sandbox_generation=row.sandbox_generation,
         applied_version=row.applied_version,
         applied_versions=_loads_versions(row.applied_versions_json),
@@ -98,13 +100,13 @@ async def load_workspace_secret_materialization(
     db: AsyncSession,
     *,
     managed_sandbox_id: UUID,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
     lock_row: bool = False,
 ) -> ManagedSandboxSecretMaterializationValue | None:
     stmt = select(ManagedSandboxSecretMaterialization).where(
         ManagedSandboxSecretMaterialization.managed_sandbox_id == managed_sandbox_id,
         ManagedSandboxSecretMaterialization.materialization_kind == "workspace",
-        ManagedSandboxSecretMaterialization.cloud_repo_config_id == cloud_repo_config_id,
+        ManagedSandboxSecretMaterialization.repo_environment_id == repo_environment_id,
     )
     if lock_row:
         stmt = stmt.with_for_update()
@@ -127,6 +129,7 @@ async def begin_global_secret_materialization(
                 materialization_kind="global",
                 cloud_secret_set_id=None,
                 cloud_repo_config_id=None,
+                repo_environment_id=None,
                 sandbox_generation=sandbox_generation,
                 applied_version=0,
                 applied_versions_json=None,
@@ -158,9 +161,10 @@ async def begin_workspace_secret_materialization(
     db: AsyncSession,
     *,
     managed_sandbox_id: UUID,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
     cloud_secret_set_id: UUID | None,
     sandbox_generation: int,
+    cloud_repo_config_id: UUID | None = None,
 ) -> ManagedSandboxSecretMaterializationValue:
     now = utcnow()
     row = (
@@ -171,6 +175,7 @@ async def begin_workspace_secret_materialization(
                 materialization_kind="workspace",
                 cloud_secret_set_id=cloud_secret_set_id,
                 cloud_repo_config_id=cloud_repo_config_id,
+                repo_environment_id=repo_environment_id,
                 sandbox_generation=sandbox_generation,
                 applied_version=0,
                 applied_versions_json=None,
@@ -184,12 +189,13 @@ async def begin_workspace_secret_materialization(
             .on_conflict_do_update(
                 index_elements=[
                     ManagedSandboxSecretMaterialization.managed_sandbox_id,
-                    ManagedSandboxSecretMaterialization.cloud_repo_config_id,
+                    ManagedSandboxSecretMaterialization.repo_environment_id,
                 ],
                 index_where=ManagedSandboxSecretMaterialization.materialization_kind
                 == "workspace",
                 set_={
                     "cloud_secret_set_id": cloud_secret_set_id,
+                    "cloud_repo_config_id": cloud_repo_config_id,
                     "sandbox_generation": sandbox_generation,
                     "status": "running",
                     "last_error": None,

--- a/server/proliferate/db/store/repositories.py
+++ b/server/proliferate/db/store/repositories.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
@@ -78,6 +79,82 @@ def _environment_value(row: RepoEnvironment, repo: RepoConfig) -> RepoEnvironmen
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+async def _ensure_repo_config(
+    db: AsyncSession,
+    *,
+    repo_config_id: UUID | None = None,
+    owner_scope: str,
+    user_id: UUID | None,
+    organization_id: UUID | None,
+    git_provider: str,
+    git_owner: str,
+    git_repo_name: str,
+    legacy_cloud_repo_config_id: UUID | None,
+    created_at: datetime,
+    updated_at: datetime,
+) -> RepoConfig:
+    values = {
+        "owner_scope": owner_scope,
+        "user_id": user_id,
+        "organization_id": organization_id,
+        "git_provider": git_provider,
+        "git_owner": git_owner,
+        "git_repo_name": git_repo_name,
+        "legacy_cloud_repo_config_id": legacy_cloud_repo_config_id,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "deleted_at": None,
+    }
+    if repo_config_id is not None:
+        values["id"] = repo_config_id
+    row = (
+        await db.execute(
+            pg_insert(RepoConfig)
+            .values(**values)
+            .on_conflict_do_nothing()
+            .returning(RepoConfig)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = (
+            await db.execute(
+                select(RepoConfig).where(
+                    RepoConfig.owner_scope == owner_scope,
+                    RepoConfig.user_id == user_id,
+                    RepoConfig.organization_id == organization_id,
+                    RepoConfig.git_provider == git_provider,
+                    RepoConfig.git_owner == git_owner,
+                    RepoConfig.git_repo_name == git_repo_name,
+                    RepoConfig.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    if row is None and legacy_cloud_repo_config_id is not None:
+        row = (
+            await db.execute(
+                select(RepoConfig).where(
+                    RepoConfig.legacy_cloud_repo_config_id == legacy_cloud_repo_config_id,
+                    RepoConfig.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    if row is None:
+        raise RuntimeError("repo config upsert failed to return or reload row")
+
+    row.owner_scope = owner_scope
+    row.user_id = user_id
+    row.organization_id = organization_id
+    row.git_provider = git_provider
+    row.git_owner = git_owner
+    row.git_repo_name = git_repo_name
+    if legacy_cloud_repo_config_id is not None:
+        row.legacy_cloud_repo_config_id = legacy_cloud_repo_config_id
+    row.updated_at = updated_at
+    row.deleted_at = None
+    await db.flush()
+    return row
 
 
 async def _repo_value(db: AsyncSession, row: RepoConfig) -> RepoConfigValue:
@@ -222,67 +299,58 @@ async def upsert_local_repo_environment(
     run_command: str,
 ) -> RepoEnvironmentValue:
     now = utcnow()
-    repo = (
-        await db.execute(
-            select(RepoConfig).where(
-                RepoConfig.owner_scope == "personal",
-                RepoConfig.user_id == user_id,
-                RepoConfig.organization_id.is_(None),
-                RepoConfig.git_provider == git_provider,
-                RepoConfig.git_owner == git_owner,
-                RepoConfig.git_repo_name == git_repo_name,
-                RepoConfig.deleted_at.is_(None),
-            )
-        )
-    ).scalar_one_or_none()
-    if repo is None:
-        repo = RepoConfig(
-            owner_scope="personal",
-            user_id=user_id,
-            organization_id=None,
-            git_provider=git_provider,
-            git_owner=git_owner,
-            git_repo_name=git_repo_name,
-            legacy_cloud_repo_config_id=None,
-            created_at=now,
-            updated_at=now,
-            deleted_at=None,
-        )
-        db.add(repo)
-        await db.flush()
+    repo = await _ensure_repo_config(
+        db,
+        owner_scope="personal",
+        user_id=user_id,
+        organization_id=None,
+        git_provider=git_provider,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        legacy_cloud_repo_config_id=None,
+        created_at=now,
+        updated_at=now,
+    )
 
+    normalized_default_branch = default_branch.strip() if default_branch and default_branch.strip() else None
     environment = (
         await db.execute(
-            select(RepoEnvironment).where(
-                RepoEnvironment.repo_config_id == repo.id,
-                RepoEnvironment.environment_kind == "local",
-                RepoEnvironment.desktop_install_id == desktop_install_id,
-                RepoEnvironment.local_path == local_path,
-                RepoEnvironment.deleted_at.is_(None),
+            pg_insert(RepoEnvironment)
+            .values(
+                repo_config_id=repo.id,
+                environment_kind="local",
+                desktop_install_id=desktop_install_id,
+                local_path=local_path,
+                configured=True,
+                configured_at=now,
+                default_branch=normalized_default_branch,
+                setup_script=setup_script,
+                setup_script_version=1 if setup_script.strip() else 0,
+                run_command=run_command,
+                config_version=1,
+                legacy_cloud_repo_config_id=None,
+                created_at=now,
+                updated_at=now,
+                deleted_at=None,
             )
+            .on_conflict_do_nothing()
+            .returning(RepoEnvironment)
         )
     ).scalar_one_or_none()
-    normalized_default_branch = default_branch.strip() if default_branch and default_branch.strip() else None
+    inserted_environment = environment is not None
     if environment is None:
-        environment = RepoEnvironment(
-            repo_config_id=repo.id,
-            environment_kind="local",
-            desktop_install_id=desktop_install_id,
-            local_path=local_path,
-            configured=True,
-            configured_at=now,
-            default_branch=normalized_default_branch,
-            setup_script=setup_script,
-            setup_script_version=1 if setup_script.strip() else 0,
-            run_command=run_command,
-            config_version=1,
-            legacy_cloud_repo_config_id=None,
-            created_at=now,
-            updated_at=now,
-            deleted_at=None,
-        )
-        db.add(environment)
-    else:
+        environment = (
+            await db.execute(
+                select(RepoEnvironment).where(
+                    RepoEnvironment.repo_config_id == repo.id,
+                    RepoEnvironment.environment_kind == "local",
+                    RepoEnvironment.desktop_install_id == desktop_install_id,
+                    RepoEnvironment.local_path == local_path,
+                    RepoEnvironment.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one()
+    if not inserted_environment:
         setup_changed = environment.setup_script != setup_script
         config_changed = (
             setup_changed
@@ -315,57 +383,19 @@ async def sync_cloud_environment_from_legacy_cloud_repo_config(
         return None
 
     now = utcnow()
-    repo = await db.get(RepoConfig, legacy.id)
-    if repo is None:
-        repo = (
-            await db.execute(
-                select(RepoConfig).where(
-                    RepoConfig.owner_scope == legacy.owner_scope,
-                    RepoConfig.user_id == legacy.user_id,
-                    RepoConfig.organization_id == legacy.organization_id,
-                    RepoConfig.git_provider == "github",
-                    RepoConfig.git_owner == legacy.git_owner,
-                    RepoConfig.git_repo_name == legacy.git_repo_name,
-                    RepoConfig.deleted_at.is_(None),
-                )
-            )
-        ).scalar_one_or_none()
-
-    if repo is None:
-        repo = RepoConfig(
-            id=legacy.id,
-            owner_scope=legacy.owner_scope,
-            user_id=legacy.user_id,
-            organization_id=legacy.organization_id,
-            git_provider="github",
-            git_owner=legacy.git_owner,
-            git_repo_name=legacy.git_repo_name,
-            legacy_cloud_repo_config_id=legacy.id,
-            created_at=legacy.created_at,
-            updated_at=legacy.updated_at,
-            deleted_at=None,
-        )
-        db.add(repo)
-        await db.flush()
-    else:
-        repo.owner_scope = legacy.owner_scope
-        repo.user_id = legacy.user_id
-        repo.organization_id = legacy.organization_id
-        repo.git_provider = "github"
-        repo.git_owner = legacy.git_owner
-        repo.git_repo_name = legacy.git_repo_name
-        repo.legacy_cloud_repo_config_id = legacy.id
-        repo.updated_at = now
-
-    environment = await db.get(RepoEnvironment, legacy.id)
-    if environment is None:
-        environment = (
-            await db.execute(
-                select(RepoEnvironment).where(
-                    RepoEnvironment.legacy_cloud_repo_config_id == legacy.id
-                )
-            )
-        ).scalar_one_or_none()
+    repo = await _ensure_repo_config(
+        db,
+        repo_config_id=legacy.id,
+        owner_scope=legacy.owner_scope,
+        user_id=legacy.user_id,
+        organization_id=legacy.organization_id,
+        git_provider="github",
+        git_owner=legacy.git_owner,
+        git_repo_name=legacy.git_repo_name,
+        legacy_cloud_repo_config_id=legacy.id,
+        created_at=legacy.created_at,
+        updated_at=now,
+    )
 
     legacy_config_version = max(
         legacy.files_version,
@@ -373,27 +403,52 @@ async def sync_cloud_environment_from_legacy_cloud_repo_config(
         legacy.setup_script_version,
         1 if legacy.configured else 0,
     )
-    if environment is None:
-        environment = RepoEnvironment(
-            id=legacy.id,
-            repo_config_id=repo.id,
-            environment_kind="cloud",
-            desktop_install_id=None,
-            local_path=None,
-            configured=legacy.configured,
-            configured_at=legacy.configured_at,
-            default_branch=legacy.default_branch,
-            setup_script=legacy.setup_script,
-            setup_script_version=legacy.setup_script_version,
-            run_command=legacy.run_command,
-            config_version=legacy_config_version,
-            legacy_cloud_repo_config_id=legacy.id,
-            created_at=legacy.created_at,
-            updated_at=legacy.updated_at,
-            deleted_at=None,
+    environment = (
+        await db.execute(
+            pg_insert(RepoEnvironment)
+            .values(
+                id=legacy.id,
+                repo_config_id=repo.id,
+                environment_kind="cloud",
+                desktop_install_id=None,
+                local_path=None,
+                configured=legacy.configured,
+                configured_at=legacy.configured_at,
+                default_branch=legacy.default_branch,
+                setup_script=legacy.setup_script,
+                setup_script_version=legacy.setup_script_version,
+                run_command=legacy.run_command,
+                config_version=legacy_config_version,
+                legacy_cloud_repo_config_id=legacy.id,
+                created_at=legacy.created_at,
+                updated_at=legacy.updated_at,
+                deleted_at=None,
+            )
+            .on_conflict_do_nothing()
+            .returning(RepoEnvironment)
         )
-        db.add(environment)
-    else:
+    ).scalar_one_or_none()
+    inserted_environment = environment is not None
+    if environment is None:
+        environment = (
+            await db.execute(
+                select(RepoEnvironment).where(
+                    RepoEnvironment.legacy_cloud_repo_config_id == legacy.id,
+                    RepoEnvironment.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    if environment is None:
+        environment = (
+            await db.execute(
+                select(RepoEnvironment).where(
+                    RepoEnvironment.repo_config_id == repo.id,
+                    RepoEnvironment.environment_kind == "cloud",
+                    RepoEnvironment.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one()
+    if not inserted_environment:
         environment_changed = (
             environment.configured != legacy.configured
             or environment.configured_at != legacy.configured_at

--- a/server/proliferate/db/store/repositories.py
+++ b/server/proliferate/db/store/repositories.py
@@ -1,0 +1,426 @@
+"""Persistence helpers for logical repositories and repo environments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.models.cloud.repositories import RepoConfig, RepoEnvironment
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class RepoEnvironmentValue:
+    id: UUID
+    repo_config_id: UUID
+    owner_scope: str
+    user_id: UUID | None
+    organization_id: UUID | None
+    git_provider: str
+    git_owner: str
+    git_repo_name: str
+    environment_kind: str
+    desktop_install_id: str | None
+    local_path: str | None
+    configured: bool
+    configured_at: datetime | None
+    default_branch: str | None
+    setup_script: str
+    setup_script_version: int
+    run_command: str
+    config_version: int
+    legacy_cloud_repo_config_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class RepoConfigValue:
+    id: UUID
+    owner_scope: str
+    user_id: UUID | None
+    organization_id: UUID | None
+    git_provider: str
+    git_owner: str
+    git_repo_name: str
+    legacy_cloud_repo_config_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+    environments: tuple[RepoEnvironmentValue, ...]
+
+
+def _environment_value(row: RepoEnvironment, repo: RepoConfig) -> RepoEnvironmentValue:
+    return RepoEnvironmentValue(
+        id=row.id,
+        repo_config_id=row.repo_config_id,
+        owner_scope=repo.owner_scope,
+        user_id=repo.user_id,
+        organization_id=repo.organization_id,
+        git_provider=repo.git_provider,
+        git_owner=repo.git_owner,
+        git_repo_name=repo.git_repo_name,
+        environment_kind=row.environment_kind,
+        desktop_install_id=row.desktop_install_id,
+        local_path=row.local_path,
+        configured=row.configured,
+        configured_at=row.configured_at,
+        default_branch=row.default_branch,
+        setup_script=row.setup_script,
+        setup_script_version=row.setup_script_version,
+        run_command=row.run_command,
+        config_version=row.config_version,
+        legacy_cloud_repo_config_id=row.legacy_cloud_repo_config_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def _repo_value(db: AsyncSession, row: RepoConfig) -> RepoConfigValue:
+    environments = list(
+        (
+            await db.execute(
+                select(RepoEnvironment)
+                .where(RepoEnvironment.repo_config_id == row.id)
+                .where(RepoEnvironment.deleted_at.is_(None))
+                .order_by(RepoEnvironment.environment_kind.asc(), RepoEnvironment.created_at.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return RepoConfigValue(
+        id=row.id,
+        owner_scope=row.owner_scope,
+        user_id=row.user_id,
+        organization_id=row.organization_id,
+        git_provider=row.git_provider,
+        git_owner=row.git_owner,
+        git_repo_name=row.git_repo_name,
+        legacy_cloud_repo_config_id=row.legacy_cloud_repo_config_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        environments=tuple(_environment_value(item, row) for item in environments),
+    )
+
+
+async def get_repo_config_for_owner(
+    db: AsyncSession,
+    *,
+    owner_scope: str,
+    user_id: UUID | None,
+    organization_id: UUID | None,
+    git_provider: str,
+    git_owner: str,
+    git_repo_name: str,
+) -> RepoConfigValue | None:
+    row = (
+        await db.execute(
+            select(RepoConfig).where(
+                RepoConfig.owner_scope == owner_scope,
+                RepoConfig.user_id == user_id,
+                RepoConfig.organization_id == organization_id,
+                RepoConfig.git_provider == git_provider,
+                RepoConfig.git_owner == git_owner,
+                RepoConfig.git_repo_name == git_repo_name,
+                RepoConfig.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    return await _repo_value(db, row) if row is not None else None
+
+
+async def get_cloud_repo_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str,
+    git_repo_name: str,
+) -> RepoEnvironmentValue | None:
+    row = (
+        await db.execute(
+            select(RepoEnvironment, RepoConfig)
+            .join(RepoConfig, RepoEnvironment.repo_config_id == RepoConfig.id)
+            .where(
+                RepoConfig.owner_scope == "personal",
+                RepoConfig.user_id == user_id,
+                RepoConfig.git_provider == "github",
+                RepoConfig.git_owner == git_owner,
+                RepoConfig.git_repo_name == git_repo_name,
+                RepoConfig.deleted_at.is_(None),
+                RepoEnvironment.environment_kind == "cloud",
+                RepoEnvironment.deleted_at.is_(None),
+            )
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    environment, repo = row
+    return _environment_value(environment, repo)
+
+
+async def list_cloud_repo_environments(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> tuple[RepoEnvironmentValue, ...]:
+    rows = (
+        await db.execute(
+            select(RepoEnvironment, RepoConfig)
+            .join(RepoConfig, RepoEnvironment.repo_config_id == RepoConfig.id)
+            .where(
+                RepoConfig.owner_scope == "personal",
+                RepoConfig.user_id == user_id,
+                RepoConfig.deleted_at.is_(None),
+                RepoEnvironment.environment_kind == "cloud",
+                RepoEnvironment.deleted_at.is_(None),
+            )
+            .order_by(RepoConfig.git_owner.asc(), RepoConfig.git_repo_name.asc())
+        )
+    ).all()
+    return tuple(_environment_value(environment, repo) for environment, repo in rows)
+
+
+async def list_repo_configs_for_user(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> tuple[RepoConfigValue, ...]:
+    rows = list(
+        (
+            await db.execute(
+                select(RepoConfig)
+                .where(
+                    RepoConfig.owner_scope == "personal",
+                    RepoConfig.user_id == user_id,
+                    RepoConfig.deleted_at.is_(None),
+                )
+                .order_by(RepoConfig.git_owner.asc(), RepoConfig.git_repo_name.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple([await _repo_value(db, row) for row in rows])
+
+
+async def upsert_local_repo_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_provider: str,
+    git_owner: str,
+    git_repo_name: str,
+    desktop_install_id: str,
+    local_path: str,
+    default_branch: str | None,
+    setup_script: str,
+    run_command: str,
+) -> RepoEnvironmentValue:
+    now = utcnow()
+    repo = (
+        await db.execute(
+            select(RepoConfig).where(
+                RepoConfig.owner_scope == "personal",
+                RepoConfig.user_id == user_id,
+                RepoConfig.organization_id.is_(None),
+                RepoConfig.git_provider == git_provider,
+                RepoConfig.git_owner == git_owner,
+                RepoConfig.git_repo_name == git_repo_name,
+                RepoConfig.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if repo is None:
+        repo = RepoConfig(
+            owner_scope="personal",
+            user_id=user_id,
+            organization_id=None,
+            git_provider=git_provider,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            legacy_cloud_repo_config_id=None,
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+        db.add(repo)
+        await db.flush()
+
+    environment = (
+        await db.execute(
+            select(RepoEnvironment).where(
+                RepoEnvironment.repo_config_id == repo.id,
+                RepoEnvironment.environment_kind == "local",
+                RepoEnvironment.desktop_install_id == desktop_install_id,
+                RepoEnvironment.local_path == local_path,
+                RepoEnvironment.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    normalized_default_branch = default_branch.strip() if default_branch and default_branch.strip() else None
+    if environment is None:
+        environment = RepoEnvironment(
+            repo_config_id=repo.id,
+            environment_kind="local",
+            desktop_install_id=desktop_install_id,
+            local_path=local_path,
+            configured=True,
+            configured_at=now,
+            default_branch=normalized_default_branch,
+            setup_script=setup_script,
+            setup_script_version=1 if setup_script.strip() else 0,
+            run_command=run_command,
+            config_version=1,
+            legacy_cloud_repo_config_id=None,
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+        db.add(environment)
+    else:
+        setup_changed = environment.setup_script != setup_script
+        config_changed = (
+            setup_changed
+            or environment.run_command != run_command
+            or environment.default_branch != normalized_default_branch
+            or not environment.configured
+        )
+        environment.configured = True
+        environment.configured_at = environment.configured_at or now
+        environment.default_branch = normalized_default_branch
+        environment.setup_script = setup_script
+        if setup_changed:
+            environment.setup_script_version += 1
+        environment.run_command = run_command
+        if config_changed:
+            environment.config_version += 1
+        environment.updated_at = now
+    repo.updated_at = now
+    await db.flush()
+    return _environment_value(environment, repo)
+
+
+async def sync_cloud_environment_from_legacy_cloud_repo_config(
+    db: AsyncSession,
+    *,
+    cloud_repo_config_id: UUID,
+) -> RepoEnvironmentValue | None:
+    legacy = await db.get(CloudRepoConfig, cloud_repo_config_id)
+    if legacy is None:
+        return None
+
+    now = utcnow()
+    repo = await db.get(RepoConfig, legacy.id)
+    if repo is None:
+        repo = (
+            await db.execute(
+                select(RepoConfig).where(
+                    RepoConfig.owner_scope == legacy.owner_scope,
+                    RepoConfig.user_id == legacy.user_id,
+                    RepoConfig.organization_id == legacy.organization_id,
+                    RepoConfig.git_provider == "github",
+                    RepoConfig.git_owner == legacy.git_owner,
+                    RepoConfig.git_repo_name == legacy.git_repo_name,
+                    RepoConfig.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+
+    if repo is None:
+        repo = RepoConfig(
+            id=legacy.id,
+            owner_scope=legacy.owner_scope,
+            user_id=legacy.user_id,
+            organization_id=legacy.organization_id,
+            git_provider="github",
+            git_owner=legacy.git_owner,
+            git_repo_name=legacy.git_repo_name,
+            legacy_cloud_repo_config_id=legacy.id,
+            created_at=legacy.created_at,
+            updated_at=legacy.updated_at,
+            deleted_at=None,
+        )
+        db.add(repo)
+        await db.flush()
+    else:
+        repo.owner_scope = legacy.owner_scope
+        repo.user_id = legacy.user_id
+        repo.organization_id = legacy.organization_id
+        repo.git_provider = "github"
+        repo.git_owner = legacy.git_owner
+        repo.git_repo_name = legacy.git_repo_name
+        repo.legacy_cloud_repo_config_id = legacy.id
+        repo.updated_at = now
+
+    environment = await db.get(RepoEnvironment, legacy.id)
+    if environment is None:
+        environment = (
+            await db.execute(
+                select(RepoEnvironment).where(
+                    RepoEnvironment.legacy_cloud_repo_config_id == legacy.id
+                )
+            )
+        ).scalar_one_or_none()
+
+    legacy_config_version = max(
+        legacy.files_version,
+        legacy.env_vars_version,
+        legacy.setup_script_version,
+        1 if legacy.configured else 0,
+    )
+    if environment is None:
+        environment = RepoEnvironment(
+            id=legacy.id,
+            repo_config_id=repo.id,
+            environment_kind="cloud",
+            desktop_install_id=None,
+            local_path=None,
+            configured=legacy.configured,
+            configured_at=legacy.configured_at,
+            default_branch=legacy.default_branch,
+            setup_script=legacy.setup_script,
+            setup_script_version=legacy.setup_script_version,
+            run_command=legacy.run_command,
+            config_version=legacy_config_version,
+            legacy_cloud_repo_config_id=legacy.id,
+            created_at=legacy.created_at,
+            updated_at=legacy.updated_at,
+            deleted_at=None,
+        )
+        db.add(environment)
+    else:
+        environment_changed = (
+            environment.configured != legacy.configured
+            or environment.configured_at != legacy.configured_at
+            or environment.default_branch != legacy.default_branch
+            or environment.setup_script != legacy.setup_script
+            or environment.setup_script_version != legacy.setup_script_version
+            or environment.run_command != legacy.run_command
+            or environment.legacy_cloud_repo_config_id != legacy.id
+            or environment.deleted_at is not None
+        )
+        environment.repo_config_id = repo.id
+        environment.environment_kind = "cloud"
+        environment.desktop_install_id = None
+        environment.local_path = None
+        environment.configured = legacy.configured
+        environment.configured_at = legacy.configured_at
+        environment.default_branch = legacy.default_branch
+        environment.setup_script = legacy.setup_script
+        environment.setup_script_version = legacy.setup_script_version
+        environment.run_command = legacy.run_command
+        environment.config_version = max(
+            legacy_config_version,
+            environment.config_version + 1 if environment_changed else environment.config_version,
+        )
+        environment.legacy_cloud_repo_config_id = legacy.id
+        environment.updated_at = now
+        environment.deleted_at = None
+
+    await db.flush()
+    return _environment_value(environment, repo)

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -21,6 +21,7 @@ from proliferate.server.cloud.mcp_oauth.api import router as mcp_oauth_router
 from proliferate.server.cloud.mobility.api import router as mobility_router
 from proliferate.server.cloud.plugins.api import router as plugins_router
 from proliferate.server.cloud.repo_config.api import router as repo_config_router
+from proliferate.server.cloud.repositories.api import router as repositories_router
 from proliferate.server.cloud.repos.api import router as repos_router
 from proliferate.server.cloud.runtime_config.api import router as runtime_config_router
 from proliferate.server.cloud.runtime_config.api import (
@@ -45,6 +46,7 @@ from proliferate.server.cloud.worktree_policy.api import router as worktree_poli
 
 router = APIRouter(prefix="/cloud", tags=["cloud"])
 router.include_router(repos_router)
+router.include_router(repositories_router)
 router.include_router(repo_config_router)
 router.include_router(github_app_router)
 router.include_router(secrets_router)

--- a/server/proliferate/server/cloud/github_app/repo_authority.py
+++ b/server/proliferate/server/cloud/github_app/repo_authority.py
@@ -43,7 +43,6 @@ async def ensure_fresh_github_app_authorization(
     authorization = await github_app_store.get_github_app_authorization_for_user(
         db,
         user_id=user_id,
-        lock_row=True,
     )
     if authorization is None:
         raise CloudApiError(
@@ -64,47 +63,10 @@ async def ensure_fresh_github_app_authorization(
             status_code=409,
         )
 
-    now = utcnow()
-    if (
-        authorization.token_expires_at is None
-        or authorization.access_token is None
-        or authorization.token_expires_at <= now + timedelta(minutes=10)
-    ):
-        if authorization.refresh_token is None:
-            await github_app_store.mark_github_app_authorization_needs_reauth(
-                db,
-                authorization.id,
-            )
-            raise CloudApiError(
-                "github_app_authorization_expired",
-                "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
-                status_code=409,
-            )
-        try:
-            refreshed = await refresh_github_app_user_authorization(
-                refresh_token=authorization.refresh_token,
-            )
-        except GitHubAppInvalidGrant as exc:
-            await github_app_store.mark_github_app_authorization_needs_reauth(
-                db,
-                authorization.id,
-            )
-            raise CloudApiError(
-                "github_app_authorization_expired",
-                "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
-                status_code=409,
-            ) from exc
-        except GitHubIntegrationError as exc:
-            raise CloudApiError(
-                "github_app_refresh_failed",
-                "Could not refresh GitHub App authorization.",
-                status_code=502,
-            ) from exc
-        authorization = await github_app_store.upsert_github_app_authorization(
-            db,
-            user_id=user_id,
-            authorization=refreshed,
-        )
+    if _github_app_authorization_is_current(authorization):
+        return authorization
+
+    authorization = await _refresh_github_app_authorization(db, user_id=user_id)
 
     if authorization.access_token is None:
         raise CloudApiError(
@@ -113,6 +75,83 @@ async def ensure_fresh_github_app_authorization(
             status_code=409,
         )
     return authorization
+
+
+def _github_app_authorization_is_current(
+    authorization: github_app_store.GitHubAppAuthorizationValue,
+) -> bool:
+    return bool(
+        authorization.access_token is not None
+        and authorization.token_expires_at is not None
+        and authorization.token_expires_at > utcnow() + timedelta(minutes=10)
+    )
+
+
+async def _refresh_github_app_authorization(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> github_app_store.GitHubAppAuthorizationValue:
+    authorization = await github_app_store.get_github_app_authorization_for_user(
+        db,
+        user_id=user_id,
+        lock_row=True,
+    )
+    if authorization is None:
+        raise CloudApiError(
+            "github_app_authorization_required",
+            "Connect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        )
+    if authorization.status == "needs_reauth":
+        raise CloudApiError(
+            "github_app_authorization_expired",
+            "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        )
+    if authorization.status != "ready":
+        raise CloudApiError(
+            "github_app_authorization_required",
+            "Connect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        )
+    if _github_app_authorization_is_current(authorization):
+        return authorization
+    if authorization.refresh_token is None:
+        await github_app_store.mark_github_app_authorization_needs_reauth(
+            db,
+            authorization.id,
+        )
+        raise CloudApiError(
+            "github_app_authorization_expired",
+            "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        )
+    try:
+        refreshed = await refresh_github_app_user_authorization(
+            refresh_token=authorization.refresh_token,
+        )
+    except GitHubAppInvalidGrant as exc:
+        await github_app_store.mark_github_app_authorization_needs_reauth(
+            db,
+            authorization.id,
+        )
+        raise CloudApiError(
+            "github_app_authorization_expired",
+            "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        ) from exc
+    except GitHubIntegrationError as exc:
+        raise CloudApiError(
+            "github_app_refresh_failed",
+            "Could not refresh GitHub App authorization.",
+            status_code=502,
+        ) from exc
+    return await github_app_store.upsert_github_app_authorization(
+        db,
+        user_id=user_id,
+        authorization=refreshed,
+    )
 
 
 async def require_github_cloud_repo_authority(

--- a/server/proliferate/server/cloud/managed_sandboxes/materialization/repos.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/materialization/repos.py
@@ -21,6 +21,7 @@ from proliferate.db.store.managed_sandbox_repo_materializations import (
     mark_repo_materialization_ready,
 )
 from proliferate.db.store.managed_sandboxes import ManagedSandboxValue
+from proliferate.db.store.repositories import sync_cloud_environment_from_legacy_cloud_repo_config
 from proliferate.integrations.anyharness import (
     resolve_runtime_workspace,
     start_remote_workspace_setup,
@@ -146,6 +147,11 @@ async def ensure_repo_materialized(
     run_setup: bool,
     target: MaterializationTarget | None = None,
 ) -> ManagedSandboxRepoMaterializationValue:
+    repo_environment = await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=repo_config.id,
+    )
+    repo_environment_id = repo_environment.id if repo_environment is not None else repo_config.id
     existing = await load_repo_materialization(
         db,
         managed_sandbox_id=sandbox.id,
@@ -164,7 +170,7 @@ async def ensure_repo_materialized(
         db,
         managed_sandbox_id=sandbox.id,
         cloud_repo_config_id=repo_config.id,
-        repo_environment_id=repo_config.id,
+        repo_environment_id=repo_environment_id,
         sandbox_generation=sandbox.runtime_generation,
         repo_path=repo_path(repo_config),
     )
@@ -199,7 +205,7 @@ async def ensure_repo_materialized(
             db,
             sandbox=sandbox,
             repo_config=repo_config,
-            repo_environment_id=repo_config.id,
+            repo_environment_id=repo_environment_id,
             repo_path=materialization.repo_path,
             target=target,
             base_env=repo_config.env_vars,

--- a/server/proliferate/server/cloud/managed_sandboxes/materialization/repos.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/materialization/repos.py
@@ -73,7 +73,7 @@ async def _managed_materialization_paths(
 ) -> tuple[str, ...]:
     workspace_secret_paths = await workspace_secret_relative_paths(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=repo_config.id,
     )
     return tuple(
         sorted(
@@ -164,6 +164,7 @@ async def ensure_repo_materialized(
         db,
         managed_sandbox_id=sandbox.id,
         cloud_repo_config_id=repo_config.id,
+        repo_environment_id=repo_config.id,
         sandbox_generation=sandbox.runtime_generation,
         repo_path=repo_path(repo_config),
     )
@@ -198,6 +199,7 @@ async def ensure_repo_materialized(
             db,
             sandbox=sandbox,
             repo_config=repo_config,
+            repo_environment_id=repo_config.id,
             repo_path=materialization.repo_path,
             target=target,
             base_env=repo_config.env_vars,

--- a/server/proliferate/server/cloud/managed_sandboxes/materialization/secrets.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/materialization/secrets.py
@@ -43,8 +43,8 @@ def _payload_key(payload: secret_store.CloudSecretSetPayload) -> str:
         return f"personal:{payload.user_id}"
     if payload.scope_kind == "organization" and payload.organization_id is not None:
         return f"organization:{payload.organization_id}"
-    if payload.scope_kind == "workspace" and payload.cloud_repo_config_id is not None:
-        return f"workspace:{payload.cloud_repo_config_id}"
+    if payload.scope_kind == "workspace" and payload.repo_environment_id is not None:
+        return f"workspace:{payload.repo_environment_id}"
     return f"{payload.scope_kind}:{payload.id}"
 
 
@@ -155,11 +155,11 @@ async def materialize_global_secrets(
 async def workspace_secret_relative_paths(
     db: AsyncSession,
     *,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
 ) -> tuple[str, ...]:
     payload = await secret_store.load_workspace_secret_payload(
         db,
-        cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
     )
     if payload is None:
         return ()
@@ -171,19 +171,21 @@ async def materialize_workspace_secrets(
     *,
     sandbox: ManagedSandboxValue,
     repo_config: CloudRepoConfigValue,
+    repo_environment_id: UUID | None = None,
     repo_path: str,
     target: MaterializationTarget | None = None,
     base_env: dict[str, str] | None = None,
     base_files: dict[str, str] | None = None,
 ) -> None:
+    resolved_repo_environment_id = repo_environment_id or repo_config.id
     payload = await secret_store.load_workspace_secret_payload(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=resolved_repo_environment_id,
     )
     materialization = await begin_workspace_secret_materialization(
         db,
         managed_sandbox_id=sandbox.id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=resolved_repo_environment_id,
         cloud_secret_set_id=payload.id if payload is not None else None,
         sandbox_generation=sandbox.runtime_generation,
     )

--- a/server/proliferate/server/cloud/managed_sandboxes/materialization/service.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/materialization/service.py
@@ -148,17 +148,11 @@ def schedule_workspace_secret_materialization_for_repo(
         )
 
         sandbox = await ensure_managed_sandbox_ready(fresh_db, user)
-        materialization = await repos.ensure_repo_materialized(
+        await repos.ensure_repo_materialized(
             fresh_db,
             sandbox=sandbox,
             repo_config=repo_config,
             run_setup=False,
-        )
-        await secrets.materialize_workspace_secrets(
-            fresh_db,
-            sandbox=sandbox,
-            repo_config=repo_config,
-            repo_path=materialization.repo_path,
         )
 
     async def _run() -> None:

--- a/server/proliferate/server/cloud/managed_sandboxes/materialization/service.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/materialization/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from pathlib import PurePosixPath
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -148,11 +149,23 @@ def schedule_workspace_secret_materialization_for_repo(
         )
 
         sandbox = await ensure_managed_sandbox_ready(fresh_db, user)
-        await repos.ensure_repo_materialized(
+        materialization = await repos.ensure_repo_materialized(
             fresh_db,
             sandbox=sandbox,
             repo_config=repo_config,
             run_setup=False,
+        )
+        await secrets.materialize_workspace_secrets(
+            fresh_db,
+            sandbox=sandbox,
+            repo_config=repo_config,
+            repo_environment_id=repo_config.id,
+            repo_path=materialization.repo_path,
+            base_env=repo_config.env_vars,
+            base_files={
+                str(PurePosixPath(materialization.repo_path) / item.relative_path): item.content
+                for item in repo_config.tracked_files
+            },
         )
 
     async def _run() -> None:

--- a/server/proliferate/server/cloud/managed_sandboxes/service.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/service.py
@@ -36,6 +36,7 @@ from proliferate.db.store.managed_sandboxes import (
     record_managed_sandbox_provider_sandbox,
     update_managed_sandbox_status,
 )
+from proliferate.db.store.managed_sandbox_repo_materializations import load_repo_materialization
 from proliferate.integrations.anyharness import (
     CloudRuntimeReconnectError,
     apply_agent_auth_config,
@@ -135,6 +136,7 @@ class _ManagedWorkspaceRow(Protocol):
     git_base_branch: str | None
     origin: str
     status: str
+    runtime_generation: int
     anyharness_workspace_id: str | None
     worktree_path: str | None
 
@@ -813,6 +815,14 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
             status_code=409,
         )
 
+    known_connection = await _known_workspace_runtime_connection_if_current(
+        db,
+        user=user,
+        workspace=workspace,
+    )
+    if known_connection is not None:
+        return known_connection
+
     repo_connection = await ensure_managed_sandbox_repo_runtime_connection(
         db,
         user,
@@ -940,6 +950,48 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
     return ManagedSandboxWorkspaceRuntimeConnection(
         anyharness_workspace_id=materialized.workspace_id,
         anyharness_repo_root_id=materialized.repo_root_id,
+        runtime_generation=sandbox.runtime_generation,
+    )
+
+
+async def _known_workspace_runtime_connection_if_current(
+    db: AsyncSession,
+    *,
+    user: _UserWithId,
+    workspace: _ManagedWorkspaceRow,
+) -> ManagedSandboxWorkspaceRuntimeConnection | None:
+    if workspace.status != "ready" or not workspace.anyharness_workspace_id:
+        return None
+
+    sandbox = await load_personal_managed_sandbox(db, user.id)
+    if (
+        sandbox is None
+        or sandbox.status != "ready"
+        or not _runtime_access_ready(sandbox)
+        or workspace.runtime_generation != sandbox.runtime_generation
+    ):
+        return None
+
+    repo_config = await get_cloud_repo_config(
+        db,
+        user_id=user.id,
+        git_owner=workspace.git_owner,
+        git_repo_name=workspace.git_repo_name,
+    )
+    materialization = (
+        await load_repo_materialization(
+            db,
+            managed_sandbox_id=sandbox.id,
+            cloud_repo_config_id=repo_config.id,
+        )
+        if repo_config is not None
+        else None
+    )
+    return ManagedSandboxWorkspaceRuntimeConnection(
+        anyharness_workspace_id=workspace.anyharness_workspace_id,
+        anyharness_repo_root_id=(
+            materialization.anyharness_repo_root_id if materialization is not None else None
+        ),
         runtime_generation=sandbox.runtime_generation,
     )
 

--- a/server/proliferate/server/cloud/managed_sandboxes/service.py
+++ b/server/proliferate/server/cloud/managed_sandboxes/service.py
@@ -24,6 +24,7 @@ from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.db.store.cloud_workspace_runtime import (
     attach_anyharness_workspace_id,
     attach_anyharness_workspace_id_to_managed_repo_workspaces,
+    mark_workspace_error_by_id,
 )
 from proliferate.db.store.managed_sandboxes import (
     ManagedSandboxValue,
@@ -36,10 +37,13 @@ from proliferate.db.store.managed_sandboxes import (
     update_managed_sandbox_status,
 )
 from proliferate.integrations.anyharness import (
+    CloudRuntimeReconnectError,
     apply_agent_auth_config,
     create_remote_worktree_workspace,
     get_agent_auth_config_status,
     get_runtime_config_status,
+    list_runtime_workspaces,
+    resolve_runtime_workspace,
 )
 from proliferate.integrations.sandbox import (
     SandboxProvider,
@@ -832,6 +836,9 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
 
     base_branch = workspace.git_base_branch.strip() if workspace.git_base_branch else None
     is_repo_root_workspace = base_branch is None or branch == base_branch
+    sandbox: ManagedSandboxValue | None = None
+    runtime_url: str | None = None
+    access_token: str | None = None
     if (
         workspace.anyharness_workspace_id
         and workspace.status == "ready"
@@ -840,11 +847,18 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
             or workspace.anyharness_workspace_id != repo_connection.anyharness_workspace_id
         )
     ):
-        return ManagedSandboxWorkspaceRuntimeConnection(
-            anyharness_workspace_id=workspace.anyharness_workspace_id,
-            anyharness_repo_root_id=repo_connection.anyharness_repo_root_id,
-            runtime_generation=repo_connection.runtime_generation,
-        )
+        sandbox = await ensure_managed_sandbox_ready(db, user)
+        runtime_url, access_token, _data_key = await load_managed_sandbox_runtime_access(sandbox)
+        if await _runtime_workspace_exists(
+            runtime_url,
+            access_token,
+            workspace.anyharness_workspace_id,
+        ):
+            return ManagedSandboxWorkspaceRuntimeConnection(
+                anyharness_workspace_id=workspace.anyharness_workspace_id,
+                anyharness_repo_root_id=repo_connection.anyharness_repo_root_id,
+                runtime_generation=repo_connection.runtime_generation,
+            )
 
     if is_repo_root_workspace:
         await attach_anyharness_workspace_id(
@@ -859,19 +873,63 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
             runtime_generation=repo_connection.runtime_generation,
         )
 
-    sandbox = await ensure_managed_sandbox_ready(db, user)
-    runtime_url, access_token, _data_key = await load_managed_sandbox_runtime_access(sandbox)
+    if sandbox is None:
+        sandbox = await ensure_managed_sandbox_ready(db, user)
+    if runtime_url is None or access_token is None:
+        runtime_url, access_token, _data_key = await load_managed_sandbox_runtime_access(sandbox)
     worktree_path = workspace.worktree_path or _managed_cloud_worktree_path(workspace)
-    materialized = await create_remote_worktree_workspace(
-        runtime_url,
-        access_token,
-        repo_root_id=repo_connection.anyharness_repo_root_id,
-        target_path=worktree_path,
-        new_branch_name=branch,
-        base_branch=base_branch,
-        origin=_workspace_origin_context(workspace),
-        creator_context={"kind": "human", "label": "Cloud workspace"},
-    )
+    if workspace.anyharness_workspace_id and workspace.worktree_path:
+        try:
+            resolved = await resolve_runtime_workspace(
+                runtime_url,
+                access_token,
+                runtime_workdir=worktree_path,
+            )
+        except CloudRuntimeReconnectError:
+            pass
+        else:
+            await attach_anyharness_workspace_id(
+                db,
+                workspace_id=workspace.id,
+                anyharness_workspace_id=resolved.workspace_id,
+                worktree_path=worktree_path,
+                runtime_generation=sandbox.runtime_generation,
+            )
+            return ManagedSandboxWorkspaceRuntimeConnection(
+                anyharness_workspace_id=resolved.workspace_id,
+                anyharness_repo_root_id=resolved.repo_root_id,
+                runtime_generation=sandbox.runtime_generation,
+            )
+
+    try:
+        materialized = await create_remote_worktree_workspace(
+            runtime_url,
+            access_token,
+            repo_root_id=repo_connection.anyharness_repo_root_id,
+            target_path=worktree_path,
+            new_branch_name=branch,
+            base_branch=base_branch,
+            origin=_workspace_origin_context(workspace),
+            creator_context={"kind": "human", "label": "Cloud workspace"},
+        )
+    except CloudRuntimeReconnectError as exc:
+        message = format_exception_message(exc) or (
+            "Managed cloud workspace materialization failed."
+        )
+        await mark_workspace_error_by_id(
+            db,
+            workspace.id,
+            message,
+            status_detail="Cloud workspace materialization failed",
+            clear_runtime_metadata=True,
+            clear_active_sandbox=False,
+        )
+        await commit_managed_sandbox_session(db)
+        raise CloudApiError(
+            "managed_cloud_workspace_materialization_failed",
+            message,
+            status_code=502,
+        ) from exc
     await attach_anyharness_workspace_id(
         db,
         workspace_id=workspace.id,
@@ -884,6 +942,15 @@ async def ensure_managed_sandbox_workspace_record_runtime_connection(
         anyharness_repo_root_id=materialized.repo_root_id,
         runtime_generation=sandbox.runtime_generation,
     )
+
+
+async def _runtime_workspace_exists(
+    runtime_url: str,
+    access_token: str,
+    anyharness_workspace_id: str,
+) -> bool:
+    workspaces = await list_runtime_workspaces(runtime_url, access_token)
+    return any(item.workspace_id == anyharness_workspace_id for item in workspaces)
 
 
 async def _materialize_synced_agent_auth_files(

--- a/server/proliferate/server/cloud/repo_config/service.py
+++ b/server/proliferate/server/cloud/repo_config/service.py
@@ -21,6 +21,9 @@ from proliferate.db.store.cloud_repo_config import (
 )
 from proliferate.db.store.cloud_slack import repo_routing_profiles as slack_routing_profile_store
 from proliferate.db.store.managed_sandboxes import load_personal_managed_sandbox
+from proliferate.db.store.repositories import (
+    sync_cloud_environment_from_legacy_cloud_repo_config,
+)
 from proliferate.server.billing.snapshots import (
     get_billing_snapshot,
     get_billing_snapshot_for_request,
@@ -226,6 +229,10 @@ async def save_repo_config(
         git_repo_name=git_repo_name,
         configured=value.configured,
     )
+    await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=value.id,
+    )
     return value
 
 
@@ -282,6 +289,10 @@ async def save_organization_repo_config(
             display_name=f"{value.git_owner}/{value.git_repo_name}",
             description=None,
         )
+    await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=value.id,
+    )
     return value
 
 
@@ -309,6 +320,10 @@ async def save_repo_file(
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         configured=value.configured,
+    )
+    await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=value.id,
     )
     return value
 
@@ -367,6 +382,10 @@ async def bootstrap_repo_config(
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         configured=value.configured,
+    )
+    await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=value.id,
     )
     return value
 

--- a/server/proliferate/server/cloud/repositories/api.py
+++ b/server/proliferate/server/cloud/repositories/api.py
@@ -1,0 +1,76 @@
+"""Repository and environment configuration routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.repositories.models import (
+    RepoConfigsListResponse,
+    RepoEnvironmentResponse,
+    SaveCloudRepoEnvironmentRequest,
+    SaveLocalRepoEnvironmentRequest,
+    repo_config_payload,
+    repo_environment_payload,
+)
+from proliferate.server.cloud.repositories.service import (
+    list_repositories,
+    save_cloud_environment,
+    save_local_environment,
+)
+
+router = APIRouter()
+
+
+@router.get("/repositories", response_model=RepoConfigsListResponse)
+async def list_repositories_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> RepoConfigsListResponse:
+    values = await list_repositories(db, user_id=user.id)
+    return RepoConfigsListResponse(repositories=[repo_config_payload(item) for item in values])
+
+
+@router.put(
+    "/repositories/{git_owner}/{git_repo_name}/environments/local",
+    response_model=RepoEnvironmentResponse,
+)
+async def save_local_repo_environment_endpoint(
+    git_owner: str,
+    git_repo_name: str,
+    body: SaveLocalRepoEnvironmentRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> RepoEnvironmentResponse:
+    value = await save_local_environment(
+        db,
+        user_id=user.id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        body=body,
+    )
+    return repo_environment_payload(value)
+
+
+@router.put(
+    "/repositories/{git_owner}/{git_repo_name}/environments/cloud",
+    response_model=RepoEnvironmentResponse,
+)
+async def save_cloud_repo_environment_endpoint(
+    git_owner: str,
+    git_repo_name: str,
+    body: SaveCloudRepoEnvironmentRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> RepoEnvironmentResponse:
+    value = await save_cloud_environment(
+        db,
+        user_id=user.id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        body=body,
+    )
+    return repo_environment_payload(value)

--- a/server/proliferate/server/cloud/repositories/models.py
+++ b/server/proliferate/server/cloud/repositories/models.py
@@ -1,0 +1,90 @@
+"""Wire models for repository and environment configuration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.repositories import RepoConfigValue, RepoEnvironmentValue
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+class RepoEnvironmentResponse(BaseModel):
+    id: UUID
+    repo_config_id: UUID = Field(serialization_alias="repoConfigId")
+    kind: str
+    desktop_install_id: str | None = Field(serialization_alias="desktopInstallId")
+    local_path: str | None = Field(serialization_alias="localPath")
+    configured: bool
+    configured_at: str | None = Field(serialization_alias="configuredAt")
+    default_branch: str | None = Field(serialization_alias="defaultBranch")
+    setup_script: str = Field(serialization_alias="setupScript")
+    setup_script_version: int = Field(serialization_alias="setupScriptVersion")
+    run_command: str = Field(serialization_alias="runCommand")
+    config_version: int = Field(serialization_alias="configVersion")
+    legacy_cloud_repo_config_id: UUID | None = Field(
+        serialization_alias="legacyCloudRepoConfigId"
+    )
+
+
+class RepoConfigResponse(BaseModel):
+    id: UUID
+    owner_scope: str = Field(serialization_alias="ownerScope")
+    git_provider: str = Field(serialization_alias="gitProvider")
+    git_owner: str = Field(serialization_alias="gitOwner")
+    git_repo_name: str = Field(serialization_alias="gitRepoName")
+    environments: list[RepoEnvironmentResponse]
+
+
+class RepoConfigsListResponse(BaseModel):
+    repositories: list[RepoConfigResponse]
+
+
+class SaveLocalRepoEnvironmentRequest(BaseModel):
+    git_provider: str = Field(default="github", alias="gitProvider")
+    desktop_install_id: str = Field(alias="desktopInstallId")
+    local_path: str = Field(alias="localPath")
+    default_branch: str | None = Field(default=None, alias="defaultBranch")
+    setup_script: str = Field(default="", alias="setupScript")
+    run_command: str = Field(default="", alias="runCommand")
+
+
+class SaveCloudRepoEnvironmentRequest(BaseModel):
+    configured: bool = True
+    default_branch: str | None = Field(default=None, alias="defaultBranch")
+    setup_script: str = Field(default="", alias="setupScript")
+    run_command: str = Field(default="", alias="runCommand")
+
+
+def repo_environment_payload(value: RepoEnvironmentValue) -> RepoEnvironmentResponse:
+    return RepoEnvironmentResponse(
+        id=value.id,
+        repo_config_id=value.repo_config_id,
+        kind=value.environment_kind,
+        desktop_install_id=value.desktop_install_id,
+        local_path=value.local_path,
+        configured=value.configured,
+        configured_at=_iso(value.configured_at),
+        default_branch=value.default_branch,
+        setup_script=value.setup_script,
+        setup_script_version=value.setup_script_version,
+        run_command=value.run_command,
+        config_version=value.config_version,
+        legacy_cloud_repo_config_id=value.legacy_cloud_repo_config_id,
+    )
+
+
+def repo_config_payload(value: RepoConfigValue) -> RepoConfigResponse:
+    return RepoConfigResponse(
+        id=value.id,
+        owner_scope=value.owner_scope,
+        git_provider=value.git_provider,
+        git_owner=value.git_owner,
+        git_repo_name=value.git_repo_name,
+        environments=[repo_environment_payload(item) for item in value.environments],
+    )

--- a/server/proliferate/server/cloud/repositories/service.py
+++ b/server/proliferate/server/cloud/repositories/service.py
@@ -1,0 +1,88 @@
+"""Repository and environment configuration orchestration."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.repositories import (
+    RepoConfigValue,
+    RepoEnvironmentValue,
+    list_repo_configs_for_user,
+    sync_cloud_environment_from_legacy_cloud_repo_config,
+    upsert_local_repo_environment,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repo_config.models import SaveCloudRepoConfigRequest
+from proliferate.server.cloud.repo_config.service import save_repo_config
+from proliferate.server.cloud.repositories.models import (
+    SaveCloudRepoEnvironmentRequest,
+    SaveLocalRepoEnvironmentRequest,
+)
+
+
+async def list_repositories(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> tuple[RepoConfigValue, ...]:
+    return await list_repo_configs_for_user(db, user_id=user_id)
+
+
+async def save_local_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str,
+    git_repo_name: str,
+    body: SaveLocalRepoEnvironmentRequest,
+) -> RepoEnvironmentValue:
+    desktop_install_id = body.desktop_install_id.strip()
+    if not desktop_install_id:
+        raise CloudApiError(
+            "desktop_install_id_required",
+            "A desktop install id is required for local environments.",
+            status_code=400,
+        )
+    return await upsert_local_repo_environment(
+        db,
+        user_id=user_id,
+        git_provider=body.git_provider,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        desktop_install_id=desktop_install_id,
+        local_path=body.local_path,
+        default_branch=body.default_branch,
+        setup_script=body.setup_script,
+        run_command=body.run_command,
+    )
+
+
+async def save_cloud_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str,
+    git_repo_name: str,
+    body: SaveCloudRepoEnvironmentRequest,
+) -> RepoEnvironmentValue:
+    legacy = await save_repo_config(
+        db,
+        user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        body=SaveCloudRepoConfigRequest(
+            configured=body.configured,
+            defaultBranch=body.default_branch,
+            setupScript=body.setup_script,
+            runCommand=body.run_command,
+        ),
+    )
+    environment = await sync_cloud_environment_from_legacy_cloud_repo_config(
+        db,
+        cloud_repo_config_id=legacy.id,
+    )
+    if environment is None:
+        raise RuntimeError("Cloud repo environment disappeared after save.")
+    return environment

--- a/server/proliferate/server/cloud/secrets/models.py
+++ b/server/proliferate/server/cloud/secrets/models.py
@@ -87,8 +87,8 @@ def _secret_set_materialization_key(value: CloudSecretSetValue) -> str:
         return f"personal:{value.user_id}"
     if value.scope_kind == "organization" and value.organization_id is not None:
         return f"organization:{value.organization_id}"
-    if value.scope_kind == "workspace" and value.cloud_repo_config_id is not None:
-        return f"workspace:{value.cloud_repo_config_id}"
+    if value.scope_kind == "workspace" and value.repo_environment_id is not None:
+        return f"workspace:{value.repo_environment_id}"
     return f"{value.scope_kind}:{value.id}"
 
 

--- a/server/proliferate/server/cloud/secrets/service.py
+++ b/server/proliferate/server/cloud/secrets/service.py
@@ -18,6 +18,11 @@ from proliferate.db.store.managed_sandbox_secrets import (
 )
 from proliferate.db.store.managed_sandboxes import load_personal_managed_sandbox
 from proliferate.db.store.organization_records import MembershipRecord
+from proliferate.db.store.repositories import (
+    RepoEnvironmentValue,
+    get_cloud_repo_environment,
+    sync_cloud_environment_from_legacy_cloud_repo_config,
+)
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.managed_sandboxes.materialization.service import (
     schedule_global_secret_materialization_for_organization,
@@ -46,7 +51,7 @@ async def _load_workspace_materialization(
     db: AsyncSession,
     *,
     user_id: UUID,
-    cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
 ) -> ManagedSandboxSecretMaterializationValue | None:
     sandbox = await load_personal_managed_sandbox(db, user_id)
     if sandbox is None:
@@ -54,7 +59,7 @@ async def _load_workspace_materialization(
     return await load_workspace_secret_materialization(
         db,
         managed_sandbox_id=sandbox.id,
-        cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
     )
 
 
@@ -63,8 +68,8 @@ def _secret_set_materialization_key(value: CloudSecretSetValue) -> str:
         return f"personal:{value.user_id}"
     if value.scope_kind == "organization" and value.organization_id is not None:
         return f"organization:{value.organization_id}"
-    if value.scope_kind == "workspace" and value.cloud_repo_config_id is not None:
-        return f"workspace:{value.cloud_repo_config_id}"
+    if value.scope_kind == "workspace" and value.repo_environment_id is not None:
+        return f"workspace:{value.repo_environment_id}"
     return f"{value.scope_kind}:{value.id}"
 
 
@@ -138,13 +143,13 @@ async def _require_organization_admin(
         )
 
 
-async def _load_workspace_repo_config(
+async def _load_workspace_repo_scope(
     db: AsyncSession,
     *,
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
-) -> CloudRepoConfigValue:
+) -> tuple[CloudRepoConfigValue, RepoEnvironmentValue]:
     repo_config = await get_cloud_repo_config(
         db,
         user_id=user_id,
@@ -157,7 +162,24 @@ async def _load_workspace_repo_config(
             "Configure this GitHub repo for cloud before managing workspace secrets.",
             status_code=404,
         )
-    return repo_config
+    environment = await get_cloud_repo_environment(
+        db,
+        user_id=user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+    )
+    if environment is None:
+        environment = await sync_cloud_environment_from_legacy_cloud_repo_config(
+            db,
+            cloud_repo_config_id=repo_config.id,
+        )
+    if environment is None or not environment.configured:
+        raise CloudApiError(
+            "cloud_repo_environment_not_configured",
+            "Configure this GitHub repo for cloud before managing workspace secrets.",
+            status_code=404,
+        )
+    return repo_config, environment
 
 
 async def get_personal_secrets(
@@ -384,7 +406,7 @@ async def get_workspace_secrets(
     git_owner: str,
     git_repo_name: str,
 ) -> tuple[CloudSecretSetValue, ManagedSandboxSecretMaterializationValue | None]:
-    repo_config = await _load_workspace_repo_config(
+    repo_config, environment = await _load_workspace_repo_scope(
         db,
         user_id=user_id,
         git_owner=git_owner,
@@ -392,13 +414,13 @@ async def get_workspace_secrets(
     )
     value = await secret_store.get_or_create_workspace_secret_set(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
         actor_user_id=user_id,
     )
     materialization = await _load_workspace_materialization(
         db,
         user_id=user_id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
     )
     if _should_repair_stale_materialization(value, materialization):
         schedule_workspace_secret_materialization_for_repo(
@@ -419,7 +441,7 @@ async def set_workspace_secret_env_var(
     name: str,
     value: str,
 ) -> tuple[CloudSecretSetValue, ManagedSandboxSecretMaterializationValue | None]:
-    repo_config = await _load_workspace_repo_config(
+    repo_config, environment = await _load_workspace_repo_scope(
         db,
         user_id=user_id,
         git_owner=git_owner,
@@ -427,7 +449,7 @@ async def set_workspace_secret_env_var(
     )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
         actor_user_id=user_id,
     )
     updated = await secret_store.upsert_secret_env_var(
@@ -446,7 +468,7 @@ async def set_workspace_secret_env_var(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
     )
 
 
@@ -458,7 +480,7 @@ async def delete_workspace_secret_env_var(
     git_repo_name: str,
     name: str,
 ) -> tuple[CloudSecretSetValue, ManagedSandboxSecretMaterializationValue | None]:
-    repo_config = await _load_workspace_repo_config(
+    repo_config, environment = await _load_workspace_repo_scope(
         db,
         user_id=user_id,
         git_owner=git_owner,
@@ -466,7 +488,7 @@ async def delete_workspace_secret_env_var(
     )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
         actor_user_id=user_id,
     )
     updated = await secret_store.delete_secret_env_var(
@@ -484,7 +506,7 @@ async def delete_workspace_secret_env_var(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
     )
 
 
@@ -497,7 +519,7 @@ async def set_workspace_secret_file(
     path: str,
     content: str,
 ) -> tuple[CloudSecretSetValue, ManagedSandboxSecretMaterializationValue | None]:
-    repo_config = await _load_workspace_repo_config(
+    repo_config, environment = await _load_workspace_repo_scope(
         db,
         user_id=user_id,
         git_owner=git_owner,
@@ -505,7 +527,7 @@ async def set_workspace_secret_file(
     )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
         actor_user_id=user_id,
     )
     updated = await secret_store.upsert_secret_file(
@@ -524,7 +546,7 @@ async def set_workspace_secret_file(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
     )
 
 
@@ -536,7 +558,7 @@ async def delete_workspace_secret_file(
     git_repo_name: str,
     path: str,
 ) -> tuple[CloudSecretSetValue, ManagedSandboxSecretMaterializationValue | None]:
-    repo_config = await _load_workspace_repo_config(
+    repo_config, environment = await _load_workspace_repo_scope(
         db,
         user_id=user_id,
         git_owner=git_owner,
@@ -544,7 +566,7 @@ async def delete_workspace_secret_file(
     )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
         actor_user_id=user_id,
     )
     updated = await secret_store.delete_secret_file(
@@ -562,5 +584,5 @@ async def delete_workspace_secret_file(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        cloud_repo_config_id=repo_config.id,
+        repo_environment_id=environment.id,
     )

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1574,6 +1574,66 @@ class TestCloudRepoConfig:
         assert len(records) == 1
 
     @pytest.mark.asyncio
+    async def test_concurrent_first_local_environment_save_returns_success(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        session = await _register_and_login(client, "local-repo-environment-race@example.com")
+        headers = {"Authorization": f"Bearer {session['access_token']}"}
+        payload = {
+            "gitProvider": "github",
+            "desktopInstallId": "desktop-dev",
+            "localPath": "/Users/example/proliferate",
+            "defaultBranch": "main",
+            "setupScript": "pnpm install",
+            "runCommand": "pnpm dev",
+        }
+
+        responses = await asyncio.gather(
+            client.put(
+                "/v1/cloud/repositories/proliferate-ai/proliferate/environments/local",
+                headers=headers,
+                json=payload,
+            ),
+            client.put(
+                "/v1/cloud/repositories/proliferate-ai/proliferate/environments/local",
+                headers=headers,
+                json=payload,
+            ),
+        )
+
+        assert [response.status_code for response in responses] == [200, 200]
+
+        repo_records = (
+            (
+                await db_session.execute(
+                    select(RepoConfig).where(
+                        RepoConfig.user_id == uuid.UUID(session["user_id"]),
+                        RepoConfig.git_owner == "proliferate-ai",
+                        RepoConfig.git_repo_name == "proliferate",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(repo_records) == 1
+        environment_records = (
+            (
+                await db_session.execute(
+                    select(RepoEnvironment).where(
+                        RepoEnvironment.repo_config_id == repo_records[0].id,
+                        RepoEnvironment.environment_kind == "local",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(environment_records) == 1
+
+    @pytest.mark.asyncio
     async def test_repository_environment_endpoints_bridge_to_legacy_cloud_config(
         self,
         client: AsyncClient,

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1,6 +1,6 @@
 import asyncio
 import base64
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import hashlib
 import json
 import uuid
@@ -26,11 +26,13 @@ from proliferate.db.models.cloud.mcp import (
 )
 from proliferate.db.models.cloud.integrations import CloudOrganizationIntegrationPolicy
 from proliferate.db.models.cloud.repo_config import CloudRepoConfig
+from proliferate.db.models.cloud.repositories import RepoConfig, RepoEnvironment
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.models.cloud.worktree_policy import CloudWorktreeRetentionPolicy
 from proliferate.db.engine import apply_rls_context_to_session
 from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import github_app as github_app_store
 from proliferate.db.store.cloud_mcp.auth import (
     update_connection_auth_if_version,
     upsert_connection_auth,
@@ -42,10 +44,12 @@ from proliferate.db.store.cloud_mcp.oauth_flows import (
 from proliferate.db.store.cloud_mcp.oauth_clients import upsert_oauth_client
 from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
 from proliferate.integrations.github import (
+    GitHubAppInstallationInfo,
     GitHubRepositoryPage,
     GitHubRepositorySummary,
     GitHubRepoBranches,
 )
+from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthorization
 from proliferate.integrations.mcp_oauth import (
     AuthorizationServerMetadata,
     ProtectedResourceMetadata,
@@ -54,6 +58,7 @@ from proliferate.integrations.mcp_oauth import (
 )
 from proliferate.rls_context import with_rls_context
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.github_app import repo_authority
 from proliferate.server.cloud.repo_config import service as repo_config_service
 from proliferate.server.cloud.repos import service as repos_service
 from proliferate.integrations.anyharness import CloudRuntimeReconnectError
@@ -169,6 +174,45 @@ async def _link_github_account(db_session: AsyncSession, user_id: str) -> None:
     )
     db_session.add(account)
     await db_session.commit()
+
+
+async def _seed_github_app_repo_authority(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    user_id: str,
+    git_owner: str = "proliferate-ai",
+) -> None:
+    await github_app_store.upsert_github_app_authorization(
+        db_session,
+        user_id=uuid.UUID(user_id),
+        authorization=GitHubAppUserAuthorization(
+            access_token="github-app-user-token",
+            refresh_token="github-app-refresh-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=8),
+            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=180),
+            github_user_id="12345",
+            github_login="cloud-tester",
+            permissions={},
+        ),
+    )
+    await github_app_store.upsert_github_app_installation(
+        db_session,
+        installation=GitHubAppInstallationInfo(
+            github_installation_id="142900805",
+            account_login=git_owner,
+            account_type="Organization",
+            repository_selection="all",
+            permissions={"contents": "read", "pull_requests": "write"},
+            suspended_at=None,
+        ),
+    )
+    await db_session.commit()
+
+    async def _has_access(**_kwargs) -> bool:  # type: ignore[no-untyped-def]
+        return True
+
+    monkeypatch.setattr(repo_authority, "verify_github_app_user_repo_access", _has_access)
 
 
 async def _link_secondary_account(db_session: AsyncSession, user_id: str) -> None:
@@ -399,8 +443,18 @@ def _patch_repo_branches_lookup(
     resolver,
 ) -> None:
     monkeypatch.setattr(repos_service, "get_github_repo_branches", resolver)
-    monkeypatch.setattr(provisioning_preflight, "get_github_repo_branches", resolver)
-    monkeypatch.setattr(provisioning_service, "get_github_repo_branches", resolver)
+    monkeypatch.setattr(
+        provisioning_preflight,
+        "get_github_repo_branches",
+        resolver,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        provisioning_service,
+        "get_github_repo_branches",
+        resolver,
+        raising=False,
+    )
     monkeypatch.setattr(repo_config_service, "get_repo_branches_for_credentials", resolver)
 
 
@@ -1174,6 +1228,11 @@ class TestCloudRepoConfig:
         session = await _register_and_login(client, "cloud-repo-default-branch@example.com")
         headers = {"Authorization": f"Bearer {session['access_token']}"}
         await _link_github_account(db_session, session["user_id"])
+        await _seed_github_app_repo_authority(
+            db_session,
+            monkeypatch,
+            user_id=session["user_id"],
+        )
 
         save_response = await client.put(
             "/v1/cloud/repos/proliferate-ai/proliferate/config",
@@ -1220,6 +1279,36 @@ class TestCloudRepoConfig:
         ).scalar_one()
         assert record.default_branch == "release"
         assert record.run_command == "make dev"
+
+        repositories_response = await client.get("/v1/cloud/repositories", headers=headers)
+        assert repositories_response.status_code == 200
+        repositories_payload = repositories_response.json()
+        assert repositories_payload["repositories"] == [
+            {
+                "id": str(record.id),
+                "ownerScope": "personal",
+                "gitProvider": "github",
+                "gitOwner": "proliferate-ai",
+                "gitRepoName": "proliferate",
+                "environments": [
+                    {
+                        "id": str(record.id),
+                        "repoConfigId": str(record.id),
+                        "kind": "cloud",
+                        "desktopInstallId": None,
+                        "localPath": None,
+                        "configured": True,
+                        "configuredAt": save_response.json()["configuredAt"],
+                        "defaultBranch": "release",
+                        "setupScript": "pnpm install",
+                        "setupScriptVersion": 1,
+                        "runCommand": "make dev",
+                        "configVersion": 1,
+                        "legacyCloudRepoConfigId": str(record.id),
+                    }
+                ],
+            }
+        ]
 
         organization_id = await _create_organization_for_user(db_session, session["user_id"])
 
@@ -1313,6 +1402,7 @@ class TestCloudRepoConfig:
     async def test_free_plan_repo_config_limit_blocks_second_configured_repo(
         self,
         client: AsyncClient,
+        db_session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         async def _repo_branches(*_args, **_kwargs) -> GitHubRepoBranches:
@@ -1327,6 +1417,11 @@ class TestCloudRepoConfig:
 
         session = await _register_and_login(client, "cloud-repo-config-limit@example.com")
         headers = {"Authorization": f"Bearer {session['access_token']}"}
+        await _seed_github_app_repo_authority(
+            db_session,
+            monkeypatch,
+            user_id=session["user_id"],
+        )
         payload = {
             "configured": True,
             "defaultBranch": None,
@@ -1398,6 +1493,11 @@ class TestCloudRepoConfig:
         )
         headers = {"Authorization": f"Bearer {session['access_token']}"}
         await _link_github_account(db_session, session["user_id"])
+        await _seed_github_app_repo_authority(
+            db_session,
+            monkeypatch,
+            user_id=session["user_id"],
+        )
 
         save_response = await client.put(
             "/v1/cloud/repos/proliferate-ai/proliferate/config",
@@ -1431,6 +1531,11 @@ class TestCloudRepoConfig:
 
         session = await _register_and_login(client, "cloud-repo-config-race@example.com")
         headers = {"Authorization": f"Bearer {session['access_token']}"}
+        await _seed_github_app_repo_authority(
+            db_session,
+            monkeypatch,
+            user_id=session["user_id"],
+        )
         payload = {
             "configured": True,
             "envVars": {"API_BASE_URL": "https://example.internal"},
@@ -1467,6 +1572,102 @@ class TestCloudRepoConfig:
             .all()
         )
         assert len(records) == 1
+
+    @pytest.mark.asyncio
+    async def test_repository_environment_endpoints_bridge_to_legacy_cloud_config(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _repo_branches(*_args, **_kwargs) -> GitHubRepoBranches:
+            return GitHubRepoBranches(
+                default_branch="main",
+                branches=["main", "release"],
+            )
+
+        _patch_repo_branches_lookup(monkeypatch, _repo_branches)
+
+        session = await _register_and_login(client, "repo-environment-bridge@example.com")
+        headers = {"Authorization": f"Bearer {session['access_token']}"}
+        await _link_github_account(db_session, session["user_id"])
+        await _seed_github_app_repo_authority(
+            db_session,
+            monkeypatch,
+            user_id=session["user_id"],
+        )
+
+        local_response = await client.put(
+            "/v1/cloud/repositories/proliferate-ai/proliferate/environments/local",
+            headers=headers,
+            json={
+                "gitProvider": "github",
+                "desktopInstallId": "desktop-dev",
+                "localPath": "/Users/example/proliferate",
+                "defaultBranch": "main",
+                "setupScript": "pnpm install",
+                "runCommand": "pnpm dev",
+            },
+        )
+        assert local_response.status_code == 200
+        assert local_response.json()["kind"] == "local"
+        assert local_response.json()["localPath"] == "/Users/example/proliferate"
+
+        cloud_response = await client.put(
+            "/v1/cloud/repositories/proliferate-ai/proliferate/environments/cloud",
+            headers=headers,
+            json={
+                "configured": True,
+                "defaultBranch": "release",
+                "setupScript": "uv sync",
+                "runCommand": "make run",
+            },
+        )
+        assert cloud_response.status_code == 200
+        assert cloud_response.json()["kind"] == "cloud"
+        assert cloud_response.json()["defaultBranch"] == "release"
+        assert cloud_response.json()["setupScript"] == "uv sync"
+        assert cloud_response.json()["runCommand"] == "make run"
+
+        legacy_response = await client.get(
+            "/v1/cloud/repos/proliferate-ai/proliferate/config",
+            headers=headers,
+        )
+        assert legacy_response.status_code == 200
+        assert legacy_response.json()["defaultBranch"] == "release"
+        assert legacy_response.json()["setupScript"] == "uv sync"
+        assert legacy_response.json()["runCommand"] == "make run"
+
+        repo_record = (
+            await db_session.execute(
+                select(RepoConfig).where(
+                    RepoConfig.user_id == uuid.UUID(session["user_id"]),
+                    RepoConfig.git_owner == "proliferate-ai",
+                    RepoConfig.git_repo_name == "proliferate",
+                )
+            )
+        ).scalar_one()
+        environment_rows = (
+            (
+                await db_session.execute(
+                    select(RepoEnvironment)
+                    .where(RepoEnvironment.repo_config_id == repo_record.id)
+                    .order_by(RepoEnvironment.environment_kind.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [row.environment_kind for row in environment_rows] == ["cloud", "local"]
+
+        repositories_response = await client.get("/v1/cloud/repositories", headers=headers)
+        assert repositories_response.status_code == 200
+        repositories_payload = repositories_response.json()
+        assert repositories_payload["repositories"][0]["gitOwner"] == "proliferate-ai"
+        assert {item["kind"] for item in repositories_payload["repositories"][0]["environments"]} == {
+            "cloud",
+            "local",
+        }
 
     @pytest.mark.asyncio
     async def test_sync_claude_main_config_rejects_nonportable_oauth_metadata(

--- a/server/tests/unit/test_cloud_orm_models.py
+++ b/server/tests/unit/test_cloud_orm_models.py
@@ -40,6 +40,8 @@ def test_cloud_orm_package_registers_all_cloud_tables() -> None:
         "sandbox_profile_agent_auth_revision",
         "sandbox_profile_target_state",
         "cloud_target_runtime_access",
+        "repo_config",
+        "repo_environment",
     }
 
     assert expected_tables <= set(Base.metadata.tables)

--- a/server/tests/unit/test_cloud_secrets_models.py
+++ b/server/tests/unit/test_cloud_secrets_models.py
@@ -14,6 +14,7 @@ from proliferate.server.cloud.secrets.service import _should_repair_stale_materi
 def _workspace_secret_set(
     *,
     cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
     version: int,
 ) -> CloudSecretSetValue:
     now = datetime.now(UTC)
@@ -23,6 +24,7 @@ def _workspace_secret_set(
         user_id=None,
         organization_id=None,
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         version=version,
         created_by_user_id=uuid4(),
         updated_by_user_id=uuid4(),
@@ -46,6 +48,7 @@ def _workspace_secret_set(
 def _workspace_materialization(
     *,
     cloud_repo_config_id: UUID,
+    repo_environment_id: UUID,
     applied_version: int,
     status: str = "ready",
 ) -> ManagedSandboxSecretMaterializationValue:
@@ -56,9 +59,10 @@ def _workspace_materialization(
         materialization_kind="workspace",
         cloud_secret_set_id=uuid4(),
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         sandbox_generation=1,
         applied_version=applied_version,
-        applied_versions={f"workspace:{cloud_repo_config_id}": applied_version},
+        applied_versions={f"workspace:{repo_environment_id}": applied_version},
         applied_manifest={},
         status=status,
         last_error=None,
@@ -70,12 +74,15 @@ def _workspace_materialization(
 
 def test_cloud_secrets_payload_marks_ready_materialization_pending_when_version_is_stale() -> None:
     cloud_repo_config_id = uuid4()
+    repo_environment_id = uuid4()
     secret_set = _workspace_secret_set(
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         version=1,
     )
     materialization = _workspace_materialization(
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         applied_version=0,
     )
 
@@ -89,12 +96,15 @@ def test_cloud_secrets_payload_marks_ready_materialization_pending_when_version_
 
 def test_cloud_secrets_payload_keeps_ready_materialization_ready_when_version_is_current() -> None:
     cloud_repo_config_id = uuid4()
+    repo_environment_id = uuid4()
     secret_set = _workspace_secret_set(
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         version=1,
     )
     materialization = _workspace_materialization(
         cloud_repo_config_id=cloud_repo_config_id,
+        repo_environment_id=repo_environment_id,
         applied_version=1,
     )
 

--- a/server/tests/unit/test_managed_sandbox_repo_materialization.py
+++ b/server/tests/unit/test_managed_sandbox_repo_materialization.py
@@ -91,6 +91,7 @@ def _materialization(
         id=uuid.uuid4(),
         managed_sandbox_id=uuid.uuid4(),
         cloud_repo_config_id=uuid.uuid4(),
+        repo_environment_id=uuid.uuid4(),
         sandbox_generation=sandbox_generation,
         repo_path="/home/user/workspace/repos/acme/rocket",
         status="ready",

--- a/server/tests/unit/test_managed_sandbox_runtime_connection.py
+++ b/server/tests/unit/test_managed_sandbox_runtime_connection.py
@@ -226,6 +226,167 @@ async def test_workspace_runtime_connection_creates_branch_worktree(
 
 
 @pytest.mark.asyncio
+async def test_workspace_runtime_connection_repairs_stale_workspace_id_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = SimpleNamespace(id=uuid4())
+    workspace_id = uuid4()
+    worktree_path = "/home/user/workspace/worktrees/Owner/Repo/feature-12345678"
+    workspace = SimpleNamespace(
+        id=workspace_id,
+        owner_scope="personal",
+        owner_user_id=user.id,
+        sandbox_profile_id=uuid4(),
+        target_id=uuid4(),
+        git_owner="Owner",
+        git_repo_name="Repo",
+        git_branch="feature",
+        git_base_branch="main",
+        origin="manual_desktop",
+        status="ready",
+        anyharness_workspace_id="stale-workspace",
+        worktree_path=worktree_path,
+    )
+    sandbox = SimpleNamespace(runtime_generation=13)
+    calls: dict[str, object] = {}
+
+    async def ensure_repo_connection(*_args: object, **_kwargs: object) -> object:
+        return service.ManagedSandboxRepoRuntimeConnection(
+            anyharness_workspace_id="base-workspace",
+            anyharness_repo_root_id="repo-root",
+            runtime_generation=13,
+        )
+
+    async def ensure_sandbox(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_runtime_access(_sandbox: object) -> tuple[str, str, str]:
+        return ("https://runtime.example", "runtime-token", "data-key")
+
+    async def list_workspaces(*_args: object, **_kwargs: object) -> list[object]:
+        calls["listed"] = True
+        return []
+
+    async def resolve_workspace(*_args: object, **_kwargs: object) -> object:
+        calls["resolve"] = _kwargs
+        return SimpleNamespace(workspace_id="resolved-workspace", repo_root_id="repo-root")
+
+    async def create_worktree(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("existing worktree path should be resolved before creating")
+
+    async def attach_workspace_id(*_args: object, **_kwargs: object) -> object:
+        calls["attach"] = _kwargs
+        return workspace
+
+    monkeypatch.setattr(
+        service,
+        "ensure_managed_sandbox_repo_runtime_connection",
+        ensure_repo_connection,
+    )
+    monkeypatch.setattr(service, "ensure_managed_sandbox_ready", ensure_sandbox)
+    monkeypatch.setattr(service, "load_managed_sandbox_runtime_access", load_runtime_access)
+    monkeypatch.setattr(service, "list_runtime_workspaces", list_workspaces)
+    monkeypatch.setattr(service, "resolve_runtime_workspace", resolve_workspace)
+    monkeypatch.setattr(service, "create_remote_worktree_workspace", create_worktree)
+    monkeypatch.setattr(service, "attach_anyharness_workspace_id", attach_workspace_id)
+
+    result = await service.ensure_managed_sandbox_workspace_record_runtime_connection(
+        cast(AsyncSession, object()),
+        cast(service._UserWithId, user),
+        workspace=workspace,
+    )
+
+    assert result.anyharness_workspace_id == "resolved-workspace"
+    assert result.anyharness_repo_root_id == "repo-root"
+    assert result.runtime_generation == 13
+    assert calls["listed"] is True
+    assert calls["resolve"] == {"runtime_workdir": worktree_path}
+    assert calls["attach"] == {
+        "workspace_id": workspace_id,
+        "anyharness_workspace_id": "resolved-workspace",
+        "worktree_path": worktree_path,
+        "runtime_generation": 13,
+    }
+
+
+@pytest.mark.asyncio
+async def test_workspace_runtime_connection_marks_error_when_worktree_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = SimpleNamespace(id=uuid4())
+    workspace_id = uuid4()
+    workspace = SimpleNamespace(
+        id=workspace_id,
+        owner_scope="personal",
+        owner_user_id=user.id,
+        sandbox_profile_id=uuid4(),
+        target_id=uuid4(),
+        git_owner="Owner",
+        git_repo_name="Repo",
+        git_branch="feature",
+        git_base_branch="missing-base",
+        origin="manual_desktop",
+        status="pending",
+        anyharness_workspace_id=None,
+        worktree_path=None,
+    )
+    sandbox = SimpleNamespace(runtime_generation=14)
+    calls: dict[str, object] = {}
+
+    async def ensure_repo_connection(*_args: object, **_kwargs: object) -> object:
+        return service.ManagedSandboxRepoRuntimeConnection(
+            anyharness_workspace_id="base-workspace",
+            anyharness_repo_root_id="repo-root",
+            runtime_generation=14,
+        )
+
+    async def ensure_sandbox(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_runtime_access(_sandbox: object) -> tuple[str, str, str]:
+        return ("https://runtime.example", "runtime-token", "data-key")
+
+    async def create_worktree(*_args: object, **_kwargs: object) -> object:
+        raise service.CloudRuntimeReconnectError(
+            "git worktree add failed: fatal: not a valid object name: 'missing-base'"
+        )
+
+    async def mark_error(*_args: object, **_kwargs: object) -> None:
+        calls["mark_error"] = _kwargs
+
+    async def commit(_db: object) -> None:
+        calls["committed"] = True
+
+    monkeypatch.setattr(
+        service,
+        "ensure_managed_sandbox_repo_runtime_connection",
+        ensure_repo_connection,
+    )
+    monkeypatch.setattr(service, "ensure_managed_sandbox_ready", ensure_sandbox)
+    monkeypatch.setattr(service, "load_managed_sandbox_runtime_access", load_runtime_access)
+    monkeypatch.setattr(service, "create_remote_worktree_workspace", create_worktree)
+    monkeypatch.setattr(service, "mark_workspace_error_by_id", mark_error)
+    monkeypatch.setattr(service, "commit_managed_sandbox_session", commit)
+
+    with pytest.raises(CloudApiError) as error:
+        await service.ensure_managed_sandbox_workspace_record_runtime_connection(
+            cast(AsyncSession, object()),
+            cast(service._UserWithId, user),
+            workspace=workspace,
+        )
+
+    assert error.value.status_code == 502
+    assert error.value.code == "managed_cloud_workspace_materialization_failed"
+    assert "missing-base" in error.value.message
+    assert calls["mark_error"] == {
+        "status_detail": "Cloud workspace materialization failed",
+        "clear_runtime_metadata": True,
+        "clear_active_sandbox": False,
+    }
+    assert calls["committed"] is True
+
+
+@pytest.mark.asyncio
 async def test_runtime_connection_singleflights_concurrent_repo_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/server/tests/unit/test_managed_sandbox_runtime_connection.py
+++ b/server/tests/unit/test_managed_sandbox_runtime_connection.py
@@ -226,6 +226,89 @@ async def test_workspace_runtime_connection_creates_branch_worktree(
 
 
 @pytest.mark.asyncio
+async def test_workspace_runtime_connection_returns_current_binding_without_wake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = SimpleNamespace(id=uuid4())
+    workspace = SimpleNamespace(
+        id=uuid4(),
+        owner_scope="personal",
+        owner_user_id=user.id,
+        sandbox_profile_id=uuid4(),
+        target_id=uuid4(),
+        git_owner="Owner",
+        git_repo_name="Repo",
+        git_branch="feature",
+        git_base_branch="main",
+        origin="manual_desktop",
+        status="ready",
+        runtime_generation=17,
+        anyharness_workspace_id="existing-workspace",
+        worktree_path="/home/user/workspace/worktrees/Owner/Repo/feature-12345678",
+    )
+    sandbox_id = uuid4()
+    sandbox = SimpleNamespace(
+        id=sandbox_id,
+        status="ready",
+        runtime_generation=17,
+        e2b_sandbox_id="sandbox-17",
+        anyharness_base_url="https://runtime.example",
+        anyharness_bearer_token_ciphertext="token",
+        anyharness_data_key_ciphertext="data-key",
+    )
+    repo_config = SimpleNamespace(id=uuid4())
+    materialization = SimpleNamespace(anyharness_repo_root_id="repo-root")
+    calls: dict[str, object] = {}
+
+    async def load_sandbox(*_args: object, **_kwargs: object) -> object:
+        calls["load_sandbox"] = True
+        return sandbox
+
+    async def get_repo_config(*_args: object, **_kwargs: object) -> object:
+        calls["repo_config"] = _kwargs
+        return repo_config
+
+    async def load_materialization(*_args: object, **_kwargs: object) -> object:
+        calls["materialization"] = _kwargs
+        return materialization
+
+    async def unexpected(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("current workspace binding should not wake or materialize")
+
+    monkeypatch.setattr(service, "load_personal_managed_sandbox", load_sandbox)
+    monkeypatch.setattr(service, "get_cloud_repo_config", get_repo_config)
+    monkeypatch.setattr(service, "load_repo_materialization", load_materialization)
+    monkeypatch.setattr(
+        service,
+        "ensure_managed_sandbox_repo_runtime_connection",
+        unexpected,
+    )
+    monkeypatch.setattr(service, "ensure_managed_sandbox_ready", unexpected)
+
+    result = await service.ensure_managed_sandbox_workspace_record_runtime_connection(
+        cast(AsyncSession, object()),
+        cast(service._UserWithId, user),
+        workspace=workspace,
+    )
+
+    assert result.anyharness_workspace_id == "existing-workspace"
+    assert result.anyharness_repo_root_id == "repo-root"
+    assert result.runtime_generation == 17
+    assert calls == {
+        "load_sandbox": True,
+        "repo_config": {
+            "user_id": user.id,
+            "git_owner": "Owner",
+            "git_repo_name": "Repo",
+        },
+        "materialization": {
+            "managed_sandbox_id": sandbox_id,
+            "cloud_repo_config_id": repo_config.id,
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_workspace_runtime_connection_repairs_stale_workspace_id_by_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -244,10 +327,18 @@ async def test_workspace_runtime_connection_repairs_stale_workspace_id_by_path(
         git_base_branch="main",
         origin="manual_desktop",
         status="ready",
+        runtime_generation=12,
         anyharness_workspace_id="stale-workspace",
         worktree_path=worktree_path,
     )
-    sandbox = SimpleNamespace(runtime_generation=13)
+    sandbox = SimpleNamespace(
+        status="ready",
+        runtime_generation=13,
+        e2b_sandbox_id="sandbox-13",
+        anyharness_base_url="https://runtime.example",
+        anyharness_bearer_token_ciphertext="token",
+        anyharness_data_key_ciphertext="data-key",
+    )
     calls: dict[str, object] = {}
 
     async def ensure_repo_connection(*_args: object, **_kwargs: object) -> object:
@@ -258,6 +349,9 @@ async def test_workspace_runtime_connection_repairs_stale_workspace_id_by_path(
         )
 
     async def ensure_sandbox(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_sandbox(*_args: object, **_kwargs: object) -> object:
         return sandbox
 
     async def load_runtime_access(_sandbox: object) -> tuple[str, str, str]:
@@ -283,6 +377,7 @@ async def test_workspace_runtime_connection_repairs_stale_workspace_id_by_path(
         "ensure_managed_sandbox_repo_runtime_connection",
         ensure_repo_connection,
     )
+    monkeypatch.setattr(service, "load_personal_managed_sandbox", load_sandbox)
     monkeypatch.setattr(service, "ensure_managed_sandbox_ready", ensure_sandbox)
     monkeypatch.setattr(service, "load_managed_sandbox_runtime_access", load_runtime_access)
     monkeypatch.setattr(service, "list_runtime_workspaces", list_workspaces)


### PR DESCRIPTION
## Summary

Adds the RepoConfig / RepoEnvironment control-plane model for local and cloud repository environments.

- introduces cloud repository and repo environment models, store helpers, API routes, and migration
- moves workspace-scoped secrets/materialization toward `repo_environment_id` ownership while preserving PR2 compatibility
- adds cloud SDK and SDK React helpers for repositories/environments
- wires Desktop settings save flow to persist local repo environments with a stable desktop install id
- updates generated cloud SDK types and targeted tests

## Why

This separates repository identity from concrete environments so local checkouts and cloud environments can share one repo config while still tracking environment-specific branch/setup/run/secrets state cleanly.

## Validation

- `git diff --check`
- `uv run python -m compileall -q ...`
- `DEBUG=1 JWT_SECRET=test-secret uv run pytest -q tests/integration/test_schema_migrations.py tests/unit/test_cloud_secrets_models.py tests/unit/test_managed_sandbox_repo_materialization.py tests/unit/test_cloud_orm_models.py tests/integration/test_cloud_api.py::TestCloudRepoConfig`
- `pnpm --filter @proliferate/cloud-sdk build`
- `pnpm --filter @proliferate/cloud-sdk-react build`
- `pnpm --filter @proliferate/product-surfaces test -- CloudEnvironmentsSettingsSurface.test.tsx`
- `pnpm --filter @proliferate/product-surfaces typecheck`
- `pnpm --filter proliferate build`
