### PR TITLE
feat(agent-auth): add LiteLLM gateway service and admin client

### DIFF
--- a/.github/workflows/_deploy-litellm.yml
+++ b/.github/workflows/_deploy-litellm.yml
@@ -1,0 +1,243 @@
+# Deploys the LiteLLM agent-gateway proxy as a separate ECS Fargate service
+# in the same cluster as the server.
+#
+# Prerequisites (managed out-of-band, like the server's RDS instance):
+#   - A dedicated RDS Postgres instance for LiteLLM key/spend state.
+#   - The ECS service + an initial task definition already registered
+#     (this workflow re-renders the latest task definition; it does not
+#     create the service).
+#
+# Required GitHub environment configuration:
+#   vars:    AWS_DEPLOY_ROLE_ARN, ECS_CLUSTER, ECS_LITELLM_SERVICE,
+#            ECS_LITELLM_CONTAINER_NAME (default: litellm),
+#            ECR_LITELLM_REPOSITORY (default: proliferate-litellm),
+#            LITELLM_DEPLOY_ENABLED (set "true" once the RDS + ECS service exist)
+#   secrets: LITELLM_DATABASE_URL, LITELLM_MASTER_KEY,
+#            AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY,
+#            AGENT_GATEWAY_MANAGED_OPENAI_API_KEY
+name: Deploy LiteLLM
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      git_sha:
+        required: true
+        type: string
+      enabled:
+        default: true
+        type: boolean
+    outputs:
+      image_uri:
+        value: ${{ jobs.deploy.outputs.image_uri }}
+      task_definition_arn:
+        value: ${{ jobs.deploy.outputs.task_definition_arn }}
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    if: ${{ inputs.enabled }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    outputs:
+      image_uri: ${{ steps.image.outputs.image_uri }}
+      task_definition_arn: ${{ steps.task.outputs.task_definition_arn }}
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_DEPLOY_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      ECR_LITELLM_REPOSITORY: ${{ vars.ECR_LITELLM_REPOSITORY || 'proliferate-litellm' }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_LITELLM_SERVICE: ${{ vars.ECS_LITELLM_SERVICE }}
+      ECS_LITELLM_CONTAINER_NAME: ${{ vars.ECS_LITELLM_CONTAINER_NAME || 'litellm' }}
+      LITELLM_DEPLOY_ENABLED: ${{ vars.LITELLM_DEPLOY_ENABLED || 'false' }}
+      LITELLM_DATABASE_URL: ${{ secrets.LITELLM_DATABASE_URL }}
+      LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+      AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY: ${{ secrets.AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY }}
+      AGENT_GATEWAY_MANAGED_OPENAI_API_KEY: ${{ secrets.AGENT_GATEWAY_MANAGED_OPENAI_API_KEY }}
+      DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+      GIT_SHA: ${{ inputs.git_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_sha }}
+
+      - name: Check LiteLLM deploy switch
+        id: switch
+        run: |
+          set -euo pipefail
+          if [[ "$LITELLM_DEPLOY_ENABLED" != "true" ]]; then
+            echo "LITELLM_DEPLOY_ENABLED is not true for this environment; skipping LiteLLM deploy."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate LiteLLM deploy config
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        run: |
+          set -euo pipefail
+          : "${AWS_DEPLOY_ROLE_ARN:?Set AWS_DEPLOY_ROLE_ARN on the GitHub environment.}"
+          : "${ECS_CLUSTER:?Set ECS_CLUSTER on the GitHub environment.}"
+          : "${ECS_LITELLM_SERVICE:?Set ECS_LITELLM_SERVICE on the GitHub environment.}"
+          : "${LITELLM_DATABASE_URL:?Set the LITELLM_DATABASE_URL secret on the GitHub environment.}"
+          : "${LITELLM_MASTER_KEY:?Set the LITELLM_MASTER_KEY secret on the GitHub environment.}"
+          : "${AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY:?Set the AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY secret on the GitHub environment.}"
+          : "${AGENT_GATEWAY_MANAGED_OPENAI_API_KEY:?Set the AGENT_GATEWAY_MANAGED_OPENAI_API_KEY secret on the GitHub environment.}"
+
+      - name: Configure AWS credentials
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Resolve image URI
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        id: image
+        run: |
+          set -euo pipefail
+          short_sha="${GIT_SHA:0:12}"
+          image_uri="${{ steps.ecr.outputs.registry }}/${ECR_LITELLM_REPOSITORY}:${short_sha}"
+          echo "image_uri=$image_uri" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push LiteLLM image
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: server/litellm/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image_uri }}
+            ${{ steps.ecr.outputs.registry }}/${{ env.ECR_LITELLM_REPOSITORY }}:${{ inputs.environment }}-latest
+
+      - name: Render ECS task definition
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        id: task
+        run: |
+          set -euo pipefail
+          task_definition_arn="$(
+            aws ecs describe-services \
+              --cluster "$ECS_CLUSTER" \
+              --services "$ECS_LITELLM_SERVICE" \
+              --query 'services[0].taskDefinition' \
+              --output text
+          )"
+          test "$task_definition_arn" != "None"
+
+          aws ecs describe-task-definition \
+            --task-definition "$task_definition_arn" \
+            --query taskDefinition \
+            > task-definition.raw.json
+
+          parameter_prefix="/proliferate/${DEPLOY_ENVIRONMENT}/litellm"
+          aws ssm put-parameter --name "${parameter_prefix}/database-url" \
+            --type SecureString --value "$LITELLM_DATABASE_URL" --overwrite >/dev/null
+          aws ssm put-parameter --name "${parameter_prefix}/master-key" \
+            --type SecureString --value "$LITELLM_MASTER_KEY" --overwrite >/dev/null
+          aws ssm put-parameter --name "${parameter_prefix}/anthropic-api-key" \
+            --type SecureString --value "$AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY" --overwrite >/dev/null
+          aws ssm put-parameter --name "${parameter_prefix}/openai-api-key" \
+            --type SecureString --value "$AGENT_GATEWAY_MANAGED_OPENAI_API_KEY" --overwrite >/dev/null
+
+          jq -n \
+            '[]' > env-updates.json
+
+          jq -n \
+            --arg prefix "$parameter_prefix" \
+            '[
+              {"name":"DATABASE_URL","valueFrom":($prefix + "/database-url")},
+              {"name":"LITELLM_MASTER_KEY","valueFrom":($prefix + "/master-key")},
+              {"name":"ANTHROPIC_API_KEY","valueFrom":($prefix + "/anthropic-api-key")},
+              {"name":"OPENAI_API_KEY","valueFrom":($prefix + "/openai-api-key")}
+            ]' > secret-updates.json
+
+          jq \
+            --arg container "$ECS_LITELLM_CONTAINER_NAME" \
+            --arg image "${{ steps.image.outputs.image_uri }}" \
+            --slurpfile updates env-updates.json \
+            --slurpfile secret_updates secret-updates.json \
+            '
+              def merge_environment($updates):
+                (.environment // []) as $current
+                | ($updates[0] | map(.name)) as $updated_names
+                | ["DATABASE_URL", "LITELLM_MASTER_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"] as $secret_names
+                | ($current | map(select(
+                    .name as $name
+                    | ($updated_names | index($name) | not)
+                    and ($secret_names | index($name) | not)
+                  ))) + $updates[0];
+
+              def merge_secrets($updates):
+                (.secrets // []) as $current
+                | ($updates[0] | map(.name)) as $updated_names
+                | ($current | map(select(.name as $name | ($updated_names | index($name) | not)))) + $updates[0];
+
+              del(
+                .taskDefinitionArn,
+                .revision,
+                .status,
+                .requiresAttributes,
+                .compatibilities,
+                .registeredAt,
+                .registeredBy
+              )
+              | .containerDefinitions |= map(
+                  if .name == $container then
+                    .image = $image
+                    | .environment = merge_environment($updates)
+                    | .secrets = merge_secrets($secret_updates)
+                  else
+                    .
+                  end
+                )
+            ' task-definition.raw.json > task-definition.json
+
+          new_task_definition_arn="$(
+            aws ecs register-task-definition \
+              --cli-input-json file://task-definition.json \
+              --query 'taskDefinition.taskDefinitionArn' \
+              --output text
+          )"
+          echo "task_definition_arn=$new_task_definition_arn" >> "$GITHUB_OUTPUT"
+
+      - name: Roll ECS service
+        if: ${{ steps.switch.outputs.deploy == 'true' }}
+        run: |
+          set -euo pipefail
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_LITELLM_SERVICE" \
+            --task-definition "${{ steps.task.outputs.task_definition_arn }}" \
+            --force-new-deployment \
+            > /tmp/service-update.json
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_LITELLM_SERVICE"
+
+      - name: Summarize LiteLLM deploy
+        if: always()
+        run: |
+          {
+            echo "### LiteLLM"
+            echo "- Environment: $DEPLOY_ENVIRONMENT"
+            echo "- Deploy switch: \`$LITELLM_DEPLOY_ENABLED\`"
+            if [[ "${{ steps.switch.outputs.deploy }}" == "true" ]]; then
+              echo "- Image: \`${{ steps.image.outputs.image_uri }}\`"
+              echo "- Task definition: \`${{ steps.task.outputs.task_definition_arn }}\`"
+              echo "- Service: \`$ECS_CLUSTER/$ECS_LITELLM_SERVICE\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,6 +46,7 @@ jobs:
       dry_run: ${{ steps.meta.outputs.dry_run }}
       server: ${{ steps.detect.outputs.server }}
       workers: ${{ steps.detect.outputs.workers }}
+      litellm: ${{ steps.detect.outputs.litellm }}
       e2b: ${{ steps.detect.outputs.e2b }}
       web: ${{ steps.detect.outputs.web }}
       mobile: ${{ steps.detect.outputs.mobile }}
@@ -164,6 +165,7 @@ jobs:
             echo "| --- | --- |"
             echo "| server | \`${{ steps.detect.outputs.server }}\` |"
             echo "| workers | \`${{ steps.detect.outputs.workers }}\` |"
+            echo "| litellm | \`${{ steps.detect.outputs.litellm }}\` |"
             echo "| e2b | \`${{ steps.detect.outputs.e2b }}\` |"
             echo "| web | \`${{ steps.detect.outputs.web }}\` |"
             echo "| mobile | \`${{ steps.detect.outputs.mobile }}\` |"
@@ -201,6 +203,16 @@ jobs:
       environment: staging
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.workers == 'true' }}
+    secrets: inherit
+
+  deploy-litellm:
+    needs: [plan]
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.plan.outputs.head_sha }}
+      enabled: ${{ needs.plan.outputs.litellm == 'true' }}
     secrets: inherit
 
   deploy-web:
@@ -244,6 +256,7 @@ jobs:
       - deploy-e2b
       - deploy-server
       - deploy-workers
+      - deploy-litellm
       - deploy-web
       - deploy-mobile
       - deploy-desktop
@@ -263,6 +276,7 @@ jobs:
             echo "- E2B: \`${{ needs.deploy-e2b.result }}\`"
             echo "- Server: \`${{ needs.deploy-server.result }}\`"
             echo "- Workers: \`${{ needs.deploy-workers.result }}\`"
+            echo "- LiteLLM: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Web: \`${{ needs.deploy-web.result }}\`"
             echo "- Mobile: \`${{ needs.deploy-mobile.result }}\`"
             echo "- Desktop: \`${{ needs.deploy-desktop.result }}\`"

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -47,6 +47,7 @@ jobs:
       dry_run: ${{ steps.meta.outputs.dry_run }}
       server: ${{ steps.detect.outputs.server }}
       workers: ${{ steps.detect.outputs.workers }}
+      litellm: ${{ steps.detect.outputs.litellm }}
       e2b: ${{ steps.detect.outputs.e2b }}
       web: ${{ steps.detect.outputs.web }}
       mobile: ${{ steps.detect.outputs.mobile }}
@@ -134,6 +135,7 @@ jobs:
             echo "| --- | --- |"
             echo "| server | \`${{ steps.detect.outputs.server }}\` |"
             echo "| workers | \`${{ steps.detect.outputs.workers }}\` |"
+            echo "| litellm | \`${{ steps.detect.outputs.litellm }}\` |"
             echo "| e2b | \`${{ steps.detect.outputs.e2b }}\` |"
             echo "| web | \`${{ steps.detect.outputs.web }}\` |"
             echo "| mobile | \`${{ steps.detect.outputs.mobile }}\` |"
@@ -171,6 +173,16 @@ jobs:
       environment: production
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.workers == 'true' }}
+    secrets: inherit
+
+  deploy-litellm:
+    needs: [plan]
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.plan.outputs.head_sha }}
+      enabled: ${{ needs.plan.outputs.litellm == 'true' }}
     secrets: inherit
 
   deploy-web:
@@ -214,6 +226,7 @@ jobs:
       - promote-e2b
       - deploy-server
       - deploy-workers
+      - deploy-litellm
       - deploy-web
       - deploy-mobile
       - deploy-desktop
@@ -233,6 +246,7 @@ jobs:
             echo "- E2B: \`${{ needs.promote-e2b.result }}\`"
             echo "- Server: \`${{ needs.deploy-server.result }}\`"
             echo "- Workers: \`${{ needs.deploy-workers.result }}\`"
+            echo "- LiteLLM: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Web: \`${{ needs.deploy-web.result }}\`"
             echo "- Mobile: \`${{ needs.deploy-mobile.result }}\`"
             echo "- Desktop: \`${{ needs.deploy-desktop.result }}\`"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ LOCAL_REDIS_PORT ?= 6379
 USE_EXISTING_REDIS ?= 0
 STRIPE_FORWARD_TO ?= http://127.0.0.1:8000/v1/billing/webhooks/stripe
 STRIPE_SNAPSHOT_EVENTS ?= checkout.session.completed,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.paid,invoice.payment_failed
+AGENT_GATEWAY ?= 0
+LOCAL_LITELLM_BASE_URL ?= http://127.0.0.1:14000
+LOCAL_LITELLM_MASTER_KEY ?= sk-proliferate-local-dev
 CLOUD_WORKER_TUNNEL ?= 0
 AUTH_PROFILE ?=
 SSO_STATUS ?= enabled
@@ -96,7 +99,8 @@ endif
 endif
 
 .PHONY: catalog-view catalog-pin catalog-update setup run dev dev-init dev-list dev-local dev-desktop dev-runtime dev-server dev-mobile-auth dev-mobile-tunnel dev-web-auth seed-sso server-db-up server-db-wait \
-        server-db-down server-db-ready server-redis-up server-redis-wait server-redis-down server-redis-ready db db-local db-ah server-migrate serve install \
+        server-db-down server-db-ready server-redis-up server-redis-wait server-redis-down server-redis-ready \
+        server-litellm-up server-litellm-wait server-litellm-down db db-local db-ah server-migrate serve install \
         check check-max-lines check-server-boundaries test test-server fmt clippy \
         dev-automation-worker \
         sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build rebuild \
@@ -231,6 +235,32 @@ run: dev-artifacts-ready
 	fi; \
 	if [ "$$use_profile_db" = "1" ]; then \
 		$(PROFILE_DB_ENSURE_COMMAND) \
+	fi; \
+	agent_gateway_mode="$(AGENT_GATEWAY)"; \
+	if [ "$$agent_gateway_mode" = "1" ] || [ "$$agent_gateway_mode" = "litellm" ]; then \
+		export AGENT_GATEWAY_ENABLED=true; \
+		export AGENT_GATEWAY_LITELLM_BASE_URL="$${AGENT_GATEWAY_LITELLM_BASE_URL:-$(LOCAL_LITELLM_BASE_URL)}"; \
+		export AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL="$${AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL:-$$AGENT_GATEWAY_LITELLM_BASE_URL}"; \
+		if [ -z "$${LITELLM_MASTER_KEY:-}" ] && [ -z "$${AGENT_GATEWAY_LITELLM_MASTER_KEY:-}" ]; then \
+			case "$$AGENT_GATEWAY_LITELLM_BASE_URL" in \
+				*127.0.0.1*|*localhost*) \
+					echo "WARNING: LITELLM_MASTER_KEY unset; booting the local LiteLLM proxy with the well-known dev default ($(LOCAL_LITELLM_MASTER_KEY)). Set LITELLM_MASTER_KEY for anything shared." >&2; \
+					export LITELLM_MASTER_KEY="$(LOCAL_LITELLM_MASTER_KEY)"; \
+					;; \
+				*) \
+					echo "ERROR: AGENT_GATEWAY_LITELLM_BASE_URL=$$AGENT_GATEWAY_LITELLM_BASE_URL is not local but LITELLM_MASTER_KEY/AGENT_GATEWAY_LITELLM_MASTER_KEY are unset. Refusing to boot with a default master key. Set the master key explicitly." >&2; \
+					exit 1; \
+					;; \
+			esac; \
+		fi; \
+		export LITELLM_MASTER_KEY="$${LITELLM_MASTER_KEY:-$(LOCAL_LITELLM_MASTER_KEY)}"; \
+		export AGENT_GATEWAY_LITELLM_MASTER_KEY="$${AGENT_GATEWAY_LITELLM_MASTER_KEY:-$$LITELLM_MASTER_KEY}"; \
+		make server-litellm-up; \
+		make server-litellm-wait; \
+		echo "Agent gateway LiteLLM enabled: admin $$AGENT_GATEWAY_LITELLM_BASE_URL, public $$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL"; \
+	elif [ "$$agent_gateway_mode" != "0" ]; then \
+		echo "Unsupported AGENT_GATEWAY=$$agent_gateway_mode. Use 0, 1, or litellm."; \
+		exit 1; \
 	fi; \
 	(cd server && DATABASE_URL="$$DATABASE_URL" .venv/bin/alembic upgrade head); \
 	stripe_listener_ready=0; \
@@ -425,6 +455,31 @@ server-redis-wait:
 
 server-redis-down:
 	@docker compose -f server/docker-compose.yml stop redis
+
+server-litellm-up:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "Docker is required for the local LiteLLM gateway. Install or start Docker and retry."; \
+		exit 1; \
+	}
+	@docker info >/dev/null 2>&1 || { \
+		echo "Docker is not running. Start Docker Desktop and retry."; \
+		exit 1; \
+	}
+	@docker compose -f server/docker-compose.yml up -d litellm
+
+server-litellm-wait:
+	@attempts=0; \
+	until curl -fsS "$(LOCAL_LITELLM_BASE_URL)/health/liveliness" >/dev/null 2>&1; do \
+		attempts=$$((attempts + 1)); \
+		if [ $$attempts -ge 30 ]; then \
+			echo "Local LiteLLM did not become ready. Check \`docker compose -f server/docker-compose.yml logs litellm\`."; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+
+server-litellm-down:
+	@docker compose -f server/docker-compose.yml stop litellm litellm-db
 
 server-redis-ready:
 ifeq ($(USE_EXISTING_REDIS),1)

--- a/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
+++ b/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
@@ -1,0 +1,59 @@
+# Harness ↔ LiteLLM Compatibility Matrix (live-verified, LiteLLM main-stable)
+
+## claude (Claude Code CLI) — WORKS
+Recipe:
+  env -u ANTHROPIC_API_KEY -u CLAUDE_CODE_USE_BEDROCK \
+    CLAUDE_CONFIG_DIR=<isolated> \
+    ANTHROPIC_BASE_URL=http://<proxy> \
+    ANTHROPIC_AUTH_TOKEN=<virtual-key> \
+    claude -p "..." --model claude-haiku-4-5-20251001
+- Endpoints observed: POST /v1/messages?beta=true (repeated), count_tokens variants. Streaming + tool calls (Bash) verified end-to-end via proxy.
+- CRITICAL: adapter must UNSET/override CLAUDE_CODE_USE_BEDROCK, AWS_BEARER_TOKEN_BEDROCK, CLAUDE_CODE_USE_VERTEX and ANTHROPIC_API_KEY — ambient provider env silently reroutes the CLI (observed: requests went to bedrock-runtime.us-east-1 despite ANTHROPIC_BASE_URL, and the "400 invalid model" came from Bedrock, not the proxy).
+- Versioned model ids (claude-haiku-4-5-20251001) required in proxy model_list; CLI sends versioned ids. Alias entries additionally useful for humans.
+- One transient 400 on first /v1/messages?beta=true observed (likely small-fast model id claude-3-5-haiku-* not in config) — add ANTHROPIC_SMALL_FAST_MODEL=<gateway model> or include the small-model id in config; verify in PR6.
+
+## codex (Codex CLI) — WORKS (incl. anthropic upstream!)
+Recipe:
+  CODEX_HOME=<isolated> with config.toml:
+    model_provider = "proliferate"
+    model = "<default model>"
+    [model_providers.proliferate]
+    name = "Proliferate Gateway"
+    base_url = "http://<proxy>/v1"
+    env_key = "PROLIFERATE_GATEWAY_KEY"
+    wire_api = "responses"
+  env: PROLIFERATE_GATEWAY_KEY=<vk>; sanitize OPENAI_API_KEY/ANTHROPIC_API_KEY.
+  codex exec -m claude-haiku-4-5-20251001 --skip-git-repo-check "..."
+- LiteLLM main-stable SERVES /v1/responses and translates it to anthropic upstream: plain completion AND a shell tool call both succeeded (verified "codex_tool_ok" run → DONE; endpoints: POST /v1/responses 200s).
+- The spec's feared "Unsupported tool type: namespace"/client_metadata errors did NOT reproduce on current LiteLLM — the /v1/responses bridge appears to have matured. Codex-on-gateway is NOT OpenAI-only.
+- codex exec without --skip-git-repo-check hangs outside a git repo — adapters must pass it or run in a repo.
+- gpt-5-mini upstream test blocked by an invalid OPENAI_API_KEY in the dev .env (upstream 401) — openai-family path unverified here, but it's the native wire format (low risk).
+
+## opencode — WORKS
+Recipe (opencode.json in workdir; XDG_CONFIG_HOME/XDG_DATA_HOME isolated):
+  {"provider":{"proliferate":{"npm":"@ai-sdk/openai-compatible","options":{"baseURL":"http://<proxy>/v1","apiKey":"{env:PROLIFERATE_GATEWAY_KEY}"},"models":{"claude-haiku-4-5-20251001":{}}}}}
+  opencode run -m proliferate/claude-haiku-4-5-20251001 "..."
+- Endpoint: POST /v1/chat/completions 200. Explicit models map REQUIRED (confirms spec).
+- CLI process lingers after completion (server keeps running) — headless runners need a timeout/kill; the completion itself returned in ~2s.
+- Title-gen uses the same model (small=true agent=title observed) — no extra alias needed.
+
+## grok — WORKS
+Recipe:
+  HOME=<isolated> GROK_MODELS_BASE_URL=http://<proxy>/v1 XAI_API_KEY=<vk> grok -p "..." -m grok-4-fast
+- Endpoints: GET /v1/models (dynamic discovery — confirms spec), then POST /v1/chat/completions 200.
+- grok-named aliases mapped to anthropic upstream work fine (CLI doesn't care about upstream provider).
+- grok-build alias was pre-added; no separate grok-build call observed in this single-turn run — likely interactive/title-gen only; keep the alias in gateway config anyway (cheap).
+
+## gemini — PARTIAL (works via facade; alias-to-anthropic broken; needs real Google upstream)
+- LiteLLM genai facade route: POST /v1beta/models/<model>:generateContent with x-goog-api-key: <vk> — WORKS (200, correct genai response shape). NOTE: /gemini/v1beta/... 500s; use the ROOT /v1beta path.
+- gemini CLI recipe that reaches the proxy: HOME=<isolated> + ~/.gemini/settings.json {"security":{"auth":{"selectedType":"gemini-api-key"}}} + GEMINI_CLI_TRUST_WORKSPACE=true + GOOGLE_GEMINI_BASE_URL=http://<proxy> + GEMINI_API_KEY=<vk>. CLI calls streamGenerateContent on gemini-3.5-flash (its default; -m respected).
+- FAILS only because our test aliases gemini→anthropic upstream: the genai→anthropic translation sends temperature+top_p together (Anthropic rejects; litellm drop_params does not fix this path). With a REAL Google upstream key (prod managed pool) this translation never happens → expected to work. Action: managed config must include real gemini upstream models; do not alias gemini to other providers.
+
+## Attribution & metadata
+- Spend logs: per-request rows with api_key = mint-time token_id; key_alias in metadata.user_api_key_alias; team_id present when key is team-scoped. Per-key attribution confirmed for claude/codex/opencode/grok runs.
+- Sandboxes/adapters can rely on key-granularity attribution; request-level tags via body metadata worked in earlier probing (metadata.tags accepted on /v1/chat/completions).
+
+## Spec §4 corrections (vs agent-auth-litellm.md)
+1. Codex: REMOVE the "OpenAI-family only" risk — LiteLLM /v1/responses bridges to anthropic correctly now (tool calls included). wire_api="responses" is the right setting; adapter must add --skip-git-repo-check for exec mode. `codex login --with-api-key` is NOT needed when env_key is set in provider config.
+2. Claude: the adapter MUST sanitize ambient provider env (CLAUDE_CODE_USE_BEDROCK, AWS_BEARER_TOKEN_BEDROCK, CLAUDE_CODE_USE_VERTEX, ANTHROPIC_API_KEY) — ambient Bedrock env silently reroutes and produces misleading errors. Proxy config needs VERSIONED model ids (CLI sends claude-haiku-4-5-20251001 style), plus consider ANTHROPIC_SMALL_FAST_MODEL for the sidecar small-model calls.
+3. Gemini: gateway route works via ROOT /v1beta genai facade (not /gemini prefix); gemini CLI needs selectedType=gemini-api-key settings + GEMINI_CLI_TRUST_WORKSPACE=true; managed pool must carry a real Google upstream (cross-provider aliasing breaks on temperature/top_p).

--- a/scripts/agent-gateway-smoke/README.md
+++ b/scripts/agent-gateway-smoke/README.md
@@ -1,0 +1,101 @@
+# Agent Gateway Smoke Harness
+
+End-to-end checks against a LiteLLM agent-gateway deployment: proxy health,
+virtual-key mint, per-key model list, one chat completion, and spend-log
+visibility, followed by per-harness CLI runs (claude, codex, opencode, grok,
+gemini) that each drive the real CLI through the gateway.
+
+## Usage
+
+```sh
+# Against the local docker-compose gateway
+# (docker compose -f server/docker-compose.yml up -d litellm, or make dev AGENT_GATEWAY=litellm)
+AGENT_GATEWAY_LITELLM_MASTER_KEY=sk-proliferate-local-dev \
+  ./scripts/agent-gateway-smoke/run.sh
+
+# Against staging
+AGENT_GATEWAY_LITELLM_BASE_URL=https://llm.staging.example \
+AGENT_GATEWAY_LITELLM_MASTER_KEY=... \
+  ./scripts/agent-gateway-smoke/run.sh
+```
+
+## Configuration
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `AGENT_GATEWAY_LITELLM_BASE_URL` | `http://127.0.0.1:14000` | Proxy base URL |
+| `AGENT_GATEWAY_LITELLM_MASTER_KEY` | (required) | Master key for management calls |
+| `AGENT_GATEWAY_SMOKE_MODEL` | `claude-haiku-4-5` | Model exercised by the core completion check |
+| `AGENT_GATEWAY_SMOKE_HARNESS_MODEL` | `claude-haiku-4-5-20251001` | **Versioned** model id the harness CLIs pin (must be in the proxy `model_list` — CLIs send dated ids) |
+| `AGENT_GATEWAY_SMOKE_GROK_MODEL` | `grok-4-fast` | Model id the grok CLI requests (aliased in `server/litellm/config.yaml`) |
+| `AGENT_GATEWAY_SMOKE_GEMINI_MODEL` | `gemini-3.5-flash` | Model id the gemini CLI requests |
+| `GEMINI_UPSTREAM_AVAILABLE` | unset | Set to `1` when the proxy has a real Google upstream (`GEMINI_API_KEY`); otherwise `gemini.sh` SKIPs |
+
+Every minted smoke key has a $1 budget, is tagged with
+`metadata.purpose=agent-gateway-smoke`, and is deleted on exit.
+
+## Checks
+
+`run.sh` runs, in order:
+
+1. `proxy-health` — `GET /health/liveliness`
+2. `mint-key` — `POST /key/generate` with a unique alias
+3. `models-list` — `GET /v1/models` using the minted virtual key (not the
+   master key); asserts the smoke model is served
+4. `chat-completion` — one small `POST /v1/chat/completions` on the virtual key
+5. `spend-log-visible` — polls `GET /spend/logs?summarize=false` (spend writes
+   are async) until a row with `api_key == <minted token_id>` appears
+
+Then each per-harness runner (`claude.sh`, `codex.sh`, `opencode.sh`,
+`grok.sh`, `gemini.sh`) runs independently. Results are aggregated into a
+`harness results: claude=PASS codex=PASS ...` line; any FAIL makes `run.sh`
+exit non-zero, SKIPs do not.
+
+## Per-harness runners
+
+Each runner (also runnable standalone with the same env vars):
+
+1. SKIPs cleanly (exit 77) if its CLI is not installed.
+2. Mints its own scoped virtual key (deleted on exit).
+3. Builds an **isolated** home/config under a `mktemp -d` dir (removed on
+   exit) so ambient user config can never leak in.
+4. Runs the CLI one-shot with the prompt `Reply with exactly: GATEWAY_OK`,
+   bounded by a timeout that kills the CLI's whole process group (needed for
+   opencode, whose server lingers after the answer).
+5. Asserts `GATEWAY_OK` appears in the output (ignoring echoes of the prompt
+   itself) and prints `PASS`/`FAIL`.
+
+Recipes are the live-verified ones in [HARNESS-MATRIX.md](HARNESS-MATRIX.md).
+Per-harness notes:
+
+- **claude** — sets `CLAUDE_CONFIG_DIR`, `ANTHROPIC_BASE_URL`,
+  `ANTHROPIC_AUTH_TOKEN`. **Env sanitization is required**: the runner
+  `env -u`'s `ANTHROPIC_API_KEY`, `CLAUDE_CODE_USE_BEDROCK`,
+  `CLAUDE_CODE_USE_VERTEX`, and `AWS_BEARER_TOKEN_BEDROCK` — ambient provider
+  env silently reroutes the CLI to Bedrock/Vertex despite
+  `ANTHROPIC_BASE_URL`, producing misleading errors. Uses the versioned model
+  id (the CLI sends dated ids) and pins `ANTHROPIC_SMALL_FAST_MODEL` to the
+  same gateway model so sidecar small-model calls stay on the proxy.
+- **codex** — isolated `CODEX_HOME` with a `config.toml` declaring a custom
+  provider (`base_url=<proxy>/v1`, `env_key=PROLIFERATE_GATEWAY_KEY`,
+  `wire_api = "responses"`); runs `codex exec --skip-git-repo-check` (exec
+  hangs outside a git repo without it). Sanitizes `OPENAI_API_KEY` /
+  `ANTHROPIC_API_KEY`. LiteLLM's `/v1/responses` bridge translates to the
+  anthropic upstream.
+- **opencode** — `opencode.json` in the isolated workdir with the
+  `@ai-sdk/openai-compatible` provider and an **explicit models map**
+  (required); XDG dirs isolated. The CLI leaves its server running after the
+  one-shot answer, so the runner detects the marker and kills the process
+  group instead of waiting for exit.
+- **grok** — isolated `HOME`, `GROK_MODELS_BASE_URL=<proxy>/v1`,
+  `XAI_API_KEY=<vk>`. The CLI discovers models via `GET /v1/models`, so
+  `grok-4-fast`/`grok-build` are aliased to Anthropic Haiku in
+  `server/litellm/config.yaml` (the CLI doesn't care about the upstream).
+- **gemini** — isolated `HOME` with `~/.gemini/settings.json`
+  (`security.auth.selectedType=gemini-api-key`),
+  `GEMINI_CLI_TRUST_WORKSPACE=true`, `GOOGLE_GEMINI_BASE_URL=<proxy>` (the
+  CLI uses the ROOT `/v1beta` genai facade; the `/gemini`-prefixed path
+  500s). **SKIPs unless `GEMINI_UPSTREAM_AVAILABLE=1`**: gemini model names
+  must map to a real Google upstream — LiteLLM's genai→anthropic translation
+  sends `temperature`+`top_p` together, which Anthropic rejects, so
+  cross-provider aliasing is broken for this path.

--- a/scripts/agent-gateway-smoke/claude.sh
+++ b/scripts/agent-gateway-smoke/claude.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# claude (Claude Code CLI) gateway smoke.
+#
+# Drives the claude CLI through the LiteLLM proxy with a freshly minted scoped
+# virtual key, an isolated CLAUDE_CONFIG_DIR, and a versioned model id.
+# Recipe: HARNESS-MATRIX.md (live-verified).
+#
+# CRITICAL (see HARNESS-MATRIX.md): ambient provider env silently reroutes the
+# CLI — CLAUDE_CODE_USE_BEDROCK / AWS_BEARER_TOKEN_BEDROCK /
+# CLAUDE_CODE_USE_VERTEX / ANTHROPIC_API_KEY must be UNSET or requests go to
+# Bedrock/Vertex despite ANTHROPIC_BASE_URL (with misleading errors).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+command -v claude >/dev/null 2>&1 || skip "claude: CLI not installed"
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+TMP_ROOT=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+  if [ -n "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mint_smoke_key "agent-gateway-smoke-claude-$(date +%s)-$$"
+TMP_ROOT="$(new_tmp_root claude)"
+mkdir -p "$TMP_ROOT/config" "$TMP_ROOT/workdir"
+OUT="$TMP_ROOT/output.log"
+
+log "claude: one-shot via $GATEWAY_BASE_URL model=$SMOKE_HARNESS_MODEL"
+status=0
+(
+  cd "$TMP_ROOT/workdir"
+  run_harness 180 "$OUT" \
+    env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_MODEL \
+    -u CLAUDE_CODE_USE_BEDROCK -u CLAUDE_CODE_USE_VERTEX \
+    -u AWS_BEARER_TOKEN_BEDROCK \
+    CLAUDE_CONFIG_DIR="$TMP_ROOT/config" \
+    ANTHROPIC_BASE_URL="$GATEWAY_BASE_URL" \
+    ANTHROPIC_AUTH_TOKEN="$SMOKE_KEY" \
+    ANTHROPIC_SMALL_FAST_MODEL="$SMOKE_HARNESS_MODEL" \
+    claude -p "$SMOKE_PROMPT" --model "$SMOKE_HARNESS_MODEL"
+) || status=$?
+
+assert_gateway_ok claude "$status" "$OUT"

--- a/scripts/agent-gateway-smoke/codex.sh
+++ b/scripts/agent-gateway-smoke/codex.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# codex (Codex CLI) gateway smoke.
+#
+# Drives codex exec through the LiteLLM proxy (/v1/responses bridge) with a
+# freshly minted scoped virtual key and an isolated CODEX_HOME whose
+# config.toml points a custom provider at the gateway (wire_api = "responses").
+# Recipe: HARNESS-MATRIX.md (live-verified, including anthropic upstream).
+#
+# Notes from the matrix:
+#   - --skip-git-repo-check is REQUIRED: codex exec hangs outside a git repo.
+#   - Sanitize OPENAI_API_KEY / ANTHROPIC_API_KEY so ambient creds cannot leak
+#     into the run; auth comes solely from env_key (PROLIFERATE_GATEWAY_KEY).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+command -v codex >/dev/null 2>&1 || skip "codex: CLI not installed"
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+TMP_ROOT=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+  if [ -n "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mint_smoke_key "agent-gateway-smoke-codex-$(date +%s)-$$"
+TMP_ROOT="$(new_tmp_root codex)"
+mkdir -p "$TMP_ROOT/codex-home" "$TMP_ROOT/workdir"
+OUT="$TMP_ROOT/output.log"
+
+cat >"$TMP_ROOT/codex-home/config.toml" <<EOF
+model_provider = "proliferate"
+model = "$SMOKE_HARNESS_MODEL"
+
+[model_providers.proliferate]
+name = "Proliferate Gateway"
+base_url = "$GATEWAY_BASE_URL/v1"
+env_key = "PROLIFERATE_GATEWAY_KEY"
+wire_api = "responses"
+EOF
+
+log "codex: one-shot via $GATEWAY_BASE_URL model=$SMOKE_HARNESS_MODEL"
+status=0
+(
+  cd "$TMP_ROOT/workdir"
+  run_harness 180 "$OUT" \
+    env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u ANTHROPIC_API_KEY \
+    CODEX_HOME="$TMP_ROOT/codex-home" \
+    PROLIFERATE_GATEWAY_KEY="$SMOKE_KEY" \
+    codex exec -m "$SMOKE_HARNESS_MODEL" --skip-git-repo-check "$SMOKE_PROMPT"
+) || status=$?
+
+assert_gateway_ok codex "$status" "$OUT"

--- a/scripts/agent-gateway-smoke/gemini.sh
+++ b/scripts/agent-gateway-smoke/gemini.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# gemini (Gemini CLI) gateway smoke.
+#
+# Drives the gemini CLI through the LiteLLM ROOT /v1beta genai facade with a
+# freshly minted scoped virtual key, an isolated HOME carrying
+# ~/.gemini/settings.json (selectedType=gemini-api-key), and
+# GEMINI_CLI_TRUST_WORKSPACE=true.
+# Recipe: HARNESS-MATRIX.md (live-verified via the facade).
+#
+# REQUIRES a real Google upstream behind the proxy: LiteLLM's genai→anthropic
+# translation sends temperature+top_p together and Anthropic rejects it, so
+# gemini model names must NOT be aliased to other providers. The gateway's
+# gemini-3.5-flash entry reads GEMINI_API_KEY from the proxy environment; this
+# runner therefore SKIPs unless GEMINI_UPSTREAM_AVAILABLE=1 asserts that the
+# proxy really has a Google key.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+command -v gemini >/dev/null 2>&1 || skip "gemini: CLI not installed"
+if [ "${GEMINI_UPSTREAM_AVAILABLE:-0}" != "1" ]; then
+  skip "gemini: needs a real Google upstream behind the proxy (set GEMINI_UPSTREAM_AVAILABLE=1 when the gateway has GEMINI_API_KEY configured)"
+fi
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+TMP_ROOT=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+  if [ -n "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mint_smoke_key "agent-gateway-smoke-gemini-$(date +%s)-$$"
+TMP_ROOT="$(new_tmp_root gemini)"
+mkdir -p "$TMP_ROOT/home/.gemini" "$TMP_ROOT/workdir"
+OUT="$TMP_ROOT/output.log"
+
+cat >"$TMP_ROOT/home/.gemini/settings.json" <<'EOF'
+{
+  "security": {
+    "auth": {
+      "selectedType": "gemini-api-key"
+    }
+  }
+}
+EOF
+
+log "gemini: one-shot via $GATEWAY_BASE_URL model=$SMOKE_GEMINI_MODEL"
+status=0
+(
+  cd "$TMP_ROOT/workdir"
+  run_harness 120 "$OUT" \
+    env -u GOOGLE_API_KEY -u GOOGLE_APPLICATION_CREDENTIALS \
+    -u GOOGLE_GENAI_USE_VERTEXAI \
+    HOME="$TMP_ROOT/home" \
+    GEMINI_CLI_TRUST_WORKSPACE=true \
+    GOOGLE_GEMINI_BASE_URL="$GATEWAY_BASE_URL" \
+    GEMINI_API_KEY="$SMOKE_KEY" \
+    gemini -p "$SMOKE_PROMPT" -m "$SMOKE_GEMINI_MODEL"
+) || status=$?
+
+assert_gateway_ok gemini "$status" "$OUT"

--- a/scripts/agent-gateway-smoke/grok.sh
+++ b/scripts/agent-gateway-smoke/grok.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# grok (Grok CLI) gateway smoke.
+#
+# Drives the grok CLI through the LiteLLM proxy with a freshly minted scoped
+# virtual key and an isolated HOME. The CLI discovers models dynamically via
+# GET /v1/models (GROK_MODELS_BASE_URL) and then POSTs /v1/chat/completions,
+# so the grok-named model must be in the proxy model_list (grok-4-fast and
+# grok-build are aliased in server/litellm/config.yaml; the CLI does not care
+# about the upstream provider).
+# Recipe: HARNESS-MATRIX.md (live-verified).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+command -v grok >/dev/null 2>&1 || skip "grok: CLI not installed"
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+TMP_ROOT=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+  if [ -n "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mint_smoke_key "agent-gateway-smoke-grok-$(date +%s)-$$"
+TMP_ROOT="$(new_tmp_root grok)"
+mkdir -p "$TMP_ROOT/home" "$TMP_ROOT/workdir"
+OUT="$TMP_ROOT/output.log"
+
+log "grok: one-shot via $GATEWAY_BASE_URL model=$SMOKE_GROK_MODEL"
+status=0
+(
+  cd "$TMP_ROOT/workdir"
+  run_harness 120 "$OUT" \
+    env -u XAI_BASE_URL \
+    HOME="$TMP_ROOT/home" \
+    GROK_MODELS_BASE_URL="$GATEWAY_BASE_URL/v1" \
+    XAI_API_KEY="$SMOKE_KEY" \
+    grok -p "$SMOKE_PROMPT" -m "$SMOKE_GROK_MODEL"
+) || status=$?
+
+assert_gateway_ok grok "$status" "$OUT"

--- a/scripts/agent-gateway-smoke/lib.sh
+++ b/scripts/agent-gateway-smoke/lib.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Shared helpers for the agent-gateway smoke harness.
+#
+# Configuration (env vars):
+#   AGENT_GATEWAY_LITELLM_BASE_URL     proxy base URL (default http://127.0.0.1:14000)
+#   AGENT_GATEWAY_LITELLM_MASTER_KEY   master key for management calls (required)
+#   AGENT_GATEWAY_SMOKE_MODEL          model for the core completion check
+#                                      (default claude-haiku-4-5)
+#   AGENT_GATEWAY_SMOKE_HARNESS_MODEL  VERSIONED model id the harness CLIs pin
+#                                      (default claude-haiku-4-5-20251001; must be
+#                                      in the proxy model_list — CLIs send dated ids)
+#   AGENT_GATEWAY_SMOKE_GROK_MODEL     model id for the grok CLI (default grok-4-fast)
+#   AGENT_GATEWAY_SMOKE_GEMINI_MODEL   model id for the gemini CLI (default gemini-3.5-flash)
+
+set -euo pipefail
+
+GATEWAY_BASE_URL="${AGENT_GATEWAY_LITELLM_BASE_URL:-http://127.0.0.1:14000}"
+GATEWAY_BASE_URL="${GATEWAY_BASE_URL%/}"
+GATEWAY_MASTER_KEY="${AGENT_GATEWAY_LITELLM_MASTER_KEY:-}"
+SMOKE_MODEL="${AGENT_GATEWAY_SMOKE_MODEL:-claude-haiku-4-5}"
+SMOKE_HARNESS_MODEL="${AGENT_GATEWAY_SMOKE_HARNESS_MODEL:-claude-haiku-4-5-20251001}"
+SMOKE_GROK_MODEL="${AGENT_GATEWAY_SMOKE_GROK_MODEL:-grok-4-fast}"
+SMOKE_GEMINI_MODEL="${AGENT_GATEWAY_SMOKE_GEMINI_MODEL:-gemini-3.5-flash}"
+SMOKE_PROMPT="Reply with exactly: GATEWAY_OK"
+SMOKE_MARKER="GATEWAY_OK"
+
+# Exit code runners use to signal SKIP; run.sh treats it as non-fatal, any
+# other non-zero exit as FAIL.
+SKIP_EXIT_CODE=77
+
+log() {
+  printf '[smoke] %s\n' "$*"
+}
+
+fail() {
+  printf '[smoke] FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+skip() {
+  printf '[smoke] SKIP: %s\n' "$*"
+  exit "$SKIP_EXIT_CODE"
+}
+
+# new_tmp_root LABEL -> prints a fresh private temp dir for a harness run
+new_tmp_root() {
+  mktemp -d "${TMPDIR:-/tmp}/agent-gateway-smoke-$1.XXXXXX"
+}
+
+# marker_present OUTPUT_FILE
+# True when the smoke marker appears on a line that is NOT an echo of the
+# prompt itself (codex exec, for example, prints the user instructions back
+# into its transcript, which would otherwise false-positive the check).
+marker_present() {
+  local out="$1"
+  [ -f "$out" ] || return 1
+  grep -- "$SMOKE_MARKER" "$out" 2>/dev/null | grep -qv 'Reply with exactly'
+}
+
+# kill_harness_tree PID
+# TERM (then KILL) the whole process group rooted at PID, falling back to the
+# single process when no group exists. Reaps the direct child.
+kill_harness_tree() {
+  local pid="$1"
+  kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  sleep 1
+  kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# run_harness SECS OUTPUT_FILE CMD [ARGS...]
+# Runs CMD with stdout+stderr captured to OUTPUT_FILE and polls once a second:
+#   - marker in output -> kill the process group, return 0 (some CLIs — e.g.
+#     opencode — leave a server running after the one-shot answer, so we cannot
+#     wait for a natural exit)
+#   - CMD exits        -> return its exit code (after sweeping the group)
+#   - SECS elapse      -> kill the process group, return 124
+# perl setpgrp gives CMD its own process group so lingering children die with
+# it. Implemented in shell because stock macOS has no coreutils `timeout`.
+run_harness() {
+  local secs="$1" out="$2"
+  shift 2
+  : >"$out"
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'setpgrp(0, 0); exec @ARGV or die "exec failed: $!"' -- "$@" \
+      >"$out" 2>&1 &
+  else
+    "$@" >"$out" 2>&1 &
+  fi
+  local pid=$!
+  local waited=0 status=0
+  while :; do
+    if marker_present "$out"; then
+      # 2>/dev/null also swallows bash's async "Terminated" job notice.
+      kill_harness_tree "$pid" 2>/dev/null
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" || status=$?
+      # Sweep group members the CLI may have left behind.
+      kill -TERM -- "-$pid" 2>/dev/null || true
+      return "$status"
+    fi
+    if [ "$waited" -ge "$secs" ]; then
+      kill_harness_tree "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+# assert_gateway_ok HARNESS STATUS OUTPUT_FILE
+# PASS when OUTPUT_FILE contains the smoke marker; otherwise dump a tail of
+# the harness output and FAIL (calling out timeouts when STATUS is 124).
+assert_gateway_ok() {
+  local harness="$1" status="$2" out="$3"
+  if marker_present "$out"; then
+    log "PASS: $harness reached the gateway ($SMOKE_MARKER)"
+    return 0
+  fi
+  if [ -f "$out" ]; then
+    log "$harness output (tail):" >&2
+    tail -n 20 "$out" | sed 's/^/[smoke]   | /' >&2 || true
+  fi
+  if [ "$status" -eq 124 ]; then
+    fail "$harness: timed out before $SMOKE_MARKER appeared in the output"
+  fi
+  fail "$harness: $SMOKE_MARKER not found in the output (harness exit $status)"
+}
+
+require_master_key() {
+  if [ -z "$GATEWAY_MASTER_KEY" ]; then
+    fail "AGENT_GATEWAY_LITELLM_MASTER_KEY is required."
+  fi
+}
+
+require_tools() {
+  command -v curl >/dev/null 2>&1 || fail "curl is required."
+  command -v python3 >/dev/null 2>&1 || fail "python3 is required."
+}
+
+# admin_request METHOD PATH [JSON_BODY]
+# Prints the response body; returns non-zero on HTTP >= 400.
+admin_request() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method" "$GATEWAY_BASE_URL$path" \
+    -H "Authorization: Bearer $GATEWAY_MASTER_KEY" \
+    -H "Content-Type: application/json" \
+    -w '\n%{http_code}')
+  if [ -n "$body" ]; then
+    args+=(-d "$body")
+  fi
+  local response status payload
+  response="$(curl "${args[@]}")"
+  status="${response##*$'\n'}"
+  payload="${response%$'\n'*}"
+  printf '%s' "$payload"
+  [ "$status" -lt 400 ]
+}
+
+# json_field JSON FIELD
+json_field() {
+  python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get(sys.argv[2], ""))' "$1" "$2"
+}
+
+check_proxy_health() {
+  log "proxy-health: GET $GATEWAY_BASE_URL/health/liveliness"
+  curl -fsS "$GATEWAY_BASE_URL/health/liveliness" >/dev/null \
+    || fail "proxy health check failed at $GATEWAY_BASE_URL/health/liveliness"
+  log "proxy-health OK"
+}
+
+# mint_smoke_key ALIAS -> sets SMOKE_KEY and SMOKE_TOKEN_ID
+mint_smoke_key() {
+  local alias="$1"
+  log "mint-key: alias=$alias"
+  local payload
+  payload="$(admin_request POST /key/generate \
+    "{\"key_alias\":\"$alias\",\"max_budget\":1,\"metadata\":{\"purpose\":\"agent-gateway-smoke\"}}")" \
+    || fail "key/generate failed: $payload"
+  SMOKE_KEY="$(json_field "$payload" key)"
+  SMOKE_TOKEN_ID="$(json_field "$payload" token_id)"
+  [ -n "$SMOKE_KEY" ] || fail "key/generate returned no key: $payload"
+  log "mint-key OK (token_id=$SMOKE_TOKEN_ID)"
+}
+
+# delete_smoke_key TOKEN_ID
+delete_smoke_key() {
+  local token_id="$1"
+  [ -n "$token_id" ] || return 0
+  admin_request POST /key/delete "{\"keys\":[\"$token_id\"]}" >/dev/null \
+    || log "warning: cleanup of smoke key $token_id failed"
+}
+
+# check_models_list VIRTUAL_KEY
+check_models_list() {
+  local virtual_key="$1"
+  log "models-list: GET /v1/models with the virtual key"
+  local payload
+  payload="$(curl -fsS "$GATEWAY_BASE_URL/v1/models" \
+    -H "Authorization: Bearer $virtual_key")" \
+    || fail "GET /v1/models with virtual key failed"
+  echo "$payload" | python3 -c '
+import json, sys
+
+payload = json.load(sys.stdin)
+models = [item["id"] for item in payload.get("data", [])]
+if not models:
+    raise SystemExit("no models visible to the virtual key")
+print("[smoke] models visible:", ", ".join(sorted(models)))
+' || fail "models-list check failed"
+  echo "$payload" | python3 -c "
+import json, sys
+models = [item['id'] for item in json.load(sys.stdin).get('data', [])]
+raise SystemExit(0 if '$SMOKE_MODEL' in models else 'smoke model $SMOKE_MODEL not in model list')
+" || fail "smoke model $SMOKE_MODEL is not served by the proxy"
+  log "models-list OK"
+}
+
+# check_chat_completion VIRTUAL_KEY
+check_chat_completion() {
+  local virtual_key="$1"
+  log "chat-completion: POST /v1/chat/completions model=$SMOKE_MODEL"
+  local payload
+  payload="$(curl -fsS "$GATEWAY_BASE_URL/v1/chat/completions" \
+    -H "Authorization: Bearer $virtual_key" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"$SMOKE_MODEL\",\"max_tokens\":32,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: pong\"}]}")" \
+    || fail "chat completion request failed"
+  echo "$payload" | python3 -c '
+import json, sys
+
+payload = json.load(sys.stdin)
+content = payload["choices"][0]["message"]["content"]
+if not content or not content.strip():
+    raise SystemExit("chat completion returned empty content")
+print("[smoke] completion content:", content.strip()[:120])
+' || fail "chat completion returned no content"
+  log "chat-completion OK"
+}
+
+# check_spend_log_visible TOKEN_ID
+# Spend log writes are async in LiteLLM; poll for up to ~30s.
+check_spend_log_visible() {
+  local token_id="$1"
+  local start_date end_date
+  start_date="$(python3 -c 'import datetime; print((datetime.date.today()-datetime.timedelta(days=1)).isoformat())')"
+  end_date="$(python3 -c 'import datetime; print((datetime.date.today()+datetime.timedelta(days=1)).isoformat())')"
+  log "spend-log: polling /spend/logs for token $token_id"
+  local attempt payload
+  for attempt in $(seq 1 15); do
+    payload="$(admin_request GET "/spend/logs?summarize=false&start_date=$start_date&end_date=$end_date")" \
+      || fail "GET /spend/logs failed: $payload"
+    if echo "$payload" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+match = [r for r in rows if r.get('api_key') == '$token_id']
+if not match:
+    raise SystemExit(1)
+row = match[0]
+print('[smoke] spend row:', json.dumps({k: row.get(k) for k in ('request_id', 'model', 'spend', 'total_tokens')}))
+"; then
+      log "spend-log OK"
+      return 0
+    fi
+    sleep 2
+  done
+  fail "no spend log row appeared for token $token_id"
+}

--- a/scripts/agent-gateway-smoke/opencode.sh
+++ b/scripts/agent-gateway-smoke/opencode.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# opencode gateway smoke.
+#
+# Drives opencode run through the LiteLLM proxy with a freshly minted scoped
+# virtual key. Provider config lives in an opencode.json in the isolated
+# workdir (explicit models map is REQUIRED); XDG dirs are isolated too.
+# Recipe: HARNESS-MATRIX.md (live-verified).
+#
+# Notes from the matrix:
+#   - The CLI process lingers after completion (its server keeps running), so
+#     the run is bounded by run_harness, which detects the marker in the
+#     output and kills the whole process group.
+#   - Some opencode builds (observed on 1.16.2) drop buffered stdout on exit
+#     when stdout is not a TTY: the assistant text never reaches the log even
+#     though the gateway round trip succeeded. The session storage in the
+#     isolated XDG_DATA_HOME is authoritative, so when the marker is missing
+#     from stdout we fall back to checking the stored assistant parts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+command -v opencode >/dev/null 2>&1 || skip "opencode: CLI not installed"
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+TMP_ROOT=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+  if [ -n "$TMP_ROOT" ]; then
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mint_smoke_key "agent-gateway-smoke-opencode-$(date +%s)-$$"
+TMP_ROOT="$(new_tmp_root opencode)"
+mkdir -p "$TMP_ROOT/workdir" "$TMP_ROOT/xdg-config" "$TMP_ROOT/xdg-data" \
+  "$TMP_ROOT/xdg-cache" "$TMP_ROOT/xdg-state"
+OUT="$TMP_ROOT/output.log"
+
+cat >"$TMP_ROOT/workdir/opencode.json" <<EOF
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "proliferate": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "$GATEWAY_BASE_URL/v1",
+        "apiKey": "{env:PROLIFERATE_GATEWAY_KEY}"
+      },
+      "models": {
+        "$SMOKE_HARNESS_MODEL": {}
+      }
+    }
+  }
+}
+EOF
+
+# marker_in_session_storage
+# True when the isolated opencode data dir contains an assistant text part
+# that is exactly the smoke marker (the stored user prompt is the full
+# "Reply with exactly: ..." string, so an exact match cannot false-positive).
+marker_in_session_storage() {
+  python3 - "$TMP_ROOT/xdg-data" "$SMOKE_MARKER" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+data_dir = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+
+
+def texts_from_sqlite(db_path):
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        for (data,) in conn.execute("SELECT data FROM part"):
+            try:
+                part = json.loads(data)
+            except (TypeError, ValueError):
+                continue
+            if part.get("type") == "text":
+                yield str(part.get("text", ""))
+    finally:
+        conn.close()
+
+
+def texts_from_json_files(root):
+    # Older opencode layouts store message parts as JSON files.
+    for path in root.rglob("*.json"):
+        try:
+            doc = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        stack = [doc]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                if node.get("type") == "text":
+                    yield str(node.get("text", ""))
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+
+
+texts = []
+for db in data_dir.rglob("opencode.db"):
+    try:
+        texts.extend(texts_from_sqlite(db))
+    except sqlite3.Error:
+        pass
+if not texts:
+    texts.extend(texts_from_json_files(data_dir))
+
+sys.exit(0 if any(t.strip() == marker for t in texts) else 1)
+PY
+}
+
+log "opencode: one-shot via $GATEWAY_BASE_URL model=proliferate/$SMOKE_HARNESS_MODEL"
+status=0
+(
+  cd "$TMP_ROOT/workdir"
+  run_harness 120 "$OUT" \
+    env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY \
+    XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" \
+    XDG_DATA_HOME="$TMP_ROOT/xdg-data" \
+    XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" \
+    XDG_STATE_HOME="$TMP_ROOT/xdg-state" \
+    PROLIFERATE_GATEWAY_KEY="$SMOKE_KEY" \
+    opencode run -m "proliferate/$SMOKE_HARNESS_MODEL" "$SMOKE_PROMPT"
+) || status=$?
+
+if ! marker_present "$OUT" && marker_in_session_storage; then
+  log "PASS: opencode reached the gateway ($SMOKE_MARKER via session storage; CLI dropped stdout)"
+  exit 0
+fi
+
+assert_gateway_ok opencode "$status" "$OUT"

--- a/scripts/agent-gateway-smoke/run.sh
+++ b/scripts/agent-gateway-smoke/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Agent-gateway smoke: proxy health -> mint key -> models list -> chat
+# completion -> spend log visible, then per-harness CLI runners.
+#
+# Usage:
+#   AGENT_GATEWAY_LITELLM_MASTER_KEY=sk-... ./run.sh
+#
+# See README.md for configuration.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "$SCRIPT_DIR/lib.sh"
+
+require_tools
+require_master_key
+
+SMOKE_KEY=""
+SMOKE_TOKEN_ID=""
+
+cleanup() {
+  delete_smoke_key "$SMOKE_TOKEN_ID"
+}
+trap cleanup EXIT
+
+check_proxy_health
+mint_smoke_key "agent-gateway-smoke-$(date +%s)-$$"
+check_models_list "$SMOKE_KEY"
+check_chat_completion "$SMOKE_KEY"
+check_spend_log_visible "$SMOKE_TOKEN_ID"
+
+log "core proxy checks passed"
+
+# Per-harness runners. Each is independent: it checks its CLI is installed
+# (SKIP otherwise), mints its own scoped virtual key, builds an isolated
+# home/config under mktemp, runs the CLI one-shot against the gateway, and
+# asserts the reply marker. SKIP (exit $SKIP_EXIT_CODE) is non-fatal; any
+# other non-zero exit marks the overall run failed.
+HARNESS_FAILURES=""
+HARNESS_SUMMARY=""
+
+for harness in claude codex opencode grok gemini; do
+  runner="$SCRIPT_DIR/$harness.sh"
+  if [ ! -x "$runner" ]; then
+    log "SKIP: $harness (no runner at $runner)"
+    HARNESS_SUMMARY="$HARNESS_SUMMARY $harness=SKIP"
+    continue
+  fi
+  log "--- harness: $harness ---"
+  status=0
+  "$runner" || status=$?
+  if [ "$status" -eq 0 ]; then
+    HARNESS_SUMMARY="$HARNESS_SUMMARY $harness=PASS"
+  elif [ "$status" -eq "$SKIP_EXIT_CODE" ]; then
+    HARNESS_SUMMARY="$HARNESS_SUMMARY $harness=SKIP"
+  else
+    HARNESS_SUMMARY="$HARNESS_SUMMARY $harness=FAIL"
+    HARNESS_FAILURES="$HARNESS_FAILURES $harness"
+  fi
+done
+
+log "harness results:$HARNESS_SUMMARY"
+
+if [ -n "$HARNESS_FAILURES" ]; then
+  fail "harness runner(s) failed:$HARNESS_FAILURES"
+fi
+
+log "PASS"

--- a/scripts/ci-cd/detect-deploy-surfaces.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 export const SURFACES = [
   "server",
   "workers",
+  "litellm",
   "e2b",
   "web",
   "mobile",
@@ -132,6 +133,10 @@ export function classifyFile(path) {
     ])
   ) {
     touched.add("workers");
+  }
+
+  if (matches(path, ["server/litellm"])) {
+    touched.add("litellm");
   }
 
   if (

--- a/scripts/ci-cd/detect-deploy-surfaces.test.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.test.mjs
@@ -52,12 +52,21 @@ test("all expands to every known surface", () => {
   assert.deepEqual([...parseSurfaceList("all", "only")].sort(), [
     "desktop",
     "e2b",
+    "litellm",
     "mobile",
     "runtime",
     "server",
     "web",
     "workers",
   ]);
+});
+
+test("litellm config changes select the litellm surface", () => {
+  const selection = selectSurfaces({
+    files: ["server/litellm/config.yaml"],
+  });
+
+  assert.deepEqual([...selection.selected].sort(), ["litellm", "server"]);
 });
 
 test("invalid surfaces fail fast", () => {

--- a/scripts/ci-cd/prepare-artifact-release.mjs
+++ b/scripts/ci-cd/prepare-artifact-release.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { parseSurfaceList } from "./detect-deploy-surfaces.mjs";
 
 const ARTIFACT_SURFACES = new Set(["desktop", "runtime", "server"]);
-const SHA_ONLY_SURFACES = new Set(["workers", "e2b", "web"]);
+const SHA_ONLY_SURFACES = new Set(["workers", "litellm", "e2b", "web"]);
 const PRODUCT_TAG_PREFIX = "proliferate-v";
 
 function parseArgs(argv) {

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -40,6 +40,48 @@ services:
       timeout: 3s
       retries: 10
 
+  litellm-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: litellm
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: litellm
+    volumes:
+      - litellmpgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U litellm"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    ports:
+      - "14000:4000"
+    environment:
+      DATABASE_URL: postgresql://litellm:localdev@litellm-db:5432/litellm
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-proliferate-local-dev}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+    volumes:
+      - ./litellm/config.yaml:/app/config.yaml:ro
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    depends_on:
+      litellm-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness', timeout=3)",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   migrate:
     build:
       context: ..
@@ -69,5 +111,6 @@ services:
 
 volumes:
   pgdata:
+  litellmpgdata:
   rabbitmqdata:
   redisdata:

--- a/server/litellm/Dockerfile
+++ b/server/litellm/Dockerfile
@@ -1,0 +1,13 @@
+# LiteLLM proxy image for the Proliferate agent gateway.
+#
+# Layers the checked-in gateway config onto the upstream LiteLLM image so the
+# deployed ECS task runs the exact model list reviewed in this repo.
+#
+# Build context: repo root (matches server/Dockerfile convention):
+#   docker build -f server/litellm/Dockerfile .
+FROM ghcr.io/berriai/litellm:main-stable
+
+COPY server/litellm/config.yaml /app/proliferate-litellm-config.yaml
+
+# Same entrypoint as upstream; pin the config and port.
+CMD ["--config", "/app/proliferate-litellm-config.yaml", "--port", "4000"]

--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -1,0 +1,85 @@
+# LiteLLM proxy config for the Proliferate agent gateway.
+#
+# Used both by the local docker-compose `litellm` service (bind-mounted) and
+# by the deployed image (server/litellm/Dockerfile layers this file onto
+# ghcr.io/berriai/litellm). Model names must be explicitly listed: unknown
+# names return 400 from the proxy.
+#
+# Both the bare alias and the dated/versioned model_name map to the same
+# upstream model so harnesses that pin dated ids (e.g. Claude Code) resolve.
+#
+# Provider keys come from the container environment:
+#   ANTHROPIC_API_KEY  (deploy: from AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY)
+#   OPENAI_API_KEY     (deploy: from AGENT_GATEWAY_MANAGED_OPENAI_API_KEY)
+#   GEMINI_API_KEY     (optional; gemini entries 401 upstream until it is set)
+
+model_list:
+  # Anthropic
+  - model_name: claude-sonnet-4-5
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250929
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-sonnet-4-5-20250929
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250929
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-haiku-4-5
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-haiku-4-5-20251001
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-4-6
+    litellm_params:
+      model: anthropic/claude-opus-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-4-6-20260205
+    litellm_params:
+      model: anthropic/claude-opus-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # OpenAI
+  - model_name: gpt-5.2
+    litellm_params:
+      model: openai/gpt-5.2
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-5.2-2025-12-11
+    litellm_params:
+      model: openai/gpt-5.2
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-5-mini
+    litellm_params:
+      model: openai/gpt-5-mini
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-5-mini-2025-08-07
+    litellm_params:
+      model: openai/gpt-5-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  # Grok CLI aliases. The grok CLI discovers models via GET /v1/models and
+  # speaks plain chat/completions, so grok-named entries can point at any
+  # upstream; we alias them to Anthropic Haiku (see HARNESS-MATRIX.md).
+  # grok-build is the CLI's interactive/title-gen model — cheap to keep.
+  - model_name: grok-4-fast
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: grok-build
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # Google (genai facade at the ROOT /v1beta path). Gemini model names MUST
+  # map to a real Google upstream: LiteLLM's genai->anthropic translation
+  # sends temperature+top_p together, which Anthropic rejects (see
+  # HARNESS-MATRIX.md). These entries return upstream auth errors until
+  # GEMINI_API_KEY is provided to the proxy environment.
+  - model_name: gemini-3.5-flash
+    litellm_params:
+      model: gemini/gemini-3.5-flash
+      api_key: os.environ/GEMINI_API_KEY
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -324,6 +324,12 @@ class Settings(BaseSettings):
     cloud_mcp_google_workspace_enabled: bool = False
     cloud_mcp_google_workspace_oauth_client_id: str = ""
     cloud_mcp_google_workspace_oauth_client_secret: str = ""
+    # Agent LLM gateway (LiteLLM proxy)
+    agent_gateway_enabled: bool = False
+    agent_gateway_litellm_base_url: str = "http://127.0.0.1:14000"
+    agent_gateway_litellm_public_base_url: str = ""
+    agent_gateway_litellm_master_key: str = ""
+    agent_gateway_litellm_timeout_seconds: float = 30.0
     e2b_api_key: str = ""
     e2b_template_name: str = ""
     e2b_webhook_signature_secret: str = ""

--- a/server/proliferate/integrations/litellm/__init__.py
+++ b/server/proliferate/integrations/litellm/__init__.py
@@ -1,0 +1,34 @@
+"""Public API for the LiteLLM proxy integration."""
+
+from __future__ import annotations
+
+from proliferate.integrations.litellm.client import (
+    disable_virtual_key,
+    ensure_team,
+    ensure_user,
+    health,
+    list_models,
+    mint_virtual_key,
+    page_spend_logs,
+    rotate_virtual_key,
+    set_key_budget,
+    update_team_budget,
+)
+from proliferate.integrations.litellm.errors import LiteLLMIntegrationError
+from proliferate.integrations.litellm.models import LiteLLMSpendLogEntry, LiteLLMVirtualKey
+
+__all__ = [
+    "LiteLLMIntegrationError",
+    "LiteLLMSpendLogEntry",
+    "LiteLLMVirtualKey",
+    "disable_virtual_key",
+    "ensure_team",
+    "ensure_user",
+    "health",
+    "list_models",
+    "mint_virtual_key",
+    "page_spend_logs",
+    "rotate_virtual_key",
+    "set_key_budget",
+    "update_team_budget",
+]

--- a/server/proliferate/integrations/litellm/client.py
+++ b/server/proliferate/integrations/litellm/client.py
@@ -1,0 +1,323 @@
+"""LiteLLM proxy admin HTTP client.
+
+Coarse operations only, per the agent-auth-litellm spec (section 2.2). This is
+the single module that knows LiteLLM endpoint paths; product services call the
+public functions re-exported from ``proliferate.integrations.litellm``.
+
+Verified against ghcr.io/berriai/litellm:main-stable:
+
+- ``/team/new`` does NOT enforce unique ``team_alias``. The pinned image also
+  ignores the ``team_alias`` query param on ``/team/list`` and returns *all*
+  teams (fully hydrated), so ``ensure_team`` must filter client-side and treat
+  alias uniqueness as an invariant *we* enforce (the enrollment writer is the
+  single writer per billing subject), not something LiteLLM guarantees. Prefer
+  the stored-id path (``ensure_team(team_id=...)``) to skip the listing entirely.
+- ``/user/new`` returns 409 for an existing ``user_id``.
+- ``/key/generate`` enforces unique ``key_alias`` (400 on duplicate).
+- ``/key/regenerate`` is an Enterprise-only feature on the OSS image (returns
+  500 with an "Enterprise feature" message) — rotation is implemented as
+  delete + mint instead.
+- ``/key/block`` takes the raw ``sk-...`` key or the token hash and is
+  immediately enforced (401 on the data plane).
+- ``/spend/logs?summarize=false`` returns per-request rows whose ``api_key``
+  field is the key's token hash (== ``token_id`` from mint time).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from proliferate.config import settings
+from proliferate.integrations.litellm.errors import LiteLLMIntegrationError
+from proliferate.integrations.litellm.models import LiteLLMSpendLogEntry, LiteLLMVirtualKey
+
+
+def _base_url() -> str:
+    base_url = settings.agent_gateway_litellm_base_url.rstrip("/")
+    if not base_url:
+        raise LiteLLMIntegrationError(
+            "litellm_unconfigured",
+            "LiteLLM base URL is not configured.",
+            status_code=503,
+        )
+    return base_url
+
+
+def _admin_headers() -> dict[str, str]:
+    master_key = settings.agent_gateway_litellm_master_key
+    if not master_key:
+        raise LiteLLMIntegrationError(
+            "litellm_unconfigured",
+            "LiteLLM master key is not configured.",
+            status_code=503,
+        )
+    return {"Authorization": f"Bearer {master_key}"}
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str],
+    json_body: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+) -> Any:
+    try:
+        async with httpx.AsyncClient(
+            timeout=settings.agent_gateway_litellm_timeout_seconds
+        ) as client:
+            response = await client.request(
+                method,
+                f"{_base_url()}{path}",
+                headers=headers,
+                json=json_body,
+                params=params,
+            )
+    except httpx.HTTPError as exc:
+        raise LiteLLMIntegrationError(
+            "litellm_request_failed",
+            "Could not reach the LiteLLM proxy. Check the gateway configuration and network.",
+        ) from exc
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if response.status_code >= 400:
+        message = "LiteLLM request failed."
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict) and isinstance(error.get("message"), str):
+                message = error["message"]
+            elif isinstance(payload.get("detail"), str):
+                message = payload["detail"]
+        raise LiteLLMIntegrationError(
+            "litellm_request_failed",
+            message,
+            status_code=response.status_code,
+        )
+    return payload
+
+
+async def _admin_request(
+    method: str,
+    path: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+) -> Any:
+    return await _request(
+        method, path, headers=_admin_headers(), json_body=json_body, params=params
+    )
+
+
+def _require_dict(payload: Any, *, context: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response",
+            f"LiteLLM returned an invalid response for {context}.",
+        )
+    return payload
+
+
+def _validate[ModelT: BaseModel](model: type[ModelT], payload: Any, *, context: str) -> ModelT:
+    """Parse ``payload`` into ``model``, wrapping pydantic errors.
+
+    A malformed 200 body (right status, wrong shape) otherwise surfaces as a raw
+    ``pydantic.ValidationError`` and bypasses ``LiteLLMIntegrationError`` handling.
+    """
+    try:
+        return model.model_validate(payload)
+    except ValidationError as exc:
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response",
+            f"LiteLLM returned a malformed response for {context}.",
+        ) from exc
+
+
+async def ensure_team(
+    *, alias: str, team_id: str | None = None, max_budget: float | None = None
+) -> str:
+    """Return the team id for ``alias``, creating the team if it does not exist.
+
+    If ``team_id`` is supplied (the caller persisted it on a previous success),
+    reuse it directly — this is the durable get-or-create path and it avoids the
+    check-then-create race entirely. Duplicate-team prevention relies on the
+    enrollment writer being the single writer per billing subject and passing
+    back the stored id; the alias listing below is only the first-create path.
+
+    LiteLLM allows duplicate team aliases and the pinned image ignores the
+    ``team_alias`` query param, returning all teams, so we filter client-side.
+    """
+    if team_id:
+        return team_id
+    existing = await _admin_request("GET", "/team/list", params={"team_alias": alias})
+    if isinstance(existing, list):
+        for team in existing:
+            if isinstance(team, dict) and team.get("team_alias") == alias:
+                team_id = team.get("team_id")
+                if isinstance(team_id, str) and team_id:
+                    return team_id
+    body: dict[str, Any] = {"team_alias": alias}
+    if max_budget is not None:
+        body["max_budget"] = max_budget
+    created = _require_dict(
+        await _admin_request("POST", "/team/new", json_body=body), context="/team/new"
+    )
+    team_id = created.get("team_id")
+    if not isinstance(team_id, str) or not team_id:
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response", "LiteLLM did not return a team id."
+        )
+    return team_id
+
+
+async def ensure_user(*, user_id: str) -> str:
+    """Create the LiteLLM user if missing; a 409 means it already exists."""
+    try:
+        await _admin_request(
+            "POST",
+            "/user/new",
+            json_body={"user_id": user_id, "auto_create_key": False},
+        )
+    except LiteLLMIntegrationError as exc:
+        if exc.status_code != 409:
+            raise
+    return user_id
+
+
+async def mint_virtual_key(
+    *,
+    user_id: str,
+    team_id: str | None = None,
+    alias: str | None = None,
+    max_budget: float | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> LiteLLMVirtualKey:
+    """Mint a virtual key. ``alias`` must be globally unique in LiteLLM."""
+    body: dict[str, Any] = {"user_id": user_id}
+    if team_id is not None:
+        body["team_id"] = team_id
+    if alias is not None:
+        body["key_alias"] = alias
+    if max_budget is not None:
+        body["max_budget"] = max_budget
+    if metadata is not None:
+        body["metadata"] = metadata
+    payload = _require_dict(
+        await _admin_request("POST", "/key/generate", json_body=body),
+        context="/key/generate",
+    )
+    key = _validate(LiteLLMVirtualKey, payload, context="/key/generate")
+    if not key.key:
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response", "LiteLLM did not return a virtual key."
+        )
+    return key
+
+
+async def rotate_virtual_key(
+    *,
+    key_or_token_id: str,
+    user_id: str,
+    team_id: str | None = None,
+    alias: str | None = None,
+    max_budget: float | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> LiteLLMVirtualKey:
+    """Replace a virtual key with a freshly minted one.
+
+    ``/key/regenerate`` is Enterprise-only on the OSS LiteLLM image, so
+    rotation is delete-then-mint. Delete (rather than block) frees the key
+    alias for reuse by the replacement key. The old key stops working the
+    moment the delete lands.
+
+    A 404 on the delete means the key is already gone (e.g. a previous attempt
+    deleted it but failed before minting). Treat that as success so a retry is
+    idempotent and proceeds to mint instead of looping on the delete forever.
+    """
+    try:
+        await _admin_request("POST", "/key/delete", json_body={"keys": [key_or_token_id]})
+    except LiteLLMIntegrationError as exc:
+        if exc.status_code != 404:
+            raise
+    return await mint_virtual_key(
+        user_id=user_id,
+        team_id=team_id,
+        alias=alias,
+        max_budget=max_budget,
+        metadata=metadata,
+    )
+
+
+async def disable_virtual_key(*, key_or_token_id: str) -> None:
+    """Block a virtual key; enforcement on the data plane is immediate."""
+    await _admin_request("POST", "/key/block", json_body={"key": key_or_token_id})
+
+
+async def set_key_budget(*, key_or_token_id: str, max_budget: float) -> None:
+    """Set the max budget (USD) on a virtual key."""
+    await _admin_request(
+        "POST",
+        "/key/update",
+        json_body={"key": key_or_token_id, "max_budget": max_budget},
+    )
+
+
+async def update_team_budget(*, team_id: str, max_budget: float) -> None:
+    """Set the max budget (USD) on a team."""
+    await _admin_request(
+        "POST",
+        "/team/update",
+        json_body={"team_id": team_id, "max_budget": max_budget},
+    )
+
+
+async def list_models(*, virtual_key: str) -> list[str]:
+    """List model ids visible to ``virtual_key`` (not the master key)."""
+    payload = _require_dict(
+        await _request(
+            "GET",
+            "/v1/models",
+            headers={"Authorization": f"Bearer {virtual_key}"},
+        ),
+        context="/v1/models",
+    )
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response", "LiteLLM returned an invalid model list."
+        )
+    return [
+        item["id"] for item in data if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+
+
+async def page_spend_logs(*, start_date: str, end_date: str) -> list[LiteLLMSpendLogEntry]:
+    """Fetch per-request spend rows for the date window (YYYY-MM-DD, inclusive)."""
+    payload = await _admin_request(
+        "GET",
+        "/spend/logs",
+        params={
+            "summarize": "false",
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+    )
+    if not isinstance(payload, list):
+        raise LiteLLMIntegrationError(
+            "litellm_invalid_response", "LiteLLM returned invalid spend logs."
+        )
+    return [
+        _validate(LiteLLMSpendLogEntry, row, context="/spend/logs")
+        for row in payload
+        if isinstance(row, dict)
+    ]
+
+
+async def health() -> bool:
+    """Liveness probe. Raises LiteLLMIntegrationError when unreachable."""
+    await _request("GET", "/health/liveliness", headers={})
+    return True

--- a/server/proliferate/integrations/litellm/errors.py
+++ b/server/proliferate/integrations/litellm/errors.py
@@ -1,0 +1,13 @@
+"""Error types for the LiteLLM integration."""
+
+from __future__ import annotations
+
+
+class LiteLLMIntegrationError(RuntimeError):
+    """Raised on failures talking to the LiteLLM proxy admin API."""
+
+    def __init__(self, code: str, message: str, *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code

--- a/server/proliferate/integrations/litellm/models.py
+++ b/server/proliferate/integrations/litellm/models.py
@@ -1,0 +1,47 @@
+"""Typed LiteLLM payload models exposed by the integration.
+
+Pydantic is used (rather than plain dataclasses) because every payload here is
+structured untrusted input parsed off the LiteLLM proxy wire.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LiteLLMVirtualKey(BaseModel):
+    """A virtual key minted by ``/key/generate``."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    key: str
+    token_id: str = ""
+    key_alias: str | None = None
+    user_id: str | None = None
+    team_id: str | None = None
+    max_budget: float | None = None
+
+
+class LiteLLMSpendLogEntry(BaseModel):
+    """One per-request row from ``/spend/logs?summarize=false``.
+
+    ``api_key`` is the SHA-256 token hash of the virtual key that made the
+    request; it equals the ``token_id`` returned at mint time.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    request_id: str
+    api_key: str = ""
+    model: str = ""
+    spend: float = 0.0
+    total_tokens: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    start_time: str | None = Field(default=None, alias="startTime")
+    end_time: str | None = Field(default=None, alias="endTime")
+    team_id: str | None = None
+    user: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/server/tests/unit/test_litellm_integration.py
+++ b/server/tests/unit/test_litellm_integration.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from proliferate.config import settings
+from proliferate.integrations import litellm
+from proliferate.integrations.litellm import client as litellm_client
+
+BASE_URL = "http://litellm.test:4000"
+MASTER_KEY = "sk-test-master-key"
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses: list[httpx.Response | Exception]) -> None:
+        self.responses = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def request(self, method: str, url: str, **kwargs: object) -> httpx.Response:
+        request = httpx.Request(
+            method,
+            url,
+            headers=kwargs.get("headers") or {},
+            params=kwargs.get("params"),
+            json=kwargs.get("json"),
+        )
+        self.requests.append(request)
+        if not self.responses:
+            raise AssertionError(f"Unexpected extra request: {method} {url}")
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _response(status_code: int, payload: object) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        request=httpx.Request("POST", f"{BASE_URL}/key/generate"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _gateway_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_litellm_base_url", BASE_URL)
+    monkeypatch.setattr(settings, "agent_gateway_litellm_master_key", MASTER_KEY)
+    monkeypatch.setattr(settings, "agent_gateway_litellm_timeout_seconds", 5.0)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, client: _FakeAsyncClient) -> None:
+    monkeypatch.setattr(litellm_client.httpx, "AsyncClient", lambda **_kwargs: client)
+
+
+def _request_body(request: httpx.Request) -> dict[str, object]:
+    return json.loads(request.content.decode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_mint_virtual_key_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                200,
+                {
+                    "key": "sk-virtual-123",
+                    "token_id": "hash-abc",
+                    "key_alias": "user-1-personal",
+                    "user_id": "user-1",
+                    "team_id": "team-1",
+                    "max_budget": 5.0,
+                },
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    key = await litellm.mint_virtual_key(
+        user_id="user-1",
+        team_id="team-1",
+        alias="user-1-personal",
+        max_budget=5.0,
+        metadata={"billing_subject_id": "bs-1"},
+    )
+
+    assert key.key == "sk-virtual-123"
+    assert key.token_id == "hash-abc"
+    assert key.team_id == "team-1"
+
+    request = client.requests[0]
+    assert request.url.path == "/key/generate"
+    assert request.headers["Authorization"] == f"Bearer {MASTER_KEY}"
+    body = _request_body(request)
+    assert body == {
+        "user_id": "user-1",
+        "team_id": "team-1",
+        "key_alias": "user-1-personal",
+        "max_budget": 5.0,
+        "metadata": {"billing_subject_id": "bs-1"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_mint_virtual_key_400_surfaces_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                400,
+                {
+                    "error": {
+                        "message": "Key with alias 'dupe' already exists.",
+                        "type": "bad_request_error",
+                    }
+                },
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.mint_virtual_key(user_id="user-1", alias="dupe")
+
+    assert excinfo.value.code == "litellm_request_failed"
+    assert excinfo.value.status_code == 400
+    assert "already exists" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_mint_virtual_key_500_surfaces_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient([_response(500, {"detail": "boom"})])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.mint_virtual_key(user_id="user-1")
+
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.message == "boom"
+
+
+@pytest.mark.asyncio
+async def test_network_error_wraps_as_integration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient([httpx.ConnectError("connection refused")])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.health()
+
+    assert excinfo.value.code == "litellm_request_failed"
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_master_key_raises_before_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_litellm_master_key", "")
+
+    def fail_if_called(**_kwargs: object) -> _FakeAsyncClient:
+        raise AssertionError("AsyncClient should not be constructed without a master key")
+
+    monkeypatch.setattr(litellm_client.httpx, "AsyncClient", fail_if_called)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.ensure_user(user_id="user-1")
+
+    assert excinfo.value.code == "litellm_unconfigured"
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_ensure_team_returns_existing_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                200,
+                [
+                    {"team_alias": "org-42", "team_id": "team-existing"},
+                ],
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    team_id = await litellm.ensure_team(alias="org-42", max_budget=10.0)
+
+    assert team_id == "team-existing"
+    # Only the lookup ran; no /team/new call.
+    assert [request.url.path for request in client.requests] == ["/team/list"]
+    assert client.requests[0].url.params["team_alias"] == "org-42"
+
+
+@pytest.mark.asyncio
+async def test_ensure_team_creates_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(200, []),
+            _response(200, {"team_id": "team-created", "team_alias": "org-42"}),
+        ]
+    )
+    _install(monkeypatch, client)
+
+    team_id = await litellm.ensure_team(alias="org-42", max_budget=10.0)
+
+    assert team_id == "team-created"
+    assert [request.url.path for request in client.requests] == ["/team/list", "/team/new"]
+    body = _request_body(client.requests[1])
+    assert body == {"team_alias": "org-42", "max_budget": 10.0}
+
+
+@pytest.mark.asyncio
+async def test_ensure_user_treats_conflict_as_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                409,
+                {"error": {"message": "User with id user-1 already exists", "code": "409"}},
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    assert await litellm.ensure_user(user_id="user-1") == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_list_models_uses_virtual_key_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                200,
+                {
+                    "data": [
+                        {"id": "claude-haiku-4-5", "object": "model"},
+                        {"id": "gpt-5-mini", "object": "model"},
+                    ]
+                },
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    models = await litellm.list_models(virtual_key="sk-virtual-123")
+
+    assert models == ["claude-haiku-4-5", "gpt-5-mini"]
+    request = client.requests[0]
+    assert request.url.path == "/v1/models"
+    assert request.headers["Authorization"] == "Bearer sk-virtual-123"
+
+
+@pytest.mark.asyncio
+async def test_page_spend_logs_parses_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(
+                200,
+                [
+                    {
+                        "request_id": "req-1",
+                        "api_key": "hash-abc",
+                        "model": "claude-haiku-4-5-20251001",
+                        "spend": 0.0123,
+                        "total_tokens": 100,
+                        "prompt_tokens": 60,
+                        "completion_tokens": 40,
+                        "startTime": "2026-07-01T10:22:36.512000Z",
+                        "endTime": "2026-07-01T10:22:38.000000Z",
+                        "team_id": "team-1",
+                        "metadata": {"user_api_key_alias": "user-1-personal"},
+                        "unknown_extra_field": {"ignored": True},
+                    },
+                    {
+                        "request_id": "req-2",
+                        "api_key": "hash-def",
+                        "model": "gpt-5-mini",
+                        "spend": 0.5,
+                        "total_tokens": 2000,
+                        "prompt_tokens": 1500,
+                        "completion_tokens": 500,
+                    },
+                ],
+            )
+        ]
+    )
+    _install(monkeypatch, client)
+
+    rows = await litellm.page_spend_logs(start_date="2026-06-30", end_date="2026-07-01")
+
+    assert len(rows) == 2
+    first = rows[0]
+    assert first.request_id == "req-1"
+    assert first.api_key == "hash-abc"
+    assert first.spend == pytest.approx(0.0123)
+    assert first.start_time == "2026-07-01T10:22:36.512000Z"
+    assert first.metadata["user_api_key_alias"] == "user-1-personal"
+    second = rows[1]
+    assert second.request_id == "req-2"
+    assert second.team_id is None
+
+    request = client.requests[0]
+    assert request.url.path == "/spend/logs"
+    assert request.url.params["summarize"] == "false"
+    assert request.url.params["start_date"] == "2026-06-30"
+    assert request.url.params["end_date"] == "2026-07-01"
+
+
+@pytest.mark.asyncio
+async def test_page_spend_logs_invalid_payload_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient([_response(200, {"not": "a list"})])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.page_spend_logs(start_date="2026-06-30", end_date="2026-07-01")
+
+    assert excinfo.value.code == "litellm_invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_rotate_virtual_key_deletes_then_mints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(200, {"deleted_keys": ["hash-old"]}),
+            _response(
+                200,
+                {"key": "sk-virtual-new", "token_id": "hash-new", "user_id": "user-1"},
+            ),
+        ]
+    )
+    _install(monkeypatch, client)
+
+    key = await litellm.rotate_virtual_key(
+        key_or_token_id="hash-old",
+        user_id="user-1",
+        alias="user-1-personal",
+    )
+
+    assert key.key == "sk-virtual-new"
+    assert [request.url.path for request in client.requests] == [
+        "/key/delete",
+        "/key/generate",
+    ]
+    assert _request_body(client.requests[0]) == {"keys": ["hash-old"]}
+
+
+@pytest.mark.asyncio
+async def test_ensure_team_reuses_stored_id_without_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A stored team id is the durable get-or-create path: no /team/list or
+    # /team/new call is made, so there is no duplicate-team window.
+    client = _FakeAsyncClient([])
+    _install(monkeypatch, client)
+
+    team_id = await litellm.ensure_team(alias="org-42", team_id="team-stored", max_budget=10.0)
+
+    assert team_id == "team-stored"
+    assert client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_rotate_virtual_key_tolerates_missing_key_on_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A previous attempt deleted the key but crashed before minting; the retry
+    # sees a 404 on /key/delete and must proceed to mint rather than loop.
+    client = _FakeAsyncClient(
+        [
+            _response(404, {"error": {"message": "key not found"}}),
+            _response(
+                200,
+                {"key": "sk-virtual-new", "token_id": "hash-new", "user_id": "user-1"},
+            ),
+        ]
+    )
+    _install(monkeypatch, client)
+
+    key = await litellm.rotate_virtual_key(
+        key_or_token_id="hash-old",
+        user_id="user-1",
+        alias="user-1-personal",
+    )
+
+    assert key.key == "sk-virtual-new"
+    assert [request.url.path for request in client.requests] == [
+        "/key/delete",
+        "/key/generate",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rotate_virtual_key_reraises_non_404_delete_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient([_response(500, {"detail": "boom"})])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.rotate_virtual_key(key_or_token_id="hash-old", user_id="user-1")
+
+    assert excinfo.value.status_code == 500
+    # No mint attempted after a hard delete failure.
+    assert [request.url.path for request in client.requests] == ["/key/delete"]
+
+
+@pytest.mark.asyncio
+async def test_mint_virtual_key_malformed_200_wraps_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 200 with the required ``key`` field missing must surface as an integration
+    # error, not a raw pydantic ValidationError.
+    client = _FakeAsyncClient([_response(200, {"token_id": "hash-only"})])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.mint_virtual_key(user_id="user-1")
+
+    assert excinfo.value.code == "litellm_invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_page_spend_logs_malformed_row_wraps_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient([_response(200, [{"api_key": "hash-abc"}])])
+    _install(monkeypatch, client)
+
+    with pytest.raises(litellm.LiteLLMIntegrationError) as excinfo:
+        await litellm.page_spend_logs(start_date="2026-06-30", end_date="2026-07-01")
+
+    assert excinfo.value.code == "litellm_invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_disable_and_budget_updates_hit_expected_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncClient(
+        [
+            _response(200, {"token": "hash-abc"}),
+            _response(200, {"key": "hash-abc", "max_budget": 9.0}),
+            _response(200, {"team_id": "team-1", "max_budget": 50.0}),
+        ]
+    )
+    _install(monkeypatch, client)
+
+    await litellm.disable_virtual_key(key_or_token_id="hash-abc")
+    await litellm.set_key_budget(key_or_token_id="hash-abc", max_budget=9.0)
+    await litellm.update_team_budget(team_id="team-1", max_budget=50.0)
+
+    assert [request.url.path for request in client.requests] == [
+        "/key/block",
+        "/key/update",
+        "/team/update",
+    ]
+    assert _request_body(client.requests[0]) == {"key": "hash-abc"}
+    assert _request_body(client.requests[1]) == {"key": "hash-abc", "max_budget": 9.0}
+    assert _request_body(client.requests[2]) == {"team_id": "team-1", "max_budget": 50.0}

--- a/specs/developing/reference/env-secrets-matrix.md
+++ b/specs/developing/reference/env-secrets-matrix.md
@@ -159,6 +159,23 @@ secrets (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `CURSOR_API_KEY`,
 The billing reconciler interval (`BILLING_RECONCILE_INTERVAL_SECONDS`) now
 lives in `server/proliferate/constants/billing.py`. It is not env-overridable.
 
+## Agent LLM Gateway
+
+| Variable | Secret | Required | Used for |
+| --- | --- | --- | --- |
+| `AGENT_GATEWAY_ENABLED` | No | No | Enables the LiteLLM-backed agent LLM gateway on the control plane |
+| `AGENT_GATEWAY_LITELLM_BASE_URL` | No | When gateway is enabled | Private LiteLLM admin/base URL (in-VPC) for teams, users, virtual keys, and spend logs |
+| `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL` | No | When gateway is enabled | Public LiteLLM inference base URL rendered into sandbox/local harness auth config |
+| `AGENT_GATEWAY_LITELLM_MASTER_KEY` | Yes | When gateway is enabled | LiteLLM master key for the management API; never sent to sandboxes or clients |
+| `AGENT_GATEWAY_LITELLM_TIMEOUT_SECONDS` | No | No | LiteLLM management API timeout |
+
+The LiteLLM service itself (a separate ECS service / docker-compose pair) is
+configured with `LITELLM_MASTER_KEY`, its own `DATABASE_URL`, and the managed
+provider keys (`AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY`,
+`AGENT_GATEWAY_MANAGED_OPENAI_API_KEY`) referenced by
+`server/litellm/config.yaml` — those are deployment secrets for the LiteLLM
+task, not control-plane settings.
+
 ## Cloud MCP
 
 | Variable | Secret | Required | Used for |

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -488,6 +488,40 @@
   tags: [local-dev]
 
 # ═══════════════════════════════════════════════════════════════════════
+# Server: Agent LLM Gateway (LiteLLM)
+# ═══════════════════════════════════════════════════════════════════════
+
+- name: AGENT_GATEWAY_ENABLED
+  secret: false
+  default: "false"
+  description: Enables the LiteLLM-backed agent LLM gateway on the control plane
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_LITELLM_BASE_URL
+  secret: false
+  default: "http://127.0.0.1:14000"
+  description: Private LiteLLM admin/base URL (in-VPC) used by the control plane for teams, users, virtual keys, and spend logs
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL
+  secret: false
+  default: ""
+  description: Public LiteLLM inference base URL rendered into sandbox/local harness auth config
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_LITELLM_MASTER_KEY
+  secret: true
+  default: ""
+  description: LiteLLM master key for the management API; never sent to sandboxes or clients
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_LITELLM_TIMEOUT_SECONDS
+  secret: false
+  default: "30.0"
+  description: Timeout for LiteLLM management API requests
+  tags: [local-dev, self-hosted, production]
+
+# ═══════════════════════════════════════════════════════════════════════
 # Server: Cloud MCP
 # ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
PR 2 of 12 in the LiteLLM agent-auth migration (spec: `specs/codebase/primitives/agent-auth-litellm.md`). Stacked on #814.

Stands up LiteLLM Proxy as the agent LLM gateway data plane plus the control-plane admin client. Dark by default (`AGENT_GATEWAY_ENABLED=false`, deploy gated by `LITELLM_DEPLOY_ENABLED`).

## What's here
- **`integrations/litellm/`** — typed async admin client: `ensure_team` / `ensure_user` / `mint_virtual_key` / `rotate_virtual_key` / `disable_virtual_key` / budgets / `list_models(vk)` / `page_spend_logs` / `health`. Quirks handled from live probing: `/key/regenerate` is enterprise-only (rotation = delete+mint), `/team/new` doesn't dedupe aliases, duplicate `/user/new` → 409, `key_alias` globally unique, spend logs are async.
- **`server/litellm/`** — checked-in proxy `config.yaml` (alias + versioned model ids so claude-code's versioned requests resolve) + Dockerfile.
- **Local dev** — `litellm` + `litellm-db` compose services; `make dev AGENT_GATEWAY=litellm`.
- **Deploy** — `_deploy-litellm.yml` (mirrors `_deploy-server.yml`: ECR → task-def → service roll) wired into `deploy-staging.yml` + `promote-production.yml`; new `litellm` deploy surface. RDS + ECS service must exist before enabling (documented in workflow header).
- **Smoke harness** — `scripts/agent-gateway-smoke/`: health → mint key → models → completion → spend-log row, live-verified against the compose stack (`spend: 4e-05`, spend row attributed to the minted key). Per-harness runners are stubs pending the compat matrix.

## Verification
- 13 new unit tests; full server suite: 587 passed, 41 failed — identical failure set on base commit (pre-existing), zero regressions
- Live smoke output in commit; compose config validates; workflow YAML parses; repo-shape checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)