### PR TITLE
fix(desktop): route raw buttons through the ui Button primitive

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
@@ -126,13 +126,15 @@ export function HomeNextScreen() {
                     {"What should we build in "}
                     <HomeProjectMenu
                       trigger={(
-                        <button
+                        <Button
                           type="button"
+                          variant="unstyled"
+                          size="unstyled"
                           aria-label={`Change project: ${promptTarget}`}
                           className="relative z-0 inline-block cursor-pointer whitespace-pre outline-none after:absolute after:-inset-x-1.5 after:inset-y-0 after:-z-10 after:rounded-xl after:content-[''] hover:after:bg-accent focus-visible:after:bg-accent data-[state=open]:after:bg-accent"
                         >
                           {promptTarget}
-                        </button>
+                        </Button>
                       )}
                       side="bottom"
                       destination={destination}

--- a/apps/desktop/src/components/home/screen/HomeTargetPickerParts.tsx
+++ b/apps/desktop/src/components/home/screen/HomeTargetPickerParts.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 import { ComputeTargetSwatch } from "@/components/compute/ComputeTargetSwatch";
+import { Button } from "@proliferate/ui/primitives/Button";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { PopoverSearchField } from "@proliferate/ui/primitives/PopoverSearchField";
 import {
@@ -111,9 +112,11 @@ export const HomeTargetRowItem = forwardRef<HTMLButtonElement, HomeTargetRowItem
     ref,
   ) {
     return (
-      <button
+      <Button
         ref={ref}
         type={type}
+        variant="unstyled"
+        size="unstyled"
         className={twMerge(
           "flex h-6 min-w-0 select-none items-center gap-1 whitespace-nowrap rounded-full border border-transparent px-1.5 py-0 text-ui text-muted-foreground outline-none transition-colors enabled:hover:bg-accent enabled:hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 data-[state=open]:bg-accent data-[state=open]:text-foreground",
           className,
@@ -127,7 +130,7 @@ export const HomeTargetRowItem = forwardRef<HTMLButtonElement, HomeTargetRowItem
         {disclosure ? (
           <ChevronDown className="size-3 shrink-0 text-faint" />
         ) : null}
-      </button>
+      </Button>
     );
   },
 );

--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
+import { Button } from "@proliferate/ui/primitives/Button";
 import {
   SETTINGS_DEFAULT_SECTION,
   TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION,
@@ -294,14 +295,16 @@ export function SettingsScreen({
           className="flex h-10 items-center gap-2 pl-[82px] pr-3"
           data-tauri-drag-region="true"
         >
-          <button
+          <Button
             type="button"
+            variant="unstyled"
+            size="unstyled"
             onClick={onNavigateHome}
             className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-ui text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
             <ArrowLeft className="size-4" />
             {SETTINGS_COPY.back}
-          </button>
+          </Button>
         </div>
         <div className="flex h-[46px] items-center gap-4 px-4">
           <SettingsScopeTabs

--- a/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 
 /**
@@ -36,8 +37,10 @@ export function ComposerOptionRow({
 }) {
   return (
     <div className="border-t border-border/60">
-      <button
+      <Button
         type="button"
+        variant="unstyled"
+        size="unstyled"
         disabled={disabled}
         onClick={onSelect}
         className={twMerge(
@@ -65,7 +68,7 @@ export function ComposerOptionRow({
             </span>
           ) : null}
         </span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx
@@ -1,6 +1,7 @@
 import type { UserInputQuestion, UserInputSubmittedAnswer } from "@anyharness/sdk";
 import { useMemo, useState } from "react";
 import { ArrowUp } from "@proliferate/ui/icons";
+import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { useActivePendingInteractionState } from "@/hooks/chat/derived/use-active-pending-session-interactions";
@@ -142,9 +143,9 @@ export function UserInputCard({
     return (
       <ComposerAttachedPanel header={header}>
         <div className="flex items-center justify-end gap-2 px-3 pb-3">
-          <button type="button" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
+          <Button type="button" variant="unstyled" size="unstyled" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
             Cancel
-          </button>
+          </Button>
         </div>
       </ComposerAttachedPanel>
     );
@@ -238,28 +239,32 @@ export function UserInputCard({
         )}
 
         <div className="flex shrink-0 items-center justify-between gap-2 px-3 pb-3 pt-1">
-          <button type="button" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
+          <Button type="button" variant="unstyled" size="unstyled" className={CHIP_BUTTON_CLASSNAME} onClick={onCancel}>
             Cancel
-          </button>
+          </Button>
           <div className="flex items-center gap-2">
             {!isFirst && (
-              <button
+              <Button
                 type="button"
+                variant="unstyled"
+                size="unstyled"
                 className={CHIP_BUTTON_CLASSNAME}
                 onClick={() =>
                   setQuestionIndex((index) => Math.max(0, index - 1))}
               >
                 Back
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="button"
+              variant="unstyled"
+              size="unstyled"
               aria-label={isLast ? "Submit" : "Next"}
               onClick={handleAdvance}
               className="flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-80"
             >
               <ArrowUp className="size-3.5" />
-            </button>
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Clears the 8 RAW_DOM_CONTROL violations in CI's "Check frontend structure drift" (strict) — half of the last red job gating Deploy Staging. Each raw `<button>` becomes the established `Button variant="unstyled" size="unstyled"` idiom with identical className/handlers/type/aria: HomeNextScreen hero trigger, HomeTargetPickerParts row item, SettingsScreen back button, ComposerOptionRow, UserInputCard ×4.

Drift check: RAW_DOM_CONTROL 0; boundaries, design check, tsc, covering tests (29/29) green. The 6 LARGE_FRONTEND_FILE violations land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)