### PR TITLE
Wave 3a: chat composer restyle + transcript polish

### DIFF
--- a/apps/desktop/src/components/workspace/chat/input/ApprovalCard.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ApprovalCard.tsx
@@ -1,5 +1,9 @@
-import { Button } from "@proliferate/ui/primitives/Button";
+import { useMemo } from "react";
 import { ComposerAttachedPanel } from "./ComposerAttachedPanel";
+import {
+  ComposerOptionRow,
+  useComposerOptionNumberKeys,
+} from "./ComposerOptionRow";
 import { useActivePendingApproval } from "@/hooks/chat/derived/use-active-pending-session-interactions";
 import { useChatPermissionActions } from "@/hooks/chat/workflows/use-chat-permission-actions";
 import type { PermissionOptionAction } from "@/lib/domain/chat/composer/chat-input-helpers";
@@ -8,6 +12,10 @@ import type { PermissionOptionAction } from "@/lib/domain/chat/composer/chat-inp
 // icon, no label chip, no uppercase prefix. The title itself is
 // self-describing (a command, a file path, or a question) so the extra
 // chrome just added visual noise.
+//
+// Options follow the Superset anatomy (UX_SPEC §5): full-width rows with
+// hairline separators, leading number-key badges, 1–9 selects. Destructive
+// options (deny/reject/cancel) render in --danger text.
 
 export interface ApprovalCardProps {
   title: string;
@@ -15,6 +23,13 @@ export interface ApprovalCardProps {
   onSelectOption: (optionId: string) => void;
   onAllow: () => void;
   onDeny: () => void;
+}
+
+interface ApprovalOption {
+  key: string;
+  label: string;
+  destructive: boolean;
+  onSelect: () => void;
 }
 
 /**
@@ -29,6 +44,25 @@ export function ApprovalCard({
   onAllow,
   onDeny,
 }: ApprovalCardProps) {
+  const options = useMemo<ApprovalOption[]>(() => {
+    if (actions.length > 0) {
+      return actions.map((action) => ({
+        key: action.optionId,
+        label: action.label,
+        destructive: isDestructiveActionKind(action.kind),
+        onSelect: () => onSelectOption(action.optionId),
+      }));
+    }
+    return [
+      { key: "allow", label: "Allow", destructive: false, onSelect: onAllow },
+      { key: "deny", label: "Deny", destructive: true, onSelect: onDeny },
+    ];
+  }, [actions, onAllow, onDeny, onSelectOption]);
+
+  useComposerOptionNumberKeys(options.length, (index) => {
+    options[index]?.onSelect();
+  });
+
   const header = (
     <div className="text-chat min-w-0 truncate font-medium leading-[var(--text-chat--line-height)] text-foreground">
       {title}
@@ -37,16 +71,24 @@ export function ApprovalCard({
 
   return (
     <ComposerAttachedPanel header={header}>
-      <div className="flex flex-col gap-3 p-3">
-        <ApprovalOptionsRow
-          actions={actions}
-          onSelectOption={onSelectOption}
-          onAllow={onAllow}
-          onDeny={onDeny}
-        />
+      <div className="max-h-[300px] overflow-y-auto px-2 pb-2">
+        {options.map((option, index) => (
+          <ComposerOptionRow
+            key={option.key}
+            index={index}
+            label={option.label}
+            destructive={option.destructive}
+            onSelect={option.onSelect}
+          />
+        ))}
       </div>
     </ComposerAttachedPanel>
   );
+}
+
+function isDestructiveActionKind(kind: string | null): boolean {
+  if (!kind) return false;
+  return kind.startsWith("reject") || kind.startsWith("deny") || kind.startsWith("cancel");
 }
 
 export function ConnectedApprovalCard() {
@@ -69,66 +111,5 @@ export function ConnectedApprovalCard() {
       onAllow={handleAllowPermission}
       onDeny={handleDenyPermission}
     />
-  );
-}
-
-const APPROVAL_BUTTON_CLASSNAME = "rounded-xl px-2.5 text-sm";
-
-function ApprovalOptionsRow({
-  actions,
-  onSelectOption,
-  onAllow,
-  onDeny,
-}: {
-  actions: PermissionOptionAction[];
-  onSelectOption: (optionId: string) => void;
-  onAllow: () => void;
-  onDeny: () => void;
-}) {
-  const hasExplicitActions = actions.length > 0;
-
-  if (!hasExplicitActions) {
-    return (
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          type="button"
-          onClick={onDeny}
-          variant="secondary"
-          size="sm"
-          className={APPROVAL_BUTTON_CLASSNAME}
-        >
-          Deny
-        </Button>
-        <Button
-          type="button"
-          onClick={onAllow}
-          variant="primary"
-          size="sm"
-          className={APPROVAL_BUTTON_CLASSNAME}
-        >
-          Allow
-        </Button>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {actions.map((action) => {
-        const isAllow = action.kind?.startsWith("allow") ?? false;
-        return (
-          <Button
-            key={action.optionId}
-            type="button"
-            onClick={() => onSelectOption(action.optionId)}
-            variant={isAllow ? "primary" : "secondary"}
-            size="sm"
-            className={APPROVAL_BUTTON_CLASSNAME}
-          >
-            {action.label}
-          </Button>
-        );
-      })}
-    </div>
   );
 }

--- a/apps/desktop/src/components/workspace/chat/input/ComposerAttachedPanel.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerAttachedPanel.tsx
@@ -15,10 +15,13 @@ export function ComposerAttachedPanel({
   expanded = true,
   onToggleExpanded,
 }: ComposerAttachedPanelProps) {
+  // Superset attached-panel anatomy (UX_SPEC §5): 13px radius (top — the
+  // bottom edge docks into the composer), 0.5px border, 2% foreground tint,
+  // question header px-12 pt-12 pb-12.
   return (
-    <div className="relative overflow-clip rounded-t-2xl border-x border-t border-border/70 bg-card/70 backdrop-blur-sm transition-colors">
+    <div className="relative overflow-clip rounded-t-[13px] border-x-[0.5px] border-t-[0.5px] border-border bg-[color:color-mix(in_oklab,var(--color-foreground)_2%,var(--color-background))] backdrop-blur-sm transition-colors">
       {header && (
-        <div className="flex w-full items-center justify-between gap-1.5 py-1.5 pr-2 pl-3 text-sm">
+        <div className="flex w-full items-start justify-between gap-1.5 py-3 pr-2 pl-3 text-chat leading-[var(--text-chat--line-height)]">
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
             {header}
           </div>

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigMenu.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigMenu.tsx
@@ -1,22 +1,19 @@
-import type {
-  Dispatch,
-  RefObject,
-  SetStateAction,
-} from "react";
+import type { RefObject } from "react";
 import { resolveComposerControlSubmenuLabel } from "@/lib/domain/chat/session-controls/composer-config-submenu-presentation";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
 import type {
   ModelSelectorGroup,
-  ModelSelectorProps,
   ModelSelectorSelection,
 } from "@/lib/domain/chat/models/model-selector-types";
 import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
+import { Plus } from "@proliferate/ui/icons";
+import { CHAT_MODEL_SELECTOR_LABELS } from "@/copy/chat/chat-copy";
 import {
   ComposerMenuSeparator,
   ComposerModelPickerContent,
 } from "./ComposerModelPickerList";
 import {
-  ComposerAddProviderRows,
   ComposerControlSubmenu,
   ComposerHarnessSubmenu,
   ComposerSubmenuMenuItem,
@@ -35,45 +32,40 @@ export function ComposerModelConfigMenu({
   activeKind,
   activeModelGroups,
   activeSubmenu,
-  addProviderOpen,
   agentKind,
   filteredGroups,
   groups,
   menuRootRef,
-  notReadyAgents,
   search,
   submenuControls,
   submenuPosition,
   submenuRef,
-  onAddProviderOpenChange,
+  onAddHarness,
   onMenuMouseEnter,
   onMenuMouseLeave,
   onOpenSubmenu,
   onSearchChange,
   onSelect,
-  onSetupAgent,
   onClose,
 }: {
   activeKind: string | null;
   activeModelGroups: ModelSelectorGroup[];
   activeSubmenu: ComposerConfigSubmenu | null;
-  addProviderOpen: boolean;
   agentKind: string | null;
   filteredGroups: ModelSelectorGroup[];
   groups: ModelSelectorGroup[];
   menuRootRef: RefObject<HTMLDivElement | null>;
-  notReadyAgents: ModelSelectorProps["notReadyAgents"];
   search: string;
   submenuControls: LiveSessionControlDescriptor[];
   submenuPosition: ComposerSubmenuPosition | null;
   submenuRef: RefObject<HTMLDivElement | null>;
-  onAddProviderOpenChange: Dispatch<SetStateAction<boolean>>;
+  /** UX_SPEC §5: "Add harness" navigates to Settings → Agents (no modal). */
+  onAddHarness: () => void;
   onMenuMouseEnter: () => void;
   onMenuMouseLeave: () => void;
   onOpenSubmenu: (submenu: ComposerConfigSubmenu, anchorElement: HTMLElement) => void;
   onSearchChange: (search: string) => void;
   onSelect: (selection: ModelSelectorSelection) => void;
-  onSetupAgent: (agent: ModelSelectorProps["notReadyAgents"][number]) => void;
   onClose: () => void;
 }) {
   const activeControl = activeSubmenu?.kind === "control"
@@ -100,37 +92,40 @@ export function ComposerModelConfigMenu({
             onSelect={onSelect}
           />
 
-          {(showSubmenuRows || notReadyAgents.length > 0) && (
-            <div className="shrink-0">
-              <ComposerMenuSeparator />
+          <div className="shrink-0">
+            <ComposerMenuSeparator />
 
-              {notReadyAgents.length > 0 && (
-                <ComposerAddProviderRows
-                  addProviderOpen={addProviderOpen}
-                  notReadyAgents={notReadyAgents}
-                  onAddProviderOpenChange={onAddProviderOpenChange}
-                  onSetupAgent={onSetupAgent}
-                />
-              )}
+            {showSubmenuRows && (
+              <>
+                {showHarnessSubmenu && (
+                  <ComposerSubmenuMenuItem
+                    active={activeSubmenu?.kind === "harness"}
+                    label="Agent"
+                    onOpen={(anchorElement) => onOpenSubmenu({ kind: "harness" }, anchorElement)}
+                  />
+                )}
 
-              {showHarnessSubmenu && (
-                <ComposerSubmenuMenuItem
-                  active={activeSubmenu?.kind === "harness"}
-                  label="Agent"
-                  onOpen={(anchorElement) => onOpenSubmenu({ kind: "harness" }, anchorElement)}
-                />
-              )}
+                {submenuControls.map((control) => (
+                  <ComposerSubmenuMenuItem
+                    key={control.key}
+                    active={activeSubmenu?.kind === "control" && activeSubmenu.key === control.key}
+                    label={resolveComposerControlSubmenuLabel(control)}
+                    onOpen={(anchorElement) => onOpenSubmenu({ kind: "control", key: control.key }, anchorElement)}
+                  />
+                ))}
+              </>
+            )}
 
-              {submenuControls.map((control) => (
-                <ComposerSubmenuMenuItem
-                  key={control.key}
-                  active={activeSubmenu?.kind === "control" && activeSubmenu.key === control.key}
-                  label={resolveComposerControlSubmenuLabel(control)}
-                  onOpen={(anchorElement) => onOpenSubmenu({ kind: "control", key: control.key }, anchorElement)}
-                />
-              ))}
-            </div>
-          )}
+            <PopoverMenuItem
+              icon={<Plus className="size-3.5 shrink-0" />}
+              label={CHAT_MODEL_SELECTOR_LABELS.addHarness}
+              className="text-muted-foreground hover:text-popover-foreground"
+              onClick={() => {
+                onAddHarness();
+                onClose();
+              }}
+            />
+          </div>
         </div>
       </ComposerPopoverSurface>
 

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
@@ -6,8 +6,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { AgentSetupModal } from "@/components/agents/AgentSetupModal";
+import { useNavigate } from "react-router-dom";
 import { CHAT_MODEL_SELECTOR_LABELS } from "@/copy/chat/chat-copy";
+import { buildSettingsHref } from "@/lib/domain/settings/navigation";
 import { summarizeComposerModelConfigControls } from "@/lib/domain/chat/session-controls/composer-control-groups";
 import { sortComposerConfigSubmenuControls } from "@/lib/domain/chat/session-controls/composer-config-submenu-presentation";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
@@ -43,15 +44,20 @@ export function ComposerModelConfigSelector({
   agentKind,
   controls,
 }: ComposerModelConfigSelectorProps) {
+  const navigate = useNavigate();
   const menuRootRef = useRef<HTMLDivElement | null>(null);
   const submenuRef = useRef<HTMLDivElement | null>(null);
   const [search, setSearch] = useState("");
-  const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [activeSubmenu, setActiveSubmenu] = useState<ComposerConfigSubmenu | null>(null);
   const [submenuAnchorTop, setSubmenuAnchorTop] = useState<number | null>(null);
   const [submenuPosition, setSubmenuPosition] = useState<ComposerSubmenuPosition | null>(null);
-  const [setupAgent, setSetupAgent] = useState<ModelSelectorProps["notReadyAgents"][number] | null>(null);
   const submenuCloseTimerRef = useRef<number | null>(null);
+
+  // UX_SPEC §5: adding a harness routes to Settings → Agents instead of
+  // opening AgentSetupModal in place.
+  const handleAddHarness = useCallback(() => {
+    navigate(buildSettingsHref({ section: "agent-authentication" }));
+  }, [navigate]);
 
   const cancelPendingSubmenuClose = useCallback(() => {
     if (submenuCloseTimerRef.current !== null) {
@@ -76,7 +82,6 @@ export function ComposerModelConfigSelector({
     groups,
     hasAgents,
     isLoading,
-    notReadyAgents,
     onSelect,
   } = modelSelectorProps;
   const selectorEnabled = connectionState === "healthy" && !isLoading && hasAgents;
@@ -209,7 +214,6 @@ export function ComposerModelConfigSelector({
             cancelPendingSubmenuClose();
             resetMenuState({
               setActiveSubmenu,
-              setAddProviderOpen,
               setSearch,
               setSubmenuAnchorTop,
               setSubmenuPosition,
@@ -222,23 +226,20 @@ export function ComposerModelConfigSelector({
             activeKind={activeKind}
             activeModelGroups={activeModelGroups}
             activeSubmenu={activeSubmenu}
-            addProviderOpen={addProviderOpen}
             agentKind={agentKind}
             filteredGroups={filteredGroups}
             groups={groups}
             menuRootRef={menuRootRef}
-            notReadyAgents={notReadyAgents}
             search={search}
             submenuControls={submenuControls}
             submenuPosition={submenuPosition}
             submenuRef={submenuRef}
-            onAddProviderOpenChange={setAddProviderOpen}
+            onAddHarness={handleAddHarness}
             onClose={close}
             onMenuMouseEnter={cancelPendingSubmenuClose}
             onMenuMouseLeave={scheduleSubmenuClose}
             onOpenSubmenu={(submenu, anchorElement) => {
               cancelPendingSubmenuClose();
-              setAddProviderOpen(false);
               setSubmenuPosition(null);
               setSubmenuAnchorTop(resolveSubmenuAnchorTop(menuRootRef.current, anchorElement));
               setActiveSubmenu(submenu);
@@ -248,36 +249,25 @@ export function ComposerModelConfigSelector({
               onSelect(selection);
               close();
             }}
-            onSetupAgent={setSetupAgent}
           />
         )}
       </PopoverButton>
-
-      {setupAgent && (
-        <AgentSetupModal
-          agent={setupAgent}
-          onClose={() => setSetupAgent(null)}
-        />
-      )}
     </>
   );
 }
 
 function resetMenuState({
   setActiveSubmenu,
-  setAddProviderOpen,
   setSearch,
   setSubmenuAnchorTop,
   setSubmenuPosition,
 }: {
   setActiveSubmenu: (value: ComposerConfigSubmenu | null) => void;
-  setAddProviderOpen: (value: boolean) => void;
   setSearch: (value: string) => void;
   setSubmenuAnchorTop: (value: number | null) => void;
   setSubmenuPosition: (value: ComposerSubmenuPosition | null) => void;
 }) {
   setSearch("");
-  setAddProviderOpen(false);
   setActiveSubmenu(null);
   setSubmenuAnchorTop(null);
   setSubmenuPosition(null);

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSubmenus.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSubmenus.tsx
@@ -1,8 +1,4 @@
-import type {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-} from "react";
+import type { ReactNode } from "react";
 import {
   resolveComposerControlOptionDescription,
   resolveComposerControlOptionLabel,
@@ -10,7 +6,6 @@ import {
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
 import type {
   ModelSelectorGroup,
-  ModelSelectorProps,
   ModelSelectorSelection,
 } from "@/lib/domain/chat/models/model-selector-types";
 import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
@@ -20,7 +15,6 @@ import {
   ChevronDown,
 } from "@proliferate/ui/icons";
 import { ProviderIcon } from "@proliferate/ui/provider-icons";
-import { CHAT_MODEL_SELECTOR_LABELS } from "@/copy/chat/chat-copy";
 import { PendingConfigIndicator } from "./PendingConfigIndicator";
 
 export function ComposerControlSubmenu({
@@ -74,37 +68,6 @@ export function ComposerHarnessSubmenu({
         />
       ))}
     </ComposerPopoverSurface>
-  );
-}
-
-export function ComposerAddProviderRows({
-  addProviderOpen,
-  notReadyAgents,
-  onAddProviderOpenChange,
-  onSetupAgent,
-}: {
-  addProviderOpen: boolean;
-  notReadyAgents: ModelSelectorProps["notReadyAgents"];
-  onAddProviderOpenChange: Dispatch<SetStateAction<boolean>>;
-  onSetupAgent: (agent: ModelSelectorProps["notReadyAgents"][number]) => void;
-}) {
-  return (
-    <>
-      <PopoverMenuItem
-        label={CHAT_MODEL_SELECTOR_LABELS.addProvider}
-        trailing={<ChevronDown className={`size-3.5 shrink-0 transition-transform ${addProviderOpen ? "rotate-180" : ""}`} />}
-        onClick={() => onAddProviderOpenChange((open) => !open)}
-      />
-      {addProviderOpen && notReadyAgents.map((agent) => (
-        <PopoverMenuItem
-          key={agent.kind}
-          label={agent.displayName}
-          trailing={<span className="text-xs text-muted-foreground">Setup</span>}
-          className="ml-2 w-[calc(100%-0.5rem)]"
-          onClick={() => onSetupAgent(agent)}
-        />
-      ))}
-    </>
   );
 }
 

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelPickerList.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelPickerList.tsx
@@ -26,7 +26,8 @@ export function ComposerModelPickerContent({
     <div className="flex min-h-0 flex-1 flex-col space-y-1">
       <div className="space-y-1">
         <div className="px-1">
-          <div className="flex h-7 items-center rounded-lg border border-border bg-surface-control px-2.5">
+          {/* Superset inset input (UX_SPEC §5): control bg + inset ring. */}
+          <div className="flex h-7 items-center rounded-lg bg-surface-control px-2.5 ring-1 ring-inset ring-input">
             <Input
               value={search}
               onChange={(event) => onSearchChange(event.target.value)}

--- a/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -1,0 +1,115 @@
+import { useEffect, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Superset-style composer option anatomy (UX_SPEC §5):
+ * full-width rows separated by 60% hairlines, leading number-key badge
+ * (24px square, 3px radius, control bg, mono), hover accent fill that
+ * promotes the label from muted to foreground. Pressing 1–9 selects.
+ */
+
+export function ComposerOptionKeyBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex size-6 shrink-0 items-center justify-center rounded-[3px] bg-surface-control font-mono text-base leading-none text-faint">
+      {children}
+    </span>
+  );
+}
+
+export function ComposerOptionRow({
+  index,
+  label,
+  description,
+  destructive = false,
+  selected = false,
+  disabled = false,
+  onSelect,
+}: {
+  /** 0-based option index; renders as a 1-based number-key badge. */
+  index: number;
+  label: ReactNode;
+  description?: ReactNode;
+  destructive?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <div className="border-t border-border/60">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onSelect}
+        className={twMerge(
+          "group/option flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent",
+          selected ? "bg-accent" : "",
+        )}
+      >
+        <ComposerOptionKeyBadge>{index + 1}</ComposerOptionKeyBadge>
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span
+            className={twMerge(
+              "text-chat leading-[var(--text-chat--line-height)] transition-colors",
+              destructive
+                ? "text-destructive"
+                : selected
+                  ? "text-foreground"
+                  : "text-muted-foreground group-hover/option:text-foreground",
+            )}
+          >
+            {label}
+          </span>
+          {description ? (
+            <span className="text-base leading-4 text-faint">
+              {description}
+            </span>
+          ) : null}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target.isContentEditable
+  );
+}
+
+/**
+ * Number-key (1–9) selection for a visible option list. Skips events while
+ * the user is typing in an input/textarea/contenteditable and events with
+ * modifiers, so plain digits in the chat editor never trigger options.
+ */
+export function useComposerOptionNumberKeys(
+  optionCount: number,
+  onSelectIndex: (index: number) => void,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled || optionCount <= 0) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+      const digit = Number.parseInt(event.key, 10);
+      if (!Number.isInteger(digit) || digit < 1 || digit > Math.min(optionCount, 9)) {
+        return;
+      }
+      event.preventDefault();
+      onSelectIndex(digit - 1);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, onSelectIndex, optionCount]);
+}

--- a/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -96,6 +96,9 @@ export function useComposerOptionNumberKeys(
       return;
     }
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.defaultPrevented) {
+        return;
+      }
       if (event.metaKey || event.ctrlKey || event.altKey) {
         return;
       }

--- a/apps/desktop/src/components/workspace/chat/input/ModelSelector.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ModelSelector.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render as renderBase, screen, waitFor, type RenderOptions } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useNativeOverlayOpen } from "@proliferate/ui/overlays/overlay-presence";
 import type { ModelSelectorGroup } from "@/lib/domain/chat/models/model-selector-types";
@@ -9,8 +11,6 @@ import { ModelSelector } from "./ModelSelector";
 const modelSelectorMenuMock = vi.hoisted(() => {
   const createState = () => ({
     open: false,
-    addProviderOpen: false,
-    setupAgent: null,
     search: "",
     triggerRef: { current: null } as { current: HTMLButtonElement | null },
     menuPos: null as { bottom: number; left: number } | null,
@@ -18,9 +18,6 @@ const modelSelectorMenuMock = vi.hoisted(() => {
     setSearch: vi.fn(),
     handleOpen: vi.fn(),
     handleClose: vi.fn(),
-    toggleAddProvider: vi.fn(),
-    openSetupAgent: vi.fn(),
-    closeSetupAgent: vi.fn(),
   });
 
   return {
@@ -42,6 +39,11 @@ afterEach(() => {
 function NativeOverlayObserver() {
   const open = useNativeOverlayOpen();
   return <div data-testid="native-overlay-state" data-open={String(open)} />;
+}
+
+// ModelSelector navigates to settings via useNavigate, so renders need a Router.
+function render(ui: ReactNode, options?: RenderOptions) {
+  return renderBase(ui, { wrapper: MemoryRouter, ...options });
 }
 
 describe("ModelSelector", () => {

--- a/apps/desktop/src/components/workspace/chat/input/ModelSelector.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ModelSelector.test.tsx
@@ -86,7 +86,6 @@ describe("ModelSelector", () => {
         groups={groups}
         hasAgents
         isLoading={false}
-        notReadyAgents={[]}
         onSelect={vi.fn()}
       />,
     );
@@ -135,7 +134,6 @@ describe("ModelSelector", () => {
         groups={groups}
         hasAgents
         isLoading={false}
-        notReadyAgents={[]}
         onSelect={vi.fn()}
       />,
     );
@@ -188,7 +186,6 @@ describe("ModelSelector", () => {
         groups={groups}
         hasAgents
         isLoading={false}
-        notReadyAgents={[]}
         onSelect={vi.fn()}
       />,
     );
@@ -213,7 +210,6 @@ describe("ModelSelector", () => {
           groups={[]}
           hasAgents
           isLoading={false}
-          notReadyAgents={[]}
           onSelect={vi.fn()}
         />
       </>,
@@ -233,7 +229,6 @@ describe("ModelSelector", () => {
           groups={[]}
           hasAgents
           isLoading={false}
-          notReadyAgents={[]}
           onSelect={vi.fn()}
         />
       </>,
@@ -262,7 +257,6 @@ describe("ModelSelector", () => {
           groups={[]}
           hasAgents
           isLoading={false}
-          notReadyAgents={[]}
           onSelect={vi.fn()}
         />
       </>,

--- a/apps/desktop/src/components/workspace/chat/input/ModelSelector.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ModelSelector.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
 import { CHAT_MODEL_SELECTOR_LABELS } from "@/copy/chat/chat-copy";
+import { buildSettingsHref } from "@/lib/domain/settings/navigation";
 import type {
   ModelSelectorGroup as ModelSelectorGroupData,
   ModelSelectorProps,
   ModelSelectorSelection,
 } from "@/lib/domain/chat/models/model-selector-types";
-import { AgentSetupModal } from "@/components/agents/AgentSetupModal";
 import { FixedPositionLayer } from "@proliferate/ui/layout/FixedPositionLayer";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { POPOVER_FRAME_CLASS, POPOVER_SURFACE_CLASS } from "@proliferate/ui/primitives/PopoverButton";
+import { POPOVER_FRAME_CLASS } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import {
   Check,
@@ -29,13 +30,11 @@ export function ModelSelector({
   groups,
   hasAgents,
   isLoading,
-  notReadyAgents,
   onSelect,
 }: ModelSelectorProps) {
+  const navigate = useNavigate();
   const {
     open,
-    addProviderOpen,
-    setupAgent,
     search,
     triggerRef,
     menuPos,
@@ -43,9 +42,6 @@ export function ModelSelector({
     setSearch,
     handleOpen,
     handleClose,
-    toggleAddProvider,
-    openSetupAgent,
-    closeSetupAgent,
   } = useModelSelectorMenu({ groups });
   const selectorEnabled = connectionState === "healthy" && !isLoading && hasAgents;
   useNativeOverlayRegistration(selectorEnabled && open && menuPos !== null);
@@ -154,40 +150,20 @@ export function ModelSelector({
               <div className="border-t border-border p-1">
                 <PopoverMenuItem
                   density="compact"
-                  onClick={toggleAddProvider}
+                  onClick={() => {
+                    handleClose();
+                    // UX_SPEC §5: add-harness routes to Settings → Agents.
+                    navigate(buildSettingsHref({ section: "agent-authentication" }));
+                  }}
                   icon={<Plus className="size-3.5 shrink-0" />}
-                  label={CHAT_MODEL_SELECTOR_LABELS.addProvider}
+                  label={CHAT_MODEL_SELECTOR_LABELS.addHarness}
                   className="px-2.5 text-muted-foreground hover:text-popover-foreground"
                 />
               </div>
             </div>
-
-            {addProviderOpen && notReadyAgents.length > 0 && (
-              <div className={`absolute bottom-0 left-[calc(18rem+8px)] w-56 ${POPOVER_SURFACE_CLASS}`}>
-                {notReadyAgents.map((agent) => (
-                  <PopoverMenuItem
-                    key={agent.kind}
-                    onClick={() => openSetupAgent(agent)}
-                    density="compact"
-                    icon={<ProviderIcon kind={agent.kind} className="size-3.5 shrink-0 text-muted-foreground" />}
-                    label={agent.displayName}
-                    trailing={<span className="shrink-0 text-xs text-muted-foreground/60">Setup</span>}
-                    className="px-2.5 leading-[18px]"
-                    trailingClassName="size-auto opacity-100"
-                  />
-                ))}
-              </div>
-            )}
           </FixedPositionLayer>
         </>,
         document.body,
-      )}
-
-      {setupAgent && (
-        <AgentSetupModal
-          agent={setupAgent}
-          onClose={closeSetupAgent}
-        />
       )}
     </div>
   );

--- a/apps/desktop/src/components/workspace/chat/input/UserInputCard.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/UserInputCard.test.tsx
@@ -26,6 +26,15 @@ const FREEFORM_ONLY: UserInputQuestion[] = [{
   options: [],
 }];
 
+const SECRET_ONLY: UserInputQuestion[] = [{
+  questionId: "api_key",
+  header: "API key",
+  question: "Paste the API key for the integration.",
+  isOther: false,
+  isSecret: true,
+  options: [],
+}];
+
 describe("UserInputCard", () => {
 
   afterEach(() => {
@@ -106,6 +115,85 @@ describe("UserInputCard", () => {
       questionId: "workspace_name",
       selectedOptionLabel: undefined,
       text: "composer-cleanup",
+    }]);
+  });
+
+  it("renders a multiline textarea where Enter does not submit", () => {
+    const onSubmit = vi.fn<(answers: UserInputSubmittedAnswer[]) => void>();
+    render(
+      <UserInputCard
+        title="Name workspace"
+        questions={FREEFORM_ONLY}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const field = screen.getByPlaceholderText("Enter your answer");
+    expect(field.tagName).toBe("TEXTAREA");
+
+    fireEvent.change(field, {
+      target: { value: "line one\nline two" },
+    });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onSubmit).toHaveBeenCalledWith([{
+      questionId: "workspace_name",
+      selectedOptionLabel: undefined,
+      text: "line one\nline two",
+    }]);
+  });
+
+  it("submits multiline text with Cmd/Ctrl+Enter", () => {
+    const onSubmit = vi.fn<(answers: UserInputSubmittedAnswer[]) => void>();
+    render(
+      <UserInputCard
+        title="Name workspace"
+        questions={FREEFORM_ONLY}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const field = screen.getByPlaceholderText("Enter your answer");
+    fireEvent.change(field, {
+      target: { value: "first line\nsecond line" },
+    });
+    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
+
+    expect(onSubmit).toHaveBeenCalledWith([{
+      questionId: "workspace_name",
+      selectedOptionLabel: undefined,
+      text: "first line\nsecond line",
+    }]);
+  });
+
+  it("keeps secret questions on a single-line password input that submits on Enter", () => {
+    const onSubmit = vi.fn<(answers: UserInputSubmittedAnswer[]) => void>();
+    render(
+      <UserInputCard
+        title="API key"
+        questions={SECRET_ONLY}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const field = screen.getByPlaceholderText("Enter your answer");
+    expect(field.tagName).toBe("INPUT");
+    expect(field).toHaveProperty("type", "password");
+
+    fireEvent.change(field, { target: { value: "sk-secret" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledWith([{
+      questionId: "api_key",
+      selectedOptionLabel: undefined,
+      text: "sk-secret",
     }]);
   });
 });

--- a/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
@@ -1,14 +1,22 @@
 import type { UserInputQuestion, UserInputSubmittedAnswer } from "@anyharness/sdk";
 import { useMemo, useState } from "react";
-import { Button } from "@proliferate/ui/primitives/Button";
+import { ArrowUp } from "@proliferate/ui/icons";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { useActivePendingInteractionState } from "@/hooks/chat/derived/use-active-pending-session-interactions";
 import { useChatUserInputActions } from "@/hooks/chat/workflows/use-chat-user-input-actions";
 import { ComposerAttachedPanel } from "./ComposerAttachedPanel";
+import {
+  ComposerOptionRow,
+  useComposerOptionNumberKeys,
+} from "./ComposerOptionRow";
+
+// Superset-style agent input (UX_SPEC §5): option rows with number-key
+// badges (1–9 selects), an inset free-text row on --control with an inset
+// ring, outline chips for secondary actions, and a circular solid submit.
 
 const OTHER_OPTION_LABEL = "None of the above";
-const BUTTON_CLASSNAME = "rounded-xl px-2.5 text-sm";
+const CHIP_BUTTON_CLASSNAME =
+  "rounded-md border border-input px-3 py-1 text-base font-medium text-muted-foreground transition-colors hover:border-border-heavy hover:text-foreground";
 
 function optionsForQuestion(question: UserInputQuestion) {
   return [
@@ -78,7 +86,7 @@ export function UserInputCard({
         {title}
       </div>
       {progressLabel && (
-        <div className="shrink-0 text-xs text-muted-foreground">
+        <div className="shrink-0 text-base text-faint">
           {progressLabel}
         </div>
       )}
@@ -94,34 +102,14 @@ export function UserInputCard({
       return buildSubmittedAnswer(question, draft);
     }), [drafts, questions]);
 
-  if (!currentQuestion) {
-    return (
-      <ComposerAttachedPanel header={header}>
-        <div className="flex items-center justify-end gap-2 p-3">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className={BUTTON_CLASSNAME}
-            onClick={onCancel}
-          >
-            Cancel
-          </Button>
-        </div>
-      </ComposerAttachedPanel>
-    );
-  }
-
-  const draft = drafts[currentQuestion.questionId] ?? {
+  const options = currentQuestion ? optionsForQuestion(currentQuestion) : [];
+  const draft: UserInputDraft = (currentQuestion && drafts[currentQuestion.questionId]) ?? {
     selectedOptionLabel: null,
     text: "",
   };
-  const options = optionsForQuestion(currentQuestion);
-  const showTextInput = allowsDraftText(currentQuestion, draft);
-  const isFirst = questionIndex === 0;
-  const isLast = questionIndex >= questions.length - 1;
 
   const updateDraft = (patch: Partial<UserInputDraft>) => {
+    if (!currentQuestion) return;
     setDrafts((current) => ({
       ...current,
       [currentQuestion.questionId]: {
@@ -134,132 +122,121 @@ export function UserInputCard({
     }));
   };
 
+  const selectOptionAtIndex = (index: number) => {
+    const option = options[index];
+    if (!option) return;
+    updateDraft({
+      selectedOptionLabel: option.label,
+      text: option.label === OTHER_OPTION_LABEL ? draft.text : "",
+    });
+  };
+
+  useComposerOptionNumberKeys(
+    options.length,
+    selectOptionAtIndex,
+    !!currentQuestion,
+  );
+
+  if (!currentQuestion) {
+    return (
+      <ComposerAttachedPanel header={header}>
+        <div className="flex items-center justify-end gap-2 px-3 pb-3">
+          <button type="button" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </ComposerAttachedPanel>
+    );
+  }
+
+  const showTextInput = allowsDraftText(currentQuestion, draft);
+  const isFirst = questionIndex === 0;
+  const isLast = questionIndex >= questions.length - 1;
+  const handleAdvance = () => {
+    if (isLast) {
+      onSubmit(answers);
+      return;
+    }
+    setQuestionIndex((index) => Math.min(questions.length - 1, index + 1));
+  };
+
   return (
     <ComposerAttachedPanel header={header}>
-      <div className="flex max-h-[min(40vh,360px)] flex-col">
-        <div className="min-h-0 overflow-y-auto p-3 pb-2">
-          <div className="flex flex-col gap-3">
-            <div className="space-y-1">
-              {currentQuestion.header && currentQuestion.header !== title && (
-                <div className="text-sm font-medium text-foreground">
-                  {currentQuestion.header}
+      <div className="flex max-h-[300px] flex-col">
+        <div className="min-h-0 overflow-y-auto px-2">
+          {(currentQuestion.header && currentQuestion.header !== title)
+            || currentQuestion.question ? (
+              <div className="space-y-1 px-1 pb-2">
+                {currentQuestion.header && currentQuestion.header !== title && (
+                  <div className="text-chat font-medium leading-[var(--text-chat--line-height)] text-foreground">
+                    {currentQuestion.header}
+                  </div>
+                )}
+                <div className="text-chat leading-[var(--text-chat--line-height)] text-muted-foreground">
+                  {currentQuestion.question}
                 </div>
-              )}
-              <div className="text-sm text-muted-foreground">
-                {currentQuestion.question}
               </div>
-            </div>
+            ) : null}
 
-            {options.length > 0 && (
-              <div className="flex flex-col gap-2">
-                {options.map((option) => {
-                  const selected = draft.selectedOptionLabel === option.label;
-                  return (
-                    <Button
-                      key={option.label}
-                      type="button"
-                      variant={selected ? "primary" : "secondary"}
-                      size="sm"
-                      className="h-auto justify-start rounded-xl px-3 py-2 text-left"
-                      onClick={() =>
-                        updateDraft({
-                          selectedOptionLabel: option.label,
-                          text: option.label === OTHER_OPTION_LABEL ? draft.text : "",
-                        })}
-                    >
-                      <span className="flex flex-col gap-0.5">
-                        <span>{option.label}</span>
-                        {option.description && (
-                          <span
-                            className={
-                              selected
-                                ? "text-primary-foreground/75"
-                                : "text-muted-foreground"
-                            }
-                          >
-                            {option.description}
-                          </span>
-                        )}
-                      </span>
-                    </Button>
-                  );
-                })}
-              </div>
-            )}
-
-            {showTextInput && (
-              currentQuestion.isSecret ? (
-                <Input
-                  type="password"
-                  value={draft.text}
-                  onChange={(event) =>
-                    updateDraft({ text: event.currentTarget.value })}
-                  placeholder="Enter your answer"
-                  autoComplete="off"
-                  data-telemetry-mask="true"
-                />
-              ) : (
-                <Textarea
-                  value={draft.text}
-                  onChange={(event) =>
-                    updateDraft({ text: event.currentTarget.value })}
-                  placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
-                    ? "Write a custom answer"
-                    : "Enter your answer"}
-                  rows={3}
-                  data-telemetry-mask="true"
-                />
-              )
-            )}
-          </div>
+          {options.map((option, index) => (
+            <ComposerOptionRow
+              key={option.label}
+              index={index}
+              label={option.label}
+              description={option.description}
+              selected={draft.selectedOptionLabel === option.label}
+              onSelect={() => selectOptionAtIndex(index)}
+            />
+          ))}
         </div>
 
-        <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-3 pt-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className={BUTTON_CLASSNAME}
-            onClick={onCancel}
+        {showTextInput && (
+          <form
+            className="mx-2 mb-2 mt-1 flex shrink-0 cursor-text items-center gap-3 rounded-lg bg-surface-control px-2.5 py-2 ring-1 ring-inset ring-input"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleAdvance();
+            }}
           >
+            <Input
+              variant="unstyled"
+              type={currentQuestion.isSecret ? "password" : "text"}
+              value={draft.text}
+              onChange={(event) =>
+                updateDraft({ text: event.currentTarget.value })}
+              placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
+                ? "Write a custom answer"
+                : "Enter your answer"}
+              autoComplete="off"
+              data-telemetry-mask="true"
+              className="flex-1 cursor-text border-0 bg-transparent px-0 py-1 text-chat text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_40%,transparent)] focus:ring-0"
+            />
+          </form>
+        )}
+
+        <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-3 pt-1">
+          <button type="button" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
             Cancel
-          </Button>
+          </button>
           <div className="flex items-center gap-2">
             {!isFirst && (
-              <Button
+              <button
                 type="button"
-                variant="secondary"
-                size="sm"
-                className={BUTTON_CLASSNAME}
+                className={CHIP_BUTTON_CLASSNAME}
                 onClick={() =>
                   setQuestionIndex((index) => Math.max(0, index - 1))}
               >
                 Back
-              </Button>
+              </button>
             )}
-            {isLast ? (
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                className={BUTTON_CLASSNAME}
-                onClick={() => onSubmit(answers)}
-              >
-                Submit
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                className={BUTTON_CLASSNAME}
-                onClick={() =>
-                  setQuestionIndex((index) =>
-                    Math.min(questions.length - 1, index + 1))}
-              >
-                Next
-              </Button>
-            )}
+            <button
+              type="button"
+              aria-label={isLast ? "Submit" : "Next"}
+              onClick={handleAdvance}
+              className="flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-80"
+            >
+              <ArrowUp className="size-3.5" />
+            </button>
           </div>
         </div>
       </div>

--- a/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
@@ -2,6 +2,7 @@ import type { UserInputQuestion, UserInputSubmittedAnswer } from "@anyharness/sd
 import { useMemo, useState } from "react";
 import { ArrowUp } from "@proliferate/ui/icons";
 import { Input } from "@proliferate/ui/primitives/Input";
+import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { useActivePendingInteractionState } from "@/hooks/chat/derived/use-active-pending-session-interactions";
 import { useChatUserInputActions } from "@/hooks/chat/workflows/use-chat-user-input-actions";
 import { ComposerAttachedPanel } from "./ComposerAttachedPanel";
@@ -191,27 +192,49 @@ export function UserInputCard({
         </div>
 
         {showTextInput && (
-          <form
-            className="mx-2 mb-2 mt-1 flex shrink-0 cursor-text items-center gap-3 rounded-lg bg-surface-control px-2.5 py-2 ring-1 ring-inset ring-input"
-            onSubmit={(event) => {
-              event.preventDefault();
-              handleAdvance();
-            }}
-          >
-            <Input
-              variant="unstyled"
-              type={currentQuestion.isSecret ? "password" : "text"}
-              value={draft.text}
-              onChange={(event) =>
-                updateDraft({ text: event.currentTarget.value })}
-              placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
-                ? "Write a custom answer"
-                : "Enter your answer"}
-              autoComplete="off"
-              data-telemetry-mask="true"
-              className="flex-1 cursor-text border-0 bg-transparent px-0 py-1 text-chat text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_40%,transparent)] focus:ring-0"
-            />
-          </form>
+          <div className="mx-2 mb-2 mt-1 flex shrink-0 cursor-text items-start gap-3 rounded-lg bg-surface-control px-2.5 py-2 ring-1 ring-inset ring-input">
+            {currentQuestion.isSecret ? (
+              <Input
+                variant="unstyled"
+                type="password"
+                value={draft.text}
+                onChange={(event) =>
+                  updateDraft({ text: event.currentTarget.value })}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    handleAdvance();
+                  }
+                }}
+                placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
+                  ? "Write a custom answer"
+                  : "Enter your answer"}
+                autoComplete="off"
+                data-telemetry-mask="true"
+                className="flex-1 cursor-text border-0 bg-transparent px-0 py-1 text-chat text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_40%,transparent)] focus:ring-0"
+              />
+            ) : (
+              <Textarea
+                variant="ghost"
+                rows={3}
+                value={draft.text}
+                onChange={(event) =>
+                  updateDraft({ text: event.currentTarget.value })}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                    event.preventDefault();
+                    handleAdvance();
+                  }
+                }}
+                placeholder={draft.selectedOptionLabel === OTHER_OPTION_LABEL
+                  ? "Write a custom answer"
+                  : "Enter your answer"}
+                autoComplete="off"
+                data-telemetry-mask="true"
+                className="flex-1 cursor-text px-0 py-1 text-chat text-foreground placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_40%,transparent)]"
+              />
+            )}
+          </div>
         )}
 
         <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-3 pt-1">

--- a/apps/desktop/src/config/chat.ts
+++ b/apps/desktop/src/config/chat.ts
@@ -1,7 +1,7 @@
 /** Default rem fallback used when computed textarea line-height is unavailable. */
 export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM = 1;
 /** CSS length; keep aligned with the shared ComposerTextarea line-height. */
-export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS = "calc(var(--text-chat, 12px) + 4px)";
+export const CHAT_COMPOSER_INPUT_LINE_HEIGHT_CSS = "calc(var(--text-chat, 12px) + 8px)";
 
 export const WORKSPACE_CHAT_COMPOSER_INPUT = {
   minRows: 2,

--- a/apps/desktop/src/copy/chat/chat-copy.ts
+++ b/apps/desktop/src/copy/chat/chat-copy.ts
@@ -28,5 +28,5 @@ export const CHAT_MODEL_SELECTOR_LABELS = {
   searchPlaceholder: "Search models",
   noMatchPrefix: "No models matching",
   noProviders: "No configured providers. Add one to get started.",
-  addProvider: "Add provider",
+  addHarness: "Add harness",
 } as const;

--- a/apps/desktop/src/copy/chat/chat-copy.ts
+++ b/apps/desktop/src/copy/chat/chat-copy.ts
@@ -27,6 +27,6 @@ export const CHAT_MODEL_SELECTOR_LABELS = {
   newChatHint: "Opens a new chat in this workspace",
   searchPlaceholder: "Search models",
   noMatchPrefix: "No models matching",
-  noProviders: "No configured providers. Add one to get started.",
+  noProviders: "No harnesses yet. Add one to get started.",
   addHarness: "Add harness",
 } as const;

--- a/apps/desktop/src/hooks/agents/derived/use-agent-catalog.ts
+++ b/apps/desktop/src/hooks/agents/derived/use-agent-catalog.ts
@@ -6,7 +6,6 @@ import { useMemo } from "react";
 import type { AgentSummary } from "@anyharness/sdk";
 import {
   getAgentsNeedingSetup,
-  getNotReadyAgents,
   getReadyAgentKinds,
   getReadyAgents,
 } from "@/lib/domain/agents/status";
@@ -25,7 +24,6 @@ export function useAgentCatalog() {
   const derived = useMemo(() => ({
     readyAgents: getReadyAgents(agents),
     agentsNeedingSetup: getAgentsNeedingSetup(agents),
-    notReadyAgents: getNotReadyAgents(agents),
     readyAgentKinds: getReadyAgentKinds(agents),
     installingAgents: agents.filter((agent) => agent.installState === "installing"),
     agentsByKind: new Map(agents.map((agent) => [agent.kind, agent])),

--- a/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
+++ b/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
@@ -69,7 +69,7 @@ export function useChatModelSelectorState(options?: { suppressActiveSessionState
       }
       : null,
   });
-  const { hasAgents, isLoading: agentsLoading, notReadyAgents } = useAgentCatalog();
+  const { hasAgents, isLoading: agentsLoading } = useAgentCatalog();
   const launchControlPreferences = useUserPreferencesStore(useShallow((state) => ({
     defaultSessionModeByAgentKind: state.defaultSessionModeByAgentKind,
     defaultLiveSessionControlValuesByAgentKind:
@@ -212,7 +212,6 @@ export function useChatModelSelectorState(options?: { suppressActiveSessionState
     groups: launchCatalog.groups,
     hasAgents: selectorHasAgents,
     isLoading: selectorIsLoading,
-    notReadyAgents,
     onSelect: handleLaunchSelect,
     launchControls,
     launchAgentKind: currentSelection?.kind ?? null,

--- a/apps/desktop/src/hooks/chat/ui/use-model-selector-menu.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-model-selector-menu.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import type { AgentSummary } from "@anyharness/sdk";
 import {
   filterModelSelectorGroups,
 } from "@/lib/domain/chat/models/model-selector-filtering";
@@ -15,8 +14,6 @@ export function useModelSelectorMenu({
   groups,
 }: UseModelSelectorMenuArgs) {
   const [open, setOpen] = useState(false);
-  const [addProviderOpen, setAddProviderOpen] = useState(false);
-  const [setupAgent, setSetupAgent] = useState<AgentSummary | null>(null);
   const [search, setSearch] = useState("");
   const triggerRef = useRef<HTMLButtonElement>(null);
   const [menuPos, setMenuPos] = useState<{ bottom: number; left: number } | null>(null);
@@ -28,7 +25,6 @@ export function useModelSelectorMenu({
 
   const handleClose = useCallback(() => {
     setOpen(false);
-    setAddProviderOpen(false);
     setSearch("");
   }, []);
 
@@ -42,27 +38,11 @@ export function useModelSelectorMenu({
     }
 
     setOpen((value) => !value);
-    setAddProviderOpen(false);
     setSearch("");
   }, [open]);
 
-  const toggleAddProvider = useCallback(() => {
-    setAddProviderOpen((value) => !value);
-  }, []);
-
-  const openSetupAgent = useCallback((agent: AgentSummary) => {
-    handleClose();
-    setSetupAgent(agent);
-  }, [handleClose]);
-
-  const closeSetupAgent = useCallback(() => {
-    setSetupAgent(null);
-  }, []);
-
   return {
     open,
-    addProviderOpen,
-    setupAgent,
     search,
     triggerRef,
     menuPos,
@@ -70,8 +50,5 @@ export function useModelSelectorMenu({
     setSearch,
     handleOpen,
     handleClose,
-    toggleAddProvider,
-    openSetupAgent,
-    closeSetupAgent,
   };
 }

--- a/apps/desktop/src/hooks/plans/workflows/use-plan-handoff-workflow.ts
+++ b/apps/desktop/src/hooks/plans/workflows/use-plan-handoff-workflow.ts
@@ -56,7 +56,7 @@ export function usePlanHandoffWorkflow({
   const launchCatalog = useChatLaunchCatalog({
     activeSelection: selection ?? configuredLaunch.selection,
   });
-  const { hasAgents, isLoading: agentsLoading, notReadyAgents } = useAgentCatalog();
+  const { hasAgents, isLoading: agentsLoading } = useAgentCatalog();
   const { createEmptySessionWithResolvedConfig } = useSessionCreationActions();
   const { dismissSession } = useSessionDismissActions();
   const { activateChatTab } = useWorkspaceShellActivation();
@@ -98,7 +98,6 @@ export function usePlanHandoffWorkflow({
     groups: launchCatalog.groups,
     hasAgents,
     isLoading: agentsLoading || launchCatalog.isLoading,
-    notReadyAgents,
     onSelect: setSelection,
   }), [
     agentsLoading,
@@ -106,7 +105,6 @@ export function usePlanHandoffWorkflow({
     hasAgents,
     launchCatalog.groups,
     launchCatalog.isLoading,
-    notReadyAgents,
     resolvedConnectionState,
   ]);
 

--- a/apps/desktop/src/lib/domain/agents/status.ts
+++ b/apps/desktop/src/lib/domain/agents/status.ts
@@ -17,10 +17,6 @@ export function getAgentsNeedingSetup(
   );
 }
 
-export function getNotReadyAgents(agents: AgentSummary[]): AgentSummary[] {
-  return agents.filter((agent) => agent.readiness !== "ready");
-}
-
 export function getReadyAgentKinds(agents: AgentSummary[]): Set<string> {
   return new Set(getReadyAgents(agents).map((agent) => agent.kind));
 }

--- a/apps/desktop/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts
+++ b/apps/desktop/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts
@@ -89,7 +89,6 @@ export function createPlaygroundModelSelectorProps(): ModelSelectorProps {
     ],
     hasAgents: true,
     isLoading: false,
-    notReadyAgents: [],
     onSelect: () => undefined,
   };
 }

--- a/apps/desktop/src/lib/domain/chat/models/model-selector-types.ts
+++ b/apps/desktop/src/lib/domain/chat/models/model-selector-types.ts
@@ -1,4 +1,3 @@
-import type { AgentSummary } from "@anyharness/sdk";
 import type { PendingSessionConfigChangeStatus } from "@proliferate/product-domain/sessions/pending-config";
 import type { ChatModelVisibilityOverridesByAgentKind } from "@/lib/domain/preferences/user/session-defaults";
 
@@ -53,6 +52,5 @@ export interface ModelSelectorProps {
   groups: ModelSelectorGroup[];
   hasAgents: boolean;
   isLoading: boolean;
-  notReadyAgents: AgentSummary[];
   onSelect: (selection: ModelSelectorSelection) => void;
 }

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -49,10 +49,13 @@
 
   /* -- Border radius -- */
   --radius: 0.5rem;
-  --radius-composer: 0.5rem; /* ship/tbpn default — conductor-style 8px */
+  --radius-composer: 1rem; /* UX_SPEC §5 — codex 2xl scale, 16px for home + chat */
 
   /* -- Shadows -- */
   --shadow-subtle: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  /* Codex --elevation-prominent minus the 0.5px stroke (the stroke is painted
+     by .chat-composer-surface with the theme border token). */
+  --shadow-composer: 0 3px 7.5px rgb(0 0 0 / 0.04), 0 0 20px rgb(0 0 0 / 0.05);
   --shadow-keystone: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --shadow-floating: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --shadow-floating-dark: 0 25px 50px -12px rgb(0 0 0 / 0.5);
@@ -199,7 +202,7 @@
   --color-composer-control-hover: var(--color-muted);
   --color-composer-send-background: var(--color-foreground);
   --color-composer-send-foreground: var(--color-background);
-  --color-composer-shadow: var(--shadow-subtle);
+  --color-composer-shadow: var(--shadow-composer);
   --color-composer-backdrop-filter: none;
 
   /* -- Prose -- */
@@ -448,8 +451,7 @@ mark.codex-thread-find-active {
   /* -- Typography -- */
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
 
-  /* -- Composer shape (codex-style 24px pill) -- */
-  --radius-composer: 1.5rem;
+  /* -- Composer shape: inherits the 16px spec default (UX_SPEC §5) -- */
 
   /* -- Core -- */
   --color-background: #181818;
@@ -733,9 +735,6 @@ mark.codex-thread-find-active {
 :root[data-theme="original"] {
   /* -- Typography: Manrope as the cross-product font -- */
   --font-sans: "Manrope Variable", Manrope, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-
-  /* -- Composer shape: sharper corner instead of mono's pill -- */
-  --radius-composer: 0.5rem;
 }
 
 /* ========================================================================
@@ -1463,10 +1462,12 @@ mark.codex-thread-find-active {
  * NON-THEME STYLES
  * ======================================================================== */
 
+/* Codex composer chrome (UX_SPEC §5): no border — a 0.5px stroke painted in
+   the shadow stack plus the prominent-elevation shadow pair. */
 .chat-composer-surface {
   background-color: var(--color-composer-background);
   box-shadow:
-    0 0 0 1px var(--color-composer-border),
+    0 0 0 0.5px var(--color-composer-border),
     var(--color-composer-shadow);
   -webkit-backdrop-filter: var(--color-composer-backdrop-filter);
   backdrop-filter: var(--color-composer-backdrop-filter);

--- a/apps/packages/design/src/css/dom.css
+++ b/apps/packages/design/src/css/dom.css
@@ -101,13 +101,38 @@ body {
   );
 }
 
+/* Codex composer chrome (UX_SPEC §5): no border — a 0.5px stroke painted in
+   the shadow stack plus the elevation shadow. */
 .chat-composer-surface {
   background-color: var(--color-composer-background);
   box-shadow:
-    0 0 0 1px var(--color-composer-border),
+    0 0 0 0.5px var(--color-composer-border),
     var(--color-composer-shadow);
   -webkit-backdrop-filter: var(--color-composer-backdrop-filter);
   backdrop-filter: var(--color-composer-backdrop-filter);
+}
+
+/* ---- Streaming text fade (UX_SPEC §13) ----
+   Shared with desktop.css: per-block 200ms opacity fade while streaming;
+   the class is only attached during live streams so history never replays. */
+@keyframes streaming-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-streaming-fade {
+  animation: streaming-fade var(--streaming-fade-duration, 200ms)
+    var(--streaming-fade-easing, cubic-bezier(0.37, 0.55, 0.86, 0.88));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-streaming-fade {
+    animation: none;
+  }
 }
 
 /* ---- Proliferate icon: one-shot resolve animation ---- */

--- a/apps/packages/product-ui/src/chat/composer/ChatComposerControlRowFrame.tsx
+++ b/apps/packages/product-ui/src/chat/composer/ChatComposerControlRowFrame.tsx
@@ -9,13 +9,14 @@ export function ChatComposerControlRowFrame({
   trailing?: ReactNode;
   action: ReactNode;
 }) {
+  // UX_SPEC §5: 28px-tall control row, gap 8px between control clusters.
   return (
-    <div className="mb-2 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-[5px] px-2">
-      <div className="flex min-w-0 items-center gap-[5px]">
+    <div className="mb-2 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-2">
+      <div className="flex min-w-0 items-center gap-1">
         {leading}
       </div>
       <div className="min-w-0" aria-hidden="true" />
-      <div className="flex min-w-0 items-center gap-[5px]">
+      <div className="flex min-w-0 items-center gap-1">
         {trailing}
         {action}
       </div>

--- a/apps/packages/product-ui/src/chat/composer/ChatComposerSurface.tsx
+++ b/apps/packages/product-ui/src/chat/composer/ChatComposerSurface.tsx
@@ -17,7 +17,7 @@ export function ChatComposerSurface({
       {...props}
       data-chat-composer-surface="true"
       className={twMerge(
-        "chat-composer-surface relative flex flex-col rounded-[var(--radius-composer,1.5rem)]",
+        "chat-composer-surface relative flex flex-col rounded-[var(--radius-composer,1rem)]",
         overflowMode === "clip"
           ? "overflow-hidden"
           : overflowMode === "visible"

--- a/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
+++ b/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
@@ -81,7 +81,7 @@ export function CloudChatComposerFooter({
   }
 
   return (
-    <div className="rounded-[var(--radius-composer,1.5rem)] px-2 pt-2">
+    <div className="rounded-[var(--radius-composer,1rem)] px-2 pt-2">
       <div className="flex min-w-0 flex-wrap items-center gap-1">
         {composerControls.map((control) => (
           <CloudChatSingleControl

--- a/apps/packages/product-ui/src/chat/composer/ComposerPopoverSurface.tsx
+++ b/apps/packages/product-ui/src/chat/composer/ComposerPopoverSurface.tsx
@@ -10,11 +10,13 @@ export function ComposerPopoverSurface({
   className = "",
   ...props
 }: ComposerPopoverSurfaceProps) {
+  // Overlay recipe (UX_SPEC §5/§7): popover bg, 0.5px ring, 12px radius,
+  // 4px padding, overlay shadow, backdrop blur.
   return (
     <div
       {...props}
       className={twMerge(
-        "rounded-[18px] border border-border/60 bg-popover/96 p-1.5 text-popover-foreground shadow-floating backdrop-blur-lg",
+        "rounded-xl bg-popover/90 p-1 text-popover-foreground shadow-popover ring-[0.5px] ring-popover-ring backdrop-blur-sm",
         className,
       )}
     >

--- a/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
@@ -178,6 +178,8 @@ export function TranscriptScrollToBottomButton({
   bottomInsetPx: number;
   onClick: () => void;
 }) {
+  // UX_SPEC §6: 32px circle, --background fill, 1px --border, muted arrow,
+  // 150ms opacity fade, floating above the composer.
   return (
     <div
       className="pointer-events-none absolute inset-x-0 z-10 flex justify-center"
@@ -185,17 +187,17 @@ export function TranscriptScrollToBottomButton({
     >
       <Button
         type="button"
-        variant="secondary"
+        variant="ghost"
         size="icon-sm"
         aria-label="Scroll to bottom"
         aria-hidden={!visible}
         tabIndex={visible ? 0 : -1}
         data-chat-transcript-ignore
         onClick={onClick}
-        className={`text-muted-foreground shadow-md transition-[opacity,transform,color] duration-200 hover:text-foreground ${
+        className={`size-8 rounded-full border border-border bg-background text-muted-foreground shadow-none transition-opacity duration-150 ease-in-out hover:bg-background hover:text-foreground ${
           visible
-            ? "pointer-events-auto translate-y-0 opacity-100"
-            : "translate-y-1 opacity-0"
+            ? "pointer-events-auto opacity-100"
+            : "opacity-0"
         }`}
       >
         <ChevronDown className="size-4" />

--- a/apps/packages/ui/src/primitives/ComposerActionButton.tsx
+++ b/apps/packages/ui/src/primitives/ComposerActionButton.tsx
@@ -14,6 +14,8 @@ export const ComposerActionButton = forwardRef<HTMLButtonElement, ComposerAction
     type = "button",
     ...props
   }, ref) {
+    // UX_SPEC §5: 28px solid circle — foreground bg / background glyph,
+    // disabled at 40%.
     return (
       <Button
         ref={ref}
@@ -21,7 +23,7 @@ export const ComposerActionButton = forwardRef<HTMLButtonElement, ComposerAction
         variant="ghost"
         size="icon-sm"
         className={twMerge(
-          "size-7 shrink-0 rounded-full bg-[var(--color-composer-send-background)] px-0 text-[color:var(--color-composer-send-foreground)] shadow-none hover:bg-[var(--color-composer-send-background)] hover:opacity-90 disabled:cursor-default disabled:opacity-50",
+          "size-7 shrink-0 rounded-full bg-[var(--color-composer-send-background)] px-0 text-[color:var(--color-composer-send-foreground)] shadow-none hover:bg-[var(--color-composer-send-background)] hover:opacity-90 disabled:cursor-default disabled:opacity-40",
           className,
         )}
         {...props}

--- a/apps/packages/ui/src/primitives/ComposerControlButton.tsx
+++ b/apps/packages/ui/src/primitives/ComposerControlButton.tsx
@@ -28,9 +28,10 @@ const toneClassNames: Record<ComposerControlTone, { idle: string; active: string
     idle: "text-[color:var(--color-composer-control-foreground)]",
     active: "text-[color:var(--color-composer-control-active-foreground)]",
   },
+  // Plan mode (UX_SPEC §5): the selected plan pill is tinted with --special.
   accent: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
+    idle: "text-[color:var(--color-special)]",
+    active: "text-[color:var(--color-special)]",
   },
   primary: {
     idle: "text-[color:var(--color-composer-control-foreground)]",
@@ -77,7 +78,7 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
     const baseClassName = `gap-1 rounded-full border border-transparent bg-transparent transition-colors hover:bg-[var(--color-composer-control-hover)] hover:text-current focus:outline-none data-[state=open]:bg-[var(--color-composer-control-hover)] ${classes}`;
     const buttonClassName = iconOnly
       ? `h-7 w-7 shrink-0 !justify-center px-0 ${baseClassName} ${className}`
-      : `h-7 min-w-0 max-w-full !justify-start px-2 py-0 text-left text-sm leading-[18px] ${baseClassName} ${className}`;
+      : `h-7 min-w-0 max-w-full !justify-start px-2 py-0 text-left text-base leading-[18px] ${baseClassName} ${className}`;
     const iconOnlyLabel = typeof label === "string"
       ? label
       : typeof props["aria-label"] === "string"
@@ -100,8 +101,9 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
           <span className="flex min-w-0 items-center gap-1">
             <span className={`min-w-0 truncate text-left ${labelClassName}`}>{label}</span>
             {detail && (
-              <span className={`truncate text-left text-[color:var(--color-composer-control-muted-foreground)] ${detailClassName}`}>
-                {detail}
+              <span className={`flex min-w-0 items-center gap-1 truncate text-left text-[color:var(--color-composer-control-muted-foreground)] ${detailClassName}`}>
+                <span aria-hidden="true" className="shrink-0">·</span>
+                <span className="min-w-0 truncate">{detail}</span>
               </span>
             )}
           </span>

--- a/apps/packages/ui/src/primitives/ComposerTextarea.tsx
+++ b/apps/packages/ui/src/primitives/ComposerTextarea.tsx
@@ -3,8 +3,10 @@ import { Textarea } from "./Textarea";
 
 type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
+// UX_SPEC §5: chat-scale text with codex's font+8 leading, placeholder
+// --muted-foreground at 75%.
 const COMPOSER_TEXTAREA_CLASSNAME =
-  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:var(--text-chat,12px)] leading-[calc(var(--text-chat,12px)+4px)] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-faint)_50%,transparent)] focus:ring-0";
+  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-[length:var(--text-chat,12px)] leading-[calc(var(--text-chat,12px)+8px)] text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_75%,transparent)] focus:ring-0";
 
 export const ComposerTextarea = forwardRef<HTMLTextAreaElement, ComposerTextareaProps>(
   function ComposerTextarea({ className = "", ...props }, ref) {

--- a/apps/packages/ui/src/primitives/ComposerTextareaFrame.tsx
+++ b/apps/packages/ui/src/primitives/ComposerTextareaFrame.tsx
@@ -18,7 +18,8 @@ export function ComposerTextareaFrame({
     <div
       {...props}
       className={twMerge(
-        "mb-1 flex-grow select-text px-4",
+        // UX_SPEC §5: input area px-12.
+        "mb-1 flex-grow select-text px-3",
         topInset === "standard" ? "pt-3" : "",
         className,
       )}

--- a/apps/web/src/components/chat/screen/CloudChatWorkspaceLoadingState.tsx
+++ b/apps/web/src/components/chat/screen/CloudChatWorkspaceLoadingState.tsx
@@ -56,7 +56,7 @@ export function CloudChatWorkspaceLoadingState({
       </div>
 
       <footer className="relative z-20 shrink-0 border-t border-border/40 px-6 py-4">
-        <div className="mx-auto w-full max-w-3xl rounded-[var(--radius-composer,1.5rem)] bg-foreground/5 p-3">
+        <div className="mx-auto w-full max-w-3xl rounded-[var(--radius-composer,1rem)] bg-foreground/5 p-3">
           <SkeletonBlock className="h-3 w-44 bg-muted/45" />
           <div className="mt-5 flex items-center justify-between gap-3" aria-hidden="true">
             <SkeletonBlock className="h-7 w-28 rounded-full bg-muted/35" />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,5 +1,6 @@
 @import "@proliferate/design/dom.css";
 
 :root {
-  --radius-composer: 1.5rem;
+  /* UX_SPEC §5: 16px composer radius (matches desktop). */
+  --radius-composer: 1rem;
 }


### PR DESCRIPTION
## What

Wave 3a of the UX overhaul (stacked on #811), per `design-system/UX_SPEC.md` §5/§6/§13. Composer is the centerpiece per the owner's steer; transcript gets polish, not a rebuild.

### Composer (§5)
- **16px radius** as the single `--radius-composer` default (mono's 24px pill and original's 8px removed); Codex elevation recipe — 0.5px stroke ring + mined `--shadow-composer`
- Input leading font+8, placeholder muted@75%; control row 8px cluster gap; model pill gains Codex's `{model} · {effort}` dot separator; plan-mode gets the `--special` tint
- Model menu on THE overlay recipe (popover/90, 12px radius, blur) with Superset-style inset search
- **"Add harness" now links out** to Settings → Agents instead of opening a modal (AgentSetupModal path removed from the composer)
- Send/stop: 28px solid circle

### Approval / input states (Superset pattern)
- New `ComposerOptionRow`: 24px mono number-key badges, hairline separators, 1–9 keyboard selection (skips typing targets)
- `ApprovalCard` + `UserInputCard` rebuilt on it — destructive kinds in `--danger`, inset free-text row, circular submit. State machines untouched; existing tests pass unmodified

### Transcript polish (§13)
- Thinking shimmer = the Codex `loading-shimmer` port: text-clipped gradient, `steps(48,end)` 2s, dims (not glows) in dark mode, reduced-motion fallback
- Streaming fade: 200ms opacity-only with Codex's easing, shared via dom.css; post-stream zeroing untouched (existing gating in AssistantMessage)
- Scroll-to-bottom pill per spec

Home shares the same composer components, so all of this flows to home automatically.

### Deliberately skipped
Context meter/dictate (new features), plan-card re-anatomy, tool-row rebuild (steer: refine, don't rebuild), and zero edits to the transcript-logic files with in-flight behavior work elsewhere.

## Verification
- ui + product-ui + design builds clean; desktop + web `tsc` 0 errors; `check:design` passes
- Desktop chat suites 140/140; ui 8/8. Pre-existing failures verified identical on stashed baseline (CloudChatComposer tooltip x2, playground QueryClient x2)

## pdev notes
Eyeball: composer chrome on ship-light + mono-dark (mono lost its 24px pill — confirm 16px feels right); an approval prompt (number badges, 1–9 keys); the thinking shimmer cadence; "Add harness" jumping to settings; the slightly taller textarea lines.

Stack: #810 ← #811 ← this (parallel to #812, 3b, 3c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)