### PR TITLE
fix(ci): green main — product-ui tooltip assertions + test_cloud_api length

### DIFF
--- a/apps/packages/product-ui/test/CloudChatComposer.test.tsx
+++ b/apps/packages/product-ui/test/CloudChatComposer.test.tsx
@@ -164,9 +164,11 @@ describe("CloudChatComposer", () => {
     expect(copyButton.getAttribute("title")).toBeNull();
     expect(copyButton.querySelector(".lucide-git-branch")).toBeTruthy();
 
-    fireEvent.mouseEnter(tooltipTrigger!);
+    // The Radix-backed Tooltip opens on focus/pointermove (not mouseenter).
+    // Focus opens it synchronously, which keeps fake timers out of the way.
+    fireEvent.focus(tooltipTrigger!);
     expect(screen.getByRole("tooltip").textContent).toBe("Copy branch name");
-    fireEvent.mouseLeave(tooltipTrigger!);
+    fireEvent.blur(tooltipTrigger!);
 
     fireEvent.click(copyButton);
 
@@ -181,9 +183,9 @@ describe("CloudChatComposer", () => {
     expect(copyButton.querySelector(".lucide-check")).toBeTruthy();
     expect(copyButton.querySelector(".lucide-git-branch")).toBeNull();
 
-    fireEvent.mouseEnter(tooltipTrigger!);
+    fireEvent.focus(tooltipTrigger!);
     expect(screen.getByRole("tooltip").textContent).toBe("Copied");
-    fireEvent.mouseLeave(tooltipTrigger!);
+    fireEvent.blur(tooltipTrigger!);
 
     act(() => {
       vi.advanceTimersByTime(1400);
@@ -227,9 +229,9 @@ describe("CloudChatComposer", () => {
     expect(tooltipTrigger).toBeTruthy();
     expect(copyButton.getAttribute("title")).toBeNull();
 
-    fireEvent.mouseEnter(tooltipTrigger!);
+    fireEvent.focus(tooltipTrigger!);
     expect(screen.getByRole("tooltip").textContent).toBe("Copy repository name");
-    fireEvent.mouseLeave(tooltipTrigger!);
+    fireEvent.blur(tooltipTrigger!);
 
     fireEvent.click(copyButton);
 

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -41,8 +41,7 @@ server/proliferate/server/cloud/agent_auth/models.py 563 managed sandbox desktop
 server/proliferate/server/cloud/agent_auth/runtime_keys.py 671 existing cloud agent auth runtime key service pending gateway/router split
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/proliferate/constants/cloud.py 660 existing cloud constants module with command and target config enums
-server/tests/integration/test_auth_flow.py 2057 existing server oversized integration test
+server/tests/integration/test_auth_flow.py 2052 existing server oversized integration test
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
-server/tests/integration/test_cloud_api.py 679 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test

--- a/server/tests/integration/cloud_api_helpers.py
+++ b/server/tests/integration/cloud_api_helpers.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.auth import OAuthAccount
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import github_app as github_app_store
+from proliferate.integrations.github import GitHubAppInstallationInfo
+from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthorization
+from proliferate.server.cloud.github_app import repo_authority
+from tests.helpers.desktop_auth import mint_desktop_token_payload
+
+
+async def register_and_login(
+    client: AsyncClient,
+    email: str,
+    *,
+    link_github: bool = True,
+) -> dict[str, str]:
+    """Create a user via the user manager and obtain tokens via PKCE."""
+    from proliferate.auth.models import UserCreate
+    from proliferate.auth.users import UserManager
+    from proliferate.db.engine import get_async_session
+    from proliferate.auth.users import get_user_db
+
+    user_id: str | None = None
+    async for session in get_async_session():
+        async for user_db in get_user_db(session):
+            manager = UserManager(user_db)
+            user = await manager.create(
+                UserCreate(email=email, password="unused-oauth-only", display_name="Cloud Tester"),
+            )
+            if link_github:
+                session.add(
+                    OAuthAccount(
+                        user_id=user.id,
+                        oauth_name="github",
+                        access_token="github-access-token",
+                        account_id=f"github-{user.id}",
+                        account_email=email,
+                    )
+                )
+            await session.commit()
+            user_id = str(user.id)
+
+    assert user_id is not None
+
+    token_data = await mint_desktop_token_payload(
+        client,
+        user_id=user_id,
+        state_prefix="cloud-state",
+    )
+    return {
+        "user_id": user_id,
+        "access_token": str(token_data["access_token"]),
+    }
+
+
+async def link_github_account(db_session: AsyncSession, user_id: str) -> None:
+    existing = (
+        await db_session.execute(
+            select(OAuthAccount).where(
+                OAuthAccount.user_id == uuid.UUID(user_id),
+                OAuthAccount.oauth_name == "github",
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.access_token = "github-access-token"
+        existing.account_id = "12345"
+        existing.account_email = "cloud@example.com"
+        await db_session.commit()
+        return
+
+    account = OAuthAccount(
+        user_id=uuid.UUID(user_id),
+        oauth_name="github",
+        access_token="github-access-token",
+        account_id="12345",
+        account_email="cloud@example.com",
+    )
+    db_session.add(account)
+    await db_session.commit()
+
+
+async def seed_github_app_repo_authority(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    user_id: str,
+    git_owner: str = "proliferate-ai",
+) -> None:
+    await github_app_store.upsert_github_app_authorization(
+        db_session,
+        user_id=uuid.UUID(user_id),
+        authorization=GitHubAppUserAuthorization(
+            access_token="github-app-user-token",
+            refresh_token="github-app-refresh-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=8),
+            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=180),
+            github_user_id="12345",
+            github_login="cloud-tester",
+            permissions={},
+        ),
+    )
+    await github_app_store.upsert_github_app_installation(
+        db_session,
+        installation=GitHubAppInstallationInfo(
+            github_installation_id="142900805",
+            account_login=git_owner,
+            account_type="Organization",
+            repository_selection="all",
+            permissions={"contents": "read", "pull_requests": "write"},
+            suspended_at=None,
+        ),
+    )
+    await db_session.commit()
+
+    async def _has_access(**_kwargs) -> bool:  # type: ignore[no-untyped-def]
+        return True
+
+    monkeypatch.setattr(repo_authority, "verify_github_app_user_repo_access", _has_access)
+
+
+async def create_organization_for_user(db_session: AsyncSession, user_id: str) -> str:
+    now = datetime.now(UTC)
+    organization = Organization(
+        name="Cloud Test Team",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(organization)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=uuid.UUID(user_id),
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()
+    return str(organization.id)
+
+
+async def add_organization_member(
+    db_session: AsyncSession,
+    *,
+    organization_id: str,
+    user_id: str,
+    role: str = ORGANIZATION_ROLE_MEMBER,
+) -> None:
+    now = datetime.now(UTC)
+    db_session.add(
+        OrganizationMembership(
+            organization_id=uuid.UUID(organization_id),
+            user_id=uuid.UUID(user_id),
+            role=role,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime, timedelta
 import uuid
 
 import pytest
@@ -6,208 +5,23 @@ from httpx import AsyncClient
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.organizations import (
-    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-    ORGANIZATION_ROLE_MEMBER,
-    ORGANIZATION_ROLE_OWNER,
-    ORGANIZATION_STATUS_ACTIVE,
-)
-from proliferate.db.models.auth import OAuthAccount
-from proliferate.db.models.cloud.mcp import (
-    CloudMcpConnection,
-    CloudMcpConnectionAuth,
-)
 from proliferate.db.models.cloud.integrations import CloudOrganizationIntegrationPolicy
 from proliferate.db.models.cloud.worktree_policy import CloudWorktreeRetentionPolicy
 from proliferate.db.engine import apply_rls_context_to_session
-from proliferate.db.models.organizations import Organization, OrganizationMembership
-from proliferate.db.store import github_app as github_app_store
-from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
 from proliferate.integrations.github import (
-    GitHubAppInstallationInfo,
     GitHubRepositoryPage,
     GitHubRepositorySummary,
     GitHubRepoBranches,
 )
-from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthorization
 from proliferate.rls_context import with_rls_context
-from proliferate.server.cloud.github_app import repo_authority
 from proliferate.server.cloud.repos import service as repos_service
-from tests.helpers.desktop_auth import mint_desktop_token_payload
-
-
-async def _billing_subject_for_user(db_session: AsyncSession, user_id: uuid.UUID):
-    return await ensure_personal_billing_subject(db_session, user_id)
-
-
-async def _register_and_login(
-    client: AsyncClient,
-    email: str,
-    *,
-    link_github: bool = True,
-) -> dict[str, str]:
-    """Create a user via the user manager and obtain tokens via PKCE."""
-    from proliferate.auth.models import UserCreate
-    from proliferate.auth.users import UserManager
-    from proliferate.db.engine import get_async_session
-    from proliferate.auth.users import get_user_db
-
-    user_id: str | None = None
-    async for session in get_async_session():
-        async for user_db in get_user_db(session):
-            manager = UserManager(user_db)
-            user = await manager.create(
-                UserCreate(email=email, password="unused-oauth-only", display_name="Cloud Tester"),
-            )
-            if link_github:
-                session.add(
-                    OAuthAccount(
-                        user_id=user.id,
-                        oauth_name="github",
-                        access_token="github-access-token",
-                        account_id=f"github-{user.id}",
-                        account_email=email,
-                    )
-                )
-            await session.commit()
-            user_id = str(user.id)
-
-    assert user_id is not None
-
-    token_data = await mint_desktop_token_payload(
-        client,
-        user_id=user_id,
-        state_prefix="cloud-state",
-    )
-    return {
-        "user_id": user_id,
-        "access_token": str(token_data["access_token"]),
-    }
-
-
-async def _link_github_account(db_session: AsyncSession, user_id: str) -> None:
-    existing = (
-        await db_session.execute(
-            select(OAuthAccount).where(
-                OAuthAccount.user_id == uuid.UUID(user_id),
-                OAuthAccount.oauth_name == "github",
-            )
-        )
-    ).scalar_one_or_none()
-    if existing is not None:
-        existing.access_token = "github-access-token"
-        existing.account_id = "12345"
-        existing.account_email = "cloud@example.com"
-        await db_session.commit()
-        return
-
-    account = OAuthAccount(
-        user_id=uuid.UUID(user_id),
-        oauth_name="github",
-        access_token="github-access-token",
-        account_id="12345",
-        account_email="cloud@example.com",
-    )
-    db_session.add(account)
-    await db_session.commit()
-
-
-async def _seed_github_app_repo_authority(
-    db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    user_id: str,
-    git_owner: str = "proliferate-ai",
-) -> None:
-    await github_app_store.upsert_github_app_authorization(
-        db_session,
-        user_id=uuid.UUID(user_id),
-        authorization=GitHubAppUserAuthorization(
-            access_token="github-app-user-token",
-            refresh_token="github-app-refresh-token",
-            expires_at=datetime.now(UTC) + timedelta(hours=8),
-            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=180),
-            github_user_id="12345",
-            github_login="cloud-tester",
-            permissions={},
-        ),
-    )
-    await github_app_store.upsert_github_app_installation(
-        db_session,
-        installation=GitHubAppInstallationInfo(
-            github_installation_id="142900805",
-            account_login=git_owner,
-            account_type="Organization",
-            repository_selection="all",
-            permissions={"contents": "read", "pull_requests": "write"},
-            suspended_at=None,
-        ),
-    )
-    await db_session.commit()
-
-    async def _has_access(**_kwargs) -> bool:  # type: ignore[no-untyped-def]
-        return True
-
-    monkeypatch.setattr(repo_authority, "verify_github_app_user_repo_access", _has_access)
-
-
-async def _link_secondary_account(db_session: AsyncSession, user_id: str) -> None:
-    account = OAuthAccount(
-        user_id=uuid.UUID(user_id),
-        oauth_name="google",
-        access_token="google-access-token",
-        account_id="secondary-12345",
-        account_email="cloud-secondary@example.com",
-    )
-    db_session.add(account)
-    await db_session.commit()
-
-
-async def _create_organization_for_user(db_session: AsyncSession, user_id: str) -> str:
-    now = datetime.now(UTC)
-    organization = Organization(
-        name="Cloud Test Team",
-        status=ORGANIZATION_STATUS_ACTIVE,
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(organization)
-    await db_session.flush()
-    db_session.add(
-        OrganizationMembership(
-            organization_id=organization.id,
-            user_id=uuid.UUID(user_id),
-            role=ORGANIZATION_ROLE_OWNER,
-            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-            joined_at=now,
-            created_at=now,
-            updated_at=now,
-        )
-    )
-    await db_session.commit()
-    return str(organization.id)
-
-
-async def _add_organization_member(
-    db_session: AsyncSession,
-    *,
-    organization_id: str,
-    user_id: str,
-    role: str = ORGANIZATION_ROLE_MEMBER,
-) -> None:
-    now = datetime.now(UTC)
-    db_session.add(
-        OrganizationMembership(
-            organization_id=uuid.UUID(organization_id),
-            user_id=uuid.UUID(user_id),
-            role=role,
-            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
-            joined_at=now,
-            created_at=now,
-            updated_at=now,
-        )
-    )
-    await db_session.commit()
+from tests.integration.cloud_api_helpers import (
+    add_organization_member,
+    create_organization_for_user,
+    link_github_account,
+    register_and_login,
+    seed_github_app_repo_authority,
+)
 
 
 async def _insert_organization_integration_policy(
@@ -280,29 +94,6 @@ async def _list_integration_policy_as_role(
     return [(row.organization_id, row.catalog_entry_id) for row in rows]
 
 
-async def _list_mcp_connections(
-    db_session: AsyncSession,
-    user_id: str,
-) -> list[CloudMcpConnection]:
-    return (
-        (
-            await db_session.execute(
-                select(CloudMcpConnection).where(
-                    CloudMcpConnection.owner_user_id == uuid.UUID(user_id)
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-
-
-async def _list_mcp_connection_auths(
-    db_session: AsyncSession,
-) -> list[CloudMcpConnectionAuth]:
-    return (await db_session.execute(select(CloudMcpConnectionAuth))).scalars().all()
-
-
 def _patch_repo_branches_lookup(
     monkeypatch: pytest.MonkeyPatch,
     resolver,
@@ -317,7 +108,7 @@ class TestCloudWorktreeRetentionPolicy:
         client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
-        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        tokens = await register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
         headers = {"Authorization": f"Bearer {tokens['access_token']}"}
 
         first = await client.get("/v1/cloud/worktree-retention-policy", headers=headers)
@@ -350,7 +141,7 @@ class TestCloudWorktreeRetentionPolicy:
         client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
-        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        tokens = await register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
         headers = {"Authorization": f"Bearer {tokens['access_token']}"}
 
         response = await client.put(
@@ -378,7 +169,7 @@ class TestCloudWorktreeRetentionPolicy:
         self,
         client: AsyncClient,
     ) -> None:
-        tokens = await _register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
+        tokens = await register_and_login(client, f"policy-{uuid.uuid4().hex[:8]}@example.com")
         response = await client.put(
             "/v1/cloud/worktree-retention-policy",
             headers={"Authorization": f"Bearer {tokens['access_token']}"},
@@ -396,16 +187,16 @@ class TestCloudOrganizationIntegrationPolicy:
         client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
-        owner = await _register_and_login(
+        owner = await register_and_login(
             client,
             f"integration-policy-owner-{uuid.uuid4().hex[:8]}@example.com",
         )
-        member = await _register_and_login(
+        member = await register_and_login(
             client,
             f"integration-policy-member-{uuid.uuid4().hex[:8]}@example.com",
         )
-        organization_id = await _create_organization_for_user(db_session, owner["user_id"])
-        await _add_organization_member(
+        organization_id = await create_organization_for_user(db_session, owner["user_id"])
+        await add_organization_member(
             db_session,
             organization_id=organization_id,
             user_id=member["user_id"],
@@ -454,11 +245,11 @@ class TestCloudOrganizationIntegrationPolicy:
         client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
-        owner = await _register_and_login(
+        owner = await register_and_login(
             client,
             f"integration-policy-missing-{uuid.uuid4().hex[:8]}@example.com",
         )
-        organization_id = await _create_organization_for_user(db_session, owner["user_id"])
+        organization_id = await create_organization_for_user(db_session, owner["user_id"])
 
         response = await client.patch(
             f"/v1/cloud/organizations/{organization_id}/integration-policy",
@@ -475,16 +266,16 @@ class TestCloudOrganizationIntegrationPolicy:
         client: AsyncClient,
         db_session: AsyncSession,
     ) -> None:
-        owner_a = await _register_and_login(
+        owner_a = await register_and_login(
             client,
             f"integration-policy-rls-a-{uuid.uuid4().hex[:8]}@example.com",
         )
-        owner_b = await _register_and_login(
+        owner_b = await register_and_login(
             client,
             f"integration-policy-rls-b-{uuid.uuid4().hex[:8]}@example.com",
         )
-        organization_a = await _create_organization_for_user(db_session, owner_a["user_id"])
-        organization_b = await _create_organization_for_user(db_session, owner_b["user_id"])
+        organization_a = await create_organization_for_user(db_session, owner_a["user_id"])
+        organization_b = await create_organization_for_user(db_session, owner_b["user_id"])
         await _insert_organization_integration_policy(
             db_session,
             actor_user_id=owner_a["user_id"],
@@ -540,12 +331,12 @@ class TestCloudRepoBranches:
 
         _patch_repo_branches_lookup(monkeypatch, _repo_branches)
 
-        session = await _register_and_login(client, "cloud-branches@example.com")
+        session = await register_and_login(client, "cloud-branches@example.com")
         headers = {"Authorization": f"Bearer {session['access_token']}"}
-        await _link_github_account(db_session, session["user_id"])
+        await link_github_account(db_session, session["user_id"])
         # /v1/cloud/repos/* requires GitHub App authorization since the #809
         # cutover (ensure_fresh_github_app_authorization).
-        await _seed_github_app_repo_authority(
+        await seed_github_app_repo_authority(
             db_session,
             monkeypatch,
             user_id=session["user_id"],
@@ -644,10 +435,10 @@ class TestCloudRepoCatalog:
             _github_repositories,
         )
 
-        session = await _register_and_login(client, "cloud-repo-catalog@example.com")
+        session = await register_and_login(client, "cloud-repo-catalog@example.com")
         headers = {"Authorization": f"Bearer {session['access_token']}"}
-        await _link_github_account(db_session, session["user_id"])
-        await _seed_github_app_repo_authority(
+        await link_github_account(db_session, session["user_id"])
+        await seed_github_app_repo_authority(
             db_session,
             monkeypatch,
             user_id=session["user_id"],


### PR DESCRIPTION
Revives the auto deploy pipeline: these were the last two red jobs on main's CI, which gates Deploy Staging (workflow_run).

- **Test product UI**: CloudChatComposer copy-feedback tests failed since #811 swapped the hand-rolled Tooltip for the Radix kit — Radix only renders role="tooltip" while open, and opens on focus/pointermove (not mouseenter). Component behavior is intact (verified: aria-label swap, live region, icon flip); tests now drive the deterministic focus/blur path.
- **Repo shape / max-lines**: `test_cloud_api.py` 687 → 478 lines by extracting shared seeding into `cloud_api_helpers.py` (sibling-helper pattern) and deleting four dead helpers from the #846 sweep; its allowlist entry removed (now under the 600 base) and a second stale entry (`test_auth_flow.py` 2057→2052) tightened.

Gates: check_max_lines ✅, product-ui 82/82 ✅, test_cloud_api 8/8 ✅, ruff ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)