### PR TITLE
feat(agent-auth): add LiteLLM schema and eager enrollment

### DIFF
--- a/server/alembic/versions/a9c0d1e2f3b4_agent_gateway_litellm_schema.py
+++ b/server/alembic/versions/a9c0d1e2f3b4_agent_gateway_litellm_schema.py
@@ -1,0 +1,417 @@
+"""agent gateway litellm schema
+
+Creates the LiteLLM-era agent auth tables (PR 3 of the agent-auth migration,
+see specs/codebase/primitives/agent-auth-litellm.md section 3.3): personal
+API key pool, route selections, gateway enrollment, catalog snapshots and
+overrides, flag-only org policy, and the usage ledger + import cursor.
+
+Revision ID: a9c0d1e2f3b4
+Revises: f8b9c0d1e2a3
+Create Date: 2026-07-01 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a9c0d1e2f3b4"
+down_revision: str | Sequence[str] | None = "f8b9c0d1e2a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def upgrade() -> None:
+    if not _has_table("agent_api_key"):
+        op.create_table(
+            "agent_api_key",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("provider", sa.String(length=32), nullable=False),
+            sa.Column("display_name", sa.String(length=255), nullable=False),
+            sa.Column("payload_ciphertext", sa.Text(), nullable=False),
+            sa.Column("payload_ciphertext_key_id", sa.String(length=255), nullable=False),
+            sa.Column("redacted_hint", sa.String(length=64), nullable=False),
+            sa.Column("status", sa.String(length=16), nullable=False),
+            sa.Column("last_validated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "provider IN ('anthropic', 'openai', 'xai', 'google', 'other')",
+                name="ck_agent_api_key_provider",
+            ),
+            sa.CheckConstraint(
+                "status IN ('active', 'revoked')",
+                name="ck_agent_api_key_status",
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_agent_api_key_user_id", "agent_api_key", ["user_id"])
+        op.create_index(
+            "ix_agent_api_key_user_status",
+            "agent_api_key",
+            ["user_id", "status"],
+        )
+
+    if not _has_table("agent_auth_route_selection"):
+        op.create_table(
+            "agent_auth_route_selection",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("harness_kind", sa.String(length=64), nullable=False),
+            sa.Column("surface", sa.String(length=16), nullable=False),
+            sa.Column("route", sa.String(length=16), nullable=False),
+            sa.Column("api_key_id", sa.Uuid(), nullable=True),
+            sa.Column("revision", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "surface IN ('local', 'cloud')",
+                name="ck_agent_auth_route_selection_surface",
+            ),
+            sa.CheckConstraint(
+                "route IN ('native', 'api_key', 'gateway')",
+                name="ck_agent_auth_route_selection_route",
+            ),
+            sa.CheckConstraint(
+                "surface != 'cloud' OR route != 'native'",
+                name="ck_agent_auth_route_selection_cloud_route",
+            ),
+            sa.CheckConstraint(
+                "(route != 'api_key') OR (api_key_id IS NOT NULL)",
+                name="ck_agent_auth_route_selection_api_key_ref",
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["api_key_id"],
+                ["agent_api_key.id"],
+                # CASCADE so deleting a key removes its api_key-route selections
+                # rather than nulling api_key_id and violating ck_..._api_key_ref.
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "user_id",
+                "harness_kind",
+                "surface",
+                name="uq_agent_auth_route_selection_scope",
+            ),
+        )
+        op.create_index(
+            "ix_agent_auth_route_selection_user_id",
+            "agent_auth_route_selection",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_agent_auth_route_selection_api_key_id",
+            "agent_auth_route_selection",
+            ["api_key_id"],
+        )
+
+    if not _has_table("agent_gateway_enrollment"):
+        op.create_table(
+            "agent_gateway_enrollment",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("subject_kind", sa.String(length=16), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=True),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("billing_subject_id", sa.Uuid(), nullable=False),
+            sa.Column("litellm_team_id", sa.String(length=255), nullable=True),
+            sa.Column("litellm_user_id", sa.String(length=255), nullable=True),
+            sa.Column("virtual_key_id", sa.String(length=255), nullable=True),
+            sa.Column("virtual_key_ciphertext", sa.Text(), nullable=True),
+            sa.Column(
+                "virtual_key_ciphertext_key_id",
+                sa.String(length=255),
+                nullable=True,
+            ),
+            sa.Column("sync_status", sa.String(length=16), nullable=False),
+            sa.Column("sync_fingerprint", sa.String(length=128), nullable=True),
+            sa.Column("last_error_code", sa.String(length=128), nullable=True),
+            sa.Column("last_error_message", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "subject_kind IN ('user', 'organization')",
+                name="ck_agent_gateway_enrollment_subject_kind",
+            ),
+            sa.CheckConstraint(
+                # Org enrollment is per (member, org): user_id required for both
+                # kinds so each member gets their own virtual key (spec §2.3).
+                "(subject_kind = 'user' AND user_id IS NOT NULL "
+                "AND organization_id IS NULL) OR "
+                "(subject_kind = 'organization' AND organization_id IS NOT NULL "
+                "AND user_id IS NOT NULL)",
+                name="ck_agent_gateway_enrollment_subject_shape",
+            ),
+            sa.CheckConstraint(
+                "sync_status IN ('pending', 'synced', 'failed')",
+                name="ck_agent_gateway_enrollment_sync_status",
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["organization_id"],
+                ["organization.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["billing_subject_id"],
+                ["billing_subject.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_agent_gateway_enrollment_user_id",
+            "agent_gateway_enrollment",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_agent_gateway_enrollment_organization_id",
+            "agent_gateway_enrollment",
+            ["organization_id"],
+        )
+        op.create_index(
+            "ix_agent_gateway_enrollment_billing_subject_id",
+            "agent_gateway_enrollment",
+            ["billing_subject_id"],
+        )
+        op.create_index(
+            "ix_agent_gateway_enrollment_sync_status",
+            "agent_gateway_enrollment",
+            ["sync_status"],
+        )
+        op.create_index(
+            "ux_agent_gateway_enrollment_active_user",
+            "agent_gateway_enrollment",
+            ["user_id"],
+            unique=True,
+            postgresql_where=sa.text("subject_kind = 'user' AND revoked_at IS NULL"),
+        )
+        op.create_index(
+            "ux_agent_gateway_enrollment_active_organization",
+            "agent_gateway_enrollment",
+            ["organization_id", "user_id"],
+            unique=True,
+            postgresql_where=sa.text("subject_kind = 'organization' AND revoked_at IS NULL"),
+        )
+
+    if not _has_table("agent_catalog_snapshot"):
+        op.create_table(
+            "agent_catalog_snapshot",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("harness_kind", sa.String(length=64), nullable=False),
+            sa.Column("surface", sa.String(length=16), nullable=False),
+            sa.Column("route", sa.String(length=16), nullable=False),
+            sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+            sa.Column("models_json", sa.Text(), nullable=False),
+            sa.Column("probed_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("source", sa.String(length=16), nullable=False),
+            sa.Column("status", sa.String(length=16), nullable=False),
+            sa.CheckConstraint(
+                "surface IN ('local', 'cloud')",
+                name="ck_agent_catalog_snapshot_surface",
+            ),
+            sa.CheckConstraint(
+                "route IN ('native', 'api_key', 'gateway')",
+                name="ck_agent_catalog_snapshot_route",
+            ),
+            sa.CheckConstraint(
+                "source IN ('probe', 'seed', 'override')",
+                name="ck_agent_catalog_snapshot_source",
+            ),
+            sa.ForeignKeyConstraint(
+                ["owner_user_id"],
+                ["user.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_agent_catalog_snapshot_owner_user_id",
+            "agent_catalog_snapshot",
+            ["owner_user_id"],
+        )
+        op.create_index(
+            "ix_agent_catalog_snapshot_scope",
+            "agent_catalog_snapshot",
+            ["harness_kind", "surface", "route", "owner_user_id", "probed_at"],
+        )
+
+    if not _has_table("agent_catalog_override"):
+        op.create_table(
+            "agent_catalog_override",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("owner_user_id", sa.Uuid(), nullable=True),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("harness_kind", sa.String(length=64), nullable=False),
+            sa.Column("patch_json", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "(owner_user_id IS NOT NULL AND organization_id IS NULL) OR "
+                "(organization_id IS NOT NULL AND owner_user_id IS NULL)",
+                name="ck_agent_catalog_override_owner_shape",
+            ),
+            sa.ForeignKeyConstraint(
+                ["owner_user_id"],
+                ["user.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["organization_id"],
+                ["organization.id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_agent_catalog_override_owner_user_id",
+            "agent_catalog_override",
+            ["owner_user_id"],
+        )
+        op.create_index(
+            "ix_agent_catalog_override_organization_id",
+            "agent_catalog_override",
+            ["organization_id"],
+        )
+        op.create_index(
+            "ux_agent_catalog_override_user_harness",
+            "agent_catalog_override",
+            ["owner_user_id", "harness_kind"],
+            unique=True,
+            postgresql_where=sa.text("owner_user_id IS NOT NULL"),
+        )
+        op.create_index(
+            "ux_agent_catalog_override_org_harness",
+            "agent_catalog_override",
+            ["organization_id", "harness_kind"],
+            unique=True,
+            postgresql_where=sa.text("organization_id IS NOT NULL"),
+        )
+
+    if not _has_table("org_agent_policy"):
+        op.create_table(
+            "org_agent_policy",
+            sa.Column("organization_id", sa.Uuid(), nullable=False),
+            sa.Column("allowed_routes_json", sa.Text(), nullable=True),
+            sa.Column("allowed_harnesses_json", sa.Text(), nullable=True),
+            sa.Column("updated_by_user_id", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["organization_id"],
+                ["organization.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["updated_by_user_id"],
+                ["user.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("organization_id"),
+        )
+
+    if not _has_table("agent_llm_usage_event"):
+        op.create_table(
+            "agent_llm_usage_event",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("litellm_request_id", sa.String(length=255), nullable=False),
+            sa.Column("virtual_key_id", sa.String(length=255), nullable=True),
+            sa.Column("litellm_team_id", sa.String(length=255), nullable=True),
+            sa.Column("user_id", sa.Uuid(), nullable=True),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("billing_subject_id", sa.Uuid(), nullable=True),
+            sa.Column("provider", sa.String(length=64), nullable=True),
+            sa.Column("model", sa.String(length=255), nullable=True),
+            sa.Column("prompt_tokens", sa.BigInteger(), nullable=False),
+            sa.Column("completion_tokens", sa.BigInteger(), nullable=False),
+            sa.Column("total_tokens", sa.BigInteger(), nullable=False),
+            sa.Column("cost_usd", sa.Numeric(18, 8), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("workspace_id", sa.String(length=255), nullable=True),
+            sa.Column("session_id", sa.String(length=255), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("imported_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("raw_metadata_json", sa.Text(), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(
+                ["organization_id"],
+                ["organization.id"],
+                ondelete="SET NULL",
+            ),
+            sa.ForeignKeyConstraint(
+                ["billing_subject_id"],
+                ["billing_subject.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "litellm_request_id",
+                name="uq_agent_llm_usage_event_litellm_request_id",
+            ),
+        )
+        op.create_index(
+            "ix_agent_llm_usage_event_user_occurred",
+            "agent_llm_usage_event",
+            ["user_id", "occurred_at"],
+        )
+        op.create_index(
+            "ix_agent_llm_usage_event_org_occurred",
+            "agent_llm_usage_event",
+            ["organization_id", "occurred_at"],
+        )
+        op.create_index(
+            "ix_agent_llm_usage_event_subject_occurred",
+            "agent_llm_usage_event",
+            ["billing_subject_id", "occurred_at"],
+        )
+
+    if not _has_table("agent_llm_usage_import_cursor"):
+        op.create_table(
+            "agent_llm_usage_import_cursor",
+            sa.Column("id", sa.String(length=16), nullable=False),
+            sa.Column("last_seen_occurred_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_polled_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("last_error_code", sa.String(length=128), nullable=True),
+            sa.Column("last_error_message", sa.Text(), nullable=True),
+            sa.Column("metadata_json", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "id = 'default'",
+                name="ck_agent_llm_usage_import_cursor_singleton",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+
+def downgrade() -> None:
+    # Children before parents so plain DROP TABLE respects foreign keys.
+    for table_name in (
+        "agent_llm_usage_import_cursor",
+        "agent_llm_usage_event",
+        "org_agent_policy",
+        "agent_catalog_override",
+        "agent_catalog_snapshot",
+        "agent_gateway_enrollment",
+        "agent_auth_route_selection",
+        "agent_api_key",
+    ):
+        if _has_table(table_name):
+            op.drop_table(table_name)

--- a/server/proliferate/auth/desktop/service.py
+++ b/server/proliferate/auth/desktop/service.py
@@ -80,6 +80,9 @@ from proliferate.integrations.github import (
     GitHubIntegrationError,
     get_github_user_profile,
 )
+from proliferate.server.cloud.agent_gateway.signup_hook import (
+    schedule_agent_gateway_user_enrollment,
+)
 from proliferate.server.notifications import (
     SignupSlackNotification,
     schedule_signup_slack_notification,
@@ -466,6 +469,7 @@ async def finish_github_desktop_callback(
         redirect_uri=state_data["redirect_uri"],
     )
     schedule_customerio_desktop_authenticated_user_sync(user)
+    schedule_agent_gateway_user_enrollment(user.id, db=db)
     if not github_account_or_email_exists:
         schedule_signup_slack_notification(
             SignupSlackNotification(

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -38,6 +38,9 @@ from proliferate.constants.auth import (
 )
 from proliferate.db.models.auth import User
 from proliferate.db.store.auth import create_auth_code
+from proliferate.server.cloud.agent_gateway.signup_hook import (
+    schedule_agent_gateway_user_enrollment,
+)
 from proliferate.server.organizations.registration import (
     ensure_default_organization_for_account,
 )
@@ -221,6 +224,7 @@ async def complete_oauth_provider_callback(
         state=challenge.client_state,
         redirect_uri=challenge.redirect_uri,
     )
+    schedule_agent_gateway_user_enrollment(user.id, db=db)
     if callback_surface == "desktop" and provider == "github":
         _schedule_desktop_github_login_side_effects(
             db,
@@ -319,6 +323,7 @@ async def complete_apple_mobile_login(
         display_name_hint=display_name,
     )
     user = await resolve_provider_user(db, verified=verified, challenge=challenge)
+    schedule_agent_gateway_user_enrollment(user.id, db=db)
     return await mint_auth_session(db, user=user)
 
 
@@ -355,6 +360,7 @@ async def complete_apple_web_callback(
         state=challenge.client_state,
         redirect_uri=challenge.redirect_uri,
     )
+    schedule_agent_gateway_user_enrollment(user.id, db=db)
     return append_query(challenge.redirect_uri, code=auth_code.code, state=challenge.client_state)
 
 

--- a/server/proliferate/auth/sso/service.py
+++ b/server/proliferate/auth/sso/service.py
@@ -59,6 +59,7 @@ from proliferate.integrations.sso.oidc import (
 from proliferate.server.billing.seat_reconciliation import (
     maybe_create_organization_seat_adjustment,
 )
+from proliferate.server.cloud.agent_gateway import signup_hook
 from proliferate.server.organizations.registration import ensure_default_organization_for_account
 
 
@@ -254,6 +255,7 @@ async def complete_oidc_sso_callback(
         state=challenge.client_state,
         redirect_uri=challenge.redirect_uri,
     )
+    signup_hook.schedule_agent_gateway_user_enrollment(user.id, db=db)
     return append_query(challenge.redirect_uri, code=auth_code.code, state=challenge.client_state)
 
 
@@ -393,6 +395,9 @@ async def _resolve_organization_sso_user(
                 organization_id=accepted.organization.id,
                 membership_id=accepted.membership.id,
             )
+            signup_hook.schedule_agent_gateway_org_enrollment(
+                accepted.organization.id, user.id, db=db
+            )
             return user
     if connection.jit_policy != SsoJitPolicy.CREATE_MEMBER:
         raise HTTPException(status_code=403, detail="SSO user is not a team member.")
@@ -407,6 +412,7 @@ async def _resolve_organization_sso_user(
         organization_id=connection.organization_id,
         membership_id=membership.id,
     )
+    signup_hook.schedule_agent_gateway_org_enrollment(connection.organization_id, user.id, db=db)
     return user
 
 

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -330,6 +330,9 @@ class Settings(BaseSettings):
     agent_gateway_litellm_public_base_url: str = ""
     agent_gateway_litellm_master_key: str = ""
     agent_gateway_litellm_timeout_seconds: float = 30.0
+    agent_gateway_default_user_budget_usd: str = "5"
+    agent_gateway_default_org_budget_usd: str = "0"
+    agent_gateway_backfill_interval_seconds: float = 300.0
     e2b_api_key: str = ""
     e2b_template_name: str = ""
     e2b_webhook_signature_secret: str = ""

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -1,0 +1,34 @@
+"""Agent LLM gateway (LiteLLM) schema constants."""
+
+AGENT_API_KEY_PROVIDERS = ("anthropic", "openai", "xai", "google", "other")
+AGENT_API_KEY_STATUS_ACTIVE = "active"
+AGENT_API_KEY_STATUS_REVOKED = "revoked"
+
+AGENT_AUTH_SURFACE_LOCAL = "local"
+AGENT_AUTH_SURFACE_CLOUD = "cloud"
+AGENT_AUTH_SURFACES = (AGENT_AUTH_SURFACE_LOCAL, AGENT_AUTH_SURFACE_CLOUD)
+
+AGENT_AUTH_ROUTE_NATIVE = "native"
+AGENT_AUTH_ROUTE_API_KEY = "api_key"
+AGENT_AUTH_ROUTE_GATEWAY = "gateway"
+AGENT_AUTH_ROUTES = (
+    AGENT_AUTH_ROUTE_NATIVE,
+    AGENT_AUTH_ROUTE_API_KEY,
+    AGENT_AUTH_ROUTE_GATEWAY,
+)
+
+AGENT_GATEWAY_SUBJECT_KIND_USER = "user"
+AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION = "organization"
+
+AGENT_GATEWAY_SYNC_STATUS_PENDING = "pending"
+AGENT_GATEWAY_SYNC_STATUS_SYNCED = "synced"
+AGENT_GATEWAY_SYNC_STATUS_FAILED = "failed"
+
+AGENT_CATALOG_SNAPSHOT_SOURCES = ("probe", "seed", "override")
+AGENT_CATALOG_SNAPSHOT_STATUS_ACTIVE = "active"
+
+AGENT_USAGE_IMPORT_CURSOR_ID = "default"
+
+# Fernet key derivation is versioned by this identifier (see utils/crypto.py);
+# matches the cloud-secret convention used by other encrypted columns.
+AGENT_GATEWAY_CIPHERTEXT_KEY_ID = "cloud-secret-v1"

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -4,6 +4,7 @@ Importing this package registers all cloud ORM tables with SQLAlchemy metadata.
 Callers should import concrete models from the owning module in this package.
 """
 
+from . import agent_gateway as agent_gateway  # noqa: F401
 from . import agent_run_config as agent_run_config  # noqa: F401
 from . import github_app as github_app  # noqa: F401
 from . import integrations as integrations  # noqa: F401

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -1,0 +1,391 @@
+"""Agent LLM gateway ORM models (LiteLLM-era agent auth).
+
+Schema follows specs/codebase/primitives/agent-auth-litellm.md section 3.3:
+personal API key pool, per-(user, harness, surface) route selections, eager
+LiteLLM enrollment state, catalog snapshots/overrides, flag-only org policy,
+and the slim usage-event ledger fed by the spend-log importer.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.db.models.base import Base, utcnow
+
+
+class AgentApiKey(Base):
+    """A raw provider API key in a user's personal key pool."""
+
+    __tablename__ = "agent_api_key"
+    __table_args__ = (
+        CheckConstraint(
+            "provider IN ('anthropic', 'openai', 'xai', 'google', 'other')",
+            name="ck_agent_api_key_provider",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'revoked')",
+            name="ck_agent_api_key_status",
+        ),
+        Index("ix_agent_api_key_user_status", "user_id", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32))
+    display_name: Mapped[str] = mapped_column(String(255))
+    payload_ciphertext: Mapped[str] = mapped_column(Text)
+    payload_ciphertext_key_id: Mapped[str] = mapped_column(String(255))
+    redacted_hint: Mapped[str] = mapped_column(String(64))
+    status: Mapped[str] = mapped_column(String(16), default="active")
+    last_validated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AgentAuthRouteSelection(Base):
+    """Server-side auth route per (user, harness, surface)."""
+
+    __tablename__ = "agent_auth_route_selection"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "harness_kind",
+            "surface",
+            name="uq_agent_auth_route_selection_scope",
+        ),
+        CheckConstraint(
+            "surface IN ('local', 'cloud')",
+            name="ck_agent_auth_route_selection_surface",
+        ),
+        CheckConstraint(
+            "route IN ('native', 'api_key', 'gateway')",
+            name="ck_agent_auth_route_selection_route",
+        ),
+        CheckConstraint(
+            "surface != 'cloud' OR route != 'native'",
+            name="ck_agent_auth_route_selection_cloud_route",
+        ),
+        CheckConstraint(
+            "(route != 'api_key') OR (api_key_id IS NOT NULL)",
+            name="ck_agent_auth_route_selection_api_key_ref",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    harness_kind: Mapped[str] = mapped_column(String(64))
+    surface: Mapped[str] = mapped_column(String(16))
+    route: Mapped[str] = mapped_column(String(16))
+    api_key_id: Mapped[uuid.UUID | None] = mapped_column(
+        # CASCADE (not SET NULL): the ck_..._api_key_ref check forbids a NULL
+        # api_key_id on an api_key-route row, so a deleted key must take its
+        # referencing selections with it rather than orphan them.
+        ForeignKey("agent_api_key.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class AgentGatewayEnrollment(Base):
+    """LiteLLM enrollment state per billing subject (team + user + virtual key)."""
+
+    __tablename__ = "agent_gateway_enrollment"
+    __table_args__ = (
+        CheckConstraint(
+            "subject_kind IN ('user', 'organization')",
+            name="ck_agent_gateway_enrollment_subject_kind",
+        ),
+        CheckConstraint(
+            # Personal enrollment: user only. Org enrollment: one row per
+            # (member, org) so every member gets their own virtual key under
+            # the org team (spec §2.3), hence user_id is required for both.
+            "(subject_kind = 'user' AND user_id IS NOT NULL AND organization_id IS NULL) OR "
+            "(subject_kind = 'organization' AND organization_id IS NOT NULL "
+            "AND user_id IS NOT NULL)",
+            name="ck_agent_gateway_enrollment_subject_shape",
+        ),
+        CheckConstraint(
+            "sync_status IN ('pending', 'synced', 'failed')",
+            name="ck_agent_gateway_enrollment_sync_status",
+        ),
+        Index(
+            "ux_agent_gateway_enrollment_active_user",
+            "user_id",
+            unique=True,
+            postgresql_where=text("subject_kind = 'user' AND revoked_at IS NULL"),
+        ),
+        Index(
+            "ux_agent_gateway_enrollment_active_organization",
+            "organization_id",
+            "user_id",
+            unique=True,
+            postgresql_where=text("subject_kind = 'organization' AND revoked_at IS NULL"),
+        ),
+        Index("ix_agent_gateway_enrollment_sync_status", "sync_status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    subject_kind: Mapped[str] = mapped_column(String(16))
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    billing_subject_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("billing_subject.id", ondelete="CASCADE"),
+        index=True,
+    )
+    litellm_team_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    litellm_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    virtual_key_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
+    virtual_key_ciphertext_key_id: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    sync_status: Mapped[str] = mapped_column(String(16), default="pending")
+    sync_fingerprint: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AgentCatalogSnapshot(Base):
+    """Probed (or seeded) model catalog per (harness, surface, route, owner)."""
+
+    __tablename__ = "agent_catalog_snapshot"
+    __table_args__ = (
+        CheckConstraint(
+            "surface IN ('local', 'cloud')",
+            name="ck_agent_catalog_snapshot_surface",
+        ),
+        CheckConstraint(
+            "route IN ('native', 'api_key', 'gateway')",
+            name="ck_agent_catalog_snapshot_route",
+        ),
+        CheckConstraint(
+            "source IN ('probe', 'seed', 'override')",
+            name="ck_agent_catalog_snapshot_source",
+        ),
+        Index(
+            "ix_agent_catalog_snapshot_scope",
+            "harness_kind",
+            "surface",
+            "route",
+            "owner_user_id",
+            "probed_at",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    harness_kind: Mapped[str] = mapped_column(String(64))
+    surface: Mapped[str] = mapped_column(String(16))
+    route: Mapped[str] = mapped_column(String(16))
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    models_json: Mapped[str] = mapped_column(Text)
+    probed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    source: Mapped[str] = mapped_column(String(16), default="probe")
+    status: Mapped[str] = mapped_column(String(16), default="active")
+
+
+class AgentCatalogOverride(Base):
+    """User/org edits layered on top of catalog snapshots."""
+
+    __tablename__ = "agent_catalog_override"
+    __table_args__ = (
+        CheckConstraint(
+            "(owner_user_id IS NOT NULL AND organization_id IS NULL) OR "
+            "(organization_id IS NOT NULL AND owner_user_id IS NULL)",
+            name="ck_agent_catalog_override_owner_shape",
+        ),
+        Index(
+            "ux_agent_catalog_override_user_harness",
+            "owner_user_id",
+            "harness_kind",
+            unique=True,
+            postgresql_where=text("owner_user_id IS NOT NULL"),
+        ),
+        Index(
+            "ux_agent_catalog_override_org_harness",
+            "organization_id",
+            "harness_kind",
+            unique=True,
+            postgresql_where=text("organization_id IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    harness_kind: Mapped[str] = mapped_column(String(64))
+    patch_json: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class OrgAgentPolicy(Base):
+    """Flag-only org agent policy; violations computed live from selections."""
+
+    __tablename__ = "org_agent_policy"
+
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    allowed_routes_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    allowed_harnesses_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
+class AgentLlmUsageEvent(Base):
+    """Slim per-request ledger imported from LiteLLM spend logs."""
+
+    __tablename__ = "agent_llm_usage_event"
+    __table_args__ = (
+        Index("ix_agent_llm_usage_event_user_occurred", "user_id", "occurred_at"),
+        Index(
+            "ix_agent_llm_usage_event_org_occurred",
+            "organization_id",
+            "occurred_at",
+        ),
+        Index(
+            "ix_agent_llm_usage_event_subject_occurred",
+            "billing_subject_id",
+            "occurred_at",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    litellm_request_id: Mapped[str] = mapped_column(String(255), unique=True)
+    virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    litellm_team_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    billing_subject_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("billing_subject.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    provider: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    model: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    prompt_tokens: Mapped[int] = mapped_column(BigInteger, default=0)
+    completion_tokens: Mapped[int] = mapped_column(BigInteger, default=0)
+    total_tokens: Mapped[int] = mapped_column(BigInteger, default=0)
+    cost_usd: Mapped[float | None] = mapped_column(
+        Numeric(18, 8, asdecimal=False),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(String(32), default="imported")
+    workspace_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    imported_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    raw_metadata_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class AgentLlmUsageImportCursor(Base):
+    """Singleton cursor for the LiteLLM spend-log importer."""
+
+    __tablename__ = "agent_llm_usage_import_cursor"
+    __table_args__ = (
+        CheckConstraint(
+            "id = 'default'",
+            name="ck_agent_llm_usage_import_cursor_singleton",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(16), primary_key=True, default="default")
+    last_seen_occurred_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_polled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(String(32), default="idle")
+    last_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/agent_gateway/__init__.py
+++ b/server/proliferate/db/store/agent_gateway/__init__.py
@@ -1,0 +1,89 @@
+"""Agent gateway (LiteLLM-era agent auth) stores."""
+
+from proliferate.db.store.agent_gateway.api_keys import (
+    build_redacted_hint,
+    create_agent_api_key,
+    get_agent_api_key_decrypted,
+    list_agent_api_keys,
+    revoke_agent_api_key,
+)
+from proliferate.db.store.agent_gateway.catalog import (
+    create_catalog_snapshot,
+    get_catalog_override,
+    get_latest_catalog_snapshot,
+    upsert_catalog_override,
+)
+from proliferate.db.store.agent_gateway.enrollments import (
+    ensure_enrollment_row,
+    get_enrollment_for_organization,
+    get_enrollment_for_user,
+    get_enrollment_virtual_key_decrypted,
+    list_enrollments_needing_sync,
+    list_org_memberships_missing_enrollment,
+    list_user_ids_missing_enrollment,
+    mark_enrollment_failed,
+    mark_enrollment_synced,
+    revoke_enrollment,
+)
+from proliferate.db.store.agent_gateway.policy import (
+    get_org_agent_policy,
+    set_org_agent_policy,
+)
+from proliferate.db.store.agent_gateway.records import (
+    AgentApiKeyRecord,
+    AgentAuthRouteSelectionRecord,
+    AgentCatalogOverrideRecord,
+    AgentCatalogSnapshotRecord,
+    AgentGatewayEnrollmentRecord,
+    AgentLlmUsageImportCursorRecord,
+    OrgAgentPolicyRecord,
+)
+from proliferate.db.store.agent_gateway.route_selections import (
+    get_route_selection,
+    list_route_selections,
+    upsert_route_selection,
+    validate_route_selection,
+)
+from proliferate.db.store.agent_gateway.usage import (
+    advance_usage_import_cursor,
+    get_usage_import_cursor,
+    insert_usage_event_once,
+)
+
+__all__ = [
+    "AgentApiKeyRecord",
+    "AgentAuthRouteSelectionRecord",
+    "AgentCatalogOverrideRecord",
+    "AgentCatalogSnapshotRecord",
+    "AgentGatewayEnrollmentRecord",
+    "AgentLlmUsageImportCursorRecord",
+    "OrgAgentPolicyRecord",
+    "advance_usage_import_cursor",
+    "build_redacted_hint",
+    "create_agent_api_key",
+    "create_catalog_snapshot",
+    "ensure_enrollment_row",
+    "get_agent_api_key_decrypted",
+    "get_catalog_override",
+    "get_enrollment_for_organization",
+    "get_enrollment_for_user",
+    "get_enrollment_virtual_key_decrypted",
+    "get_latest_catalog_snapshot",
+    "get_org_agent_policy",
+    "get_route_selection",
+    "get_usage_import_cursor",
+    "insert_usage_event_once",
+    "list_agent_api_keys",
+    "list_enrollments_needing_sync",
+    "list_org_memberships_missing_enrollment",
+    "list_route_selections",
+    "list_user_ids_missing_enrollment",
+    "mark_enrollment_failed",
+    "mark_enrollment_synced",
+    "revoke_agent_api_key",
+    "revoke_enrollment",
+    "set_org_agent_policy",
+    "upsert_catalog_override",
+    "upsert_route_selection",
+    "validate_route_selection",
+]

--- a/server/proliferate/db/store/agent_gateway/api_keys.py
+++ b/server/proliferate/db/store/agent_gateway/api_keys.py
@@ -1,0 +1,113 @@
+"""Personal agent API key pool persistence."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.agent_gateway import (
+    AGENT_API_KEY_PROVIDERS,
+    AGENT_API_KEY_STATUS_ACTIVE,
+    AGENT_API_KEY_STATUS_REVOKED,
+    AGENT_GATEWAY_CIPHERTEXT_KEY_ID,
+)
+from proliferate.db.models.cloud.agent_gateway import AgentApiKey
+from proliferate.db.store.agent_gateway.mappers import api_key_record
+from proliferate.db.store.agent_gateway.records import AgentApiKeyRecord
+from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.utils.time import utcnow
+
+
+def build_redacted_hint(payload: str) -> str:
+    """A safe display hint like ``sk-...abc4`` built from the raw key."""
+    tail = payload[-4:] if len(payload) >= 4 else payload
+    prefix = payload.split("-", 1)[0] if "-" in payload[:12] else ""
+    shown_prefix = f"{prefix}-" if prefix and len(prefix) <= 8 else ""
+    return f"{shown_prefix}...{tail}"
+
+
+async def create_agent_api_key(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    provider: str,
+    display_name: str,
+    payload: str,
+) -> AgentApiKeyRecord:
+    if provider not in AGENT_API_KEY_PROVIDERS:
+        raise ValueError(f"Unsupported agent API key provider: {provider}")
+    if not payload:
+        raise ValueError("Agent API key payload must not be empty.")
+    row = AgentApiKey(
+        user_id=user_id,
+        provider=provider,
+        display_name=display_name,
+        payload_ciphertext=encrypt_text(payload),
+        payload_ciphertext_key_id=AGENT_GATEWAY_CIPHERTEXT_KEY_ID,
+        redacted_hint=build_redacted_hint(payload),
+        status=AGENT_API_KEY_STATUS_ACTIVE,
+    )
+    db.add(row)
+    await db.flush()
+    return api_key_record(row)
+
+
+async def revoke_agent_api_key(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    api_key_id: UUID,
+) -> AgentApiKeyRecord | None:
+    row = (
+        await db.execute(
+            select(AgentApiKey).where(
+                AgentApiKey.id == api_key_id,
+                AgentApiKey.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    if row.status != AGENT_API_KEY_STATUS_REVOKED:
+        now = utcnow()
+        row.status = AGENT_API_KEY_STATUS_REVOKED
+        row.revoked_at = now
+        row.updated_at = now
+        await db.flush()
+    return api_key_record(row)
+
+
+async def list_agent_api_keys(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    include_revoked: bool = False,
+) -> list[AgentApiKeyRecord]:
+    query = select(AgentApiKey).where(AgentApiKey.user_id == user_id)
+    if not include_revoked:
+        query = query.where(AgentApiKey.status == AGENT_API_KEY_STATUS_ACTIVE)
+    rows = (await db.execute(query.order_by(AgentApiKey.created_at))).scalars().all()
+    return [api_key_record(row) for row in rows]
+
+
+async def get_agent_api_key_decrypted(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    api_key_id: UUID,
+) -> tuple[AgentApiKeyRecord, str] | None:
+    """Internal-use fetch of the raw key payload for materialization."""
+    row = (
+        await db.execute(
+            select(AgentApiKey).where(
+                AgentApiKey.id == api_key_id,
+                AgentApiKey.user_id == user_id,
+                AgentApiKey.status == AGENT_API_KEY_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return api_key_record(row), decrypt_text(row.payload_ciphertext)

--- a/server/proliferate/db/store/agent_gateway/catalog.py
+++ b/server/proliferate/db/store/agent_gateway/catalog.py
@@ -1,0 +1,119 @@
+"""Agent catalog snapshot and override persistence (minimal CRUD for PR 7)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.agent_gateway import AgentCatalogOverride, AgentCatalogSnapshot
+from proliferate.db.store.agent_gateway.mappers import (
+    catalog_override_record,
+    catalog_snapshot_record,
+)
+from proliferate.db.store.agent_gateway.records import (
+    AgentCatalogOverrideRecord,
+    AgentCatalogSnapshotRecord,
+)
+from proliferate.utils.time import utcnow
+
+
+async def create_catalog_snapshot(
+    db: AsyncSession,
+    *,
+    harness_kind: str,
+    surface: str,
+    route: str,
+    owner_user_id: UUID | None,
+    models_json: str,
+    source: str = "probe",
+) -> AgentCatalogSnapshotRecord:
+    row = AgentCatalogSnapshot(
+        harness_kind=harness_kind,
+        surface=surface,
+        route=route,
+        owner_user_id=owner_user_id,
+        models_json=models_json,
+        source=source,
+        status="active",
+    )
+    db.add(row)
+    await db.flush()
+    return catalog_snapshot_record(row)
+
+
+async def get_latest_catalog_snapshot(
+    db: AsyncSession,
+    *,
+    harness_kind: str,
+    surface: str,
+    route: str,
+    owner_user_id: UUID | None,
+) -> AgentCatalogSnapshotRecord | None:
+    query = (
+        select(AgentCatalogSnapshot)
+        .where(
+            AgentCatalogSnapshot.harness_kind == harness_kind,
+            AgentCatalogSnapshot.surface == surface,
+            AgentCatalogSnapshot.route == route,
+            AgentCatalogSnapshot.status == "active",
+        )
+        .order_by(AgentCatalogSnapshot.probed_at.desc())
+        .limit(1)
+    )
+    if owner_user_id is None:
+        query = query.where(AgentCatalogSnapshot.owner_user_id.is_(None))
+    else:
+        query = query.where(AgentCatalogSnapshot.owner_user_id == owner_user_id)
+    row = (await db.execute(query)).scalar_one_or_none()
+    return catalog_snapshot_record(row) if row is not None else None
+
+
+async def upsert_catalog_override(
+    db: AsyncSession,
+    *,
+    harness_kind: str,
+    patch_json: str,
+    owner_user_id: UUID | None = None,
+    organization_id: UUID | None = None,
+) -> AgentCatalogOverrideRecord:
+    if (owner_user_id is None) == (organization_id is None):
+        raise ValueError("A catalog override needs exactly one of owner_user_id/organization_id.")
+    query = select(AgentCatalogOverride).where(AgentCatalogOverride.harness_kind == harness_kind)
+    if owner_user_id is not None:
+        query = query.where(AgentCatalogOverride.owner_user_id == owner_user_id)
+    else:
+        query = query.where(AgentCatalogOverride.organization_id == organization_id)
+    row = (await db.execute(query)).scalar_one_or_none()
+    if row is None:
+        row = AgentCatalogOverride(
+            owner_user_id=owner_user_id,
+            organization_id=organization_id,
+            harness_kind=harness_kind,
+            patch_json=patch_json,
+        )
+        db.add(row)
+    else:
+        row.patch_json = patch_json
+        row.updated_at = utcnow()
+    await db.flush()
+    return catalog_override_record(row)
+
+
+async def get_catalog_override(
+    db: AsyncSession,
+    *,
+    harness_kind: str,
+    owner_user_id: UUID | None = None,
+    organization_id: UUID | None = None,
+) -> AgentCatalogOverrideRecord | None:
+    if (owner_user_id is None) == (organization_id is None):
+        raise ValueError("A catalog override needs exactly one of owner_user_id/organization_id.")
+    query = select(AgentCatalogOverride).where(AgentCatalogOverride.harness_kind == harness_kind)
+    if owner_user_id is not None:
+        query = query.where(AgentCatalogOverride.owner_user_id == owner_user_id)
+    else:
+        query = query.where(AgentCatalogOverride.organization_id == organization_id)
+    row = (await db.execute(query)).scalar_one_or_none()
+    return catalog_override_record(row) if row is not None else None

--- a/server/proliferate/db/store/agent_gateway/enrollments.py
+++ b/server/proliferate/db/store/agent_gateway/enrollments.py
@@ -1,0 +1,295 @@
+"""LiteLLM enrollment row persistence."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import ColumnElement, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
+
+from proliferate.constants.agent_gateway import (
+    AGENT_GATEWAY_CIPHERTEXT_KEY_ID,
+    AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION,
+    AGENT_GATEWAY_SUBJECT_KIND_USER,
+    AGENT_GATEWAY_SYNC_STATUS_FAILED,
+    AGENT_GATEWAY_SYNC_STATUS_PENDING,
+    AGENT_GATEWAY_SYNC_STATUS_SYNCED,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.agent_gateway import AgentGatewayEnrollment
+from proliferate.db.models.organizations import OrganizationMembership
+from proliferate.db.store.agent_gateway.mappers import enrollment_record
+from proliferate.db.store.agent_gateway.records import AgentGatewayEnrollmentRecord
+from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.utils.time import utcnow
+
+
+async def ensure_enrollment_row(
+    db: AsyncSession,
+    *,
+    subject_kind: str,
+    billing_subject_id: UUID,
+    user_id: UUID | None = None,
+    organization_id: UUID | None = None,
+) -> AgentGatewayEnrollmentRecord:
+    """Idempotently create the pending enrollment row for a subject."""
+    index_elements: list[InstrumentedAttribute[UUID | None]]
+    index_where: ColumnElement[bool]
+    if subject_kind == AGENT_GATEWAY_SUBJECT_KIND_USER:
+        if user_id is None or organization_id is not None:
+            raise ValueError("A user enrollment requires user_id and no organization_id.")
+        index_elements = [AgentGatewayEnrollment.user_id]
+        index_where = (
+            AgentGatewayEnrollment.subject_kind == AGENT_GATEWAY_SUBJECT_KIND_USER
+        ) & AgentGatewayEnrollment.revoked_at.is_(None)
+    elif subject_kind == AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION:
+        if organization_id is None or user_id is None:
+            raise ValueError(
+                "An organization enrollment requires organization_id and user_id "
+                "(one virtual key per member, spec §2.3)."
+            )
+        index_elements = [
+            AgentGatewayEnrollment.organization_id,
+            AgentGatewayEnrollment.user_id,
+        ]
+        index_where = (
+            AgentGatewayEnrollment.subject_kind == AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION
+        ) & AgentGatewayEnrollment.revoked_at.is_(None)
+    else:
+        raise ValueError(f"Unknown enrollment subject kind: {subject_kind}")
+
+    now = utcnow()
+    await db.execute(
+        pg_insert(AgentGatewayEnrollment)
+        .values(
+            subject_kind=subject_kind,
+            user_id=user_id,
+            organization_id=organization_id,
+            billing_subject_id=billing_subject_id,
+            sync_status=AGENT_GATEWAY_SYNC_STATUS_PENDING,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(index_elements=index_elements, index_where=index_where)
+    )
+    row = await _load_active_row(
+        db,
+        subject_kind=subject_kind,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    if row is None:
+        raise RuntimeError("Agent gateway enrollment disappeared after creation.")
+    return enrollment_record(row)
+
+
+async def _load_active_row(
+    db: AsyncSession,
+    *,
+    subject_kind: str,
+    user_id: UUID | None,
+    organization_id: UUID | None,
+) -> AgentGatewayEnrollment | None:
+    query = select(AgentGatewayEnrollment).where(
+        AgentGatewayEnrollment.subject_kind == subject_kind,
+        AgentGatewayEnrollment.revoked_at.is_(None),
+    )
+    if subject_kind == AGENT_GATEWAY_SUBJECT_KIND_USER:
+        query = query.where(AgentGatewayEnrollment.user_id == user_id)
+    else:
+        query = query.where(
+            AgentGatewayEnrollment.organization_id == organization_id,
+            AgentGatewayEnrollment.user_id == user_id,
+        )
+    return (await db.execute(query)).scalar_one_or_none()
+
+
+async def get_enrollment_for_user(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord | None:
+    row = await _load_active_row(
+        db,
+        subject_kind=AGENT_GATEWAY_SUBJECT_KIND_USER,
+        user_id=user_id,
+        organization_id=None,
+    )
+    return enrollment_record(row) if row is not None else None
+
+
+async def get_enrollment_for_organization(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord | None:
+    """Fetch a single member's org enrollment (one virtual key per member)."""
+    row = await _load_active_row(
+        db,
+        subject_kind=AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    return enrollment_record(row) if row is not None else None
+
+
+async def mark_enrollment_synced(
+    db: AsyncSession,
+    *,
+    enrollment_id: UUID,
+    litellm_team_id: str,
+    litellm_user_id: str | None,
+    virtual_key_id: str | None,
+    virtual_key: str | None,
+    sync_fingerprint: str | None,
+) -> AgentGatewayEnrollmentRecord:
+    row = await db.get(AgentGatewayEnrollment, enrollment_id)
+    if row is None:
+        raise RuntimeError("Agent gateway enrollment not found.")
+    row.litellm_team_id = litellm_team_id
+    row.litellm_user_id = litellm_user_id
+    row.virtual_key_id = virtual_key_id
+    if virtual_key is not None:
+        row.virtual_key_ciphertext = encrypt_text(virtual_key)
+        row.virtual_key_ciphertext_key_id = AGENT_GATEWAY_CIPHERTEXT_KEY_ID
+    row.sync_status = AGENT_GATEWAY_SYNC_STATUS_SYNCED
+    row.sync_fingerprint = sync_fingerprint
+    row.last_error_code = None
+    row.last_error_message = None
+    row.updated_at = utcnow()
+    await db.flush()
+    return enrollment_record(row)
+
+
+async def mark_enrollment_failed(
+    db: AsyncSession,
+    *,
+    enrollment_id: UUID,
+    error_code: str,
+    error_message: str,
+) -> AgentGatewayEnrollmentRecord:
+    row = await db.get(AgentGatewayEnrollment, enrollment_id)
+    if row is None:
+        raise RuntimeError("Agent gateway enrollment not found.")
+    row.sync_status = AGENT_GATEWAY_SYNC_STATUS_FAILED
+    row.last_error_code = error_code
+    row.last_error_message = error_message
+    row.updated_at = utcnow()
+    await db.flush()
+    return enrollment_record(row)
+
+
+async def list_enrollments_needing_sync(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[AgentGatewayEnrollmentRecord]:
+    rows = (
+        (
+            await db.execute(
+                select(AgentGatewayEnrollment)
+                .where(
+                    AgentGatewayEnrollment.revoked_at.is_(None),
+                    AgentGatewayEnrollment.sync_status.in_(
+                        [
+                            AGENT_GATEWAY_SYNC_STATUS_PENDING,
+                            AGENT_GATEWAY_SYNC_STATUS_FAILED,
+                        ]
+                    ),
+                )
+                .order_by(AgentGatewayEnrollment.updated_at)
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [enrollment_record(row) for row in rows]
+
+
+async def list_user_ids_missing_enrollment(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[UUID]:
+    """Users with no active personal enrollment row (backfill discovery)."""
+    active_user_enrollment = (
+        select(AgentGatewayEnrollment.id)
+        .where(
+            AgentGatewayEnrollment.subject_kind == AGENT_GATEWAY_SUBJECT_KIND_USER,
+            AgentGatewayEnrollment.user_id == User.id,
+            AgentGatewayEnrollment.revoked_at.is_(None),
+        )
+        .exists()
+    )
+    rows = (
+        await db.execute(
+            select(User.id).where(~active_user_enrollment).order_by(User.created_at).limit(limit)
+        )
+    ).scalars()
+    return list(rows.all())
+
+
+async def list_org_memberships_missing_enrollment(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[tuple[UUID, UUID]]:
+    """(organization_id, user_id) pairs for active memberships lacking a row.
+
+    Symmetric to :func:`list_user_ids_missing_enrollment`: recovers org members
+    whose join hook was lost so a per-member virtual key is still minted.
+    """
+    active_org_enrollment = (
+        select(AgentGatewayEnrollment.id)
+        .where(
+            AgentGatewayEnrollment.subject_kind == AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION,
+            AgentGatewayEnrollment.organization_id == OrganizationMembership.organization_id,
+            AgentGatewayEnrollment.user_id == OrganizationMembership.user_id,
+            AgentGatewayEnrollment.revoked_at.is_(None),
+        )
+        .exists()
+    )
+    rows = await db.execute(
+        select(
+            OrganizationMembership.organization_id,
+            OrganizationMembership.user_id,
+        )
+        .where(
+            OrganizationMembership.status == "active",
+            ~active_org_enrollment,
+        )
+        .order_by(OrganizationMembership.created_at)
+        .limit(limit)
+    )
+    return [(org_id, user_id) for org_id, user_id in rows.all()]
+
+
+async def get_enrollment_virtual_key_decrypted(
+    db: AsyncSession,
+    *,
+    enrollment_id: UUID,
+) -> str | None:
+    """Internal-use fetch of the raw virtual key for materialization."""
+    row = await db.get(AgentGatewayEnrollment, enrollment_id)
+    if row is None or row.virtual_key_ciphertext is None:
+        return None
+    return decrypt_text(row.virtual_key_ciphertext)
+
+
+async def revoke_enrollment(
+    db: AsyncSession,
+    *,
+    enrollment_id: UUID,
+) -> AgentGatewayEnrollmentRecord | None:
+    row = await db.get(AgentGatewayEnrollment, enrollment_id)
+    if row is None:
+        return None
+    if row.revoked_at is None:
+        row.revoked_at = utcnow()
+        row.updated_at = row.revoked_at
+        await db.flush()
+    return enrollment_record(row)

--- a/server/proliferate/db/store/agent_gateway/mappers.py
+++ b/server/proliferate/db/store/agent_gateway/mappers.py
@@ -1,0 +1,124 @@
+"""ORM row → frozen record mappers for the agent-gateway stores."""
+
+from __future__ import annotations
+
+from proliferate.db.models.cloud.agent_gateway import (
+    AgentApiKey,
+    AgentAuthRouteSelection,
+    AgentCatalogOverride,
+    AgentCatalogSnapshot,
+    AgentGatewayEnrollment,
+    AgentLlmUsageImportCursor,
+    OrgAgentPolicy,
+)
+from proliferate.db.store.agent_gateway.records import (
+    AgentApiKeyRecord,
+    AgentAuthRouteSelectionRecord,
+    AgentCatalogOverrideRecord,
+    AgentCatalogSnapshotRecord,
+    AgentGatewayEnrollmentRecord,
+    AgentLlmUsageImportCursorRecord,
+    OrgAgentPolicyRecord,
+)
+
+
+def api_key_record(row: AgentApiKey) -> AgentApiKeyRecord:
+    return AgentApiKeyRecord(
+        id=row.id,
+        user_id=row.user_id,
+        provider=row.provider,
+        display_name=row.display_name,
+        redacted_hint=row.redacted_hint,
+        status=row.status,
+        last_validated_at=row.last_validated_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        revoked_at=row.revoked_at,
+    )
+
+
+def route_selection_record(row: AgentAuthRouteSelection) -> AgentAuthRouteSelectionRecord:
+    return AgentAuthRouteSelectionRecord(
+        id=row.id,
+        user_id=row.user_id,
+        harness_kind=row.harness_kind,
+        surface=row.surface,
+        route=row.route,
+        api_key_id=row.api_key_id,
+        revision=row.revision,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def enrollment_record(row: AgentGatewayEnrollment) -> AgentGatewayEnrollmentRecord:
+    return AgentGatewayEnrollmentRecord(
+        id=row.id,
+        subject_kind=row.subject_kind,
+        user_id=row.user_id,
+        organization_id=row.organization_id,
+        billing_subject_id=row.billing_subject_id,
+        litellm_team_id=row.litellm_team_id,
+        litellm_user_id=row.litellm_user_id,
+        virtual_key_id=row.virtual_key_id,
+        sync_status=row.sync_status,
+        sync_fingerprint=row.sync_fingerprint,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        revoked_at=row.revoked_at,
+    )
+
+
+def catalog_snapshot_record(row: AgentCatalogSnapshot) -> AgentCatalogSnapshotRecord:
+    return AgentCatalogSnapshotRecord(
+        id=row.id,
+        harness_kind=row.harness_kind,
+        surface=row.surface,
+        route=row.route,
+        owner_user_id=row.owner_user_id,
+        models_json=row.models_json,
+        probed_at=row.probed_at,
+        source=row.source,
+        status=row.status,
+    )
+
+
+def catalog_override_record(row: AgentCatalogOverride) -> AgentCatalogOverrideRecord:
+    return AgentCatalogOverrideRecord(
+        id=row.id,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        harness_kind=row.harness_kind,
+        patch_json=row.patch_json,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def org_agent_policy_record(row: OrgAgentPolicy) -> OrgAgentPolicyRecord:
+    return OrgAgentPolicyRecord(
+        organization_id=row.organization_id,
+        allowed_routes_json=row.allowed_routes_json,
+        allowed_harnesses_json=row.allowed_harnesses_json,
+        updated_by_user_id=row.updated_by_user_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def usage_import_cursor_record(
+    row: AgentLlmUsageImportCursor,
+) -> AgentLlmUsageImportCursorRecord:
+    return AgentLlmUsageImportCursorRecord(
+        id=row.id,
+        last_seen_occurred_at=row.last_seen_occurred_at,
+        last_polled_at=row.last_polled_at,
+        status=row.status,
+        last_error_code=row.last_error_code,
+        last_error_message=row.last_error_message,
+        metadata_json=row.metadata_json,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )

--- a/server/proliferate/db/store/agent_gateway/policy.py
+++ b/server/proliferate/db/store/agent_gateway/policy.py
@@ -1,0 +1,47 @@
+"""Flag-only org agent policy persistence (PR 11 consumer)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.agent_gateway import OrgAgentPolicy
+from proliferate.db.store.agent_gateway.mappers import org_agent_policy_record
+from proliferate.db.store.agent_gateway.records import OrgAgentPolicyRecord
+from proliferate.utils.time import utcnow
+
+
+async def get_org_agent_policy(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+) -> OrgAgentPolicyRecord | None:
+    row = await db.get(OrgAgentPolicy, organization_id)
+    return org_agent_policy_record(row) if row is not None else None
+
+
+async def set_org_agent_policy(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    allowed_routes_json: str | None,
+    allowed_harnesses_json: str | None,
+    updated_by_user_id: UUID | None,
+) -> OrgAgentPolicyRecord:
+    row = await db.get(OrgAgentPolicy, organization_id)
+    if row is None:
+        row = OrgAgentPolicy(
+            organization_id=organization_id,
+            allowed_routes_json=allowed_routes_json,
+            allowed_harnesses_json=allowed_harnesses_json,
+            updated_by_user_id=updated_by_user_id,
+        )
+        db.add(row)
+    else:
+        row.allowed_routes_json = allowed_routes_json
+        row.allowed_harnesses_json = allowed_harnesses_json
+        row.updated_by_user_id = updated_by_user_id
+        row.updated_at = utcnow()
+    await db.flush()
+    return org_agent_policy_record(row)

--- a/server/proliferate/db/store/agent_gateway/records.py
+++ b/server/proliferate/db/store/agent_gateway/records.py
@@ -1,0 +1,100 @@
+"""Frozen value records returned by the agent-gateway stores."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class AgentApiKeyRecord:
+    id: UUID
+    user_id: UUID
+    provider: str
+    display_name: str
+    redacted_hint: str
+    status: str
+    last_validated_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    revoked_at: datetime | None
+
+
+@dataclass(frozen=True)
+class AgentAuthRouteSelectionRecord:
+    id: UUID
+    user_id: UUID
+    harness_kind: str
+    surface: str
+    route: str
+    api_key_id: UUID | None
+    revision: int
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentGatewayEnrollmentRecord:
+    id: UUID
+    subject_kind: str
+    user_id: UUID | None
+    organization_id: UUID | None
+    billing_subject_id: UUID
+    litellm_team_id: str | None
+    litellm_user_id: str | None
+    virtual_key_id: str | None
+    sync_status: str
+    sync_fingerprint: str | None
+    last_error_code: str | None
+    last_error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+    revoked_at: datetime | None
+
+
+@dataclass(frozen=True)
+class AgentCatalogSnapshotRecord:
+    id: UUID
+    harness_kind: str
+    surface: str
+    route: str
+    owner_user_id: UUID | None
+    models_json: str
+    probed_at: datetime
+    source: str
+    status: str
+
+
+@dataclass(frozen=True)
+class AgentCatalogOverrideRecord:
+    id: UUID
+    owner_user_id: UUID | None
+    organization_id: UUID | None
+    harness_kind: str
+    patch_json: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class OrgAgentPolicyRecord:
+    organization_id: UUID
+    allowed_routes_json: str | None
+    allowed_harnesses_json: str | None
+    updated_by_user_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentLlmUsageImportCursorRecord:
+    id: str
+    last_seen_occurred_at: datetime | None
+    last_polled_at: datetime | None
+    status: str
+    last_error_code: str | None
+    last_error_message: str | None
+    metadata_json: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/server/proliferate/db/store/agent_gateway/route_selections.py
+++ b/server/proliferate/db/store/agent_gateway/route_selections.py
@@ -1,0 +1,139 @@
+"""Agent auth route selection persistence.
+
+Cross-column legality that SQL CHECKs cannot express cleanly (api_key
+ownership + active status) is enforced here; callers get typed ValueErrors.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.agent_gateway import (
+    AGENT_API_KEY_STATUS_ACTIVE,
+    AGENT_AUTH_ROUTE_API_KEY,
+    AGENT_AUTH_ROUTE_NATIVE,
+    AGENT_AUTH_ROUTES,
+    AGENT_AUTH_SURFACE_CLOUD,
+    AGENT_AUTH_SURFACES,
+)
+from proliferate.db.models.cloud.agent_gateway import AgentApiKey, AgentAuthRouteSelection
+from proliferate.db.store.agent_gateway.mappers import route_selection_record
+from proliferate.db.store.agent_gateway.records import AgentAuthRouteSelectionRecord
+from proliferate.utils.time import utcnow
+
+
+def validate_route_selection(
+    *,
+    surface: str,
+    route: str,
+    api_key_id: UUID | None,
+) -> None:
+    """Pure legality checks shared by the store and unit tests."""
+    if surface not in AGENT_AUTH_SURFACES:
+        raise ValueError(f"Unknown agent auth surface: {surface}")
+    if route not in AGENT_AUTH_ROUTES:
+        raise ValueError(f"Unknown agent auth route: {route}")
+    if surface == AGENT_AUTH_SURFACE_CLOUD and route == AGENT_AUTH_ROUTE_NATIVE:
+        raise ValueError("The native route is not available on the cloud surface.")
+    if route == AGENT_AUTH_ROUTE_API_KEY and api_key_id is None:
+        raise ValueError("An api_key route selection requires an api_key_id.")
+    if route != AGENT_AUTH_ROUTE_API_KEY and api_key_id is not None:
+        raise ValueError("api_key_id is only valid for api_key route selections.")
+
+
+async def upsert_route_selection(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+    route: str,
+    api_key_id: UUID | None = None,
+) -> AgentAuthRouteSelectionRecord:
+    validate_route_selection(surface=surface, route=route, api_key_id=api_key_id)
+    if api_key_id is not None:
+        key_row = (
+            await db.execute(
+                select(AgentApiKey).where(
+                    AgentApiKey.id == api_key_id,
+                    AgentApiKey.user_id == user_id,
+                    AgentApiKey.status == AGENT_API_KEY_STATUS_ACTIVE,
+                )
+            )
+        ).scalar_one_or_none()
+        if key_row is None:
+            raise ValueError("api_key_id must reference an active key owned by the user.")
+
+    row = (
+        await db.execute(
+            select(AgentAuthRouteSelection).where(
+                AgentAuthRouteSelection.user_id == user_id,
+                AgentAuthRouteSelection.harness_kind == harness_kind,
+                AgentAuthRouteSelection.surface == surface,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = AgentAuthRouteSelection(
+            user_id=user_id,
+            harness_kind=harness_kind,
+            surface=surface,
+            route=route,
+            api_key_id=api_key_id,
+            revision=1,
+        )
+        db.add(row)
+        await db.flush()
+        return route_selection_record(row)
+
+    if row.route != route or row.api_key_id != api_key_id:
+        row.route = route
+        row.api_key_id = api_key_id
+        row.revision += 1
+        row.updated_at = utcnow()
+        await db.flush()
+    return route_selection_record(row)
+
+
+async def get_route_selection(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+) -> AgentAuthRouteSelectionRecord | None:
+    row = (
+        await db.execute(
+            select(AgentAuthRouteSelection).where(
+                AgentAuthRouteSelection.user_id == user_id,
+                AgentAuthRouteSelection.harness_kind == harness_kind,
+                AgentAuthRouteSelection.surface == surface,
+            )
+        )
+    ).scalar_one_or_none()
+    return route_selection_record(row) if row is not None else None
+
+
+async def list_route_selections(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> list[AgentAuthRouteSelectionRecord]:
+    rows = (
+        (
+            await db.execute(
+                select(AgentAuthRouteSelection)
+                .where(AgentAuthRouteSelection.user_id == user_id)
+                .order_by(
+                    AgentAuthRouteSelection.harness_kind,
+                    AgentAuthRouteSelection.surface,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [route_selection_record(row) for row in rows]

--- a/server/proliferate/db/store/agent_gateway/usage.py
+++ b/server/proliferate/db/store/agent_gateway/usage.py
@@ -1,0 +1,124 @@
+"""Agent LLM usage ledger + import cursor persistence (PR 8 consumer)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.agent_gateway import AGENT_USAGE_IMPORT_CURSOR_ID
+from proliferate.db.models.cloud.agent_gateway import (
+    AgentLlmUsageEvent,
+    AgentLlmUsageImportCursor,
+)
+from proliferate.db.store.agent_gateway.mappers import usage_import_cursor_record
+from proliferate.db.store.agent_gateway.records import AgentLlmUsageImportCursorRecord
+from proliferate.utils.time import utcnow
+
+
+async def insert_usage_event_once(
+    db: AsyncSession,
+    *,
+    litellm_request_id: str,
+    occurred_at: datetime,
+    virtual_key_id: str | None = None,
+    litellm_team_id: str | None = None,
+    user_id: UUID | None = None,
+    organization_id: UUID | None = None,
+    billing_subject_id: UUID | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    total_tokens: int = 0,
+    cost_usd: float | None = None,
+    status: str = "imported",
+    workspace_id: str | None = None,
+    session_id: str | None = None,
+    raw_metadata_json: str | None = None,
+) -> bool:
+    """Insert a usage event; returns False when the request id was already seen."""
+    result = await db.execute(
+        pg_insert(AgentLlmUsageEvent)
+        .values(
+            litellm_request_id=litellm_request_id,
+            virtual_key_id=virtual_key_id,
+            litellm_team_id=litellm_team_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            billing_subject_id=billing_subject_id,
+            provider=provider,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            cost_usd=cost_usd,
+            status=status,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            occurred_at=occurred_at,
+            imported_at=utcnow(),
+            raw_metadata_json=raw_metadata_json,
+        )
+        .on_conflict_do_nothing(index_elements=[AgentLlmUsageEvent.litellm_request_id])
+        .returning(AgentLlmUsageEvent.id)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def get_usage_import_cursor(
+    db: AsyncSession,
+) -> AgentLlmUsageImportCursorRecord | None:
+    row = (
+        await db.execute(
+            select(AgentLlmUsageImportCursor).where(
+                AgentLlmUsageImportCursor.id == AGENT_USAGE_IMPORT_CURSOR_ID
+            )
+        )
+    ).scalar_one_or_none()
+    return usage_import_cursor_record(row) if row is not None else None
+
+
+async def advance_usage_import_cursor(
+    db: AsyncSession,
+    *,
+    last_seen_occurred_at: datetime | None,
+    status: str = "idle",
+    last_error_code: str | None = None,
+    last_error_message: str | None = None,
+    metadata_json: str | None = None,
+) -> AgentLlmUsageImportCursorRecord:
+    now = utcnow()
+    row = (
+        await db.execute(
+            select(AgentLlmUsageImportCursor).where(
+                AgentLlmUsageImportCursor.id == AGENT_USAGE_IMPORT_CURSOR_ID
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = AgentLlmUsageImportCursor(
+            id=AGENT_USAGE_IMPORT_CURSOR_ID,
+            last_seen_occurred_at=last_seen_occurred_at,
+            last_polled_at=now,
+            status=status,
+            last_error_code=last_error_code,
+            last_error_message=last_error_message,
+            metadata_json=metadata_json,
+        )
+        db.add(row)
+    else:
+        if last_seen_occurred_at is not None:
+            row.last_seen_occurred_at = last_seen_occurred_at
+        row.last_polled_at = now
+        row.status = status
+        row.last_error_code = last_error_code
+        row.last_error_message = last_error_message
+        if metadata_json is not None:
+            row.metadata_json = metadata_json
+        row.updated_at = now
+    await db.flush()
+    return usage_import_cursor_record(row)

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -47,6 +47,10 @@ from proliferate.server.billing.api import router as billing_router
 #     stop_billing_reconciler,
 # )
 from proliferate.server.catalogs.api import router as catalogs_router
+from proliferate.server.cloud.agent_gateway.worker import (
+    start_agent_gateway_enrollment_backfill,
+    stop_agent_gateway_enrollment_backfill,
+)
 from proliferate.server.cloud.api import router as cloud_router
 from proliferate.server.cloud.gateway.api import router as gateway_router
 from proliferate.server.cloud.github_app.api import callback_router as github_app_callback_router
@@ -162,9 +166,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # start_billing_reconciler()
         pass
     anonymous_telemetry_task = await start_server_anonymous_telemetry_sender()
+    agent_gateway_backfill_task = await start_agent_gateway_enrollment_backfill()
     try:
         yield
     finally:
+        await stop_agent_gateway_enrollment_backfill(agent_gateway_backfill_task)
         await stop_server_anonymous_telemetry_sender(anonymous_telemetry_task)
         # BILLING RECONCILER PARKED.
         # await stop_billing_reconciler()

--- a/server/proliferate/server/billing/team_checkout/activation.py
+++ b/server/proliferate/server/billing/team_checkout/activation.py
@@ -47,6 +47,9 @@ from proliferate.server.billing.domain.webhooks import (
 )
 from proliferate.server.billing.models import BillingServiceError, coerce_utc, utcnow
 from proliferate.server.billing.pricing import billing_price_ids_from_settings
+from proliferate.server.cloud.agent_gateway.signup_hook import (
+    schedule_agent_gateway_org_enrollment,
+)
 from proliferate.server.organizations.join_links import organization_join_url
 
 logger = logging.getLogger("proliferate.billing.team_checkout.activation")
@@ -359,6 +362,9 @@ async def activate_team_checkout_from_stripe_session(
             activated_creator_email,
             activated_invite_emails_json,
         ) = staged_invites
+        schedule_agent_gateway_org_enrollment(
+            activated_organization_id, activated_created_by_user_id
+        )
         await _send_staged_team_checkout_invitations(
             organization_id=activated_organization_id,
             organization_name=activated_organization_name,

--- a/server/proliferate/server/cloud/agent_gateway/__init__.py
+++ b/server/proliferate/server/cloud/agent_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Agent LLM gateway enrollment domain (LiteLLM)."""

--- a/server/proliferate/server/cloud/agent_gateway/enrollment.py
+++ b/server/proliferate/server/cloud/agent_gateway/enrollment.py
@@ -1,0 +1,268 @@
+"""Eager LiteLLM enrollment for users and organizations.
+
+Every enrollment ensures the durable row first (idempotent), then — when the
+gateway is enabled — provisions the LiteLLM team, user, and virtual key and
+marks the row synced. Failures mark the row failed; the backfill worker
+retries pending/failed rows and discovers users created before the hooks
+existed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.agent_gateway import (
+    AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION,
+    AGENT_GATEWAY_SUBJECT_KIND_USER,
+    AGENT_GATEWAY_SYNC_STATUS_SYNCED,
+)
+from proliferate.db.store import agent_gateway as agent_gateway_store
+from proliferate.db.store.agent_gateway import AgentGatewayEnrollmentRecord
+from proliferate.db.store.billing_subjects import (
+    ensure_organization_billing_subject,
+    ensure_personal_billing_subject,
+)
+from proliferate.integrations import litellm
+from proliferate.integrations.litellm import LiteLLMIntegrationError, LiteLLMVirtualKey
+
+logger = logging.getLogger(__name__)
+
+
+def build_sync_fingerprint(*, team_id: str, budget: str, key_alias: str) -> str:
+    """Stable hash of the provisioned LiteLLM state, used to detect drift."""
+    material = f"{team_id}|{budget}|{key_alias}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _parse_budget(raw: str) -> float | None:
+    """Budget settings are strings; "0"/empty means uncapped (no budget sent)."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _key_alias(enrollment_id: UUID, subject_label: str) -> str:
+    return f"vk-{subject_label}-{str(enrollment_id)[:8]}"
+
+
+def _is_duplicate_alias_error(error: LiteLLMIntegrationError) -> bool:
+    """A 400 whose message mentions the alias == LiteLLM rejecting a dup alias."""
+    return error.status_code == 400 and "alias" in error.message.lower()
+
+
+async def _mint_virtual_key_idempotent(
+    *,
+    user_id: str,
+    team_id: str,
+    alias: str,
+    max_budget: float | None,
+    metadata: dict[str, str],
+) -> LiteLLMVirtualKey:
+    """Mint a virtual key, tolerating an orphaned key under the same alias.
+
+    The alias is deterministic per enrollment, so a crash/rollback after a
+    prior mint (id never committed) leaves a live key we no longer track. On
+    the duplicate-alias 400 we purge that orphan and re-mint, guaranteeing the
+    enrollment ends up owning a key we also hold the raw secret for.
+    """
+    try:
+        return await litellm.mint_virtual_key(
+            user_id=user_id,
+            team_id=team_id,
+            alias=alias,
+            max_budget=max_budget,
+            metadata=metadata,
+        )
+    except LiteLLMIntegrationError as error:
+        if not _is_duplicate_alias_error(error):
+            raise
+        await litellm.delete_virtual_keys_by_alias(alias=alias)
+        return await litellm.mint_virtual_key(
+            user_id=user_id,
+            team_id=team_id,
+            alias=alias,
+            max_budget=max_budget,
+            metadata=metadata,
+        )
+
+
+async def ensure_user_enrollment(
+    db: AsyncSession,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord:
+    subject = await ensure_personal_billing_subject(db, user_id)
+    enrollment = await agent_gateway_store.ensure_enrollment_row(
+        db,
+        subject_kind=AGENT_GATEWAY_SUBJECT_KIND_USER,
+        billing_subject_id=subject.id,
+        user_id=user_id,
+    )
+    if not settings.agent_gateway_enabled:
+        return enrollment
+    if enrollment.sync_status == AGENT_GATEWAY_SYNC_STATUS_SYNCED:
+        return enrollment
+    return await _sync_enrollment(
+        db,
+        enrollment=enrollment,
+        team_alias=f"user-{user_id}",
+        litellm_user_id=f"user-{user_id}",
+        subject_label=f"user-{user_id}",
+        budget_raw=settings.agent_gateway_default_user_budget_usd,
+    )
+
+
+async def ensure_org_enrollment(
+    db: AsyncSession,
+    organization_id: UUID,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord:
+    """Enroll one member under the org team.
+
+    Per spec §2.3 the virtual key is per (user, team): every org member gets
+    their own key under the shared org team/budget so gateway spend is
+    attributable to the member who spent it.
+    """
+    subject = await ensure_organization_billing_subject(db, organization_id)
+    enrollment = await agent_gateway_store.ensure_enrollment_row(
+        db,
+        subject_kind=AGENT_GATEWAY_SUBJECT_KIND_ORGANIZATION,
+        billing_subject_id=subject.id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    if not settings.agent_gateway_enabled:
+        return enrollment
+    if enrollment.sync_status == AGENT_GATEWAY_SYNC_STATUS_SYNCED:
+        return enrollment
+    return await _sync_enrollment(
+        db,
+        enrollment=enrollment,
+        team_alias=f"org-{organization_id}",
+        litellm_user_id=f"user-{user_id}",
+        subject_label=f"org-{organization_id}-user-{user_id}",
+        budget_raw=settings.agent_gateway_default_org_budget_usd,
+    )
+
+
+async def _sync_enrollment(
+    db: AsyncSession,
+    *,
+    enrollment: AgentGatewayEnrollmentRecord,
+    team_alias: str,
+    litellm_user_id: str | None,
+    subject_label: str,
+    budget_raw: str,
+) -> AgentGatewayEnrollmentRecord:
+    budget = _parse_budget(budget_raw)
+    key_alias = _key_alias(enrollment.id, subject_label)
+    metadata: dict[str, str] = {
+        "proliferate_billing_subject_id": str(enrollment.billing_subject_id),
+    }
+    if enrollment.user_id is not None:
+        metadata["proliferate_user_id"] = str(enrollment.user_id)
+    if enrollment.organization_id is not None:
+        metadata["proliferate_organization_id"] = str(enrollment.organization_id)
+    try:
+        team_id = await litellm.ensure_team(alias=team_alias, max_budget=budget)
+        if litellm_user_id is not None:
+            await litellm.ensure_user(user_id=litellm_user_id)
+        virtual_key = enrollment.virtual_key_id
+        if virtual_key is None:
+            minted = await _mint_virtual_key_idempotent(
+                user_id=litellm_user_id or team_alias,
+                team_id=team_id,
+                alias=key_alias,
+                max_budget=budget,
+                metadata=metadata,
+            )
+            return await agent_gateway_store.mark_enrollment_synced(
+                db,
+                enrollment_id=enrollment.id,
+                litellm_team_id=team_id,
+                litellm_user_id=litellm_user_id,
+                virtual_key_id=minted.token_id or None,
+                virtual_key=minted.key,
+                sync_fingerprint=build_sync_fingerprint(
+                    team_id=team_id,
+                    budget=budget_raw,
+                    key_alias=key_alias,
+                ),
+            )
+        # A key already exists (retry after a partial failure); refresh metadata only.
+        return await agent_gateway_store.mark_enrollment_synced(
+            db,
+            enrollment_id=enrollment.id,
+            litellm_team_id=team_id,
+            litellm_user_id=litellm_user_id,
+            virtual_key_id=enrollment.virtual_key_id,
+            virtual_key=None,
+            sync_fingerprint=build_sync_fingerprint(
+                team_id=team_id,
+                budget=budget_raw,
+                key_alias=key_alias,
+            ),
+        )
+    except LiteLLMIntegrationError as error:
+        logger.warning(
+            "Agent gateway enrollment sync failed",
+            extra={
+                "enrollment_id": str(enrollment.id),
+                "subject_kind": enrollment.subject_kind,
+                "error_code": error.code,
+            },
+        )
+        return await agent_gateway_store.mark_enrollment_failed(
+            db,
+            enrollment_id=enrollment.id,
+            error_code=error.code,
+            error_message=error.message,
+        )
+
+
+async def backfill_enrollments(db: AsyncSession, *, limit: int = 50) -> int:
+    """Sync pending/failed enrollments and enroll users missing rows.
+
+    Work is bounded to ``limit`` subjects per invocation. Returns the number
+    of subjects processed.
+    """
+    processed = 0
+    pending = await agent_gateway_store.list_enrollments_needing_sync(db, limit=limit)
+    for enrollment in pending:
+        is_user = enrollment.subject_kind == AGENT_GATEWAY_SUBJECT_KIND_USER
+        if is_user and enrollment.user_id is not None:
+            await ensure_user_enrollment(db, enrollment.user_id)
+        elif enrollment.organization_id is not None and enrollment.user_id is not None:
+            await ensure_org_enrollment(db, enrollment.organization_id, enrollment.user_id)
+        processed += 1
+
+    remaining = limit - processed
+    if remaining <= 0:
+        return processed
+    missing_user_ids = await agent_gateway_store.list_user_ids_missing_enrollment(
+        db,
+        limit=remaining,
+    )
+    for user_id in missing_user_ids:
+        await ensure_user_enrollment(db, user_id)
+        processed += 1
+
+    remaining = limit - processed
+    if remaining <= 0:
+        return processed
+    # Symmetric org recovery: a lost org-join hook leaves an active membership
+    # with no enrollment row, which would otherwise never self-heal.
+    missing_memberships = await agent_gateway_store.list_org_memberships_missing_enrollment(
+        db,
+        limit=remaining,
+    )
+    for organization_id, member_user_id in missing_memberships:
+        await ensure_org_enrollment(db, organization_id, member_user_id)
+        processed += 1
+    return processed

--- a/server/proliferate/server/cloud/agent_gateway/signup_hook.py
+++ b/server/proliferate/server/cloud/agent_gateway/signup_hook.py
@@ -1,0 +1,114 @@
+"""Fire-and-forget agent gateway enrollment scheduling for signup flows.
+
+Mirrors the Customer.io desktop-auth scheduler: auth flows call the
+``schedule_*`` functions synchronously; enrollment runs on its own task with
+its own DB transaction so login latency and login success never depend on
+LiteLLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import session_ops as db_session
+from proliferate.server.cloud.agent_gateway.enrollment import (
+    ensure_org_enrollment,
+    ensure_user_enrollment,
+)
+
+logger = logging.getLogger(__name__)
+
+type AfterCommit = Callable[[], Coroutine[None, None, None]]
+
+
+async def _enroll_user(user_id: UUID) -> None:
+    async with db_session.open_async_transaction() as db:
+        await ensure_user_enrollment(db, user_id)
+
+
+async def _enroll_organization(organization_id: UUID, user_id: UUID) -> None:
+    async with db_session.open_async_transaction() as db:
+        await ensure_org_enrollment(db, organization_id, user_id)
+
+
+def _handle_enrollment_task_completion(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is None:
+        return
+    logger.exception(
+        "Agent gateway enrollment task failed unexpectedly",
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+
+
+def _spawn(coro_name: str, coro: Coroutine[None, None, None]) -> None:
+    try:
+        task = asyncio.create_task(coro, name=coro_name)
+    except Exception:
+        coro.close()
+        logger.exception("Could not schedule agent gateway enrollment task")
+        return
+    task.add_done_callback(_handle_enrollment_task_completion)
+
+
+def _defer_or_skip(db: AsyncSession, name: str, spawn_after_commit: AfterCommit) -> None:
+    """Best-effort deferral; enrollment must never break an auth flow.
+
+    When deferral is impossible (e.g. a stubbed session in tests), skip —
+    the backfill worker enrolls any subject the hooks missed.
+    """
+    try:
+        db_session.defer_after_commit(db, spawn_after_commit)
+    except Exception:
+        logger.warning(
+            "Could not defer agent gateway enrollment scheduling; backfill will cover it",
+            extra={"task_name": name},
+        )
+
+
+def schedule_agent_gateway_user_enrollment(
+    user_id: UUID,
+    *,
+    db: AsyncSession | None = None,
+) -> None:
+    """Schedule enrollment for a user.
+
+    Passing the request ``db`` defers scheduling until after its transaction
+    commits so the enrollment task (own session) can see a freshly created
+    user row; rows that never commit never enroll. Without a ``db`` the task
+    starts immediately (customerio-scheduler pattern).
+    """
+    name = f"agent-gateway-enroll-user-{user_id}"
+    if db is None:
+        _spawn(name, _enroll_user(user_id))
+        return
+
+    async def _spawn_after_commit() -> None:
+        _spawn(name, _enroll_user(user_id))
+
+    _defer_or_skip(db, name, _spawn_after_commit)
+
+
+def schedule_agent_gateway_org_enrollment(
+    organization_id: UUID,
+    user_id: UUID,
+    *,
+    db: AsyncSession | None = None,
+) -> None:
+    """Schedule org enrollment for a single member (one virtual key per member)."""
+    name = f"agent-gateway-enroll-org-{organization_id}-user-{user_id}"
+    if db is None:
+        _spawn(name, _enroll_organization(organization_id, user_id))
+        return
+
+    async def _spawn_after_commit() -> None:
+        _spawn(name, _enroll_organization(organization_id, user_id))
+
+    _defer_or_skip(db, name, _spawn_after_commit)

--- a/server/proliferate/server/cloud/agent_gateway/worker.py
+++ b/server/proliferate/server/cloud/agent_gateway/worker.py
@@ -1,0 +1,59 @@
+"""Background enrollment backfill worker.
+
+Started from the app lifespan (mirroring the anonymous-telemetry sender):
+every ``agent_gateway_backfill_interval_seconds`` it retries pending/failed
+enrollments and enrolls users that predate the signup hooks. Only runs when
+the gateway is enabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+
+from proliferate.config import settings
+from proliferate.db import session_ops as db_session
+from proliferate.server.cloud.agent_gateway.enrollment import backfill_enrollments
+
+logger = logging.getLogger(__name__)
+
+_BACKFILL_BATCH_LIMIT = 50
+
+
+async def run_enrollment_backfill_once(*, limit: int = _BACKFILL_BATCH_LIMIT) -> int:
+    async with db_session.open_async_transaction() as db:
+        return await backfill_enrollments(db, limit=limit)
+
+
+async def _backfill_loop() -> None:
+    while True:
+        try:
+            processed = await run_enrollment_backfill_once()
+            if processed:
+                logger.info(
+                    "Agent gateway enrollment backfill processed subjects",
+                    extra={"processed": processed},
+                )
+        except Exception:
+            logger.exception("Agent gateway enrollment backfill tick failed")
+        await asyncio.sleep(settings.agent_gateway_backfill_interval_seconds)
+
+
+async def start_agent_gateway_enrollment_backfill() -> asyncio.Task[None] | None:
+    if not settings.agent_gateway_enabled:
+        return None
+    return asyncio.create_task(
+        _backfill_loop(),
+        name="agent-gateway-enrollment-backfill",
+    )
+
+
+async def stop_agent_gateway_enrollment_backfill(
+    task: asyncio.Task[None] | None,
+) -> None:
+    if task is None:
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -37,6 +37,9 @@ from proliferate.server.billing.subjects import (
     ensure_organization_billing_subject_state,
     ensure_personal_billing_subject_state,
 )
+from proliferate.server.cloud.agent_gateway.signup_hook import (
+    schedule_agent_gateway_org_enrollment,
+)
 from proliferate.server.organizations import invitation_delivery
 from proliferate.server.organizations.domain.policy import (
     is_membership_update_status,
@@ -418,6 +421,7 @@ async def accept_current_user_invitation(
         organization_id=accepted.organization.id,
         membership_id=accepted.membership.id,
     )
+    schedule_agent_gateway_org_enrollment(accepted.organization.id, actor_user.id, db=db)
     return OrganizationWithMembershipRecord(
         organization=accepted.organization,
         membership=accepted.membership,
@@ -478,6 +482,7 @@ async def accept_invitation(
         organization_id=accepted.organization.id,
         membership_id=accepted.membership.id,
     )
+    schedule_agent_gateway_org_enrollment(accepted.organization.id, actor_user.id, db=db)
     return OrganizationWithMembershipRecord(
         organization=accepted.organization,
         membership=accepted.membership,

--- a/server/tests/integration/test_agent_gateway_enrollment.py
+++ b/server/tests/integration/test_agent_gateway_enrollment.py
@@ -1,0 +1,360 @@
+"""Enrollment service tests with a stubbed LiteLLM admin client."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.agent_gateway import AgentGatewayEnrollment
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import agent_gateway as store
+from proliferate.integrations.litellm import LiteLLMIntegrationError, LiteLLMVirtualKey
+from proliferate.server.cloud.agent_gateway import enrollment as enrollment_service
+from proliferate.server.cloud.agent_gateway.enrollment import (
+    backfill_enrollments,
+    ensure_org_enrollment,
+    ensure_user_enrollment,
+)
+
+
+async def _create_user(db_session: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"enroll-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+class StubLiteLLM:
+    def __init__(self) -> None:
+        self.teams: dict[str, str] = {}
+        self.users: set[str] = set()
+        self.minted: list[dict[str, Any]] = []
+        # Live keys keyed by alias -> token_id, mirroring LiteLLM's globally
+        # unique key_alias enforcement so idempotency can be exercised.
+        self.live_aliases: dict[str, str] = {}
+        self.deleted_aliases: list[str] = []
+        self.fail_mint = False
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(enrollment_service.litellm, "ensure_team", self.ensure_team)
+        monkeypatch.setattr(enrollment_service.litellm, "ensure_user", self.ensure_user)
+        monkeypatch.setattr(
+            enrollment_service.litellm,
+            "mint_virtual_key",
+            self.mint_virtual_key,
+        )
+        monkeypatch.setattr(
+            enrollment_service.litellm,
+            "delete_virtual_keys_by_alias",
+            self.delete_virtual_keys_by_alias,
+        )
+
+    async def ensure_team(self, *, alias: str, max_budget: float | None = None) -> str:
+        team_id = self.teams.setdefault(alias, f"team-{alias}")
+        return team_id
+
+    async def ensure_user(self, *, user_id: str) -> str:
+        self.users.add(user_id)
+        return user_id
+
+    async def mint_virtual_key(
+        self,
+        *,
+        user_id: str,
+        team_id: str | None = None,
+        alias: str | None = None,
+        max_budget: float | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> LiteLLMVirtualKey:
+        if self.fail_mint:
+            raise LiteLLMIntegrationError("litellm_request_failed", "mint exploded")
+        if alias is not None and alias in self.live_aliases:
+            raise LiteLLMIntegrationError(
+                "litellm_request_failed",
+                f"Unable to create key: key_alias {alias} already exists",
+                status_code=400,
+            )
+        record = {
+            "user_id": user_id,
+            "team_id": team_id,
+            "alias": alias,
+            "max_budget": max_budget,
+            "metadata": metadata or {},
+        }
+        self.minted.append(record)
+        token_id = f"token-{len(self.minted)}"
+        if alias is not None:
+            self.live_aliases[alias] = token_id
+        return LiteLLMVirtualKey(
+            key=f"sk-litellm-{len(self.minted)}",
+            token_id=token_id,
+            key_alias=alias,
+            user_id=user_id,
+            team_id=team_id,
+            max_budget=max_budget,
+        )
+
+    async def delete_virtual_keys_by_alias(self, *, alias: str) -> int:
+        if alias not in self.live_aliases:
+            return 0
+        del self.live_aliases[alias]
+        self.deleted_aliases.append(alias)
+        return 1
+
+
+@pytest.fixture
+def stub_litellm(monkeypatch: pytest.MonkeyPatch) -> StubLiteLLM:
+    stub = StubLiteLLM()
+    stub.install(monkeypatch)
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_user_enrollment_stays_pending_when_gateway_disabled(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", False)
+    user_id = await _create_user(db_session)
+
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+
+    assert enrollment.sync_status == "pending"
+    assert stub_litellm.minted == []
+
+
+@pytest.mark.asyncio
+async def test_user_enrollment_syncs_against_gateway(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+
+    assert enrollment.sync_status == "synced"
+    assert enrollment.litellm_team_id == f"team-user-{user_id}"
+    assert enrollment.litellm_user_id == f"user-{user_id}"
+    assert enrollment.virtual_key_id == "token-1"
+    assert enrollment.sync_fingerprint is not None
+    assert f"user-{user_id}" in stub_litellm.users
+    minted = stub_litellm.minted[0]
+    assert minted["metadata"]["proliferate_user_id"] == str(user_id)
+    assert minted["metadata"]["proliferate_billing_subject_id"] == str(
+        enrollment.billing_subject_id
+    )
+    assert minted["max_budget"] == 5.0
+    assert (
+        await store.get_enrollment_virtual_key_decrypted(
+            db_session,
+            enrollment_id=enrollment.id,
+        )
+        == "sk-litellm-1"
+    )
+
+    again = await ensure_user_enrollment(db_session, user_id)
+    assert again.id == enrollment.id
+    assert len(stub_litellm.minted) == 1
+
+
+@pytest.mark.asyncio
+async def test_user_enrollment_marks_failed_on_litellm_error(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    stub_litellm.fail_mint = True
+    user_id = await _create_user(db_session)
+
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+
+    assert enrollment.sync_status == "failed"
+    assert enrollment.last_error_code == "litellm_request_failed"
+    assert enrollment.last_error_message == "mint exploded"
+
+    # Backfill retries the failed row once LiteLLM recovers.
+    stub_litellm.fail_mint = False
+    processed = await backfill_enrollments(db_session, limit=10)
+    assert processed >= 1
+    retried = await store.get_enrollment_for_user(db_session, user_id=user_id)
+    assert retried is not None
+    assert retried.sync_status == "synced"
+
+
+@pytest.mark.asyncio
+async def test_org_enrollment_syncs_without_budget_cap(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    organization = Organization(name="Enroll Org")
+    db_session.add(organization)
+    await db_session.flush()
+    member_id = await _create_user(db_session)
+
+    enrollment = await ensure_org_enrollment(db_session, organization.id, member_id)
+
+    assert enrollment.sync_status == "synced"
+    assert enrollment.subject_kind == "organization"
+    assert enrollment.organization_id == organization.id
+    assert enrollment.user_id == member_id
+    assert enrollment.litellm_team_id == f"team-org-{organization.id}"
+    # Per member (spec §2.3): the key is attributed to the member's litellm user.
+    assert enrollment.litellm_user_id == f"user-{member_id}"
+    minted = stub_litellm.minted[0]
+    # Default org budget "0" means uncapped: no budget forwarded.
+    assert minted["max_budget"] is None
+    assert minted["metadata"]["proliferate_organization_id"] == str(organization.id)
+    assert minted["metadata"]["proliferate_user_id"] == str(member_id)
+
+
+@pytest.mark.asyncio
+async def test_org_enrollment_is_per_member(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    organization = Organization(name="Two Member Org")
+    db_session.add(organization)
+    await db_session.flush()
+    first = await _create_user(db_session)
+    second = await _create_user(db_session)
+
+    first_enrollment = await ensure_org_enrollment(db_session, organization.id, first)
+    second_enrollment = await ensure_org_enrollment(db_session, organization.id, second)
+
+    # Distinct rows and distinct virtual keys under the same shared org team.
+    assert first_enrollment.id != second_enrollment.id
+    assert first_enrollment.virtual_key_id != second_enrollment.virtual_key_id
+    assert first_enrollment.litellm_team_id == second_enrollment.litellm_team_id
+    assert len(stub_litellm.minted) == 2
+
+
+@pytest.mark.asyncio
+async def test_user_enrollment_recovers_orphaned_key_on_retry(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """A mint that landed but never committed must not wedge the retry."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    assert enrollment.sync_status == "synced"
+    assert len(stub_litellm.minted) == 1
+    orphan_alias = stub_litellm.minted[0]["alias"]
+    # The alias is still live in LiteLLM (the orphan).
+    assert orphan_alias in stub_litellm.live_aliases
+
+    # Simulate a crash/rollback between mint and DB write: the key id was never
+    # persisted, so the row forgets the key while LiteLLM still holds the alias.
+    row = await db_session.get(AgentGatewayEnrollment, enrollment.id)
+    assert row is not None
+    row.virtual_key_id = None
+    row.virtual_key_ciphertext = None
+    row.virtual_key_ciphertext_key_id = None
+    row.sync_status = "failed"
+    await db_session.flush()
+
+    # The retry must adopt-by-purge the orphan and re-mint (no duplicate-alias 400).
+    retried = await ensure_user_enrollment(db_session, user_id)
+    assert retried.sync_status == "synced"
+    assert retried.virtual_key_id is not None
+    assert len(stub_litellm.minted) == 2
+    assert orphan_alias in stub_litellm.deleted_aliases
+    # Exactly one live key remains under the deterministic alias.
+    assert orphan_alias in stub_litellm.live_aliases
+    assert (
+        await store.get_enrollment_virtual_key_decrypted(
+            db_session,
+            enrollment_id=enrollment.id,
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_discovers_users_without_enrollment_rows(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    first = await _create_user(db_session)
+    second = await _create_user(db_session)
+
+    processed = await backfill_enrollments(db_session, limit=10)
+
+    assert processed >= 2
+    for user_id in (first, second):
+        enrollment = await store.get_enrollment_for_user(db_session, user_id=user_id)
+        assert enrollment is not None
+        assert enrollment.sync_status == "synced"
+
+
+@pytest.mark.asyncio
+async def test_backfill_recovers_org_members_without_enrollment(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """A lost org-join hook is recovered symmetrically to personal enrollment."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    organization = Organization(name="Backfill Org")
+    db_session.add(organization)
+    await db_session.flush()
+    member_id = await _create_user(db_session)
+    # Active membership exists but the org enrollment hook never ran.
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=member_id,
+            role="member",
+            status="active",
+        )
+    )
+    await db_session.flush()
+
+    processed = await backfill_enrollments(db_session, limit=50)
+
+    assert processed >= 1
+    enrollment = await store.get_enrollment_for_organization(
+        db_session,
+        organization_id=organization.id,
+        user_id=member_id,
+    )
+    assert enrollment is not None
+    assert enrollment.sync_status == "synced"
+    assert enrollment.user_id == member_id
+
+
+@pytest.mark.asyncio
+async def test_backfill_bounds_work_per_tick(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    for _ in range(3):
+        await _create_user(db_session)
+
+    processed = await backfill_enrollments(db_session, limit=2)
+    assert processed == 2

--- a/server/tests/integration/test_agent_gateway_store.py
+++ b/server/tests/integration/test_agent_gateway_store.py
@@ -1,0 +1,482 @@
+"""Integration tests for the agent gateway stores (real Postgres)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import delete as sql_delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.agent_gateway import AgentApiKey
+from proliferate.db.store import agent_gateway as store
+from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
+
+
+async def _create_user(db_session: AsyncSession, *, email: str | None = None) -> uuid.UUID:
+    user = User(
+        email=email or f"agent-gateway-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+@pytest.mark.asyncio
+async def test_api_key_create_list_revoke(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+
+    created = await store.create_agent_api_key(
+        db_session,
+        user_id=user_id,
+        provider="anthropic",
+        display_name="Work key",
+        payload="sk-ant-api03-secretsecretabc4",
+    )
+    assert created.redacted_hint == "sk-...abc4"
+    assert created.status == "active"
+
+    listed = await store.list_agent_api_keys(db_session, user_id=user_id)
+    assert [record.id for record in listed] == [created.id]
+
+    decrypted = await store.get_agent_api_key_decrypted(
+        db_session,
+        user_id=user_id,
+        api_key_id=created.id,
+    )
+    assert decrypted is not None
+    assert decrypted[1] == "sk-ant-api03-secretsecretabc4"
+
+    revoked = await store.revoke_agent_api_key(
+        db_session,
+        user_id=user_id,
+        api_key_id=created.id,
+    )
+    assert revoked is not None
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+
+    assert await store.list_agent_api_keys(db_session, user_id=user_id) == []
+    with_revoked = await store.list_agent_api_keys(
+        db_session,
+        user_id=user_id,
+        include_revoked=True,
+    )
+    assert len(with_revoked) == 1
+    assert (
+        await store.get_agent_api_key_decrypted(
+            db_session,
+            user_id=user_id,
+            api_key_id=created.id,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_revoke_rejects_foreign_key(db_session: AsyncSession) -> None:
+    owner_id = await _create_user(db_session)
+    other_id = await _create_user(db_session)
+    created = await store.create_agent_api_key(
+        db_session,
+        user_id=owner_id,
+        provider="openai",
+        display_name="Key",
+        payload="sk-proj-abcdef1234",
+    )
+    assert (
+        await store.revoke_agent_api_key(db_session, user_id=other_id, api_key_id=created.id)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_selection_upsert_bumps_revision(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+
+    first = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        route="native",
+    )
+    assert first.revision == 1
+
+    unchanged = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        route="native",
+    )
+    assert unchanged.id == first.id
+    assert unchanged.revision == 1
+
+    changed = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        route="gateway",
+    )
+    assert changed.id == first.id
+    assert changed.revision == 2
+
+    fetched = await store.get_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+    )
+    assert fetched is not None
+    assert fetched.route == "gateway"
+
+    listed = await store.list_route_selections(db_session, user_id=user_id)
+    assert len(listed) == 1
+
+
+@pytest.mark.asyncio
+async def test_route_selection_rejects_cloud_native(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    with pytest.raises(ValueError, match="native route"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="claude",
+            surface="cloud",
+            route="native",
+        )
+
+
+@pytest.mark.asyncio
+async def test_route_selection_rejects_foreign_or_revoked_api_key(
+    db_session: AsyncSession,
+) -> None:
+    owner_id = await _create_user(db_session)
+    other_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session,
+        user_id=owner_id,
+        provider="anthropic",
+        display_name="Key",
+        payload="sk-ant-1234abcd",
+    )
+
+    with pytest.raises(ValueError, match="active key owned by the user"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=other_id,
+            harness_kind="claude",
+            surface="cloud",
+            route="api_key",
+            api_key_id=key.id,
+        )
+
+    await store.revoke_agent_api_key(db_session, user_id=owner_id, api_key_id=key.id)
+    with pytest.raises(ValueError, match="active key owned by the user"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=owner_id,
+            harness_kind="claude",
+            surface="cloud",
+            route="api_key",
+            api_key_id=key.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_api_key_hard_delete_cascades_api_key_route_selection(
+    db_session: AsyncSession,
+) -> None:
+    """Hard-deleting a key must not abort on the api_key-route CHECK.
+
+    ``api_key_id`` is ``ondelete=CASCADE`` (not ``SET NULL``): nulling it on an
+    ``api_key``-route selection would violate ``ck_..._api_key_ref``, so the key
+    must take its referencing selections with it rather than orphan them.
+    """
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session,
+        user_id=user_id,
+        provider="anthropic",
+        display_name="Key",
+        payload="sk-ant-1234abcd",
+    )
+    selection = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="cloud",
+        route="api_key",
+        api_key_id=key.id,
+    )
+    assert selection.api_key_id == key.id
+
+    # Hard delete of the key succeeds and cascades away the selection.
+    await db_session.execute(sql_delete(AgentApiKey).where(AgentApiKey.id == key.id))
+    await db_session.flush()
+
+    assert await store.list_route_selections(db_session, user_id=user_id) == []
+
+
+@pytest.mark.asyncio
+async def test_user_hard_delete_with_api_key_selection_succeeds(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting a user that owns an api_key-route selection must not abort.
+
+    User delete cascades to both the key and the selection; the api_key_id
+    CASCADE prevents a SET-NULL/CHECK collision from aborting the delete.
+    """
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session,
+        user_id=user_id,
+        provider="anthropic",
+        display_name="Key",
+        payload="sk-ant-1234abcd",
+    )
+    await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="cloud",
+        route="api_key",
+        api_key_id=key.id,
+    )
+
+    await db_session.execute(sql_delete(User).where(User.id == user_id))
+    await db_session.flush()
+
+    assert await db_session.get(User, user_id) is None
+    assert await store.list_route_selections(db_session, user_id=user_id) == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_enrollment_row_is_idempotent(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+
+    first = await store.ensure_enrollment_row(
+        db_session,
+        subject_kind="user",
+        billing_subject_id=subject.id,
+        user_id=user_id,
+    )
+    second = await store.ensure_enrollment_row(
+        db_session,
+        subject_kind="user",
+        billing_subject_id=subject.id,
+        user_id=user_id,
+    )
+    assert first.id == second.id
+    assert first.sync_status == "pending"
+
+    fetched = await store.get_enrollment_for_user(db_session, user_id=user_id)
+    assert fetched is not None
+    assert fetched.id == first.id
+
+
+@pytest.mark.asyncio
+async def test_enrollment_sync_lifecycle(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    enrollment = await store.ensure_enrollment_row(
+        db_session,
+        subject_kind="user",
+        billing_subject_id=subject.id,
+        user_id=user_id,
+    )
+
+    needing = await store.list_enrollments_needing_sync(db_session)
+    assert enrollment.id in {record.id for record in needing}
+
+    failed = await store.mark_enrollment_failed(
+        db_session,
+        enrollment_id=enrollment.id,
+        error_code="litellm_request_failed",
+        error_message="boom",
+    )
+    assert failed.sync_status == "failed"
+    needing = await store.list_enrollments_needing_sync(db_session)
+    assert enrollment.id in {record.id for record in needing}
+
+    synced = await store.mark_enrollment_synced(
+        db_session,
+        enrollment_id=enrollment.id,
+        litellm_team_id="team-1",
+        litellm_user_id=f"user-{user_id}",
+        virtual_key_id="token-1",
+        virtual_key="sk-litellm-secret",
+        sync_fingerprint="fp",
+    )
+    assert synced.sync_status == "synced"
+    assert synced.last_error_code is None
+    assert (
+        await store.get_enrollment_virtual_key_decrypted(
+            db_session,
+            enrollment_id=enrollment.id,
+        )
+        == "sk-litellm-secret"
+    )
+
+    needing = await store.list_enrollments_needing_sync(db_session)
+    assert enrollment.id not in {record.id for record in needing}
+
+    revoked = await store.revoke_enrollment(db_session, enrollment_id=enrollment.id)
+    assert revoked is not None
+    assert revoked.revoked_at is not None
+    assert await store.get_enrollment_for_user(db_session, user_id=user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_list_user_ids_missing_enrollment(db_session: AsyncSession) -> None:
+    enrolled_id = await _create_user(db_session)
+    missing_id = await _create_user(db_session)
+    subject = await ensure_personal_billing_subject(db_session, enrolled_id)
+    await store.ensure_enrollment_row(
+        db_session,
+        subject_kind="user",
+        billing_subject_id=subject.id,
+        user_id=enrolled_id,
+    )
+
+    missing = await store.list_user_ids_missing_enrollment(db_session, limit=100)
+    assert missing_id in missing
+    assert enrolled_id not in missing
+
+
+@pytest.mark.asyncio
+async def test_usage_insert_once_dedupes(db_session: AsyncSession) -> None:
+    occurred_at = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    inserted = await store.insert_usage_event_once(
+        db_session,
+        litellm_request_id="req-1",
+        occurred_at=occurred_at,
+        model="claude-sonnet-4-5",
+        total_tokens=100,
+        cost_usd=0.01,
+    )
+    duplicate = await store.insert_usage_event_once(
+        db_session,
+        litellm_request_id="req-1",
+        occurred_at=occurred_at,
+        model="claude-sonnet-4-5",
+        total_tokens=100,
+        cost_usd=0.01,
+    )
+    assert inserted is True
+    assert duplicate is False
+
+
+@pytest.mark.asyncio
+async def test_usage_import_cursor_roundtrip(db_session: AsyncSession) -> None:
+    assert await store.get_usage_import_cursor(db_session) is None
+    seen = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+    advanced = await store.advance_usage_import_cursor(
+        db_session,
+        last_seen_occurred_at=seen,
+        status="idle",
+    )
+    assert advanced.last_seen_occurred_at == seen
+
+    fetched = await store.get_usage_import_cursor(db_session)
+    assert fetched is not None
+    assert fetched.id == "default"
+
+    kept = await store.advance_usage_import_cursor(
+        db_session,
+        last_seen_occurred_at=None,
+        status="error",
+        last_error_code="poll_failed",
+        last_error_message="boom",
+    )
+    assert kept.last_seen_occurred_at == seen
+    assert kept.status == "error"
+
+
+@pytest.mark.asyncio
+async def test_catalog_snapshot_and_override(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    await store.create_catalog_snapshot(
+        db_session,
+        harness_kind="claude",
+        surface="cloud",
+        route="gateway",
+        owner_user_id=None,
+        models_json='["claude-sonnet-4-5"]',
+        source="seed",
+    )
+    newer = await store.create_catalog_snapshot(
+        db_session,
+        harness_kind="claude",
+        surface="cloud",
+        route="gateway",
+        owner_user_id=None,
+        models_json='["claude-sonnet-4-5", "claude-haiku-4-5"]',
+    )
+    latest = await store.get_latest_catalog_snapshot(
+        db_session,
+        harness_kind="claude",
+        surface="cloud",
+        route="gateway",
+        owner_user_id=None,
+    )
+    assert latest is not None
+    assert latest.id == newer.id
+
+    override = await store.upsert_catalog_override(
+        db_session,
+        harness_kind="claude",
+        patch_json='{"hidden": ["claude-haiku-4-5"]}',
+        owner_user_id=user_id,
+    )
+    replaced = await store.upsert_catalog_override(
+        db_session,
+        harness_kind="claude",
+        patch_json='{"hidden": []}',
+        owner_user_id=user_id,
+    )
+    assert replaced.id == override.id
+    fetched = await store.get_catalog_override(
+        db_session,
+        harness_kind="claude",
+        owner_user_id=user_id,
+    )
+    assert fetched is not None
+    assert fetched.patch_json == '{"hidden": []}'
+
+
+@pytest.mark.asyncio
+async def test_org_agent_policy_get_set(db_session: AsyncSession) -> None:
+    from proliferate.db.models.organizations import Organization
+
+    organization = Organization(name="Policy Org")
+    db_session.add(organization)
+    await db_session.flush()
+
+    assert await store.get_org_agent_policy(db_session, organization_id=organization.id) is None
+    created = await store.set_org_agent_policy(
+        db_session,
+        organization_id=organization.id,
+        allowed_routes_json='["gateway"]',
+        allowed_harnesses_json=None,
+        updated_by_user_id=None,
+    )
+    assert created.allowed_routes_json == '["gateway"]'
+    updated = await store.set_org_agent_policy(
+        db_session,
+        organization_id=organization.id,
+        allowed_routes_json='["gateway", "api_key"]',
+        allowed_harnesses_json='["claude"]',
+        updated_by_user_id=None,
+    )
+    assert updated.allowed_routes_json == '["gateway", "api_key"]'
+    assert updated.allowed_harnesses_json == '["claude"]'

--- a/server/tests/unit/test_agent_gateway_domain.py
+++ b/server/tests/unit/test_agent_gateway_domain.py
@@ -1,0 +1,71 @@
+"""Pure-logic tests for agent gateway route legality, hints, and fingerprints."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from proliferate.db.store.agent_gateway.api_keys import build_redacted_hint
+from proliferate.db.store.agent_gateway.route_selections import validate_route_selection
+from proliferate.server.cloud.agent_gateway.enrollment import build_sync_fingerprint
+
+
+class TestRouteSelectionLegality:
+    def test_all_routes_are_legal_on_local(self) -> None:
+        validate_route_selection(surface="local", route="native", api_key_id=None)
+        validate_route_selection(surface="local", route="gateway", api_key_id=None)
+        validate_route_selection(surface="local", route="api_key", api_key_id=uuid.uuid4())
+
+    def test_cloud_allows_gateway_and_api_key(self) -> None:
+        validate_route_selection(surface="cloud", route="gateway", api_key_id=None)
+        validate_route_selection(surface="cloud", route="api_key", api_key_id=uuid.uuid4())
+
+    def test_cloud_rejects_native(self) -> None:
+        with pytest.raises(ValueError, match="native route"):
+            validate_route_selection(surface="cloud", route="native", api_key_id=None)
+
+    def test_api_key_route_requires_key_reference(self) -> None:
+        with pytest.raises(ValueError, match="requires an api_key_id"):
+            validate_route_selection(surface="local", route="api_key", api_key_id=None)
+
+    def test_non_api_key_routes_reject_key_reference(self) -> None:
+        with pytest.raises(ValueError, match="only valid for api_key"):
+            validate_route_selection(surface="local", route="gateway", api_key_id=uuid.uuid4())
+
+    def test_unknown_surface_and_route_are_rejected(self) -> None:
+        with pytest.raises(ValueError, match="surface"):
+            validate_route_selection(surface="mobile", route="gateway", api_key_id=None)
+        with pytest.raises(ValueError, match="route"):
+            validate_route_selection(surface="local", route="magic", api_key_id=None)
+
+
+class TestRedactedHint:
+    def test_prefixed_key_keeps_prefix_and_tail(self) -> None:
+        assert build_redacted_hint("sk-ant-api03-abcdefabc4") == "sk-...abc4"
+
+    def test_short_key_is_not_over_redacted(self) -> None:
+        assert build_redacted_hint("abc") == "...abc"
+
+    def test_unprefixed_key_shows_tail_only(self) -> None:
+        assert build_redacted_hint("0123456789abcdefwxyz") == "...wxyz"
+
+    def test_hint_never_contains_middle_of_key(self) -> None:
+        payload = "sk-proj-SECRETMIDDLEPARTxyz9"
+        hint = build_redacted_hint(payload)
+        assert "SECRETMIDDLEPART" not in hint
+        assert hint.endswith("xyz9")
+
+
+class TestSyncFingerprint:
+    def test_fingerprint_is_stable(self) -> None:
+        first = build_sync_fingerprint(team_id="t1", budget="5", key_alias="vk-user-x")
+        second = build_sync_fingerprint(team_id="t1", budget="5", key_alias="vk-user-x")
+        assert first == second
+        assert len(first) == 64
+
+    def test_fingerprint_changes_with_any_component(self) -> None:
+        base = build_sync_fingerprint(team_id="t1", budget="5", key_alias="vk-user-x")
+        assert base != build_sync_fingerprint(team_id="t2", budget="5", key_alias="vk-user-x")
+        assert base != build_sync_fingerprint(team_id="t1", budget="10", key_alias="vk-user-x")
+        assert base != build_sync_fingerprint(team_id="t1", budget="5", key_alias="vk-user-y")

--- a/specs/developing/reference/env-secrets-matrix.md
+++ b/specs/developing/reference/env-secrets-matrix.md
@@ -168,6 +168,9 @@ lives in `server/proliferate/constants/billing.py`. It is not env-overridable.
 | `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL` | No | When gateway is enabled | Public LiteLLM inference base URL rendered into sandbox/local harness auth config |
 | `AGENT_GATEWAY_LITELLM_MASTER_KEY` | Yes | When gateway is enabled | LiteLLM master key for the management API; never sent to sandboxes or clients |
 | `AGENT_GATEWAY_LITELLM_TIMEOUT_SECONDS` | No | No | LiteLLM management API timeout |
+| `AGENT_GATEWAY_DEFAULT_USER_BUDGET_USD` | No | No | Default LiteLLM budget (USD) for personal enrollments; "0" = uncapped |
+| `AGENT_GATEWAY_DEFAULT_ORG_BUDGET_USD` | No | No | Default LiteLLM budget (USD) for organization enrollments; "0" = uncapped |
+| `AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS` | No | No | Enrollment backfill worker interval |
 
 The LiteLLM service itself (a separate ECS service / docker-compose pair) is
 configured with `LITELLM_MASTER_KEY`, its own `DATABASE_URL`, and the managed

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -521,6 +521,24 @@
   description: Timeout for LiteLLM management API requests
   tags: [local-dev, self-hosted, production]
 
+- name: AGENT_GATEWAY_DEFAULT_USER_BUDGET_USD
+  secret: false
+  default: "5"
+  description: Default LiteLLM budget (USD) applied to a personal team and virtual key at enrollment; "0" means uncapped
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_DEFAULT_ORG_BUDGET_USD
+  secret: false
+  default: "0"
+  description: Default LiteLLM budget (USD) applied to an organization team at enrollment; "0" means uncapped (hard caps arrive with limits/top-ups)
+  tags: [local-dev, self-hosted, production]
+
+- name: AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS
+  secret: false
+  default: "300.0"
+  description: Interval for the enrollment backfill worker that retries pending/failed LiteLLM enrollments and enrolls pre-existing users
+  tags: [local-dev, self-hosted, production]
+
 # ═══════════════════════════════════════════════════════════════════════
 # Server: Cloud MCP
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
PR 3 of 12 in the LiteLLM agent-auth migration (spec: `specs/codebase/primitives/agent-auth-litellm.md` §3.3, §2.3). Stacked on #818.

## What's here
- **Schema** (`agent_gateway.py` models + migration `a9c0d1e2f3b4`): `agent_api_key` (personal encrypted key pool), `agent_auth_route_selection` (UNIQUE per user×harness×surface; CHECKs: cloud≠native, api_key route requires key), `agent_gateway_enrollment` (partial-unique active row per user/org, encrypted VK, sync state), `agent_catalog_snapshot`/`agent_catalog_override`, `org_agent_policy`, `agent_llm_usage_event` (unique `litellm_request_id`), `agent_llm_usage_import_cursor`.
- **Store layer** (`db/store/agent_gateway/`): frozen-record returns, idempotent ensures via `ON CONFLICT DO NOTHING`, route-selection legality validation + revision bumps, usage insert-once dedupe.
- **Enrollment service**: `ensure_user_enrollment` / `ensure_org_enrollment` provision LiteLLM team+user+VK (budgets from settings, sha256 sync fingerprint), mark failed on client errors, stay pending while gateway disabled; bounded `backfill_enrollments`.
- **Eager hooks** on every signup/join entry: desktop GitHub callback, web/desktop identity OAuth + Apple, OIDC SSO login + SSO membership, invitation acceptance, team-checkout Stripe activation — all deferred-after-commit fire-and-forget; lifespan backfill worker sweeps stragglers.

## Verification
- 30 new unit/integration tests pass; full-suite failure set byte-identical to baseline (42 pre-existing, zero new)
- Migration: fresh-DB upgrade → downgrade → re-upgrade green
- **Live check**: real LiteLLM via compose — `ensure_user_enrollment` produced a synced enrollment, team/user/VK visible via admin client, VK lists models, second call idempotent
- ruff, boundary + max-lines checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)