### PR TITLE
feat(cloud): integration health endpoint

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1328,6 +1328,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/integrations/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Integration Health Endpoint */
+        get: operations["list_integration_health_endpoint_v1_cloud_integrations_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/integrations/authentications": {
         parameters: {
             query?: never;
@@ -3401,6 +3418,41 @@ export interface components {
             url: string;
             /** Authorization */
             authorization: string;
+        };
+        /** IntegrationHealthItem */
+        IntegrationHealthItem: {
+            /**
+             * Definitionid
+             * Format: uuid
+             */
+            definitionId: string;
+            /** Accountid */
+            accountId?: string | null;
+            /** Namespace */
+            namespace: string;
+            /** Displayname */
+            displayName: string;
+            /** Authkind */
+            authKind: string;
+            /** Effectiveenabled */
+            effectiveEnabled: boolean;
+            /** Policyenabled */
+            policyEnabled?: boolean | null;
+            /** Accountenabled */
+            accountEnabled?: boolean | null;
+            /** Health */
+            health: string;
+            /** Tokenexpiresat */
+            tokenExpiresAt?: string | null;
+            /** Toolcount */
+            toolCount?: number | null;
+            /** Lasterrorcode */
+            lastErrorCode?: string | null;
+        };
+        /** IntegrationHealthResponse */
+        IntegrationHealthResponse: {
+            /** Items */
+            items: components["schemas"]["IntegrationHealthItem"][];
         };
         /** IntegrationOAuthFlowStatusResponse */
         IntegrationOAuthFlowStatusResponse: {
@@ -7450,6 +7502,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    list_integration_health_endpoint_v1_cloud_integrations_health_get: {
+        parameters: {
+            query?: {
+                organizationId?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationHealthResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/server/proliferate/server/cloud/integrations/api.py
+++ b/server/proliferate/server/cloud/integrations/api.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -19,11 +20,14 @@ from proliferate.config import settings
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.health import list_integration_health
 from proliferate.server.cloud.integrations.models import (
     AdminIntegrationDefinitionResponse,
     AuthenticateIntegrationRequest,
     AuthenticateIntegrationResponse,
     CreateAdminIntegrationDefinitionRequest,
+    IntegrationHealthItem,
+    IntegrationHealthResponse,
     IntegrationOAuthFlowStatusResponse,
     SetIntegrationEnabledRequest,
 )
@@ -63,6 +67,18 @@ def _flow_status_response(status: OAuthFlowStatus) -> IntegrationOAuthFlowStatus
 # --------------------------------------------------------------------------- #
 # User routes
 # --------------------------------------------------------------------------- #
+
+
+@router.get("/health", response_model=IntegrationHealthResponse)
+async def list_integration_health_endpoint(
+    organization_id: UUID | None = Query(default=None, alias="organizationId"),
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> IntegrationHealthResponse:
+    health = await list_integration_health(db, user_id=user.id, organization_id=organization_id)
+    return IntegrationHealthResponse(
+        items=[IntegrationHealthItem(**dataclasses.asdict(item)) for item in health]
+    )
 
 
 @router.post("/authentications", response_model=AuthenticateIntegrationResponse)

--- a/server/proliferate/server/cloud/integrations/health.py
+++ b/server/proliferate/server/cloud/integrations/health.py
@@ -1,0 +1,156 @@
+"""Integration health: what's connected, and what needs the user's attention.
+
+For each definition visible to the user we compute a single health verdict by
+combining org policy, the user's account state, and — for OAuth accounts that
+claim to be ready — an active credential probe so a silently-expired token
+surfaces as ``needs_reauth`` rather than failing mid-session.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import organizations as organization_store
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.db.store.integrations import policies as policies_store
+from proliferate.db.store.integrations import tool_cache as tool_cache_store
+from proliferate.db.store.integrations.accounts import IntegrationAccountRecord
+from proliferate.db.store.integrations.definitions import IntegrationDefinitionRecord
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.access import ensure_provider_access
+
+
+class HealthVerdict(StrEnum):
+    """Health verdicts, in rough "needs attention" order."""
+
+    READY = "ready"
+    NEEDS_AUTH = "needs_auth"
+    NEEDS_REAUTH = "needs_reauth"
+    DISABLED_BY_USER = "disabled_by_user"
+    DISABLED_BY_ORG = "disabled_by_org"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class IntegrationHealth:
+    definition_id: UUID
+    account_id: UUID | None
+    namespace: str
+    display_name: str
+    auth_kind: str
+    effective_enabled: bool
+    policy_enabled: bool | None
+    account_enabled: bool | None
+    health: HealthVerdict
+    token_expires_at: datetime | None
+    tool_count: int | None
+    last_error_code: str | None
+
+
+async def _tool_count(db: AsyncSession, account_id: UUID) -> int | None:
+    cache = await tool_cache_store.get_tool_cache(db, account_id)
+    if cache is None or cache.status != "ready":
+        return None
+    try:
+        return len(json.loads(cache.tools_json))
+    except (ValueError, TypeError):
+        return None
+
+
+async def _account_health(
+    db: AsyncSession,
+    *,
+    account: IntegrationAccountRecord,
+    definition: IntegrationDefinitionRecord,
+) -> tuple[HealthVerdict, str | None]:
+    """Return (health, last_error_code) for an existing account."""
+    if not account.enabled:
+        return HealthVerdict.DISABLED_BY_USER, account.last_error_code
+    if account.status == "setup_required":
+        return HealthVerdict.NEEDS_AUTH, account.last_error_code
+    if account.status == "error":
+        return HealthVerdict.ERROR, account.last_error_code
+    # status == "ready": actively probe OAuth so expired tokens surface early.
+    if account.auth_kind == "oauth2":
+        try:
+            await ensure_provider_access(db, account_record=account, definition_record=definition)
+        except CloudApiError as exc:
+            if exc.code == "integration_reauth_required":
+                return HealthVerdict.NEEDS_REAUTH, exc.code
+            return HealthVerdict.ERROR, exc.code
+    return HealthVerdict.READY, None
+
+
+async def list_integration_health(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    organization_id: UUID | None = None,
+) -> list[IntegrationHealth]:
+    if organization_id is not None:
+        # An org's custom definitions + policy are private to its members; a
+        # non-member must not learn about them by supplying the org id.
+        membership = await organization_store.get_active_membership(
+            db, organization_id=organization_id, user_id=user_id
+        )
+        if membership is None:
+            raise CloudApiError(
+                "organization_not_found", "Organization not found.", status_code=404
+            )
+        definitions = await definitions_store.list_definitions_visible_to_org(db, organization_id)
+        policies = {
+            policy.definition_id: policy.enabled
+            for policy in await policies_store.list_policies_for_org(db, organization_id)
+        }
+    else:
+        definitions = await definitions_store.list_seed_definitions(db)
+        policies = {}
+
+    accounts = {
+        account.definition_id: account
+        for account in await accounts_store.list_accounts_for_user(db, user_id)
+    }
+
+    items: list[IntegrationHealth] = []
+    for definition in definitions:
+        if definition.archived_at is not None:
+            continue
+        policy_enabled = policies.get(definition.id)
+        effective_enabled = (
+            policy_enabled if policy_enabled is not None else definition.enabled_by_default
+        )
+        account = accounts.get(definition.id)
+
+        if not effective_enabled:
+            health = HealthVerdict.DISABLED_BY_ORG
+            last_error = None
+        elif account is None:
+            health = HealthVerdict.NEEDS_AUTH
+            last_error = None
+        else:
+            health, last_error = await _account_health(db, account=account, definition=definition)
+
+        items.append(
+            IntegrationHealth(
+                definition_id=definition.id,
+                account_id=account.id if account else None,
+                namespace=definition.namespace,
+                display_name=definition.display_name,
+                auth_kind=definition.auth_kind,
+                effective_enabled=effective_enabled,
+                policy_enabled=policy_enabled,
+                account_enabled=account.enabled if account else None,
+                health=health,
+                token_expires_at=account.token_expires_at if account else None,
+                tool_count=await _tool_count(db, account.id) if account else None,
+                last_error_code=last_error,
+            )
+        )
+    return items

--- a/server/proliferate/server/cloud/integrations/models.py
+++ b/server/proliferate/server/cloud/integrations/models.py
@@ -63,6 +63,25 @@ class IntegrationOAuthFlowStatusResponse(_CamelModel):
     final_surface: str
 
 
+class IntegrationHealthItem(_CamelModel):
+    definition_id: UUID
+    account_id: UUID | None = None
+    namespace: str
+    display_name: str
+    auth_kind: str
+    effective_enabled: bool
+    policy_enabled: bool | None = None
+    account_enabled: bool | None = None
+    health: str
+    token_expires_at: datetime | None = None
+    tool_count: int | None = None
+    last_error_code: str | None = None
+
+
+class IntegrationHealthResponse(_CamelModel):
+    items: list[IntegrationHealthItem]
+
+
 # --------------------------------------------------------------------------- #
 # Org-admin definition management
 # --------------------------------------------------------------------------- #

--- a/server/tests/integration/test_cloud_integration_health_api.py
+++ b/server/tests/integration/test_cloud_integration_health_api.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
+from proliferate.utils.crypto import encrypt_json
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+from tests.e2e.cloud.helpers.github import seed_linked_github_account
+
+HEALTH_URL = "/v1/cloud/integrations/health"
+
+
+async def _authed(client: AsyncClient, db_session: AsyncSession, *, prefix: str):
+    auth = await create_user_and_login(client, db_session, email_prefix=prefix)
+    await seed_linked_github_account(db_session, user_id=auth.user_id, access_token=f"gh-{prefix}")
+    await sync_seed_definitions(db_session)
+    await db_session.commit()
+    return auth
+
+
+@pytest.mark.asyncio
+async def test_health_requires_auth(client: AsyncClient) -> None:
+    response = await client.get(HEALTH_URL)
+    assert response.status_code in {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_health_reports_needs_auth_for_unconnected_seeds(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed(client, db_session, prefix="health-none")
+    response = await client.get(HEALTH_URL, headers=auth.headers)
+    assert response.status_code == 200, response.text
+    items = {i["namespace"]: i for i in response.json()["items"]}
+    # Every seed is visible and, with no account, needs auth.
+    assert items["context7"]["health"] == "needs_auth"
+    assert items["linear"]["health"] == "needs_auth"
+    assert items["context7"]["accountId"] is None
+
+
+@pytest.mark.asyncio
+async def test_health_reports_ready_for_connected_api_key(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed(client, db_session, prefix="health-ready")
+    definition = await definitions_store.get_seed_by_namespace(db_session, "context7")
+    account = await accounts_store.upsert_account(
+        db_session,
+        user_id=uuid.UUID(auth.user_id),
+        definition_id=definition.id,
+        auth_kind="api_key",
+        status="ready",
+    )
+    await accounts_store.set_account_credentials(
+        db_session,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json({"secretFields": {"api_key": "secret"}}),
+        credential_format="secret-fields-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+    await db_session.commit()
+
+    response = await client.get(HEALTH_URL, headers=auth.headers)
+    items = {i["namespace"]: i for i in response.json()["items"]}
+    assert items["context7"]["health"] == "ready"
+    assert items["context7"]["accountId"] is not None
+
+
+@pytest.mark.asyncio
+async def test_health_reports_needs_reauth_when_oauth_refresh_fails(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth = await _authed(client, db_session, prefix="health-reauth")
+    definition = await definitions_store.get_seed_by_namespace(db_session, "linear")
+    account = await accounts_store.upsert_account(
+        db_session,
+        user_id=uuid.UUID(auth.user_id),
+        definition_id=definition.id,
+        auth_kind="oauth2",
+        status="ready",
+    )
+    # An expired bundle with no usable refresh forces the reauth path.
+    await accounts_store.set_account_credentials(
+        db_session,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json(
+            {
+                "issuer": "https://auth.linear.app",
+                "resource": "https://mcp.linear.app/mcp",
+                "clientId": "c",
+                "accessToken": "expired",
+                "refreshToken": None,
+                "expiresAt": "2000-01-01T00:00:00+00:00",
+                "scopes": [],
+                "tokenEndpoint": "https://auth.linear.app/oauth/token",
+                "redirectUri": "https://api.example.com/cb",
+            }
+        ),
+        credential_format="oauth-bundle-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+    await db_session.commit()
+
+    response = await client.get(HEALTH_URL, headers=auth.headers)
+    items = {i["namespace"]: i for i in response.json()["items"]}
+    assert items["linear"]["health"] == "needs_reauth"
+
+
+@pytest.mark.asyncio
+async def test_health_rejects_non_member_org_id(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed(client, db_session, prefix="health-crosstenant")
+    # A random org the user is not a member of must not be readable.
+    response = await client.get(
+        HEALTH_URL,
+        headers=auth.headers,
+        params={"organizationId": str(uuid.uuid4())},
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

Sixth PR in the stack (on #835). `GET /v1/cloud/integrations/health` returns, for each definition visible to the user, a single health verdict combining org policy, the user's account state, and — for OAuth accounts claiming to be ready — an **active credential probe** so a silently-expired token surfaces as `needs_reauth` instead of failing mid-session.

Verdicts: `ready` | `needs_auth` | `needs_reauth` | `disabled_by_user` | `disabled_by_org` | `error`, plus `tokenExpiresAt`, `toolCount` (from the tool cache), `lastErrorCode`. This is exactly the data the settings badges and the proactive chat-input reconnect chip consume.

Regenerates the cloud SDK openapi types.

## Verification
4 integration tests — unconnected seeds → `needs_auth`, connected api_key → `ready`, expired-oauth-without-refresh → `needs_reauth`, auth required. Ruff clean; cloud-sdk builds.

## Remaining follow-up (desktop UI)
The desktop **integrations settings surface** + the **proactive chat-input reconnect chip** are the one remaining piece. They're a substantial product-ui effort with a prerequisite (A0 removed the old integrations settings surface; E/F deferred the new one), so they land as a dedicated follow-up rather than rushed here — the health data + SDK types they consume are ready.

> Inherits the pre-existing `main`-red server-ci `test` + repo-shape frontend-drift; no new real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)