### PR TITLE
feat(agent-auth): opencode slot composition, provider registry, key picker

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -116,6 +116,7 @@ pub(super) fn map_create_session_error(error: CreateAndStartSessionError) -> Api
 pub(super) fn map_route_auth_error(error: &RouteAuthError) -> ApiError {
     match error {
         RouteAuthError::SelectionMissing { .. }
+        | RouteAuthError::SelectionConflict { .. }
         | RouteAuthError::SelectionIncomplete { .. }
         | RouteAuthError::UnsupportedRoute { .. }
         | RouteAuthError::UnknownHarness { .. } => {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod test_support;
 
 use std::path::{Path, PathBuf};
 
-pub use profile::{resolve_profile, AgentRuntimeAuthProfile};
+pub use profile::{resolve_profile, AgentRuntimeAuthProfile, OpenCodeCompositeProfile};
 pub use render::{render_profile, RenderedRouteAuth};
 pub use state::{load_state_file, state_file_path, AgentAuthState, AuthRoute, AuthSelection};
 
@@ -46,6 +46,11 @@ pub enum RouteAuthError {
     MalformedStateFile { path: PathBuf, detail: String },
     #[error("no agent-auth route selection for harness '{harness_kind}' at revision {revision}")]
     SelectionMissing { harness_kind: String, revision: i64 },
+    #[error(
+        "conflicting agent-auth selections for harness '{harness_kind}': \
+         {count} entries where one is allowed"
+    )]
+    SelectionConflict { harness_kind: String, count: usize },
     #[error("agent-auth route selection for '{harness_kind}' is incomplete: {detail}")]
     SelectionIncomplete {
         harness_kind: String,
@@ -70,6 +75,7 @@ impl RouteAuthError {
         match self {
             Self::MalformedStateFile { .. } => "AGENT_ROUTE_STATE_MALFORMED",
             Self::SelectionMissing { .. } => "AGENT_ROUTE_SELECTION_MISSING",
+            Self::SelectionConflict { .. } => "AGENT_ROUTE_SELECTION_CONFLICT",
             Self::SelectionIncomplete { .. } => "AGENT_ROUTE_SELECTION_INCOMPLETE",
             Self::UnsupportedRoute { .. } => "AGENT_ROUTE_UNSUPPORTED",
             Self::UnknownHarness { .. } => "AGENT_ROUTE_UNKNOWN_HARNESS",

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
@@ -9,6 +9,10 @@
 use super::state::{AgentAuthState, AuthRoute, AuthSelection};
 use super::RouteAuthError;
 
+/// Harness kind that composes multiple auth sources (spec §3.3 slot
+/// semantics). Everything else is single-source: exactly one selection.
+const OPENCODE_HARNESS: &str = "opencode";
+
 /// The resolved auth profile for one harness launch (spec §4
 /// `AgentRuntimeAuthProfile`). `Native` means "unchanged legacy behavior"; the
 /// render layer emits nothing for it.
@@ -19,6 +23,16 @@ pub enum AgentRuntimeAuthProfile {
     Native,
     ApiKey(ApiKeyProfile),
     Gateway(GatewayProfile),
+    /// OpenCode's merged multi-slot profile: an optional gateway source plus
+    /// any number of direct provider keys, rendered ADDITIVELY into one launch
+    /// delta (one injected config + per-provider env keys).
+    OpenCodeComposite(OpenCodeCompositeProfile),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenCodeCompositeProfile {
+    pub gateway: Option<GatewayProfile>,
+    pub provider_keys: Vec<ApiKeyProfile>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,7 +60,9 @@ pub struct GatewayProfile {
 /// Resolve the auth profile for `harness_kind` from the loaded state.
 ///
 /// - `state == None` (no file): legacy `Native`.
-/// - state present, has a selection for the harness: profile per its route.
+/// - state present, has selection(s) for the harness: profile per route.
+///   OpenCode merges ALL its selections into one composite profile
+///   (spec §3.3); single-source harnesses error (typed) on more than one.
 /// - state present + scoped (`revision > 0`) but NO selection for the harness:
 ///   fail-closed [`RouteAuthError::SelectionMissing`] (spec §3), mirroring the
 ///   old `AGENT_AUTH_SELECTION_REQUIRED` semantics against the new model.
@@ -59,19 +75,74 @@ pub fn resolve_profile(
     let Some(state) = state else {
         return Ok(AgentRuntimeAuthProfile::Native);
     };
-    match state.selection_for(harness_kind) {
-        Some(selection) => profile_from_selection(harness_kind, selection, state.revision),
-        None => {
-            if state.is_scoped() {
-                Err(RouteAuthError::SelectionMissing {
+    let selections = state.selections_for(harness_kind);
+    if selections.is_empty() {
+        return if state.is_scoped() {
+            Err(RouteAuthError::SelectionMissing {
+                harness_kind: harness_kind.to_string(),
+                revision: state.revision,
+            })
+        } else {
+            Ok(AgentRuntimeAuthProfile::Native)
+        };
+    }
+    if harness_kind == OPENCODE_HARNESS {
+        return resolve_opencode_composite(harness_kind, &selections, state.revision);
+    }
+    if selections.len() > 1 {
+        return Err(RouteAuthError::SelectionConflict {
+            harness_kind: harness_kind.to_string(),
+            count: selections.len(),
+        });
+    }
+    profile_from_selection(harness_kind, selections[0], state.revision)
+}
+
+/// Merge OpenCode's slot entries into one composite profile: at most one
+/// gateway source plus any number of direct provider keys. Native entries are
+/// tolerated (they render nothing); an all-native entry set resolves `Native`.
+fn resolve_opencode_composite(
+    harness_kind: &str,
+    selections: &[&AuthSelection],
+    revision: i64,
+) -> Result<AgentRuntimeAuthProfile, RouteAuthError> {
+    let mut gateway: Option<GatewayProfile> = None;
+    let mut provider_keys: Vec<ApiKeyProfile> = Vec::new();
+    for selection in selections {
+        match selection.route {
+            AuthRoute::Native => continue,
+            AuthRoute::ApiKey => {
+                let key = require_key(harness_kind, selection, AuthRoute::ApiKey)?;
+                provider_keys.push(ApiKeyProfile {
                     harness_kind: harness_kind.to_string(),
-                    revision: state.revision,
-                })
-            } else {
-                Ok(AgentRuntimeAuthProfile::Native)
+                    provider: selection.provider.clone(),
+                    key,
+                });
+            }
+            AuthRoute::Gateway => {
+                if gateway.is_some() {
+                    return Err(RouteAuthError::SelectionConflict {
+                        harness_kind: harness_kind.to_string(),
+                        count: selections.len(),
+                    });
+                }
+                gateway = Some(gateway_profile_from_selection(
+                    harness_kind,
+                    selection,
+                    revision,
+                )?);
             }
         }
     }
+    if gateway.is_none() && provider_keys.is_empty() {
+        return Ok(AgentRuntimeAuthProfile::Native);
+    }
+    Ok(AgentRuntimeAuthProfile::OpenCodeComposite(
+        OpenCodeCompositeProfile {
+            gateway,
+            provider_keys,
+        },
+    ))
 }
 
 fn profile_from_selection(
@@ -89,26 +160,34 @@ fn profile_from_selection(
                 key,
             }))
         }
-        AuthRoute::Gateway => {
-            let key = require_key(harness_kind, selection, AuthRoute::Gateway)?;
-            let base_url = selection
-                .base_url
-                .clone()
-                .filter(|url| !url.trim().is_empty())
-                .ok_or_else(|| RouteAuthError::SelectionIncomplete {
-                    harness_kind: harness_kind.to_string(),
-                    route: AuthRoute::Gateway,
-                    detail: "gateway route requires baseUrl".to_string(),
-                })?;
-            Ok(AgentRuntimeAuthProfile::Gateway(GatewayProfile {
-                harness_kind: harness_kind.to_string(),
-                base_url,
-                key,
-                model_catalog: selection.model_catalog.clone(),
-                revision,
-            }))
-        }
+        AuthRoute::Gateway => Ok(AgentRuntimeAuthProfile::Gateway(
+            gateway_profile_from_selection(harness_kind, selection, revision)?,
+        )),
     }
+}
+
+fn gateway_profile_from_selection(
+    harness_kind: &str,
+    selection: &AuthSelection,
+    revision: i64,
+) -> Result<GatewayProfile, RouteAuthError> {
+    let key = require_key(harness_kind, selection, AuthRoute::Gateway)?;
+    let base_url = selection
+        .base_url
+        .clone()
+        .filter(|url| !url.trim().is_empty())
+        .ok_or_else(|| RouteAuthError::SelectionIncomplete {
+            harness_kind: harness_kind.to_string(),
+            route: AuthRoute::Gateway,
+            detail: "gateway route requires baseUrl".to_string(),
+        })?;
+    Ok(GatewayProfile {
+        harness_kind: harness_kind.to_string(),
+        base_url,
+        key,
+        model_catalog: selection.model_catalog.clone(),
+        revision,
+    })
 }
 
 fn require_key(
@@ -153,6 +232,7 @@ mod tests {
             vec![AuthSelection {
                 harness: "codex".into(),
                 route: AuthRoute::Gateway,
+                slot: "primary".into(),
                 provider: None,
                 base_url: Some("https://gw".into()),
                 key: Some("sk".into()),
@@ -180,6 +260,7 @@ mod tests {
             vec![AuthSelection {
                 harness: "claude".into(),
                 route: AuthRoute::Native,
+                slot: "primary".into(),
                 provider: None,
                 base_url: None,
                 key: None,
@@ -197,6 +278,7 @@ mod tests {
             vec![AuthSelection {
                 harness: "claude".into(),
                 route: AuthRoute::Gateway,
+                slot: "primary".into(),
                 provider: None,
                 base_url: Some("https://gw".into()),
                 key: None,
@@ -213,6 +295,7 @@ mod tests {
             vec![AuthSelection {
                 harness: "claude".into(),
                 route: AuthRoute::Gateway,
+                slot: "primary".into(),
                 provider: None,
                 base_url: None,
                 key: Some("sk".into()),
@@ -232,6 +315,7 @@ mod tests {
             vec![AuthSelection {
                 harness: "claude".into(),
                 route: AuthRoute::ApiKey,
+                slot: "primary".into(),
                 provider: Some("anthropic".into()),
                 base_url: None,
                 key: None,
@@ -244,13 +328,183 @@ mod tests {
         ));
     }
 
+    fn slot_selection(
+        harness: &str,
+        route: AuthRoute,
+        slot: &str,
+        provider: Option<&str>,
+        key: Option<&str>,
+        base_url: Option<&str>,
+    ) -> AuthSelection {
+        AuthSelection {
+            harness: harness.into(),
+            route,
+            slot: slot.into(),
+            provider: provider.map(Into::into),
+            base_url: base_url.map(Into::into),
+            key: key.map(Into::into),
+            model_catalog: None,
+        }
+    }
+
+    #[test]
+    fn single_source_harness_with_multiple_entries_is_typed_conflict() {
+        let state = state(
+            4,
+            vec![
+                slot_selection(
+                    "claude",
+                    AuthRoute::Gateway,
+                    "primary",
+                    None,
+                    Some("sk-vk"),
+                    Some("https://gw"),
+                ),
+                slot_selection(
+                    "claude",
+                    AuthRoute::ApiKey,
+                    "anthropic",
+                    Some("anthropic"),
+                    Some("sk-raw"),
+                    None,
+                ),
+            ],
+        );
+        let error = resolve_profile(Some(&state), "claude").expect_err("conflict");
+        assert!(matches!(
+            error,
+            RouteAuthError::SelectionConflict { count: 2, .. }
+        ));
+        assert_eq!(error.code(), "AGENT_ROUTE_SELECTION_CONFLICT");
+    }
+
+    #[test]
+    fn opencode_merges_gateway_and_provider_slots() {
+        let state = state(
+            6,
+            vec![
+                slot_selection(
+                    "opencode",
+                    AuthRoute::Gateway,
+                    "gateway",
+                    None,
+                    Some("sk-vk"),
+                    Some("https://gw"),
+                ),
+                slot_selection(
+                    "opencode",
+                    AuthRoute::ApiKey,
+                    "anthropic",
+                    Some("anthropic"),
+                    Some("sk-ant"),
+                    None,
+                ),
+                slot_selection(
+                    "opencode",
+                    AuthRoute::ApiKey,
+                    "xai",
+                    Some("xai"),
+                    Some("xai-raw"),
+                    None,
+                ),
+            ],
+        );
+        let profile = resolve_profile(Some(&state), "opencode").expect("resolve");
+        match profile {
+            AgentRuntimeAuthProfile::OpenCodeComposite(composite) => {
+                let gateway = composite.gateway.expect("gateway source");
+                assert_eq!(gateway.base_url, "https://gw");
+                assert_eq!(gateway.revision, 6);
+                assert_eq!(
+                    composite
+                        .provider_keys
+                        .iter()
+                        .map(|entry| entry.provider.as_deref().unwrap())
+                        .collect::<Vec<_>>(),
+                    vec!["anthropic", "xai"],
+                );
+            }
+            other => panic!("expected composite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opencode_provider_keys_without_gateway_compose() {
+        let state = state(
+            2,
+            vec![slot_selection(
+                "opencode",
+                AuthRoute::ApiKey,
+                "openai",
+                Some("openai"),
+                Some("sk-openai"),
+                None,
+            )],
+        );
+        let profile = resolve_profile(Some(&state), "opencode").expect("resolve");
+        match profile {
+            AgentRuntimeAuthProfile::OpenCodeComposite(composite) => {
+                assert!(composite.gateway.is_none());
+                assert_eq!(composite.provider_keys.len(), 1);
+            }
+            other => panic!("expected composite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opencode_double_gateway_entries_are_conflict() {
+        let state = state(
+            3,
+            vec![
+                slot_selection(
+                    "opencode",
+                    AuthRoute::Gateway,
+                    "gateway",
+                    None,
+                    Some("sk-a"),
+                    Some("https://gw"),
+                ),
+                slot_selection(
+                    "opencode",
+                    AuthRoute::Gateway,
+                    "gateway",
+                    None,
+                    Some("sk-b"),
+                    Some("https://gw"),
+                ),
+            ],
+        );
+        let error = resolve_profile(Some(&state), "opencode").expect_err("conflict");
+        assert!(matches!(error, RouteAuthError::SelectionConflict { .. }));
+    }
+
+    #[test]
+    fn opencode_all_native_entries_resolve_native() {
+        let state = state(
+            1,
+            vec![slot_selection(
+                "opencode",
+                AuthRoute::Native,
+                "gateway",
+                None,
+                None,
+                None,
+            )],
+        );
+        let profile = resolve_profile(Some(&state), "opencode").expect("resolve");
+        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
+    }
+
     #[test]
     fn gateway_profile_carries_revision_and_catalog() {
+        // OpenCode resolves through the composite path; its gateway member
+        // still carries the revision + model catalog like a plain profile.
         let state = state(
             9,
             vec![AuthSelection {
                 harness: "opencode".into(),
                 route: AuthRoute::Gateway,
+                slot: "gateway".into(),
                 provider: None,
                 base_url: Some("https://gw".into()),
                 key: Some("sk".into()),
@@ -259,11 +513,12 @@ mod tests {
         );
         let profile = resolve_profile(Some(&state), "opencode").expect("resolve");
         match profile {
-            AgentRuntimeAuthProfile::Gateway(gw) => {
+            AgentRuntimeAuthProfile::OpenCodeComposite(composite) => {
+                let gw = composite.gateway.expect("gateway source");
                 assert_eq!(gw.revision, 9);
                 assert_eq!(gw.model_catalog.as_deref().unwrap().len(), 2);
             }
-            other => panic!("expected gateway, got {other:?}"),
+            other => panic!("expected composite, got {other:?}"),
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
@@ -14,7 +14,9 @@ use std::path::Path;
 use crate::domains::agents::model::AgentKind;
 
 use super::materialize;
-use super::profile::{AgentRuntimeAuthProfile, ApiKeyProfile, GatewayProfile};
+use super::profile::{
+    AgentRuntimeAuthProfile, ApiKeyProfile, GatewayProfile, OpenCodeCompositeProfile,
+};
 use super::RouteAuthError;
 
 /// A sensible default small/fast model for Claude's sidecar calls when the
@@ -64,7 +66,36 @@ pub fn render_profile(
         AgentRuntimeAuthProfile::Native => Ok(RenderedRouteAuth::default()),
         AgentRuntimeAuthProfile::ApiKey(profile) => render_api_key(profile, runtime_home),
         AgentRuntimeAuthProfile::Gateway(profile) => render_gateway(profile, runtime_home),
+        AgentRuntimeAuthProfile::OpenCodeComposite(profile) => {
+            render_opencode_composite(profile, runtime_home)
+        }
     }
+}
+
+/// Render OpenCode's merged multi-slot profile into ONE launch delta
+/// (spec §3.3): the gateway slot materializes the injected opencode.json
+/// (provider `proliferate` only) exactly like the single-selection gateway
+/// route, and each direct provider key rides its plain provider env var.
+///
+/// Additivity: opencode deep-merges the `OPENCODE_CONFIG` file with the
+/// user's own global/project configs (verified against opencode 1.16.2), and
+/// per-provider env keys enable providers without any config at all — so our
+/// injected sources ADD to, and never replace, the user's local providers.
+fn render_opencode_composite(
+    profile: &OpenCodeCompositeProfile,
+    runtime_home: &Path,
+) -> Result<RenderedRouteAuth, RouteAuthError> {
+    let mut rendered = RenderedRouteAuth::default();
+    if let Some(gateway) = &profile.gateway {
+        render_opencode_gateway(gateway, runtime_home, &mut rendered)?;
+    }
+    for key_profile in &profile.provider_keys {
+        rendered.set(
+            provider_env_key(key_profile.provider.as_deref()),
+            &key_profile.key,
+        );
+    }
+    Ok(rendered)
 }
 
 fn parse_harness(harness_kind: &str) -> Result<AgentKind, RouteAuthError> {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -240,6 +240,90 @@ fn opencode_api_key_passthrough_provider_env() {
     assert_eq!(rendered.set.get("ANTHROPIC_API_KEY").unwrap(), "sk-a");
 }
 
+#[test]
+fn opencode_multi_slot_state_merges_into_one_additive_delta() {
+    // Gateway slot + two direct provider slots (spec §3.3): one injected
+    // config for the gateway plus plain env keys for the direct providers,
+    // all in a single launch delta.
+    let home = TempHome::new("opencode-multi-slot");
+    home.write_state_json(&json!({
+        "revision": 11,
+        "user_id": "user-1",
+        "selections": [
+            { "harness": "opencode", "route": "gateway", "slot": "gateway",
+              "base_url": GATEWAY_BASE_URL, "key": VK,
+              "model_catalog": ["claude-haiku-4-5-20251001"] },
+            { "harness": "opencode", "route": "api_key", "slot": "anthropic",
+              "provider": "anthropic", "key": "sk-ant-direct" },
+            { "harness": "opencode", "route": "api_key", "slot": "xai",
+              "provider": "xai", "key": "xai-direct" }
+        ]
+    }));
+
+    let rendered = resolve_launch_route_auth(home.path(), "opencode").expect("render");
+
+    // Gateway slot: injected config + virtual key env.
+    let config_path = rendered
+        .set
+        .get("OPENCODE_CONFIG")
+        .expect("OPENCODE_CONFIG");
+    assert_eq!(rendered.set.get("PROLIFERATE_GATEWAY_KEY").unwrap(), VK);
+    // Direct provider slots: additive plain env keys, no removals.
+    assert_eq!(
+        rendered.set.get("ANTHROPIC_API_KEY").unwrap(),
+        "sk-ant-direct"
+    );
+    assert_eq!(rendered.set.get("XAI_API_KEY").unwrap(), "xai-direct");
+    assert!(rendered.remove.is_empty());
+
+    // The injected config must contain ONLY our provider — no top-level
+    // model/default keys and no other providers — so opencode's config-layer
+    // merge ADDS it to the user's own local providers instead of replacing
+    // them (verified against opencode 1.16.2).
+    let config: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(config_path).expect("read config")).expect("json");
+    let top_level: Vec<&String> = config.as_object().unwrap().keys().collect();
+    assert_eq!(top_level, vec!["provider"]);
+    let providers: Vec<&String> = config["provider"].as_object().unwrap().keys().collect();
+    assert_eq!(providers, vec!["proliferate"]);
+}
+
+#[test]
+fn opencode_provider_slots_without_gateway_render_env_only() {
+    let home = TempHome::new("opencode-direct-only");
+    home.write_state_json(&json!({
+        "revision": 2,
+        "selections": [
+            { "harness": "opencode", "route": "api_key", "slot": "openai",
+              "provider": "openai", "key": "sk-openai-direct" }
+        ]
+    }));
+    let rendered = resolve_launch_route_auth(home.path(), "opencode").expect("render");
+    assert_eq!(
+        rendered.set.get("OPENAI_API_KEY").unwrap(),
+        "sk-openai-direct"
+    );
+    assert!(!rendered.set.contains_key("OPENCODE_CONFIG"));
+    assert!(!rendered.set.contains_key("PROLIFERATE_GATEWAY_KEY"));
+}
+
+#[test]
+fn single_source_harness_with_multiple_entries_errors_end_to_end() {
+    let home = TempHome::new("claude-multi-entry");
+    home.write_state_json(&json!({
+        "revision": 5,
+        "selections": [
+            { "harness": "claude", "route": "gateway", "slot": "primary",
+              "base_url": GATEWAY_BASE_URL, "key": VK },
+            { "harness": "claude", "route": "api_key", "slot": "anthropic",
+              "provider": "anthropic", "key": "sk-raw" }
+        ]
+    }));
+    let error = resolve_launch_route_auth(home.path(), "claude").expect_err("conflict");
+    assert_eq!(error.code(), "AGENT_ROUTE_SELECTION_CONFLICT");
+    assert!(matches!(error, RouteAuthError::SelectionConflict { .. }));
+}
+
 // --- grok ------------------------------------------------------------------
 
 #[test]
@@ -410,6 +494,7 @@ fn unknown_harness_in_state_is_typed_error() {
         selections: vec![super::state::AuthSelection {
             harness: "bogus".into(),
             route: AuthRoute::Gateway,
+            slot: "primary".into(),
             provider: None,
             base_url: Some(GATEWAY_BASE_URL.into()),
             key: Some(VK.into()),

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
@@ -54,7 +54,14 @@ impl AuthRoute {
     }
 }
 
-/// A single (harness, route) selection materialized by the control plane. The
+/// The default slot: the one selection of a single-source harness.
+pub const SLOT_PRIMARY: &str = "primary";
+
+fn default_slot() -> String {
+    SLOT_PRIMARY.to_string()
+}
+
+/// A single (harness, slot) selection materialized by the control plane. The
 /// optional fields carry only what a route needs: `key`/`base_url`/`provider`
 /// for api_key/gateway, `model_catalog` for OpenCode's explicit models map.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +70,12 @@ pub struct AuthSelection {
     /// [`AgentKind::as_str`](crate::domains::agents::model::AgentKind::as_str)).
     pub harness: String,
     pub route: AuthRoute,
+    /// Composition axis (spec §3.3): single-source harnesses carry exactly one
+    /// `"primary"` entry; OpenCode carries one entry per slot (`"gateway"` +
+    /// direct provider slots), merged into one additive launch profile.
+    /// Defaults keep pre-slot state files parsing.
+    #[serde(default = "default_slot")]
+    pub slot: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -92,11 +105,21 @@ pub struct AgentAuthState {
 }
 
 impl AgentAuthState {
-    /// The selection for a harness kind, if any.
+    /// The selection for a harness kind, if any (first match; use
+    /// [`Self::selections_for`] where multiple slots are legal).
     pub fn selection_for(&self, harness_kind: &str) -> Option<&AuthSelection> {
         self.selections
             .iter()
             .find(|selection| selection.harness == harness_kind)
+    }
+
+    /// Every selection for a harness kind, in state-file order. OpenCode may
+    /// carry several (one per slot); single-source harnesses must not.
+    pub fn selections_for(&self, harness_kind: &str) -> Vec<&AuthSelection> {
+        self.selections
+            .iter()
+            .filter(|selection| selection.harness == harness_kind)
+            .collect()
     }
 
     /// Whether the state engages fail-closed semantics (a scoped launch, spec
@@ -170,6 +193,7 @@ mod tests {
                 AuthSelection {
                     harness: "claude".into(),
                     route: AuthRoute::Gateway,
+                    slot: SLOT_PRIMARY.into(),
                     provider: None,
                     base_url: Some("https://llm.proliferate.ai".into()),
                     key: Some("sk-virtual".into()),
@@ -178,6 +202,7 @@ mod tests {
                 AuthSelection {
                     harness: "opencode".into(),
                     route: AuthRoute::Gateway,
+                    slot: "gateway".into(),
                     provider: None,
                     base_url: Some("https://llm.proliferate.ai".into()),
                     key: Some("sk-virtual".into()),
@@ -200,6 +225,7 @@ mod tests {
             selections: vec![AuthSelection {
                 harness: "codex".into(),
                 route: AuthRoute::ApiKey,
+                slot: SLOT_PRIMARY.into(),
                 provider: Some("openai".into()),
                 base_url: None,
                 key: Some("sk-raw".into()),
@@ -229,5 +255,43 @@ mod tests {
         let selection = state.selection_for("claude").expect("selection");
         assert_eq!(selection.route, AuthRoute::Native);
         assert!(selection.key.is_none());
+    }
+
+    #[test]
+    fn missing_slot_defaults_to_primary_and_round_trips() {
+        // Pre-slot state files (no "slot" key) parse with the primary default.
+        let json = r#"{
+            "revision": 4,
+            "selections": [
+                { "harness": "claude", "route": "gateway",
+                  "base_url": "https://gw", "key": "sk-vk" }
+            ]
+        }"#;
+        let state: AgentAuthState = serde_json::from_str(json).expect("parse");
+        assert_eq!(state.selection_for("claude").unwrap().slot, SLOT_PRIMARY);
+
+        // And the default survives a serialize→parse round trip.
+        let serialized = serde_json::to_string(&state).expect("serialize");
+        let parsed: AgentAuthState = serde_json::from_str(&serialized).expect("reparse");
+        assert_eq!(state, parsed);
+    }
+
+    #[test]
+    fn multiple_entries_per_harness_are_representable() {
+        let json = r#"{
+            "revision": 9,
+            "selections": [
+                { "harness": "opencode", "route": "gateway", "slot": "gateway",
+                  "base_url": "https://gw", "key": "sk-vk" },
+                { "harness": "opencode", "route": "api_key", "slot": "anthropic",
+                  "provider": "anthropic", "key": "sk-ant" }
+            ]
+        }"#;
+        let state: AgentAuthState = serde_json::from_str(json).expect("parse");
+        let selections = state.selections_for("opencode");
+        assert_eq!(selections.len(), 2);
+        assert_eq!(selections[0].slot, "gateway");
+        assert_eq!(selections[1].slot, "anthropic");
+        assert!(state.selections_for("claude").is_empty());
     }
 }

--- a/apps/desktop/src/components/settings/panes/agent-auth/AgentApiKeysSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/AgentApiKeysSection.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
 import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
 import { Select } from "@proliferate/ui/primitives/Select";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { useToastStore } from "@/stores/toast/toast-store";
@@ -16,7 +17,7 @@ import {
   AGENT_API_KEY_PROVIDERS,
   agentApiKeyProviderLabel,
   type AgentApiKeyProviderId,
-} from "./agent-api-key-providers";
+} from "@/config/agent-api-key-providers";
 
 export function AgentApiKeysSection() {
   const keysQuery = useAgentApiKeys();
@@ -129,9 +130,12 @@ export function AgentApiKeysSection() {
             </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
-            <label className="sm:w-44">
-              <span className="sr-only">Provider</span>
+            <div className="sm:w-44">
+              <Label htmlFor="agent-api-key-add-provider" className="sr-only">
+                Provider
+              </Label>
               <Select
+                id="agent-api-key-add-provider"
                 aria-label="Provider"
                 value={provider}
                 onChange={(event) =>
@@ -143,7 +147,7 @@ export function AgentApiKeysSection() {
                   </option>
                 ))}
               </Select>
-            </label>
+            </div>
             <Input
               aria-label="Key name"
               placeholder="Key name"

--- a/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.test.tsx
@@ -4,6 +4,32 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentAuthenticationSection } from "./AgentAuthenticationSection";
 
+const PROVIDERS = vi.hoisted(() => [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    envKey: "ANTHROPIC_API_KEY",
+    keyUrl: "https://console.anthropic.com/settings/keys",
+    harnesses: ["claude", "opencode"],
+    recommendedFor: ["claude", "opencode"],
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    envKey: "OPENAI_API_KEY",
+    keyUrl: "https://platform.openai.com/api-keys",
+    harnesses: ["codex", "opencode"],
+    recommendedFor: ["codex"],
+  },
+]);
+
+type CapabilitiesData = {
+  gatewayEnabled: boolean;
+  publicBaseUrl: string | null;
+  enrollmentStatus: string;
+  providers?: typeof PROVIDERS;
+};
+
 const state = vi.hoisted(() => ({
   cloudActive: true,
   capabilities: {
@@ -11,7 +37,8 @@ const state = vi.hoisted(() => ({
       gatewayEnabled: true,
       publicBaseUrl: "https://gateway.example",
       enrollmentStatus: "synced",
-    } as { gatewayEnabled: boolean; publicBaseUrl: string | null; enrollmentStatus: string } | undefined,
+      providers: PROVIDERS,
+    } as CapabilitiesData | undefined,
   },
   enrollment: {
     data: undefined as
@@ -32,6 +59,7 @@ const state = vi.hoisted(() => ({
 }));
 const upsertMutate = vi.hoisted(() => vi.fn());
 const clearMutate = vi.hoisted(() => vi.fn());
+const createKeyMutate = vi.hoisted(() => vi.fn());
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
   useAgentGatewayCapabilities: () => state.capabilities,
@@ -40,10 +68,15 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   useAgentApiKeys: () => state.apiKeys,
   useUpsertRouteSelection: () => ({ mutate: upsertMutate, isPending: false }),
   useClearRouteSelection: () => ({ mutate: clearMutate, isPending: false }),
+  useCreateAgentApiKey: () => ({ mutate: createKeyMutate, isPending: false }),
 }));
 
 vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
   useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+}));
+
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => ({ openExternal: vi.fn() }),
 }));
 
 function selection(overrides: Partial<Record<string, unknown>> = {}) {
@@ -74,6 +107,7 @@ afterEach(() => {
     gatewayEnabled: true,
     publicBaseUrl: "https://gateway.example",
     enrollmentStatus: "synced",
+    providers: PROVIDERS,
   };
   state.enrollment.data = undefined;
   state.selections.data = { selections: [] };
@@ -130,7 +164,7 @@ describe("AgentAuthenticationSection", () => {
       {
         harnessKind: "claude",
         surface: "local",
-        body: { route: "gateway" },
+        body: { route: "gateway", slot: "primary" },
       },
       expect.anything(),
     );
@@ -171,15 +205,15 @@ describe("AgentAuthenticationSection", () => {
     fireEvent.click(screen.getByText("API key"));
     expect(upsertMutate).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByLabelText("API key"), {
-      target: { value: "key-1" },
-    });
+    // The KeyPicker replaced the raw select: open it and pick by name.
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    fireEvent.click(screen.getByText("Work key"));
 
     expect(upsertMutate).toHaveBeenCalledWith(
       {
         harnessKind: "claude",
         surface: "local",
-        body: { route: "api_key", apiKeyId: "key-1" },
+        body: { route: "api_key", apiKeyId: "key-1", slot: "primary" },
       },
       expect.anything(),
     );
@@ -200,9 +234,8 @@ describe("AgentAuthenticationSection", () => {
     renderSection();
 
     fireEvent.click(screen.getByText("API key"));
-    fireEvent.change(screen.getByLabelText("API key"), {
-      target: { value: "key-1" },
-    });
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    fireEvent.click(screen.getByText("Work key"));
 
     // Mutation resolves, but the invalidated selections query has NOT refetched
     // yet (state.selections.data is still the stale empty list). The optimistic
@@ -214,8 +247,7 @@ describe("AgentAuthenticationSection", () => {
       onSuccess?.();
     });
 
-    const picker = screen.getByLabelText("API key") as HTMLSelectElement;
-    expect(picker.value).toBe("key-1");
+    expect(screen.queryByText("Work key (sk-...abcd)")).not.toBeNull();
     expect(
       screen.getByRole("radio", { name: /API key/ }).getAttribute("aria-checked"),
     ).toBe("true");
@@ -239,12 +271,46 @@ describe("AgentAuthenticationSection", () => {
     ).toBeNull();
   });
 
-  it("points at the key pool page when api_key is chosen with no keys", () => {
+  it("filters the key pool to the harness's direct provider", () => {
+    state.apiKeys.data = {
+      keys: [
+        {
+          id: "key-1",
+          provider: "anthropic",
+          displayName: "Anthropic key",
+          redactedHint: "sk-...abcd",
+          status: "active",
+          lastValidatedAt: null,
+          createdAt: "2026-07-01T00:00:00Z",
+        },
+        {
+          id: "key-2",
+          provider: "openai",
+          displayName: "OpenAI key",
+          redactedHint: "sk-...zzzz",
+          status: "active",
+          lastValidatedAt: null,
+          createdAt: "2026-07-01T00:00:00Z",
+        },
+      ],
+    };
     renderSection();
 
     fireEvent.click(screen.getByText("API key"));
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
 
-    expect(screen.queryByText(/No API keys available/)).not.toBeNull();
+    // Claude's direct provider is anthropic (from the capabilities registry).
+    expect(screen.queryByText("Anthropic key")).not.toBeNull();
+    expect(screen.queryByText("OpenAI key")).toBeNull();
+  });
+
+  it("offers inline key creation when the pool is empty", () => {
+    renderSection();
+
+    fireEvent.click(screen.getByText("API key"));
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+
+    expect(screen.queryByText("+ Add new key")).not.toBeNull();
   });
 
   it("clears the selection from the reset button", () => {
@@ -268,7 +334,7 @@ describe("AgentAuthenticationSection", () => {
     state.apiKeys.data = {
       keys: [{
         id: "key-9",
-        provider: "openai",
+        provider: "anthropic",
         displayName: "Cloud key",
         redactedHint: "sk-...zzzz",
         status: "active",
@@ -280,7 +346,9 @@ describe("AgentAuthenticationSection", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Cloud" }));
 
-    const picker = screen.getByLabelText("API key") as HTMLSelectElement;
-    expect(picker.value).toBe("key-9");
+    // The picker trigger summarizes the attached key; the secret stays hidden.
+    expect(
+      screen.queryByRole("button", { name: /Cloud key \(sk-\.\.\.zzzz\)/ }),
+    ).not.toBeNull();
   });
 });

--- a/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/AgentAuthenticationSection.tsx
@@ -3,8 +3,6 @@ import type {
   AgentAuthRoute,
   AgentAuthRouteSelection,
   AgentAuthSurface,
-  AgentGatewayCapabilities,
-  AgentGatewayEnrollment,
 } from "@proliferate/cloud-sdk";
 import {
   useAgentApiKeys,
@@ -15,13 +13,14 @@ import {
   useUpsertRouteSelection,
 } from "@proliferate/cloud-sdk-react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Select } from "@proliferate/ui/primitives/Select";
 import { SelectionRow } from "@proliferate/ui/primitives/SelectionRow";
 import { Tabs } from "@proliferate/ui/primitives/Tabs";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { useToastStore } from "@/stores/toast/toast-store";
-import { agentApiKeyProviderLabel } from "./agent-api-key-providers";
+import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
+import { KeyPicker } from "./KeyPicker";
+import { OpenCodeAuthSection } from "./OpenCodeAuthSection";
 
 const SURFACE_TABS = [
   { id: "local", label: "Local" },
@@ -37,25 +36,22 @@ function defaultRouteForSurface(surface: AgentAuthSurface): AgentAuthRoute {
   return surface === "cloud" ? "gateway" : "native";
 }
 
-function gatewaySubtitle(
-  capabilities: AgentGatewayCapabilities | undefined,
-  enrollment: AgentGatewayEnrollment | undefined,
-): string {
-  if (capabilities && !capabilities.gatewayEnabled) {
-    return "Unavailable for your account";
+export function AgentAuthenticationSection({
+  agentKind,
+  displayName,
+}: AgentAuthenticationSectionProps) {
+  // OpenCode composes sources (gateway + N provider keys) instead of picking
+  // one route; it gets per-source toggles rather than this radio group.
+  // `agentKind` is fixed per mount, so the branch is hook-safe.
+  if (agentKind === "opencode") {
+    return <OpenCodeAuthSection displayName={displayName} />;
   }
-  if (enrollment?.syncStatus === "failed") {
-    return enrollment.lastErrorCode
-      ? `Enrollment failed (${enrollment.lastErrorCode})`
-      : "Enrollment failed";
-  }
-  if (enrollment?.syncStatus === "pending") {
-    return "Enrollment pending";
-  }
-  return "Proliferate-managed model access. Free credits included, no setup required.";
+  return (
+    <SingleSourceAuthSection agentKind={agentKind} displayName={displayName} />
+  );
 }
 
-export function AgentAuthenticationSection({
+function SingleSourceAuthSection({
   agentKind,
   displayName,
 }: AgentAuthenticationSectionProps) {
@@ -106,6 +102,10 @@ export function AgentAuthenticationSection({
   const gatewayKnownUnavailable =
     capabilities !== undefined && !capabilities.gatewayEnabled;
   const apiKeys = apiKeysQuery.data?.keys ?? [];
+  // Which provider's keys can serve this harness directly (registry-driven).
+  const directProvider = (capabilities?.providers ?? []).find(
+    (provider) => provider.harnesses.includes(agentKind),
+  );
   const serverSelection: AgentAuthRouteSelection | null =
     selectionsQuery.data?.selections.find(
       (entry) => entry.harnessKind === agentKind && entry.surface === surface,
@@ -122,8 +122,8 @@ export function AgentAuthenticationSection({
     ? "api_key"
     : effectiveRoute ?? defaultRouteForSurface(surface);
   const selectedApiKeyId = !draftApiKeyRoute && effectiveRoute === "api_key"
-    ? effectiveApiKeyId ?? ""
-    : "";
+    ? effectiveApiKeyId ?? null
+    : null;
 
   // Drop the optimistic selection once the refetched server state matches it.
   useEffect(() => {
@@ -150,8 +150,8 @@ export function AgentAuthenticationSection({
         harnessKind: agentKind,
         surface,
         body: route === "api_key"
-          ? { route, apiKeyId: apiKeyId ?? null }
-          : { route },
+          ? { route, apiKeyId: apiKeyId ?? null, slot: "primary" }
+          : { route, slot: "primary" },
       },
       {
         onSuccess: () => {
@@ -263,34 +263,15 @@ export function AgentAuthenticationSection({
         ) : null}
 
         {selectedRoute === "api_key" ? (
-          apiKeys.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No API keys available. Add one under Agents → API Keys first.
-            </p>
-          ) : (
-            <label className="block sm:w-72">
-              <span className="sr-only">API key</span>
-              <Select
-                aria-label="API key"
-                value={selectedApiKeyId}
-                disabled={upsertSelection.isPending}
-                onChange={(event) => {
-                  if (event.target.value) {
-                    applyRoute("api_key", event.target.value);
-                  }
-                }}
-              >
-                <option value="" disabled>
-                  Select an API key
-                </option>
-                {apiKeys.map((key) => (
-                  <option key={key.id} value={key.id}>
-                    {agentApiKeyProviderLabel(key.provider)} — {key.displayName} ({key.redactedHint})
-                  </option>
-                ))}
-              </Select>
-            </label>
-          )
+          <div className="sm:w-80">
+            <KeyPicker
+              keys={apiKeys}
+              provider={directProvider?.id}
+              selectedKeyId={selectedApiKeyId}
+              disabled={upsertSelection.isPending}
+              onSelect={(keyId) => applyRoute("api_key", keyId)}
+            />
+          </div>
         ) : null}
 
         {selection ? (

--- a/apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { AgentApiKey } from "@proliferate/cloud-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { KeyPicker } from "./KeyPicker";
+
+const createKeyMutate = vi.hoisted(() => vi.fn());
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useCreateAgentApiKey: () => ({ mutate: createKeyMutate, isPending: false }),
+}));
+
+function key(overrides: Partial<AgentApiKey> = {}): AgentApiKey {
+  return {
+    id: "key-1",
+    provider: "anthropic",
+    displayName: "Work key",
+    redactedHint: "sk-...abcd",
+    status: "active",
+    lastValidatedAt: null,
+    createdAt: "2026-07-01T00:00:00Z",
+    ...overrides,
+  } as AgentApiKey;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("KeyPicker", () => {
+  it("lists keys with name, provider, and redacted hint, and selects by id", () => {
+    const onSelect = vi.fn();
+    render(
+      <KeyPicker
+        keys={[key(), key({ id: "key-2", displayName: "Backup key", redactedHint: "sk-...wxyz" })]}
+        selectedKeyId={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    expect(screen.queryByText(/Anthropic · sk-\.\.\.abcd/)).not.toBeNull();
+
+    fireEvent.click(screen.getByText("Backup key"));
+    expect(onSelect).toHaveBeenCalledWith("key-2");
+  });
+
+  it("filters the pool by provider and hides revoked keys", () => {
+    render(
+      <KeyPicker
+        keys={[
+          key(),
+          key({ id: "key-2", provider: "openai", displayName: "OpenAI key" }),
+          key({ id: "key-3", displayName: "Old key", status: "revoked" }),
+        ]}
+        provider="anthropic"
+        selectedKeyId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    expect(screen.queryByText("Work key")).not.toBeNull();
+    expect(screen.queryByText("OpenAI key")).toBeNull();
+    expect(screen.queryByText("Old key")).toBeNull();
+  });
+
+  it("summarizes the selected key on the trigger without re-showing the secret", () => {
+    render(
+      <KeyPicker keys={[key()]} selectedKeyId="key-1" onSelect={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Work key \(sk-\.\.\.abcd\)/ }),
+    ).not.toBeNull();
+  });
+
+  it("creates a new key inline and attaches it", () => {
+    const onSelect = vi.fn();
+    createKeyMutate.mockImplementation((input, callbacks) => {
+      callbacks.onSuccess({ ...key({ id: "key-new" }), ...input });
+    });
+    render(
+      <KeyPicker
+        keys={[]}
+        provider="anthropic"
+        selectedKeyId={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    fireEvent.click(screen.getByText("+ Add new key"));
+
+    fireEvent.change(screen.getByLabelText("Key name"), {
+      target: { value: "Fresh key" },
+    });
+    fireEvent.change(screen.getByLabelText("Secret"), {
+      target: { value: "sk-ant-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save key" }));
+
+    expect(createKeyMutate).toHaveBeenCalledWith(
+      { provider: "anthropic", displayName: "Fresh key", secret: "sk-ant-secret" },
+      expect.anything(),
+    );
+    expect(onSelect).toHaveBeenCalledWith("key-new");
+    // The row-fixed provider means no provider select is shown inline.
+    expect(screen.queryByLabelText("Provider")).toBeNull();
+  });
+
+  it("asks for a provider when the picker is not provider-scoped", () => {
+    render(<KeyPicker keys={[]} selectedKeyId={null} onSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    fireEvent.click(screen.getByText("+ Add new key"));
+
+    expect(screen.queryByLabelText("Provider")).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.tsx
@@ -1,0 +1,175 @@
+import { useMemo, useState, type FormEvent } from "react";
+import type { AgentApiKey } from "@proliferate/cloud-sdk";
+import { useCreateAgentApiKey } from "@proliferate/cloud-sdk-react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { EnvironmentSearchSelect } from "@proliferate/ui/primitives/EnvironmentSearchSelect";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
+import { Select } from "@proliferate/ui/primitives/Select";
+import { useToastStore } from "@/stores/toast/toast-store";
+import {
+  AGENT_API_KEY_PROVIDERS,
+  agentApiKeyProviderLabel,
+  type AgentApiKeyProviderId,
+} from "@/config/agent-api-key-providers";
+
+const ADD_NEW_KEY_OPTION_ID = "__add-new-key__";
+
+export interface KeyPickerProps {
+  /** The caller's key pool (usually `useAgentApiKeys().data.keys`). */
+  keys: AgentApiKey[];
+  /** Restrict the pool (and inline creation) to one provider. */
+  provider?: string;
+  selectedKeyId: string | null;
+  disabled?: boolean;
+  /** Called with the chosen (or freshly created) key id. */
+  onSelect: (keyId: string) => void;
+}
+
+/**
+ * Reusable searchable picker over the personal API key pool: display name +
+ * provider + redacted hint, secrets never re-shown. "+ Add new key" pastes a
+ * new secret inline, saves it to the pool, and attaches it in one step.
+ */
+export function KeyPicker({
+  keys,
+  provider,
+  selectedKeyId,
+  disabled = false,
+  onSelect,
+}: KeyPickerProps) {
+  const createKey = useCreateAgentApiKey();
+  const showToast = useToastStore((state) => state.show);
+
+  const [adding, setAdding] = useState(false);
+  const [newProvider, setNewProvider] = useState<AgentApiKeyProviderId>("anthropic");
+  const [displayName, setDisplayName] = useState("");
+  const [secret, setSecret] = useState("");
+
+  const pool = useMemo(
+    () =>
+      keys.filter(
+        (key) => key.status === "active" && (!provider || key.provider === provider),
+      ),
+    [keys, provider],
+  );
+  const selected = pool.find((key) => key.id === selectedKeyId) ?? null;
+
+  const options = [
+    ...pool.map((key) => ({
+      id: key.id,
+      label: key.displayName,
+      detail: `${agentApiKeyProviderLabel(key.provider)} · ${key.redactedHint}`,
+      selected: key.id === selectedKeyId,
+      searchValues: [key.provider, key.redactedHint],
+      onSelect: () => onSelect(key.id),
+    })),
+    {
+      id: ADD_NEW_KEY_OPTION_ID,
+      label: "+ Add new key",
+      detail: "Paste a key to save it to your pool and attach it here.",
+      onSelect: () => setAdding(true),
+    },
+  ];
+
+  const canSubmit =
+    displayName.trim().length > 0 && secret.trim().length > 0 && !createKey.isPending;
+
+  function handleAddKey(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    createKey.mutate(
+      {
+        provider: provider ?? newProvider,
+        displayName: displayName.trim(),
+        secret: secret.trim(),
+      },
+      {
+        onSuccess: (created) => {
+          setAdding(false);
+          setDisplayName("");
+          setSecret("");
+          onSelect(created.id);
+        },
+        onError: (error) => {
+          showToast(error.message || "Could not add the API key.");
+        },
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <EnvironmentSearchSelect
+        label={selected
+          ? `${selected.displayName} (${selected.redactedHint})`
+          : "Select an API key"}
+        options={options}
+        searchPlaceholder="Search keys..."
+        emptyLabel={provider
+          ? `No ${agentApiKeyProviderLabel(provider)} keys in your pool.`
+          : "No API keys in your pool."}
+        disabled={disabled}
+      />
+      {adding ? (
+        <form className="flex flex-col gap-2 sm:flex-row" onSubmit={handleAddKey}>
+          {provider === undefined ? (
+            <div className="sm:w-40">
+              <Label htmlFor="agent-api-key-provider" className="sr-only">
+                Provider
+              </Label>
+              <Select
+                id="agent-api-key-provider"
+                aria-label="Provider"
+                value={newProvider}
+                onChange={(event) =>
+                  setNewProvider(event.target.value as AgentApiKeyProviderId)}
+              >
+                {AGENT_API_KEY_PROVIDERS.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : null}
+          <Input
+            aria-label="Key name"
+            placeholder="Key name"
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+            className="sm:flex-1"
+          />
+          <Input
+            aria-label="Secret"
+            placeholder="Secret"
+            type="password"
+            autoComplete="off"
+            value={secret}
+            onChange={(event) => setSecret(event.target.value)}
+            className="sm:flex-1"
+          />
+          <Button
+            type="submit"
+            variant="secondary"
+            size="md"
+            disabled={!canSubmit}
+            loading={createKey.isPending}
+          >
+            Save key
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="md"
+            onClick={() => setAdding(false)}
+          >
+            Cancel
+          </Button>
+        </form>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/settings/panes/agent-auth/OpenCodeAuthSection.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/OpenCodeAuthSection.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenCodeAuthSection } from "./OpenCodeAuthSection";
+
+const PROVIDERS = vi.hoisted(() => [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    envKey: "ANTHROPIC_API_KEY",
+    keyUrl: "https://console.anthropic.com/settings/keys",
+    harnesses: ["claude", "opencode"],
+    recommendedFor: ["claude", "opencode"],
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    envKey: "OPENAI_API_KEY",
+    keyUrl: "https://platform.openai.com/api-keys",
+    harnesses: ["codex", "opencode"],
+    recommendedFor: ["codex"],
+  },
+  {
+    id: "xai",
+    label: "xAI",
+    envKey: "XAI_API_KEY",
+    keyUrl: "https://console.x.ai",
+    harnesses: ["grok"],
+    recommendedFor: ["grok"],
+  },
+]);
+
+const state = vi.hoisted(() => ({
+  cloudActive: true,
+  capabilities: {
+    data: {
+      gatewayEnabled: true,
+      publicBaseUrl: "https://gateway.example",
+      enrollmentStatus: "synced",
+      providers: PROVIDERS,
+    } as
+      | {
+        gatewayEnabled: boolean;
+        publicBaseUrl: string | null;
+        enrollmentStatus: string;
+        providers: typeof PROVIDERS;
+      }
+      | undefined,
+    isLoading: false,
+  },
+  enrollment: { data: undefined },
+  selections: {
+    data: { selections: [] as Array<Record<string, unknown>> },
+    isLoading: false,
+  },
+  apiKeys: { data: { keys: [] as Array<Record<string, unknown>> } },
+}));
+const upsertMutate = vi.hoisted(() => vi.fn());
+const clearMutate = vi.hoisted(() => vi.fn());
+const createKeyMutate = vi.hoisted(() => vi.fn());
+const openExternal = vi.hoisted(() => vi.fn());
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useAgentGatewayCapabilities: () => state.capabilities,
+  useAgentGatewayEnrollment: () => state.enrollment,
+  useRouteSelections: () => state.selections,
+  useAgentApiKeys: () => state.apiKeys,
+  useUpsertRouteSelection: () => ({ mutate: upsertMutate, isPending: false }),
+  useClearRouteSelection: () => ({ mutate: clearMutate, isPending: false }),
+  useCreateAgentApiKey: () => ({ mutate: createKeyMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+}));
+
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => ({ openExternal }),
+}));
+
+function selection(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "sel-1",
+    harnessKind: "opencode",
+    surface: "local",
+    slot: "gateway",
+    route: "gateway",
+    apiKeyId: null,
+    revision: 1,
+    createdAt: "2026-07-01T00:00:00Z",
+    updatedAt: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderSection() {
+  return render(<OpenCodeAuthSection displayName="OpenCode" />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  state.cloudActive = true;
+  state.capabilities.data = {
+    gatewayEnabled: true,
+    publicBaseUrl: "https://gateway.example",
+    enrollmentStatus: "synced",
+    providers: PROVIDERS,
+  };
+  state.capabilities.isLoading = false;
+  state.selections.data = { selections: [] };
+  state.selections.isLoading = false;
+  state.apiKeys.data = { keys: [] };
+});
+
+describe("OpenCodeAuthSection", () => {
+  it("asks the user to sign in when cloud is inactive", () => {
+    state.cloudActive = false;
+    renderSection();
+
+    expect(screen.queryByText(/Sign in to Proliferate Cloud/)).not.toBeNull();
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+
+  it("renders a gateway toggle plus one row per opencode-capable provider", () => {
+    renderSection();
+
+    expect(screen.queryByText("Proliferate gateway")).not.toBeNull();
+    // anthropic + openai serve opencode; xai (grok-only here) is filtered out.
+    expect(screen.queryByText("Anthropic")).not.toBeNull();
+    expect(screen.queryByText("OpenAI")).not.toBeNull();
+    expect(screen.queryByText("xAI")).toBeNull();
+    // Registry-driven recommendation badge.
+    expect(screen.queryByText("Recommended")).not.toBeNull();
+  });
+
+  it("toggling the gateway on upserts the gateway slot", () => {
+    renderSection();
+
+    fireEvent.click(screen.getByRole("switch", { name: "Proliferate gateway" }));
+
+    expect(upsertMutate).toHaveBeenCalledWith(
+      {
+        harnessKind: "opencode",
+        surface: "local",
+        body: { route: "gateway", slot: "gateway" },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("toggling the gateway off clears only the gateway slot", () => {
+    state.selections.data = { selections: [selection()] };
+    renderSection();
+
+    fireEvent.click(screen.getByRole("switch", { name: "Proliferate gateway" }));
+
+    expect(clearMutate).toHaveBeenCalledWith(
+      { harnessKind: "opencode", surface: "local", slot: "gateway" },
+      expect.anything(),
+    );
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("enabling a provider waits for a key pick, then upserts that slot", () => {
+    state.apiKeys.data = {
+      keys: [{
+        id: "key-1",
+        provider: "anthropic",
+        displayName: "Work key",
+        redactedHint: "sk-...abcd",
+        status: "active",
+        lastValidatedAt: null,
+        createdAt: "2026-07-01T00:00:00Z",
+      }],
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole("switch", { name: "Anthropic key" }));
+    expect(upsertMutate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
+    fireEvent.click(screen.getByText("Work key"));
+
+    expect(upsertMutate).toHaveBeenCalledWith(
+      {
+        harnessKind: "opencode",
+        surface: "local",
+        body: { route: "api_key", apiKeyId: "key-1", slot: "anthropic" },
+      },
+      expect.anything(),
+    );
+  });
+
+  it("disabling a provider clears its slot", () => {
+    state.selections.data = {
+      selections: [
+        selection({ id: "sel-2", slot: "anthropic", route: "api_key", apiKeyId: "key-1" }),
+      ],
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole("switch", { name: "Anthropic key" }));
+
+    expect(clearMutate).toHaveBeenCalledWith(
+      { harnessKind: "opencode", surface: "local", slot: "anthropic" },
+      expect.anything(),
+    );
+  });
+
+  it("gateway and provider toggles are independent (both can be on)", () => {
+    state.selections.data = {
+      selections: [
+        selection(),
+        selection({ id: "sel-2", slot: "anthropic", route: "api_key", apiKeyId: "key-1" }),
+      ],
+    };
+    state.apiKeys.data = {
+      keys: [{
+        id: "key-1",
+        provider: "anthropic",
+        displayName: "Work key",
+        redactedHint: "sk-...abcd",
+        status: "active",
+        lastValidatedAt: null,
+        createdAt: "2026-07-01T00:00:00Z",
+      }],
+    };
+    renderSection();
+
+    const gatewaySwitch = screen.getByRole("switch", { name: "Proliferate gateway" });
+    const anthropicSwitch = screen.getByRole("switch", { name: "Anthropic key" });
+    expect(gatewaySwitch.getAttribute("aria-checked")).toBe("true");
+    expect(anthropicSwitch.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("links to the provider's key console via the registry url", () => {
+    renderSection();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Get an API key/ })[0]);
+
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://console.anthropic.com/settings/keys",
+    );
+  });
+});

--- a/apps/desktop/src/components/settings/panes/agent-auth/OpenCodeAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agent-auth/OpenCodeAuthSection.tsx
@@ -1,0 +1,246 @@
+import { useState } from "react";
+import type {
+  AgentAuthRouteSelection,
+  AgentAuthSurface,
+  AgentGatewayProviderInfo,
+} from "@proliferate/cloud-sdk";
+import {
+  useAgentApiKeys,
+  useAgentGatewayCapabilities,
+  useAgentGatewayEnrollment,
+  useClearRouteSelection,
+  useRouteSelections,
+  useUpsertRouteSelection,
+} from "@proliferate/cloud-sdk-react";
+import { ExternalLink } from "@proliferate/ui/icons";
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Switch } from "@proliferate/ui/primitives/Switch";
+import { Tabs } from "@proliferate/ui/primitives/Tabs";
+import { SettingsCard } from "@/components/settings/shared/SettingsCard";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
+import { useToastStore } from "@/stores/toast/toast-store";
+import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
+import { KeyPicker } from "./KeyPicker";
+
+const OPENCODE_HARNESS = "opencode";
+const GATEWAY_SLOT = "gateway";
+
+const SURFACE_TABS = [
+  { id: "local", label: "Local" },
+  { id: "cloud", label: "Cloud" },
+] as const;
+
+interface OpenCodeAuthSectionProps {
+  displayName: string;
+}
+
+/**
+ * OpenCode composes model sources instead of picking one (spec §3.3 slot
+ * semantics): the managed gateway plus any number of direct provider keys are
+ * independent per-source toggles, each persisted as its own route-selection
+ * slot. Provider rows come from the server's provider registry (capabilities)
+ * so nothing here is hardcoded.
+ */
+export function OpenCodeAuthSection({ displayName }: OpenCodeAuthSectionProps) {
+  const { cloudActive } = useCloudAvailabilityState();
+  const showToast = useToastStore((state) => state.show);
+  const { openExternal } = useTauriShellActions();
+
+  const [surface, setSurface] = useState<AgentAuthSurface>("local");
+  // Provider rows toggled on but with no key attached yet (per surface+slot).
+  const [draftSlots, setDraftSlots] = useState<Record<string, boolean>>({});
+
+  const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
+  const enrollmentQuery = useAgentGatewayEnrollment(cloudActive);
+  const selectionsQuery = useRouteSelections(cloudActive);
+  const apiKeysQuery = useAgentApiKeys(cloudActive);
+  const upsertSelection = useUpsertRouteSelection();
+  const clearSelection = useClearRouteSelection();
+
+  if (!cloudActive) {
+    return (
+      <SettingsCard>
+        <div className="space-y-1 px-4 py-3">
+          <p className="text-sm font-semibold text-foreground">Authentication</p>
+          <p className="text-sm text-muted-foreground">
+            Sign in to Proliferate Cloud to manage how {displayName} authenticates
+            to models.
+          </p>
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  const capabilities = capabilitiesQuery.data;
+  const enrollment = enrollmentQuery.data;
+  const gatewayDisabled = capabilities !== undefined && !capabilities.gatewayEnabled;
+  const providers = (capabilities?.providers ?? []).filter((provider) =>
+    provider.harnesses.includes(OPENCODE_HARNESS),
+  );
+  const apiKeys = apiKeysQuery.data?.keys ?? [];
+  const busy = upsertSelection.isPending || clearSelection.isPending;
+
+  function selectionForSlot(slot: string): AgentAuthRouteSelection | null {
+    return (
+      selectionsQuery.data?.selections.find(
+        (entry) =>
+          entry.harnessKind === OPENCODE_HARNESS
+          && entry.surface === surface
+          && entry.slot === slot,
+      ) ?? null
+    );
+  }
+
+  function draftKeyFor(slot: string): string {
+    return `${surface}:${slot}`;
+  }
+
+  function setDraft(slot: string, active: boolean) {
+    setDraftSlots((current) => ({ ...current, [draftKeyFor(slot)]: active }));
+  }
+
+  function isDraft(slot: string): boolean {
+    return draftSlots[draftKeyFor(slot)] ?? false;
+  }
+
+  function upsertSlot(slot: string, route: "gateway" | "api_key", apiKeyId?: string) {
+    upsertSelection.mutate(
+      {
+        harnessKind: OPENCODE_HARNESS,
+        surface,
+        body: route === "api_key"
+          ? { route, apiKeyId: apiKeyId ?? null, slot }
+          : { route, slot },
+      },
+      {
+        onSuccess: () => setDraft(slot, false),
+        onError: (error) => {
+          showToast(error.message || `Could not update the ${displayName} sources.`);
+        },
+      },
+    );
+  }
+
+  function clearSlot(slot: string) {
+    clearSelection.mutate(
+      { harnessKind: OPENCODE_HARNESS, surface, slot },
+      {
+        onError: (error) => {
+          showToast(error.message || `Could not update the ${displayName} sources.`);
+        },
+      },
+    );
+  }
+
+  function handleGatewayToggle(next: boolean) {
+    if (next) {
+      upsertSlot(GATEWAY_SLOT, "gateway");
+    } else {
+      clearSlot(GATEWAY_SLOT);
+    }
+  }
+
+  function handleProviderToggle(provider: AgentGatewayProviderInfo, next: boolean) {
+    const selection = selectionForSlot(provider.id);
+    if (!next) {
+      setDraft(provider.id, false);
+      if (selection) {
+        clearSlot(provider.id);
+      }
+      return;
+    }
+    // Enabling a provider needs a key; wait for an explicit pick.
+    setDraft(provider.id, true);
+  }
+
+  function providerRow(provider: AgentGatewayProviderInfo) {
+    const selection = selectionForSlot(provider.id);
+    const enabled = selection !== null || isDraft(provider.id);
+    return (
+      <div key={provider.id} className="space-y-2 border-b border-border-light px-4 py-3 last:border-b-0">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0 space-y-0.5">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-foreground">{provider.label}</p>
+              {provider.recommendedFor.includes(OPENCODE_HARNESS) ? (
+                <Badge tone="neutral">Recommended</Badge>
+              ) : null}
+            </div>
+            <Button
+              type="button"
+              variant="unstyled"
+              size="unstyled"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => { void openExternal(provider.keyUrl); }}
+            >
+              Get an API key
+              <ExternalLink className="size-3" />
+            </Button>
+          </div>
+          <Switch
+            aria-label={`${provider.label} key`}
+            checked={enabled}
+            disabled={busy}
+            onChange={(next) => handleProviderToggle(provider, next)}
+          />
+        </div>
+        {enabled ? (
+          <KeyPicker
+            keys={apiKeys}
+            provider={provider.id}
+            selectedKeyId={selection?.apiKeyId ?? null}
+            disabled={busy}
+            onSelect={(keyId) => upsertSlot(provider.id, "api_key", keyId)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  const gatewaySelection = selectionForSlot(GATEWAY_SLOT);
+
+  return (
+    <SettingsCard>
+      <div className="flex flex-col gap-2 p-4 pb-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-sm font-semibold text-foreground">Authentication</p>
+          <p className="text-sm text-muted-foreground">
+            {displayName} combines sources: the gateway and your own provider keys
+            can be enabled together.
+          </p>
+        </div>
+        <Tabs
+          items={SURFACE_TABS}
+          activeId={surface}
+          onChange={(next) => setSurface(next === "cloud" ? "cloud" : "local")}
+        />
+      </div>
+
+      {selectionsQuery.isLoading || capabilitiesQuery.isLoading ? (
+        <p className="px-4 pb-3 text-sm text-muted-foreground">
+          Loading model sources...
+        </p>
+      ) : (
+        <div>
+          <div className="flex items-center justify-between gap-3 border-b border-border-light px-4 py-3">
+            <div className="min-w-0 space-y-0.5">
+              <p className="text-sm font-medium text-foreground">Proliferate gateway</p>
+              <p className="text-xs text-muted-foreground">
+                {gatewaySubtitle(capabilities, enrollment)}
+              </p>
+            </div>
+            <Switch
+              aria-label="Proliferate gateway"
+              checked={gatewaySelection !== null}
+              disabled={gatewayDisabled || busy}
+              onChange={handleGatewayToggle}
+            />
+          </div>
+          {providers.map((provider) => providerRow(provider))}
+        </div>
+      )}
+    </SettingsCard>
+  );
+}

--- a/apps/desktop/src/config/agent-api-key-providers.ts
+++ b/apps/desktop/src/config/agent-api-key-providers.ts
@@ -1,0 +1,16 @@
+// Mirrors AGENT_API_KEY_PROVIDERS on the server
+// (server/proliferate/constants/agent_gateway.py).
+export const AGENT_API_KEY_PROVIDERS = [
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openai", label: "OpenAI" },
+  { id: "xai", label: "xAI" },
+  { id: "google", label: "Google" },
+  { id: "other", label: "Other" },
+] as const;
+
+export type AgentApiKeyProviderId = (typeof AGENT_API_KEY_PROVIDERS)[number]["id"];
+
+export function agentApiKeyProviderLabel(provider: string): string {
+  const match = AGENT_API_KEY_PROVIDERS.find((entry) => entry.id === provider);
+  return match?.label ?? provider;
+}

--- a/apps/desktop/src/copy/settings/agent-auth-copy.ts
+++ b/apps/desktop/src/copy/settings/agent-auth-copy.ts
@@ -1,0 +1,22 @@
+import type {
+  AgentGatewayCapabilities,
+  AgentGatewayEnrollment,
+} from "@proliferate/cloud-sdk";
+
+export function gatewaySubtitle(
+  capabilities: AgentGatewayCapabilities | undefined,
+  enrollment: AgentGatewayEnrollment | undefined,
+): string {
+  if (capabilities && !capabilities.gatewayEnabled) {
+    return "Unavailable for your account";
+  }
+  if (enrollment?.syncStatus === "failed") {
+    return enrollment.lastErrorCode
+      ? `Enrollment failed (${enrollment.lastErrorCode})`
+      : "Enrollment failed";
+  }
+  if (enrollment?.syncStatus === "pending") {
+    return "Enrollment pending";
+  }
+  return "Proliferate-managed model access. No setup required.";
+}

--- a/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -68,7 +68,7 @@ export function useFirstRunAuthAdoption() {
         {
           harnessKind: action.harnessKind,
           surface: action.surface,
-          body: { route: action.route },
+          body: { route: action.route, slot: "primary" },
         },
         {
           onError: (error) => {

--- a/cloud/sdk-react/src/hooks/agent-gateway.ts
+++ b/cloud/sdk-react/src/hooks/agent-gateway.ts
@@ -54,6 +54,8 @@ export interface UpsertRouteSelectionInput {
 export interface ClearRouteSelectionInput {
   harnessKind: string;
   surface: string;
+  /** Slot to clear; defaults to 'primary' (single-source harnesses). */
+  slot?: string;
 }
 
 export interface AgentCatalogScope {
@@ -130,8 +132,8 @@ export function useClearRouteSelection() {
   const client = useCloudClient();
   const queryClient = useQueryClient();
   return useMutation<void, Error, ClearRouteSelectionInput>({
-    mutationFn: ({ harnessKind, surface }) =>
-      clearAgentRouteSelection(harnessKind, surface, client),
+    mutationFn: ({ harnessKind, surface, slot }) =>
+      clearAgentRouteSelection(harnessKind, surface, slot ?? "primary", client),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agentRouteSelectionsKey() });
     },

--- a/cloud/sdk/src/client/agent-gateway.ts
+++ b/cloud/sdk/src/client/agent-gateway.ts
@@ -86,11 +86,13 @@ export async function upsertAgentRouteSelection(
 export async function clearAgentRouteSelection(
   harnessKind: string,
   surface: string,
+  slot: string = "primary",
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<void> {
   await client.requestJson<void>({
     method: "DELETE",
     path: routeSelectionPath(harnessKind, surface),
+    query: { slot },
   });
 }
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -2326,6 +2326,8 @@ export interface components {
              * @enum {string}
              */
             surface: "local" | "cloud";
+            /** Slot */
+            slot: string;
             /**
              * Route
              * @enum {string}
@@ -2349,6 +2351,11 @@ export interface components {
             route: "native" | "api_key" | "gateway";
             /** Apikeyid */
             apiKeyId?: string | null;
+            /**
+             * Slot
+             * @default primary
+             */
+            slot: string;
         };
         /** AgentCatalogAgent */
         AgentCatalogAgent: {
@@ -2627,6 +2634,8 @@ export interface components {
             publicBaseUrl: string | null;
             /** Enrollmentstatus */
             enrollmentStatus: string;
+            /** Providers */
+            providers?: components["schemas"]["AgentGatewayProviderInfo"][];
         };
         /** AgentGatewayCatalogOverrideResponse */
         AgentGatewayCatalogOverrideResponse: {
@@ -2707,6 +2716,24 @@ export interface components {
             createdAt: string;
             /** Updatedat */
             updatedAt: string;
+        };
+        /**
+         * AgentGatewayProviderInfo
+         * @description One PROVIDER_REGISTRY entry; the UI never hardcodes provider metadata.
+         */
+        AgentGatewayProviderInfo: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Envkey */
+            envKey: string;
+            /** Keyurl */
+            keyUrl: string;
+            /** Harnesses */
+            harnesses: string[];
+            /** Recommendedfor */
+            recommendedFor: string[];
         };
         /** AgentRunConfigCreateRequest */
         AgentRunConfigCreateRequest: {
@@ -7573,7 +7600,9 @@ export interface operations {
     };
     clear_agent_route_selection_endpoint_v1_cloud_agent_gateway_route_selections__harness_kind___surface__delete: {
         parameters: {
-            query?: never;
+            query?: {
+                slot?: string;
+            };
             header?: never;
             path: {
                 harness_kind: string;

--- a/cloud/sdk/src/types/agent-gateway.ts
+++ b/cloud/sdk/src/types/agent-gateway.ts
@@ -9,6 +9,7 @@ export type AgentAuthRouteSelectionListResponse =
 export type UpsertAgentAuthRouteSelectionRequest =
   Schema<"AgentAuthRouteSelectionUpsertRequest">;
 export type AgentGatewayCapabilities = Schema<"AgentGatewayCapabilitiesResponse">;
+export type AgentGatewayProviderInfo = Schema<"AgentGatewayProviderInfo">;
 export type AgentGatewayEnrollment = Schema<"AgentGatewayEnrollmentResponse">;
 export type AgentGatewayCatalog = Schema<"AgentGatewayCatalogResponse">;
 export type RefreshAgentGatewayCatalogRequest =

--- a/server/alembic/versions/e5f6a7b8c9d0_agent_auth_route_selection_slot.py
+++ b/server/alembic/versions/e5f6a7b8c9d0_agent_auth_route_selection_slot.py
@@ -1,0 +1,72 @@
+"""agent auth route selection slot
+
+Adds the slot composition axis to agent_auth_route_selection (PR 13, spec
+section 3.3 slot semantics): single-source harnesses keep exactly one
+slot='primary' row; OpenCode composes one row per slot (gateway + direct
+provider keys). The unique scope widens from (user, harness, surface) to
+(user, harness, surface, slot). No data migration is needed (no users).
+
+Revision ID: e5f6a7b8c9d0
+Revises: a9c0d1e2f3b4
+Create Date: 2026-07-01 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "a9c0d1e2f3b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "agent_auth_route_selection"
+_UNIQUE = "uq_agent_auth_route_selection_scope"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "slot",
+            sa.String(length=32),
+            nullable=False,
+            server_default="primary",
+        ),
+    )
+    op.drop_constraint(_UNIQUE, _TABLE, type_="unique")
+    op.create_unique_constraint(
+        _UNIQUE,
+        _TABLE,
+        ["user_id", "harness_kind", "surface", "slot"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_UNIQUE, _TABLE, type_="unique")
+    # Collapse any multi-slot scopes so the narrower unique key can be
+    # restored (keep the primary/gateway row, else an arbitrary one).
+    op.execute(
+        sa.text(
+            f"""
+            DELETE FROM {_TABLE} keep
+            WHERE keep.id NOT IN (
+                SELECT DISTINCT ON (user_id, harness_kind, surface) id
+                FROM {_TABLE}
+                ORDER BY user_id, harness_kind, surface,
+                         (slot IN ('primary', 'gateway')) DESC,
+                         created_at
+            )
+            """
+        )
+    )
+    op.drop_column(_TABLE, "slot")
+    op.create_unique_constraint(
+        _UNIQUE,
+        _TABLE,
+        ["user_id", "harness_kind", "surface"],
+    )

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -1,5 +1,7 @@
 """Agent LLM gateway (LiteLLM) schema constants."""
 
+from dataclasses import dataclass
+
 AGENT_API_KEY_PROVIDERS = ("anthropic", "openai", "xai", "google", "other")
 AGENT_API_KEY_STATUS_ACTIVE = "active"
 AGENT_API_KEY_STATUS_REVOKED = "revoked"
@@ -20,6 +22,71 @@ AGENT_AUTH_ROUTES = (
     AGENT_AUTH_ROUTE_NATIVE,
     AGENT_AUTH_ROUTE_API_KEY,
     AGENT_AUTH_ROUTE_GATEWAY,
+)
+
+# Slot semantics (spec §3.3): single-source harnesses keep radio semantics on
+# the one 'primary' slot; OpenCode composes multiple sources, one row per slot.
+AGENT_AUTH_SLOT_PRIMARY = "primary"
+AGENT_AUTH_SLOT_GATEWAY = "gateway"
+AGENT_AUTH_OPENCODE_HARNESS = "opencode"
+# gateway slot must carry the gateway route; provider slots must carry an
+# api_key route whose key belongs to that provider.
+AGENT_AUTH_OPENCODE_SLOTS = (
+    AGENT_AUTH_SLOT_GATEWAY,
+    "openai",
+    "anthropic",
+    "xai",
+    "google",
+)
+
+
+# Provider registry for direct api_key routes. The capabilities endpoint
+# exposes this so UIs never hardcode provider metadata. `harnesses` = which
+# harnesses a direct key of this provider can serve; `recommended_for` = the
+# harnesses for which this provider is the recommended direct key.
+@dataclass(frozen=True)
+class AgentProviderRegistryEntry:
+    id: str
+    label: str
+    env_key: str
+    key_url: str
+    harnesses: tuple[str, ...]
+    recommended_for: tuple[str, ...]
+
+
+AGENT_PROVIDER_REGISTRY: tuple[AgentProviderRegistryEntry, ...] = (
+    AgentProviderRegistryEntry(
+        id="anthropic",
+        label="Anthropic",
+        env_key="ANTHROPIC_API_KEY",
+        key_url="https://console.anthropic.com/settings/keys",
+        harnesses=("claude", "opencode"),
+        recommended_for=("claude", "opencode"),
+    ),
+    AgentProviderRegistryEntry(
+        id="openai",
+        label="OpenAI",
+        env_key="OPENAI_API_KEY",
+        key_url="https://platform.openai.com/api-keys",
+        harnesses=("codex", "opencode"),
+        recommended_for=("codex",),
+    ),
+    AgentProviderRegistryEntry(
+        id="xai",
+        label="xAI",
+        env_key="XAI_API_KEY",
+        key_url="https://console.x.ai",
+        harnesses=("grok", "opencode"),
+        recommended_for=("grok",),
+    ),
+    AgentProviderRegistryEntry(
+        id="google",
+        label="Google",
+        env_key="GEMINI_API_KEY",
+        key_url="https://aistudio.google.com/apikey",
+        harnesses=("gemini", "opencode"),
+        recommended_for=("gemini",),
+    ),
 )
 
 AGENT_GATEWAY_SUBJECT_KIND_USER = "user"

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -69,7 +69,11 @@ class AgentApiKey(Base):
 
 
 class AgentAuthRouteSelection(Base):
-    """Server-side auth route per (user, harness, surface)."""
+    """Server-side auth route per (user, harness, surface, slot).
+
+    Single-source harnesses only ever use slot='primary'; OpenCode composes
+    one row per slot (gateway + direct provider keys, simultaneously).
+    """
 
     __tablename__ = "agent_auth_route_selection"
     __table_args__ = (
@@ -77,6 +81,7 @@ class AgentAuthRouteSelection(Base):
             "user_id",
             "harness_kind",
             "surface",
+            "slot",
             name="uq_agent_auth_route_selection_scope",
         ),
         CheckConstraint(
@@ -104,6 +109,7 @@ class AgentAuthRouteSelection(Base):
     )
     harness_kind: Mapped[str] = mapped_column(String(64))
     surface: Mapped[str] = mapped_column(String(16))
+    slot: Mapped[str] = mapped_column(String(32), default="primary", server_default="primary")
     route: Mapped[str] = mapped_column(String(16))
     api_key_id: Mapped[uuid.UUID | None] = mapped_column(
         # CASCADE (not SET NULL): the ck_..._api_key_ref check forbids a NULL

--- a/server/proliferate/db/store/agent_gateway/__init__.py
+++ b/server/proliferate/db/store/agent_gateway/__init__.py
@@ -55,6 +55,7 @@ from proliferate.db.store.agent_gateway.records import (
     OrgAgentPolicyRecord,
 )
 from proliferate.db.store.agent_gateway.route_selections import (
+    AgentApiKeyNotUsableError,
     delete_route_selection,
     get_route_selection,
     list_route_selections,
@@ -68,6 +69,7 @@ from proliferate.db.store.agent_gateway.usage import (
 )
 
 __all__ = [
+    "AgentApiKeyNotUsableError",
     "AgentApiKeyRecord",
     "AgentAuthRouteSelectionRecord",
     "AgentCatalogOverrideRecord",

--- a/server/proliferate/db/store/agent_gateway/mappers.py
+++ b/server/proliferate/db/store/agent_gateway/mappers.py
@@ -45,6 +45,7 @@ def route_selection_record(row: AgentAuthRouteSelection) -> AgentAuthRouteSelect
         user_id=row.user_id,
         harness_kind=row.harness_kind,
         surface=row.surface,
+        slot=row.slot,
         route=row.route,
         api_key_id=row.api_key_id,
         revision=row.revision,

--- a/server/proliferate/db/store/agent_gateway/records.py
+++ b/server/proliferate/db/store/agent_gateway/records.py
@@ -33,6 +33,7 @@ class AgentAuthRouteSelectionRecord:
     revision: int
     created_at: datetime
     updated_at: datetime
+    slot: str = "primary"
 
 
 @dataclass(frozen=True)

--- a/server/proliferate/db/store/agent_gateway/route_selections.py
+++ b/server/proliferate/db/store/agent_gateway/route_selections.py
@@ -1,7 +1,15 @@
 """Agent auth route selection persistence.
 
 Cross-column legality that SQL CHECKs cannot express cleanly (api_key
-ownership + active status) is enforced here; callers get typed ValueErrors.
+ownership + active status, slot semantics) is enforced here; callers get
+typed ValueErrors.
+
+Slot semantics (spec §3.3): single-source harnesses (claude/codex/grok/
+gemini — and any harness that is not opencode) only ever use slot='primary',
+so their selection keeps radio semantics. OpenCode is additive: one row per
+slot in {'gateway','openai','anthropic','xai','google'} — the gateway slot
+must carry the gateway route, provider slots must carry an api_key route
+whose key belongs to that provider.
 """
 
 from __future__ import annotations
@@ -15,9 +23,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.constants.agent_gateway import (
     AGENT_API_KEY_STATUS_ACTIVE,
     AGENT_AUTH_HARNESS_KINDS,
+    AGENT_AUTH_OPENCODE_HARNESS,
+    AGENT_AUTH_OPENCODE_SLOTS,
     AGENT_AUTH_ROUTE_API_KEY,
+    AGENT_AUTH_ROUTE_GATEWAY,
     AGENT_AUTH_ROUTE_NATIVE,
     AGENT_AUTH_ROUTES,
+    AGENT_AUTH_SLOT_GATEWAY,
+    AGENT_AUTH_SLOT_PRIMARY,
     AGENT_AUTH_SURFACE_CLOUD,
     AGENT_AUTH_SURFACES,
 )
@@ -27,21 +40,30 @@ from proliferate.db.store.agent_gateway.records import AgentAuthRouteSelectionRe
 from proliferate.utils.time import utcnow
 
 
+class AgentApiKeyNotUsableError(ValueError):
+    """The referenced api key is not an active key owned by the caller."""
+
+
 def validate_route_selection(
     *,
     surface: str,
     route: str,
     api_key_id: UUID | None,
     harness_kind: str | None = None,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> None:
     """Pure legality checks shared by the store and unit tests.
 
     ``harness_kind`` is optional so surface/route legality can be exercised in
-    isolation; when supplied it is checked against the known allowlist so that
-    unbounded path params cannot reach the ``String(64)`` column.
+    isolation; when supplied, slot semantics are enforced first (unknown
+    harnesses behave as single-source, spec §3.3) and the kind is then checked
+    against the known allowlist so that unbounded path params cannot reach the
+    ``String(64)`` column.
     """
-    if harness_kind is not None and harness_kind not in AGENT_AUTH_HARNESS_KINDS:
-        raise ValueError(f"Unknown agent harness kind: {harness_kind}")
+    if harness_kind is not None:
+        _validate_slot(harness_kind=harness_kind, route=route, slot=slot)
+        if harness_kind not in AGENT_AUTH_HARNESS_KINDS:
+            raise ValueError(f"Unknown agent harness kind: {harness_kind}")
     if surface not in AGENT_AUTH_SURFACES:
         raise ValueError(f"Unknown agent auth surface: {surface}")
     if route not in AGENT_AUTH_ROUTES:
@@ -54,6 +76,31 @@ def validate_route_selection(
         raise ValueError("api_key_id is only valid for api_key route selections.")
 
 
+def _validate_slot(*, harness_kind: str, route: str, slot: str) -> None:
+    if harness_kind != AGENT_AUTH_OPENCODE_HARNESS:
+        if slot != AGENT_AUTH_SLOT_PRIMARY:
+            raise ValueError(
+                f"Harness '{harness_kind}' is single-source and only supports "
+                f"the '{AGENT_AUTH_SLOT_PRIMARY}' slot (got '{slot}')."
+            )
+        return
+    if slot not in AGENT_AUTH_OPENCODE_SLOTS:
+        raise ValueError(
+            "OpenCode selections must target one of the slots: "
+            f"{', '.join(AGENT_AUTH_OPENCODE_SLOTS)} (got '{slot}')."
+        )
+    if slot == AGENT_AUTH_SLOT_GATEWAY:
+        if route != AGENT_AUTH_ROUTE_GATEWAY:
+            raise ValueError(
+                f"The opencode 'gateway' slot only carries the gateway route (got '{route}')."
+            )
+        return
+    if route != AGENT_AUTH_ROUTE_API_KEY:
+        raise ValueError(
+            f"The opencode '{slot}' provider slot only carries the api_key route (got '{route}')."
+        )
+
+
 async def upsert_route_selection(
     db: AsyncSession,
     *,
@@ -62,12 +109,14 @@ async def upsert_route_selection(
     surface: str,
     route: str,
     api_key_id: UUID | None = None,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> AgentAuthRouteSelectionRecord:
     validate_route_selection(
         surface=surface,
         route=route,
         api_key_id=api_key_id,
         harness_kind=harness_kind,
+        slot=slot,
     )
     if api_key_id is not None:
         key_row = (
@@ -80,7 +129,17 @@ async def upsert_route_selection(
             )
         ).scalar_one_or_none()
         if key_row is None:
-            raise ValueError("api_key_id must reference an active key owned by the user.")
+            raise AgentApiKeyNotUsableError(
+                "api_key_id must reference an active key owned by the user."
+            )
+        if (
+            harness_kind == AGENT_AUTH_OPENCODE_HARNESS
+            and slot != AGENT_AUTH_SLOT_GATEWAY
+            and key_row.provider != slot
+        ):
+            raise ValueError(
+                f"The opencode '{slot}' slot requires a {slot} key (got a {key_row.provider} key)."
+            )
 
     # Atomic upsert: two concurrent first writes for the same scope resolve via
     # ON CONFLICT instead of racing a select-then-insert into an IntegrityError.
@@ -91,6 +150,7 @@ async def upsert_route_selection(
         user_id=user_id,
         harness_kind=harness_kind,
         surface=surface,
+        slot=slot,
         route=route,
         api_key_id=api_key_id,
         revision=1,
@@ -125,6 +185,7 @@ async def upsert_route_selection(
                 AgentAuthRouteSelection.user_id == user_id,
                 AgentAuthRouteSelection.harness_kind == harness_kind,
                 AgentAuthRouteSelection.surface == surface,
+                AgentAuthRouteSelection.slot == slot,
             )
             .execution_options(populate_existing=True)
         )
@@ -138,6 +199,7 @@ async def get_route_selection(
     user_id: UUID,
     harness_kind: str,
     surface: str,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> AgentAuthRouteSelectionRecord | None:
     row = (
         await db.execute(
@@ -145,6 +207,7 @@ async def get_route_selection(
                 AgentAuthRouteSelection.user_id == user_id,
                 AgentAuthRouteSelection.harness_kind == harness_kind,
                 AgentAuthRouteSelection.surface == surface,
+                AgentAuthRouteSelection.slot == slot,
             )
         )
     ).scalar_one_or_none()
@@ -157,6 +220,7 @@ async def delete_route_selection(
     user_id: UUID,
     harness_kind: str,
     surface: str,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> bool:
     """Clear the selection for a scope. Returns whether a row was deleted."""
     result = await db.execute(
@@ -164,6 +228,7 @@ async def delete_route_selection(
             AgentAuthRouteSelection.user_id == user_id,
             AgentAuthRouteSelection.harness_kind == harness_kind,
             AgentAuthRouteSelection.surface == surface,
+            AgentAuthRouteSelection.slot == slot,
         )
     )
     return (result.rowcount or 0) > 0
@@ -182,6 +247,7 @@ async def list_route_selections(
                 .order_by(
                     AgentAuthRouteSelection.harness_kind,
                     AgentAuthRouteSelection.surface,
+                    AgentAuthRouteSelection.slot,
                 )
             )
         )

--- a/server/proliferate/server/cloud/agent_gateway/api.py
+++ b/server/proliferate/server/cloud/agent_gateway/api.py
@@ -37,6 +37,7 @@ from proliferate.server.cloud.agent_gateway.models import (
     enrollment_payload,
     org_agent_policy_payload,
     org_agent_policy_violation_payload,
+    provider_registry_payload,
     route_selection_payload,
 )
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
@@ -135,6 +136,7 @@ async def upsert_agent_route_selection_endpoint(
             surface=surface,
             route=body.route,
             api_key_id=api_key_id,
+            slot=body.slot,
         )
     except CloudApiError as error:
         raise_cloud_error(error)
@@ -145,6 +147,7 @@ async def upsert_agent_route_selection_endpoint(
 async def clear_agent_route_selection_endpoint(
     harness_kind: str,
     surface: str,
+    slot: str = Query("primary"),
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> None:
@@ -154,6 +157,7 @@ async def clear_agent_route_selection_endpoint(
             user_id=user.id,
             harness_kind=harness_kind,
             surface=surface,
+            slot=slot,
         )
     except CloudApiError as error:
         raise_cloud_error(error)
@@ -260,6 +264,7 @@ async def get_agent_gateway_capabilities_endpoint(
         gateway_enabled=gateway_enabled,
         public_base_url=public_base_url,
         enrollment_status=enrollment_status,
+        providers=provider_registry_payload(),
     )
 
 

--- a/server/proliferate/server/cloud/agent_gateway/models.py
+++ b/server/proliferate/server/cloud/agent_gateway/models.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from proliferate.constants.agent_gateway import AGENT_PROVIDER_REGISTRY
 from proliferate.db.store.agent_gateway import (
     AgentApiKeyRecord,
     AgentAuthRouteSelectionRecord,
@@ -55,6 +56,7 @@ class AgentAuthRouteSelectionResponse(AgentGatewayBaseModel):
     id: str
     harness_kind: str = Field(alias="harnessKind")
     surface: AgentAuthSurface
+    slot: str
     route: AgentAuthRoute
     api_key_id: str | None = Field(alias="apiKeyId")
     revision: int
@@ -69,12 +71,27 @@ class AgentAuthRouteSelectionListResponse(AgentGatewayBaseModel):
 class AgentAuthRouteSelectionUpsertRequest(AgentGatewayBaseModel):
     route: AgentAuthRoute
     api_key_id: str | None = Field(default=None, alias="apiKeyId")
+    # Composition axis (spec §3.3): 'primary' for single-source harnesses;
+    # opencode uses per-source slots. Defaults keep pre-slot callers working.
+    slot: str = "primary"
+
+
+class AgentGatewayProviderInfo(AgentGatewayBaseModel):
+    """One PROVIDER_REGISTRY entry; the UI never hardcodes provider metadata."""
+
+    id: str
+    label: str
+    env_key: str = Field(alias="envKey")
+    key_url: str = Field(alias="keyUrl")
+    harnesses: list[str]
+    recommended_for: list[str] = Field(alias="recommendedFor")
 
 
 class AgentGatewayCapabilitiesResponse(AgentGatewayBaseModel):
     gateway_enabled: bool = Field(alias="gatewayEnabled")
     public_base_url: str | None = Field(alias="publicBaseUrl")
     enrollment_status: str = Field(alias="enrollmentStatus")
+    providers: list[AgentGatewayProviderInfo] = Field(default_factory=list)
 
 
 class AgentGatewayCatalogResponse(AgentGatewayBaseModel):
@@ -173,12 +190,27 @@ def route_selection_payload(
         id=str(record.id),
         harness_kind=record.harness_kind,
         surface=record.surface,  # type: ignore[arg-type]
+        slot=record.slot,
         route=record.route,  # type: ignore[arg-type]
         api_key_id=str(record.api_key_id) if record.api_key_id is not None else None,
         revision=record.revision,
         created_at=record.created_at.isoformat(),
         updated_at=record.updated_at.isoformat(),
     )
+
+
+def provider_registry_payload() -> list[AgentGatewayProviderInfo]:
+    return [
+        AgentGatewayProviderInfo(
+            id=entry.id,
+            label=entry.label,
+            env_key=entry.env_key,
+            key_url=entry.key_url,
+            harnesses=list(entry.harnesses),
+            recommended_for=list(entry.recommended_for),
+        )
+        for entry in AGENT_PROVIDER_REGISTRY
+    ]
 
 
 def catalog_payload(

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -19,6 +19,7 @@ from proliferate.config import settings
 from proliferate.constants.agent_gateway import (
     AGENT_API_KEY_PROVIDERS,
     AGENT_AUTH_ROUTES,
+    AGENT_AUTH_SLOT_PRIMARY,
     AGENT_AUTH_SURFACE_CLOUD,
 )
 from proliferate.db.store import agent_gateway as agent_gateway_store
@@ -157,6 +158,7 @@ async def upsert_route_selection(
     surface: str,
     route: str,
     api_key_id: UUID | None,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> AgentAuthRouteSelectionRecord:
     try:
         agent_gateway_store.validate_route_selection(
@@ -164,6 +166,7 @@ async def upsert_route_selection(
             surface=surface,
             route=route,
             api_key_id=api_key_id,
+            slot=slot,
         )
     except ValueError as error:
         raise CloudApiError(
@@ -179,20 +182,28 @@ async def upsert_route_selection(
             surface=surface,
             route=route,
             api_key_id=api_key_id,
+            slot=slot,
         )
-    except ValueError as error:
-        # Pure legality already passed; the remaining failure mode is an
-        # api_key_id that is not an active key owned by the caller.
+    except agent_gateway_store.AgentApiKeyNotUsableError as error:
         raise CloudApiError(
             "agent_api_key_not_found",
             "api_key_id must reference an active key owned by the caller.",
             status_code=404,
+        ) from error
+    except ValueError as error:
+        # Pure legality already passed; the remaining failure mode is an
+        # opencode provider slot fed a key of another provider.
+        raise CloudApiError(
+            "invalid_agent_route_selection",
+            str(error),
+            status_code=400,
         ) from error
     log_cloud_event(
         "agent_route_selection_upserted",
         user_id=str(user_id),
         harness_kind=harness_kind,
         surface=surface,
+        slot=slot,
         route=route,
         api_key_id=str(api_key_id) if api_key_id is not None else None,
         revision=record.revision,
@@ -208,17 +219,19 @@ async def clear_route_selection(
     user_id: UUID,
     harness_kind: str,
     surface: str,
+    slot: str = AGENT_AUTH_SLOT_PRIMARY,
 ) -> None:
     deleted = await agent_gateway_store.delete_route_selection(
         db,
         user_id=user_id,
         harness_kind=harness_kind,
         surface=surface,
+        slot=slot,
     )
     if not deleted:
         raise CloudApiError(
             "agent_route_selection_not_found",
-            "No route selection exists for this harness and surface.",
+            "No route selection exists for this harness, surface, and slot.",
             status_code=404,
         )
     log_cloud_event(
@@ -226,6 +239,7 @@ async def clear_route_selection(
         user_id=str(user_id),
         harness_kind=harness_kind,
         surface=surface,
+        slot=slot,
     )
     if surface == AGENT_AUTH_SURFACE_CLOUD:
         await materialization_service.schedule_materialize_agent_auth(db, user_id=user_id)

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -10,12 +10,20 @@ lives at ``<anyharness home>/agent-auth/state.json`` (mode 0600):
       "revision": 42,
       "user_id": "...",
       "selections": [
-        {"harness": "claude", "route": "gateway",
+        {"harness": "claude", "route": "gateway", "slot": "primary",
          "base_url": "https://llm.example/v1", "key": "<virtual key>"},
-        {"harness": "codex", "route": "api_key",
-         "provider": "openai", "key": "<raw key>"}
+        {"harness": "codex", "route": "api_key", "slot": "primary",
+         "provider": "openai", "key": "<raw key>"},
+        {"harness": "opencode", "route": "gateway", "slot": "gateway",
+         "base_url": "https://llm.example/v1", "key": "<virtual key>"},
+        {"harness": "opencode", "route": "api_key", "slot": "anthropic",
+         "provider": "anthropic", "key": "<raw key>"}
       ]
     }
+
+Multiple entries per harness are allowed (spec §3.3 slot semantics): OpenCode
+composes one entry per slot; AnyHarness merges them into a single additive
+launch profile and rejects multi-entry state for single-source harnesses.
 
 Only ``surface='cloud'`` selections are materialized. ``revision`` is the max
 revision across the user's cloud route-selection rows; it is informational
@@ -108,7 +116,10 @@ def render_agent_auth_state(
         return None, ""
 
     rendered: list[dict[str, object]] = []
-    for selection in sorted(cloud_selections, key=lambda item: item.harness_kind):
+    for selection in sorted(
+        cloud_selections,
+        key=lambda item: (item.harness_kind, item.slot),
+    ):
         entry: dict[str, object] | None = None
         if selection.route == AGENT_AUTH_ROUTE_GATEWAY:
             entry = _render_gateway_selection(inputs, selection)
@@ -162,6 +173,7 @@ def _render_gateway_selection(
     return {
         "harness": selection.harness_kind,
         "route": AGENT_AUTH_ROUTE_GATEWAY,
+        "slot": selection.slot,
         "base_url": inputs.gateway_base_url,
         "key": inputs.gateway_virtual_key,
     }
@@ -182,6 +194,7 @@ def _render_api_key_selection(
     return {
         "harness": selection.harness_kind,
         "route": AGENT_AUTH_ROUTE_API_KEY,
+        "slot": selection.slot,
         "provider": provider,
         "key": secret,
     }

--- a/server/tests/integration/test_agent_auth_materialization.py
+++ b/server/tests/integration/test_agent_auth_materialization.py
@@ -171,6 +171,7 @@ class TestBuildAgentAuthStateSyncedGateway:
             {
                 "harness": "claude",
                 "route": "gateway",
+                "slot": "primary",
                 "base_url": "https://llm.proliferate.ai",
                 "key": "sk-litellm-vk",
             }

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -233,6 +233,7 @@ class TestAgentRouteSelections:
         payload = upserted.json()
         assert payload["harnessKind"] == "claude"
         assert payload["surface"] == "cloud"
+        assert payload["slot"] == "primary"
         assert payload["route"] == "api_key"
         assert payload["apiKeyId"] == created["id"]
         assert payload["revision"] == 1
@@ -332,6 +333,82 @@ class TestAgentRouteSelections:
         assert overlong.json()["detail"]["code"] == "invalid_agent_route_selection"
 
     @pytest.mark.asyncio
+    async def test_opencode_slots_compose_and_clear_independently(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        created = await _create_key(client, headers)
+
+        gateway = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/opencode/cloud",
+            headers=headers,
+            json={"route": "gateway", "slot": "gateway"},
+        )
+        assert gateway.status_code == 200, gateway.text
+        assert gateway.json()["slot"] == "gateway"
+
+        direct = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/opencode/cloud",
+            headers=headers,
+            json={"route": "api_key", "apiKeyId": created["id"], "slot": "anthropic"},
+        )
+        assert direct.status_code == 200, direct.text
+        assert direct.json()["slot"] == "anthropic"
+
+        listed = await client.get(
+            "/v1/cloud/agent-gateway/route-selections",
+            headers=headers,
+        )
+        assert [entry["slot"] for entry in listed.json()["selections"]] == [
+            "anthropic",
+            "gateway",
+        ]
+
+        cleared = await client.delete(
+            "/v1/cloud/agent-gateway/route-selections/opencode/cloud",
+            headers=headers,
+            params={"slot": "anthropic"},
+        )
+        assert cleared.status_code == 204
+        remaining = await client.get(
+            "/v1/cloud/agent-gateway/route-selections",
+            headers=headers,
+        )
+        assert [entry["slot"] for entry in remaining.json()["selections"]] == ["gateway"]
+
+    @pytest.mark.asyncio
+    async def test_slot_validation_errors_are_typed(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        created = await _create_key(client, headers)  # anthropic key
+
+        single_source = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/claude/cloud",
+            headers=headers,
+            json={"route": "gateway", "slot": "gateway"},
+        )
+        assert single_source.status_code == 400
+        assert single_source.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+        default_slot_for_opencode = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/opencode/cloud",
+            headers=headers,
+            json={"route": "gateway"},
+        )
+        assert default_slot_for_opencode.status_code == 400
+        assert (
+            default_slot_for_opencode.json()["detail"]["code"] == "invalid_agent_route_selection"
+        )
+
+        provider_mismatch = await client.put(
+            "/v1/cloud/agent-gateway/route-selections/opencode/cloud",
+            headers=headers,
+            json={"route": "api_key", "apiKeyId": created["id"], "slot": "openai"},
+        )
+        assert provider_mismatch.status_code == 400
+        assert provider_mismatch.json()["detail"]["code"] == "invalid_agent_route_selection"
+
+    @pytest.mark.asyncio
     async def test_unknown_surface_is_400(self, client: AsyncClient) -> None:
         _, headers = await _authed_user(client)
         response = await client.put(
@@ -359,11 +436,19 @@ class TestAgentGatewayCapabilities:
             headers=headers,
         )
         assert response.status_code == 200
-        assert response.json() == {
-            "gatewayEnabled": False,
-            "publicBaseUrl": None,
-            "enrollmentStatus": "none",
-        }
+        payload = response.json()
+        assert payload["gatewayEnabled"] is False
+        assert payload["publicBaseUrl"] is None
+        assert payload["enrollmentStatus"] == "none"
+        # The provider registry rides along so UIs never hardcode metadata.
+        providers = {entry["id"]: entry for entry in payload["providers"]}
+        assert set(providers) == {"anthropic", "openai", "xai", "google"}
+        anthropic = providers["anthropic"]
+        assert anthropic["label"] == "Anthropic"
+        assert anthropic["envKey"] == "ANTHROPIC_API_KEY"
+        assert anthropic["keyUrl"].startswith("https://")
+        assert "opencode" in anthropic["harnesses"]
+        assert "opencode" in anthropic["recommendedFor"]
 
     @pytest.mark.asyncio
     async def test_capabilities_gateway_on_with_enrollment(
@@ -394,11 +479,11 @@ class TestAgentGatewayCapabilities:
             headers=headers,
         )
         assert response.status_code == 200
-        assert response.json() == {
-            "gatewayEnabled": True,
-            "publicBaseUrl": "https://llm.proliferate.ai",
-            "enrollmentStatus": "pending",
-        }
+        payload = response.json()
+        assert payload["gatewayEnabled"] is True
+        assert payload["publicBaseUrl"] == "https://llm.proliferate.ai"
+        assert payload["enrollmentStatus"] == "pending"
+        assert len(payload["providers"]) == 4
 
 
 class TestAgentGatewayEnrollment:

--- a/server/tests/integration/test_agent_gateway_store_slots.py
+++ b/server/tests/integration/test_agent_gateway_store_slots.py
@@ -1,0 +1,160 @@
+"""Integration tests for route-selection slot composition (real Postgres)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+from proliferate.db.store import agent_gateway as store
+
+
+async def _create_user(db_session: AsyncSession, *, email: str | None = None) -> uuid.UUID:
+    user = User(
+        email=email or f"agent-gateway-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+@pytest.mark.asyncio
+async def test_single_source_harness_rejects_non_primary_slot(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _create_user(db_session)
+    for harness in ("claude", "codex", "grok", "gemini"):
+        with pytest.raises(ValueError, match="single-source"):
+            await store.upsert_route_selection(
+                db_session,
+                user_id=user_id,
+                harness_kind=harness,
+                surface="local",
+                route="gateway",
+                slot="gateway",
+            )
+
+
+@pytest.mark.asyncio
+async def test_opencode_slots_compose_additively(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    anthropic_key = await store.create_agent_api_key(
+        db_session,
+        user_id=user_id,
+        provider="anthropic",
+        display_name="Anthropic key",
+        payload="sk-ant-api03-abcdefabc4",
+    )
+
+    gateway = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        route="gateway",
+        slot="gateway",
+    )
+    direct = await store.upsert_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        route="api_key",
+        api_key_id=anthropic_key.id,
+        slot="anthropic",
+    )
+    assert gateway.slot == "gateway"
+    assert direct.slot == "anthropic"
+    assert gateway.id != direct.id
+
+    listed = await store.list_route_selections(db_session, user_id=user_id)
+    assert [(record.harness_kind, record.slot) for record in listed] == [
+        ("opencode", "anthropic"),
+        ("opencode", "gateway"),
+    ]
+
+    # Slot-scoped get/delete leave sibling slots untouched.
+    fetched = await store.get_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        slot="anthropic",
+    )
+    assert fetched is not None
+    assert fetched.id == direct.id
+    assert (
+        await store.get_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="opencode",
+            surface="cloud",
+        )
+        is None
+    )
+    assert await store.delete_route_selection(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        slot="anthropic",
+    )
+    remaining = await store.list_route_selections(db_session, user_id=user_id)
+    assert [record.slot for record in remaining] == ["gateway"]
+
+
+@pytest.mark.asyncio
+async def test_opencode_slot_route_legality(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    openai_key = await store.create_agent_api_key(
+        db_session,
+        user_id=user_id,
+        provider="openai",
+        display_name="OpenAI key",
+        payload="sk-proj-abcdef1234",
+    )
+
+    with pytest.raises(ValueError, match="slots"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="opencode",
+            surface="cloud",
+            route="gateway",
+        )
+    with pytest.raises(ValueError, match="gateway.*slot"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="opencode",
+            surface="cloud",
+            route="api_key",
+            api_key_id=openai_key.id,
+            slot="gateway",
+        )
+    with pytest.raises(ValueError, match="api_key"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="opencode",
+            surface="cloud",
+            route="gateway",
+            slot="openai",
+        )
+    # Provider slots require a key of the same provider.
+    with pytest.raises(ValueError, match="requires a anthropic key"):
+        await store.upsert_route_selection(
+            db_session,
+            user_id=user_id,
+            harness_kind="opencode",
+            surface="cloud",
+            route="api_key",
+            api_key_id=openai_key.id,
+            slot="anthropic",
+        )

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -25,6 +25,7 @@ def _selection(
     route: str = "gateway",
     api_key_id: uuid.UUID | None = None,
     revision: int = 1,
+    slot: str = "primary",
 ) -> AgentAuthRouteSelectionRecord:
     return AgentAuthRouteSelectionRecord(
         id=uuid.uuid4(),
@@ -36,6 +37,7 @@ def _selection(
         revision=revision,
         created_at=NOW,
         updated_at=NOW,
+        slot=slot,
     )
 
 
@@ -81,14 +83,73 @@ class TestRenderAgentAuthState:
                 {
                     "harness": "claude",
                     "route": "gateway",
+                    "slot": "primary",
                     "base_url": "https://llm.proliferate.ai",
                     "key": "sk-litellm-vk",
                 },
                 {
                     "harness": "codex",
                     "route": "api_key",
+                    "slot": "primary",
                     "provider": "openai",
                     "key": "sk-openai-raw",
+                },
+            ],
+        }
+        assert fingerprint == agent_auth.agent_auth_state_fingerprint(state)
+
+    def test_opencode_multi_slot_selections_all_materialize(self) -> None:
+        anthropic_id = uuid.uuid4()
+        xai_id = uuid.uuid4()
+        state, fingerprint = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    _selection(harness="opencode", route="gateway", slot="gateway", revision=2),
+                    _selection(
+                        harness="opencode",
+                        route="api_key",
+                        api_key_id=anthropic_id,
+                        slot="anthropic",
+                        revision=5,
+                    ),
+                    _selection(
+                        harness="opencode",
+                        route="api_key",
+                        api_key_id=xai_id,
+                        slot="xai",
+                        revision=3,
+                    ),
+                ),
+                api_key_secrets={
+                    anthropic_id: ("anthropic", "sk-ant-raw"),
+                    xai_id: ("xai", "xai-raw"),
+                },
+            )
+        )
+        assert state == {
+            "revision": 5,
+            "user_id": str(USER_ID),
+            "selections": [
+                {
+                    "harness": "opencode",
+                    "route": "api_key",
+                    "slot": "anthropic",
+                    "provider": "anthropic",
+                    "key": "sk-ant-raw",
+                },
+                {
+                    "harness": "opencode",
+                    "route": "gateway",
+                    "slot": "gateway",
+                    "base_url": "https://llm.proliferate.ai",
+                    "key": "sk-litellm-vk",
+                },
+                {
+                    "harness": "opencode",
+                    "route": "api_key",
+                    "slot": "xai",
+                    "provider": "xai",
+                    "key": "xai-raw",
                 },
             ],
         }

--- a/server/tests/unit/test_agent_gateway_domain.py
+++ b/server/tests/unit/test_agent_gateway_domain.py
@@ -13,31 +13,130 @@ from proliferate.server.cloud.agent_gateway.enrollment import build_sync_fingerp
 
 class TestRouteSelectionLegality:
     def test_all_routes_are_legal_on_local(self) -> None:
-        validate_route_selection(surface="local", route="native", api_key_id=None)
-        validate_route_selection(surface="local", route="gateway", api_key_id=None)
-        validate_route_selection(surface="local", route="api_key", api_key_id=uuid.uuid4())
+        validate_route_selection(
+            harness_kind="claude", surface="local", route="native", api_key_id=None
+        )
+        validate_route_selection(
+            harness_kind="claude", surface="local", route="gateway", api_key_id=None
+        )
+        validate_route_selection(
+            harness_kind="claude", surface="local", route="api_key", api_key_id=uuid.uuid4()
+        )
 
     def test_cloud_allows_gateway_and_api_key(self) -> None:
-        validate_route_selection(surface="cloud", route="gateway", api_key_id=None)
-        validate_route_selection(surface="cloud", route="api_key", api_key_id=uuid.uuid4())
+        validate_route_selection(
+            harness_kind="claude", surface="cloud", route="gateway", api_key_id=None
+        )
+        validate_route_selection(
+            harness_kind="claude", surface="cloud", route="api_key", api_key_id=uuid.uuid4()
+        )
 
     def test_cloud_rejects_native(self) -> None:
         with pytest.raises(ValueError, match="native route"):
-            validate_route_selection(surface="cloud", route="native", api_key_id=None)
+            validate_route_selection(
+                harness_kind="claude", surface="cloud", route="native", api_key_id=None
+            )
 
     def test_api_key_route_requires_key_reference(self) -> None:
         with pytest.raises(ValueError, match="requires an api_key_id"):
-            validate_route_selection(surface="local", route="api_key", api_key_id=None)
+            validate_route_selection(
+                harness_kind="claude", surface="local", route="api_key", api_key_id=None
+            )
 
     def test_non_api_key_routes_reject_key_reference(self) -> None:
         with pytest.raises(ValueError, match="only valid for api_key"):
-            validate_route_selection(surface="local", route="gateway", api_key_id=uuid.uuid4())
+            validate_route_selection(
+                harness_kind="claude",
+                surface="local",
+                route="gateway",
+                api_key_id=uuid.uuid4(),
+            )
 
     def test_unknown_surface_and_route_are_rejected(self) -> None:
         with pytest.raises(ValueError, match="surface"):
-            validate_route_selection(surface="mobile", route="gateway", api_key_id=None)
+            validate_route_selection(
+                harness_kind="claude", surface="mobile", route="gateway", api_key_id=None
+            )
         with pytest.raises(ValueError, match="route"):
-            validate_route_selection(surface="local", route="magic", api_key_id=None)
+            validate_route_selection(
+                harness_kind="claude", surface="local", route="magic", api_key_id=None
+            )
+
+
+class TestSlotLegality:
+    def test_single_source_harnesses_only_use_primary(self) -> None:
+        for harness in ("claude", "codex", "grok", "gemini"):
+            validate_route_selection(
+                harness_kind=harness,
+                surface="local",
+                route="gateway",
+                api_key_id=None,
+                slot="primary",
+            )
+            with pytest.raises(ValueError, match="single-source"):
+                validate_route_selection(
+                    harness_kind=harness,
+                    surface="local",
+                    route="gateway",
+                    api_key_id=None,
+                    slot="gateway",
+                )
+
+    def test_unknown_harness_is_treated_as_single_source(self) -> None:
+        with pytest.raises(ValueError, match="single-source"):
+            validate_route_selection(
+                harness_kind="cursor",
+                surface="local",
+                route="gateway",
+                api_key_id=None,
+                slot="openai",
+            )
+
+    def test_opencode_rejects_primary_and_unknown_slots(self) -> None:
+        for slot in ("primary", "mistral", ""):
+            with pytest.raises(ValueError, match="slots"):
+                validate_route_selection(
+                    harness_kind="opencode",
+                    surface="local",
+                    route="gateway",
+                    api_key_id=None,
+                    slot=slot,
+                )
+
+    def test_opencode_gateway_slot_requires_gateway_route(self) -> None:
+        validate_route_selection(
+            harness_kind="opencode",
+            surface="cloud",
+            route="gateway",
+            api_key_id=None,
+            slot="gateway",
+        )
+        with pytest.raises(ValueError, match="gateway.*slot"):
+            validate_route_selection(
+                harness_kind="opencode",
+                surface="cloud",
+                route="api_key",
+                api_key_id=uuid.uuid4(),
+                slot="gateway",
+            )
+
+    def test_opencode_provider_slots_require_api_key_route(self) -> None:
+        for slot in ("openai", "anthropic", "xai", "google"):
+            validate_route_selection(
+                harness_kind="opencode",
+                surface="cloud",
+                route="api_key",
+                api_key_id=uuid.uuid4(),
+                slot=slot,
+            )
+            with pytest.raises(ValueError, match="api_key"):
+                validate_route_selection(
+                    harness_kind="opencode",
+                    surface="cloud",
+                    route="gateway",
+                    api_key_id=None,
+                    slot=slot,
+                )
 
     def test_unknown_harness_kind_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="harness kind"):


### PR DESCRIPTION
PR 13 of the agent-auth LiteLLM migration (spec: `specs/codebase/primitives/agent-auth-litellm.md` §3.3 slot semantics + §10 PR 13) — the final PR of the stack.

> **NOTE:** this branch is based on `agent-auth/07-catalog` and merges in `agent-auth/05-cloud-materialization` + `agent-auth/10-settings-ui`, so the diff includes those merge commits until the stack collapses. The PR-13-only delta is the last commit.

## Scope

**Slot axis on route selections** (spec §3.3, 2026-07-01 amendment)
- Migration `e5f6a7b8c9d0`: adds `slot` (default `'primary'`) to `agent_auth_route_selection`; unique scope widens to `(user_id, harness_kind, surface, slot)`. No data migration (no users). Downgrade collapses multi-slot scopes before restoring the narrow key.
- Store: single-source harnesses (claude/codex/grok/gemini — and any non-opencode kind) only accept `slot='primary'`; opencode accepts `{'gateway','openai','anthropic','xai','google'}` with per-slot route legality (`gateway` slot → gateway route; provider slots → `api_key` route with a key of that provider). Ownership failures are a distinct typed error (`AgentApiKeyNotUsableError` → 404) vs. legality (→ 400 `invalid_agent_route_selection`).
- API/SDK: upsert body + DELETE query gain `slot` (default `primary`, backward compatible); responses carry `slot`.

**PROVIDER_REGISTRY** (`constants/agent_gateway.py`)
- `{id, label, env_key, key_url, harnesses, recommended_for}` for anthropic/openai/xai/google, exposed on `/agent-gateway/capabilities` as `providers[]` so no UI hardcodes provider metadata.

**Materializer** (`materialize/agent_auth.py`)
- state.json selections now carry `"slot"`; multiple entries per harness are allowed (sorted by harness, slot). Field names otherwise unchanged.

**Renderer** (`anyharness .../route_auth/`)
- `AuthSelection.slot` with serde default `"primary"` (pre-slot state files keep parsing).
- OpenCode resolves through a new `OpenCodeComposite` profile: ALL its selections merge into ONE launch delta — the gateway slot materializes the injected `opencode.json` + `PROLIFERATE_GATEWAY_KEY`, each direct provider slot rides its plain provider env var, additively (no removals).
- Single-source harnesses with >1 state entries fail closed with new typed `AGENT_ROUTE_SELECTION_CONFLICT` (mapped to 409 like the other route-shape errors).

**Desktop UI**
- New reusable `KeyPicker` (searchable select over the key pool: display name + provider + redacted hint, secret never re-shown; `+ Add new key` pastes inline → saves to pool → attaches). It replaces the raw key `<select>` for single-source `api_key` routes too, filtered to the harness's direct provider from the registry.
- OpenCode's authentication pane becomes per-source toggles: gateway switch + one row per registry provider serving opencode, each with enable switch + KeyPicker + `Get an API key ↗` (registry `key_url`) + `Recommended` badge (registry `recommended_for`).

## OpenCode config merge semantics (verified finding)

The renderer supplies config via the **`OPENCODE_CONFIG` env var pointing at a materialized file** (not `OPENCODE_CONFIG_CONTENT`). Verified empirically against opencode **1.16.2**: with a user global config defining provider `userlocal` and `OPENCODE_CONFIG` pointing at our injected config defining only provider `proliferate`, `opencode models` lists models from **both** providers — opencode deep-merges the `OPENCODE_CONFIG` layer with the user's global/project configs. Our injected config therefore **adds to — never replaces —** the user's own local providers, and direct provider keys ride plain env vars that opencode picks up without any config. A render test now pins the injected config to contain ONLY `{"provider": {"proliferate": …}}` (no full replacement config, no disabled defaults).

## Verification

- `pytest` (fresh DB `pr13_final`): 110 passed across `test_agent_gateway_*` unit+integration, `test_agent_auth_materialization` unit+integration (incl. new slot-validation, opencode slot API, multi-slot materializer tests).
- Migration `upgrade head` → `downgrade -1` → `upgrade head` on a fresh database: clean.
- `ruff check` + `ruff format --check`: clean. `mypy`: no new errors beyond the pydantic-plugin `explicit-any` noise every model class in this file already carries (repo baseline 1113 errors).
- Boundary scripts (server/frontend/anyharness) + max-lines: pass.
- `cargo check --workspace`: clean. `cargo test -p anyharness-lib route_auth`: 44 passed (new: serde default-slot round-trip, multi-entry state, opencode multi-slot merge snapshot incl. only-our-provider config assertion, single-source conflict end-to-end).
- `cloud-openapi` + `cloud-client-generate` regenerated; `cloud/sdk` + `cloud/sdk-react` build.
- Desktop `tsc --noEmit` clean; targeted vitest 28 passed (KeyPicker, OpenCodeAuthSection toggles, updated AgentAuthenticationSection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
