### PR TITLE
feat(server): membership policy seam + SINGLE_ORG_MODE

### DIFF
--- a/server/alembic/versions/a1c2e3f4b5d6_organization_instance_marker.py
+++ b/server/alembic/versions/a1c2e3f4b5d6_organization_instance_marker.py
@@ -1,0 +1,78 @@
+"""organization instance marker for single-org mode
+
+Revision ID: a1c2e3f4b5d6
+Revises: e7a8b9c0d1e3
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1c2e3f4b5d6"
+down_revision: str | Sequence[str] | None = "e7a8b9c0d1e3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INSTANCE_ORG_INDEX = "ux_organization_instance"
+
+
+def _inspector() -> sa.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return column_name in {column["name"] for column in _inspector().get_columns(table_name)}
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _has_table("organization"):
+        return
+
+    if not _has_column("organization", "is_instance"):
+        op.add_column(
+            "organization",
+            sa.Column(
+                "is_instance",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+        )
+
+    # At most one organization may be the instance org. A partial unique index
+    # keeps that invariant durable at the database, not just in application code.
+    if not _has_index("organization", _INSTANCE_ORG_INDEX):
+        op.create_index(
+            _INSTANCE_ORG_INDEX,
+            "organization",
+            ["is_instance"],
+            unique=True,
+            postgresql_where=sa.text("is_instance"),
+        )
+
+
+def downgrade() -> None:
+    if not _has_table("organization"):
+        return
+
+    if _has_index("organization", _INSTANCE_ORG_INDEX):
+        op.drop_index(_INSTANCE_ORG_INDEX, table_name="organization")
+    if _has_column("organization", "is_instance"):
+        op.drop_column("organization", "is_instance")

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -38,9 +38,7 @@ from proliferate.constants.auth import (
 )
 from proliferate.db.models.auth import User
 from proliferate.db.store.auth import create_auth_code
-from proliferate.server.organizations.registration import (
-    ensure_default_organization_for_account,
-)
+from proliferate.server.organizations.membership_policy import place_new_identity
 
 AUTH_CHALLENGE_LIFETIME_SECONDS = 600
 
@@ -481,7 +479,7 @@ async def resolve_provider_user(
         display_name=verified.display_name,
         avatar_url=verified.avatar_url,
     )
-    await ensure_default_organization_for_account(db, user)
+    await place_new_identity(db, user)
     await attach_verified_identity(db, user=user, verified=verified)
     return user
 

--- a/server/proliferate/auth/sso/service.py
+++ b/server/proliferate/auth/sso/service.py
@@ -59,7 +59,7 @@ from proliferate.integrations.sso.oidc import (
 from proliferate.server.billing.seat_reconciliation import (
     maybe_create_organization_seat_adjustment,
 )
-from proliferate.server.organizations.registration import ensure_default_organization_for_account
+from proliferate.server.organizations.membership_policy import place_new_identity
 
 
 @dataclass(frozen=True)
@@ -307,7 +307,7 @@ async def resolve_sso_user(
         elif connection.jit_policy == SsoJitPolicy.DISABLED:
             raise HTTPException(status_code=403, detail="SSO user provisioning is disabled.")
         _ensure_active_user(user)
-        await ensure_default_organization_for_account(db, user)
+        await place_new_identity(db, user)
 
     await _attach_sso_identity(db, user=user, connection=connection, verified=verified)
     return user
@@ -371,7 +371,7 @@ async def _resolve_organization_sso_user(
             display_name=verified.display_name,
             avatar_url=verified.avatar_url,
         )
-        await ensure_default_organization_for_account(db, user)
+        await place_new_identity(db, user)
     _ensure_active_user(user)
     membership = await organization_store.get_active_membership(
         db,

--- a/server/proliferate/auth/users.py
+++ b/server/proliferate/auth/users.py
@@ -12,9 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.config import settings
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import OAuthAccount, User
-from proliferate.server.organizations.registration import (
-    ensure_default_organization_for_account,
-)
+from proliferate.server.organizations.membership_policy import place_new_identity
 
 
 async def get_user_db(
@@ -31,7 +29,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         # Customer.io lifecycle sync is owned by the desktop GitHub auth flow in v1.
         db = getattr(self.user_db, "session", None)
         if isinstance(db, AsyncSession):
-            await ensure_default_organization_for_account(db, user)
+            await place_new_identity(db, user)
 
     async def on_after_login(  # type: ignore[override]  # fastapi-users signature mismatch
         self,

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -24,6 +24,14 @@ class Settings(BaseSettings):
         default="local_dev",
         validation_alias=AliasChoices("PROLIFERATE_TELEMETRY_MODE", "TELEMETRY_MODE"),
     )
+    # Org membership mode. When single-org mode is on, every new identity joins
+    # the one instance organization instead of getting a personal default org.
+    # The default is derived (hosted production stays multi-org; every other
+    # deployment posture defaults to single-org); an explicit env value wins.
+    single_org_mode_override: bool | None = Field(
+        default=None,
+        validation_alias=AliasChoices("SINGLE_ORG_MODE", "PROLIFERATE_SINGLE_ORG_MODE"),
+    )
     cors_allow_origins: str = (
         "http://localhost:1420,"
         "http://127.0.0.1:1420,"
@@ -364,6 +372,12 @@ class Settings(BaseSettings):
         "install/proliferate-target-install.sh"
     )
     proliferate_target_artifact_base_url: str = ""
+
+    @property
+    def single_org_mode(self) -> bool:
+        if self.single_org_mode_override is not None:
+            return self.single_org_mode_override
+        return self.telemetry_mode != "hosted_product"
 
     @model_validator(mode="after")
     def validate_secrets_in_production(self) -> "Settings":

--- a/server/proliferate/db/models/organizations.py
+++ b/server/proliferate/db/models/organizations.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -25,6 +26,12 @@ class Organization(Base):
             "status IN ('pending_checkout', 'active', 'suspended', 'archived')",
             name="ck_organization_status",
         ),
+        Index(
+            "ux_organization_instance",
+            "is_instance",
+            unique=True,
+            postgresql_where=text("is_instance"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -36,6 +43,14 @@ class Organization(Base):
         default="active",
         server_default=text("'active'"),
         index=True,
+    )
+    # Marks the single instance organization for single-org-mode deployments.
+    # A partial unique index guarantees at most one row has this set to true.
+    is_instance: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=text("false"),
+        nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/server/proliferate/db/store/organization_records.py
+++ b/server/proliferate/db/store/organization_records.py
@@ -21,6 +21,7 @@ class OrganizationRecord:
     logo_domain: str | None
     logo_image: str | None
     status: str
+    is_instance: bool
     created_at: datetime
     updated_at: datetime
 
@@ -134,6 +135,7 @@ def organization_record(organization: Organization) -> OrganizationRecord:
         logo_domain=organization.logo_domain,
         logo_image=organization.logo_image,
         status=organization.status,
+        is_instance=organization.is_instance,
         created_at=organization.created_at,
         updated_at=organization.updated_at,
     )

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -180,6 +180,71 @@ async def ensure_default_organization_for_user(
     return await _list_organizations_for_user(db, user_id)
 
 
+async def get_instance_organization(db: AsyncSession) -> OrganizationRecord | None:
+    """Return the single instance organization, or None when unclaimed.
+
+    Single-org-mode deployments mark exactly one organization as the instance
+    org. A partial unique index guarantees at most one, so this can never match
+    more than one row.
+    """
+    organization = (
+        await db.execute(
+            select(Organization).where(
+                Organization.is_instance.is_(True),
+                Organization.status.in_(tuple(ORGANIZATION_CURRENT_STATUSES)),
+            )
+        )
+    ).scalar_one_or_none()
+    return organization_record(organization) if organization is not None else None
+
+
+async def add_active_membership(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    user_id: UUID,
+    role: str,
+) -> MembershipRecord:
+    """Add or reactivate a user's active membership in an organization.
+
+    Idempotent: an already-active membership is returned unchanged (its role is
+    left intact); a removed membership is reactivated with the requested role.
+    """
+    await acquire_organization_membership_lock(db, organization_id)
+    now = utcnow()
+    membership = (
+        await db.execute(
+            select(OrganizationMembership)
+            .where(
+                OrganizationMembership.organization_id == organization_id,
+                OrganizationMembership.user_id == user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if membership is None:
+        membership = OrganizationMembership(
+            organization_id=organization_id,
+            user_id=user_id,
+            role=role,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            removed_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(membership)
+    elif membership.status != ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE:
+        membership.status = ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE
+        membership.role = role
+        membership.removed_at = None
+        if membership.joined_at is None:
+            membership.joined_at = now
+        membership.updated_at = now
+    await db.flush()
+    return membership_record(membership)
+
+
 async def get_organization_with_membership(
     db: AsyncSession,
     *,

--- a/server/proliferate/server/organizations/errors.py
+++ b/server/proliferate/server/organizations/errors.py
@@ -14,3 +14,22 @@ class OrganizationServiceError(ProliferateError):
     ) -> None:
         super().__init__(message=message, code=code, status_code=status_code)
         self.extra_detail = dict(extra_detail or {})
+
+
+class InstanceOrganizationNotClaimed(OrganizationServiceError):
+    """Raised when single-org mode is on but the instance org does not exist yet.
+
+    In single-org deployments the instance organization is created once, by the
+    first-run claim flow. Until that happens the membership policy fails closed
+    rather than silently minting a personal organization.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            code="instance_not_claimed",
+            message=(
+                "This Proliferate instance has not been set up yet. "
+                "Complete first-run setup before signing in."
+            ),
+            status_code=503,
+        )

--- a/server/proliferate/server/organizations/membership_policy.py
+++ b/server/proliferate/server/organizations/membership_policy.py
@@ -1,0 +1,86 @@
+"""Membership policy: the one place that decides where a new identity lands.
+
+Every account-creation call site (password registration, provider identity
+linking, and SSO just-in-time provisioning) routes through
+``place_new_identity`` instead of deciding org placement inline. That keeps the
+hosted-vs-single-org branch in one seam rather than scattered across the auth
+surfaces.
+
+- ``HostedPolicy`` reproduces today's hosted behavior: every new identity gets
+  its own personal default organization (owner role).
+- ``SingleOrgPolicy`` joins the one instance organization as a member. The
+  instance org is created exactly once by the first-run claim flow; until then
+  this policy fails closed with a clear error rather than minting a personal
+  org.
+
+Which policy applies is decided by ``settings.single_org_mode`` at call time.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.organizations import ORGANIZATION_ROLE_MEMBER
+from proliferate.db.store import organizations as organization_store
+from proliferate.server.organizations.errors import InstanceOrganizationNotClaimed
+from proliferate.server.organizations.registration import (
+    OrganizationRegistrationUser,
+    ensure_default_organization_for_account,
+)
+
+
+class MembershipPolicy(Protocol):
+    async def place_new_identity(
+        self,
+        db: AsyncSession,
+        user: OrganizationRegistrationUser,
+    ) -> None: ...
+
+
+class HostedPolicy:
+    """Hosted behavior: create a personal default organization per identity."""
+
+    async def place_new_identity(
+        self,
+        db: AsyncSession,
+        user: OrganizationRegistrationUser,
+    ) -> None:
+        await ensure_default_organization_for_account(db, user)
+
+
+class SingleOrgPolicy:
+    """Self-host behavior: join the single instance organization."""
+
+    async def place_new_identity(
+        self,
+        db: AsyncSession,
+        user: OrganizationRegistrationUser,
+    ) -> None:
+        instance_organization = await organization_store.get_instance_organization(db)
+        if instance_organization is None:
+            # No instance org yet. Only the first-run claim flow may create one;
+            # a normal sign-in must not, so we fail closed.
+            raise InstanceOrganizationNotClaimed()
+        await organization_store.add_active_membership(
+            db,
+            organization_id=instance_organization.id,
+            user_id=user.id,
+            role=ORGANIZATION_ROLE_MEMBER,
+        )
+
+
+def select_membership_policy() -> MembershipPolicy:
+    if settings.single_org_mode:
+        return SingleOrgPolicy()
+    return HostedPolicy()
+
+
+async def place_new_identity(
+    db: AsyncSession,
+    user: OrganizationRegistrationUser,
+) -> None:
+    """Place a newly created identity into its organization per the active mode."""
+    await select_membership_policy().place_new_identity(db, user)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from proliferate.config import settings
 from tests.postgres import (
     TEST_DATABASE_NAME,
     TEST_DATABASE_URL,
@@ -20,6 +21,18 @@ from tests.postgres import (
 
 async def _cancel_test_background_tasks() -> None:
     return None
+
+
+@pytest.fixture(autouse=True)
+def _hosted_membership_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the membership policy to hosted (personal org per user) by default.
+
+    The suite predates single-org mode and asserts hosted behavior. The default
+    single-org expression (`telemetry_mode != "hosted_product"`) would otherwise
+    flip local/test deployments into single-org mode. Tests that exercise
+    single-org mode override this within the test body.
+    """
+    monkeypatch.setattr(settings, "single_org_mode_override", False)
 
 
 @pytest.fixture(scope="session")

--- a/server/tests/integration/schema_migration_assertions.py
+++ b/server/tests/integration/schema_migration_assertions.py
@@ -55,6 +55,19 @@ async def assert_current_schema(conn: AsyncConnection, head_revision: str) -> No
     await assert_background_outbox_schema(conn)
     await assert_sso_schema(conn)
 
+    organization_columns = await conn.run_sync(
+        lambda sync_conn: {
+            column["name"] for column in inspect(sync_conn).get_columns("organization")
+        }
+    )
+    assert "is_instance" in organization_columns
+    organization_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"] for index in inspect(sync_conn).get_indexes("organization")
+        }
+    )
+    assert "ux_organization_instance" in organization_indexes
+
     repo_config_columns = await conn.run_sync(
         lambda sync_conn: {
             column["name"] for column in inspect(sync_conn).get_columns("repo_config")

--- a/server/tests/unit/auth/test_sso_service_security.py
+++ b/server/tests/unit/auth/test_sso_service_security.py
@@ -201,7 +201,7 @@ async def test_resolve_sso_user_ensures_default_org_for_new_deployment_user(
     async def fake_create_auth_user(*_args: object, **_kwargs: object) -> User:
         return user
 
-    async def fake_ensure_default_organization_for_account(
+    async def fake_place_new_identity(
         _db: AsyncSession,
         ensured_user: User,
     ) -> None:
@@ -219,8 +219,8 @@ async def test_resolve_sso_user_ensures_default_org_for_new_deployment_user(
     monkeypatch.setattr(sso_service, "create_auth_user", fake_create_auth_user)
     monkeypatch.setattr(
         sso_service,
-        "ensure_default_organization_for_account",
-        fake_ensure_default_organization_for_account,
+        "place_new_identity",
+        fake_place_new_identity,
     )
     monkeypatch.setattr(sso_service, "_attach_sso_identity", fake_attach_sso_identity)
 
@@ -316,7 +316,7 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
     async def fake_create_auth_user(*_args: object, **_kwargs: object) -> User:
         return user
 
-    async def fake_ensure_default_organization_for_account(
+    async def fake_place_new_identity(
         _db: AsyncSession,
         ensured_user: User,
     ) -> None:
@@ -364,8 +364,8 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
     monkeypatch.setattr(sso_service, "create_auth_user", fake_create_auth_user)
     monkeypatch.setattr(
         sso_service,
-        "ensure_default_organization_for_account",
-        fake_ensure_default_organization_for_account,
+        "place_new_identity",
+        fake_place_new_identity,
     )
     monkeypatch.setattr(
         sso_service.invitation_store,

--- a/server/tests/unit/test_membership_policy.py
+++ b/server/tests/unit/test_membership_policy.py
@@ -1,0 +1,217 @@
+"""Tests for the membership policy seam and the single_org_mode setting."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.identity.store import create_auth_user
+from proliferate.config import Settings, settings
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+)
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import organizations as organization_store
+from proliferate.server.organizations.errors import InstanceOrganizationNotClaimed
+from proliferate.server.organizations.membership_policy import (
+    HostedPolicy,
+    SingleOrgPolicy,
+    place_new_identity,
+    select_membership_policy,
+)
+
+
+def _settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    telemetry_mode: str | None = None,
+    single_org_mode: str | None = None,
+) -> Settings:
+    # telemetry_mode and single_org_mode are populated by their env aliases, so
+    # exercise them the way an operator would rather than via constructor kwargs.
+    if telemetry_mode is not None:
+        monkeypatch.setenv("TELEMETRY_MODE", telemetry_mode)
+    if single_org_mode is not None:
+        monkeypatch.setenv("SINGLE_ORG_MODE", single_org_mode)
+    return Settings(
+        _env_file=None,
+        debug=True,
+        jwt_secret="test-jwt-secret",
+        cloud_secret_key="test-cloud-secret",
+    )
+
+
+# ---------------------------------------------------------------------------
+# single_org_mode default expression + env override
+# ---------------------------------------------------------------------------
+
+
+def test_single_org_mode_defaults_true_for_local_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _settings(monkeypatch, telemetry_mode="local_dev").single_org_mode is True
+
+
+def test_single_org_mode_defaults_true_for_self_managed(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _settings(monkeypatch, telemetry_mode="self_managed").single_org_mode is True
+
+
+def test_single_org_mode_defaults_false_for_hosted_product(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _settings(monkeypatch, telemetry_mode="hosted_product").single_org_mode is False
+
+
+def test_single_org_mode_env_override_wins_off_for_non_hosted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _settings(monkeypatch, telemetry_mode="self_managed", single_org_mode="false")
+    assert resolved.single_org_mode is False
+
+
+def test_single_org_mode_env_override_wins_on_for_hosted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = _settings(monkeypatch, telemetry_mode="hosted_product", single_org_mode="true")
+    assert resolved.single_org_mode is True
+
+
+def test_select_policy_follows_single_org_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", False)
+    assert isinstance(select_membership_policy(), HostedPolicy)
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+    assert isinstance(select_membership_policy(), SingleOrgPolicy)
+
+
+# ---------------------------------------------------------------------------
+# HostedPolicy: personal default org per identity (today's behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hosted_mode_creates_personal_org_per_user(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", False)
+
+    first = await create_auth_user(
+        db_session, email="a@example.com", display_name="A", avatar_url=None
+    )
+    second = await create_auth_user(
+        db_session, email="b@example.com", display_name="B", avatar_url=None
+    )
+
+    await place_new_identity(db_session, first)
+    await place_new_identity(db_session, second)
+
+    first_orgs = await organization_store.list_organizations_for_user(db_session, first.id)
+    second_orgs = await organization_store.list_organizations_for_user(db_session, second.id)
+
+    assert len(first_orgs) == 1
+    assert len(second_orgs) == 1
+    assert first_orgs[0].membership.role == ORGANIZATION_ROLE_OWNER
+    assert second_orgs[0].membership.role == ORGANIZATION_ROLE_OWNER
+    # Distinct personal organizations, not a shared one.
+    assert first_orgs[0].organization.id != second_orgs[0].organization.id
+    assert first_orgs[0].organization.is_instance is False
+
+
+# ---------------------------------------------------------------------------
+# SingleOrgPolicy: join the one instance org
+# ---------------------------------------------------------------------------
+
+
+async def _seed_instance_org(db: AsyncSession, *, owner_id) -> Organization:  # type: ignore[no-untyped-def]
+    organization = Organization(name="Acme", logo_domain=None, logo_image=None, is_instance=True)
+    db.add(organization)
+    await db.flush()
+    db.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner_id,
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+        )
+    )
+    await db.flush()
+    return organization
+
+
+@pytest.mark.asyncio
+async def test_single_org_mode_places_second_user_into_instance_org(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+
+    owner = await create_auth_user(
+        db_session, email="owner@acme.test", display_name="Owner", avatar_url=None
+    )
+    instance_org = await _seed_instance_org(db_session, owner_id=owner.id)
+
+    joiner = await create_auth_user(
+        db_session, email="teammate@acme.test", display_name="Teammate", avatar_url=None
+    )
+    await place_new_identity(db_session, joiner)
+
+    joiner_orgs = await organization_store.list_organizations_for_user(db_session, joiner.id)
+    assert len(joiner_orgs) == 1
+    assert joiner_orgs[0].organization.id == instance_org.id
+    assert joiner_orgs[0].membership.role == ORGANIZATION_ROLE_MEMBER
+
+    # No new organization was minted; the instance org is still the only one.
+    all_orgs = (await db_session.execute(_count_organizations())).scalar_one()
+    assert all_orgs == 1
+
+
+@pytest.mark.asyncio
+async def test_single_org_mode_join_is_idempotent(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+
+    owner = await create_auth_user(
+        db_session, email="owner2@acme.test", display_name="Owner", avatar_url=None
+    )
+    await _seed_instance_org(db_session, owner_id=owner.id)
+
+    joiner = await create_auth_user(
+        db_session, email="dup@acme.test", display_name="Dup", avatar_url=None
+    )
+    await place_new_identity(db_session, joiner)
+    await place_new_identity(db_session, joiner)
+
+    joiner_orgs = await organization_store.list_organizations_for_user(db_session, joiner.id)
+    assert len(joiner_orgs) == 1
+    assert joiner_orgs[0].membership.role == ORGANIZATION_ROLE_MEMBER
+
+
+@pytest.mark.asyncio
+async def test_single_org_mode_without_instance_org_fails_closed(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+
+    user = await create_auth_user(
+        db_session, email="early@acme.test", display_name="Early", avatar_url=None
+    )
+
+    with pytest.raises(InstanceOrganizationNotClaimed) as exc_info:
+        await place_new_identity(db_session, user)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "instance_not_claimed"
+
+    # Fail-closed: no organization and no membership were created.
+    assert (await db_session.execute(_count_organizations())).scalar_one() == 0
+    user_orgs = await organization_store.list_organizations_for_user(db_session, user.id)
+    assert user_orgs == []
+
+
+def _count_organizations():  # type: ignore[no-untyped-def]
+    from sqlalchemy import func, select
+
+    return select(func.count(Organization.id))


### PR DESCRIPTION
A1 of the self-hosting stack (~/delete/self-hosting-execution.md; spec §5). Foundation PR, hosted behavior byte-identical.

- single_org_mode: env override (SINGLE_ORG_MODE) over computed default telemetry_mode != hosted_product
- Membership-policy seam: HostedPolicy (today's personal-org path) / SingleOrgPolicy (join instance org, fail closed 503 instance_not_claimed before A2's claim exists); all four account-creation call sites routed through place_new_identity
- Instance-org marker: organization.is_instance + partial unique index (DB-enforced at-most-one); nothing sets it yet (A2's claim will)
- 10 new tests; conftest pins hosted mode for the existing suite; ruff clean; one pre-existing unrelated failure verified identical on the clean base

🤖 Generated with [Claude Code](https://claude.com/claude-code)