### PR TITLE
feat(agent-auth): first-run auth adoption and onboarding defaults

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { useAppShortcuts } from "@/hooks/app/lifecycle/use-app-shortcuts"
 import { useAppCommandActions } from "@/hooks/app/workflows/use-app-command-actions"
 import { useAuthBootstrap } from "@/hooks/auth/lifecycle/use-auth-bootstrap"
 import { useAgentAutoReconcile } from "@/hooks/agents/lifecycle/use-agent-auto-reconcile"
+import { useFirstRunAuthAdoption } from "@/hooks/agents/lifecycle/use-first-run-auth-adoption"
 import { useLocalAutomationExecutor } from "@/hooks/automations/lifecycle/use-local-automation-executor"
 import { useHomeDeferredLaunchRunner } from "@/hooks/home/lifecycle/use-home-deferred-launch-runner"
 import { useAppearancePreferenceLifecycle } from "@/hooks/preferences/lifecycle/use-appearance-preference-lifecycle"
@@ -203,6 +204,9 @@ function AppRuntime() {
   recordBootDiagnosticOnce("app_runtime.render.before.use_agent_auto_reconcile")
   useAgentAutoReconcile()
   recordBootDiagnosticOnce("app_runtime.render.after.use_agent_auto_reconcile")
+  recordBootDiagnosticOnce("app_runtime.render.before.use_first_run_auth_adoption")
+  useFirstRunAuthAdoption()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_first_run_auth_adoption")
   recordBootDiagnosticOnce("app_runtime.render.before.use_local_automation_executor")
   useLocalAutomationExecutor()
   recordBootDiagnosticOnce("app_runtime.render.after.use_local_automation_executor")

--- a/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AgentDefaultsPane.tsx
@@ -13,6 +13,7 @@ import { SettingsRow, SETTINGS_CONTROL_WIDTH_CLASS } from "@proliferate/product-
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
 import { AgentAuthenticationSection } from "@/components/settings/panes/agent-auth/AgentAuthenticationSection";
+import { AgentAuthInstallGate } from "@/components/settings/panes/agent-auth/AgentAuthInstallGate";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 import { ProviderIcon } from "@proliferate/ui/provider-icons";
 import { SettingsMenu } from "@proliferate/ui/primitives/SettingsMenu";
@@ -27,6 +28,7 @@ import {
 import { withUpdatedDefaultModelIdByAgentKind } from "@/lib/domain/agents/model-options";
 import { withUpdatedModelVisibilityOverride } from "@/lib/domain/chat/models/model-visibility";
 import { isReadyAgent } from "@/lib/domain/agents/status";
+import { resolveAgentAuthDisplay } from "@/lib/domain/agents/auth-onboarding";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { buildPrimaryHarnessPreferenceUpdate } from "@/lib/domain/settings/chat-defaults";
 
@@ -53,6 +55,10 @@ export function AgentDefaultsPane() {
   } = useModelRegistrySettings();
   const cloudAgentCatalogQuery = useCloudAgentCatalog(connectionState !== "failed");
   const canUpdateLocalInstalls = connectionState === "healthy" && !isReconciling;
+  const localAgentsByKind = useMemo(
+    () => new Map(agents.map((agent) => [agent.kind, agent] as const)),
+    [agents],
+  );
   const launchAgents = useMemo(
     () => mergeRuntimeLaunchOptionsIntoDesktopLaunchAgents(
       cloudAgentCatalogQuery.data?.agents ?? [],
@@ -216,74 +222,86 @@ export function AgentDefaultsPane() {
           )}
       </SettingsSection>
 
-      {connectionState !== "failed" && orderedAgentDefaultRows.map((row) => (
-        <SettingsSection key={row.kind} title={`${row.displayName} defaults`}>
-          <div className="space-y-2">
-            <AgentDefaultComposer
-              row={row}
-              launchAgent={launchAgents.find((agent) => agent.kind === row.kind) ?? null}
-              preferences={preferences}
-            />
-
-            <AgentAuthenticationSection
-              agentKind={row.kind}
-              displayName={row.displayName}
-            />
-
-            {row.visibilityModels.length > 0 ? (
-              <ModelRegistryPane
-                agentKind={row.kind}
-                models={row.visibilityModels}
-                refreshable={row.kind === "cursor" || row.kind === "opencode"}
-                refreshing={runtimeLaunchOptions.isRefetching}
-                onRefresh={() => {
-                  void runtimeLaunchOptions.refetch().then((result) => {
-                    if (result.error) {
-                      showToast(
-                        result.error instanceof Error
-                          ? result.error.message
-                          : `Could not refresh ${row.displayName} models.`,
-                      );
-                    }
-                  });
-                }}
-                onVisibilityChange={(modelId, visible, catalogDefaultOptIn) => {
-                  if (!visible) {
-                    const visibleRows = row.visibilityModels.filter((model) => model.isVisible);
-                    if (visibleRows.length <= 1 && visibleRows.some((model) => model.id === modelId)) {
-                      return;
-                    }
-                  }
-
-                  const nextVisibilityOverrides = withUpdatedModelVisibilityOverride(
-                    preferences.chatModelVisibilityOverridesByAgentKind,
-                    row.kind,
-                    modelId,
-                    visible,
-                    catalogDefaultOptIn,
-                  );
-                  const nextVisibleModel = row.visibilityModels.find((model) =>
-                    model.id !== modelId && model.isVisible
-                  ) ?? null;
-                  const nextDefaultModelIds =
-                    !visible && row.selectedModel.id === modelId && nextVisibleModel
-                      ? withUpdatedDefaultModelIdByAgentKind(
-                        preferences.defaultChatModelIdByAgentKind,
-                        row.kind,
-                        nextVisibleModel.id,
-                      )
-                      : preferences.defaultChatModelIdByAgentKind;
-
-                  preferences.setMultiple({
-                    chatModelVisibilityOverridesByAgentKind: nextVisibilityOverrides,
-                    defaultChatModelIdByAgentKind: nextDefaultModelIds,
-                  });
-                }}
+      {connectionState !== "failed" && orderedAgentDefaultRows.map((row) => {
+        const localAgent = localAgentsByKind.get(row.kind) ?? null;
+        const authDisplay = resolveAgentAuthDisplay(localAgent, agentsLoading);
+        return (
+          <SettingsSection key={row.kind} title={`${row.displayName} defaults`}>
+            <div className="space-y-2">
+              <AgentDefaultComposer
+                row={row}
+                launchAgent={launchAgents.find((agent) => agent.kind === row.kind) ?? null}
+                preferences={preferences}
               />
-            ) : null}
-          </div>
-        </SettingsSection>
-      ))}
+
+              {authDisplay === "auth-controls" ? (
+                <AgentAuthenticationSection
+                  agentKind={row.kind}
+                  displayName={row.displayName}
+                />
+              ) : (
+                <AgentAuthInstallGate
+                  displayName={row.displayName}
+                  loading={authDisplay === "loading"}
+                  onInstall={localAgent ? () => setSetupAgent(localAgent) : undefined}
+                />
+              )}
+
+              {row.visibilityModels.length > 0 ? (
+                <ModelRegistryPane
+                  agentKind={row.kind}
+                  models={row.visibilityModels}
+                  refreshable={row.kind === "cursor" || row.kind === "opencode"}
+                  refreshing={runtimeLaunchOptions.isRefetching}
+                  onRefresh={() => {
+                    void runtimeLaunchOptions.refetch().then((result) => {
+                      if (result.error) {
+                        showToast(
+                          result.error instanceof Error
+                            ? result.error.message
+                            : `Could not refresh ${row.displayName} models.`,
+                        );
+                      }
+                    });
+                  }}
+                  onVisibilityChange={(modelId, visible, catalogDefaultOptIn) => {
+                    if (!visible) {
+                      const visibleRows = row.visibilityModels.filter((model) => model.isVisible);
+                      if (visibleRows.length <= 1 && visibleRows.some((model) => model.id === modelId)) {
+                        return;
+                      }
+                    }
+
+                    const nextVisibilityOverrides = withUpdatedModelVisibilityOverride(
+                      preferences.chatModelVisibilityOverridesByAgentKind,
+                      row.kind,
+                      modelId,
+                      visible,
+                      catalogDefaultOptIn,
+                    );
+                    const nextVisibleModel = row.visibilityModels.find((model) =>
+                      model.id !== modelId && model.isVisible
+                    ) ?? null;
+                    const nextDefaultModelIds =
+                      !visible && row.selectedModel.id === modelId && nextVisibleModel
+                        ? withUpdatedDefaultModelIdByAgentKind(
+                          preferences.defaultChatModelIdByAgentKind,
+                          row.kind,
+                          nextVisibleModel.id,
+                        )
+                        : preferences.defaultChatModelIdByAgentKind;
+
+                    preferences.setMultiple({
+                      chatModelVisibilityOverridesByAgentKind: nextVisibilityOverrides,
+                      defaultChatModelIdByAgentKind: nextDefaultModelIds,
+                    });
+                  }}
+                />
+              ) : null}
+            </div>
+          </SettingsSection>
+        );
+      })}
 
       {connectionState !== "failed" && agentsNeedingSetup.length > 0 ? (
         <AgentConfigurationIssuesSection

--- a/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthInstallGate.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthInstallGate.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@proliferate/ui/primitives/Button";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+
+interface AgentAuthInstallGateProps {
+  displayName: string;
+  /** Omitted when there is no local agent record to set up (missing/loading). */
+  onInstall?: () => void;
+  /** True while the local agent record is still being loaded. */
+  loading?: boolean;
+}
+
+/**
+ * Shown in place of the authentication controls when a harness is not
+ * installed on this machine, or while its local record is still loading
+ * (spec §9): install first, then pick a route. Never renders auth controls
+ * for a missing/not-yet-loaded harness.
+ */
+export function AgentAuthInstallGate({
+  displayName,
+  onInstall,
+  loading = false,
+}: AgentAuthInstallGateProps) {
+  if (loading) {
+    return (
+      <SettingsCard>
+        <div className="flex flex-col gap-2 p-4">
+          <p className="text-sm font-semibold text-foreground">Authentication</p>
+          <p className="text-sm text-muted-foreground">
+            Checking {displayName} on this machine…
+          </p>
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  return (
+    <SettingsCard>
+      <div className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-sm font-semibold text-foreground">Authentication</p>
+          <p className="text-sm text-muted-foreground">
+            {displayName} is not installed on this machine. Install it to
+            configure authentication.
+          </p>
+        </div>
+        {onInstall ? (
+          <Button type="button" variant="secondary" size="sm" onClick={onInstall}>
+            Install
+          </Button>
+        ) : null}
+      </div>
+    </SettingsCard>
+  );
+}

--- a/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.tsx
@@ -52,7 +52,7 @@ function gatewaySubtitle(
   if (enrollment?.syncStatus === "pending") {
     return "Enrollment pending";
   }
-  return "Proliferate-managed model access. No setup required.";
+  return "Proliferate-managed model access. Free credits included, no setup required.";
 }
 
 export function AgentAuthenticationSection({

--- a/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSummary } from "@anyharness/sdk";
+import { useFirstRunAuthAdoption } from "./use-first-run-auth-adoption";
+
+const state = vi.hoisted(() => ({
+  cloudActive: true,
+  capabilities: {
+    data: { gatewayEnabled: true } as { gatewayEnabled: boolean } | undefined,
+  },
+  selections: {
+    data: { selections: [] as Array<Record<string, unknown>> } as
+      | { selections: Array<Record<string, unknown>> }
+      | undefined,
+  },
+  agents: [] as AgentSummary[],
+  agentsLoading: false,
+  reconcileSnapshot: {} as Record<string, unknown> | null,
+  reconcileStatus: "completed" as string,
+}));
+const upsertMutate = vi.hoisted(() => vi.fn());
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useAgentGatewayCapabilities: () => state.capabilities,
+  useRouteSelections: () => state.selections,
+  useUpsertRouteSelection: () => ({ mutate: upsertMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+}));
+
+vi.mock("@/hooks/agents/derived/use-agent-catalog", () => ({
+  useAgentCatalog: () => ({
+    agents: state.agents,
+    isLoading: state.agentsLoading,
+    reconcileSnapshot: state.reconcileSnapshot,
+    reconcileStatus: state.reconcileStatus,
+  }),
+}));
+
+function agent(overrides: Partial<AgentSummary> = {}): AgentSummary {
+  return {
+    kind: "claude",
+    displayName: "Claude Code",
+    credentialState: "ready",
+    installState: "installed",
+    readiness: "ready",
+    supportsLogin: true,
+    ...overrides,
+  } as AgentSummary;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  state.cloudActive = true;
+  state.capabilities.data = { gatewayEnabled: true };
+  state.selections.data = { selections: [] };
+  state.agents = [];
+  state.agentsLoading = false;
+  state.reconcileSnapshot = {};
+  state.reconcileStatus = "completed";
+});
+
+describe("useFirstRunAuthAdoption", () => {
+  it("adopts detected native auth when no selections exist", () => {
+    state.agents = [
+      agent({ kind: "claude" }),
+      agent({ kind: "codex", credentialState: "login_required" }),
+    ];
+
+    renderHook(() => useFirstRunAuthAdoption());
+
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+    expect(upsertMutate).toHaveBeenCalledWith(
+      {
+        harnessKind: "claude",
+        surface: "local",
+        body: { route: "native" },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("is a no-op when selections already exist", () => {
+    state.agents = [agent({ kind: "claude" })];
+    state.selections.data = {
+      selections: [{ harnessKind: "claude", surface: "local", route: "gateway" }],
+    };
+
+    renderHook(() => useFirstRunAuthAdoption());
+
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("preselects the gateway when nothing is detected and the gateway is enabled", () => {
+    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
+
+    renderHook(() => useFirstRunAuthAdoption());
+
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+    expect(upsertMutate).toHaveBeenCalledWith(
+      {
+        harnessKind: "claude",
+        surface: "local",
+        body: { route: "gateway" },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("does nothing when nothing is detected and the gateway is disabled", () => {
+    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
+    state.capabilities.data = { gatewayEnabled: false };
+
+    renderHook(() => useFirstRunAuthAdoption());
+
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("waits for selections to load and then runs only once", () => {
+    state.agents = [agent({ kind: "claude" })];
+    state.selections.data = undefined;
+
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    expect(upsertMutate).not.toHaveBeenCalled();
+
+    state.selections.data = { selections: [] };
+    rerender();
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for reconcile hydration to settle before deciding, then adopts freshly-hydrated native creds", () => {
+    // Mid-hydration: the reconcile job is still running and Codex has not yet
+    // had its native credentials detected (reads login_required for now).
+    state.reconcileStatus = "running";
+    state.agents = [
+      agent({ kind: "claude", credentialState: "login_required" }),
+      agent({ kind: "codex", credentialState: "login_required" }),
+    ];
+
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    // A mid-hydration snapshot must NOT drive the one-shot decision.
+    expect(upsertMutate).not.toHaveBeenCalled();
+
+    // Reconcile settles and Codex's native creds are now detected.
+    state.reconcileStatus = "completed";
+    state.agents = [
+      agent({ kind: "claude", credentialState: "login_required" }),
+      agent({ kind: "codex", credentialState: "ready" }),
+    ];
+    rerender();
+
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+    expect(upsertMutate).toHaveBeenCalledWith(
+      {
+        harnessKind: "codex",
+        surface: "local",
+        body: { route: "native" },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("waits until a reconcile snapshot exists before deciding", () => {
+    state.reconcileSnapshot = null;
+    state.agents = [agent({ kind: "claude" })];
+
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    expect(upsertMutate).not.toHaveBeenCalled();
+
+    state.reconcileSnapshot = {};
+    rerender();
+    expect(upsertMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing while cloud is inactive", () => {
+    state.cloudActive = false;
+    state.agents = [agent({ kind: "claude" })];
+
+    renderHook(() => useFirstRunAuthAdoption());
+
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+import {
+  useAgentGatewayCapabilities,
+  useRouteSelections,
+  useUpsertRouteSelection,
+} from "@proliferate/cloud-sdk-react";
+import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
+import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
+import { planFirstRunAuthAdoption } from "@/lib/domain/agents/auth-onboarding";
+
+/**
+ * First-run adoption of local native credentials into route selections
+ * (spec §9). Runs once per app run, and only when the user has zero route
+ * selections, so a fresh profile picks up whatever the local AnyHarness
+ * credential scan detected (or falls back to the managed gateway).
+ *
+ * Fire-and-forget: adoption failures are logged and never surfaced — the
+ * settings page stays the authoritative place to manage routes.
+ */
+export function useFirstRunAuthAdoption() {
+  const { cloudActive } = useCloudAvailabilityState();
+  const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
+  const selectionsQuery = useRouteSelections(cloudActive);
+  const {
+    agents,
+    isLoading: agentsLoading,
+    reconcileSnapshot,
+    reconcileStatus,
+  } = useAgentCatalog();
+  const upsertSelection = useUpsertRouteSelection();
+  const attemptedRef = useRef(false);
+
+  const selections = selectionsQuery.data?.selections;
+  const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
+  const upsertMutate = upsertSelection.mutate;
+
+  // The runtime hydrates the bundled seed then runs an installed-only reconcile
+  // at startup; agent credential/install states are only trustworthy once that
+  // pass has SETTLED. Deciding from a mid-hydration snapshot permanently misses
+  // native creds for harnesses that hydrate after the (one-shot) decision.
+  const reconcileActive =
+    reconcileStatus === "queued" || reconcileStatus === "running";
+  const readinessSettled = reconcileSnapshot !== null && !reconcileActive;
+
+  useEffect(() => {
+    if (attemptedRef.current || !cloudActive) {
+      return;
+    }
+    // Wait until every input has settled before deciding anything.
+    if (selections === undefined || gatewayEnabled === undefined) {
+      return;
+    }
+    if (agentsLoading || agents.length === 0) {
+      return;
+    }
+    if (!readinessSettled) {
+      return;
+    }
+
+    attemptedRef.current = true;
+    const actions = planFirstRunAuthAdoption({
+      agents,
+      selectionCount: selections.length,
+      gatewayEnabled,
+    });
+    for (const action of actions) {
+      upsertMutate(
+        {
+          harnessKind: action.harnessKind,
+          surface: action.surface,
+          body: { route: action.route },
+        },
+        {
+          onError: (error) => {
+            console.warn(
+              `[agent-auth] first-run adoption failed for ${action.harnessKind}`,
+              error,
+            );
+          },
+        },
+      );
+    }
+  }, [
+    agents,
+    agentsLoading,
+    cloudActive,
+    gatewayEnabled,
+    readinessSettled,
+    selections,
+    upsertMutate,
+  ]);
+}

--- a/apps/desktop/src/lib/domain/agents/auth-onboarding.test.ts
+++ b/apps/desktop/src/lib/domain/agents/auth-onboarding.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { AgentSummary } from "@anyharness/sdk";
+import {
+  hasDetectedNativeAuth,
+  planFirstRunAuthAdoption,
+  resolveAgentAuthDisplay,
+} from "./auth-onboarding";
+
+function agent(overrides: Partial<AgentSummary> = {}): AgentSummary {
+  return {
+    kind: "claude",
+    displayName: "Claude Code",
+    agentProcess: { state: "ready" },
+    credentialState: "ready",
+    expectedEnvVars: [],
+    installState: "installed",
+    nativeRequired: false,
+    readiness: "ready",
+    supportsLogin: true,
+    ...overrides,
+  } as AgentSummary;
+}
+
+describe("hasDetectedNativeAuth", () => {
+  it("detects installed agents with ready credentials", () => {
+    expect(hasDetectedNativeAuth(agent())).toBe(true);
+  });
+
+  it("rejects agents that still need login or install", () => {
+    expect(
+      hasDetectedNativeAuth(agent({ credentialState: "login_required" })),
+    ).toBe(false);
+    expect(
+      hasDetectedNativeAuth(
+        agent({ installState: "install_required", readiness: "install_required" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveAgentAuthDisplay", () => {
+  it("shows the loading gate for a not-yet-loaded record instead of auth controls", () => {
+    expect(resolveAgentAuthDisplay(null, true)).toBe("loading");
+  });
+
+  it("shows the install gate for a missing record once loading has finished", () => {
+    expect(resolveAgentAuthDisplay(null, false)).toBe("install-gate");
+  });
+
+  it("shows the install gate when the local agent still needs installing", () => {
+    expect(
+      resolveAgentAuthDisplay(
+        agent({ installState: "install_required", readiness: "install_required" }),
+        false,
+      ),
+    ).toBe("install-gate");
+  });
+
+  it("shows auth controls only for a present, installed record", () => {
+    expect(resolveAgentAuthDisplay(agent(), false)).toBe("auth-controls");
+  });
+});
+
+describe("planFirstRunAuthAdoption", () => {
+  it("adopts native local selections for each harness with detected auth", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [
+        agent({ kind: "claude" }),
+        agent({ kind: "codex" }),
+        agent({ kind: "gemini", credentialState: "login_required" }),
+      ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([
+      { harnessKind: "claude", surface: "local", route: "native" },
+      { harnessKind: "codex", surface: "local", route: "native" },
+    ]);
+  });
+
+  it("is a no-op when any route selection already exists", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [agent({ kind: "claude" })],
+      selectionCount: 1,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([]);
+  });
+
+  it("preselects the gateway for installed harnesses when nothing is detected", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [
+        agent({ kind: "claude", credentialState: "login_required" }),
+        agent({
+          kind: "codex",
+          credentialState: "unknown",
+          installState: "install_required",
+          readiness: "install_required",
+        }),
+      ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([
+      { harnessKind: "claude", surface: "local", route: "gateway" },
+    ]);
+  });
+
+  it("does nothing when nothing is detected and the gateway is disabled", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [agent({ kind: "claude", credentialState: "login_required" })],
+      selectionCount: 0,
+      gatewayEnabled: false,
+    });
+
+    expect(actions).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/domain/agents/auth-onboarding.ts
+++ b/apps/desktop/src/lib/domain/agents/auth-onboarding.ts
@@ -1,0 +1,84 @@
+import type { AgentSummary } from "@anyharness/sdk";
+import { agentNeedsInstall } from "@/lib/domain/agents/status";
+
+/**
+ * First-run auth adoption (spec §9, PR 12).
+ *
+ * When the user has NO route selections yet, the desktop adopts what the
+ * local AnyHarness credential scan already detected:
+ * - each harness with detected native auth → (harness, local, native)
+ * - nothing detected → preselect the managed gateway for installed
+ *   harnesses (only when the gateway is enabled for the account)
+ *
+ * The plan is only produced when zero selections exist, which makes the
+ * whole flow idempotent: after the first write (or any manual choice in
+ * settings) later runs are a no-op.
+ */
+
+export interface AuthAdoptionAction {
+  harnessKind: string;
+  surface: "local";
+  route: "native" | "gateway";
+}
+
+export interface FirstRunAuthAdoptionInput {
+  agents: AgentSummary[];
+  /** Existing route selections across all surfaces. */
+  selectionCount: number;
+  gatewayEnabled: boolean;
+}
+
+/** Native credentials detected by the local AnyHarness credential scan. */
+export function hasDetectedNativeAuth(agent: AgentSummary): boolean {
+  return agent.credentialState === "ready" && agent.installState === "installed";
+}
+
+/** Which authentication surface the settings pane shows for a harness. */
+export type AgentAuthDisplay = "auth-controls" | "install-gate" | "loading";
+
+/**
+ * Decide what to render for a harness's auth section (spec §9).
+ *
+ * A missing or not-yet-loaded local agent record must NOT fall through to the
+ * full auth controls — that would let a user pick a route for a harness that
+ * isn't installed/known yet. Missing → install gate; still loading → loading;
+ * only a present, installed record gets the auth controls.
+ */
+export function resolveAgentAuthDisplay(
+  localAgent: AgentSummary | null,
+  agentsLoading: boolean,
+): AgentAuthDisplay {
+  if (!localAgent) {
+    return agentsLoading ? "loading" : "install-gate";
+  }
+  return agentNeedsInstall(localAgent) ? "install-gate" : "auth-controls";
+}
+
+export function planFirstRunAuthAdoption(
+  input: FirstRunAuthAdoptionInput,
+): AuthAdoptionAction[] {
+  if (input.selectionCount > 0) {
+    return [];
+  }
+
+  const detected = input.agents.filter(hasDetectedNativeAuth);
+  if (detected.length > 0) {
+    return detected.map((agent) => ({
+      harnessKind: agent.kind,
+      surface: "local",
+      route: "native",
+    }));
+  }
+
+  if (!input.gatewayEnabled) {
+    return [];
+  }
+
+  return input.agents
+    .filter((agent) => agent.installState === "installed")
+    .map((agent) => ({
+      harnessKind: agent.kind,
+      surface: "local",
+      route: "gateway",
+    }));
+}


### PR DESCRIPTION
PR 12 of the agent-auth stack (spec §9 Onboarding, §10 PR 12). Desktop-only.

## What

- **First-run local adoption** (`useFirstRunAuthAdoption`, mounted at app startup in `App.tsx`): once cloud is active and route selections + gateway capabilities + the AnyHarness agent list have settled, and the user has **zero** route selections, each harness with detected native auth (`credentialState === "ready"` + installed) gets a `(harness, local, native)` selection upserted via the PR 4 hook. Fire-and-forget with per-harness error tolerance (failures only logged); idempotent because the plan is only produced when zero selections exist.
- **Gateway default**: when nothing is detected locally and `capabilities.gatewayEnabled`, installed harnesses are preselected onto `(harness, local, gateway)`; the gateway route row now carries the minimal free-credits pitch ("Free credits included, no setup required."). Cloud surface already defaults to gateway in the settings UI (PR 10).
- **Install gates**: on the agents settings overview (`AgentDefaultsPane`), harnesses whose local runtime state is `install_required` show an `AgentAuthInstallGate` card with an Install action (opens the existing `AgentSetupModal`) instead of the auth route controls.
- Pure planning logic lives in `lib/domain/agents/auth-onboarding.ts` for unit testing.

## Verification

- `npx tsc --noEmit` (apps/desktop): clean.
- New tests: `auth-onboarding.test.ts` (6) + `use-first-run-auth-adoption.test.tsx` (6) — cover: no selections → adopts detected native; existing selections → no-op; nothing detected → gateway preselect when enabled; gateway disabled → nothing; waits for queries and runs once; cloud inactive → nothing.
- Full desktop suite: 18 failures in 8 files, byte-identical to the clean base branch run (pre-existing); zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)