### PR TITLE
refactor(frontend): split six files under the 400-line structure threshold

### DIFF
--- a/apps/desktop/src/components/settings/panes/organization/GitHubAppInstallationSection.tsx
+++ b/apps/desktop/src/components/settings/panes/organization/GitHubAppInstallationSection.tsx
@@ -1,0 +1,83 @@
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
+import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
+
+export function GitHubAppInstallationSection({
+  loading,
+  installing,
+  canManage,
+  status,
+  onInstall,
+  onManage,
+}: {
+  loading: boolean;
+  installing: boolean;
+  canManage: boolean;
+  status: {
+    installed: boolean;
+    accountLogin?: string | null;
+    repositorySelection?: string | null;
+    suspendedAt?: string | null;
+  } | undefined;
+  onInstall: () => void | Promise<void>;
+  onManage: () => void | Promise<void>;
+}) {
+  const installed = status?.installed === true;
+  const repositorySelection = formatRepositorySelection(status?.repositorySelection ?? null);
+  const statusLabel = loading
+    ? "Checking"
+    : installed
+      ? "Installed"
+      : "Not installed";
+  const description = installed
+    ? `Installed on ${status?.accountLogin ? `@${status.accountLogin}` : "this GitHub account"}${repositorySelection ? ` with ${repositorySelection}` : ""}.`
+    : canManage
+      ? "Install the Proliferate GitHub App for this organization before members can enable cloud repositories."
+      : "Ask an organization admin to install the Proliferate GitHub App before you enable cloud repositories.";
+
+  return (
+    <SettingsSection
+      title="GitHub App"
+      description="Repository access for organization cloud environments."
+    >
+      <SettingsRow
+        label="Organization installation"
+        description={description}
+      >
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Badge tone={installed ? "success" : "warning"}>{statusLabel}</Badge>
+          {canManage ? (
+            <Button
+              type="button"
+              variant="secondary"
+              loading={installing}
+              disabled={installing}
+              onClick={() => {
+                void (installed ? onManage() : onInstall());
+              }}
+            >
+              {!installing ? <ProviderBrandIcon provider="github" className="size-[13px]" /> : null}
+              {installed ? "Manage in GitHub" : "Install GitHub App"}
+            </Button>
+          ) : null}
+        </div>
+      </SettingsRow>
+    </SettingsSection>
+  );
+}
+
+export function isOrganizationAdminRole(role: string | null | undefined): boolean {
+  return role === "owner" || role === "admin";
+}
+
+function formatRepositorySelection(repositorySelection: string | null): string | null {
+  if (repositorySelection === "all") {
+    return "all repositories";
+  }
+  if (repositorySelection === "selected") {
+    return "selected repositories";
+  }
+  return null;
+}

--- a/apps/desktop/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx
@@ -1,0 +1,27 @@
+import type { MouseEventHandler } from "react";
+
+/**
+ * Vertical drag handle between the workspace shell panels. The negative
+ * margin keeps the 4px hit area overlapping the adjacent panel edge.
+ */
+export function WorkspaceResizeSeparator({
+  edge,
+  onMouseDown,
+  ariaControls,
+}: {
+  edge: "left" | "right";
+  onMouseDown: MouseEventHandler<HTMLDivElement>;
+  ariaControls?: string;
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-controls={ariaControls}
+      onMouseDown={onMouseDown}
+      className={`relative z-10 flex w-1 shrink-0 cursor-col-resize items-center justify-center ${
+        edge === "left" ? "-ml-1" : "-mr-1"
+      } hover:bg-primary/30 active:bg-primary/50 transition-colors`}
+    />
+  );
+}

--- a/apps/desktop/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
@@ -1,0 +1,49 @@
+import type { ComponentProps, MouseEventHandler } from "react";
+import { DebugProfiler } from "@/components/diagnostics/DebugProfiler";
+import { RightPanel } from "@/components/workspace/shell/right-panel/RightPanel";
+import { WorkspaceResizeSeparator } from "@/components/workspace/shell/screen/WorkspaceResizeSeparator";
+
+interface WorkspaceShellRightRailProps
+  extends Omit<ComponentProps<typeof RightPanel>, "isOpen"> {
+  /** Whether the rail (separator + panel container) participates in layout. */
+  visible: boolean;
+  open: boolean;
+  width: number;
+  onSeparatorMouseDown: MouseEventHandler<HTMLDivElement>;
+}
+
+/**
+ * Right-hand rail of the standard workspace shell: the resize separator plus
+ * the width-animated container that hosts the right panel.
+ */
+export function WorkspaceShellRightRail({
+  visible,
+  open,
+  width,
+  onSeparatorMouseDown,
+  ...rightPanelProps
+}: WorkspaceShellRightRailProps) {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <>
+      {open && (
+        <WorkspaceResizeSeparator
+          edge="right"
+          onMouseDown={onSeparatorMouseDown}
+        />
+      )}
+      <div
+        className="shrink-0 overflow-hidden transition-[width] duration-150 ease-in-out"
+        style={{ width: open ? width : 0 }}
+      >
+        <DebugProfiler id="workspace-right-panel">
+          <div className="h-full" style={{ minWidth: 260 }}>
+            <RightPanel isOpen={open} {...rightPanelProps} />
+          </div>
+        </DebugProfiler>
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
@@ -1,0 +1,129 @@
+import { SHORTCUTS } from "@/config/shortcuts/registry";
+import {
+  Archive,
+  Folder,
+  GitBranch,
+  MoreHorizontal,
+  Pencil,
+  Trash,
+} from "@proliferate/ui/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@proliferate/ui/kit/DropdownMenu";
+import { IconButton } from "@proliferate/ui/primitives/IconButton";
+import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
+
+interface WorkspaceItemMenuProps {
+  archived: boolean;
+  /** Current git branch, shown read-only in the git section. */
+  branchName: string | null;
+  workspaceLocationCopyLabel?: string | null;
+  /** Handlers are optional; omitted ones hide their menu item. */
+  onRename?: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
+  onCopyWorkspaceLocation?: () => void;
+  onCopyBranchName?: () => void;
+  onMarkDone?: () => void;
+}
+
+/**
+ * Three-dot workspace menu (UX spec §2), built on the kit DropdownMenu with
+ * the §7 overlay recipe. The git section carries the items that exist at
+ * sidebar level today: the read-only branch row + copy branch name. PR /
+ * pull–push actions are not plumbed to sidebar rows and are not invented.
+ */
+export function WorkspaceItemMenu({
+  archived,
+  branchName,
+  workspaceLocationCopyLabel,
+  onRename,
+  onArchive,
+  onUnarchive,
+  onCopyWorkspaceLocation,
+  onCopyBranchName,
+  onMarkDone,
+}: WorkspaceItemMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <IconButton
+          tone="sidebar"
+          size="xs"
+          onClick={(e) => e.stopPropagation()}
+          title="Workspace actions"
+          className="opacity-50 hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
+        >
+          <MoreHorizontal className="size-3.5" />
+        </IconButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+        className="min-w-[220px]"
+      >
+        {onRename && (
+          <DropdownMenuItem onSelect={onRename}>
+            <Pencil className="size-4 text-muted-foreground" />
+            Rename
+          </DropdownMenuItem>
+        )}
+        {onArchive && !archived && (
+          <DropdownMenuItem onSelect={onArchive}>
+            <Archive className="size-4 text-muted-foreground" />
+            Archive...
+          </DropdownMenuItem>
+        )}
+        {onUnarchive && archived && (
+          <DropdownMenuItem onSelect={onUnarchive}>
+            <Archive className="size-4 text-muted-foreground" />
+            Unarchive
+          </DropdownMenuItem>
+        )}
+        {onCopyWorkspaceLocation && (
+          <DropdownMenuItem onSelect={onCopyWorkspaceLocation}>
+            <Folder className="size-4 text-muted-foreground" />
+            {workspaceLocationCopyLabel ?? "Copy workspace location"}
+            <DropdownMenuShortcut>
+              {getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
+            </DropdownMenuShortcut>
+          </DropdownMenuItem>
+        )}
+        {(branchName || onCopyBranchName) && (
+          <>
+            <DropdownMenuSeparator />
+            {branchName && (
+              <div className="flex items-center gap-2 px-2 py-1.5 font-mono text-ui-sm text-muted-foreground">
+                <GitBranch className="size-3.5 shrink-0" />
+                <span className="min-w-0 truncate">{branchName}</span>
+              </div>
+            )}
+            {onCopyBranchName && (
+              <DropdownMenuItem onSelect={onCopyBranchName}>
+                <GitBranch className="size-4 text-muted-foreground" />
+                Copy branch name
+                <DropdownMenuShortcut>
+                  {getShortcutDisplayLabel(SHORTCUTS.copyBranchName)}
+                </DropdownMenuShortcut>
+              </DropdownMenuItem>
+            )}
+          </>
+        )}
+        {onMarkDone && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive" onSelect={onMarkDone}>
+              <Trash className="size-4" />
+              Delete workspace...
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/mobile/src/lib/domain/chat/mobile-chat-anyharness-projection.ts
+++ b/apps/mobile/src/lib/domain/chat/mobile-chat-anyharness-projection.ts
@@ -1,0 +1,121 @@
+import type {
+  PendingInteraction,
+  Session,
+  SessionEventEnvelope,
+  SessionExecutionSummary,
+} from "@anyharness/sdk";
+import type {
+  CloudPendingInteraction,
+  CloudSessionEvent,
+  CloudSessionProjection,
+} from "@proliferate/cloud-sdk";
+
+export function cloudSessionProjectionFromAnyHarness(
+  session: Session,
+  cloudWorkspaceId: string,
+  anyharnessWorkspaceId: string,
+): CloudSessionProjection {
+  return {
+    cloudWorkspaceId,
+    targetId: cloudWorkspaceId,
+    workspaceId: session.workspaceId ?? anyharnessWorkspaceId,
+    sessionId: session.id,
+    nativeSessionId: session.id,
+    sourceAgentKind: session.agentKind ?? null,
+    title: session.title ?? null,
+    status: session.status,
+    phase: session.executionSummary?.phase ?? session.status ?? null,
+    pendingInteractionCount: session.executionSummary?.pendingInteractions?.length ?? 0,
+    executionSummary: session.executionSummary ?? null,
+    liveConfig: session.liveConfig ?? null,
+    lastEventSeq: 0,
+    lastEventAt: session.updatedAt ?? session.lastPromptAt ?? session.createdAt ?? null,
+    startedAt: session.createdAt ?? null,
+    endedAt: null,
+  };
+}
+
+export function cloudPendingInteractionsFromExecutionSummary(
+  executionSummary: SessionExecutionSummary | null | undefined,
+  sessionId: string | null,
+): CloudPendingInteraction[] {
+  return (executionSummary?.pendingInteractions ?? []).map((interaction) => ({
+    requestId: interaction.requestId,
+    sessionId,
+    status: "pending",
+    kind: interaction.kind,
+    title: interaction.title,
+    description: interaction.description ?? null,
+    toolCallId: interaction.source.toolCallId ?? null,
+    toolKind: interaction.source.toolKind ?? null,
+    toolStatus: interaction.source.toolStatus ?? null,
+    linkedPlanId: interaction.source.linkedPlanId ?? null,
+    ...(interaction.payload.type === "permission"
+      ? {
+        options: interaction.payload.options ?? [],
+        context: interaction.payload.context ?? null,
+      }
+      : {}),
+    ...(interaction.payload.type === "user_input"
+      ? { questions: interaction.payload.questions ?? [] }
+      : {}),
+    ...(interaction.payload.type === "mcp_elicitation"
+      ? {
+        mcpElicitation: {
+          serverName: interaction.payload.serverName,
+          mode: interaction.payload.mode,
+        },
+      }
+      : {}),
+  }));
+}
+
+export function cloudPendingInteractionsFromReducer(
+  pendingInteractions: readonly PendingInteraction[],
+  sessionId: string,
+): CloudPendingInteraction[] {
+  return pendingInteractions.map((interaction) => ({
+    requestId: interaction.requestId,
+    sessionId,
+    status: "pending",
+    kind: interaction.kind,
+    title: interaction.title,
+    description: interaction.description ?? null,
+    toolCallId: interaction.toolCallId ?? null,
+    toolKind: interaction.toolKind ?? null,
+    toolStatus: interaction.toolStatus ?? null,
+    linkedPlanId: interaction.linkedPlanId ?? null,
+    ...(interaction.kind === "permission"
+      ? {
+        options: interaction.options ?? [],
+        context: interaction.context ?? null,
+      }
+      : {}),
+    ...(interaction.kind === "user_input"
+      ? { questions: interaction.questions ?? [] }
+      : {}),
+    ...(interaction.kind === "mcp_elicitation"
+      ? { mcpElicitation: interaction.mcpElicitation }
+      : {}),
+  }));
+}
+
+export function cloudSessionEventFromAnyHarness(
+  envelope: SessionEventEnvelope,
+  cloudWorkspaceId: string,
+  sessionId: string,
+): CloudSessionEvent {
+  return {
+    targetId: cloudWorkspaceId,
+    sessionId,
+    cloudWorkspaceId,
+    seq: envelope.seq,
+    eventType: envelope.event.type,
+    sourceKind: "anyharness",
+    turnId: null,
+    itemId: null,
+    occurredAt: envelope.timestamp ?? new Date().toISOString(),
+    payload: envelope.event as unknown as Record<string, unknown>,
+    envelope: envelope as unknown as Record<string, unknown>,
+  };
+}

--- a/apps/packages/product-surfaces/src/settings/cloud-environments/add-cloud-environment-helpers.ts
+++ b/apps/packages/product-surfaces/src/settings/cloud-environments/add-cloud-environment-helpers.ts
@@ -1,0 +1,112 @@
+import type { CloudGitRepositorySummary } from "@proliferate/cloud-sdk";
+import { formatGitRepoId } from "@proliferate/product-domain/repos/repo-id";
+import type {
+  AddCloudEnvironmentBlockerView,
+} from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+
+export function buildGitHubAppPrerequisiteBlocker({
+  organizationId,
+  canManageGitHubAppInstallation,
+  userAuthorizationLoading,
+  userAuthorizationConnected,
+  userAuthorizationNeedsReconnect,
+  authorizingUser,
+  installationLoading,
+  installationInstalled,
+  installingGitHubApp,
+  onAuthorizeUser,
+  onInstallGitHubApp,
+  onCopyAdminRequest,
+}: {
+  organizationId: string | null;
+  canManageGitHubAppInstallation: boolean;
+  userAuthorizationLoading: boolean;
+  userAuthorizationConnected: boolean;
+  userAuthorizationNeedsReconnect: boolean;
+  authorizingUser: boolean;
+  installationLoading: boolean;
+  installationInstalled: boolean;
+  installingGitHubApp: boolean;
+  onAuthorizeUser: () => void;
+  onInstallGitHubApp: () => void;
+  onCopyAdminRequest: () => void;
+}): AddCloudEnvironmentBlockerView | null {
+  if (!organizationId) {
+    return {
+      title: "Organization required",
+      description: "Cloud environments require an active organization before repositories can be added.",
+    };
+  }
+
+  if (userAuthorizationLoading || installationLoading) {
+    return {
+      title: "Checking GitHub App access",
+      description: "Proliferate is checking your GitHub authorization and organization installation.",
+    };
+  }
+
+  if (!userAuthorizationConnected) {
+    return {
+      title: userAuthorizationNeedsReconnect
+        ? "Reauthorize GitHub App"
+        : "Authorize GitHub App",
+      description: "Authorize the Proliferate GitHub App so Cloud can use your GitHub identity for repository access.",
+      actionLabel: userAuthorizationNeedsReconnect
+        ? "Reauthorize GitHub App"
+        : "Authorize GitHub App",
+      actionLoading: authorizingUser,
+      onAction: onAuthorizeUser,
+    };
+  }
+
+  if (!installationInstalled) {
+    if (canManageGitHubAppInstallation) {
+      return {
+        title: "Install GitHub App",
+        description: "Install the Proliferate GitHub App for this organization before adding Cloud environments.",
+        actionLabel: "Install GitHub App",
+        actionLoading: installingGitHubApp,
+        onAction: onInstallGitHubApp,
+      };
+    }
+    return {
+      title: "GitHub App installation required",
+      description: "Ask an organization admin to install the Proliferate GitHub App before adding Cloud environments.",
+      actionLabel: "Copy admin request",
+      onAction: onCopyAdminRequest,
+    };
+  }
+
+  return null;
+}
+
+export function mergeRepositories(
+  current: CloudGitRepositorySummary[],
+  incoming: CloudGitRepositorySummary[],
+): CloudGitRepositorySummary[] {
+  const byId = new Map<string, CloudGitRepositorySummary>();
+  for (const repo of current) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  for (const repo of incoming) {
+    byId.set(formatGitRepoId(repo), repo);
+  }
+  return Array.from(byId.values());
+}
+
+export function repoAuthorityMessage(status: string): string {
+  switch (status) {
+    case "missing_user_authorization":
+      return "Authorize the Proliferate GitHub App in Account settings before adding this cloud environment.";
+    case "expired_user_authorization":
+      return "Reauthorize the Proliferate GitHub App in Account settings before adding this cloud environment.";
+    case "missing_installation":
+      return "An organization admin needs to install the Proliferate GitHub App for this repository.";
+    case "repo_not_covered":
+      return "Update the Proliferate GitHub App installation so it has access to this repository.";
+    case "missing_user_repo_access":
+      return "Your GitHub user does not have access to this repository.";
+    default:
+      return "GitHub App repository access is not ready for this repository.";
+  }
+}

--- a/apps/web/src/lib/access/anyharness/cloud-sandbox-pending-home-prompt.ts
+++ b/apps/web/src/lib/access/anyharness/cloud-sandbox-pending-home-prompt.ts
@@ -1,0 +1,82 @@
+import type {
+  CloudSessionProjection,
+  CloudWorkspaceDetail,
+  ProliferateCloudClient,
+} from "@proliferate/cloud-sdk";
+import {
+  DEFAULT_DIRECT_PROMPT_AGENT_KIND,
+} from "@proliferate/product-domain/chats/cloud/composer-controls";
+
+import type { PendingHomePrompt } from "../cloud/pending-home-prompt-store";
+import { getWebCloudSandboxAnyHarnessClient } from "./cloud-sandbox-runtime";
+
+export async function startCloudSandboxPendingHomePrompt(args: {
+  client: ProliferateCloudClient;
+  productToken: string | null;
+  workspace: CloudWorkspaceDetail;
+  pendingPrompt: PendingHomePrompt;
+  onStatus: (status: string) => void;
+  shouldContinue: () => boolean;
+}): Promise<{ sessionId: string }> {
+  args.onStatus("Preparing cloud sandbox runtime.");
+  const { connection, anyharness } = await getWebCloudSandboxAnyHarnessClient({
+    workspace: args.workspace,
+    productToken: args.productToken,
+    client: args.client,
+  });
+  assertCurrent(args.shouldContinue);
+  args.onStatus("Starting session.");
+  const session = await anyharness.sessions.create({
+    workspaceId: connection.anyharnessWorkspaceId,
+    agentKind: args.pendingPrompt.agentKind ?? DEFAULT_DIRECT_PROMPT_AGENT_KIND,
+    ...(args.pendingPrompt.modelId ? { modelId: args.pendingPrompt.modelId } : {}),
+    ...(args.pendingPrompt.modeId ? { modeId: args.pendingPrompt.modeId } : {}),
+    subagentsEnabled: false,
+    origin: { kind: "system", entrypoint: "cloud" },
+  });
+  for (const update of args.pendingPrompt.sessionConfigUpdates ?? []) {
+    await anyharness.sessions.setConfigOption(session.id, update);
+  }
+  assertCurrent(args.shouldContinue);
+  args.onStatus("Sending prompt.");
+  await anyharness.sessions.prompt(session.id, {
+    blocks: [{ type: "text", text: args.pendingPrompt.text }],
+    promptId: args.pendingPrompt.id,
+  });
+  args.onStatus("Queued prompt; waiting for transcript.");
+  return { sessionId: session.id };
+}
+
+export async function resumeCloudSandboxPendingHomePrompt(args: {
+  client: ProliferateCloudClient;
+  productToken: string | null;
+  workspace: CloudWorkspaceDetail;
+  session: CloudSessionProjection;
+  pendingPrompt: PendingHomePrompt;
+  onStatus: (status: string) => void;
+  shouldContinue: () => boolean;
+}): Promise<{ sessionId: string }> {
+  args.onStatus("Preparing cloud sandbox runtime.");
+  const { anyharness } = await getWebCloudSandboxAnyHarnessClient({
+    workspace: args.workspace,
+    productToken: args.productToken,
+    client: args.client,
+  });
+  for (const update of args.pendingPrompt.sessionConfigUpdates ?? []) {
+    await anyharness.sessions.setConfigOption(args.session.sessionId, update);
+  }
+  assertCurrent(args.shouldContinue);
+  args.onStatus("Sending queued prompt.");
+  await anyharness.sessions.prompt(args.session.sessionId, {
+    blocks: [{ type: "text", text: args.pendingPrompt.text }],
+    promptId: args.pendingPrompt.id,
+  });
+  args.onStatus("Queued prompt; waiting for transcript.");
+  return { sessionId: args.session.sessionId };
+}
+
+function assertCurrent(shouldContinue: () => boolean): void {
+  if (!shouldContinue()) {
+    throw new Error("Action was cancelled.");
+  }
+}


### PR DESCRIPTION
Clears the final 6 LARGE_FRONTEND_FILE violations in CI's "Check frontend structure drift" (strict) — the last red job gating Deploy Staging. Mechanical cohesive extractions, zero behavior change, no allowlist bumps:

- `OrganizationPane` 403→325 (GitHubAppInstallationSection extracted)
- `StandardWorkspaceShell` 403→373 (WorkspaceResizeSeparator + WorkspaceShellRightRail)
- `WorkspaceItem` 431→356 (WorkspaceItemMenu + resolveWorkspaceRepoSettingsHref to settings/navigation)
- `use-mobile-chat-data` 409→302 (anyharness projection to lib/domain)
- `AddCloudEnvironmentDialogController` 462→359 (helpers module)
- `use-web-cloud-pending-home-prompt-lifecycle` 411→337 (access helper module)

Verified: drift TOTAL 0, boundaries, max-lines, desktop/web/mobile/product-surfaces typechecks, covering tests 72/72. With #852 this makes main CI fully green — reviving the auto Deploy Staging pipeline.

Note for the parallel session: an equivalent split was in progress on `fix/large-frontend-files` in the server-test-align worktree — this PR is the verified earlier pass; the redo can be dropped once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)