### PR TITLE
fix(frontend): wire the six oversized files onto their split-out modules

### DIFF
--- a/apps/desktop/src/components/settings/panes/OrganizationPane.tsx
+++ b/apps/desktop/src/components/settings/panes/OrganizationPane.tsx
@@ -10,14 +10,14 @@ import {
   useGitHubAppInstallationStatus,
   useStartGitHubAppInstallation,
 } from "@proliferate/cloud-sdk-react";
-import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
-import { Badge } from "@proliferate/ui/primitives/Badge";
 import { UpgradeGateDialog } from "@/components/billing/UpgradeGateDialog";
 import { OrganizationBillingLinkSection } from "@/components/settings/panes/organization/OrganizationBillingLinkSection";
 import { OrganizationSettingsCard } from "@/components/settings/panes/organization/OrganizationSettingsCard";
 import { OrganizationSection } from "@/components/settings/panes/organization/OrganizationLogo";
-import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
-import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import {
+  GitHubAppInstallationSection,
+  isOrganizationAdminRole,
+} from "@/components/settings/panes/organization/GitHubAppInstallationSection";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
 import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
@@ -314,84 +314,6 @@ export function OrganizationPane() {
       ) : null}
     </section>
   );
-}
-
-function GitHubAppInstallationSection({
-  loading,
-  installing,
-  canManage,
-  status,
-  onInstall,
-  onManage,
-}: {
-  loading: boolean;
-  installing: boolean;
-  canManage: boolean;
-  status: {
-    installed: boolean;
-    accountLogin?: string | null;
-    repositorySelection?: string | null;
-    suspendedAt?: string | null;
-  } | undefined;
-  onInstall: () => void | Promise<void>;
-  onManage: () => void | Promise<void>;
-}) {
-  const installed = status?.installed === true;
-  const repositorySelection = formatRepositorySelection(status?.repositorySelection ?? null);
-  const statusLabel = loading
-    ? "Checking"
-    : installed
-      ? "Installed"
-      : "Not installed";
-  const description = installed
-    ? `Installed on ${status?.accountLogin ? `@${status.accountLogin}` : "this GitHub account"}${repositorySelection ? ` with ${repositorySelection}` : ""}.`
-    : canManage
-      ? "Install the Proliferate GitHub App for this organization before members can enable cloud repositories."
-      : "Ask an organization admin to install the Proliferate GitHub App before you enable cloud repositories.";
-
-  return (
-    <SettingsSection
-      title="GitHub App"
-      description="Repository access for organization cloud environments."
-    >
-      <SettingsRow
-        label="Organization installation"
-        description={description}
-      >
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <Badge tone={installed ? "success" : "warning"}>{statusLabel}</Badge>
-          {canManage ? (
-            <Button
-              type="button"
-              variant="secondary"
-              loading={installing}
-              disabled={installing}
-              onClick={() => {
-                void (installed ? onManage() : onInstall());
-              }}
-            >
-              {!installing ? <ProviderBrandIcon provider="github" className="size-[13px]" /> : null}
-              {installed ? "Manage in GitHub" : "Install GitHub App"}
-            </Button>
-          ) : null}
-        </div>
-      </SettingsRow>
-    </SettingsSection>
-  );
-}
-
-function isOrganizationAdminRole(role: string | null | undefined): boolean {
-  return role === "owner" || role === "admin";
-}
-
-function formatRepositorySelection(repositorySelection: string | null): string | null {
-  if (repositorySelection === "all") {
-    return "all repositories";
-  }
-  if (repositorySelection === "selected") {
-    return "selected repositories";
-  }
-  return null;
 }
 
 function OrganizationNotice({ children }: { children: ReactNode }) {

--- a/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -9,12 +9,13 @@ import { ChatView } from "@/components/workspace/chat/ChatView";
 import { GlobalHeader } from "@/components/workspace/shell/topbar/GlobalHeader";
 import { WorkspaceContentView } from "@/components/workspace/shell/screen/WorkspaceContentView";
 import { WorkspaceShellShortcuts } from "@/components/workspace/shell/screen/WorkspaceShellShortcuts";
+import { WorkspaceResizeSeparator } from "@/components/workspace/shell/screen/WorkspaceResizeSeparator";
 import {
   WorkspaceHeaderTabsViewModelProvider,
 } from "@/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext";
 import { WorkspaceShellActionsProvider } from "@/components/workspace/shell/providers/WorkspaceShellActionsContext";
 import { WorkspaceCommandPalette } from "@/components/workspace/shell/command-palette/WorkspaceCommandPalette";
-import { RightPanel } from "@/components/workspace/shell/right-panel/RightPanel";
+import { WorkspaceShellRightRail } from "@/components/workspace/shell/screen/WorkspaceShellRightRail";
 import { WorkspaceShellSidebar } from "@/components/workspace/shell/sidebar/WorkspaceShellSidebar";
 import {
   WorkspaceSidebarHeaderControls,
@@ -37,8 +38,8 @@ import { WorkspacePathProvider } from "@/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import {
-  buildCloudRepoSettingsHref,
   buildSettingsHref,
+  resolveWorkspaceRepoSettingsHref,
 } from "@/lib/domain/settings/navigation";
 import type { WorkspaceRenderSurface } from "@/lib/domain/workspaces/tabs/shell-activation";
 import { resolvePendingWorkspacePath } from "@/lib/domain/workspaces/creation/pending-entry";
@@ -149,23 +150,12 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     hasRuntimeReadyWorkspace,
     runtimeBlockedReason,
   ]);
-  const repoSettingsHref = useMemo(() => {
-    const cloudOwner = selectedCloudWorkspace?.repo?.owner?.trim() ?? "";
-    const cloudName = selectedCloudWorkspace?.repo?.name?.trim() ?? "";
-    if (cloudOwner && cloudName) {
-      return buildCloudRepoSettingsHref(cloudOwner, cloudName);
-    }
-    const localRepoPath = selectedRepoRoot?.path?.trim()
-      || selectedWorkspace?.path?.trim()
-      || "";
-    if (!localRepoPath) {
-      return null;
-    }
-    return buildSettingsHref({
-      section: "repo",
-      repo: localRepoPath,
-    });
-  }, [
+  const repoSettingsHref = useMemo(() => resolveWorkspaceRepoSettingsHref({
+    cloudRepoOwner: selectedCloudWorkspace?.repo?.owner,
+    cloudRepoName: selectedCloudWorkspace?.repo?.name,
+    repoRootPath: selectedRepoRoot?.path,
+    workspacePath: selectedWorkspace?.path,
+  }), [
     selectedCloudWorkspace?.repo?.name,
     selectedCloudWorkspace?.repo?.owner,
     selectedRepoRoot?.path,
@@ -249,12 +239,10 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                 onOpenRestartPrompt={openRestartPrompt}
               />
               {sidebarOpen && (
-                <div
-                  role="separator"
-                  aria-orientation="vertical"
-                  aria-controls="main-sidebar"
+                <WorkspaceResizeSeparator
+                  edge="left"
+                  ariaControls="main-sidebar"
                   onMouseDown={onLeftSeparatorDown}
-                  className="relative z-10 flex w-1 shrink-0 cursor-col-resize items-center justify-center -ml-1 hover:bg-primary/30 active:bg-primary/50 transition-colors"
                 />
               )}
 
@@ -335,17 +323,15 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                         </DebugProfiler>
 
                         {hasRuntimeReadyWorkspace && (
-                          <>
-                            <PublishDialog
-                              open={publishDialog.open}
-                              workspaceId={publishDialog.workspaceId}
-                              initialIntent={publishDialog.initialIntent}
-                              runtimeBlockedReason={runtimeBlockedReason}
-                              repoDefaultBranch={publishRepoDefaultBranch}
-                              onClose={actions.closePublishDialog}
-                              onViewPr={actions.handlePublishDialogViewPr}
-                            />
-                          </>
+                          <PublishDialog
+                            open={publishDialog.open}
+                            workspaceId={publishDialog.workspaceId}
+                            initialIntent={publishDialog.initialIntent}
+                            runtimeBlockedReason={runtimeBlockedReason}
+                            repoDefaultBranch={publishRepoDefaultBranch}
+                            onClose={actions.closePublishDialog}
+                            onViewPr={actions.handlePublishDialogViewPr}
+                          />
                         )}
                       </>
                     ) : (
@@ -354,45 +340,29 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                   </div>
                 </div>
 
-                {hasWorkspaceShell && !hasLaunchIntentOnlyShell && rightPanelOpen && (
-                  <div
-                    role="separator"
-                    aria-orientation="vertical"
-                    onMouseDown={onRightSeparatorDown}
-                    className="relative z-10 flex w-1 shrink-0 cursor-col-resize items-center justify-center -mr-1 hover:bg-primary/30 active:bg-primary/50 transition-colors"
-                  />
-                )}
-                {hasWorkspaceShell && !hasLaunchIntentOnlyShell && (
-                  <div
-                    className="shrink-0 overflow-hidden transition-[width] duration-150 ease-in-out"
-                    style={{ width: rightPanelOpen ? rightPanelWidth : 0 }}
-                  >
-                    <DebugProfiler id="workspace-right-panel">
-                      <div className="h-full" style={{ minWidth: 260 }}>
-                        <RightPanel
-                          workspaceId={selectedWorkspaceId}
-                          workspaceUiKey={workspaceUiKey}
-                          isWorkspaceReady={hasRuntimeReadyWorkspace}
-                          isOpen={rightPanelOpen}
-                          shouldKeepContentVisible={shouldKeepRuntimePanelsVisible}
-                          isCloudWorkspaceSelected={isCloudWorkspaceSelected}
-                          state={rightPanelState}
-                          repoSettingsHref={repoSettingsHref ?? buildSettingsHref({
-                            section: "repo",
-                            repo: null,
-                          })}
-                          onStateChange={layout.setRightPanelState}
-                          terminalActivationRequest={terminalActivationRequest}
-                          focusRequestToken={rightPanelFocusRequestToken}
-                          nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
-                          onOpenPanel={actions.openRightPanel}
-                          onTogglePanel={actions.toggleRightPanel}
-                          onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
-                        />
-                      </div>
-                    </DebugProfiler>
-                  </div>
-                )}
+                <WorkspaceShellRightRail
+                  visible={hasWorkspaceShell && !hasLaunchIntentOnlyShell}
+                  open={rightPanelOpen}
+                  width={rightPanelWidth}
+                  onSeparatorMouseDown={onRightSeparatorDown}
+                  workspaceId={selectedWorkspaceId}
+                  workspaceUiKey={workspaceUiKey}
+                  isWorkspaceReady={hasRuntimeReadyWorkspace}
+                  shouldKeepContentVisible={shouldKeepRuntimePanelsVisible}
+                  isCloudWorkspaceSelected={isCloudWorkspaceSelected}
+                  state={rightPanelState}
+                  repoSettingsHref={repoSettingsHref ?? buildSettingsHref({
+                    section: "repo",
+                    repo: null,
+                  })}
+                  onStateChange={layout.setRightPanelState}
+                  terminalActivationRequest={terminalActivationRequest}
+                  focusRequestToken={rightPanelFocusRequestToken}
+                  nativeOverlaysHidden={nativeWorkspaceOverlaysHidden}
+                  onOpenPanel={actions.openRightPanel}
+                  onTogglePanel={actions.toggleRightPanel}
+                  onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
+                />
               </div>
             </div>
           </WorkspaceHeaderTabsViewModelProvider>

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -8,18 +8,9 @@ import {
   Archive,
   Folder,
   GitBranch,
-  MoreHorizontal,
   Pencil,
   Trash,
 } from "@proliferate/ui/icons";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from "@proliferate/ui/kit/DropdownMenu";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { ShortcutBadge } from "@proliferate/ui/layout/ShortcutBadge";
@@ -36,7 +27,7 @@ import {
   SidebarDetailIndicatorsView,
   SidebarStatusIndicatorView,
 } from "./SidebarIndicators";
-import { IconButton } from "@proliferate/ui/primitives/IconButton";
+import { WorkspaceItemMenu } from "./WorkspaceItemMenu";
 import { WorkspaceRenamePopover } from "./WorkspaceRenamePopover";
 import { ProductSidebarWorkspaceRow } from "@proliferate/product-ui/sidebar/ProductSidebarRepositories";
 import type { PrStatusView } from "@proliferate/product-ui/workspaces/PrStatusBadge";
@@ -171,86 +162,20 @@ export function WorkspaceItem({
     || !!onMarkDone
     || !!branchName;
 
-  // Three-dot workspace menu (UX spec §2), built on the kit DropdownMenu with
-  // the §7 overlay recipe. The git section carries the items that exist at
-  // sidebar level today: the read-only branch row + copy branch name. PR /
-  // pull–push actions are not plumbed to sidebar rows and are not invented.
   const workspaceMenu = hasMenuActions ? (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <IconButton
-          tone="sidebar"
-          size="xs"
-          onClick={(e) => e.stopPropagation()}
-          title="Workspace actions"
-          className="opacity-50 hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
-        >
-          <MoreHorizontal className="size-3.5" />
-        </IconButton>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        onClick={(e) => e.stopPropagation()}
-        className="min-w-[220px]"
-      >
-        {onRename && (
-          <DropdownMenuItem onSelect={handleRenameCommand}>
-            <Pencil className="size-4 text-muted-foreground" />
-            Rename
-          </DropdownMenuItem>
-        )}
-        {onArchive && !archived && (
-          <DropdownMenuItem onSelect={handleArchiveCommand}>
-            <Archive className="size-4 text-muted-foreground" />
-            Archive...
-          </DropdownMenuItem>
-        )}
-        {onUnarchive && archived && (
-          <DropdownMenuItem onSelect={handleUnarchiveCommand}>
-            <Archive className="size-4 text-muted-foreground" />
-            Unarchive
-          </DropdownMenuItem>
-        )}
-        {onCopyWorkspaceLocation && (
-          <DropdownMenuItem onSelect={handleCopyWorkspaceLocationCommand}>
-            <Folder className="size-4 text-muted-foreground" />
-            {workspaceLocationCopyLabel ?? "Copy workspace location"}
-            <DropdownMenuShortcut>
-              {getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
-            </DropdownMenuShortcut>
-          </DropdownMenuItem>
-        )}
-        {(branchName || onCopyBranchName) && (
-          <>
-            <DropdownMenuSeparator />
-            {branchName && (
-              <div className="flex items-center gap-2 px-2 py-1.5 font-mono text-ui-sm text-muted-foreground">
-                <GitBranch className="size-3.5 shrink-0" />
-                <span className="min-w-0 truncate">{branchName}</span>
-              </div>
-            )}
-            {onCopyBranchName && (
-              <DropdownMenuItem onSelect={handleCopyBranchNameCommand}>
-                <GitBranch className="size-4 text-muted-foreground" />
-                Copy branch name
-                <DropdownMenuShortcut>
-                  {getShortcutDisplayLabel(SHORTCUTS.copyBranchName)}
-                </DropdownMenuShortcut>
-              </DropdownMenuItem>
-            )}
-          </>
-        )}
-        {onMarkDone && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onSelect={handleMarkDoneCommand}>
-              <Trash className="size-4" />
-              Delete workspace...
-            </DropdownMenuItem>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <WorkspaceItemMenu
+      archived={archived}
+      branchName={branchName}
+      workspaceLocationCopyLabel={workspaceLocationCopyLabel}
+      onRename={onRename ? handleRenameCommand : undefined}
+      onArchive={onArchive ? handleArchiveCommand : undefined}
+      onUnarchive={onUnarchive ? handleUnarchiveCommand : undefined}
+      onCopyWorkspaceLocation={
+        onCopyWorkspaceLocation ? handleCopyWorkspaceLocationCommand : undefined
+      }
+      onCopyBranchName={onCopyBranchName ? handleCopyBranchNameCommand : undefined}
+      onMarkDone={onMarkDone ? handleMarkDoneCommand : undefined}
+    />
   ) : null;
 
   const row = (

--- a/apps/desktop/src/lib/domain/settings/navigation.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation.ts
@@ -112,6 +112,34 @@ export function buildCloudRepoSettingsHref(
   });
 }
 
+/**
+ * Repository settings link for a workspace: cloud repos deep-link into the
+ * cloud environment entry; local workspaces fall back to the repo root path
+ * (or the workspace path) and resolve to null when neither is known.
+ */
+export function resolveWorkspaceRepoSettingsHref(input: {
+  cloudRepoOwner?: string | null;
+  cloudRepoName?: string | null;
+  repoRootPath?: string | null;
+  workspacePath?: string | null;
+}): string | null {
+  const cloudOwner = input.cloudRepoOwner?.trim() ?? "";
+  const cloudName = input.cloudRepoName?.trim() ?? "";
+  if (cloudOwner && cloudName) {
+    return buildCloudRepoSettingsHref(cloudOwner, cloudName);
+  }
+  const localRepoPath = input.repoRootPath?.trim()
+    || input.workspacePath?.trim()
+    || "";
+  if (!localRepoPath) {
+    return null;
+  }
+  return buildSettingsHref({
+    section: "repo",
+    repo: localRepoPath,
+  });
+}
+
 export interface SettingsSelectionInput {
   rawSection: string | null;
   rawRepo?: string | null;

--- a/apps/mobile/src/hooks/chat/derived/use-mobile-chat-data.ts
+++ b/apps/mobile/src/hooks/chat/derived/use-mobile-chat-data.ts
@@ -1,6 +1,4 @@
 import type {
-  PendingInteraction,
-  Session,
   SessionEventEnvelope,
   SessionExecutionSummary,
 } from "@anyharness/sdk";
@@ -10,7 +8,6 @@ import { useMemo } from "react";
 import type {
   CloudPendingInteraction,
   CloudSessionEvent,
-  CloudSessionProjection,
   CloudTranscriptItem,
 } from "@proliferate/cloud-sdk";
 import {
@@ -34,6 +31,12 @@ import {
   latestPendingPromptCommandId,
   optimisticPromptFromPending,
 } from "../../../lib/domain/chat/mobile-chat-transcript";
+import {
+  cloudPendingInteractionsFromExecutionSummary,
+  cloudPendingInteractionsFromReducer,
+  cloudSessionEventFromAnyHarness,
+  cloudSessionProjectionFromAnyHarness,
+} from "../../../lib/domain/chat/mobile-chat-anyharness-projection";
 import {
   compareSessions,
   effectiveWorkspaceStatus,
@@ -295,115 +298,5 @@ export function useMobileChatData({
     pendingPromptTranscriptState,
     pendingPromptDurable,
     visibleTranscriptRows,
-  };
-}
-
-function cloudSessionProjectionFromAnyHarness(
-  session: Session,
-  cloudWorkspaceId: string,
-  anyharnessWorkspaceId: string,
-): CloudSessionProjection {
-  return {
-    cloudWorkspaceId,
-    targetId: cloudWorkspaceId,
-    workspaceId: session.workspaceId ?? anyharnessWorkspaceId,
-    sessionId: session.id,
-    nativeSessionId: session.id,
-    sourceAgentKind: session.agentKind ?? null,
-    title: session.title ?? null,
-    status: session.status,
-    phase: session.executionSummary?.phase ?? session.status ?? null,
-    pendingInteractionCount: session.executionSummary?.pendingInteractions?.length ?? 0,
-    executionSummary: session.executionSummary ?? null,
-    liveConfig: session.liveConfig ?? null,
-    lastEventSeq: 0,
-    lastEventAt: session.updatedAt ?? session.lastPromptAt ?? session.createdAt ?? null,
-    startedAt: session.createdAt ?? null,
-    endedAt: null,
-  };
-}
-
-function cloudPendingInteractionsFromExecutionSummary(
-  executionSummary: SessionExecutionSummary | null | undefined,
-  sessionId: string | null,
-): CloudPendingInteraction[] {
-  return (executionSummary?.pendingInteractions ?? []).map((interaction) => ({
-    requestId: interaction.requestId,
-    sessionId,
-    status: "pending",
-    kind: interaction.kind,
-    title: interaction.title,
-    description: interaction.description ?? null,
-    toolCallId: interaction.source.toolCallId ?? null,
-    toolKind: interaction.source.toolKind ?? null,
-    toolStatus: interaction.source.toolStatus ?? null,
-    linkedPlanId: interaction.source.linkedPlanId ?? null,
-    ...(interaction.payload.type === "permission"
-      ? {
-        options: interaction.payload.options ?? [],
-        context: interaction.payload.context ?? null,
-      }
-      : {}),
-    ...(interaction.payload.type === "user_input"
-      ? { questions: interaction.payload.questions ?? [] }
-      : {}),
-    ...(interaction.payload.type === "mcp_elicitation"
-      ? {
-        mcpElicitation: {
-          serverName: interaction.payload.serverName,
-          mode: interaction.payload.mode,
-        },
-      }
-      : {}),
-  }));
-}
-
-function cloudPendingInteractionsFromReducer(
-  pendingInteractions: readonly PendingInteraction[],
-  sessionId: string,
-): CloudPendingInteraction[] {
-  return pendingInteractions.map((interaction) => ({
-    requestId: interaction.requestId,
-    sessionId,
-    status: "pending",
-    kind: interaction.kind,
-    title: interaction.title,
-    description: interaction.description ?? null,
-    toolCallId: interaction.toolCallId ?? null,
-    toolKind: interaction.toolKind ?? null,
-    toolStatus: interaction.toolStatus ?? null,
-    linkedPlanId: interaction.linkedPlanId ?? null,
-    ...(interaction.kind === "permission"
-      ? {
-        options: interaction.options ?? [],
-        context: interaction.context ?? null,
-      }
-      : {}),
-    ...(interaction.kind === "user_input"
-      ? { questions: interaction.questions ?? [] }
-      : {}),
-    ...(interaction.kind === "mcp_elicitation"
-      ? { mcpElicitation: interaction.mcpElicitation }
-      : {}),
-  }));
-}
-
-function cloudSessionEventFromAnyHarness(
-  envelope: SessionEventEnvelope,
-  cloudWorkspaceId: string,
-  sessionId: string,
-): CloudSessionEvent {
-  return {
-    targetId: cloudWorkspaceId,
-    sessionId,
-    cloudWorkspaceId,
-    seq: envelope.seq,
-    eventType: envelope.event.type,
-    sourceKind: "anyharness",
-    turnId: null,
-    itemId: null,
-    occurredAt: envelope.timestamp ?? new Date().toISOString(),
-    payload: envelope.event as unknown as Record<string, unknown>,
-    envelope: envelope as unknown as Record<string, unknown>,
   };
 }

--- a/apps/packages/product-surfaces/src/settings/cloud-environments/AddCloudEnvironmentDialogController.tsx
+++ b/apps/packages/product-surfaces/src/settings/cloud-environments/AddCloudEnvironmentDialogController.tsx
@@ -22,9 +22,13 @@ import {
 } from "@proliferate/product-domain/repos/repo-id";
 import { AddCloudEnvironmentDialog } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
 import type {
-  AddCloudEnvironmentBlockerView,
   AddCloudEnvironmentRepositoryView,
 } from "@proliferate/product-ui/environments/AddCloudEnvironmentDialog";
+import {
+  buildGitHubAppPrerequisiteBlocker,
+  mergeRepositories,
+  repoAuthorityMessage,
+} from "./add-cloud-environment-helpers";
 
 const REPO_PAGE_LIMIT = 50;
 
@@ -343,113 +347,6 @@ function useCloudEnvironmentAddActions({
       }
     },
   };
-}
-
-function buildGitHubAppPrerequisiteBlocker({
-  organizationId,
-  canManageGitHubAppInstallation,
-  userAuthorizationLoading,
-  userAuthorizationConnected,
-  userAuthorizationNeedsReconnect,
-  authorizingUser,
-  installationLoading,
-  installationInstalled,
-  installingGitHubApp,
-  onAuthorizeUser,
-  onInstallGitHubApp,
-  onCopyAdminRequest,
-}: {
-  organizationId: string | null;
-  canManageGitHubAppInstallation: boolean;
-  userAuthorizationLoading: boolean;
-  userAuthorizationConnected: boolean;
-  userAuthorizationNeedsReconnect: boolean;
-  authorizingUser: boolean;
-  installationLoading: boolean;
-  installationInstalled: boolean;
-  installingGitHubApp: boolean;
-  onAuthorizeUser: () => void;
-  onInstallGitHubApp: () => void;
-  onCopyAdminRequest: () => void;
-}): AddCloudEnvironmentBlockerView | null {
-  if (!organizationId) {
-    return {
-      title: "Organization required",
-      description: "Cloud environments require an active organization before repositories can be added.",
-    };
-  }
-
-  if (userAuthorizationLoading || installationLoading) {
-    return {
-      title: "Checking GitHub App access",
-      description: "Proliferate is checking your GitHub authorization and organization installation.",
-    };
-  }
-
-  if (!userAuthorizationConnected) {
-    return {
-      title: userAuthorizationNeedsReconnect
-        ? "Reauthorize GitHub App"
-        : "Authorize GitHub App",
-      description: "Authorize the Proliferate GitHub App so Cloud can use your GitHub identity for repository access.",
-      actionLabel: userAuthorizationNeedsReconnect
-        ? "Reauthorize GitHub App"
-        : "Authorize GitHub App",
-      actionLoading: authorizingUser,
-      onAction: onAuthorizeUser,
-    };
-  }
-
-  if (!installationInstalled) {
-    if (canManageGitHubAppInstallation) {
-      return {
-        title: "Install GitHub App",
-        description: "Install the Proliferate GitHub App for this organization before adding Cloud environments.",
-        actionLabel: "Install GitHub App",
-        actionLoading: installingGitHubApp,
-        onAction: onInstallGitHubApp,
-      };
-    }
-    return {
-      title: "GitHub App installation required",
-      description: "Ask an organization admin to install the Proliferate GitHub App before adding Cloud environments.",
-      actionLabel: "Copy admin request",
-      onAction: onCopyAdminRequest,
-    };
-  }
-
-  return null;
-}
-
-function mergeRepositories(
-  current: CloudGitRepositorySummary[],
-  incoming: CloudGitRepositorySummary[],
-): CloudGitRepositorySummary[] {
-  const byId = new Map<string, CloudGitRepositorySummary>();
-  for (const repo of current) {
-    byId.set(formatGitRepoId(repo), repo);
-  }
-  for (const repo of incoming) {
-    byId.set(formatGitRepoId(repo), repo);
-  }
-  return Array.from(byId.values());
-}
-
-function repoAuthorityMessage(status: string): string {
-  switch (status) {
-    case "missing_user_authorization":
-      return "Authorize the Proliferate GitHub App in Account settings before adding this cloud environment.";
-    case "expired_user_authorization":
-      return "Reauthorize the Proliferate GitHub App in Account settings before adding this cloud environment.";
-    case "missing_installation":
-      return "An organization admin needs to install the Proliferate GitHub App for this repository.";
-    case "repo_not_covered":
-      return "Update the Proliferate GitHub App installation so it has access to this repository.";
-    case "missing_user_repo_access":
-      return "Your GitHub user does not have access to this repository.";
-    default:
-      return "GitHub App repository access is not ready for this repository.";
-  }
 }
 
 function useDebouncedValue(value: string, delayMs: number): string {

--- a/apps/web/src/hooks/chat/lifecycle/use-web-cloud-pending-home-prompt-lifecycle.ts
+++ b/apps/web/src/hooks/chat/lifecycle/use-web-cloud-pending-home-prompt-lifecycle.ts
@@ -5,10 +5,6 @@ import type {
   CloudWorkspaceDetail,
   ProliferateCloudClient,
 } from "@proliferate/cloud-sdk";
-import {
-  DEFAULT_DIRECT_PROMPT_AGENT_KIND,
-} from "@proliferate/product-domain/chats/cloud/composer-controls";
-
 import { routes } from "../../../config/routes";
 import {
   isWorkspacePreparationStatus,
@@ -24,8 +20,9 @@ import {
   type PendingHomePrompt,
 } from "../../../lib/access/cloud/pending-home-prompt-store";
 import {
-  getWebCloudSandboxAnyHarnessClient,
-} from "../../../lib/access/anyharness/cloud-sandbox-runtime";
+  resumeCloudSandboxPendingHomePrompt,
+  startCloudSandboxPendingHomePrompt,
+} from "../../../lib/access/anyharness/cloud-sandbox-pending-home-prompt";
 import {
   type WebCloudPromptIntent,
 } from "../../../stores/cloud/web-cloud-prompt-intent-store";
@@ -337,75 +334,4 @@ export function useWebCloudPendingHomePromptLifecycle(input: {
     workspace,
     workspaceRefetch,
   ]);
-}
-
-async function startCloudSandboxPendingHomePrompt(args: {
-  client: ProliferateCloudClient;
-  productToken: string | null;
-  workspace: CloudWorkspaceDetail;
-  pendingPrompt: PendingHomePrompt;
-  onStatus: (status: string) => void;
-  shouldContinue: () => boolean;
-}): Promise<{ sessionId: string }> {
-  args.onStatus("Preparing cloud sandbox runtime.");
-  const { connection, anyharness } = await getWebCloudSandboxAnyHarnessClient({
-    workspace: args.workspace,
-    productToken: args.productToken,
-    client: args.client,
-  });
-  assertCurrent(args.shouldContinue);
-  args.onStatus("Starting session.");
-  const session = await anyharness.sessions.create({
-    workspaceId: connection.anyharnessWorkspaceId,
-    agentKind: args.pendingPrompt.agentKind ?? DEFAULT_DIRECT_PROMPT_AGENT_KIND,
-    ...(args.pendingPrompt.modelId ? { modelId: args.pendingPrompt.modelId } : {}),
-    ...(args.pendingPrompt.modeId ? { modeId: args.pendingPrompt.modeId } : {}),
-    subagentsEnabled: false,
-    origin: { kind: "system", entrypoint: "cloud" },
-  });
-  for (const update of args.pendingPrompt.sessionConfigUpdates ?? []) {
-    await anyharness.sessions.setConfigOption(session.id, update);
-  }
-  assertCurrent(args.shouldContinue);
-  args.onStatus("Sending prompt.");
-  await anyharness.sessions.prompt(session.id, {
-    blocks: [{ type: "text", text: args.pendingPrompt.text }],
-    promptId: args.pendingPrompt.id,
-  });
-  args.onStatus("Queued prompt; waiting for transcript.");
-  return { sessionId: session.id };
-}
-
-async function resumeCloudSandboxPendingHomePrompt(args: {
-  client: ProliferateCloudClient;
-  productToken: string | null;
-  workspace: CloudWorkspaceDetail;
-  session: CloudSessionProjection;
-  pendingPrompt: PendingHomePrompt;
-  onStatus: (status: string) => void;
-  shouldContinue: () => boolean;
-}): Promise<{ sessionId: string }> {
-  args.onStatus("Preparing cloud sandbox runtime.");
-  const { anyharness } = await getWebCloudSandboxAnyHarnessClient({
-    workspace: args.workspace,
-    productToken: args.productToken,
-    client: args.client,
-  });
-  for (const update of args.pendingPrompt.sessionConfigUpdates ?? []) {
-    await anyharness.sessions.setConfigOption(args.session.sessionId, update);
-  }
-  assertCurrent(args.shouldContinue);
-  args.onStatus("Sending queued prompt.");
-  await anyharness.sessions.prompt(args.session.sessionId, {
-    blocks: [{ type: "text", text: args.pendingPrompt.text }],
-    promptId: args.pendingPrompt.id,
-  });
-  args.onStatus("Queued prompt; waiting for transcript.");
-  return { sessionId: args.session.sessionId };
-}
-
-function assertCurrent(shouldContinue: () => boolean): void {
-  if (!shouldContinue()) {
-    throw new Error("Action was cancelled.");
-  }
 }


### PR DESCRIPTION
Completes #853, which landed the seven extracted helper modules but not the edits that make the six oversized files consume them — so the "Repo shape checks / Check frontend structure drift" step stayed red on main (`LARGE_FRONTEND_FILE` ×6) and the new modules were dead code.

This PR lands the missing half (the tracked-file modifications stashed during the #853 landing):

- `OrganizationPane.tsx` 403 → 325 (uses `organization/GitHubAppInstallationSection`)
- `StandardWorkspaceShell.tsx` 403 → 371 (uses `WorkspaceResizeSeparator` + `WorkspaceShellRightRail`; `repoSettingsHref` logic moved to `resolveWorkspaceRepoSettingsHref`)
- `WorkspaceItem.tsx` 431 → 356 (uses `sidebar/WorkspaceItemMenu`)
- `use-mobile-chat-data.ts` 409 → 302 (uses `mobile-chat-anyharness-projection`)
- `AddCloudEnvironmentDialogController.tsx` 462 → 359 (uses `add-cloud-environment-helpers`)
- `use-web-cloud-pending-home-prompt-lifecycle.ts` 411 → 337 (uses `cloud-sandbox-pending-home-prompt`)

All verbatim relocations, no behavior change. Verified locally on this exact combined tree: `report_frontend_structure.py --strict` TOTAL: 0, `check_max_lines.py` pass, all seven repo-shape checks pass, desktop `pnpm run build`, `shared:typecheck`/`shared:build`, product-domain + product-ui tests, mobile typecheck, web typecheck + build all green.

With this, the last red job on main's CI goes green, reviving the Deploy Staging auto-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)