### PR TITLE
feat(agent-auth): add gateway auth APIs and SDK surface

### DIFF
--- a/cloud/sdk-react/src/hooks/agent-gateway.ts
+++ b/cloud/sdk-react/src/hooks/agent-gateway.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  clearAgentRouteSelection,
+  createAgentApiKey,
+  getAgentGatewayCapabilities,
+  getAgentGatewayEnrollment,
+  listAgentApiKeys,
+  listAgentRouteSelections,
+  revokeAgentApiKey,
+  upsertAgentRouteSelection,
+  type AgentApiKey,
+  type AgentApiKeyListResponse,
+  type AgentAuthRouteSelection,
+  type AgentAuthRouteSelectionListResponse,
+  type AgentGatewayCapabilities,
+  type AgentGatewayEnrollment,
+  type CreateAgentApiKeyRequest,
+  type UpsertAgentAuthRouteSelectionRequest,
+} from "@proliferate/cloud-sdk";
+import { useCloudClient } from "../context/CloudClientProvider.js";
+import {
+  agentApiKeysKey,
+  agentGatewayCapabilitiesKey,
+  agentGatewayEnrollmentKey,
+  agentRouteSelectionsKey,
+} from "../lib/query-keys.js";
+
+export interface UpsertRouteSelectionInput {
+  harnessKind: string;
+  surface: string;
+  body: UpsertAgentAuthRouteSelectionRequest;
+}
+
+export interface ClearRouteSelectionInput {
+  harnessKind: string;
+  surface: string;
+}
+
+export function useAgentApiKeys(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<AgentApiKeyListResponse>({
+    queryKey: agentApiKeysKey(),
+    queryFn: () => listAgentApiKeys(client),
+    enabled,
+  });
+}
+
+export function useCreateAgentApiKey() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<AgentApiKey, Error, CreateAgentApiKeyRequest>({
+    mutationFn: (input) => createAgentApiKey(input, client),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentApiKeysKey() });
+    },
+  });
+}
+
+export function useRevokeAgentApiKey() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<AgentApiKey, Error, string>({
+    mutationFn: (keyId) => revokeAgentApiKey(keyId, client),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentApiKeysKey() });
+      // Revoking a key can invalidate api_key route selections downstream.
+      void queryClient.invalidateQueries({ queryKey: agentRouteSelectionsKey() });
+    },
+  });
+}
+
+export function useRouteSelections(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<AgentAuthRouteSelectionListResponse>({
+    queryKey: agentRouteSelectionsKey(),
+    queryFn: () => listAgentRouteSelections(client),
+    enabled,
+  });
+}
+
+export function useUpsertRouteSelection() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<AgentAuthRouteSelection, Error, UpsertRouteSelectionInput>({
+    mutationFn: ({ harnessKind, surface, body }) =>
+      upsertAgentRouteSelection(harnessKind, surface, body, client),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentRouteSelectionsKey() });
+    },
+  });
+}
+
+export function useClearRouteSelection() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, ClearRouteSelectionInput>({
+    mutationFn: ({ harnessKind, surface }) =>
+      clearAgentRouteSelection(harnessKind, surface, client),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentRouteSelectionsKey() });
+    },
+  });
+}
+
+export function useAgentGatewayCapabilities(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<AgentGatewayCapabilities>({
+    queryKey: agentGatewayCapabilitiesKey(),
+    queryFn: () => getAgentGatewayCapabilities(client),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useAgentGatewayEnrollment(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<AgentGatewayEnrollment>({
+    queryKey: agentGatewayEnrollmentKey(),
+    queryFn: () => getAgentGatewayEnrollment(client),
+    enabled,
+  });
+}

--- a/cloud/sdk-react/src/index.ts
+++ b/cloud/sdk-react/src/index.ts
@@ -2,6 +2,7 @@ export * from "./context/CloudClientProvider.js";
 export * from "./hooks/auth.js";
 export * from "./hooks/automations.js";
 export * from "./hooks/agent-catalog.js";
+export * from "./hooks/agent-gateway.js";
 export * from "./hooks/agent-run-configs.js";
 export * from "./hooks/billing.js";
 export * from "./hooks/cloud-secrets.js";

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -18,6 +18,26 @@ export function cloudAgentCatalogKey() {
   return [...cloudRootKey(), "agent-catalog", "v1"] as const;
 }
 
+export function agentGatewayRootKey() {
+  return [...cloudRootKey(), "agent-gateway"] as const;
+}
+
+export function agentApiKeysKey() {
+  return [...agentGatewayRootKey(), "api-keys"] as const;
+}
+
+export function agentRouteSelectionsKey() {
+  return [...agentGatewayRootKey(), "route-selections"] as const;
+}
+
+export function agentGatewayCapabilitiesKey() {
+  return [...agentGatewayRootKey(), "capabilities"] as const;
+}
+
+export function agentGatewayEnrollmentKey() {
+  return [...agentGatewayRootKey(), "enrollment"] as const;
+}
+
 export function cloudPluginInventoryRootKey() {
   return [...cloudRootKey(), "plugin-inventory"] as const;
 }

--- a/cloud/sdk/src/client/agent-gateway.ts
+++ b/cloud/sdk/src/client/agent-gateway.ts
@@ -1,0 +1,96 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type {
+  AgentApiKey,
+  AgentApiKeyListResponse,
+  AgentAuthRouteSelection,
+  AgentAuthRouteSelectionListResponse,
+  AgentGatewayCapabilities,
+  AgentGatewayEnrollment,
+  CreateAgentApiKeyRequest,
+  UpsertAgentAuthRouteSelectionRequest,
+} from "../types/index.js";
+
+function routeSelectionPath(harnessKind: string, surface: string): string {
+  return `/v1/cloud/agent-gateway/route-selections/${encodeURIComponent(harnessKind)}/${encodeURIComponent(surface)}`;
+}
+
+export async function listAgentApiKeys(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentApiKeyListResponse> {
+  return client.requestJson<AgentApiKeyListResponse>({
+    method: "GET",
+    path: "/v1/cloud/agent-gateway/api-keys",
+  });
+}
+
+export async function createAgentApiKey(
+  input: CreateAgentApiKeyRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentApiKey> {
+  return client.requestJson<AgentApiKey>({
+    method: "POST",
+    path: "/v1/cloud/agent-gateway/api-keys",
+    body: input,
+  });
+}
+
+export async function revokeAgentApiKey(
+  keyId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentApiKey> {
+  return client.requestJson<AgentApiKey>({
+    method: "DELETE",
+    path: `/v1/cloud/agent-gateway/api-keys/${encodeURIComponent(keyId)}`,
+  });
+}
+
+export async function listAgentRouteSelections(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthRouteSelectionListResponse> {
+  return client.requestJson<AgentAuthRouteSelectionListResponse>({
+    method: "GET",
+    path: "/v1/cloud/agent-gateway/route-selections",
+  });
+}
+
+export async function upsertAgentRouteSelection(
+  harnessKind: string,
+  surface: string,
+  input: UpsertAgentAuthRouteSelectionRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentAuthRouteSelection> {
+  return client.requestJson<AgentAuthRouteSelection>({
+    method: "PUT",
+    path: routeSelectionPath(harnessKind, surface),
+    body: input,
+  });
+}
+
+export async function clearAgentRouteSelection(
+  harnessKind: string,
+  surface: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<void> {
+  await client.requestJson<void>({
+    method: "DELETE",
+    path: routeSelectionPath(harnessKind, surface),
+  });
+}
+
+export async function getAgentGatewayCapabilities(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentGatewayCapabilities> {
+  return client.requestJson<AgentGatewayCapabilities>({
+    method: "GET",
+    path: "/v1/cloud/agent-gateway/capabilities",
+  });
+}
+
+export async function getAgentGatewayEnrollment(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AgentGatewayEnrollment> {
+  return client.requestJson<AgentGatewayEnrollment>({
+    method: "GET",
+    path: "/v1/cloud/agent-gateway/enrollment",
+  });
+}

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1171,6 +1171,110 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/agent-gateway/api-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Api Keys Endpoint */
+        get: operations["list_agent_api_keys_endpoint_v1_cloud_agent_gateway_api_keys_get"];
+        put?: never;
+        /** Create Agent Api Key Endpoint */
+        post: operations["create_agent_api_key_endpoint_v1_cloud_agent_gateway_api_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-gateway/api-keys/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke Agent Api Key Endpoint */
+        delete: operations["revoke_agent_api_key_endpoint_v1_cloud_agent_gateway_api_keys__key_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-gateway/route-selections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Route Selections Endpoint */
+        get: operations["list_agent_route_selections_endpoint_v1_cloud_agent_gateway_route_selections_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-gateway/route-selections/{harness_kind}/{surface}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Upsert Agent Route Selection Endpoint */
+        put: operations["upsert_agent_route_selection_endpoint_v1_cloud_agent_gateway_route_selections__harness_kind___surface__put"];
+        post?: never;
+        /** Clear Agent Route Selection Endpoint */
+        delete: operations["clear_agent_route_selection_endpoint_v1_cloud_agent_gateway_route_selections__harness_kind___surface__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-gateway/capabilities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Agent Gateway Capabilities Endpoint */
+        get: operations["get_agent_gateway_capabilities_endpoint_v1_cloud_agent_gateway_capabilities_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/agent-gateway/enrollment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Agent Gateway Enrollment Endpoint */
+        get: operations["get_agent_gateway_enrollment_endpoint_v1_cloud_agent_gateway_enrollment_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/agent-run-configs": {
         parameters: {
             query?: never;
@@ -2088,6 +2192,77 @@ export interface components {
             /** Effectiveenabled */
             effectiveEnabled: boolean;
         };
+        /** AgentApiKeyCreateRequest */
+        AgentApiKeyCreateRequest: {
+            /** Provider */
+            provider: string;
+            /** Displayname */
+            displayName: string;
+            /** Secret */
+            secret: string;
+        };
+        /** AgentApiKeyListResponse */
+        AgentApiKeyListResponse: {
+            /** Keys */
+            keys: components["schemas"]["AgentApiKeyResponse"][];
+        };
+        /** AgentApiKeyResponse */
+        AgentApiKeyResponse: {
+            /** Id */
+            id: string;
+            /** Provider */
+            provider: string;
+            /** Displayname */
+            displayName: string;
+            /** Redactedhint */
+            redactedHint: string;
+            /** Status */
+            status: string;
+            /** Lastvalidatedat */
+            lastValidatedAt: string | null;
+            /** Createdat */
+            createdAt: string;
+        };
+        /** AgentAuthRouteSelectionListResponse */
+        AgentAuthRouteSelectionListResponse: {
+            /** Selections */
+            selections: components["schemas"]["AgentAuthRouteSelectionResponse"][];
+        };
+        /** AgentAuthRouteSelectionResponse */
+        AgentAuthRouteSelectionResponse: {
+            /** Id */
+            id: string;
+            /** Harnesskind */
+            harnessKind: string;
+            /**
+             * Surface
+             * @enum {string}
+             */
+            surface: "local" | "cloud";
+            /**
+             * Route
+             * @enum {string}
+             */
+            route: "native" | "api_key" | "gateway";
+            /** Apikeyid */
+            apiKeyId: string | null;
+            /** Revision */
+            revision: number;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** AgentAuthRouteSelectionUpsertRequest */
+        AgentAuthRouteSelectionUpsertRequest: {
+            /**
+             * Route
+             * @enum {string}
+             */
+            route: "native" | "api_key" | "gateway";
+            /** Apikeyid */
+            apiKeyId?: string | null;
+        };
         /** AgentCatalogAgent */
         AgentCatalogAgent: {
             /**
@@ -2356,6 +2531,32 @@ export interface components {
             mapping?: components["schemas"]["AgentCatalogControlMapping"] | null;
         } & {
             [key: string]: unknown;
+        };
+        /** AgentGatewayCapabilitiesResponse */
+        AgentGatewayCapabilitiesResponse: {
+            /** Gatewayenabled */
+            gatewayEnabled: boolean;
+            /** Publicbaseurl */
+            publicBaseUrl: string | null;
+            /** Enrollmentstatus */
+            enrollmentStatus: string;
+        };
+        /** AgentGatewayEnrollmentResponse */
+        AgentGatewayEnrollmentResponse: {
+            /** Id */
+            id: string;
+            /** Subjectkind */
+            subjectKind: string;
+            /** Litellmteamid */
+            litellmTeamId: string | null;
+            /** Syncstatus */
+            syncStatus: string;
+            /** Lasterrorcode */
+            lastErrorCode: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
         };
         /** AgentRunConfigCreateRequest */
         AgentRunConfigCreateRequest: {
@@ -7025,6 +7226,216 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_api_keys_endpoint_v1_cloud_agent_gateway_api_keys_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentApiKeyListResponse"];
+                };
+            };
+        };
+    };
+    create_agent_api_key_endpoint_v1_cloud_agent_gateway_api_keys_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentApiKeyCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentApiKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_agent_api_key_endpoint_v1_cloud_agent_gateway_api_keys__key_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentApiKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_route_selections_endpoint_v1_cloud_agent_gateway_route_selections_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthRouteSelectionListResponse"];
+                };
+            };
+        };
+    };
+    upsert_agent_route_selection_endpoint_v1_cloud_agent_gateway_route_selections__harness_kind___surface__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                harness_kind: string;
+                surface: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentAuthRouteSelectionUpsertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentAuthRouteSelectionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_agent_route_selection_endpoint_v1_cloud_agent_gateway_route_selections__harness_kind___surface__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                harness_kind: string;
+                surface: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_agent_gateway_capabilities_endpoint_v1_cloud_agent_gateway_capabilities_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentGatewayCapabilitiesResponse"];
+                };
+            };
+        };
+    };
+    get_agent_gateway_enrollment_endpoint_v1_cloud_agent_gateway_enrollment_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentGatewayEnrollmentResponse"];
                 };
             };
         };

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from "./client/core.js";
 export * from "./client/auth.js";
 export * from "./client/sso.js";
 export * from "./client/viewer.js";
+export * from "./client/agent-gateway.js";
 export * from "./client/agent-run-configs.js";
 export * from "./client/agent-catalog.js";
 export * from "./client/ai-magic.js";

--- a/cloud/sdk/src/types/agent-gateway.ts
+++ b/cloud/sdk/src/types/agent-gateway.ts
@@ -1,0 +1,14 @@
+import type { Schema } from "./schema.js";
+
+export type AgentApiKey = Schema<"AgentApiKeyResponse">;
+export type AgentApiKeyListResponse = Schema<"AgentApiKeyListResponse">;
+export type CreateAgentApiKeyRequest = Schema<"AgentApiKeyCreateRequest">;
+export type AgentAuthRouteSelection = Schema<"AgentAuthRouteSelectionResponse">;
+export type AgentAuthRouteSelectionListResponse =
+  Schema<"AgentAuthRouteSelectionListResponse">;
+export type UpsertAgentAuthRouteSelectionRequest =
+  Schema<"AgentAuthRouteSelectionUpsertRequest">;
+export type AgentGatewayCapabilities = Schema<"AgentGatewayCapabilitiesResponse">;
+export type AgentGatewayEnrollment = Schema<"AgentGatewayEnrollmentResponse">;
+export type AgentAuthSurface = AgentAuthRouteSelection["surface"];
+export type AgentAuthRoute = AgentAuthRouteSelection["route"];

--- a/cloud/sdk/src/types/index.ts
+++ b/cloud/sdk/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./generated.js";
+export * from "./agent-gateway.js";
 export * from "./auth.js";
 export * from "./sso.js";
 export * from "./agent-run-configs.js";

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -8,6 +8,11 @@ AGENT_AUTH_SURFACE_LOCAL = "local"
 AGENT_AUTH_SURFACE_CLOUD = "cloud"
 AGENT_AUTH_SURFACES = (AGENT_AUTH_SURFACE_LOCAL, AGENT_AUTH_SURFACE_CLOUD)
 
+# Route selections are keyed by harness. The set mirrors the supported cloud
+# agent kinds; validating against it keeps unbounded/junk path params out of the
+# String(64) column (an over-length value would otherwise surface as a 500).
+AGENT_AUTH_HARNESS_KINDS = ("claude", "codex", "opencode", "gemini", "grok")
+
 AGENT_AUTH_ROUTE_NATIVE = "native"
 AGENT_AUTH_ROUTE_API_KEY = "api_key"
 AGENT_AUTH_ROUTE_GATEWAY = "gateway"

--- a/server/proliferate/db/store/agent_gateway/__init__.py
+++ b/server/proliferate/db/store/agent_gateway/__init__.py
@@ -39,6 +39,7 @@ from proliferate.db.store.agent_gateway.records import (
     OrgAgentPolicyRecord,
 )
 from proliferate.db.store.agent_gateway.route_selections import (
+    delete_route_selection,
     get_route_selection,
     list_route_selections,
     upsert_route_selection,
@@ -62,6 +63,7 @@ __all__ = [
     "build_redacted_hint",
     "create_agent_api_key",
     "create_catalog_snapshot",
+    "delete_route_selection",
     "ensure_enrollment_row",
     "get_agent_api_key_decrypted",
     "get_catalog_override",

--- a/server/proliferate/db/store/agent_gateway/route_selections.py
+++ b/server/proliferate/db/store/agent_gateway/route_selections.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import case, delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.agent_gateway import (
     AGENT_API_KEY_STATUS_ACTIVE,
+    AGENT_AUTH_HARNESS_KINDS,
     AGENT_AUTH_ROUTE_API_KEY,
     AGENT_AUTH_ROUTE_NATIVE,
     AGENT_AUTH_ROUTES,
@@ -30,8 +32,16 @@ def validate_route_selection(
     surface: str,
     route: str,
     api_key_id: UUID | None,
+    harness_kind: str | None = None,
 ) -> None:
-    """Pure legality checks shared by the store and unit tests."""
+    """Pure legality checks shared by the store and unit tests.
+
+    ``harness_kind`` is optional so surface/route legality can be exercised in
+    isolation; when supplied it is checked against the known allowlist so that
+    unbounded path params cannot reach the ``String(64)`` column.
+    """
+    if harness_kind is not None and harness_kind not in AGENT_AUTH_HARNESS_KINDS:
+        raise ValueError(f"Unknown agent harness kind: {harness_kind}")
     if surface not in AGENT_AUTH_SURFACES:
         raise ValueError(f"Unknown agent auth surface: {surface}")
     if route not in AGENT_AUTH_ROUTES:
@@ -53,7 +63,12 @@ async def upsert_route_selection(
     route: str,
     api_key_id: UUID | None = None,
 ) -> AgentAuthRouteSelectionRecord:
-    validate_route_selection(surface=surface, route=route, api_key_id=api_key_id)
+    validate_route_selection(
+        surface=surface,
+        route=route,
+        api_key_id=api_key_id,
+        harness_kind=harness_kind,
+    )
     if api_key_id is not None:
         key_row = (
             await db.execute(
@@ -67,34 +82,53 @@ async def upsert_route_selection(
         if key_row is None:
             raise ValueError("api_key_id must reference an active key owned by the user.")
 
+    # Atomic upsert: two concurrent first writes for the same scope resolve via
+    # ON CONFLICT instead of racing a select-then-insert into an IntegrityError.
+    # The revision (and updated_at) only advance when route/api_key_id actually
+    # change, preserving the prior idempotent semantics.
+    now = utcnow()
+    insert_stmt = pg_insert(AgentAuthRouteSelection).values(
+        user_id=user_id,
+        harness_kind=harness_kind,
+        surface=surface,
+        route=route,
+        api_key_id=api_key_id,
+        revision=1,
+        created_at=now,
+        updated_at=now,
+    )
+    changed = AgentAuthRouteSelection.route.is_distinct_from(
+        insert_stmt.excluded.route
+    ) | AgentAuthRouteSelection.api_key_id.is_distinct_from(insert_stmt.excluded.api_key_id)
+    await db.execute(
+        insert_stmt.on_conflict_do_update(
+            constraint="uq_agent_auth_route_selection_scope",
+            set_={
+                "route": insert_stmt.excluded.route,
+                "api_key_id": insert_stmt.excluded.api_key_id,
+                "revision": case(
+                    (changed, AgentAuthRouteSelection.revision + 1),
+                    else_=AgentAuthRouteSelection.revision,
+                ),
+                "updated_at": case(
+                    (changed, now),
+                    else_=AgentAuthRouteSelection.updated_at,
+                ),
+            },
+        )
+    )
+    await db.flush()
     row = (
         await db.execute(
-            select(AgentAuthRouteSelection).where(
+            select(AgentAuthRouteSelection)
+            .where(
                 AgentAuthRouteSelection.user_id == user_id,
                 AgentAuthRouteSelection.harness_kind == harness_kind,
                 AgentAuthRouteSelection.surface == surface,
             )
+            .execution_options(populate_existing=True)
         )
-    ).scalar_one_or_none()
-    if row is None:
-        row = AgentAuthRouteSelection(
-            user_id=user_id,
-            harness_kind=harness_kind,
-            surface=surface,
-            route=route,
-            api_key_id=api_key_id,
-            revision=1,
-        )
-        db.add(row)
-        await db.flush()
-        return route_selection_record(row)
-
-    if row.route != route or row.api_key_id != api_key_id:
-        row.route = route
-        row.api_key_id = api_key_id
-        row.revision += 1
-        row.updated_at = utcnow()
-        await db.flush()
+    ).scalar_one()
     return route_selection_record(row)
 
 
@@ -115,6 +149,24 @@ async def get_route_selection(
         )
     ).scalar_one_or_none()
     return route_selection_record(row) if row is not None else None
+
+
+async def delete_route_selection(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+) -> bool:
+    """Clear the selection for a scope. Returns whether a row was deleted."""
+    result = await db.execute(
+        delete(AgentAuthRouteSelection).where(
+            AgentAuthRouteSelection.user_id == user_id,
+            AgentAuthRouteSelection.harness_kind == harness_kind,
+            AgentAuthRouteSelection.surface == surface,
+        )
+    )
+    return (result.rowcount or 0) > 0
 
 
 async def list_route_selections(

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -4,6 +4,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import SQLAlchemyError
@@ -124,6 +126,55 @@ def _validate_support_tracker_configuration() -> None:
         )
 
 
+# Fragments that mark a request-body field as secret-bearing. FastAPI's default
+# 422 handler echoes the offending input verbatim, so a single unrelated invalid
+# field (e.g. a missing displayName) would otherwise reflect the whole body —
+# including a plaintext API-key secret — back to the caller.
+_SENSITIVE_INPUT_FRAGMENTS = ("secret", "password", "token", "payload", "ciphertext")
+_REDACTED_INPUT = "[redacted]"
+
+
+def _is_sensitive_field(key: object) -> bool:
+    return isinstance(key, str) and any(
+        fragment in key.lower() for fragment in _SENSITIVE_INPUT_FRAGMENTS
+    )
+
+
+def _redact_validation_input(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: (_REDACTED_INPUT if _is_sensitive_field(key) else _redact_validation_input(child))
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_validation_input(child) for child in value]
+    return value
+
+
+def _redacts_entire_body(request: Request) -> bool:
+    # The agent-gateway key-create endpoint accepts a raw secret in the body;
+    # redact its echoed input wholesale so no malformed shape can leak it.
+    return request.method == "POST" and request.url.path.endswith("/agent-gateway/api-keys")
+
+
+async def _validation_error_handler(
+    request: Request,
+    error: RequestValidationError,
+) -> JSONResponse:
+    redact_all = _redacts_entire_body(request)
+    errors: list[dict[str, object]] = []
+    for raw in error.errors():
+        item = dict(raw)
+        if "input" in item:
+            loc = item.get("loc") or ()
+            if redact_all or (loc and _is_sensitive_field(loc[-1])):
+                item["input"] = _REDACTED_INPUT
+            else:
+                item["input"] = _redact_validation_input(item["input"])
+        errors.append(item)
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": errors}))
+
+
 async def _proliferate_error_handler(
     _request: Request,
     error: ProliferateError,
@@ -197,6 +248,7 @@ def create_app() -> FastAPI:
     )
     app.add_middleware(RequestTelemetryMiddleware)
     app.add_middleware(RequestContextMiddleware)
+    app.add_exception_handler(RequestValidationError, _validation_error_handler)
     app.add_exception_handler(ProliferateError, _proliferate_error_handler)
 
     # ── Auth: users/me (read-only profile) ──

--- a/server/proliferate/server/cloud/agent_gateway/api.py
+++ b/server/proliferate/server/cloud/agent_gateway/api.py
@@ -1,0 +1,167 @@
+"""HTTP routes for agent gateway auth: key pool, route selections, capabilities."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.agent_gateway import service
+from proliferate.server.cloud.agent_gateway.models import (
+    AgentApiKeyCreateRequest,
+    AgentApiKeyListResponse,
+    AgentApiKeyResponse,
+    AgentAuthRouteSelectionListResponse,
+    AgentAuthRouteSelectionResponse,
+    AgentAuthRouteSelectionUpsertRequest,
+    AgentGatewayCapabilitiesResponse,
+    AgentGatewayEnrollmentResponse,
+    api_key_payload,
+    enrollment_payload,
+    route_selection_payload,
+)
+from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+
+router = APIRouter(prefix="/agent-gateway", tags=["cloud-agent-gateway"])
+
+
+def _parse_uuid(value: str, *, code: str, message: str, status_code: int) -> UUID:
+    try:
+        return UUID(value)
+    except ValueError as error:
+        raise CloudApiError(code, message, status_code=status_code) from error
+
+
+@router.get("/api-keys", response_model=AgentApiKeyListResponse)
+async def list_agent_api_keys_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentApiKeyListResponse:
+    records = await service.list_api_keys(db, user_id=user.id)
+    return AgentApiKeyListResponse(keys=[api_key_payload(record) for record in records])
+
+
+@router.post("/api-keys", response_model=AgentApiKeyResponse)
+async def create_agent_api_key_endpoint(
+    body: AgentApiKeyCreateRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentApiKeyResponse:
+    try:
+        record = await service.create_api_key(
+            db,
+            user_id=user.id,
+            provider=body.provider,
+            display_name=body.display_name,
+            secret=body.secret,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return api_key_payload(record)
+
+
+@router.delete("/api-keys/{key_id}", response_model=AgentApiKeyResponse)
+async def revoke_agent_api_key_endpoint(
+    key_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentApiKeyResponse:
+    try:
+        record = await service.revoke_api_key(db, user_id=user.id, api_key_id=key_id)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return api_key_payload(record)
+
+
+@router.get("/route-selections", response_model=AgentAuthRouteSelectionListResponse)
+async def list_agent_route_selections_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentAuthRouteSelectionListResponse:
+    records = await service.list_route_selections(db, user_id=user.id)
+    return AgentAuthRouteSelectionListResponse(
+        selections=[route_selection_payload(record) for record in records],
+    )
+
+
+@router.put(
+    "/route-selections/{harness_kind}/{surface}",
+    response_model=AgentAuthRouteSelectionResponse,
+)
+async def upsert_agent_route_selection_endpoint(
+    harness_kind: str,
+    surface: str,
+    body: AgentAuthRouteSelectionUpsertRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentAuthRouteSelectionResponse:
+    try:
+        api_key_id: UUID | None = None
+        if body.api_key_id is not None:
+            api_key_id = _parse_uuid(
+                body.api_key_id,
+                code="invalid_agent_route_selection",
+                message="apiKeyId must be a UUID.",
+                status_code=400,
+            )
+        record = await service.upsert_route_selection(
+            db,
+            user_id=user.id,
+            harness_kind=harness_kind,
+            surface=surface,
+            route=body.route,
+            api_key_id=api_key_id,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return route_selection_payload(record)
+
+
+@router.delete("/route-selections/{harness_kind}/{surface}", status_code=204)
+async def clear_agent_route_selection_endpoint(
+    harness_kind: str,
+    surface: str,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> None:
+    try:
+        await service.clear_route_selection(
+            db,
+            user_id=user.id,
+            harness_kind=harness_kind,
+            surface=surface,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)
+
+
+@router.get("/capabilities", response_model=AgentGatewayCapabilitiesResponse)
+async def get_agent_gateway_capabilities_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentGatewayCapabilitiesResponse:
+    gateway_enabled, public_base_url, enrollment_status = await service.get_capabilities(
+        db,
+        user_id=user.id,
+    )
+    return AgentGatewayCapabilitiesResponse(
+        gateway_enabled=gateway_enabled,
+        public_base_url=public_base_url,
+        enrollment_status=enrollment_status,
+    )
+
+
+@router.get("/enrollment", response_model=AgentGatewayEnrollmentResponse)
+async def get_agent_gateway_enrollment_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AgentGatewayEnrollmentResponse:
+    try:
+        record = await service.get_enrollment(db, user_id=user.id)
+    except CloudApiError as error:
+        raise_cloud_error(error)
+    return enrollment_payload(record)

--- a/server/proliferate/server/cloud/agent_gateway/models.py
+++ b/server/proliferate/server/cloud/agent_gateway/models.py
@@ -1,0 +1,124 @@
+"""Request and response models for the agent gateway auth APIs.
+
+Responses never carry key material: no secret, payload, ciphertext, or
+virtual-key fields exist on any model here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from proliferate.db.store.agent_gateway import (
+    AgentApiKeyRecord,
+    AgentAuthRouteSelectionRecord,
+    AgentGatewayEnrollmentRecord,
+)
+
+AgentAuthSurface = Literal["local", "cloud"]
+AgentAuthRoute = Literal["native", "api_key", "gateway"]
+
+
+class AgentGatewayBaseModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AgentApiKeyResponse(AgentGatewayBaseModel):
+    id: str
+    provider: str
+    display_name: str = Field(alias="displayName")
+    redacted_hint: str = Field(alias="redactedHint")
+    status: str
+    last_validated_at: str | None = Field(alias="lastValidatedAt")
+    created_at: str = Field(alias="createdAt")
+
+
+class AgentApiKeyListResponse(AgentGatewayBaseModel):
+    keys: list[AgentApiKeyResponse]
+
+
+class AgentApiKeyCreateRequest(AgentGatewayBaseModel):
+    provider: str
+    display_name: str = Field(alias="displayName")
+    secret: str
+
+
+class AgentAuthRouteSelectionResponse(AgentGatewayBaseModel):
+    id: str
+    harness_kind: str = Field(alias="harnessKind")
+    surface: AgentAuthSurface
+    route: AgentAuthRoute
+    api_key_id: str | None = Field(alias="apiKeyId")
+    revision: int
+    created_at: str = Field(alias="createdAt")
+    updated_at: str = Field(alias="updatedAt")
+
+
+class AgentAuthRouteSelectionListResponse(AgentGatewayBaseModel):
+    selections: list[AgentAuthRouteSelectionResponse]
+
+
+class AgentAuthRouteSelectionUpsertRequest(AgentGatewayBaseModel):
+    route: AgentAuthRoute
+    api_key_id: str | None = Field(default=None, alias="apiKeyId")
+
+
+class AgentGatewayCapabilitiesResponse(AgentGatewayBaseModel):
+    gateway_enabled: bool = Field(alias="gatewayEnabled")
+    public_base_url: str | None = Field(alias="publicBaseUrl")
+    enrollment_status: str = Field(alias="enrollmentStatus")
+
+
+class AgentGatewayEnrollmentResponse(AgentGatewayBaseModel):
+    id: str
+    subject_kind: str = Field(alias="subjectKind")
+    litellm_team_id: str | None = Field(alias="litellmTeamId")
+    sync_status: str = Field(alias="syncStatus")
+    last_error_code: str | None = Field(alias="lastErrorCode")
+    created_at: str = Field(alias="createdAt")
+    updated_at: str = Field(alias="updatedAt")
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def api_key_payload(record: AgentApiKeyRecord) -> AgentApiKeyResponse:
+    return AgentApiKeyResponse(
+        id=str(record.id),
+        provider=record.provider,
+        display_name=record.display_name,
+        redacted_hint=record.redacted_hint,
+        status=record.status,
+        last_validated_at=_iso(record.last_validated_at),
+        created_at=record.created_at.isoformat(),
+    )
+
+
+def route_selection_payload(
+    record: AgentAuthRouteSelectionRecord,
+) -> AgentAuthRouteSelectionResponse:
+    return AgentAuthRouteSelectionResponse(
+        id=str(record.id),
+        harness_kind=record.harness_kind,
+        surface=record.surface,  # type: ignore[arg-type]
+        route=record.route,  # type: ignore[arg-type]
+        api_key_id=str(record.api_key_id) if record.api_key_id is not None else None,
+        revision=record.revision,
+        created_at=record.created_at.isoformat(),
+        updated_at=record.updated_at.isoformat(),
+    )
+
+
+def enrollment_payload(record: AgentGatewayEnrollmentRecord) -> AgentGatewayEnrollmentResponse:
+    return AgentGatewayEnrollmentResponse(
+        id=str(record.id),
+        subject_kind=record.subject_kind,
+        litellm_team_id=record.litellm_team_id,
+        sync_status=record.sync_status,
+        last_error_code=record.last_error_code,
+        created_at=record.created_at.isoformat(),
+        updated_at=record.updated_at.isoformat(),
+    )

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -1,0 +1,217 @@
+"""Agent gateway auth services: key pool, route selections, capabilities.
+
+Store legality errors surface as typed :class:`CloudApiError` values so the
+API layer maps them uniformly. Key create/revoke and selection changes emit
+structured audit log events (the Bifrost-era audit table was dropped; the
+cloud event log is the post-teardown audit surface).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.agent_gateway import AGENT_API_KEY_PROVIDERS
+from proliferate.db.store import agent_gateway as agent_gateway_store
+from proliferate.db.store.agent_gateway import (
+    AgentApiKeyRecord,
+    AgentAuthRouteSelectionRecord,
+    AgentGatewayEnrollmentRecord,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.event_logging import log_cloud_event
+
+_ENROLLMENT_STATUS_NONE = "none"
+_MAX_DISPLAY_NAME_LENGTH = 255
+_MAX_SECRET_LENGTH = 4096
+
+
+async def list_api_keys(db: AsyncSession, *, user_id: UUID) -> list[AgentApiKeyRecord]:
+    return await agent_gateway_store.list_agent_api_keys(db, user_id=user_id)
+
+
+async def create_api_key(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    provider: str,
+    display_name: str,
+    secret: str,
+) -> AgentApiKeyRecord:
+    if provider not in AGENT_API_KEY_PROVIDERS:
+        raise CloudApiError(
+            "invalid_agent_api_key_provider",
+            f"Provider must be one of: {', '.join(AGENT_API_KEY_PROVIDERS)}.",
+            status_code=400,
+        )
+    display_name = display_name.strip()
+    if not display_name or len(display_name) > _MAX_DISPLAY_NAME_LENGTH:
+        raise CloudApiError(
+            "invalid_agent_api_key_display_name",
+            f"Display name must be 1-{_MAX_DISPLAY_NAME_LENGTH} characters.",
+            status_code=400,
+        )
+    secret = secret.strip()
+    if not secret or len(secret) > _MAX_SECRET_LENGTH:
+        raise CloudApiError(
+            "invalid_agent_api_key_secret",
+            "The key secret must be a non-empty string.",
+            status_code=400,
+        )
+    record = await agent_gateway_store.create_agent_api_key(
+        db,
+        user_id=user_id,
+        provider=provider,
+        display_name=display_name,
+        payload=secret,
+    )
+    log_cloud_event(
+        "agent_api_key_created",
+        user_id=str(user_id),
+        api_key_id=str(record.id),
+        provider=record.provider,
+    )
+    return record
+
+
+async def revoke_api_key(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    api_key_id: UUID,
+) -> AgentApiKeyRecord:
+    record = await agent_gateway_store.revoke_agent_api_key(
+        db,
+        user_id=user_id,
+        api_key_id=api_key_id,
+    )
+    if record is None:
+        raise CloudApiError(
+            "agent_api_key_not_found",
+            "Agent API key not found.",
+            status_code=404,
+        )
+    log_cloud_event(
+        "agent_api_key_revoked",
+        user_id=str(user_id),
+        api_key_id=str(record.id),
+        provider=record.provider,
+    )
+    return record
+
+
+async def list_route_selections(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> list[AgentAuthRouteSelectionRecord]:
+    return await agent_gateway_store.list_route_selections(db, user_id=user_id)
+
+
+async def upsert_route_selection(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+    route: str,
+    api_key_id: UUID | None,
+) -> AgentAuthRouteSelectionRecord:
+    try:
+        agent_gateway_store.validate_route_selection(
+            harness_kind=harness_kind,
+            surface=surface,
+            route=route,
+            api_key_id=api_key_id,
+        )
+    except ValueError as error:
+        raise CloudApiError(
+            "invalid_agent_route_selection",
+            str(error),
+            status_code=400,
+        ) from error
+    try:
+        record = await agent_gateway_store.upsert_route_selection(
+            db,
+            user_id=user_id,
+            harness_kind=harness_kind,
+            surface=surface,
+            route=route,
+            api_key_id=api_key_id,
+        )
+    except ValueError as error:
+        # Pure legality already passed; the remaining failure mode is an
+        # api_key_id that is not an active key owned by the caller.
+        raise CloudApiError(
+            "agent_api_key_not_found",
+            "api_key_id must reference an active key owned by the caller.",
+            status_code=404,
+        ) from error
+    log_cloud_event(
+        "agent_route_selection_upserted",
+        user_id=str(user_id),
+        harness_kind=harness_kind,
+        surface=surface,
+        route=route,
+        api_key_id=str(api_key_id) if api_key_id is not None else None,
+        revision=record.revision,
+    )
+    return record
+
+
+async def clear_route_selection(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+) -> None:
+    deleted = await agent_gateway_store.delete_route_selection(
+        db,
+        user_id=user_id,
+        harness_kind=harness_kind,
+        surface=surface,
+    )
+    if not deleted:
+        raise CloudApiError(
+            "agent_route_selection_not_found",
+            "No route selection exists for this harness and surface.",
+            status_code=404,
+        )
+    log_cloud_event(
+        "agent_route_selection_cleared",
+        user_id=str(user_id),
+        harness_kind=harness_kind,
+        surface=surface,
+    )
+
+
+async def get_capabilities(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> tuple[bool, str | None, str]:
+    """Return (gateway_enabled, public_base_url, enrollment_status)."""
+    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    return (
+        settings.agent_gateway_enabled,
+        settings.agent_gateway_litellm_public_base_url or None,
+        enrollment.sync_status if enrollment is not None else _ENROLLMENT_STATUS_NONE,
+    )
+
+
+async def get_enrollment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord:
+    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    if enrollment is None:
+        raise CloudApiError(
+            "agent_gateway_enrollment_not_found",
+            "No agent gateway enrollment exists for this user.",
+            status_code=404,
+        )
+    return enrollment

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from proliferate.server.cloud.agent_gateway.api import router as agent_gateway_router
 from proliferate.server.cloud.agent_run_config.api import router as agent_run_config_router
 from proliferate.server.cloud.cloud_sandboxes.api import router as cloud_sandboxes_router
 from proliferate.server.cloud.github_app.api import (
@@ -37,6 +38,7 @@ router.include_router(secrets_router)
 router.include_router(cloud_sandboxes_router)
 router.include_router(workspaces_router)
 router.include_router(worktree_policy_router)
+router.include_router(agent_gateway_router)
 router.include_router(agent_run_config_router)
 router.include_router(runtime_workers_router)
 router.include_router(runtime_worker_router)

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -1,0 +1,445 @@
+"""Integration tests for the agent gateway auth APIs (key pool, selections)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.models.auth import OAuthAccount
+from proliferate.db.models.cloud.agent_gateway import AgentApiKey
+from proliferate.db.store import agent_gateway as store
+from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
+from tests.helpers.desktop_auth import mint_desktop_token_payload
+
+SECRET = "sk-ant-api03-super-secret-payload-abc4"
+
+
+async def _register_and_login(client: AsyncClient, email: str) -> dict[str, str]:
+    from proliferate.auth.models import UserCreate
+    from proliferate.auth.users import UserManager, get_user_db
+    from proliferate.db.engine import get_async_session
+
+    user_id: str | None = None
+    async for session in get_async_session():
+        async for user_db in get_user_db(session):
+            manager = UserManager(user_db)
+            user = await manager.create(
+                UserCreate(
+                    email=email,
+                    password="unused-oauth-only",
+                    display_name="Gateway Tester",
+                ),
+            )
+            session.add(
+                OAuthAccount(
+                    user_id=user.id,
+                    oauth_name="github",
+                    access_token="github-access-token",
+                    account_id=f"github-{user.id}",
+                    account_email=email,
+                )
+            )
+            await session.commit()
+            user_id = str(user.id)
+
+    assert user_id is not None
+    token_data = await mint_desktop_token_payload(
+        client,
+        user_id=user_id,
+        state_prefix="agent-gateway",
+    )
+    return {"user_id": user_id, "access_token": str(token_data["access_token"])}
+
+
+async def _authed_user(client: AsyncClient) -> tuple[str, dict[str, str]]:
+    tokens = await _register_and_login(
+        client,
+        f"agent-gateway-api-{uuid.uuid4().hex[:8]}@example.com",
+    )
+    return tokens["user_id"], {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def _assert_no_secret(response: Response) -> None:
+    assert SECRET not in response.text
+    for key in _iter_keys(response.json()):
+        for fragment in ("secret", "payload", "ciphertext"):
+            assert fragment not in key.lower(), f"response leaks field {key}"
+
+
+def _iter_keys(value: object) -> list[str]:
+    keys: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            keys.append(str(key))
+            keys.extend(_iter_keys(child))
+    elif isinstance(value, list):
+        for child in value:
+            keys.extend(_iter_keys(child))
+    return keys
+
+
+async def _create_key(
+    client: AsyncClient,
+    headers: dict[str, str],
+    *,
+    provider: str = "anthropic",
+    secret: str = SECRET,
+) -> dict[str, object]:
+    response = await client.post(
+        "/v1/cloud/agent-gateway/api-keys",
+        headers=headers,
+        json={"provider": provider, "displayName": "Work key", "secret": secret},
+    )
+    assert response.status_code == 200, response.text
+    _assert_no_secret(response)
+    return response.json()
+
+
+class TestAgentApiKeys:
+    @pytest.mark.asyncio
+    async def test_create_list_revoke_happy_path(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        user_id, headers = await _authed_user(client)
+
+        created = await _create_key(client, headers)
+        assert created["provider"] == "anthropic"
+        assert created["displayName"] == "Work key"
+        assert created["redactedHint"] == "sk-...abc4"
+        assert created["status"] == "active"
+
+        listed = await client.get("/v1/cloud/agent-gateway/api-keys", headers=headers)
+        assert listed.status_code == 200
+        _assert_no_secret(listed)
+        keys = listed.json()["keys"]
+        assert [key["id"] for key in keys] == [created["id"]]
+
+        revoked = await client.delete(
+            f"/v1/cloud/agent-gateway/api-keys/{created['id']}",
+            headers=headers,
+        )
+        assert revoked.status_code == 200
+        _assert_no_secret(revoked)
+        assert revoked.json()["status"] == "revoked"
+
+        listed_after = await client.get("/v1/cloud/agent-gateway/api-keys", headers=headers)
+        assert listed_after.json()["keys"] == []
+
+        # Ciphertext lives in the DB; the raw secret never does.
+        row = (
+            await db_session.execute(
+                select(AgentApiKey).where(AgentApiKey.id == uuid.UUID(str(created["id"])))
+            )
+        ).scalar_one()
+        assert row.payload_ciphertext != SECRET
+        assert SECRET not in row.payload_ciphertext
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_unknown_provider_and_empty_secret(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        _, headers = await _authed_user(client)
+
+        bad_provider = await client.post(
+            "/v1/cloud/agent-gateway/api-keys",
+            headers=headers,
+            json={"provider": "bedrock", "displayName": "Key", "secret": SECRET},
+        )
+        assert bad_provider.status_code == 400
+        assert bad_provider.json()["detail"]["code"] == "invalid_agent_api_key_provider"
+
+        empty_secret = await client.post(
+            "/v1/cloud/agent-gateway/api-keys",
+            headers=headers,
+            json={"provider": "anthropic", "displayName": "Key", "secret": "   "},
+        )
+        assert empty_secret.status_code == 400
+        assert empty_secret.json()["detail"]["code"] == "invalid_agent_api_key_secret"
+
+    @pytest.mark.asyncio
+    async def test_create_validation_error_never_echoes_secret(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        _, headers = await _authed_user(client)
+
+        # A single unrelated invalid field (missing displayName) must not cause
+        # FastAPI's 422 handler to reflect the plaintext secret back to the caller.
+        missing_field = await client.post(
+            "/v1/cloud/agent-gateway/api-keys",
+            headers=headers,
+            json={"provider": "anthropic", "secret": SECRET},
+        )
+        assert missing_field.status_code == 422, missing_field.text
+        assert SECRET not in missing_field.text
+
+        # Same guarantee when the secret field itself is the wrong type.
+        wrong_type = await client.post(
+            "/v1/cloud/agent-gateway/api-keys",
+            headers=headers,
+            json={"provider": "anthropic", "displayName": "Key", "secret": [SECRET]},
+        )
+        assert wrong_type.status_code == 422, wrong_type.text
+        assert SECRET not in wrong_type.text
+
+        # And when the whole body is a malformed shape carrying the secret.
+        malformed_body = await client.post(
+            "/v1/cloud/agent-gateway/api-keys",
+            headers=headers,
+            json=[SECRET],
+        )
+        assert malformed_body.status_code == 422, malformed_body.text
+        assert SECRET not in malformed_body.text
+
+    @pytest.mark.asyncio
+    async def test_revoke_foreign_key_is_404(self, client: AsyncClient) -> None:
+        _, owner_headers = await _authed_user(client)
+        _, other_headers = await _authed_user(client)
+        created = await _create_key(client, owner_headers)
+
+        response = await client.delete(
+            f"/v1/cloud/agent-gateway/api-keys/{created['id']}",
+            headers=other_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "agent_api_key_not_found"
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/cloud/agent-gateway/api-keys")
+        assert response.status_code == 401
+
+
+class TestAgentRouteSelections:
+    @pytest.mark.asyncio
+    async def test_upsert_list_clear_happy_path(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        created = await _create_key(client, headers)
+
+        upserted = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+            json={"route": "api_key", "apiKeyId": created["id"]},
+        )
+        assert upserted.status_code == 200, upserted.text
+        payload = upserted.json()
+        assert payload["harnessKind"] == "claude"
+        assert payload["surface"] == "cloud"
+        assert payload["route"] == "api_key"
+        assert payload["apiKeyId"] == created["id"]
+        assert payload["revision"] == 1
+
+        changed = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+            json={"route": "gateway"},
+        )
+        assert changed.status_code == 200
+        assert changed.json()["revision"] == 2
+
+        listed = await client.get(
+            "/v1/cloud/agent-gateway/route-selections",
+            headers=headers,
+        )
+        assert listed.status_code == 200
+        selections = listed.json()["selections"]
+        assert len(selections) == 1
+        assert selections[0]["route"] == "gateway"
+
+        cleared = await client.delete(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+        )
+        assert cleared.status_code == 204
+
+        empty = await client.get(
+            "/v1/cloud/agent-gateway/route-selections",
+            headers=headers,
+        )
+        assert empty.json()["selections"] == []
+
+        missing = await client.delete(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+        )
+        assert missing.status_code == 404
+        assert missing.json()["detail"]["code"] == "agent_route_selection_not_found"
+
+    @pytest.mark.asyncio
+    async def test_cloud_native_is_400(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        response = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+            json={"route": "native"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+    @pytest.mark.asyncio
+    async def test_api_key_route_without_key_is_400(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        response = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+            json={"route": "api_key"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+    @pytest.mark.asyncio
+    async def test_foreign_api_key_is_404(self, client: AsyncClient) -> None:
+        _, owner_headers = await _authed_user(client)
+        _, other_headers = await _authed_user(client)
+        created = await _create_key(client, owner_headers)
+
+        response = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=other_headers,
+            json={"route": "api_key", "apiKeyId": created["id"]},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "agent_api_key_not_found"
+
+    @pytest.mark.asyncio
+    async def test_unknown_harness_kind_is_400(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+
+        unknown = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/bogus/cloud",
+            headers=headers,
+            json={"route": "gateway"},
+        )
+        assert unknown.status_code == 400
+        assert unknown.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+        # An over-length harness must be rejected up front rather than tripping a
+        # String(64) truncation error (500) and persisting junk.
+        overlong = await client.put(
+            f"/v1/cloud/agent-gateway/route-selections/{'x' * 200}/cloud",
+            headers=headers,
+            json={"route": "gateway"},
+        )
+        assert overlong.status_code == 400
+        assert overlong.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+    @pytest.mark.asyncio
+    async def test_unknown_surface_is_400(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        response = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/orbital",
+            headers=headers,
+            json={"route": "gateway"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+
+class TestAgentGatewayCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_gateway_off(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "agent_gateway_enabled", False)
+        monkeypatch.setattr(settings, "agent_gateway_litellm_public_base_url", "")
+        _, headers = await _authed_user(client)
+
+        response = await client.get(
+            "/v1/cloud/agent-gateway/capabilities",
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "gatewayEnabled": False,
+            "publicBaseUrl": None,
+            "enrollmentStatus": "none",
+        }
+
+    @pytest.mark.asyncio
+    async def test_capabilities_gateway_on_with_enrollment(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+        monkeypatch.setattr(
+            settings,
+            "agent_gateway_litellm_public_base_url",
+            "https://llm.proliferate.ai",
+        )
+        user_id, headers = await _authed_user(client)
+
+        subject = await ensure_personal_billing_subject(db_session, uuid.UUID(user_id))
+        await store.ensure_enrollment_row(
+            db_session,
+            subject_kind="user",
+            billing_subject_id=subject.id,
+            user_id=uuid.UUID(user_id),
+        )
+        await db_session.commit()
+
+        response = await client.get(
+            "/v1/cloud/agent-gateway/capabilities",
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "gatewayEnabled": True,
+            "publicBaseUrl": "https://llm.proliferate.ai",
+            "enrollmentStatus": "pending",
+        }
+
+
+class TestAgentGatewayEnrollment:
+    @pytest.mark.asyncio
+    async def test_enrollment_summary_never_leaks_virtual_key(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        user_id, headers = await _authed_user(client)
+        subject = await ensure_personal_billing_subject(db_session, uuid.UUID(user_id))
+        enrollment = await store.ensure_enrollment_row(
+            db_session,
+            subject_kind="user",
+            billing_subject_id=subject.id,
+            user_id=uuid.UUID(user_id),
+        )
+        await store.mark_enrollment_synced(
+            db_session,
+            enrollment_id=enrollment.id,
+            litellm_team_id="team-1",
+            litellm_user_id=f"user-{user_id}",
+            virtual_key_id="token-1",
+            virtual_key="sk-litellm-virtual-key-plaintext",
+            sync_fingerprint="fp",
+        )
+        await db_session.commit()
+
+        response = await client.get("/v1/cloud/agent-gateway/enrollment", headers=headers)
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["subjectKind"] == "user"
+        assert payload["litellmTeamId"] == "team-1"
+        assert payload["syncStatus"] == "synced"
+        assert "sk-litellm-virtual-key-plaintext" not in response.text
+        for key in _iter_keys(payload):
+            assert "key" not in key.lower(), f"enrollment response exposes field {key}"
+
+    @pytest.mark.asyncio
+    async def test_enrollment_missing_is_404(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        response = await client.get("/v1/cloud/agent-gateway/enrollment", headers=headers)
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "agent_gateway_enrollment_not_found"

--- a/server/tests/integration/test_agent_gateway_store.py
+++ b/server/tests/integration/test_agent_gateway_store.py
@@ -143,6 +143,91 @@ async def test_route_selection_upsert_bumps_revision(db_session: AsyncSession) -
 
 
 @pytest.mark.asyncio
+async def test_route_selection_upsert_resolves_conflicting_row(
+    db_session: AsyncSession,
+) -> None:
+    """A row inserted out-of-band (as a racing first writer would) must be
+    resolved by the ON CONFLICT upsert rather than raising IntegrityError."""
+    from proliferate.db.models.cloud.agent_gateway import AgentAuthRouteSelection
+
+    user_id = await _create_user(db_session)
+    # Simulate the row a concurrent first PUT committed just before us.
+    db_session.add(
+        AgentAuthRouteSelection(
+            user_id=user_id,
+            harness_kind="claude",
+            surface="local",
+            route="native",
+            revision=1,
+        )
+    )
+    await db_session.flush()
+
+    resolved = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        route="gateway",
+    )
+    assert resolved.route == "gateway"
+    assert resolved.revision == 2
+
+    listed = await store.list_route_selections(db_session, user_id=user_id)
+    assert len(listed) == 1
+
+
+@pytest.mark.asyncio
+async def test_route_selection_rejects_unknown_harness(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    with pytest.raises(ValueError, match="harness kind"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="x" * 200,
+            surface="local",
+            route="native",
+        )
+
+
+@pytest.mark.asyncio
+async def test_route_selection_delete(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        route="native",
+    )
+
+    deleted = await store.delete_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+    )
+    assert deleted is True
+    assert (
+        await store.get_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="claude",
+            surface="local",
+        )
+        is None
+    )
+
+    again = await store.delete_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+    )
+    assert again is False
+
+
+@pytest.mark.asyncio
 async def test_route_selection_rejects_cloud_native(db_session: AsyncSession) -> None:
     user_id = await _create_user(db_session)
     with pytest.raises(ValueError, match="native route"):

--- a/server/tests/unit/test_agent_gateway_domain.py
+++ b/server/tests/unit/test_agent_gateway_domain.py
@@ -39,6 +39,22 @@ class TestRouteSelectionLegality:
         with pytest.raises(ValueError, match="route"):
             validate_route_selection(surface="local", route="magic", api_key_id=None)
 
+    def test_unknown_harness_kind_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="harness kind"):
+            validate_route_selection(
+                surface="local",
+                route="native",
+                api_key_id=None,
+                harness_kind="bogus",
+            )
+        # A known harness passes the same check.
+        validate_route_selection(
+            surface="local",
+            route="native",
+            api_key_id=None,
+            harness_kind="claude",
+        )
+
 
 class TestRedactedHint:
     def test_prefixed_key_keeps_prefix_and_tail(self) -> None:


### PR DESCRIPTION
PR 4 of 12 in the LiteLLM agent-auth migration (spec: `specs/codebase/primitives/agent-auth-litellm.md` §10 PR 4). Stacked on #819.

## What's here
- **API** under `/v1/cloud/agent-gateway/`: key-pool CRUD (secret never echoed; non-owner → 404), route-selection get/put/delete (legality → typed 400s), `capabilities` (gatewayEnabled/publicBaseUrl/enrollmentStatus — Desktop reads this instead of hardcoding), `enrollment` summary (VK never leaves the server).
- **Layering**: thin `api.py` → `service.py` (typed `CloudApiError` codes + `log_cloud_event` structured audit) → PR 3 stores, per boundary-checker rules. The Bifrost audit table died in PR 1; no new table invented.
- **SDKs**: openapi regen; `cloud/sdk` client module + `cloud/sdk-react` hooks (`useAgentApiKeys`, `useCreateAgentApiKey`, `useRevokeAgentApiKey`, `useRouteSelections`, `useUpsertRouteSelection`, `useClearRouteSelection`, `useAgentGatewayCapabilities`, `useAgentGatewayEnrollment`) with query keys.

## Verification
- 14 new tests (incl. recursive response-key scan asserting no secret/ciphertext field ever appears); full-suite failure set identical to baseline — zero new failures
- ruff, boundary, max-lines checks green; both SDKs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)