### PR TITLE
feat(agent-auth): render harness auth profiles from cloud state

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
@@ -241,6 +241,11 @@ fn map_create_cowork_thread_error(error: CoworkCreateThreadError) -> ApiError {
             crate::domains::sessions::runtime::CreateAndStartSessionError::MissingDataKey => {
                 ApiError::internal(SessionMcpBindingsError::missing_data_key_detail())
             }
+            crate::domains::sessions::runtime::CreateAndStartSessionError::RouteAuth(error) => {
+                // Malformed-state / materialization IO are 500s; selection/route
+                // shape problems are 409s — same split as the sessions API.
+                super::sessions_errors::map_route_auth_error(&error)
+            }
             crate::domains::sessions::runtime::CreateAndStartSessionError::StartFailed(error) => {
                 ApiError::internal(format!("ACP session start failed: {error}"))
             }
@@ -469,4 +474,40 @@ async fn load_workspace(state: &AppState, workspace_id: &str) -> Result<Workspac
             })
     })
     .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use super::CoworkCreateThreadError;
+    use crate::domains::agents::route_auth::RouteAuthError;
+    use crate::domains::sessions::runtime::CreateAndStartSessionError;
+
+    /// Materialization IO / malformed-state route-auth failures are server-side
+    /// problems → 500, matching the sessions API (not a client 409).
+    #[test]
+    fn route_auth_materialize_failure_maps_to_internal_error() {
+        let error = CoworkCreateThreadError::CreateSession(CreateAndStartSessionError::RouteAuth(
+            RouteAuthError::Materialize {
+                detail: "disk full".into(),
+            },
+        ));
+        let response = super::map_create_cowork_thread_error(error).into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    /// Selection-shape route-auth failures remain a 409 (launch precondition).
+    #[test]
+    fn route_auth_selection_missing_maps_to_conflict() {
+        let error = CoworkCreateThreadError::CreateSession(CreateAndStartSessionError::RouteAuth(
+            RouteAuthError::SelectionMissing {
+                harness_kind: "claude".into(),
+                revision: 1,
+            },
+        ));
+        let response = super::map_create_cowork_thread_error(error).into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -1,5 +1,6 @@
 use super::access::map_access_error;
 use super::error::ApiError;
+use crate::domains::agents::route_auth::RouteAuthError;
 use crate::domains::sessions::mcp_bindings::crypto::SessionMcpBindingsError;
 use crate::domains::sessions::runtime::{
     CreateAndStartSessionError, EnsureLiveSessionError, ForkSessionError,
@@ -99,10 +100,30 @@ pub(super) fn map_create_session_error(error: CreateAndStartSessionError) -> Api
         CreateAndStartSessionError::MissingDataKey => {
             ApiError::internal(SessionMcpBindingsError::missing_data_key_detail())
         }
+        CreateAndStartSessionError::RouteAuth(error) => map_route_auth_error(&error),
         CreateAndStartSessionError::StartFailed(error) => {
             ApiError::internal(format!("ACP session start failed: {error}"))
         }
         CreateAndStartSessionError::Internal(error) => ApiError::internal(error.to_string()),
+    }
+}
+
+/// Typed agent-auth launch refusals, keyed by the stable `AGENT_ROUTE_*` code
+/// (see `RouteAuthError::code`). Fail-closed / route-shape problems are 409s
+/// (the session request was fine; the launch precondition is not satisfied
+/// until a selection changes); state-file corruption and materialization IO
+/// are 500s.
+pub(super) fn map_route_auth_error(error: &RouteAuthError) -> ApiError {
+    match error {
+        RouteAuthError::SelectionMissing { .. }
+        | RouteAuthError::SelectionIncomplete { .. }
+        | RouteAuthError::UnsupportedRoute { .. }
+        | RouteAuthError::UnknownHarness { .. } => {
+            ApiError::conflict(error.to_string(), error.code())
+        }
+        RouteAuthError::MalformedStateFile { .. } | RouteAuthError::Materialize { .. } => {
+            ApiError::internal(error.to_string())
+        }
     }
 }
 
@@ -124,6 +145,7 @@ pub(super) fn map_ensure_live_session_error(error: EnsureLiveSessionError) -> Ap
         EnsureLiveSessionError::MissingDataKey => {
             ApiError::internal(SessionMcpBindingsError::missing_data_key_detail())
         }
+        EnsureLiveSessionError::RouteAuth(error) => map_route_auth_error(&error),
         EnsureLiveSessionError::Internal(error) => {
             ApiError::internal(format!("resume failed: {error}"))
         }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/mod.rs
@@ -5,4 +5,5 @@ pub mod model;
 pub mod portability;
 pub mod readiness;
 pub mod registry;
+pub mod route_auth;
 pub mod runtime;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/materialize.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/materialize.rs
@@ -1,0 +1,277 @@
+//! Switch-time filesystem materialization for gateway routes that need
+//! isolated harness state (codex CODEX_HOME, grok/gemini HOME).
+//!
+//! Bookkeeping is filesystem-only (spec §4): the applied revision is carried in
+//! the directory name (`codex-home-<rev>`, `grok-home-<rev>`, ...), so no new
+//! SQLite table is introduced. Each materialization garbage-collects sibling
+//! dirs for *stale* revisions, then writes the current revision's dir
+//! idempotently. This keeps "next process launch after a revision change picks
+//! up new state" working with zero schema churn.
+//!
+//! Cleanup is deliberately conservative: the current revision's dir AND the
+//! immediately-previous revision's dir are always kept, so in-flight processes
+//! launched under the prior revision keep reading valid isolated state (spec §0
+//! decision: "In-flight agent processes finish on old creds; the next process
+//! launch picks up new state"). Only revisions strictly older than the
+//! immediately-previous one are removed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use super::profile::GatewayProfile;
+use super::RouteAuthError;
+
+const ROUTE_AUTH_DIR: &str = "agent-auth";
+
+/// Directory family prefixes; the applied revision is appended (`-<rev>`).
+const CODEX_HOME_PREFIX: &str = "codex-home";
+const GROK_HOME_PREFIX: &str = "grok-home";
+const GEMINI_HOME_PREFIX: &str = "gemini-home";
+const OPENCODE_CONFIG_PREFIX: &str = "opencode-config";
+
+/// Isolated CLAUDE_CONFIG_DIR family. Claude Code reads `~/.claude` (settings,
+/// cached credentials) unless CLAUDE_CONFIG_DIR points elsewhere; an ambient
+/// `~/.claude` can otherwise defeat the env sanitization the claude adapter
+/// performs (spec §13.3 / HARNESS-MATRIX claude recipe: `CLAUDE_CONFIG_DIR=<iso>`).
+/// This dir is stable (not revision-keyed) — it holds no revision-specific
+/// content; the launch env vars are authoritative each launch.
+const CLAUDE_CONFIG_DIR_NAME: &str = "claude-config";
+
+/// Default model written into the codex gateway config.toml. Codex refuses to
+/// launch without a `model` and otherwise falls back to a codex-native default
+/// id the gateway does not serve (HARNESS-MATRIX codex recipe: `model = "<default>"`).
+/// A gateway-served versioned Anthropic id is used.
+const CODEX_DEFAULT_MODEL: &str = "claude-sonnet-4-5-20250929";
+
+fn route_auth_root(runtime_home: &Path) -> PathBuf {
+    runtime_home.join(ROUTE_AUTH_DIR)
+}
+
+/// Materialize `CODEX_HOME` for the gateway route. Writes config.toml with the
+/// proliferate provider (wire_api="responses", env_key=PROLIFERATE_GATEWAY_KEY,
+/// base_url=<base_url>/v1). Returns the isolated home dir.
+pub(super) fn materialize_codex_home(
+    runtime_home: &Path,
+    profile: &GatewayProfile,
+) -> Result<PathBuf, RouteAuthError> {
+    let home = prepare_revision_dir(runtime_home, CODEX_HOME_PREFIX, profile.revision)?;
+    let base_url = format!("{}/v1", trim_trailing_slash(&profile.base_url));
+    // TOML written by hand (small, deterministic) so the snapshot test can
+    // assert exact content without pulling a toml serializer.
+    let config = format!(
+        "model_provider = \"proliferate\"\n\
+         model = \"{CODEX_DEFAULT_MODEL}\"\n\
+         \n\
+         [model_providers.proliferate]\n\
+         name = \"Proliferate Gateway\"\n\
+         base_url = \"{base_url}\"\n\
+         env_key = \"PROLIFERATE_GATEWAY_KEY\"\n\
+         wire_api = \"responses\"\n"
+    );
+    write_private_file(&home.join("config.toml"), config.as_bytes())?;
+    Ok(home)
+}
+
+/// Materialize (idempotently) an isolated CLAUDE_CONFIG_DIR so Claude Code does
+/// not read an ambient `~/.claude` (which could carry stale provider/auth
+/// settings that defeat env sanitization). Used by BOTH the gateway and
+/// api_key claude routes. Not revision-keyed: it holds no revision-specific
+/// content (the launch env is authoritative), and keeping it stable lets the
+/// CLI reuse its own local state across revisions.
+pub(super) fn materialize_claude_config_dir(
+    runtime_home: &Path,
+) -> Result<PathBuf, RouteAuthError> {
+    let root = route_auth_root(runtime_home);
+    let dir = root.join(CLAUDE_CONFIG_DIR_NAME);
+    fs::create_dir_all(&dir).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to create {}: {error}", dir.display()),
+    })?;
+    Ok(dir)
+}
+
+/// Materialize the OpenCode config file (opencode.json) for the gateway route
+/// and return its path (pointed at by OPENCODE_CONFIG). Provider `proliferate`
+/// via `@ai-sdk/openai-compatible`, explicit models map (required).
+pub(super) fn materialize_opencode_config(
+    runtime_home: &Path,
+    profile: &GatewayProfile,
+    models: &[String],
+) -> Result<PathBuf, RouteAuthError> {
+    let dir = prepare_revision_dir(runtime_home, OPENCODE_CONFIG_PREFIX, profile.revision)?;
+    let base_url = format!("{}/v1", trim_trailing_slash(&profile.base_url));
+    let models_map: serde_json::Map<String, serde_json::Value> = models
+        .iter()
+        .map(|model| (model.clone(), json!({})))
+        .collect();
+    let config = json!({
+        "provider": {
+            "proliferate": {
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {
+                    "baseURL": base_url,
+                    "apiKey": "{env:PROLIFERATE_GATEWAY_KEY}"
+                },
+                "models": models_map
+            }
+        }
+    });
+    let config_path = dir.join("opencode.json");
+    let serialized =
+        serde_json::to_vec_pretty(&config).map_err(|error| RouteAuthError::Materialize {
+            detail: format!("failed to serialize opencode config: {error}"),
+        })?;
+    write_private_file(&config_path, &serialized)?;
+    // Isolate XDG so opencode cannot reach the user's global config/auth
+    // (HARNESS-MATRIX opencode recipe: XDG_CONFIG_HOME/XDG_DATA_HOME isolated).
+    for sub in [OPENCODE_XDG_CONFIG_SUBDIR, OPENCODE_XDG_DATA_SUBDIR] {
+        let xdg_dir = dir.join(sub);
+        fs::create_dir_all(&xdg_dir).map_err(|error| RouteAuthError::Materialize {
+            detail: format!("failed to create {}: {error}", xdg_dir.display()),
+        })?;
+    }
+    Ok(config_path)
+}
+
+/// Isolated XDG subdir names materialized beside the opencode config; the
+/// render layer points XDG_CONFIG_HOME/XDG_DATA_HOME at these.
+pub(super) const OPENCODE_XDG_CONFIG_SUBDIR: &str = "xdg-config";
+pub(super) const OPENCODE_XDG_DATA_SUBDIR: &str = "xdg-data";
+
+/// Materialize an isolated HOME for the grok CLI (it keys config off HOME).
+pub(super) fn materialize_grok_home(
+    runtime_home: &Path,
+    profile: &GatewayProfile,
+) -> Result<PathBuf, RouteAuthError> {
+    prepare_revision_dir(runtime_home, GROK_HOME_PREFIX, profile.revision)
+}
+
+/// Materialize an isolated HOME for the gemini CLI with
+/// ~/.gemini/settings.json {security.auth.selectedType = "gemini-api-key"}.
+pub(super) fn materialize_gemini_home(
+    runtime_home: &Path,
+    profile: &GatewayProfile,
+) -> Result<PathBuf, RouteAuthError> {
+    let home = prepare_revision_dir(runtime_home, GEMINI_HOME_PREFIX, profile.revision)?;
+    let gemini_dir = home.join(".gemini");
+    fs::create_dir_all(&gemini_dir).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to create {}: {error}", gemini_dir.display()),
+    })?;
+    let settings = json!({
+        "security": { "auth": { "selectedType": "gemini-api-key" } }
+    });
+    let serialized =
+        serde_json::to_vec_pretty(&settings).map_err(|error| RouteAuthError::Materialize {
+            detail: format!("failed to serialize gemini settings: {error}"),
+        })?;
+    write_private_file(&gemini_dir.join("settings.json"), &serialized)?;
+    Ok(home)
+}
+
+/// Create (idempotently) the revision-keyed directory for a family, removing
+/// any sibling dirs of the same family carrying a different revision.
+fn prepare_revision_dir(
+    runtime_home: &Path,
+    prefix: &str,
+    revision: i64,
+) -> Result<PathBuf, RouteAuthError> {
+    let root = route_auth_root(runtime_home);
+    fs::create_dir_all(&root).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to create {}: {error}", root.display()),
+    })?;
+    let target_name = format!("{prefix}-{revision}");
+    gc_old_revision_dirs(&root, prefix, revision)?;
+    let dir = root.join(&target_name);
+    fs::create_dir_all(&dir).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to create {}: {error}", dir.display()),
+    })?;
+    Ok(dir)
+}
+
+/// Garbage-collect `<prefix>-<rev>` sibling dirs, KEEPING the current revision's
+/// dir and the immediately-previous revision's dir. Only dirs strictly older
+/// than the immediately-previous revision are removed.
+///
+/// Why keep the immediately-previous dir: a session launched under revision N-1
+/// may still be running when revision N is materialized. Its isolated home
+/// (`codex-home-<N-1>`, `grok-home-<N-1>`, ...) must remain intact so the
+/// in-flight process finishes on the old state (spec §0). Dirs we cannot parse
+/// a revision from, and any revision >= current (shouldn't normally occur), are
+/// left untouched as well.
+fn gc_old_revision_dirs(
+    root: &Path,
+    prefix: &str,
+    current_revision: i64,
+) -> Result<(), RouteAuthError> {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(RouteAuthError::Materialize {
+                detail: format!("failed to read {}: {error}", root.display()),
+            })
+        }
+    };
+    let stale_prefix = format!("{prefix}-");
+    let mut revisions: Vec<(i64, PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(rev_str) = name.strip_prefix(&stale_prefix) else {
+            continue;
+        };
+        let Ok(rev) = rev_str.parse::<i64>() else {
+            continue;
+        };
+        revisions.push((rev, entry.path()));
+    }
+    // Immediately-previous revision = greatest revision strictly below current.
+    let Some(previous_revision) = revisions
+        .iter()
+        .map(|(rev, _)| *rev)
+        .filter(|rev| *rev < current_revision)
+        .max()
+    else {
+        return Ok(());
+    };
+    for (rev, path) in revisions {
+        if rev < previous_revision {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+    Ok(())
+}
+
+fn trim_trailing_slash(url: &str) -> &str {
+    url.trim_end_matches('/')
+}
+
+fn write_private_file(path: &Path, contents: &[u8]) -> Result<(), RouteAuthError> {
+    let tmp_path = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
+    fs::write(&tmp_path, contents).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to write {}: {error}", tmp_path.display()),
+    })?;
+    set_private_file_permissions(&tmp_path)?;
+    fs::rename(&tmp_path, path).map_err(|error| RouteAuthError::Materialize {
+        detail: format!("failed to move {} into place: {error}", tmp_path.display()),
+    })?;
+    set_private_file_permissions(path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> Result<(), RouteAuthError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|error| {
+        RouteAuthError::Materialize {
+            detail: format!("failed to chmod {}: {error}", path.display()),
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> Result<(), RouteAuthError> {
+    Ok(())
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
@@ -1,0 +1,92 @@
+//! Runtime auth-profile ingestion + per-harness launch rendering.
+//!
+//! This is the AnyHarness "render plane" (spec §1) for the LiteLLM agent-auth
+//! model. It is deliberately separate from the kept `agents/auth/` module,
+//! which owns *native* credential detection and interactive login; this module
+//! owns the declarative *route* selections delivered by the control plane.
+//!
+//! Flow at each session launch:
+//!
+//! ```text
+//! state.json (<home>/agent-auth/state.json, 0600)
+//!   → load_state_file            (state.rs: tolerant read+parse)
+//!   → resolve_profile(harness)   (profile.rs: pure route decision, fail-closed)
+//!   → render_profile             (render.rs + materialize.rs: env delta + FS)
+//!   → RenderedRouteAuth { set, remove } merged into the launch env
+//! ```
+//!
+//! No watch/refresh: the file is read fresh per launch (spec §1). Absent file
+//! = legacy/native behavior; present-and-scoped file with no selection for the
+//! requested harness = fail-closed error.
+
+mod materialize;
+pub mod profile;
+pub mod render;
+pub mod state;
+
+#[cfg(test)]
+mod render_tests;
+#[cfg(test)]
+pub(crate) mod test_support;
+
+use std::path::{Path, PathBuf};
+
+pub use profile::{resolve_profile, AgentRuntimeAuthProfile};
+pub use render::{render_profile, RenderedRouteAuth};
+pub use state::{load_state_file, state_file_path, AgentAuthState, AuthRoute, AuthSelection};
+
+use state::AuthRoute as RouteKind;
+
+/// Errors from the route-auth render plane. `SelectionMissing` is the
+/// fail-closed error (spec §3): a scoped state file with no selection for the
+/// requested harness must error rather than fall through to ambient creds.
+#[derive(Debug, thiserror::Error)]
+pub enum RouteAuthError {
+    #[error("agent-auth state file is malformed ({path}): {detail}")]
+    MalformedStateFile { path: PathBuf, detail: String },
+    #[error("no agent-auth route selection for harness '{harness_kind}' at revision {revision}")]
+    SelectionMissing { harness_kind: String, revision: i64 },
+    #[error("agent-auth route selection for '{harness_kind}' is incomplete: {detail}")]
+    SelectionIncomplete {
+        harness_kind: String,
+        route: RouteKind,
+        detail: String,
+    },
+    #[error("agent-auth route for '{harness_kind}' is unsupported: {detail}")]
+    UnsupportedRoute {
+        harness_kind: String,
+        detail: String,
+    },
+    #[error("unknown harness kind '{harness_kind}' in agent-auth state")]
+    UnknownHarness { harness_kind: String },
+    #[error("failed to materialize agent-auth harness state: {detail}")]
+    Materialize { detail: String },
+}
+
+impl RouteAuthError {
+    /// Stable machine code for the API/contract surface. `SelectionMissing`
+    /// maps to the fail-closed code consumed by the desktop/cloud UIs.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::MalformedStateFile { .. } => "AGENT_ROUTE_STATE_MALFORMED",
+            Self::SelectionMissing { .. } => "AGENT_ROUTE_SELECTION_MISSING",
+            Self::SelectionIncomplete { .. } => "AGENT_ROUTE_SELECTION_INCOMPLETE",
+            Self::UnsupportedRoute { .. } => "AGENT_ROUTE_UNSUPPORTED",
+            Self::UnknownHarness { .. } => "AGENT_ROUTE_UNKNOWN_HARNESS",
+            Self::Materialize { .. } => "AGENT_ROUTE_MATERIALIZE_FAILED",
+        }
+    }
+}
+
+/// End-to-end at launch: load the state file, resolve the profile for
+/// `harness_kind`, and render its env delta (materializing isolated homes as a
+/// side effect). Absent file → an empty (native) delta. This is the single
+/// entry point the session runtime calls.
+pub fn resolve_launch_route_auth(
+    runtime_home: &Path,
+    harness_kind: &str,
+) -> Result<RenderedRouteAuth, RouteAuthError> {
+    let state = load_state_file(runtime_home)?;
+    let profile = resolve_profile(state.as_ref(), harness_kind)?;
+    render_profile(&profile, runtime_home)
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
@@ -1,0 +1,269 @@
+//! Runtime auth-profile resolution: state file + requested harness → the
+//! decided [`AgentRuntimeAuthProfile`], or a typed fail-closed error.
+//!
+//! This is the pure decision layer (spec §2/§3). It does NOT touch the
+//! filesystem or render env; `render.rs` turns a resolved profile into
+//! env/args/config at launch time. Keeping resolution pure keeps the
+//! fail-closed matrix trivially testable.
+
+use super::state::{AgentAuthState, AuthRoute, AuthSelection};
+use super::RouteAuthError;
+
+/// The resolved auth profile for one harness launch (spec §4
+/// `AgentRuntimeAuthProfile`). `Native` means "unchanged legacy behavior"; the
+/// render layer emits nothing for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentRuntimeAuthProfile {
+    /// No state file, or a native selection: render nothing (detection/login
+    /// stack owns auth).
+    Native,
+    ApiKey(ApiKeyProfile),
+    Gateway(GatewayProfile),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiKeyProfile {
+    pub harness_kind: String,
+    pub provider: Option<String>,
+    pub key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayProfile {
+    pub harness_kind: String,
+    /// The public gateway base URL (root, no per-harness suffix — the adapters
+    /// append `/v1`, `/anthropic`, etc. per the live matrix).
+    pub base_url: String,
+    pub key: String,
+    /// Explicit model list for adapters that require it in-config (OpenCode).
+    pub model_catalog: Option<Vec<String>>,
+    /// The revision that produced this profile — carried so switch-time
+    /// materialization (codex/grok/gemini isolated homes) can key directory
+    /// names and clean up stale ones.
+    pub revision: i64,
+}
+
+/// Resolve the auth profile for `harness_kind` from the loaded state.
+///
+/// - `state == None` (no file): legacy `Native`.
+/// - state present, has a selection for the harness: profile per its route.
+/// - state present + scoped (`revision > 0`) but NO selection for the harness:
+///   fail-closed [`RouteAuthError::SelectionMissing`] (spec §3), mirroring the
+///   old `AGENT_AUTH_SELECTION_REQUIRED` semantics against the new model.
+/// - state present but NOT scoped (`revision == 0`) with no selection: legacy
+///   `Native` (bootstrapping state before any selection exists).
+pub fn resolve_profile(
+    state: Option<&AgentAuthState>,
+    harness_kind: &str,
+) -> Result<AgentRuntimeAuthProfile, RouteAuthError> {
+    let Some(state) = state else {
+        return Ok(AgentRuntimeAuthProfile::Native);
+    };
+    match state.selection_for(harness_kind) {
+        Some(selection) => profile_from_selection(harness_kind, selection, state.revision),
+        None => {
+            if state.is_scoped() {
+                Err(RouteAuthError::SelectionMissing {
+                    harness_kind: harness_kind.to_string(),
+                    revision: state.revision,
+                })
+            } else {
+                Ok(AgentRuntimeAuthProfile::Native)
+            }
+        }
+    }
+}
+
+fn profile_from_selection(
+    harness_kind: &str,
+    selection: &AuthSelection,
+    revision: i64,
+) -> Result<AgentRuntimeAuthProfile, RouteAuthError> {
+    match selection.route {
+        AuthRoute::Native => Ok(AgentRuntimeAuthProfile::Native),
+        AuthRoute::ApiKey => {
+            let key = require_key(harness_kind, selection, AuthRoute::ApiKey)?;
+            Ok(AgentRuntimeAuthProfile::ApiKey(ApiKeyProfile {
+                harness_kind: harness_kind.to_string(),
+                provider: selection.provider.clone(),
+                key,
+            }))
+        }
+        AuthRoute::Gateway => {
+            let key = require_key(harness_kind, selection, AuthRoute::Gateway)?;
+            let base_url = selection
+                .base_url
+                .clone()
+                .filter(|url| !url.trim().is_empty())
+                .ok_or_else(|| RouteAuthError::SelectionIncomplete {
+                    harness_kind: harness_kind.to_string(),
+                    route: AuthRoute::Gateway,
+                    detail: "gateway route requires baseUrl".to_string(),
+                })?;
+            Ok(AgentRuntimeAuthProfile::Gateway(GatewayProfile {
+                harness_kind: harness_kind.to_string(),
+                base_url,
+                key,
+                model_catalog: selection.model_catalog.clone(),
+                revision,
+            }))
+        }
+    }
+}
+
+fn require_key(
+    harness_kind: &str,
+    selection: &AuthSelection,
+    route: AuthRoute,
+) -> Result<String, RouteAuthError> {
+    selection
+        .key
+        .clone()
+        .filter(|key| !key.trim().is_empty())
+        .ok_or_else(|| RouteAuthError::SelectionIncomplete {
+            harness_kind: harness_kind.to_string(),
+            route,
+            detail: format!("{} route requires a key", route.as_str()),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::route_auth::state::AuthSelection;
+
+    fn state(revision: i64, selections: Vec<AuthSelection>) -> AgentAuthState {
+        AgentAuthState {
+            revision,
+            user_id: None,
+            selections,
+        }
+    }
+
+    #[test]
+    fn no_state_file_is_native() {
+        let profile = resolve_profile(None, "claude").expect("resolve");
+        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
+    }
+
+    #[test]
+    fn scoped_missing_selection_fails_closed() {
+        let state = state(
+            7,
+            vec![AuthSelection {
+                harness: "codex".into(),
+                route: AuthRoute::Gateway,
+                provider: None,
+                base_url: Some("https://gw".into()),
+                key: Some("sk".into()),
+                model_catalog: None,
+            }],
+        );
+        let error = resolve_profile(Some(&state), "claude").expect_err("fail-closed");
+        assert!(matches!(
+            error,
+            RouteAuthError::SelectionMissing { revision: 7, .. }
+        ));
+    }
+
+    #[test]
+    fn unscoped_missing_selection_is_native() {
+        let state = state(0, vec![]);
+        let profile = resolve_profile(Some(&state), "claude").expect("resolve");
+        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
+    }
+
+    #[test]
+    fn native_selection_is_native() {
+        let state = state(
+            3,
+            vec![AuthSelection {
+                harness: "claude".into(),
+                route: AuthRoute::Native,
+                provider: None,
+                base_url: None,
+                key: None,
+                model_catalog: None,
+            }],
+        );
+        let profile = resolve_profile(Some(&state), "claude").expect("resolve");
+        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
+    }
+
+    #[test]
+    fn gateway_requires_key_and_base_url() {
+        let missing_key = state(
+            1,
+            vec![AuthSelection {
+                harness: "claude".into(),
+                route: AuthRoute::Gateway,
+                provider: None,
+                base_url: Some("https://gw".into()),
+                key: None,
+                model_catalog: None,
+            }],
+        );
+        assert!(matches!(
+            resolve_profile(Some(&missing_key), "claude").expect_err("no key"),
+            RouteAuthError::SelectionIncomplete { .. }
+        ));
+
+        let missing_url = state(
+            1,
+            vec![AuthSelection {
+                harness: "claude".into(),
+                route: AuthRoute::Gateway,
+                provider: None,
+                base_url: None,
+                key: Some("sk".into()),
+                model_catalog: None,
+            }],
+        );
+        assert!(matches!(
+            resolve_profile(Some(&missing_url), "claude").expect_err("no url"),
+            RouteAuthError::SelectionIncomplete { .. }
+        ));
+    }
+
+    #[test]
+    fn api_key_requires_key() {
+        let missing_key = state(
+            1,
+            vec![AuthSelection {
+                harness: "claude".into(),
+                route: AuthRoute::ApiKey,
+                provider: Some("anthropic".into()),
+                base_url: None,
+                key: None,
+                model_catalog: None,
+            }],
+        );
+        assert!(matches!(
+            resolve_profile(Some(&missing_key), "claude").expect_err("no key"),
+            RouteAuthError::SelectionIncomplete { .. }
+        ));
+    }
+
+    #[test]
+    fn gateway_profile_carries_revision_and_catalog() {
+        let state = state(
+            9,
+            vec![AuthSelection {
+                harness: "opencode".into(),
+                route: AuthRoute::Gateway,
+                provider: None,
+                base_url: Some("https://gw".into()),
+                key: Some("sk".into()),
+                model_catalog: Some(vec!["m1".into(), "m2".into()]),
+            }],
+        );
+        let profile = resolve_profile(Some(&state), "opencode").expect("resolve");
+        match profile {
+            AgentRuntimeAuthProfile::Gateway(gw) => {
+                assert_eq!(gw.revision, 9);
+                assert_eq!(gw.model_catalog.as_deref().unwrap().len(), 2);
+            }
+            other => panic!("expected gateway, got {other:?}"),
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
@@ -1,0 +1,334 @@
+//! Launch-time rendering: a resolved [`AgentRuntimeAuthProfile`] → the env
+//! vars to set, the env vars to remove, and (where a route needs isolated
+//! filesystem state) the on-disk materialization the launcher must perform.
+//!
+//! Recipes are the live-verified ones from
+//! `scripts/agent-gateway-smoke/HARNESS-MATRIX.md` and the hard requirements
+//! in spec §13. Rendering the env is pure; writing isolated homes/config files
+//! is done by [`super::materialize`], invoked at first launch after a revision
+//! change (spec §4 "switch-time").
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::domains::agents::model::AgentKind;
+
+use super::materialize;
+use super::profile::{AgentRuntimeAuthProfile, ApiKeyProfile, GatewayProfile};
+use super::RouteAuthError;
+
+/// A sensible default small/fast model for Claude's sidecar calls when the
+/// gateway route is active. Versioned so the proxy model_list resolves it (see
+/// HARNESS-MATRIX.md §3: the CLI's ambient small-fast model is otherwise not in
+/// the gateway config and 400s).
+const CLAUDE_DEFAULT_SMALL_FAST_MODEL: &str = "claude-haiku-4-5-20251001";
+
+/// Fallback OpenCode gateway model list used only when the selection carries no
+/// `model_catalog` (PR 7 populates it). Mirrors the gateway config's Anthropic
+/// entries so a bare launch still resolves at least one model.
+const OPENCODE_FALLBACK_MODELS: &[&str] = &[
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+];
+
+/// The rendered launch delta for a route-auth profile.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RenderedRouteAuth {
+    /// Env vars to inject into the session launch layer.
+    pub set: BTreeMap<String, String>,
+    /// Env vars to REMOVE from the inherited/ambient spawn env (sanitization).
+    /// These are applied last, so they win even against ambient values.
+    pub remove: Vec<String>,
+}
+
+impl RenderedRouteAuth {
+    fn set(&mut self, key: &str, value: impl Into<String>) {
+        self.set.insert(key.to_string(), value.into());
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.remove.push(key.to_string());
+    }
+}
+
+/// Render the env delta for a resolved profile. `runtime_home` is where
+/// isolated harness homes (codex/grok/gemini) are materialized when a route
+/// needs them; nothing is written for `Native` or for pure-env routes.
+pub fn render_profile(
+    profile: &AgentRuntimeAuthProfile,
+    runtime_home: &Path,
+) -> Result<RenderedRouteAuth, RouteAuthError> {
+    match profile {
+        AgentRuntimeAuthProfile::Native => Ok(RenderedRouteAuth::default()),
+        AgentRuntimeAuthProfile::ApiKey(profile) => render_api_key(profile, runtime_home),
+        AgentRuntimeAuthProfile::Gateway(profile) => render_gateway(profile, runtime_home),
+    }
+}
+
+fn parse_harness(harness_kind: &str) -> Result<AgentKind, RouteAuthError> {
+    AgentKind::parse(harness_kind).ok_or_else(|| RouteAuthError::UnknownHarness {
+        harness_kind: harness_kind.to_string(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// api_key route: raw provider key, direct to provider (no gateway).
+// ---------------------------------------------------------------------------
+
+fn render_api_key(
+    profile: &ApiKeyProfile,
+    runtime_home: &Path,
+) -> Result<RenderedRouteAuth, RouteAuthError> {
+    let kind = parse_harness(&profile.harness_kind)?;
+    let mut rendered = RenderedRouteAuth::default();
+    match kind {
+        AgentKind::Claude => {
+            rendered.set("ANTHROPIC_API_KEY", &profile.key);
+            set_claude_config_dir(&mut rendered, runtime_home)?;
+            sanitize_claude_ambient(&mut rendered);
+        }
+        AgentKind::Codex => {
+            // Codex direct = OpenAI family only in v1 (spec §4 codex note):
+            // anthropic-via-codex-direct is out of scope. The provider, when
+            // present, must be openai.
+            if let Some(provider) = &profile.provider {
+                if provider != "openai" {
+                    return Err(RouteAuthError::UnsupportedRoute {
+                        harness_kind: profile.harness_kind.clone(),
+                        detail: format!(
+                            "codex api_key route supports only the openai provider in v1 (got '{provider}')"
+                        ),
+                    });
+                }
+            }
+            rendered.set("OPENAI_API_KEY", &profile.key);
+        }
+        AgentKind::OpenCode => {
+            // Passthrough per-provider env key for direct opencode use.
+            rendered.set(provider_env_key(profile.provider.as_deref()), &profile.key);
+        }
+        AgentKind::Grok => {
+            rendered.set("XAI_API_KEY", &profile.key);
+        }
+        AgentKind::Gemini => {
+            rendered.set("GEMINI_API_KEY", &profile.key);
+        }
+        AgentKind::Cursor => {
+            return Err(RouteAuthError::UnsupportedRoute {
+                harness_kind: profile.harness_kind.clone(),
+                detail: "cursor has no rendered api_key route".to_string(),
+            })
+        }
+    }
+    Ok(rendered)
+}
+
+/// Map an api_key provider to the env var the harness passthrough reads.
+/// Defaults to Anthropic when unspecified (the most common OpenCode direct
+/// case).
+fn provider_env_key(provider: Option<&str>) -> &'static str {
+    match provider {
+        Some("openai") => "OPENAI_API_KEY",
+        Some("xai") | Some("grok") => "XAI_API_KEY",
+        Some("google") | Some("gemini") => "GEMINI_API_KEY",
+        _ => "ANTHROPIC_API_KEY",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gateway route: LiteLLM virtual key + public base URL.
+// ---------------------------------------------------------------------------
+
+fn render_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+) -> Result<RenderedRouteAuth, RouteAuthError> {
+    let kind = parse_harness(&profile.harness_kind)?;
+    let mut rendered = RenderedRouteAuth::default();
+    match kind {
+        AgentKind::Claude => render_claude_gateway(profile, runtime_home, &mut rendered)?,
+        AgentKind::Codex => render_codex_gateway(profile, runtime_home, &mut rendered)?,
+        AgentKind::OpenCode => render_opencode_gateway(profile, runtime_home, &mut rendered)?,
+        AgentKind::Grok => render_grok_gateway(profile, runtime_home, &mut rendered)?,
+        AgentKind::Gemini => render_gemini_gateway(profile, runtime_home, &mut rendered)?,
+        AgentKind::Cursor => {
+            return Err(RouteAuthError::UnsupportedRoute {
+                harness_kind: profile.harness_kind.clone(),
+                detail: "cursor has no gateway route".to_string(),
+            })
+        }
+    }
+    Ok(rendered)
+}
+
+fn render_claude_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+    rendered: &mut RenderedRouteAuth,
+) -> Result<(), RouteAuthError> {
+    // Claude Code speaks the Anthropic messages API; LiteLLM serves it at the
+    // root (the CLI hits POST /v1/messages under ANTHROPIC_BASE_URL).
+    rendered.set("ANTHROPIC_BASE_URL", trim_trailing_slash(&profile.base_url));
+    rendered.set("ANTHROPIC_AUTH_TOKEN", &profile.key);
+    rendered.set(
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        CLAUDE_DEFAULT_SMALL_FAST_MODEL,
+    );
+    set_claude_config_dir(rendered, runtime_home)?;
+    sanitize_claude_ambient(rendered);
+    Ok(())
+}
+
+/// Point CLAUDE_CONFIG_DIR at an isolated dir (materialized) so the CLI does not
+/// read an ambient `~/.claude` that could carry stale provider/auth settings and
+/// defeat the env sanitization below (HARNESS-MATRIX claude recipe). Applies to
+/// both the gateway and api_key claude routes.
+fn set_claude_config_dir(
+    rendered: &mut RenderedRouteAuth,
+    runtime_home: &Path,
+) -> Result<(), RouteAuthError> {
+    let config_dir = materialize::materialize_claude_config_dir(runtime_home)?;
+    rendered.set(
+        "CLAUDE_CONFIG_DIR",
+        config_dir.to_string_lossy().into_owned(),
+    );
+    Ok(())
+}
+
+/// HARD REQUIREMENT (spec §13.3 / HARNESS-MATRIX.md §claude): ambient provider
+/// env silently reroutes the Claude CLI (observed: Bedrock). Remove the
+/// rerouting flags and any Anthropic base-url/token/key we did NOT just set, so
+/// the selected route's credentials are authoritative. Removal wins over
+/// inherited values (applied last at spawn); we do not just set empties because
+/// the CLI treats a present-but-empty flag inconsistently.
+///
+/// - gateway route: SET base-url + auth-token → those are kept; ANTHROPIC_API_KEY
+///   is removed (an ambient raw key must not shadow the gateway token).
+/// - api_key route: SET ANTHROPIC_API_KEY → it is kept; ambient ANTHROPIC_AUTH_TOKEN
+///   and ANTHROPIC_BASE_URL are removed (they would reroute the CLI away from the
+///   selected key / provider).
+fn sanitize_claude_ambient(rendered: &mut RenderedRouteAuth) {
+    for key in [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "AWS_BEARER_TOKEN_BEDROCK",
+    ] {
+        rendered.remove(key);
+    }
+    // Remove each Anthropic selector we didn't explicitly set on this route, so
+    // ambient values can't shadow the chosen credential path.
+    for key in [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+    ] {
+        if !rendered.set.contains_key(key) {
+            rendered.remove(key);
+        }
+    }
+}
+
+fn render_codex_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+    rendered: &mut RenderedRouteAuth,
+) -> Result<(), RouteAuthError> {
+    // Isolated CODEX_HOME with a config.toml pointing at the proliferate
+    // provider (wire_api=responses). The provider config references
+    // PROLIFERATE_GATEWAY_KEY via env_key, so no `codex login` is needed.
+    let codex_home = materialize::materialize_codex_home(runtime_home, profile)?;
+    rendered.set("CODEX_HOME", codex_home.to_string_lossy().into_owned());
+    rendered.set("PROLIFERATE_GATEWAY_KEY", &profile.key);
+    // Ambient direct-provider keys would let the CLI bypass the provider
+    // config; drop them so the gateway provider is authoritative.
+    rendered.remove("OPENAI_API_KEY");
+    rendered.remove("ANTHROPIC_API_KEY");
+    Ok(())
+}
+
+fn render_opencode_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+    rendered: &mut RenderedRouteAuth,
+) -> Result<(), RouteAuthError> {
+    let models = profile
+        .model_catalog
+        .clone()
+        .filter(|models| !models.is_empty())
+        .unwrap_or_else(|| {
+            OPENCODE_FALLBACK_MODELS
+                .iter()
+                .map(|model| model.to_string())
+                .collect()
+        });
+    // opencode reads config from an explicit file path via OPENCODE_CONFIG.
+    // We materialize opencode.json (provider proliferate, openai-compatible,
+    // baseURL, apiKey {env:PROLIFERATE_GATEWAY_KEY}, explicit models map) into
+    // an isolated dir and point OPENCODE_CONFIG at it. See materialize.rs.
+    let config_path = materialize::materialize_opencode_config(runtime_home, profile, &models)?;
+    // The isolated dir holding opencode.json plus the XDG subdirs materialized
+    // beside it. Point XDG_CONFIG_HOME/XDG_DATA_HOME there so opencode cannot
+    // reach the user's global config/auth (HARNESS-MATRIX opencode recipe).
+    if let Some(config_dir) = config_path.parent() {
+        rendered.set(
+            "XDG_CONFIG_HOME",
+            config_dir
+                .join(materialize::OPENCODE_XDG_CONFIG_SUBDIR)
+                .to_string_lossy()
+                .into_owned(),
+        );
+        rendered.set(
+            "XDG_DATA_HOME",
+            config_dir
+                .join(materialize::OPENCODE_XDG_DATA_SUBDIR)
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
+    rendered.set(
+        "OPENCODE_CONFIG",
+        config_path.to_string_lossy().into_owned(),
+    );
+    rendered.set("PROLIFERATE_GATEWAY_KEY", &profile.key);
+    Ok(())
+}
+
+fn render_grok_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+    rendered: &mut RenderedRouteAuth,
+) -> Result<(), RouteAuthError> {
+    let grok_home = materialize::materialize_grok_home(runtime_home, profile)?;
+    rendered.set("HOME", grok_home.to_string_lossy().into_owned());
+    rendered.set(
+        "GROK_MODELS_BASE_URL",
+        format!("{}/v1", trim_trailing_slash(&profile.base_url)),
+    );
+    rendered.set("XAI_API_KEY", &profile.key);
+    Ok(())
+}
+
+fn render_gemini_gateway(
+    profile: &GatewayProfile,
+    runtime_home: &Path,
+    rendered: &mut RenderedRouteAuth,
+) -> Result<(), RouteAuthError> {
+    // ROOT /v1beta genai facade — GOOGLE_GEMINI_BASE_URL is the proxy root, no
+    // /gemini prefix (HARNESS-MATRIX.md §gemini). Isolated home carries
+    // settings.json selectedType=gemini-api-key.
+    let gemini_home = materialize::materialize_gemini_home(runtime_home, profile)?;
+    rendered.set("HOME", gemini_home.to_string_lossy().into_owned());
+    rendered.set(
+        "GOOGLE_GEMINI_BASE_URL",
+        trim_trailing_slash(&profile.base_url).to_string(),
+    );
+    rendered.set("GEMINI_API_KEY", &profile.key);
+    rendered.set("GEMINI_CLI_TRUST_WORKSPACE", "true");
+    Ok(())
+}
+
+fn trim_trailing_slash(url: &str) -> &str {
+    url.trim_end_matches('/')
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -1,0 +1,431 @@
+//! Adapter render snapshots + fail-closed + missing/malformed-file behavior.
+//! Exercises the full loader→profile→render→spawn-env path against a real
+//! filesystem (this is the PR 6 live-gate at unit level, per the brief).
+
+use serde_json::json;
+
+use super::render::render_profile;
+use super::state::{state_file_path, AgentAuthState, AuthRoute};
+use super::test_support::TempHome;
+use super::{resolve_launch_route_auth, resolve_profile, RouteAuthError};
+
+const GATEWAY_BASE_URL: &str = "https://llm.proliferate.ai";
+const VK: &str = "sk-virtual-1234";
+
+fn gateway_state(harness: &str, catalog: Option<Vec<&str>>) -> serde_json::Value {
+    let mut selection = json!({
+        "harness": harness,
+        "route": "gateway",
+        "base_url": GATEWAY_BASE_URL,
+        "key": VK,
+    });
+    if let Some(models) = catalog {
+        selection["model_catalog"] = json!(models);
+    }
+    json!({ "revision": 42, "user_id": "user-1", "selections": [selection] })
+}
+
+// --- claude ----------------------------------------------------------------
+
+#[test]
+fn claude_gateway_sets_base_url_token_and_sanitizes_ambient() {
+    let home = TempHome::new("claude-gw");
+    home.write_state_json(&gateway_state("claude", None));
+
+    let rendered = resolve_launch_route_auth(home.path(), "claude").expect("render");
+
+    assert_eq!(
+        rendered.set.get("ANTHROPIC_BASE_URL").unwrap(),
+        GATEWAY_BASE_URL
+    );
+    assert_eq!(rendered.set.get("ANTHROPIC_AUTH_TOKEN").unwrap(), VK);
+    assert_eq!(
+        rendered.set.get("ANTHROPIC_SMALL_FAST_MODEL").unwrap(),
+        "claude-haiku-4-5-20251001"
+    );
+    // Isolated CLAUDE_CONFIG_DIR so ambient ~/.claude cannot defeat sanitization.
+    let config_dir = rendered
+        .set
+        .get("CLAUDE_CONFIG_DIR")
+        .expect("CLAUDE_CONFIG_DIR");
+    assert!(config_dir.contains("claude-config"));
+    assert!(std::path::Path::new(config_dir).is_dir());
+    // Ambient Bedrock/Vertex + stale api key removed (spec §13.3).
+    for key in [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "ANTHROPIC_API_KEY",
+    ] {
+        assert!(
+            rendered.remove.contains(&key.to_string()),
+            "missing removal of {key}"
+        );
+    }
+    assert!(!rendered.set.contains_key("ANTHROPIC_API_KEY"));
+    // The gateway base-url/token we SET must NOT be scheduled for removal.
+    assert!(!rendered.remove.contains(&"ANTHROPIC_BASE_URL".to_string()));
+    assert!(!rendered
+        .remove
+        .contains(&"ANTHROPIC_AUTH_TOKEN".to_string()));
+}
+
+#[test]
+fn claude_api_key_sets_key_and_removes_reroute_flags_only() {
+    let home = TempHome::new("claude-key");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "claude", "route": "api_key", "provider": "anthropic", "key": "sk-raw" } ]
+    }));
+
+    let rendered = resolve_launch_route_auth(home.path(), "claude").expect("render");
+    assert_eq!(rendered.set.get("ANTHROPIC_API_KEY").unwrap(), "sk-raw");
+    // Isolated CLAUDE_CONFIG_DIR on the api_key route too.
+    assert!(rendered
+        .set
+        .get("CLAUDE_CONFIG_DIR")
+        .expect("CLAUDE_CONFIG_DIR")
+        .contains("claude-config"));
+    // Bedrock/Vertex reroute flags still removed, but NOT the key we just set.
+    assert!(rendered
+        .remove
+        .contains(&"CLAUDE_CODE_USE_BEDROCK".to_string()));
+    assert!(!rendered.remove.contains(&"ANTHROPIC_API_KEY".to_string()));
+    // Ambient gateway-style creds must be removed so they cannot shadow the key.
+    assert!(
+        rendered
+            .remove
+            .contains(&"ANTHROPIC_AUTH_TOKEN".to_string()),
+        "api_key route must strip ambient ANTHROPIC_AUTH_TOKEN"
+    );
+    assert!(
+        rendered.remove.contains(&"ANTHROPIC_BASE_URL".to_string()),
+        "api_key route must strip ambient ANTHROPIC_BASE_URL"
+    );
+}
+
+// --- codex -----------------------------------------------------------------
+
+#[test]
+fn codex_gateway_materializes_config_toml_and_sets_env() {
+    let home = TempHome::new("codex-gw");
+    home.write_state_json(&gateway_state("codex", None));
+
+    let rendered = resolve_launch_route_auth(home.path(), "codex").expect("render");
+
+    let codex_home = rendered.set.get("CODEX_HOME").expect("CODEX_HOME");
+    assert!(codex_home.contains("codex-home-42"));
+    assert_eq!(rendered.set.get("PROLIFERATE_GATEWAY_KEY").unwrap(), VK);
+    assert!(rendered.remove.contains(&"OPENAI_API_KEY".to_string()));
+    assert!(rendered.remove.contains(&"ANTHROPIC_API_KEY".to_string()));
+
+    let config = std::fs::read_to_string(std::path::Path::new(codex_home).join("config.toml"))
+        .expect("read config.toml");
+    assert!(config.contains("model_provider = \"proliferate\""));
+    // Explicit default model line: codex otherwise falls back to a codex-native
+    // model id the gateway cannot serve (HARNESS-MATRIX codex recipe).
+    assert!(
+        config.contains("model = \"claude-sonnet-4-5-20250929\""),
+        "config.toml must pin a gateway-served default model, got:\n{config}"
+    );
+    assert!(config.contains("base_url = \"https://llm.proliferate.ai/v1\""));
+    assert!(config.contains("env_key = \"PROLIFERATE_GATEWAY_KEY\""));
+    assert!(config.contains("wire_api = \"responses\""));
+}
+
+#[test]
+fn codex_api_key_openai_sets_only_openai_key() {
+    let home = TempHome::new("codex-key");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "codex", "route": "api_key", "provider": "openai", "key": "sk-openai" } ]
+    }));
+
+    let rendered = resolve_launch_route_auth(home.path(), "codex").expect("render");
+    assert_eq!(rendered.set.get("OPENAI_API_KEY").unwrap(), "sk-openai");
+    assert!(!rendered.set.contains_key("CODEX_HOME"));
+    assert!(rendered.remove.is_empty());
+}
+
+#[test]
+fn codex_api_key_anthropic_is_rejected_out_of_scope() {
+    let home = TempHome::new("codex-key-anthropic");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "codex", "route": "api_key", "provider": "anthropic", "key": "sk-a" } ]
+    }));
+
+    let error = resolve_launch_route_auth(home.path(), "codex").expect_err("rejected");
+    assert!(matches!(error, RouteAuthError::UnsupportedRoute { .. }));
+    assert_eq!(error.code(), "AGENT_ROUTE_UNSUPPORTED");
+}
+
+// --- opencode --------------------------------------------------------------
+
+#[test]
+fn opencode_gateway_writes_config_with_explicit_models() {
+    let home = TempHome::new("opencode-gw");
+    home.write_state_json(&gateway_state(
+        "opencode",
+        Some(vec!["claude-haiku-4-5-20251001"]),
+    ));
+
+    let rendered = resolve_launch_route_auth(home.path(), "opencode").expect("render");
+    let config_path = rendered
+        .set
+        .get("OPENCODE_CONFIG")
+        .expect("OPENCODE_CONFIG");
+    assert_eq!(rendered.set.get("PROLIFERATE_GATEWAY_KEY").unwrap(), VK);
+
+    let config: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(config_path).expect("read config")).expect("json");
+    let provider = &config["provider"]["proliferate"];
+    assert_eq!(provider["npm"], "@ai-sdk/openai-compatible");
+    assert_eq!(
+        provider["options"]["baseURL"],
+        "https://llm.proliferate.ai/v1"
+    );
+    assert_eq!(
+        provider["options"]["apiKey"],
+        "{env:PROLIFERATE_GATEWAY_KEY}"
+    );
+    assert!(provider["models"]
+        .as_object()
+        .unwrap()
+        .contains_key("claude-haiku-4-5-20251001"));
+
+    // XDG isolation: opencode must not reach the user's global config/auth.
+    let xdg_config = rendered
+        .set
+        .get("XDG_CONFIG_HOME")
+        .expect("XDG_CONFIG_HOME");
+    let xdg_data = rendered.set.get("XDG_DATA_HOME").expect("XDG_DATA_HOME");
+    assert!(std::path::Path::new(xdg_config).is_dir());
+    assert!(std::path::Path::new(xdg_data).is_dir());
+    // They live beside the materialized config, inside the isolated route-auth root.
+    assert!(xdg_config.contains("opencode-config"));
+    assert!(xdg_data.contains("opencode-config"));
+}
+
+#[test]
+fn opencode_gateway_falls_back_to_static_models_without_catalog() {
+    let home = TempHome::new("opencode-fallback");
+    home.write_state_json(&gateway_state("opencode", None));
+
+    let rendered = resolve_launch_route_auth(home.path(), "opencode").expect("render");
+    let config_path = rendered
+        .set
+        .get("OPENCODE_CONFIG")
+        .expect("OPENCODE_CONFIG");
+    let config: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(config_path).expect("read config")).expect("json");
+    let models = config["provider"]["proliferate"]["models"]
+        .as_object()
+        .unwrap();
+    assert!(
+        !models.is_empty(),
+        "fallback models must be non-empty (PR 7 catalog dependency)"
+    );
+    assert!(models.contains_key("claude-haiku-4-5-20251001"));
+}
+
+#[test]
+fn opencode_api_key_passthrough_provider_env() {
+    let home = TempHome::new("opencode-key");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "opencode", "route": "api_key", "provider": "anthropic", "key": "sk-a" } ]
+    }));
+    let rendered = resolve_launch_route_auth(home.path(), "opencode").expect("render");
+    assert_eq!(rendered.set.get("ANTHROPIC_API_KEY").unwrap(), "sk-a");
+}
+
+// --- grok ------------------------------------------------------------------
+
+#[test]
+fn grok_gateway_sets_models_base_url_and_isolated_home() {
+    let home = TempHome::new("grok-gw");
+    home.write_state_json(&gateway_state("grok", None));
+
+    let rendered = resolve_launch_route_auth(home.path(), "grok").expect("render");
+    assert_eq!(
+        rendered.set.get("GROK_MODELS_BASE_URL").unwrap(),
+        "https://llm.proliferate.ai/v1"
+    );
+    assert_eq!(rendered.set.get("XAI_API_KEY").unwrap(), VK);
+    assert!(rendered.set.get("HOME").unwrap().contains("grok-home-42"));
+}
+
+#[test]
+fn grok_api_key_sets_only_xai_key() {
+    let home = TempHome::new("grok-key");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "grok", "route": "api_key", "key": "xai-raw" } ]
+    }));
+    let rendered = resolve_launch_route_auth(home.path(), "grok").expect("render");
+    assert_eq!(rendered.set.get("XAI_API_KEY").unwrap(), "xai-raw");
+    assert!(!rendered.set.contains_key("HOME"));
+}
+
+// --- gemini ----------------------------------------------------------------
+
+#[test]
+fn gemini_gateway_uses_root_base_url_and_writes_settings() {
+    let home = TempHome::new("gemini-gw");
+    home.write_state_json(&gateway_state("gemini", None));
+
+    let rendered = resolve_launch_route_auth(home.path(), "gemini").expect("render");
+    // ROOT base url, NO /gemini prefix, NO trailing /v1beta (CLI appends it).
+    assert_eq!(
+        rendered.set.get("GOOGLE_GEMINI_BASE_URL").unwrap(),
+        GATEWAY_BASE_URL
+    );
+    assert_eq!(rendered.set.get("GEMINI_API_KEY").unwrap(), VK);
+    assert_eq!(
+        rendered.set.get("GEMINI_CLI_TRUST_WORKSPACE").unwrap(),
+        "true"
+    );
+    let gemini_home = rendered.set.get("HOME").expect("HOME");
+    assert!(gemini_home.contains("gemini-home-42"));
+
+    let settings: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(std::path::Path::new(gemini_home).join(".gemini/settings.json"))
+            .expect("read settings"),
+    )
+    .expect("json");
+    assert_eq!(
+        settings["security"]["auth"]["selectedType"],
+        "gemini-api-key"
+    );
+}
+
+#[test]
+fn gemini_api_key_sets_only_gemini_key() {
+    let home = TempHome::new("gemini-key");
+    home.write_state_json(&json!({
+        "revision": 1,
+        "selections": [ { "harness": "gemini", "route": "api_key", "key": "g-raw" } ]
+    }));
+    let rendered = resolve_launch_route_auth(home.path(), "gemini").expect("render");
+    assert_eq!(rendered.set.get("GEMINI_API_KEY").unwrap(), "g-raw");
+    assert!(!rendered.set.contains_key("HOME"));
+}
+
+// --- fail-closed / missing / malformed / native ----------------------------
+
+#[test]
+fn scoped_state_without_selection_fails_closed_with_code() {
+    let home = TempHome::new("fail-closed");
+    home.write_state_json(&gateway_state("codex", None)); // no claude selection
+
+    let error = resolve_launch_route_auth(home.path(), "claude").expect_err("fail-closed");
+    assert_eq!(error.code(), "AGENT_ROUTE_SELECTION_MISSING");
+    assert!(matches!(error, RouteAuthError::SelectionMissing { .. }));
+}
+
+#[test]
+fn missing_state_file_is_legacy_empty_delta() {
+    let home = TempHome::new("legacy");
+    let rendered = resolve_launch_route_auth(home.path(), "claude").expect("render");
+    assert!(rendered.set.is_empty());
+    assert!(rendered.remove.is_empty());
+}
+
+#[test]
+fn malformed_state_file_is_typed_error() {
+    let home = TempHome::new("broken");
+    home.write_state_raw(b"{{{ not json");
+    let error = resolve_launch_route_auth(home.path(), "claude").expect_err("malformed");
+    assert_eq!(error.code(), "AGENT_ROUTE_STATE_MALFORMED");
+}
+
+#[test]
+fn native_selection_renders_empty_delta() {
+    let home = TempHome::new("native");
+    home.write_state_json(&json!({
+        "revision": 3,
+        "selections": [ { "harness": "claude", "route": "native" } ]
+    }));
+    let rendered = resolve_launch_route_auth(home.path(), "claude").expect("render");
+    assert!(rendered.set.is_empty());
+    assert!(rendered.remove.is_empty());
+}
+
+// --- revision-keyed materialization + cleanup ------------------------------
+
+#[test]
+fn codex_home_keeps_immediately_previous_and_gcs_older_revision_dirs() {
+    let home = TempHome::new("codex-rev");
+
+    let render_rev = |rev: i64| {
+        home.write_state_json(&json!({
+            "revision": rev,
+            "selections": [ { "harness": "codex", "route": "gateway", "base_url": GATEWAY_BASE_URL, "key": VK } ]
+        }));
+        std::path::PathBuf::from(
+            resolve_launch_route_auth(home.path(), "codex")
+                .expect("render")
+                .set
+                .get("CODEX_HOME")
+                .unwrap(),
+        )
+    };
+
+    let dir1 = render_rev(1);
+    assert!(dir1.exists());
+
+    // Revision 2 — the immediately-previous dir (rev 1) MUST be kept, because a
+    // session launched under rev 1 may still be running on it (spec §0).
+    let dir2 = render_rev(2);
+    assert!(dir2.exists());
+    assert_ne!(dir1, dir2);
+    assert!(
+        dir1.exists(),
+        "immediately-previous codex-home-1 must be kept for in-flight rev-1 sessions"
+    );
+
+    // Revision 3 — now rev 1 is older than the immediately-previous (rev 2) and
+    // is GC'd; rev 2 (immediately-previous) is kept.
+    let dir3 = render_rev(3);
+    assert!(dir3.exists());
+    assert!(
+        dir2.exists(),
+        "immediately-previous codex-home-2 must be kept"
+    );
+    assert!(
+        !dir1.exists(),
+        "stale codex-home-1 should be removed at rev 3"
+    );
+}
+
+// --- unknown harness --------------------------------------------------------
+
+#[test]
+fn unknown_harness_in_state_is_typed_error() {
+    // A profile carrying a harness kind that AgentKind cannot parse.
+    let state = AgentAuthState {
+        revision: 1,
+        user_id: None,
+        selections: vec![super::state::AuthSelection {
+            harness: "bogus".into(),
+            route: AuthRoute::Gateway,
+            provider: None,
+            base_url: Some(GATEWAY_BASE_URL.into()),
+            key: Some(VK.into()),
+            model_catalog: None,
+        }],
+    };
+    let profile = resolve_profile(Some(&state), "bogus").expect("resolve");
+    let error = render_profile(&profile, std::path::Path::new("/tmp")).expect_err("unknown");
+    assert_eq!(error.code(), "AGENT_ROUTE_UNKNOWN_HARNESS");
+}
+
+#[test]
+fn state_file_path_snapshot() {
+    let path = state_file_path(std::path::Path::new("/home/u/.proliferate/anyharness"));
+    assert_eq!(
+        path,
+        std::path::PathBuf::from("/home/u/.proliferate/anyharness/agent-auth/state.json")
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
@@ -1,0 +1,233 @@
+//! The declarative agent-auth state file contract.
+//!
+//! Both delivery surfaces (the cloud materialization worker and the desktop
+//! dispatch worker) write the SAME file at `<anyharness home>/agent-auth/
+//! state.json` (mode 0600); AnyHarness reads it fresh at every session launch
+//! and renders per-harness launch profiles from it (spec §5). There is no
+//! watch/refresh — the render plane re-reads on demand.
+//!
+//! Tolerance model:
+//! - file absent          -> `None` (legacy / native behavior; local desktop
+//!   without cloud state keeps working)
+//! - file present, valid  -> `Some(AgentAuthState)`
+//! - file present, broken -> typed [`RouteAuthError::MalformedStateFile`]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::RouteAuthError;
+
+/// Well-known relative path of the state file under the AnyHarness home.
+pub const STATE_FILE_RELATIVE_PATH: &[&str] = &["agent-auth", "state.json"];
+
+/// Resolve the absolute path of the agent-auth state file for a given
+/// AnyHarness runtime home. Single source of truth for the layout so delivery
+/// (worker/desktop) and the render plane agree.
+pub fn state_file_path(runtime_home: &Path) -> PathBuf {
+    let mut path = runtime_home.to_path_buf();
+    for segment in STATE_FILE_RELATIVE_PATH {
+        path.push(segment);
+    }
+    path
+}
+
+/// Which route pays for a harness's LLM calls (spec §1). `native` is local-only
+/// (the harness's own auth; we detect + leave alone) and carries no rendered
+/// credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthRoute {
+    Native,
+    ApiKey,
+    Gateway,
+}
+
+impl AuthRoute {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::ApiKey => "api_key",
+            Self::Gateway => "gateway",
+        }
+    }
+}
+
+/// A single (harness, route) selection materialized by the control plane. The
+/// optional fields carry only what a route needs: `key`/`base_url`/`provider`
+/// for api_key/gateway, `model_catalog` for OpenCode's explicit models map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthSelection {
+    /// Harness kind string, e.g. `"claude"`, `"codex"` (matches
+    /// [`AgentKind::as_str`](crate::domains::agents::model::AgentKind::as_str)).
+    pub harness: String,
+    pub route: AuthRoute,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// The rendered credential (virtual key for gateway, raw provider key for
+    /// api_key). Never logged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    /// Explicit model ids for adapters that require them in-config (OpenCode).
+    /// Populated by the catalog (PR 7); absent means the adapter falls back to
+    /// a static minimal list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_catalog: Option<Vec<String>>,
+}
+
+/// The whole declarative state file (spec §5).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAuthState {
+    /// Monotonic revision. `0` means "no scoped selections yet" (legacy /
+    /// native behavior); `> 0` engages fail-closed semantics for harnesses
+    /// without a selection.
+    pub revision: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub selections: Vec<AuthSelection>,
+}
+
+impl AgentAuthState {
+    /// The selection for a harness kind, if any.
+    pub fn selection_for(&self, harness_kind: &str) -> Option<&AuthSelection> {
+        self.selections
+            .iter()
+            .find(|selection| selection.harness == harness_kind)
+    }
+
+    /// Whether the state engages fail-closed semantics (a scoped launch, spec
+    /// §3): the file exists with a real revision, so a harness with no
+    /// selection must error rather than fall through to ambient credentials.
+    pub fn is_scoped(&self) -> bool {
+        self.revision > 0
+    }
+}
+
+/// Read + parse the state file on demand. Returns:
+/// - `Ok(None)` when the file is absent (legacy behavior),
+/// - `Ok(Some(state))` when present and valid,
+/// - `Err(RouteAuthError::MalformedStateFile)` when present but unparseable.
+pub fn load_state_file(runtime_home: &Path) -> Result<Option<AgentAuthState>, RouteAuthError> {
+    let path = state_file_path(runtime_home);
+    load_state_from_path(&path)
+}
+
+pub(super) fn load_state_from_path(path: &Path) -> Result<Option<AgentAuthState>, RouteAuthError> {
+    let contents = match fs::read(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(RouteAuthError::MalformedStateFile {
+                path: path.to_path_buf(),
+                detail: format!("failed to read state file: {error}"),
+            })
+        }
+    };
+    let state: AgentAuthState =
+        serde_json::from_slice(&contents).map_err(|error| RouteAuthError::MalformedStateFile {
+            path: path.to_path_buf(),
+            detail: format!("failed to parse state file JSON: {error}"),
+        })?;
+    Ok(Some(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::route_auth::test_support::TempHome;
+
+    #[test]
+    fn state_file_path_uses_well_known_layout() {
+        let path = state_file_path(Path::new("/home/x/.proliferate/anyharness"));
+        assert!(path.ends_with("agent-auth/state.json"));
+    }
+
+    #[test]
+    fn missing_file_is_legacy_none() {
+        let home = TempHome::new("state-missing");
+        let state = load_state_file(home.path()).expect("load");
+        assert!(state.is_none());
+    }
+
+    #[test]
+    fn malformed_file_is_typed_error() {
+        let home = TempHome::new("state-malformed");
+        home.write_state_raw(b"{ not json");
+        let error = load_state_file(home.path()).expect_err("malformed");
+        assert!(matches!(error, RouteAuthError::MalformedStateFile { .. }));
+    }
+
+    #[test]
+    fn round_trip_serde_preserves_selection_fields() {
+        let state = AgentAuthState {
+            revision: 42,
+            user_id: Some("user-1".into()),
+            selections: vec![
+                AuthSelection {
+                    harness: "claude".into(),
+                    route: AuthRoute::Gateway,
+                    provider: None,
+                    base_url: Some("https://llm.proliferate.ai".into()),
+                    key: Some("sk-virtual".into()),
+                    model_catalog: None,
+                },
+                AuthSelection {
+                    harness: "opencode".into(),
+                    route: AuthRoute::Gateway,
+                    provider: None,
+                    base_url: Some("https://llm.proliferate.ai".into()),
+                    key: Some("sk-virtual".into()),
+                    model_catalog: Some(vec!["claude-haiku-4-5-20251001".into()]),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&state).expect("serialize");
+        let parsed: AgentAuthState = serde_json::from_str(&json).expect("parse");
+        assert_eq!(state, parsed);
+        // camelCase-insensitive: routes serialize snake_case.
+        assert!(json.contains("\"gateway\""));
+    }
+
+    #[test]
+    fn selection_lookup_and_scoping() {
+        let state = AgentAuthState {
+            revision: 5,
+            user_id: None,
+            selections: vec![AuthSelection {
+                harness: "codex".into(),
+                route: AuthRoute::ApiKey,
+                provider: Some("openai".into()),
+                base_url: None,
+                key: Some("sk-raw".into()),
+                model_catalog: None,
+            }],
+        };
+        assert!(state.is_scoped());
+        assert_eq!(
+            state.selection_for("codex").unwrap().route,
+            AuthRoute::ApiKey
+        );
+        assert!(state.selection_for("claude").is_none());
+
+        let legacy = AgentAuthState {
+            revision: 0,
+            user_id: None,
+            selections: vec![],
+        };
+        assert!(!legacy.is_scoped());
+    }
+
+    #[test]
+    fn tolerates_minimal_native_selection() {
+        let json =
+            r#"{ "revision": 3, "selections": [ { "harness": "claude", "route": "native" } ] }"#;
+        let state: AgentAuthState = serde_json::from_str(json).expect("parse");
+        let selection = state.selection_for("claude").expect("selection");
+        assert_eq!(selection.route, AuthRoute::Native);
+        assert!(selection.key.is_none());
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/test_support.rs
@@ -1,0 +1,45 @@
+//! Test-only helpers for the route-auth module: a self-cleaning temp home and
+//! a state-file writer.
+
+use std::path::{Path, PathBuf};
+
+use super::state::state_file_path;
+
+pub(crate) struct TempHome {
+    path: PathBuf,
+}
+
+impl TempHome {
+    pub(crate) fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-route-auth-{prefix}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).expect("create temp home");
+        Self { path }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Write raw bytes to the state file location (used for malformed-file
+    /// tests).
+    pub(crate) fn write_state_raw(&self, bytes: &[u8]) {
+        let path = state_file_path(&self.path);
+        std::fs::create_dir_all(path.parent().expect("state parent"))
+            .expect("create agent-auth dir");
+        std::fs::write(&path, bytes).expect("write state file");
+    }
+
+    /// Write a JSON value as the state file.
+    pub(crate) fn write_state_json(&self, value: &serde_json::Value) {
+        self.write_state_raw(serde_json::to_string(value).expect("serialize").as_bytes());
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
@@ -55,11 +55,13 @@ impl SessionRuntime {
                 StartSessionError::Closed => {
                     SetSessionConfigOptionError::Rejected("session is closed".to_string())
                 }
-                StartSessionError::MissingDataKey
-                | StartSessionError::RestartRequired(_) => {
+                StartSessionError::MissingDataKey | StartSessionError::RestartRequired(_) => {
                     SetSessionConfigOptionError::Internal(anyhow::anyhow!(
                         "{SESSION_RESTART_REQUIRED_DETAIL}"
                     ))
+                }
+                StartSessionError::RouteAuth(error) => {
+                    SetSessionConfigOptionError::Rejected(error.to_string())
                 }
                 StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
                     SetSessionConfigOptionError::Internal(error)

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
@@ -259,6 +259,7 @@ fn map_start_error_to_fork(error: StartSessionError) -> ForkSessionError {
         StartSessionError::Closed => ForkSessionError::Invalid("session is closed".to_string()),
         StartSessionError::MissingDataKey => ForkSessionError::MissingDataKey,
         StartSessionError::RestartRequired(detail) => ForkSessionError::Invalid(detail),
+        StartSessionError::RouteAuth(error) => ForkSessionError::Invalid(error.to_string()),
         StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
             ForkSessionError::Internal(error)
         }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::domains::agents::model::{AgentKind, ResolvedAgent};
+use crate::domains::agents::route_auth::RenderedRouteAuth;
 use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
 use crate::domains::sessions::model::SessionRecord;
 use crate::live::sessions::model::{LaunchEnv, SessionLaunch, SystemPromptAppends};
@@ -171,6 +172,9 @@ pub(super) struct SessionLaunchContext {
     pub workspace_path: PathBuf,
     pub workspace_env: BTreeMap<String, String>,
     pub session_env: BTreeMap<String, String>,
+    /// Rendered agent-auth route layer for this launch (empty for
+    /// native/legacy). See `domains::agents::route_auth`.
+    pub route_auth: RenderedRouteAuth,
     pub mcp_servers: Vec<SessionMcpServer>,
     pub startup: SessionStartupStrategy,
     pub every_prompt_append: Option<String>,
@@ -186,6 +190,8 @@ pub(super) fn assemble_session_launch(ctx: SessionLaunchContext) -> SessionLaunc
         env: LaunchEnv {
             workspace: ctx.workspace_env,
             session: ctx.session_env,
+            route_auth: ctx.route_auth.set,
+            route_auth_remove: ctx.route_auth.remove,
         },
         mcp_servers: ctx.mcp_servers,
         startup: ctx.startup,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -14,6 +14,7 @@ use super::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
 use super::model::SessionRecord;
 use super::plan_references::{PlanInteractionLinkResolver, PlanReferenceResolver};
 use super::service::SessionService;
+use crate::domains::agents::route_auth::RouteAuthError;
 use crate::domains::sessions::extensions::SessionExtension;
 use crate::domains::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
@@ -70,6 +71,10 @@ pub enum CreateAndStartSessionError {
         session_id: String,
     },
     MissingDataKey,
+    /// Agent-auth route resolution refused the launch (fail-closed selection
+    /// missing, malformed state file, unsupported route, ...). Typed so the
+    /// API layer surfaces the stable machine code (`AGENT_ROUTE_*`).
+    RouteAuth(RouteAuthError),
     StartFailed(anyhow::Error),
     Internal(anyhow::Error),
 }
@@ -81,6 +86,8 @@ pub enum EnsureLiveSessionError {
     RestartRequired(String),
     Invalid(String),
     MissingDataKey,
+    /// See [`CreateAndStartSessionError::RouteAuth`].
+    RouteAuth(RouteAuthError),
     Internal(anyhow::Error),
 }
 
@@ -242,6 +249,8 @@ pub(super) enum StartSessionError {
     Closed,
     MissingDataKey,
     RestartRequired(String),
+    /// Agent-auth route resolution refused the launch (fail-closed, spec §3).
+    RouteAuth(RouteAuthError),
     Internal(anyhow::Error),
     AcpStart(anyhow::Error),
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -193,10 +193,17 @@ fn map_start_error_to_prompt(error: StartSessionError) -> SendPromptError {
             SendPromptError::Internal(anyhow::anyhow!("agent descriptor not found: {agent_kind}"))
         }
         StartSessionError::Closed => SendPromptError::SessionClosed,
-        StartSessionError::MissingDataKey
-        | StartSessionError::RestartRequired(_) => {
+        StartSessionError::MissingDataKey | StartSessionError::RestartRequired(_) => {
             SendPromptError::Internal(anyhow::anyhow!(SESSION_RESTART_REQUIRED_DETAIL))
         }
+        // Lazy-start on prompt: surface the typed agent-auth code so clients
+        // can distinguish the fail-closed launch refusal from generic errors.
+        StartSessionError::RouteAuth(error) => SendPromptError::InvalidPrompt(
+            crate::domains::sessions::prompt::PromptValidationError::new(
+                error.code(),
+                error.to_string(),
+            ),
+        ),
         StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
             SendPromptError::Internal(error)
         }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use crate::domains::agents::readiness::service::resolve_agent_with_env;
 use crate::domains::agents::registry;
+use crate::domains::agents::route_auth::resolve_launch_route_auth;
 use crate::domains::sessions::extensions::SessionTurnFinishedContext;
 use crate::domains::sessions::links::model::SessionLinkRelation;
 use crate::domains::sessions::mcp_bindings::assembly::{
@@ -157,6 +158,7 @@ impl SessionRuntime {
                 StartSessionError::RestartRequired(detail) => {
                     EnsureLiveSessionError::RestartRequired(detail)
                 }
+                StartSessionError::RouteAuth(error) => EnsureLiveSessionError::RouteAuth(error),
                 StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
                     EnsureLiveSessionError::Internal(error)
                 }
@@ -323,6 +325,22 @@ impl SessionRuntime {
             record.requested_model_id.as_deref(),
         )
         .map_err(StartSessionError::Internal)?;
+        // Agent-auth render plane: read the declarative state file fresh and
+        // render the route layer for this harness. Absent file = empty layer
+        // (legacy/native); a scoped file with no selection fails the launch
+        // closed with a typed error (spec §3).
+        let route_auth = resolve_launch_route_auth(&self.runtime_home, &record.agent_kind)
+            .map_err(|error| {
+                tracing::warn!(
+                    session_id = %record.id,
+                    workspace_id = %record.workspace_id,
+                    agent_kind = %record.agent_kind,
+                    code = error.code(),
+                    error = %error,
+                    "agent-auth route resolution failed; refusing launch"
+                );
+                StartSessionError::RouteAuth(error)
+            })?;
         let mcp_launch = assemble_session_mcp_launch(
             self.session_data_cipher.as_ref(),
             &self.session_extensions,
@@ -345,6 +363,7 @@ impl SessionRuntime {
             workspace_path,
             workspace_env,
             session_env: session_launch_env,
+            route_auth,
             mcp_servers: mcp_launch.mcp_servers,
             startup: startup_strategy,
             every_prompt_append: mcp_launch.system_prompt_append,
@@ -400,6 +419,7 @@ pub(super) fn map_start_session_error_to_anyhow(error: StartSessionError) -> any
             anyhow::anyhow!("{}", SessionMcpBindingsError::missing_data_key_detail())
         }
         StartSessionError::RestartRequired(detail) => anyhow::anyhow!(detail),
+        StartSessionError::RouteAuth(error) => anyhow::Error::new(error),
         StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => error,
     }
 }
@@ -449,6 +469,7 @@ fn map_start_session_error_to_create(error: StartSessionError) -> CreateAndStart
         StartSessionError::RestartRequired(detail) => {
             CreateAndStartSessionError::Internal(anyhow::anyhow!(detail))
         }
+        StartSessionError::RouteAuth(error) => CreateAndStartSessionError::RouteAuth(error),
         StartSessionError::Internal(error) => CreateAndStartSessionError::Internal(error),
         StartSessionError::AcpStart(error) => CreateAndStartSessionError::StartFailed(error),
     }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -58,8 +58,7 @@ impl SessionActor {
         let spawned = spawn_agent_process(
             &config.launch.agent,
             &config.launch.workspace_path,
-            &config.launch.env.workspace,
-            &config.launch.env.session,
+            &config.launch.env,
             &session_id,
             &workspace_id,
             &source_agent_kind,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use super::*;
 use crate::live::sessions::driver::stderr::{spawn_agent_stderr_logger, AgentStderrTail};
+use crate::live::sessions::model::LaunchEnv;
 use crate::process_env::remove_runtime_private_env;
 
 pub(in crate::live::sessions) struct SpawnedAgentProcess {
@@ -15,12 +16,14 @@ pub(in crate::live::sessions) struct SpawnedAgentProcess {
 }
 
 pub(in crate::live::sessions) fn merge_spawn_env(
-    workspace_env: &BTreeMap<String, String>,
-    session_launch_env: &BTreeMap<String, String>,
+    launch_env: &LaunchEnv,
     override_env: Option<&HashMap<String, String>>,
 ) -> BTreeMap<String, String> {
-    let mut merged = workspace_env.clone();
-    for (key, value) in session_launch_env {
+    let mut merged = launch_env.workspace.clone();
+    for (key, value) in &launch_env.session {
+        merged.insert(key.clone(), value.clone());
+    }
+    for (key, value) in &launch_env.route_auth {
         merged.insert(key.clone(), value.clone());
     }
     if let Some(override_env) = override_env {
@@ -28,14 +31,18 @@ pub(in crate::live::sessions) fn merge_spawn_env(
             merged.insert(key.clone(), value.clone());
         }
     }
+    // Route-auth removals win over every set layer. The ambient (inherited)
+    // copies are stripped separately via `Command::env_remove` at spawn.
+    for key in &launch_env.route_auth_remove {
+        merged.remove(key);
+    }
     merged
 }
 
 pub(in crate::live::sessions) fn spawn_agent_process(
     agent: &ResolvedAgent,
     workspace_path: &Path,
-    workspace_env: &BTreeMap<String, String>,
-    session_launch_env: &BTreeMap<String, String>,
+    launch_env: &LaunchEnv,
     session_id: &str,
     workspace_id: &str,
     source_agent_kind: &str,
@@ -59,11 +66,7 @@ pub(in crate::live::sessions) fn spawn_agent_process(
         .map_or((workspace_path, "workspace"), |path| {
             (path.as_path(), "agent_override")
         });
-    let spawn_env = merge_spawn_env(
-        workspace_env,
-        session_launch_env,
-        spawn_spec.map(|spec| &spec.env),
-    );
+    let spawn_env = merge_spawn_env(launch_env, spawn_spec.map(|spec| &spec.env));
     if let Err(error) = validate_spawn_cwd(spawn_cwd, spawn_cwd_source) {
         tracing::warn!(
             session_id = %session_id,
@@ -91,6 +94,12 @@ pub(in crate::live::sessions) fn spawn_agent_process(
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
     remove_runtime_private_env(&mut command);
+    // Agent-auth sanitization: removal wins over the inherited ambient env
+    // (e.g. a developer shell exporting CLAUDE_CODE_USE_BEDROCK would silently
+    // reroute the Claude CLI away from the configured gateway).
+    for key in &launch_env.route_auth_remove {
+        command.env_remove(key);
+    }
     let mut child = command.spawn().map_err(|e| {
         tracing::warn!(
             session_id = %session_id,
@@ -216,8 +225,7 @@ mod tests {
         let result = spawn_agent_process(
             &agent,
             &missing_workspace,
-            &BTreeMap::new(),
-            &BTreeMap::new(),
+            &LaunchEnv::default(),
             "session-1",
             "workspace-1",
             AgentKind::Codex.as_str(),
@@ -243,19 +251,22 @@ mod tests {
 
     #[test]
     fn merge_spawn_env_prefers_session_launch_over_workspace_env() {
-        let workspace_env = BTreeMap::from([
-            (
+        let launch_env = LaunchEnv {
+            workspace: BTreeMap::from([
+                (
+                    "CLAUDE_CODE_EXECUTABLE".to_string(),
+                    "/workspace/bin/claude".to_string(),
+                ),
+                ("PATH".to_string(), "/usr/bin".to_string()),
+            ]),
+            session: BTreeMap::from([(
                 "CLAUDE_CODE_EXECUTABLE".to_string(),
-                "/workspace/bin/claude".to_string(),
-            ),
-            ("PATH".to_string(), "/usr/bin".to_string()),
-        ]);
-        let session_launch_env = BTreeMap::from([(
-            "CLAUDE_CODE_EXECUTABLE".to_string(),
-            "/managed/bin/claude".to_string(),
-        )]);
+                "/managed/bin/claude".to_string(),
+            )]),
+            ..Default::default()
+        };
 
-        let merged = merge_spawn_env(&workspace_env, &session_launch_env, None);
+        let merged = merge_spawn_env(&launch_env, None);
 
         assert_eq!(
             merged.get("CLAUDE_CODE_EXECUTABLE").map(String::as_str),
@@ -266,17 +277,80 @@ mod tests {
 
     #[test]
     fn merge_spawn_env_prefers_explicit_override_env_over_session_env() {
-        let workspace_env = BTreeMap::from([("PATH".to_string(), "/usr/bin".to_string())]);
-        let session_launch_env = BTreeMap::from([("DEBUG".to_string(), "0".to_string())]);
+        let launch_env = LaunchEnv {
+            workspace: BTreeMap::from([("PATH".to_string(), "/usr/bin".to_string())]),
+            session: BTreeMap::from([("DEBUG".to_string(), "0".to_string())]),
+            ..Default::default()
+        };
         let override_env = std::collections::HashMap::from([
             ("DEBUG".to_string(), "1".to_string()),
             ("FOO".to_string(), "bar".to_string()),
         ]);
 
-        let merged = merge_spawn_env(&workspace_env, &session_launch_env, Some(&override_env));
+        let merged = merge_spawn_env(&launch_env, Some(&override_env));
 
         assert_eq!(merged.get("PATH").map(String::as_str), Some("/usr/bin"));
         assert_eq!(merged.get("DEBUG").map(String::as_str), Some("1"));
         assert_eq!(merged.get("FOO").map(String::as_str), Some("bar"));
+    }
+
+    #[test]
+    fn merge_spawn_env_route_auth_layer_wins_over_session_layer() {
+        let launch_env = LaunchEnv {
+            session: BTreeMap::from([(
+                "CODEX_HOME".to_string(),
+                "/runtime/agent-auth/codex-local".to_string(),
+            )]),
+            route_auth: BTreeMap::from([
+                (
+                    "CODEX_HOME".to_string(),
+                    "/runtime/agent-auth/codex-home-42".to_string(),
+                ),
+                (
+                    "PROLIFERATE_GATEWAY_KEY".to_string(),
+                    "sk-virtual".to_string(),
+                ),
+            ]),
+            ..Default::default()
+        };
+
+        let merged = merge_spawn_env(&launch_env, None);
+
+        assert_eq!(
+            merged.get("CODEX_HOME").map(String::as_str),
+            Some("/runtime/agent-auth/codex-home-42")
+        );
+        assert_eq!(
+            merged.get("PROLIFERATE_GATEWAY_KEY").map(String::as_str),
+            Some("sk-virtual")
+        );
+    }
+
+    #[test]
+    fn merge_spawn_env_route_auth_removals_strip_every_set_layer() {
+        let launch_env = LaunchEnv {
+            workspace: BTreeMap::from([(
+                "ANTHROPIC_API_KEY".to_string(),
+                "sk-workspace-stale".to_string(),
+            )]),
+            session: BTreeMap::from([("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string())]),
+            route_auth: BTreeMap::from([(
+                "ANTHROPIC_AUTH_TOKEN".to_string(),
+                "sk-virtual".to_string(),
+            )]),
+            route_auth_remove: vec![
+                "ANTHROPIC_API_KEY".to_string(),
+                "CLAUDE_CODE_USE_BEDROCK".to_string(),
+            ],
+        };
+
+        let merged = merge_spawn_env(&launch_env, None);
+
+        assert!(!merged.contains_key("ANTHROPIC_API_KEY"));
+        assert!(!merged.contains_key("CLAUDE_CODE_USE_BEDROCK"));
+        assert_eq!(
+            merged.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str),
+            Some("sk-virtual")
+        );
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -86,10 +86,21 @@ impl SessionStartupStrategy {
 
 /// The named environment layers a session launch carries. Keeping the layers
 /// named (rather than adjacent maps) removes the positional swap hazard.
+///
+/// Layering at spawn: `workspace` → `session` → `route_auth` (later layers
+/// win), then `route_auth_remove` strips keys from BOTH the merged layers and
+/// the inherited ambient process env — removal always wins (the agent-auth
+/// sanitization contract; see `domains::agents::route_auth::render`).
 #[derive(Debug, Clone, Default)]
 pub struct LaunchEnv {
     pub workspace: BTreeMap<String, String>,
     pub session: BTreeMap<String, String>,
+    /// Rendered agent-auth route layer (gateway/api_key credentials, isolated
+    /// homes). Empty for native/legacy launches.
+    pub route_auth: BTreeMap<String, String>,
+    /// Env keys the route-auth render plane requires ABSENT in the spawned
+    /// process (ambient Bedrock/Vertex reroutes, stale provider keys).
+    pub route_auth_remove: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
@@ -175,22 +175,23 @@ pub async fn probe_agent(options: ProbeOptions) -> anyhow::Result<ProbeSnapshot>
     }
 
     let (ready_tx, _ready_rx) = std::sync::mpsc::channel::<anyhow::Result<String>>();
-    let empty = BTreeMap::new();
     // Credential env vars are merged into the session layer (after the
     // workspace layer); the probe passes no other layer that could shadow
     // them, so they reach the agent process unchanged.
-    let mut session_launch_env = session_launch_env;
     session_launch_env.extend(
         options
             .auth_env
             .iter()
             .map(|(key, value)| (key.clone(), value.clone())),
     );
+    let launch_env = crate::live::sessions::model::LaunchEnv {
+        session: session_launch_env,
+        ..Default::default()
+    };
     let spawned = spawn_agent_process(
         &resolved,
         &workspace,
-        &empty,
-        &session_launch_env,
+        &launch_env,
         PROBE_SESSION_ID,
         PROBE_WORKSPACE_ID,
         options.agent_kind.as_str(),

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -18,7 +18,7 @@ anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 15
 anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 704 existing AnyHarness oversized test file
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
-anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 653 catalog probe with per-harness model-source fallbacks and tests
+anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 654 catalog probe with per-harness model-source fallbacks and tests
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 653 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 759 existing generated cloud SDK type surface


### PR DESCRIPTION
PR 6 of the agent-auth LiteLLM stack (spec: `specs/codebase/primitives/agent-auth-litellm.md` §4/§5/§13; recipes live-verified in `scripts/agent-gateway-smoke/HARNESS-MATRIX.md` on PR 2).

## What

AnyHarness "render plane": the control plane (cloud materialization worker in PR 5 / desktop dispatch worker) writes a declarative state file at `<anyharness home>/agent-auth/state.json`; AnyHarness reads it fresh at every session launch and renders a per-harness route-auth env layer into the real spawn env. No watch/refresh; running processes are never mutated.

### New module `domains/agents/route_auth/`
- `state.rs` — state-file contract + tolerant loader: absent file = legacy/native behavior; malformed = typed `AGENT_ROUTE_STATE_MALFORMED`.
- `profile.rs` — pure route decision. Fail-closed (spec §3): a scoped file (`revision > 0`) with no selection for the requested harness errors with `AGENT_ROUTE_SELECTION_MISSING` instead of falling through to ambient creds.
- `render.rs` + `materialize.rs` — per-adapter launch rendering exactly per the live-verified matrix:
  - **claude**: gateway sets `ANTHROPIC_BASE_URL` (proxy root) + `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_SMALL_FAST_MODEL`; both routes **remove** ambient `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `AWS_BEARER_TOKEN_BEDROCK` and (gateway) stale `ANTHROPIC_API_KEY` — ambient Bedrock env silently reroutes the CLI.
  - **codex**: gateway materializes isolated `CODEX_HOME` `config.toml` (`model_provider = "proliferate"`, `base_url = <base>/v1`, `env_key = "PROLIFERATE_GATEWAY_KEY"`, `wire_api = "responses"`); `api_key` route is openai-family only and rejects other providers with a clear `AGENT_ROUTE_UNSUPPORTED` note.
  - **opencode**: gateway writes `OPENCODE_CONFIG` json (provider `proliferate` via `@ai-sdk/openai-compatible`, `apiKey {env:PROLIFERATE_GATEWAY_KEY}`, explicit models map — static fallback list until the PR 7 catalog populates `model_catalog`).
  - **grok**: `GROK_MODELS_BASE_URL=<base>/v1` + `XAI_API_KEY` + isolated `HOME`.
  - **gemini**: `GOOGLE_GEMINI_BASE_URL=<base>` **root** (no `/gemini` prefix) + isolated home `~/.gemini/settings.json` `security.auth.selectedType=gemini-api-key` + `GEMINI_CLI_TRUST_WORKSPACE=true`.
- Isolated homes are revision-keyed (`codex-home-<rev>`, `grok-home-<rev>`, `gemini-home-<rev>`, `opencode-config-<rev>`) with stale-sibling cleanup at materialization — filesystem bookkeeping only, **no new SQLite tables** (schema snapshot unchanged).

### Wiring into the real launch path
- `LaunchEnv` gains a named `route_auth` set layer plus `route_auth_remove`; merge order is workspace → session → route_auth → dev spawn-override, then removals — and removals are also applied via `Command::env_remove`, so they win over the inherited ambient process env.
- `SessionRuntime::start_live_session` resolves the profile per launch and refuses the launch on a typed `RouteAuthError`, surfaced as stable `AGENT_ROUTE_*` codes through create-session, ensure-live (409 for fail-closed/route-shape, 500 for state corruption/IO), lazy-start-on-prompt, config, fork, and cowork error mappings.

### Contract / SDK
No contract type changed; error codes ride the existing ProblemDetails envelope. Verified `anyharness print-openapi` output is byte-identical to `anyharness/sdk/generated/openapi.json`, so no SDK regen.

## Verification
- `cargo check --workspace` clean.
- `cargo test --workspace` — 13 suites, all green (anyharness-lib 736 passed; includes 32 route_auth tests: per-adapter render snapshots incl. claude sanitization, codex openai-only rejection, opencode explicit-models + fallback, grok/gemini isolated homes, fail-closed, missing-file, malformed-file, serde round-trip, revision-dir cleanup; plus spawn-env layering/removal merge tests).
- Schema snapshot test (`specs/generated/anyharness-db-schema.sql`) green.
- `python3 scripts/check_anyharness_old_paths.py` and `scripts/check_proliferate_worker_structure.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)