### PR TITLE
feat(cloud): integration management APIs (authenticate, oauth, admin)

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1259,6 +1259,195 @@ export interface paths {
         patch: operations["update_agent_run_config_endpoint_v1_cloud_agent_run_configs__config_id__patch"];
         trace?: never;
     };
+    "/v1/cloud/workers/desktop/enrollment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Desktop Worker Enrollment Endpoint */
+        post: operations["create_desktop_worker_enrollment_endpoint_v1_cloud_workers_desktop_enrollment_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/enroll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Enroll Worker Endpoint */
+        post: operations["enroll_worker_endpoint_v1_cloud_worker_enroll_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/worker/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Worker Heartbeat Endpoint */
+        post: operations["worker_heartbeat_endpoint_v1_cloud_worker_heartbeat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integration-gateway/mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Integration Gateway Mcp Get */
+        get: operations["integration_gateway_mcp_get_v1_cloud_integration_gateway_mcp_get"];
+        put?: never;
+        /** Integration Gateway Mcp Post */
+        post: operations["integration_gateway_mcp_post_v1_cloud_integration_gateway_mcp_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/authentications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticate Integration Endpoint */
+        post: operations["authenticate_integration_endpoint_v1_cloud_integrations_authentications_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/accounts/{account_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove Integration Account Endpoint */
+        delete: operations["remove_integration_account_endpoint_v1_cloud_integrations_accounts__account_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/oauth/flows/{flow_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Integration Oauth Flow Endpoint */
+        get: operations["get_integration_oauth_flow_endpoint_v1_cloud_integrations_oauth_flows__flow_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/oauth/flows/{flow_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel Integration Oauth Flow Endpoint */
+        post: operations["cancel_integration_oauth_flow_endpoint_v1_cloud_integrations_oauth_flows__flow_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/oauth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Integration Oauth Callback Endpoint */
+        get: operations["integration_oauth_callback_endpoint_v1_cloud_integrations_oauth_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/admin/organizations/{organization_id}/definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Admin Integration Definitions Endpoint */
+        get: operations["list_admin_integration_definitions_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions_get"];
+        put?: never;
+        /** Create Admin Integration Definition Endpoint */
+        post: operations["create_admin_integration_definition_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/integrations/admin/organizations/{organization_id}/definitions/{definition_id}/enabled": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Set Admin Integration Enabled Endpoint */
+        patch: operations["set_admin_integration_enabled_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions__definition_id__enabled_patch"];
+        trace?: never;
+    };
     "/v1/cloud/webhooks/e2b": {
         parameters: {
             query?: never;
@@ -1874,6 +2063,30 @@ export interface components {
             githubIdentityId: string | null;
             /** Githubgrantstatus */
             githubGrantStatus: string | null;
+        };
+        /** AdminIntegrationDefinitionResponse */
+        AdminIntegrationDefinitionResponse: {
+            /**
+             * Definitionid
+             * Format: uuid
+             */
+            definitionId: string;
+            /** Namespace */
+            namespace: string;
+            /** Displayname */
+            displayName: string;
+            /** Source */
+            source: string;
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Authkind */
+            authKind: string;
+            /** Enabledbydefault */
+            enabledByDefault: boolean;
+            /** Policyenabled */
+            policyEnabled?: boolean | null;
+            /** Effectiveenabled */
+            effectiveEnabled: boolean;
         };
         /** AgentAuthSlotCapability */
         AgentAuthSlotCapability: {
@@ -2518,6 +2731,41 @@ export interface components {
             providerAvailability: components["schemas"]["AuthProviderAvailability"][];
             passwordCredential: components["schemas"]["AuthPasswordCredential"];
         };
+        /** AuthenticateIntegrationRequest */
+        AuthenticateIntegrationRequest: {
+            /**
+             * Definitionid
+             * Format: uuid
+             */
+            definitionId: string;
+            /**
+             * Authkind
+             * @enum {string}
+             */
+            authKind: "oauth2" | "api_key" | "none";
+            /** Apikey */
+            apiKey?: string | null;
+            /** Settings */
+            settings?: {
+                [key: string]: unknown;
+            } | null;
+            /** Callbacksurface */
+            callbackSurface?: ("desktop" | "web") | null;
+            /** Finalsurface */
+            finalSurface?: ("desktop" | "web") | null;
+            /** Returnpath */
+            returnPath?: string | null;
+        };
+        /** AuthenticateIntegrationResponse */
+        AuthenticateIntegrationResponse: {
+            account: components["schemas"]["IntegrationAccountResponse"];
+            /** Oauthflowid */
+            oauthFlowId?: string | null;
+            /** Authorizationurl */
+            authorizationUrl?: string | null;
+            /** Expiresat */
+            expiresAt?: string | null;
+        };
         /**
          * AuthorizeParams
          * @description Query params the desktop app sends when opening the browser.
@@ -2927,6 +3175,15 @@ export interface components {
              */
             source: "persisted" | "default";
         };
+        /** CreateAdminIntegrationDefinitionRequest */
+        CreateAdminIntegrationDefinitionRequest: {
+            /** Displayname */
+            displayName: string;
+            /** Namespace */
+            namespace: string;
+            /** Mcpurl */
+            mcpUrl: string;
+        };
         /** CreateCloudWorkspaceRequest */
         CreateCloudWorkspaceRequest: {
             /**
@@ -2958,6 +3215,21 @@ export interface components {
         DeleteCloudSecretFileRequest: {
             /** Path */
             path: string;
+        };
+        /** DesktopWorkerEnrollmentRequest */
+        DesktopWorkerEnrollmentRequest: {
+            /** Desktopinstallid */
+            desktopInstallId: string;
+        };
+        /** DesktopWorkerEnrollmentResponse */
+        DesktopWorkerEnrollmentResponse: {
+            /** Enrollmenttoken */
+            enrollmentToken: string;
+            /**
+             * Expiresat
+             * Format: date-time
+             */
+            expiresAt: string;
         };
         /** DevDesktopHandoffPollResponse */
         DevDesktopHandoffPollResponse: {
@@ -3096,6 +3368,62 @@ export interface components {
              * @default 0.1.0
              */
             version: string;
+        };
+        /** IntegrationAccountResponse */
+        IntegrationAccountResponse: {
+            /**
+             * Accountid
+             * Format: uuid
+             */
+            accountId: string;
+            /**
+             * Definitionid
+             * Format: uuid
+             */
+            definitionId: string;
+            /** Namespace */
+            namespace: string;
+            /** Displayname */
+            displayName: string;
+            /** Authkind */
+            authKind: string;
+            /** Status */
+            status: string;
+            /** Enabled */
+            enabled: boolean;
+        };
+        /**
+         * IntegrationGatewayConfig
+         * @description The AnyHarness-facing gateway config the worker writes to a dotfile.
+         */
+        IntegrationGatewayConfig: {
+            /** Url */
+            url: string;
+            /** Authorization */
+            authorization: string;
+        };
+        /** IntegrationOAuthFlowStatusResponse */
+        IntegrationOAuthFlowStatusResponse: {
+            /**
+             * Flowid
+             * Format: uuid
+             */
+            flowId: string;
+            /** Status */
+            status: string;
+            /** Authorizationurl */
+            authorizationUrl?: string | null;
+            /**
+             * Expiresat
+             * Format: date-time
+             */
+            expiresAt: string;
+            /** Failurecode */
+            failureCode?: string | null;
+            /** Callbacksurface */
+            callbackSurface: string;
+            /** Finalsurface */
+            finalSurface: string;
         };
         /** OAuthAvailabilityResponse */
         OAuthAvailabilityResponse: {
@@ -3706,6 +4034,11 @@ export interface components {
              */
             runCommand: string;
         };
+        /** SetIntegrationEnabledRequest */
+        SetIntegrationEnabledRequest: {
+            /** Enabled */
+            enabled: boolean;
+        };
         /** SsoDiscoveryResponse */
         SsoDiscoveryResponse: {
             /** Enabled */
@@ -3976,6 +4309,46 @@ export interface components {
             input?: unknown;
             /** Context */
             ctx?: Record<string, never>;
+        };
+        /** WorkerEnrollRequest */
+        WorkerEnrollRequest: {
+            /** Enrollmenttoken */
+            enrollmentToken: string;
+            /** Machinefingerprint */
+            machineFingerprint?: string | null;
+            /** Hostname */
+            hostname?: string | null;
+            /** Workerversion */
+            workerVersion?: string | null;
+            /** Anyharnessversion */
+            anyharnessVersion?: string | null;
+        };
+        /** WorkerEnrollResponse */
+        WorkerEnrollResponse: {
+            /** Workerid */
+            workerId: string;
+            /** Workertoken */
+            workerToken: string;
+            /** Heartbeatintervalseconds */
+            heartbeatIntervalSeconds: number;
+            integrationGateway: components["schemas"]["IntegrationGatewayConfig"];
+        };
+        /** WorkerHeartbeatRequest */
+        WorkerHeartbeatRequest: {
+            /** Status */
+            status?: string | null;
+        };
+        /** WorkerHeartbeatResponse */
+        WorkerHeartbeatResponse: {
+            /** Workerid */
+            workerId: string;
+            /**
+             * Servertime
+             * Format: date-time
+             */
+            serverTime: string;
+            /** Heartbeatintervalseconds */
+            heartbeatIntervalSeconds: number;
         };
         /** WorkspaceCloudAccessSummary */
         WorkspaceCloudAccessSummary: {
@@ -6929,6 +7302,411 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentRunConfigResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_desktop_worker_enrollment_endpoint_v1_cloud_workers_desktop_enrollment_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DesktopWorkerEnrollmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DesktopWorkerEnrollmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enroll_worker_endpoint_v1_cloud_worker_enroll_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerEnrollRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerEnrollResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_heartbeat_endpoint_v1_cloud_worker_heartbeat_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkerHeartbeatRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerHeartbeatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    integration_gateway_mcp_get_v1_cloud_integration_gateway_mcp_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    integration_gateway_mcp_post_v1_cloud_integration_gateway_mcp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    authenticate_integration_endpoint_v1_cloud_integrations_authentications_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthenticateIntegrationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthenticateIntegrationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_integration_account_endpoint_v1_cloud_integrations_accounts__account_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_integration_oauth_flow_endpoint_v1_cloud_integrations_oauth_flows__flow_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                flow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationOAuthFlowStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_integration_oauth_flow_endpoint_v1_cloud_integrations_oauth_flows__flow_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                flow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationOAuthFlowStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    integration_oauth_callback_endpoint_v1_cloud_integrations_oauth_callback_get: {
+        parameters: {
+            query?: {
+                code?: string | null;
+                state?: string | null;
+                error?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+            /** @description Redirect to web OAuth completion */
+            303: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_admin_integration_definitions_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminIntegrationDefinitionResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_admin_integration_definition_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAdminIntegrationDefinitionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminIntegrationDefinitionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_admin_integration_enabled_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions__definition_id__enabled_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+                definition_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetIntegrationEnabledRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminIntegrationDefinitionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/server/proliferate/db/store/integrations/tool_cache.py
+++ b/server/proliferate/db/store/integrations/tool_cache.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.cloud.integrations import CloudIntegrationToolSchemaCache
@@ -121,3 +121,20 @@ async def mark_tool_cache_stale(
     await db.flush()
     await db.refresh(cache)
     return _record(cache)
+
+
+async def delete_tool_cache(
+    db: AsyncSession,
+    account_id: UUID,
+) -> None:
+    """Delete the tool-schema cache row for ``account_id`` (no-op if absent).
+
+    The cache keys on ``account_id`` with no FK cascade, so account deletion
+    must clear this row explicitly.
+    """
+    await db.execute(
+        delete(CloudIntegrationToolSchemaCache).where(
+            CloudIntegrationToolSchemaCache.account_id == account_id
+        )
+    )
+    await db.flush()

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -10,6 +10,8 @@ from proliferate.server.cloud.github_app.api import (
 )
 from proliferate.server.cloud.github_app.api import router as github_app_router
 from proliferate.server.cloud.integration_gateway.api import router as integration_gateway_router
+from proliferate.server.cloud.integrations.api import admin_router as integrations_admin_router
+from proliferate.server.cloud.integrations.api import router as integrations_router
 from proliferate.server.cloud.repos.api import router as repos_router
 from proliferate.server.cloud.repositories.api import router as repositories_router
 from proliferate.server.cloud.runtime_workers.api import (
@@ -37,4 +39,6 @@ router.include_router(agent_run_config_router)
 router.include_router(runtime_workers_router)
 router.include_router(runtime_worker_router)
 router.include_router(integration_gateway_router)
+router.include_router(integrations_router)
+router.include_router(integrations_admin_router)
 router.include_router(webhooks_router)

--- a/server/proliferate/server/cloud/integrations/api.py
+++ b/server/proliferate/server/cloud/integrations/api.py
@@ -1,0 +1,225 @@
+"""HTTP routes for integration management.
+
+- ``router`` (``/integrations``): user-authenticated authentication,
+  account removal, and OAuth flow lifecycle + the shared browser callback.
+- ``admin_router`` (``/integrations/admin``): org-admin definition/policy
+  management (admin authorization is enforced inside the service).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.config import settings
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.models import (
+    AdminIntegrationDefinitionResponse,
+    AuthenticateIntegrationRequest,
+    AuthenticateIntegrationResponse,
+    CreateAdminIntegrationDefinitionRequest,
+    IntegrationOAuthFlowStatusResponse,
+    SetIntegrationEnabledRequest,
+)
+from proliferate.server.cloud.integrations.oauth import OAuthFlowStatus
+from proliferate.server.cloud.integrations.pages import (
+    build_integration_oauth_web_completion_url,
+    make_integration_oauth_callback_page,
+)
+from proliferate.server.cloud.integrations.service import (
+    authenticate_integration,
+    cancel_integration_oauth_flow,
+    complete_integration_oauth_callback,
+    create_admin_integration_definition,
+    get_integration_oauth_flow_status,
+    list_admin_integration_definitions,
+    remove_integration_account,
+    set_admin_integration_enabled,
+)
+
+router = APIRouter(prefix="/integrations", tags=["integrations"])
+admin_router = APIRouter(prefix="/integrations/admin", tags=["integrations-admin"])
+
+
+def _flow_status_response(status: OAuthFlowStatus) -> IntegrationOAuthFlowStatusResponse:
+    flow = status.flow
+    return IntegrationOAuthFlowStatusResponse(
+        flow_id=flow.id,
+        status=flow.status,
+        authorization_url=(flow.authorization_url if status.include_authorization_url else None),
+        expires_at=flow.expires_at,
+        failure_code=flow.failure_code,
+        callback_surface=flow.callback_surface,
+        final_surface=flow.final_surface,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# User routes
+# --------------------------------------------------------------------------- #
+
+
+@router.post("/authentications", response_model=AuthenticateIntegrationResponse)
+async def authenticate_integration_endpoint(
+    body: AuthenticateIntegrationRequest,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AuthenticateIntegrationResponse:
+    return await authenticate_integration(
+        db,
+        user_id=user.id,
+        definition_id=body.definition_id,
+        auth_kind=body.auth_kind,
+        api_key=body.api_key,
+        settings=body.settings,
+        callback_surface=body.callback_surface,
+        final_surface=body.final_surface,
+        return_path=body.return_path,
+    )
+
+
+@router.delete("/accounts/{account_id}", status_code=204)
+async def remove_integration_account_endpoint(
+    account_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> Response:
+    await remove_integration_account(db, user_id=user.id, account_id=account_id)
+    return Response(status_code=204)
+
+
+@router.get("/oauth/flows/{flow_id}", response_model=IntegrationOAuthFlowStatusResponse)
+async def get_integration_oauth_flow_endpoint(
+    flow_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> IntegrationOAuthFlowStatusResponse:
+    status = await get_integration_oauth_flow_status(db, user_id=user.id, flow_id=flow_id)
+    return _flow_status_response(status)
+
+
+@router.post("/oauth/flows/{flow_id}/cancel", response_model=IntegrationOAuthFlowStatusResponse)
+async def cancel_integration_oauth_flow_endpoint(
+    flow_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> IntegrationOAuthFlowStatusResponse:
+    status = await cancel_integration_oauth_flow(db, user_id=user.id, flow_id=flow_id)
+    return _flow_status_response(status)
+
+
+@router.get(
+    "/oauth/callback",
+    response_class=HTMLResponse,
+    responses={303: {"description": "Redirect to web OAuth completion"}},
+)
+async def integration_oauth_callback_endpoint(
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_async_session),
+) -> Response:
+    if not state:
+        return make_integration_oauth_callback_page(
+            ok=False,
+            status="failed",
+            failure_code="invalid_state",
+        )
+    try:
+        result = await complete_integration_oauth_callback(
+            db,
+            state=state,
+            code=code,
+            provider_error=error,
+        )
+    except CloudApiError:
+        return make_integration_oauth_callback_page(
+            ok=False,
+            status="failed",
+            failure_code="invalid_state",
+        )
+    if result.callback_surface == "web" and result.return_path:
+        return RedirectResponse(
+            build_integration_oauth_web_completion_url(
+                frontend_base_url=settings.frontend_base_url,
+                return_path=result.return_path,
+                flow_id=str(result.flow_id) if result.flow_id else "",
+                status=result.status,
+                final_surface=result.final_surface,
+                failure_code=result.failure_code,
+            ),
+            status_code=303,
+        )
+    return make_integration_oauth_callback_page(
+        ok=result.ok,
+        status=result.status,
+        flow_id=result.flow_id,
+        failure_code=result.failure_code,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Org-admin routes
+# --------------------------------------------------------------------------- #
+
+
+@admin_router.get(
+    "/organizations/{organization_id}/definitions",
+    response_model=list[AdminIntegrationDefinitionResponse],
+)
+async def list_admin_integration_definitions_endpoint(
+    organization_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> list[AdminIntegrationDefinitionResponse]:
+    return await list_admin_integration_definitions(
+        db,
+        organization_id=organization_id,
+        actor_user_id=user.id,
+    )
+
+
+@admin_router.post(
+    "/organizations/{organization_id}/definitions",
+    response_model=AdminIntegrationDefinitionResponse,
+)
+async def create_admin_integration_definition_endpoint(
+    organization_id: UUID,
+    body: CreateAdminIntegrationDefinitionRequest,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AdminIntegrationDefinitionResponse:
+    return await create_admin_integration_definition(
+        db,
+        organization_id=organization_id,
+        actor_user_id=user.id,
+        display_name=body.display_name,
+        namespace=body.namespace,
+        mcp_url=body.mcp_url,
+    )
+
+
+@admin_router.patch(
+    "/organizations/{organization_id}/definitions/{definition_id}/enabled",
+    response_model=AdminIntegrationDefinitionResponse,
+)
+async def set_admin_integration_enabled_endpoint(
+    organization_id: UUID,
+    definition_id: UUID,
+    body: SetIntegrationEnabledRequest,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> AdminIntegrationDefinitionResponse:
+    return await set_admin_integration_enabled(
+        db,
+        organization_id=organization_id,
+        definition_id=definition_id,
+        actor_user_id=user.id,
+        enabled=body.enabled,
+    )

--- a/server/proliferate/server/cloud/integrations/models.py
+++ b/server/proliferate/server/cloud/integrations/models.py
@@ -1,0 +1,90 @@
+"""Request/response models for the integration management API.
+
+camelCase on the wire (``alias_generator=to_camel``); accept snake_case too
+(``populate_by_name=True``), mirroring the runtime_workers models.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+AuthKind = Literal["oauth2", "api_key", "none"]
+Surface = Literal["desktop", "web"]
+
+
+class _CamelModel(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+# --------------------------------------------------------------------------- #
+# User-facing authentication
+# --------------------------------------------------------------------------- #
+
+
+class AuthenticateIntegrationRequest(_CamelModel):
+    definition_id: UUID
+    auth_kind: AuthKind
+    api_key: str | None = None
+    settings: dict[str, Any] | None = None
+    callback_surface: Surface | None = None
+    final_surface: Surface | None = None
+    return_path: str | None = None
+
+
+class IntegrationAccountResponse(_CamelModel):
+    account_id: UUID
+    definition_id: UUID
+    namespace: str
+    display_name: str
+    auth_kind: str
+    status: str
+    enabled: bool
+
+
+class AuthenticateIntegrationResponse(_CamelModel):
+    account: IntegrationAccountResponse
+    oauth_flow_id: str | None = None
+    authorization_url: str | None = None
+    expires_at: datetime | None = None
+
+
+class IntegrationOAuthFlowStatusResponse(_CamelModel):
+    flow_id: UUID
+    status: str
+    authorization_url: str | None = None
+    expires_at: datetime
+    failure_code: str | None = None
+    callback_surface: str
+    final_surface: str
+
+
+# --------------------------------------------------------------------------- #
+# Org-admin definition management
+# --------------------------------------------------------------------------- #
+
+
+class AdminIntegrationDefinitionResponse(_CamelModel):
+    definition_id: UUID
+    namespace: str
+    display_name: str
+    source: str
+    organization_id: UUID | None = None
+    auth_kind: str
+    enabled_by_default: bool
+    policy_enabled: bool | None = None
+    effective_enabled: bool
+
+
+class CreateAdminIntegrationDefinitionRequest(_CamelModel):
+    display_name: str
+    namespace: str
+    mcp_url: str
+
+
+class SetIntegrationEnabledRequest(_CamelModel):
+    enabled: bool

--- a/server/proliferate/server/cloud/integrations/pages.py
+++ b/server/proliferate/server/cloud/integrations/pages.py
@@ -1,0 +1,105 @@
+"""Browser-facing OAuth callback rendering for cloud integrations.
+
+Ported from ``server/cloud/mcp_oauth/pages.py`` +
+``mcp_oauth/domain/flow_rules.build_oauth_web_completion_url`` (commit
+``4b54c9f2b``), adapted onto the integrations flow result shape.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote, urlsplit
+from uuid import UUID
+
+from fastapi.responses import HTMLResponse
+
+from proliferate.constants.auth import (
+    DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
+    DESKTOP_REDIRECT_SCHEME,
+)
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
+
+
+def make_integration_oauth_callback_page(
+    *,
+    ok: bool,
+    status: str,
+    flow_id: UUID | None = None,
+    failure_code: str | None = None,
+) -> HTMLResponse:
+    deep_link_url = _integration_oauth_desktop_deep_link(
+        status=status,
+        flow_id=flow_id,
+        failure_code=failure_code,
+    )
+    title = "Authorization done" if ok else "Authorization failed"
+    message = (
+        "Redirecting to desktop app..."
+        if ok
+        else "Return to Proliferate and try connecting this integration again."
+    )
+    detail = (
+        None
+        if ok
+        else (
+            "No tokens were exposed in this browser page. The desktop app will show "
+            "the latest connection state."
+        )
+    )
+    fallback_message = "If Proliferate did not open automatically, use the button below."
+    return make_redirect_callback_response(
+        title=title,
+        status_label="Integrations",
+        message=message,
+        tone="success" if ok else "error",
+        detail=detail,
+        action_label="Open Proliferate",
+        action_href=deep_link_url,
+        action_visible=not DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
+        launch_url=deep_link_url if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
+        fallback_message=fallback_message if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
+        variant="handoff" if ok else "default",
+    )
+
+
+def _integration_oauth_desktop_deep_link(
+    *,
+    status: str,
+    flow_id: UUID | None,
+    failure_code: str | None,
+) -> str:
+    url = f"{DESKTOP_REDIRECT_SCHEME}://plugins?source=integration_oauth_callback&status={status}"
+    if flow_id is not None:
+        url += f"&flowId={flow_id}"
+    if failure_code:
+        url += f"&failureCode={failure_code}"
+    return url
+
+
+def build_integration_oauth_web_completion_url(
+    *,
+    frontend_base_url: str,
+    return_path: str,
+    flow_id: str,
+    status: str,
+    final_surface: str,
+    failure_code: str | None,
+) -> str:
+    base = frontend_base_url.strip().rstrip("/")
+    parts = urlsplit(base)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        raise CloudApiError(
+            "invalid_payload", "Frontend base URL is not configured correctly.", status_code=400
+        )
+    query = {
+        "source": "integration_oauth_callback",
+        "flowId": flow_id,
+        "status": status,
+        "finalSurface": final_surface,
+    }
+    if failure_code:
+        query["failureCode"] = failure_code
+    encoded = "&".join(
+        f"{quote(key, safe='')}={quote(value, safe='')}" for key, value in query.items()
+    )
+    return f"{base}{return_path}?{encoded}"

--- a/server/proliferate/server/cloud/integrations/service.py
+++ b/server/proliferate/server/cloud/integrations/service.py
@@ -1,0 +1,392 @@
+"""Service layer for integration management.
+
+A thin API/service layer over the integration primitives (accounts,
+definitions, policies stores + the OAuth flow lifecycle in
+``oauth``). It authenticates a user's integration accounts, removes
+them, and lets org admins manage which definitions their organization exposes.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import organizations as organization_store
+from proliferate.db.store.integrations.accounts import (
+    IntegrationAccountRecord,
+    delete_account,
+    get_account,
+    set_account_credentials,
+    upsert_account,
+)
+from proliferate.db.store.integrations.definitions import (
+    IntegrationDefinitionRecord,
+    create_org_custom_definition,
+    get_definition,
+    list_definitions_visible_to_org,
+)
+from proliferate.db.store.integrations.policies import (
+    list_policies_for_org,
+    upsert_policy,
+)
+from proliferate.db.store.integrations.tool_cache import delete_tool_cache
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.config import (
+    IntegrationConfig,
+    StaticUrl,
+    parse_definition_config,
+    serialize_definition_config,
+)
+from proliferate.server.cloud.integrations.models import (
+    AdminIntegrationDefinitionResponse,
+    AuthenticateIntegrationResponse,
+    IntegrationAccountResponse,
+)
+from proliferate.server.cloud.integrations.oauth import (
+    OAuthCallbackResult,
+    OAuthFlowStatus,
+    cancel_oauth_flow,
+    complete_oauth_callback,
+    get_oauth_flow_status,
+    start_oauth_flow,
+)
+from proliferate.server.organizations.domain.policy import organization_admin_roles
+from proliferate.utils.crypto import encrypt_json
+
+_DEFAULT_SECRET_FIELD_ID = "api_key"
+
+_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _account_response(
+    account: IntegrationAccountRecord,
+    definition: IntegrationDefinitionRecord,
+) -> IntegrationAccountResponse:
+    return IntegrationAccountResponse(
+        account_id=account.id,
+        definition_id=account.definition_id,
+        namespace=definition.namespace,
+        display_name=definition.display_name,
+        auth_kind=account.auth_kind,
+        status=account.status,
+        enabled=account.enabled,
+    )
+
+
+def _admin_definition_response(
+    definition: IntegrationDefinitionRecord,
+    *,
+    policy_enabled: bool | None,
+) -> AdminIntegrationDefinitionResponse:
+    effective_enabled = (
+        policy_enabled if policy_enabled is not None else definition.enabled_by_default
+    )
+    return AdminIntegrationDefinitionResponse(
+        definition_id=definition.id,
+        namespace=definition.namespace,
+        display_name=definition.display_name,
+        source=definition.source,
+        organization_id=definition.organization_id,
+        auth_kind=definition.auth_kind,
+        enabled_by_default=definition.enabled_by_default,
+        policy_enabled=policy_enabled,
+        effective_enabled=effective_enabled,
+    )
+
+
+async def _require_org_admin(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    membership = await organization_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    if membership is None:
+        raise CloudApiError("organization_not_found", "Organization not found.", status_code=404)
+    if membership.role not in organization_admin_roles():
+        raise CloudApiError(
+            "organization_permission_denied",
+            "You do not have permission to manage organization integrations.",
+            status_code=403,
+        )
+
+
+def _first_secret_field_id(definition: IntegrationDefinitionRecord) -> str:
+    try:
+        config = parse_definition_config(definition.config_json)
+    except ValueError:
+        return _DEFAULT_SECRET_FIELD_ID
+    if config.secret_fields:
+        return config.secret_fields[0].id
+    return _DEFAULT_SECRET_FIELD_ID
+
+
+# --------------------------------------------------------------------------- #
+# User-facing authentication
+# --------------------------------------------------------------------------- #
+
+
+async def authenticate_integration(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    definition_id: UUID,
+    auth_kind: str,
+    api_key: str | None = None,
+    settings: dict[str, Any] | None = None,
+    callback_surface: str | None = None,
+    final_surface: str | None = None,
+    return_path: str | None = None,
+) -> AuthenticateIntegrationResponse:
+    """Authenticate ``user_id`` against ``definition_id``.
+
+    - ``none``: mark the account ready immediately.
+    - ``api_key``: store the key under the definition's first secret field and
+      mark the account ready.
+    - ``oauth2``: create the account in ``setup_required`` and start an OAuth
+      flow, returning the authorization URL for the browser handoff.
+    """
+    definition = await get_definition(db, definition_id)
+    if definition is None:
+        raise CloudApiError("not_found", "Integration was not found.", status_code=404)
+    if auth_kind != definition.auth_kind:
+        raise CloudApiError(
+            "invalid_payload",
+            "Requested auth kind does not match this integration.",
+            status_code=400,
+        )
+
+    if auth_kind == "none":
+        account = await upsert_account(
+            db,
+            user_id=user_id,
+            definition_id=definition.id,
+            auth_kind="none",
+            status="ready",
+        )
+        return AuthenticateIntegrationResponse(account=_account_response(account, definition))
+
+    if auth_kind == "api_key":
+        secret = (api_key or "").strip()
+        if not secret:
+            raise CloudApiError("invalid_payload", "API key is required.", status_code=400)
+        account = await upsert_account(
+            db,
+            user_id=user_id,
+            definition_id=definition.id,
+            auth_kind="api_key",
+            status="setup_required",
+        )
+        field_id = _first_secret_field_id(definition)
+        updated = await set_account_credentials(
+            db,
+            account_id=account.id,
+            credential_ciphertext=encrypt_json({"secretFields": {field_id: secret}}),
+            credential_format="secret-fields-v1",
+            auth_status="ready",
+            token_expires_at=None,
+        )
+        account = updated or account
+        return AuthenticateIntegrationResponse(account=_account_response(account, definition))
+
+    # oauth2
+    account = await upsert_account(
+        db,
+        user_id=user_id,
+        definition_id=definition.id,
+        auth_kind="oauth2",
+        status="setup_required",
+    )
+    flow = await start_oauth_flow(
+        db,
+        user_id=user_id,
+        definition=definition,
+        account_id=account.id,
+        settings=settings or {},
+        callback_surface=callback_surface,
+        final_surface=final_surface,
+        return_path=return_path,
+    )
+    return AuthenticateIntegrationResponse(
+        account=_account_response(account, definition),
+        oauth_flow_id=str(flow.flow_id),
+        authorization_url=flow.authorization_url,
+        expires_at=flow.expires_at,
+    )
+
+
+async def remove_integration_account(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    account_id: UUID,
+) -> None:
+    """Delete an integration account (and its tool-schema cache) owned by ``user_id``."""
+    account = await get_account(db, account_id)
+    if account is None or account.owner_user_id != user_id:
+        raise CloudApiError("not_found", "Integration account was not found.", status_code=404)
+    await delete_tool_cache(db, account_id)
+    await delete_account(db, account_id)
+
+
+# --------------------------------------------------------------------------- #
+# OAuth flow adapters (thin wrappers around the oauth package)
+# --------------------------------------------------------------------------- #
+
+
+async def get_integration_oauth_flow_status(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    flow_id: UUID,
+) -> OAuthFlowStatus:
+    return await get_oauth_flow_status(db, user_id=user_id, flow_id=flow_id)
+
+
+async def cancel_integration_oauth_flow(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    flow_id: UUID,
+) -> OAuthFlowStatus:
+    return await cancel_oauth_flow(db, user_id=user_id, flow_id=flow_id)
+
+
+async def complete_integration_oauth_callback(
+    db: AsyncSession,
+    *,
+    state: str,
+    code: str | None,
+    provider_error: str | None = None,
+) -> OAuthCallbackResult:
+    return await complete_oauth_callback(
+        db,
+        state=state,
+        code=code,
+        provider_error=provider_error,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Org-admin definition management
+# --------------------------------------------------------------------------- #
+
+
+async def list_admin_integration_definitions(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    actor_user_id: UUID,
+) -> list[AdminIntegrationDefinitionResponse]:
+    await _require_org_admin(db, user_id=actor_user_id, organization_id=organization_id)
+    definitions = await list_definitions_visible_to_org(db, organization_id)
+    policies = await list_policies_for_org(db, organization_id)
+    policy_by_definition = {policy.definition_id: policy.enabled for policy in policies}
+    return [
+        _admin_definition_response(
+            definition,
+            policy_enabled=policy_by_definition.get(definition.id),
+        )
+        for definition in definitions
+    ]
+
+
+async def create_admin_integration_definition(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    actor_user_id: UUID,
+    display_name: str,
+    namespace: str,
+    mcp_url: str,
+) -> AdminIntegrationDefinitionResponse:
+    await _require_org_admin(db, user_id=actor_user_id, organization_id=organization_id)
+    display_name = display_name.strip()
+    namespace = namespace.strip()
+    mcp_url = mcp_url.strip()
+    if not display_name:
+        raise CloudApiError("invalid_payload", "Display name is required.", status_code=400)
+    if not _NAMESPACE_PATTERN.fullmatch(namespace):
+        raise CloudApiError(
+            "invalid_payload",
+            "Namespace must be 1-64 lowercase alphanumeric, '_' or '-' characters and "
+            "start with a letter or digit.",
+            status_code=400,
+        )
+    try:
+        parsed_url = urlsplit(mcp_url)
+    except ValueError:
+        raise CloudApiError(
+            "invalid_payload",
+            "MCP URL must be a valid http(s) URL.",
+            status_code=400,
+        ) from None
+    if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+        raise CloudApiError(
+            "invalid_payload",
+            "MCP URL must be a valid http(s) URL.",
+            status_code=400,
+        )
+
+    config = IntegrationConfig(
+        transport="http",
+        url=StaticUrl(mcp_url),
+        display_url=mcp_url,
+    )
+    definition = await create_org_custom_definition(
+        db,
+        organization_id=organization_id,
+        namespace=namespace,
+        display_name=display_name,
+        description=None,
+        auth_kind="none",
+        oauth_client_mode=None,
+        config_json=serialize_definition_config(config),
+    )
+    await upsert_policy(
+        db,
+        organization_id=organization_id,
+        definition_id=definition.id,
+        enabled=True,
+        updated_by_user_id=actor_user_id,
+    )
+    return _admin_definition_response(definition, policy_enabled=True)
+
+
+async def set_admin_integration_enabled(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    definition_id: UUID,
+    actor_user_id: UUID,
+    enabled: bool,
+) -> AdminIntegrationDefinitionResponse:
+    await _require_org_admin(db, user_id=actor_user_id, organization_id=organization_id)
+    definition = await get_definition(db, definition_id)
+    if (
+        definition is None
+        or definition.archived_at is not None
+        or (definition.source == "org_custom" and definition.organization_id != organization_id)
+    ):
+        raise CloudApiError("not_found", "Integration was not found.", status_code=404)
+    await upsert_policy(
+        db,
+        organization_id=organization_id,
+        definition_id=definition.id,
+        enabled=enabled,
+        updated_by_user_id=actor_user_id,
+    )
+    return _admin_definition_response(definition, policy_enabled=enabled)

--- a/server/tests/integration/test_cloud_integrations_api.py
+++ b/server/tests/integration/test_cloud_integrations_api.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.integrations.integration_oauth.models import (
+    AuthorizationServerMetadata,
+    ProtectedResourceMetadata,
+    RegisteredOAuthClient,
+)
+from proliferate.server.cloud.integrations.oauth import clients as oauth_clients
+from proliferate.server.cloud.integrations.oauth import service as oauth_service
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
+from proliferate.utils.crypto import decrypt_json
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+from tests.e2e.cloud.helpers.github import seed_linked_github_account
+
+
+async def _authed_user(client: AsyncClient, db_session: AsyncSession, *, prefix: str):
+    auth = await create_user_and_login(client, db_session, email_prefix=prefix)
+    await seed_linked_github_account(
+        db_session,
+        user_id=auth.user_id,
+        access_token=f"gh-{prefix}",
+    )
+    return auth
+
+
+async def _seed_definitions(db_session: AsyncSession):
+    await sync_seed_definitions(db_session)
+    await db_session.commit()
+
+
+async def _definition_id(db_session: AsyncSession, namespace: str) -> str:
+    definition = await definitions_store.get_seed_by_namespace(db_session, namespace)
+    assert definition is not None
+    return str(definition.id)
+
+
+async def _create_org_with_role(db_session: AsyncSession, *, user_id: str, role: str) -> str:
+    now = datetime.now(UTC)
+    organization = Organization(
+        name="Acme",
+        logo_domain="acme.dev",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(organization)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=uuid.UUID(user_id),
+            role=role,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()
+    return str(organization.id)
+
+
+class TestAuthenticateIntegration:
+    @pytest.mark.asyncio
+    async def test_requires_auth(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            json={"definitionId": str(uuid.uuid4()), "authKind": "none"},
+        )
+        assert response.status_code in {401, 403}
+
+    @pytest.mark.asyncio
+    async def test_authenticate_none_returns_ready_account(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-none")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "cloudflare_docs")
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "none"},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["oauthFlowId"] is None
+        account = body["account"]
+        assert account["status"] == "ready"
+        assert account["authKind"] == "none"
+        assert account["namespace"] == "cloudflare_docs"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_api_key_stores_credential(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-key")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "context7")
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={
+                "definitionId": definition_id,
+                "authKind": "api_key",
+                "apiKey": "ctx7sk-secret-value",
+            },
+        )
+        assert response.status_code == 200, response.text
+        account = response.json()["account"]
+        assert account["status"] == "ready"
+        assert account["authKind"] == "api_key"
+
+        stored = await accounts_store.get_account_for_user_definition(
+            db_session,
+            uuid.UUID(auth.user_id),
+            uuid.UUID(definition_id),
+        )
+        assert stored is not None
+        assert stored.credential_format == "secret-fields-v1"
+        assert stored.credential_ciphertext is not None
+        decoded = decrypt_json(stored.credential_ciphertext)
+        assert decoded["secretFields"]["api_key"] == "ctx7sk-secret-value"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_api_key_requires_key(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-key-missing")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "context7")
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "api_key", "apiKey": ""},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "invalid_payload"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_mismatched_auth_kind(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-mismatch")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "context7")
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "none"},
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_authenticate_oauth2_starts_flow(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-oauth")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "sentry")
+
+        async def _fake_protected(server_url: str) -> ProtectedResourceMetadata:
+            return ProtectedResourceMetadata(
+                authorization_servers=("https://auth.example.com",),
+                resource="https://mcp.sentry.dev/mcp",
+                challenged_scope=None,
+            )
+
+        async def _fake_auth_metadata(issuer: str) -> AuthorizationServerMetadata:
+            return AuthorizationServerMetadata(
+                issuer="https://auth.example.com",
+                authorization_endpoint="https://auth.example.com/authorize",
+                token_endpoint="https://auth.example.com/token",
+                registration_endpoint="https://auth.example.com/register",
+                token_endpoint_auth_methods_supported=("none",),
+            )
+
+        async def _fake_register(metadata, redirect_uri) -> RegisteredOAuthClient:
+            return RegisteredOAuthClient(
+                client_id="client-abc",
+                client_secret=None,
+                client_secret_expires_at=None,
+                token_endpoint_auth_method="none",
+                registration_client_uri=None,
+                registration_access_token=None,
+            )
+
+        monkeypatch.setattr(oauth_service, "discover_protected_resource_metadata", _fake_protected)
+        monkeypatch.setattr(
+            oauth_service, "discover_authorization_server_metadata", _fake_auth_metadata
+        )
+        monkeypatch.setattr(
+            oauth_clients, "discover_authorization_server_metadata", _fake_auth_metadata
+        )
+        monkeypatch.setattr(oauth_clients, "register_client", _fake_register)
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "oauth2"},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["account"]["status"] == "setup_required"
+        assert body["oauthFlowId"]
+        assert body["authorizationUrl"].startswith("https://auth.example.com/authorize")
+        assert body["expiresAt"]
+
+        # Flow status endpoint exposes the active flow with its authorization URL.
+        flow_response = await client.get(
+            f"/v1/cloud/integrations/oauth/flows/{body['oauthFlowId']}",
+            headers=auth.headers,
+        )
+        assert flow_response.status_code == 200, flow_response.text
+        flow = flow_response.json()
+        assert flow["status"] == "active"
+        assert flow["authorizationUrl"].startswith("https://auth.example.com/authorize")
+
+
+class TestRemoveAccount:
+    @pytest.mark.asyncio
+    async def test_remove_account(self, client: AsyncClient, db_session: AsyncSession) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-remove")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "cloudflare_docs")
+
+        created = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "none"},
+        )
+        account_id = created.json()["account"]["accountId"]
+
+        removed = await client.delete(
+            f"/v1/cloud/integrations/accounts/{account_id}",
+            headers=auth.headers,
+        )
+        assert removed.status_code == 204, removed.text
+
+        gone = await accounts_store.get_account(db_session, uuid.UUID(account_id))
+        assert gone is None
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_account(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-remove-missing")
+        response = await client.delete(
+            f"/v1/cloud/integrations/accounts/{uuid.uuid4()}",
+            headers=auth.headers,
+        )
+        assert response.status_code == 404
+
+
+class TestAdminDefinitions:
+    @pytest.mark.asyncio
+    async def test_admin_create_and_set_enabled(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-admin")
+        await _seed_definitions(db_session)
+        org_id = await _create_org_with_role(
+            db_session, user_id=auth.user_id, role=ORGANIZATION_ROLE_OWNER
+        )
+
+        created = await client.post(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}/definitions",
+            headers=auth.headers,
+            json={
+                "displayName": "Internal Tools",
+                "namespace": "internal-tools",
+                "mcpUrl": "https://mcp.internal.example.com/mcp",
+            },
+        )
+        assert created.status_code == 200, created.text
+        definition = created.json()
+        assert definition["source"] == "org_custom"
+        assert definition["authKind"] == "none"
+        assert definition["effectiveEnabled"] is True
+        definition_id = definition["definitionId"]
+
+        listed = await client.get(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}/definitions",
+            headers=auth.headers,
+        )
+        assert listed.status_code == 200, listed.text
+        namespaces = {d["namespace"] for d in listed.json()}
+        assert "internal-tools" in namespaces
+        assert "context7" in namespaces  # seed definitions are visible too
+
+        disabled = await client.patch(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}"
+            f"/definitions/{definition_id}/enabled",
+            headers=auth.headers,
+            json={"enabled": False},
+        )
+        assert disabled.status_code == 200, disabled.text
+        assert disabled.json()["effectiveEnabled"] is False
+        assert disabled.json()["policyEnabled"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "namespace",
+        ["", "Internal Tools", "-leading-dash", "UPPER", "a" * 65],
+    )
+    async def test_admin_create_rejects_invalid_namespace(
+        self, client: AsyncClient, db_session: AsyncSession, namespace: str
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-admin-badns")
+        org_id = await _create_org_with_role(
+            db_session, user_id=auth.user_id, role=ORGANIZATION_ROLE_OWNER
+        )
+
+        response = await client.post(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}/definitions",
+            headers=auth.headers,
+            json={
+                "displayName": "Internal Tools",
+                "namespace": namespace,
+                "mcpUrl": "https://mcp.internal.example.com/mcp",
+            },
+        )
+        assert response.status_code == 400, response.text
+        assert response.json()["detail"]["code"] == "invalid_payload"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mcp_url",
+        ["", "not-a-url", "ftp://mcp.example.com/mcp", "https://", "http:///path-only"],
+    )
+    async def test_admin_create_rejects_invalid_mcp_url(
+        self, client: AsyncClient, db_session: AsyncSession, mcp_url: str
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-admin-badurl")
+        org_id = await _create_org_with_role(
+            db_session, user_id=auth.user_id, role=ORGANIZATION_ROLE_OWNER
+        )
+
+        response = await client.post(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}/definitions",
+            headers=auth.headers,
+            json={
+                "displayName": "Internal Tools",
+                "namespace": "internal-tools",
+                "mcpUrl": mcp_url,
+            },
+        )
+        assert response.status_code == 400, response.text
+        assert response.json()["detail"]["code"] == "invalid_payload"
+
+    @pytest.mark.asyncio
+    async def test_admin_create_requires_admin(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-nonadmin")
+        org_id = await _create_org_with_role(
+            db_session, user_id=auth.user_id, role=ORGANIZATION_ROLE_MEMBER
+        )
+
+        response = await client.post(
+            f"/v1/cloud/integrations/admin/organizations/{org_id}/definitions",
+            headers=auth.headers,
+            json={
+                "displayName": "Nope",
+                "namespace": "nope",
+                "mcpUrl": "https://mcp.internal.example.com/mcp",
+            },
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "organization_permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_admin_requires_membership(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-noorg")
+        response = await client.get(
+            f"/v1/cloud/integrations/admin/organizations/{uuid.uuid4()}/definitions",
+            headers=auth.headers,
+        )
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

Fifth PR in the stack (on #832). User- and admin-facing REST APIs over the integration primitives, so users can connect integrations and org admins can manage which are available. Thin layer over the #830 stores + `oauth_service`.

## User routes (product-user auth)
- `POST /v1/cloud/integrations/authentications` — `none` → ready; `api_key` → encrypt + ready; `oauth2` → `setup_required` + `authorizationUrl` + `flowId`
- `DELETE /v1/cloud/integrations/accounts/{account_id}` — also clears the account's tool-schema cache (no DB cascade)
- `GET /v1/cloud/integrations/oauth/flows/{flow_id}` · `POST .../cancel`
- `GET /v1/cloud/integrations/oauth/callback` — desktop HTML page / web 303 redirect

## Admin routes (org-admin enforced in service, reusing the existing membership + admin-role check)
- `GET`/`POST /v1/cloud/integrations/admin/organizations/{org}/definitions`
- `PATCH .../definitions/{definition_id}/enabled` (never deletes user credentials)

Regenerates the cloud SDK openapi types; `tool_cache` gains `delete_tool_cache`.

## Verification
11 integration tests — none/api_key/oauth2 authenticate (oauth discovery+DCR monkeypatched), account removal, admin create + enable, non-admin → 403 / no-membership → 404. Ruff clean; cloud-sdk builds with regenerated types.

> Minimal settings UI + the health endpoint land in the next PR (F). Inherits the pre-existing `main`-red server-ci `test` + repo-shape frontend-drift; no new real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)