### PR TITLE
feat(desktop): chat input cleanup — monochrome pills, tone system removed, placeholder variants

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/desktop/src/components/home/screen/HomeComposerForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, type ReactNode } from "react";
 import { HOME_CHAT_COMPOSER_INPUT } from "@/config/chat";
+import { CHAT_COMPOSER_LABELS } from "@/copy/chat/chat-copy";
 import { ChatComposerActions } from "@/components/workspace/chat/input/ChatComposerActions";
 import { ChatComposerControlRowFrame } from "@proliferate/product-ui/chat/composer/ChatComposerControlRowFrame";
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
@@ -158,7 +159,7 @@ export function HomeComposerForm({
                 value={composer.draft}
                 onChange={(event) => handleDraftChange(event.target.value, event.timeStamp)}
                 onKeyDown={composer.handleKeyDown}
-                placeholder="Describe a task"
+                placeholder={CHAT_COMPOSER_LABELS.placeholder}
                 spellCheck={false}
                 autoComplete="off"
                 autoCorrect="off"

--- a/apps/desktop/src/components/settings/panes/AgentDefaultComposer.tsx
+++ b/apps/desktop/src/components/settings/panes/AgentDefaultComposer.tsx
@@ -108,7 +108,6 @@ export function AgentDefaultComposer({
         })),
       }]}
       controls={controls}
-      placeholder="Describe a task"
       onSelectModel={(_agentKind, modelId) => {
         preferences.set(
           "defaultChatModelIdByAgentKind",

--- a/apps/desktop/src/components/settings/shared/AgentHarnessConfigComposer.tsx
+++ b/apps/desktop/src/components/settings/shared/AgentHarnessConfigComposer.tsx
@@ -8,6 +8,7 @@ import {
   type AgentHarnessModelOption,
 } from "@/components/agents/AgentHarnessModelSelector";
 import { SessionConfigControls } from "@/components/workspace/chat/input/SessionConfigControls";
+import { CHAT_COMPOSER_LABELS } from "@/copy/chat/chat-copy";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
 
 export type AgentHarnessConfigModelOption = AgentHarnessModelOption;
@@ -38,7 +39,7 @@ export function AgentHarnessConfigComposer({
   disabled = false,
   saving = false,
   actionLabel,
-  placeholder = "Describe a task",
+  placeholder = CHAT_COMPOSER_LABELS.placeholder,
   onSelectModel,
   onAction,
 }: AgentHarnessConfigComposerProps) {

--- a/apps/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/apps/desktop/src/components/workspace/chat/ChatView.tsx
@@ -159,12 +159,16 @@ export const ChatView = memo(function ChatView({
   useSessionErrorAcknowledgement();
   useWorkspaceMobilityLifecycle();
 
+  // The composer placeholder flips to the follow-up variant once the session
+  // transcript already has turns; the surface mode is the cheap signal.
+  const hasSessionTurns = mode.kind === "session-transcript";
   const chatInput = useMemo(() => (
     <ChatInput
       attachments={promptAttachments}
       suppressActiveSessionState={suppressComposerActiveSessionState}
+      hasSessionTurns={hasSessionTurns}
     />
-  ), [promptAttachments, suppressComposerActiveSessionState]);
+  ), [hasSessionTurns, promptAttachments, suppressComposerActiveSessionState]);
   const footerSlot = useMemo(
     () => showWorkspaceFooter ? <WorkspaceMobilityFooterRow /> : null,
     [showWorkspaceFooter],

--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -64,9 +64,12 @@ const CHAT_INPUT_ATTACHMENT_ACCEPT =
 export function ChatInput({
   attachments,
   suppressActiveSessionState = false,
+  hasSessionTurns = false,
 }: {
   attachments: PromptAttachmentController;
   suppressActiveSessionState?: boolean;
+  /** Flips the placeholder to the follow-up variant once the transcript has turns. */
+  hasSessionTurns?: boolean;
 }) {
   useDebugRenderCount("chat-composer");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -338,6 +341,7 @@ export function ChatInput({
               accept={CHAT_INPUT_ATTACHMENT_ACCEPT}
             />
             <ChatInputDraftArea
+              hasSessionTurns={hasSessionTurns}
               isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
               editDraft={editDraft}
               onEditDraftChange={setEditDraftText}

--- a/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -106,7 +106,7 @@ export function ChatInputControlRow({
         <>
           <RuntimePressureIndicator />
           <div
-            className={`flex min-w-0 items-center gap-[5px] ${
+            className={`flex min-w-0 items-center gap-1 ${
               runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
             }`}
           >

--- a/apps/desktop/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -13,6 +13,8 @@ import { ComposerTextareaFrame } from "@proliferate/ui/primitives/ComposerTextar
 import { QueuedPromptEditBanner } from "./QueuedPromptEditBanner";
 
 interface ChatInputDraftAreaProps {
+  /** Picks the follow-up placeholder once the session transcript has turns. */
+  hasSessionTurns: boolean;
   isEditingQueuedPrompt: boolean;
   editDraft: string;
   onEditDraftChange: (value: string) => void;
@@ -35,6 +37,7 @@ interface ChatInputDraftAreaProps {
 }
 
 export function ChatInputDraftArea({
+  hasSessionTurns,
   isEditingQueuedPrompt,
   editDraft,
   onEditDraftChange,
@@ -52,6 +55,9 @@ export function ChatInputDraftArea({
   onCancelEdit,
 }: ChatInputDraftAreaProps) {
   const draft = useChatDraftValue(workspaceUiKey);
+  const placeholder = hasSessionTurns
+    ? CHAT_COMPOSER_LABELS.followUpPlaceholder
+    : CHAT_COMPOSER_LABELS.placeholder;
   if (isEditingQueuedPrompt) {
     return (
       <>
@@ -65,7 +71,7 @@ export function ChatInputDraftArea({
             value={editDraft}
             onChange={(event) => onEditDraftChange(event.target.value)}
             onKeyDown={onKeyDown}
-            placeholder={CHAT_COMPOSER_LABELS.placeholder}
+            placeholder={placeholder}
             spellCheck={false}
             autoComplete="off"
             autoCorrect="off"
@@ -85,7 +91,7 @@ export function ChatInputDraftArea({
       <ComposerCommandEditor
         draft={draft}
         onDraftChange={onDraftChange}
-        placeholder={CHAT_COMPOSER_LABELS.placeholder}
+        placeholder={placeholder}
         canSubmit={canSubmit}
         disabled={isDisabled}
         onSubmit={onSubmit}

--- a/apps/desktop/src/components/workspace/chat/input/ComposerAddActionPopover.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerAddActionPopover.tsx
@@ -10,7 +10,7 @@ import {
 } from "@proliferate/ui/icons";
 import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
 import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
-import { PlanPickerContentBody } from "./PlanPickerPopover";
+import { PlanPickerContentBody } from "./PlanPickerContentBody";
 
 interface ComposerAddActionPopoverProps {
   canAttachFile: boolean;

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelConfigSelector.tsx
@@ -178,7 +178,6 @@ export function ComposerModelConfigSelector({
     return (
       <ComposerControlButton
         disabled
-        tone="quiet"
         icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="size-4 shrink-0" /> : undefined}
         label={triggerLabel}
         detail={triggerDetail}
@@ -192,6 +191,7 @@ export function ComposerModelConfigSelector({
       <PopoverButton
         trigger={(
           <ComposerControlButton
+            emphasizeLabel
             icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="size-4 shrink-0" /> : undefined}
             label={triggerLabel}
             detail={triggerDetail}

--- a/apps/desktop/src/components/workspace/chat/input/ModelSelector.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ModelSelector.tsx
@@ -55,7 +55,6 @@ export function ModelSelector({
     return (
       <ComposerControlButton
         disabled
-        tone="quiet"
         label={
           connectionState === "connecting"
             ? "Connecting…"

--- a/apps/desktop/src/components/workspace/chat/input/PlanPickerContentBody.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PlanPickerContentBody.tsx
@@ -1,74 +1,12 @@
-import { PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
-import { AddPlan, ClipboardList, Spinner } from "@proliferate/ui/icons";
-import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
-import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
+import { ClipboardList, Spinner } from "@proliferate/ui/icons";
 import { usePlanPicker } from "@/hooks/plans/ui/use-plan-picker";
 import {
   formatPlanAgentKindLabel,
   formatPlanDecisionStateLabel,
 } from "@/lib/domain/plans/plan-presentation";
 import { PLAN_PICKER_SEARCH_PLACEHOLDER } from "@/copy/plans/plan-picker-copy";
-
-interface PlanPickerPopoverProps {
-  workspaceUiKey: string | null;
-  sdkWorkspaceId: string | null;
-  disabled?: boolean;
-}
-
-export function PlanPickerPopover({
-  workspaceUiKey,
-  sdkWorkspaceId,
-  disabled = false,
-}: PlanPickerPopoverProps) {
-  return (
-    <PopoverButton
-      trigger={(
-        <ComposerControlButton
-          iconOnly
-          disabled={disabled}
-          icon={<AddPlan className="size-4" />}
-          label="Attach plan"
-          title={disabled ? "Select a workspace before attaching a plan" : "Attach plan"}
-          aria-label="Attach plan"
-        />
-      )}
-      align="end"
-      side="top"
-      offset={8}
-      className="w-auto border-0 bg-transparent p-0 shadow-none"
-    >
-      {(close) => (
-        <PlanPickerPopoverSurface
-          workspaceUiKey={workspaceUiKey}
-          sdkWorkspaceId={sdkWorkspaceId}
-          onClose={close}
-        />
-      )}
-    </PopoverButton>
-  );
-}
-
-export function PlanPickerPopoverSurface({
-  workspaceUiKey,
-  sdkWorkspaceId,
-  onClose,
-}: {
-  workspaceUiKey: string | null;
-  sdkWorkspaceId: string | null;
-  onClose: () => void;
-}) {
-  return (
-    <ComposerPopoverSurface className="w-[min(24rem,calc(100vw-2rem))] p-0" data-telemetry-mask>
-      <PlanPickerContentBody
-        workspaceUiKey={workspaceUiKey}
-        sdkWorkspaceId={sdkWorkspaceId}
-        onClose={onClose}
-      />
-    </ComposerPopoverSurface>
-  );
-}
 
 export function PlanPickerContentBody({
   workspaceUiKey,

--- a/apps/desktop/src/components/workspace/chat/input/RuntimePressureIndicator.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/RuntimePressureIndicator.tsx
@@ -24,7 +24,6 @@ export function RuntimePressureIndicator() {
       <Tooltip content={tooltip}>
         <ComposerControlButton
           iconOnly
-          tone="quiet"
           label="Workspace pressure"
           aria-label="Open pruning details"
           aria-haspopup="dialog"

--- a/apps/desktop/src/components/workspace/chat/input/SessionConfigControls.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/SessionConfigControls.tsx
@@ -1,7 +1,7 @@
 import {
   resolveSessionControlTooltip,
   resolveSessionToggleControlPresentation,
-  resolveSessionToggleControlStateIndicator,
+  resolveSessionToggleControlStateLabel,
 } from "@/lib/domain/chat/session-controls/session-toggle-control";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
 import type { ConfiguredSessionControlKey } from "@/lib/domain/chat/session-controls/presentation";
@@ -70,19 +70,18 @@ function ToggleControl({ control }: { control: LiveSessionControlDescriptor }) {
   if (control.key === "reasoning" || control.key === "fast_mode") {
     const presentation = resolveSessionToggleControlPresentation(control.key);
     const Icon = presentation.icon === "brain" ? Brain : Zap;
-    const indicator = resolveSessionToggleControlStateIndicator(control.key, !!control.isEnabled);
+    const stateLabel = resolveSessionToggleControlStateLabel(control.key, !!control.isEnabled);
     const tooltip = resolveSessionControlTooltip(
       control.label,
       control.detail,
       selectedOption?.description,
     );
-    const triggerLabel = control.key === "fast_mode" ? indicator.label : control.label;
+    const triggerLabel = control.key === "fast_mode" ? stateLabel : control.label;
 
     return (
       <Tooltip content={tooltip}>
         <ComposerControlButton
           disabled={!control.settable || !nextValue}
-          tone={control.isEnabled ? presentation.tone : "quiet"}
           active={!!control.isEnabled}
           icon={<Icon className={`size-3.5 ${control.isEnabled ? "" : "opacity-65"}`} />}
           label={triggerLabel}
@@ -102,7 +101,7 @@ function ToggleControl({ control }: { control: LiveSessionControlDescriptor }) {
   return (
     <ComposerControlButton
       disabled={!control.settable || !nextValue}
-      tone={control.isEnabled ? "accent" : "neutral"}
+      active={!!control.isEnabled}
       label={control.label}
       detail={control.detail}
       trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
@@ -121,7 +120,6 @@ function SelectControl({ control }: { control: LiveSessionControlDescriptor }) {
     return (
       <ComposerControlButton
         disabled
-        tone="quiet"
         label={control.label}
         detail={control.detail}
       />

--- a/apps/desktop/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -41,7 +41,7 @@ export function SessionModeControl({
     return (
       <ComposerControlButton
         disabled
-        tone={currentPresentation.tone}
+        emphasizeLabel={triggerStyle === "value"}
         icon={<SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />}
         label={triggerLabel}
         detail={triggerDetail}
@@ -55,7 +55,7 @@ export function SessionModeControl({
     <PopoverButton
       trigger={
         <ComposerControlButton
-          tone={currentPresentation.tone}
+          emphasizeLabel={triggerStyle === "value"}
           icon={<SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />}
           label={triggerLabel}
           detail={triggerDetail}

--- a/apps/desktop/src/components/workspace/chat/input/SessionReasoningEffortControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/SessionReasoningEffortControl.tsx
@@ -30,7 +30,6 @@ export function SessionReasoningEffortControl({ control }: SessionReasoningEffor
       <Tooltip content={tooltip}>
         <ComposerControlButton
           disabled
-          tone={currentPresentation.tone}
           icon={<Brain className="size-3.5" />}
           label={currentLabel}
           trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
@@ -47,7 +46,6 @@ export function SessionReasoningEffortControl({ control }: SessionReasoningEffor
         <span className="inline-flex shrink-0">
           <Tooltip content={tooltip}>
             <ComposerControlButton
-              tone={currentPresentation.tone}
               icon={<Brain className="size-3.5" />}
               label={currentLabel}
               trailing={

--- a/apps/desktop/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx
@@ -16,7 +16,6 @@ export function WorkspaceRemoteAccessFooterControl() {
     <ComposerControlButton
       icon={isPending ? <Spinner className="size-3.5" /> : <Smartphone className="size-3.5" />}
       label={isPending ? "Updating access" : label}
-      tone={isEnabled ? "info" : "neutral"}
       active={isEnabled}
       disabled={disabled}
       onClick={handleClick}

--- a/apps/desktop/src/copy/chat/chat-copy.ts
+++ b/apps/desktop/src/copy/chat/chat-copy.ts
@@ -1,5 +1,6 @@
 export const CHAT_COMPOSER_LABELS = {
   placeholder: "Describe a task",
+  followUpPlaceholder: "Ask for a follow-up",
   send: "Send message",
   stop: "Stop run",
 } as const;

--- a/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.ts
@@ -5,7 +5,7 @@ import {
   resolveConfiguredSessionControlValue,
 } from "@/lib/domain/chat/session-controls/session-mode-control";
 import {
-  resolveSessionToggleControlStateIndicator,
+  resolveSessionToggleControlStateLabel,
 } from "@/lib/domain/chat/session-controls/session-toggle-control";
 import type {
   LiveSessionControlDescriptor,
@@ -55,7 +55,7 @@ export function summarizeComposerModelConfigControls(
       if (!control.isEnabled) {
         return [];
       }
-      return [resolveSessionToggleControlStateIndicator(control.key, true).label];
+      return [resolveSessionToggleControlStateLabel(control.key, true)];
     }
 
     if (control.key === "mode" || control.key === "collaboration_mode") {

--- a/apps/desktop/src/lib/domain/chat/session-controls/presentation.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/presentation.ts
@@ -4,6 +4,5 @@ export {
   type ConfiguredSessionControlKey,
   type ConfiguredSessionControlValue,
   type SessionControlIconKey,
-  type SessionControlTone,
   type SupportedLiveControlKey,
 } from "@proliferate/product-domain/chats/session-controls/presentation";

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-mode-control.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-mode-control.ts
@@ -8,16 +8,13 @@ import {
   resolveSessionControlPresentation,
   type ConfiguredSessionControlValue,
   type SessionControlIconKey,
-  type SessionControlTone,
 } from "@proliferate/product-domain/chats/session-controls/presentation";
 import type { DesktopAgentLaunchControl } from "@/lib/domain/agents/cloud-launch-catalog";
 
-export type SessionModeTone = SessionControlTone;
 export type SessionModeIconKey = SessionControlIconKey;
 
 export interface SessionModePresentation {
   icon: SessionModeIconKey | null;
-  tone: SessionModeTone;
   shortLabel?: string | null;
 }
 

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts
@@ -4,14 +4,12 @@ import { resolveReasoningEffortPresentation } from "./session-reasoning-effort-c
 describe("resolveReasoningEffortPresentation", () => {
   it("normalizes legacy max reasoning to xhigh presentation", () => {
     expect(resolveReasoningEffortPresentation("max", "Max")).toEqual({
-      tone: "warning",
       shortLabel: "Xhigh",
     });
   });
 
   it("uses the canonical xhigh label even when a raw option label is present", () => {
     expect(resolveReasoningEffortPresentation("xhigh", "Extra High")).toEqual({
-      tone: "warning",
       shortLabel: "Xhigh",
     });
   });

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
@@ -1,12 +1,4 @@
-export type SessionReasoningEffortTone =
-  | "neutral"
-  | "accent"
-  | "primary"
-  | "warning"
-  | "destructive";
-
 export interface SessionReasoningEffortPresentation {
-  tone: SessionReasoningEffortTone;
   shortLabel: string | null;
 }
 
@@ -19,7 +11,6 @@ export function resolveReasoningEffortPresentation(
   const normalizedValue = normalizeReasoningEffortValue(value);
 
   return {
-    tone: resolveTone(normalizedValue),
     shortLabel: resolveShortLabel(normalizedValue, label),
   };
 }
@@ -27,20 +18,6 @@ export function resolveReasoningEffortPresentation(
 function normalizeReasoningEffortValue(value: string | null): string | null {
   const normalizedValue = value?.toLowerCase() ?? null;
   return normalizedValue === "max" ? "xhigh" : normalizedValue;
-}
-
-function resolveTone(value: string | null): SessionReasoningEffortTone {
-  switch (value) {
-    case "medium":
-      return "accent";
-    case "high":
-      return "primary";
-    case "xhigh":
-      return "warning";
-    case "low":
-    default:
-      return "neutral";
-  }
 }
 
 function resolveShortLabel(value: string | null, label?: string | null): string | null {

--- a/apps/desktop/src/lib/domain/chat/session-controls/session-toggle-control.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/session-toggle-control.ts
@@ -1,37 +1,19 @@
 export type SessionToggleControlKey = "reasoning" | "fast_mode";
 
-export type SessionToggleControlTone =
-  | "accent"
-  | "primary"
-  | "warning";
-
 export type SessionToggleControlIconKey =
   | "brain"
   | "zap";
 
-export type SessionToggleControlIndicatorTone =
-  | "accent"
-  | "muted"
-  | "warning";
-
 export interface SessionToggleControlPresentation {
   icon: SessionToggleControlIconKey;
-  tone: SessionToggleControlTone;
-}
-
-export interface SessionToggleControlStateIndicator {
-  tone: SessionToggleControlIndicatorTone;
-  label: string;
 }
 
 const TOGGLE_PRESENTATIONS: Record<SessionToggleControlKey, SessionToggleControlPresentation> = {
   reasoning: {
     icon: "brain",
-    tone: "accent",
   },
   fast_mode: {
     icon: "zap",
-    tone: "warning",
   },
 };
 
@@ -41,19 +23,15 @@ export function resolveSessionToggleControlPresentation(
   return TOGGLE_PRESENTATIONS[key];
 }
 
-export function resolveSessionToggleControlStateIndicator(
+export function resolveSessionToggleControlStateLabel(
   key: SessionToggleControlKey,
   isEnabled: boolean,
-): SessionToggleControlStateIndicator {
+): string {
   switch (key) {
     case "reasoning":
-      return isEnabled
-        ? { tone: "accent", label: "On" }
-        : { tone: "muted", label: "Off" };
+      return isEnabled ? "On" : "Off";
     case "fast_mode":
-      return isEnabled
-        ? { tone: "warning", label: "Fast" }
-        : { tone: "muted", label: "Slow" };
+      return isEnabled ? "Fast" : "Slow";
   }
 }
 

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -193,7 +193,6 @@
   --color-tip-secondary-border: rgb(204 125 94 / 0.5);
   --color-tip-muted: rgb(224 176 157);
   --color-tip-foreground: #f9f9f7;
-  --color-plan-border: rgb(204 125 94 / 0.5);
 
   /* -- Switch -- */
   --color-switch-background: #f9f9f7;
@@ -544,7 +543,6 @@ mark.codex-thread-find-active {
   --color-tip-secondary-border: rgba(51, 156, 255, 0.5);
   --color-tip-muted: rgba(51, 156, 255, 0.6);
   --color-tip-foreground: #ffffff;
-  --color-plan-border: rgba(51, 156, 255, 0.4);
 
   /* -- Switch -- */
   --color-switch-background: #ffffff;
@@ -836,7 +834,6 @@ mark.codex-thread-find-active {
   --color-tip-secondary-border: rgba(125, 198, 255, 0.22);
   --color-tip-muted: rgba(240, 245, 242, 0.7);
   --color-tip-foreground: #f0f5f2;
-  --color-plan-border: rgba(89, 229, 191, 0.34);
 
   /* -- Switch -- */
   --color-switch-background: #f0f5f2;
@@ -1026,7 +1023,6 @@ mark.codex-thread-find-active {
   --color-tip-secondary-border: hsl(17 52% 58% / 0.35);
   --color-tip-muted: hsl(17 52% 44%);
   --color-tip-foreground: hsl(14 15% 22%);
-  --color-plan-border: hsl(17 52% 58% / 0.5);
 
   --color-switch-background: #21201c;
   --color-switch-foreground: #faf9f5;
@@ -1212,7 +1208,6 @@ mark.codex-thread-find-active {
   --color-tip-secondary-border: rgba(13, 13, 13, 0.078);
   --color-tip-muted: #0285ff;
   --color-tip-foreground: #0d0d0d;
-  --color-plan-border: #0285ff;
 
   --color-switch-background: #0d0d0d;
   --color-switch-foreground: #ffffff;
@@ -1373,7 +1368,6 @@ mark.codex-thread-find-active {
   --color-tip-secondary-border: var(--color-border);
   --color-tip-muted: #339cff;
   --color-tip-foreground: var(--color-foreground);
-  --color-plan-border: #339cff;
 
   --color-switch-background: var(--color-primary);
   --color-switch-foreground: #ffffff;

--- a/apps/packages/product-domain/src/chats/session-controls/presentation.ts
+++ b/apps/packages/product-domain/src/chats/session-controls/presentation.ts
@@ -6,15 +6,6 @@ export type SupportedLiveControlKey =
   | "effort"
   | "fast_mode";
 
-export type SessionControlTone =
-  | "neutral"
-  | "accent"
-  | "primary"
-  | "warning"
-  | "destructive"
-  | "success"
-  | "info";
-
 export type SessionControlIconKey =
   | "branch"
   | "build"
@@ -36,14 +27,12 @@ export interface ConfiguredSessionControlValue {
   label: string;
   shortLabel?: string | null;
   description?: string | null;
-  tone: SessionControlTone;
   icon: SessionControlIconKey;
   isDefault?: boolean;
 }
 
 export interface SessionControlPresentation {
   icon: SessionControlIconKey | null;
-  tone: SessionControlTone;
   shortLabel?: string | null;
 }
 
@@ -79,7 +68,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Default",
         shortLabel: "Default",
         description: "Ask before each action.",
-        tone: "info",
         icon: "chat",
         isDefault: true,
       },
@@ -88,7 +76,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Accept Edits",
         shortLabel: "Edits",
         description: "Auto-approve file edits.",
-        tone: "success",
         icon: "edit",
       },
       {
@@ -96,7 +83,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Auto",
         shortLabel: "Auto",
         description: "Use a model classifier to approve or deny permission prompts.",
-        tone: "success",
         icon: "sparkles",
       },
       {
@@ -104,7 +90,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Plan",
         shortLabel: "Plan",
         description: "Plan without execution.",
-        tone: "accent",
         icon: "plan",
       },
       {
@@ -112,7 +97,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Don't Ask",
         shortLabel: "Don't Ask",
         description: "Auto-approve most actions.",
-        tone: "warning",
         icon: "shieldCheck",
       },
       {
@@ -120,7 +104,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Bypass",
         shortLabel: "Bypass",
         description: "Skip permission checks.",
-        tone: "destructive",
         icon: "zap",
       },
     ],
@@ -132,7 +115,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Read Only",
         shortLabel: "Read Only",
         description: "Inspect and plan without editing.",
-        tone: "info",
         icon: "read",
         isDefault: true,
       },
@@ -141,7 +123,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Auto",
         shortLabel: "Auto",
         description: "Auto-approve standard edits.",
-        tone: "success",
         icon: "edit",
       },
       {
@@ -149,7 +130,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Full Access",
         shortLabel: "Full Access",
         description: "Allow unrestricted changes.",
-        tone: "destructive",
         icon: "zap",
       },
     ],
@@ -159,7 +139,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Default",
         shortLabel: "Default",
         description: "Standard collaboration behavior.",
-        tone: "info",
         icon: "chat",
         isDefault: true,
       },
@@ -168,7 +147,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Plan",
         shortLabel: "Plan",
         description: "Plan before applying changes.",
-        tone: "accent",
         icon: "plan",
       },
     ],
@@ -180,7 +158,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Agent",
         shortLabel: "Agent",
         description: "Full agent capabilities.",
-        tone: "success",
         icon: "edit",
         isDefault: true,
       },
@@ -189,7 +166,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Plan",
         shortLabel: "Plan",
         description: "Plan before applying changes.",
-        tone: "accent",
         icon: "plan",
       },
       {
@@ -197,7 +173,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Ask",
         shortLabel: "Ask",
         description: "Answer without making changes.",
-        tone: "info",
         icon: "chat",
       },
     ],
@@ -209,7 +184,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Default",
         shortLabel: "Default",
         description: "Ask before each action.",
-        tone: "info",
         icon: "chat",
         isDefault: true,
       },
@@ -218,7 +192,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Auto Edit",
         shortLabel: "Auto Edit",
         description: "Auto-approve edits.",
-        tone: "success",
         icon: "edit",
       },
       {
@@ -226,7 +199,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "YOLO",
         shortLabel: "YOLO",
         description: "Skip permission checks.",
-        tone: "destructive",
         icon: "zap",
       },
       {
@@ -234,7 +206,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Plan",
         shortLabel: "Plan",
         description: "Plan without execution.",
-        tone: "accent",
         icon: "plan",
       },
     ],
@@ -246,7 +217,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Build",
         shortLabel: "Build",
         description: "Default build mode.",
-        tone: "success",
         icon: "opencodeBuild",
         isDefault: true,
       },
@@ -255,7 +225,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
         label: "Plan",
         shortLabel: "Plan",
         description: "Plan before applying changes.",
-        tone: "accent",
         icon: "opencodePlan",
       },
     ],
@@ -264,7 +233,6 @@ export const SESSION_CONTROL_PRESENTATIONS: Record<string, ConfiguredSessionCont
 
 const FALLBACK_PRESENTATION: SessionControlPresentation = {
   icon: null,
-  tone: "neutral",
   shortLabel: null,
 };
 
@@ -334,7 +302,6 @@ export function launchControlToConfiguredSessionControlValues(
       label: presentation?.label ?? value.label,
       shortLabel: presentation?.shortLabel ?? value.label,
       description: value.description ?? presentation?.description ?? null,
-      tone: presentation?.tone ?? inferred.tone,
       icon: presentation?.icon ?? inferred.icon,
       isDefault: Boolean(value.isDefault),
     };
@@ -350,26 +317,24 @@ export function resolveSessionControlPresentation(
   return configured
     ? {
       icon: configured.icon,
-      tone: configured.tone,
       shortLabel: configured.shortLabel ?? null,
     }
     : FALLBACK_PRESENTATION;
 }
 
 export function inferSessionControlPresentation(value: string): {
-  tone: SessionControlTone;
   icon: SessionControlIconKey;
 } {
   const normalized = value.toLowerCase();
   if (normalized.includes("plan")) {
-    return { tone: "accent", icon: "plan" };
+    return { icon: "plan" };
   }
   if (
     normalized.includes("yolo")
     || normalized.includes("bypass")
     || normalized.includes("full")
   ) {
-    return { tone: "destructive", icon: "zap" };
+    return { icon: "zap" };
   }
   if (
     normalized.includes("auto")
@@ -377,10 +342,10 @@ export function inferSessionControlPresentation(value: string): {
     || normalized.includes("build")
     || normalized.includes("edit")
   ) {
-    return { tone: "success", icon: "edit" };
+    return { icon: "edit" };
   }
   if (normalized.includes("ask") || normalized.includes("read")) {
-    return { tone: "info", icon: "read" };
+    return { icon: "read" };
   }
-  return { tone: "neutral", icon: "read" };
+  return { icon: "read" };
 }

--- a/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
+++ b/apps/packages/product-ui/src/chat/composer/CloudChatComposerFooter.tsx
@@ -103,7 +103,6 @@ export function CloudChatComposerFooter({
               type="button"
               disabled={control.disabled || control.pending}
               active={control.active}
-              tone={control.active ? "accent" : "neutral"}
               icon={copied ? <Check size={14} /> : <Icon size={14} />}
               label={control.label}
               detail={control.detail}

--- a/apps/packages/product-ui/src/chat/composer/CloudChatSingleControl.tsx
+++ b/apps/packages/product-ui/src/chat/composer/CloudChatSingleControl.tsx
@@ -48,7 +48,6 @@ export function CloudChatSingleControl({
     return (
       <ComposerControlButton
         disabled
-        tone={control.active ? "accent" : "quiet"}
         active={control.active}
         icon={icon}
         label={displayLabel}
@@ -62,7 +61,7 @@ export function CloudChatSingleControl({
   return (
     <div ref={rootRef} className="relative min-w-0">
       <ComposerControlButton
-        tone={control.active ? "accent" : "neutral"}
+        active={control.active}
         icon={icon}
         label={displayLabel}
         detail={displayDetail}

--- a/apps/packages/ui/src/primitives/ComposerControlButton.tsx
+++ b/apps/packages/ui/src/primitives/ComposerControlButton.tsx
@@ -1,63 +1,22 @@
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { Button } from "./Button";
 
-export type ComposerControlTone =
-  | "neutral"
-  | "accent"
-  | "primary"
-  | "warning"
-  | "destructive"
-  | "success"
-  | "info"
-  | "quiet";
-
 interface ComposerControlButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
   icon?: ReactNode;
   label: ReactNode;
   detail?: ReactNode | null;
   trailing?: ReactNode;
-  tone?: ComposerControlTone;
   active?: boolean;
   iconOnly?: boolean;
+  /**
+   * Two-tone value hierarchy: renders the label (the pill's value text) in the
+   * active control color while icon, detail, and trailing affordances stay in
+   * the muted control colors.
+   */
+  emphasizeLabel?: boolean;
   labelClassName?: string;
   detailClassName?: string;
 }
-
-const toneClassNames: Record<ComposerControlTone, { idle: string; active: string }> = {
-  neutral: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  // Plan mode (UX_SPEC §5): the selected plan pill is tinted with --special.
-  accent: {
-    idle: "text-[color:var(--color-special)]",
-    active: "text-[color:var(--color-special)]",
-  },
-  primary: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  warning: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  destructive: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  success: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  info: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-active-foreground)]",
-  },
-  quiet: {
-    idle: "text-[color:var(--color-composer-control-foreground)]",
-    active: "text-[color:var(--color-composer-control-foreground)]",
-  },
-};
 
 export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerControlButtonProps>(
   function ComposerControlButton({
@@ -65,16 +24,18 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
     label,
     detail = null,
     trailing,
-    tone = "neutral",
     active = false,
     iconOnly = false,
+    emphasizeLabel = false,
     labelClassName = "",
     detailClassName = "",
     className = "",
     type = "button",
     ...props
   }, ref) {
-    const classes = active ? toneClassNames[tone].active : toneClassNames[tone].idle;
+    const classes = active
+      ? "text-[color:var(--color-composer-control-active-foreground)]"
+      : "text-[color:var(--color-composer-control-foreground)]";
     const baseClassName = `gap-1 rounded-full border border-transparent bg-transparent transition-colors hover:bg-[var(--color-composer-control-hover)] hover:text-current focus:outline-none data-[state=open]:bg-[var(--color-composer-control-hover)] ${classes}`;
     const buttonClassName = iconOnly
       ? `h-7 w-7 shrink-0 !justify-center px-0 ${baseClassName} ${className}`
@@ -99,7 +60,13 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
           <span className="sr-only">{iconOnlyLabel}</span>
         ) : (
           <span className="flex min-w-0 items-center gap-1">
-            <span className={`min-w-0 truncate text-left ${labelClassName}`}>{label}</span>
+            <span
+              className={`min-w-0 truncate text-left ${
+                emphasizeLabel ? "text-[color:var(--color-composer-control-active-foreground)]" : ""
+              } ${labelClassName}`}
+            >
+              {label}
+            </span>
             {detail && (
               <span className={`flex min-w-0 items-center gap-1 truncate text-left text-[color:var(--color-composer-control-muted-foreground)] ${detailClassName}`}>
                 <span aria-hidden="true" className="shrink-0">·</span>

--- a/apps/packages/ui/src/primitives/ComposerTextarea.tsx
+++ b/apps/packages/ui/src/primitives/ComposerTextarea.tsx
@@ -5,9 +5,10 @@ type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 // UX_SPEC §5 + owner rev 2026-07-01: the input reads LARGER than the 13px
 // composer controls (codex hierarchy: input > controls). 14px with codex's
-// font+8 leading; placeholder --muted-foreground at 75%.
+// font+8 leading; placeholder --muted-foreground at 55% so it sits well below
+// typed text in both mono dark and light themes.
 const COMPOSER_TEXTAREA_CLASSNAME =
-  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-composer text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_75%,transparent)] focus:ring-0";
+  "min-h-0 resize-none rounded-none border-0 bg-transparent px-0 py-0 text-composer text-foreground shadow-none outline-none placeholder:text-[color:color-mix(in_oklab,var(--color-muted-foreground)_55%,transparent)] focus:ring-0";
 
 export const ComposerTextarea = forwardRef<HTMLTextAreaElement, ComposerTextareaProps>(
   function ComposerTextarea({ className = "", ...props }, ref) {

--- a/specs/codebase/features/chat-composer.md
+++ b/specs/codebase/features/chat-composer.md
@@ -1,11 +1,17 @@
 # Chat Composer Standards
 
-Status: authoritative for the chat composer area (`apps/desktop/src/components/workspace/chat/input/**`, the panels above the input, and the Claude plan card in the transcript).
+Status: authoritative for the chat composer area (`apps/desktop/src/components/workspace/chat/input/**`, the panels above the input, and the Claude plan card in the transcript). Owner rev 2026-07-02.
 
 Scope:
 
 - `apps/desktop/src/components/workspace/chat/input/**`
-- `apps/desktop/src/components/workspace/chat/transcript/ProposedPlanCard.tsx`
+- `apps/packages/product-ui/src/chat/composer/**` — the shared composer surface
+  pieces live here, not in Desktop: `ChatComposerSurface`,
+  `ChatComposerControlRowFrame`, `ComposerPopoverSurface`.
+- `apps/packages/product-ui/src/chat/transcript/ProposedPlanCard.tsx` — the
+  desktop file at
+  `apps/desktop/src/components/workspace/chat/transcript/ProposedPlanCard.tsx`
+  is a re-export only.
 - `apps/desktop/src/components/workspace/chat/content/PlanReferenceAttachmentCard.tsx`
 - `apps/desktop/src/components/workspace/chat/plans/**`
 - `apps/desktop/src/components/workspace/reviews/**`
@@ -49,9 +55,17 @@ ChatView
         └── WorkspaceMobilityFooterRow
 ```
 
+The home screen reuses the same composer: `HomeComposerForm`
+(`apps/desktop/src/components/home/screen/HomeComposerForm.tsx`) renders the
+same `ChatComposerSurface` + `ChatComposerControlRowFrame` from
+`@proliferate/product-ui`, with slot-based render isolation (controls, trailing
+controls, and actions are passed in as stable slot elements so keystrokes only
+re-render the composer subtree).
+
 Non-negotiable:
 
 - **`ChatComposerDock` owns the dock shell.** Background, scrim, padding, max-width column, slot ordering, and the inset region wrappers all live in `ChatComposerDock.tsx`. The production app (`ChatView`) and the dev playground (`ChatPlaygroundPage`) both render `ChatComposerDock` directly. Do not reconstruct this backdrop in a third place — if you need it somewhere new, reuse the dock.
+- **No `backdrop-blur` on the dock's transcript-covering layer.** That layer sits over the scrolling transcript, and backdrop blur forces WKWebView to re-blur everything behind it on every frame. The implementation is a gradient fade into an opaque-ish `bg-background/95` sheet (`ChatComposerDock.tsx`), not a blur.
 - **`ChatInput` is the composer surface only.** It does not own any of the outer wrapping. It takes no `topSlot` prop. Everything above and below the composer surface is the dock's responsibility, and the workspace footer row is rendered via the dock's dedicated footer slot rather than ad hoc workspace logic in `ChatInput.tsx`.
 - **Do not add in-composer read-only status badges.** MCP/plugin state belongs in settings, session details, or explicit action surfaces, not as a persistent strip inside `ChatInput`.
 - **The composer surface stays unchanged and paints the seam.** There is no `flatTop` mode. Dock-region panels are narrower attached trays that sit directly above the composer: rounded top corners, side/top borders, no bottom border, and no gap. The composer surface paints after the dock regions so its own top outline remains visible at the seam.
@@ -238,9 +252,11 @@ Borrowed directly from `references/codex_todo.html` and `references/codex_plan.h
 `ChatComposerDock` wraps dock panes in one shared inset width (`px-5`) so queue,
 active state, and attached context read as one dock. Slots have no bottom margin
 and no positive z-index: `ComposerAttachedPanel` is an attached cap above the
-composer, using `rounded-t-2xl border-x border-t border-border/70 bg-card/70`,
-while the composer surface paints after the dock panes so the input's top
-outline remains visible at the seam. When several trays stack, only the top
+composer, using `rounded-t-[13px] border-x-[0.5px] border-t-[0.5px]
+border-border bg-[color:color-mix(in_oklab,var(--color-foreground)_2%,var(--color-background))]
+backdrop-blur-sm` (the Superset tray shell: 13px top radius, 0.5px hairlines, a
+2% foreground tint on the background), while the composer surface paints after
+the dock panes so the input's top outline remains visible at the seam. When several trays stack, only the top
 visible tray keeps top rounding; inner trays flatten into a hairline seam. Do
 not add a `flatTop` mode, a detached gap, a full-perimeter dock card, a width
 staircase, a separate color per slot, or a `z-*` layer that lets a dock pane
@@ -258,9 +274,19 @@ At most **one** visual element in a header's leading position:
 
 Do **not** stack icon + uppercase label + `·` separator + title. That was the pre-cleanup pattern and it read as noise. If you find yourself adding a second leading element, stop and pick one.
 
-### 4.3 Button sizing is uniform in ApprovalCard
+### 4.3 Approval options are Superset-style rows, not buttons
 
-All approval action buttons use `size="sm"` with `className="rounded-xl px-2.5 text-sm"`. Both branches (explicit-actions and fallback allow/deny) use the same constant (`APPROVAL_BUTTON_CLASSNAME`). Do not diverge the two rows, and do not use `!important` modifiers — the `Button` primitive uses `tailwind-merge` so plain className overrides win.
+`APPROVAL_BUTTON_CLASSNAME` is gone. Approval options render as full-width
+`ComposerOptionRow` rows (`apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx`):
+hairline `border-t border-border/60` separators, a leading number-key badge
+(`ComposerOptionKeyBadge` — 24px square, 3px radius, `bg-surface-control`,
+mono), and a hover accent fill that promotes the label from muted to
+foreground. `useComposerOptionNumberKeys` makes pressing 1–9 select the
+corresponding option (skipped while typing in an input/textarea/contenteditable).
+Destructive options (deny/reject/cancel) render their label in
+`text-destructive`. Both branches (explicit actions and the fallback
+Allow/Deny pair) go through the same row component — do not reintroduce a
+button row.
 
 ### 4.4 Todo tracker specifics
 
@@ -275,14 +301,56 @@ Do **not** grow the scroll cap past `max-h-40` — the Codex reference is exactl
 
 ### 4.5 ProposedPlanCard specifics
 
-- Shell: `rounded-lg bg-foreground/5` (borderless, very subtle tint — no outline).
-- Header: bold plan title + optional decision state + `Button size="icon-sm"` Copy + `Button size="icon-sm"` Collapse.
-- Body expanded: plain markdown at `px-4 py-3`.
-- Body collapsed: `max-height: min(20rem, 45vh)` with a bottom-only `mask-image` fade + a floating `Button size="pill" variant="inverted"` "Expand plan" pill centered near the bottom.
+- `ProposedPlanCard` (product-ui `chat/transcript`) is built on
+  `CollapsiblePlanCard`, which owns the shell and collapse behavior.
+- Shell: `rounded-md border border-border/70 bg-card/85 shadow-sm`.
+- Header: bold plan title + optional decision state + icon-only Copy/Collapse
+  buttons.
+- Body expanded: plain markdown.
+- Body collapsed: capped height with a bottom-only `mask-image` fade + a
+  floating expand pill labeled "Expand plan summary" centered near the bottom.
+- Approve copy: "Approve and continue" when the plan is a native continuation
+  (the harness resumes implementation in-session after approval), "Approve
+  plan" otherwise.
 - Pending decision actions render in the transcript card, not in the composer
   interaction slot. Generic linked permission interactions are suppressed from
   `ConnectedApprovalCard`.
 - Default: expanded. Collapse is via the header chevron.
+
+### 4.6 Composer surface + control-row tone (owner rev 2026-07-02)
+
+Control-row tone rule — the pills are **monochrome**:
+
+- Every control pill is a `ComposerControlButton`
+  (`apps/packages/ui/src/primitives/ComposerControlButton.tsx`). It has no
+  `tone` prop; the tone system was deleted 2026-07-02 along with the plan-mode
+  tint (`--color-plan-border` is gone). Do **not** reintroduce mode-based
+  tinting on the mode pill or any other control.
+- Hierarchy is two-tone value-vs-affordance, not color: the pill's *value*
+  (active state or `emphasizeLabel`) renders in
+  `--color-composer-control-active-foreground` (bright), while icons, details,
+  and idle affordances stay in `--color-composer-control-foreground` /
+  `--color-composer-control-muted-foreground` (dim).
+
+As-built composer surface — `ChatComposerSurface` (product-ui) tags itself with
+the `chat-composer-surface` class, whose paint lives in
+`apps/packages/design/src/css/dom.css`:
+
+- Background: `--color-composer-background`.
+- Outline: a 0.5px stroke-in-shadow (`0 0 0 0.5px var(--color-composer-border)`)
+  stacked with `--color-composer-shadow` (the desktop theme sets it to
+  `--shadow-composer`; the `dom.css` baseline is `--shadow-subtle`) — there is
+  no CSS `border`.
+- Radius: `rounded-[var(--radius-composer,1rem)]`; `--radius-composer` is 1rem.
+
+Placeholder variants — strings live in
+`apps/desktop/src/copy/chat/chat-copy.ts` (`CHAT_COMPOSER_LABELS`):
+
+- "Describe a task" — the home composer and any chat whose transcript has no
+  turns yet.
+- "Ask for a follow-up" — once the session transcript has turns. The signal is
+  `ChatView`'s surface mode (`session-transcript`), threaded into `ChatInput`
+  as the optional `hasSessionTurns` prop; no store or query is involved.
 
 ## 5. No raw primitives, no inline SVGs
 
@@ -296,7 +364,7 @@ Rules that apply everywhere in `apps/desktop/src/**` but are easy to violate in 
 
 These are patterns that were tried and rejected. Reintroducing them reopens known problems:
 
-- **Detached dock-region cards (`rounded-2xl border` plus a dock gap).** Panels above the composer are attached trays, not separate floating cards. Keep `ComposerAttachedPanel` on the `rounded-t-2xl border-x border-t` shell and keep dock-region wrappers gapless.
+- **Detached dock-region cards (`rounded-2xl border` plus a dock gap).** Panels above the composer are attached trays, not separate floating cards. Keep `ComposerAttachedPanel` on the rounded-top hairline tray shell (§4.1) and keep dock-region wrappers gapless.
 - **Positive z-index on dock-region wrappers.** The composer must paint after attached trays so its top outline remains visible at the seam.
 - **Ad hoc `first:*` stacking rounded-corner tricks.** Dock-region order is explicit in `ChatComposerDock`; do not fake region-specific corner behavior with selector tricks.
 - **`flatTop` on `ChatComposerSurface`.** The prop was deleted. The composer surface keeps its normal styling. Panels above are attached trays, not a replacement shell for the composer.

--- a/specs/codebase/features/chat-composer.md
+++ b/specs/codebase/features/chat-composer.md
@@ -326,11 +326,11 @@ Control-row tone rule — the pills are **monochrome**:
   `tone` prop; the tone system was deleted 2026-07-02 along with the plan-mode
   tint (`--color-plan-border` is gone). Do **not** reintroduce mode-based
   tinting on the mode pill or any other control.
-- Hierarchy is two-tone value-vs-affordance, not color: the pill's *value*
-  (active state or `emphasizeLabel`) renders in
-  `--color-composer-control-active-foreground` (bright), while icons, details,
-  and idle affordances stay in `--color-composer-control-foreground` /
-  `--color-composer-control-muted-foreground` (dim).
+- Hierarchy is two-tone value-vs-affordance, not color. Two bright paths:
+  `emphasizeLabel` brightens ONLY the label span (icons/chevrons/details stay
+  in `--color-composer-control-foreground` / `-muted-foreground`, dim), while
+  `active` brightens the whole button — including its icon — with only the
+  detail span forced back to muted. Idle pills are fully dim.
 
 As-built composer surface — `ChatComposerSurface` (product-ui) tags itself with
 the `chat-composer-surface` class, whose paint lives in


### PR DESCRIPTION
## What

Full cleanup of the chat input (owner-directed, codex-calibrated):

- **Blue planning mode is gone, structurally**: the composer tone system is deleted end-to-end — `ComposerControlButton`'s tone prop/map (the single `accent → --color-special` sink), `SessionControlTone` in product-domain, and every emitter (plan modes across all harnesses, the `includes("plan")` fallback, enabled toggles, reasoning "medium"). Plan renders like every other mode.
- **Two-tone pill hierarchy** (codex's "5.5 Extra High" trick): new `emphasizeLabel` on `ComposerControlButton` — mode value and model name render in the active control color (foreground) while icons/chevrons/`·`/detail stay muted. Hierarchy via brightness, not hue.
- **Quieter placeholder**: mix dropped 75%→55% of muted-foreground.
- **Placeholder variants**: "Describe a task" (home + fresh chats) / "Ask for a follow-up" (thread has turns; signal = chat-surface `session-transcript` mode, no new stores). Hardcoded copies de-duped into `chat-copy.ts` (3 sites).
- **Dead code out**: `--color-plan-border` (6 theme blocks, zero consumers), standalone `PlanPickerPopover` pill (`PlanPickerContentBody` extracted for the add-popover path).
- **Spec refreshed**: `chat-composer.md` brought to as-built (owner rev 2026-07-02 — product-ui scope, home reuse, tray/approval/plan-card reality, new §4.6 monochrome tone rule); UX_SPEC §5 updated.

Note: `--color-special` now has zero consumers in the composer; declarations left in place (update pill etc. may still want it — follow-up sweep candidate).

## Verification

Full desktop suite: only the 12 known pre-existing failures. Builds (design/ui/product-domain/product-ui), tsc, check-design-system, boundaries, max-lines all green. Verified live in desktop-web: plan mode monochrome, two-tone measured (value `rgb(255,255,255)`, chrome 50–70% white).

🤖 Generated with [Claude Code](https://claude.com/claude-code)