### PR TITLE
release(server): publish self-host deploy bundle

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -222,9 +222,16 @@ jobs:
         working-directory: .
 
       - name: Prepare release assets
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/server-v}"
+          else
+            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
+          fi
           tar czf artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz \
             -C target/x86_64-unknown-linux-musl/release \
             anyharness \
@@ -237,10 +244,22 @@ jobs:
             proliferate-supervisor
           cp server/infra/self-hosted-aws/template.yaml \
             artifacts/proliferate-self-hosted-aws-template.yaml
-          sha256sum artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz \
-            artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz \
-            artifacts/proliferate-self-hosted-aws-template.yaml \
-            > artifacts/self-hosted-assets.SHA256SUMS
+          bundle_root="$(mktemp -d)"
+          mkdir -p "$bundle_root/proliferate-deploy"
+          cp -R server/deploy/. "$bundle_root/proliferate-deploy/"
+          rm -rf "$bundle_root/proliferate-deploy/smoke"
+          printf '%s\n' "$VERSION" > "$bundle_root/proliferate-deploy/VERSION"
+          tar czf artifacts/proliferate-deploy.tar.gz -C "$bundle_root" proliferate-deploy
+          rm -rf "$bundle_root"
+          (
+            cd artifacts
+            sha256sum \
+              anyharness-x86_64-unknown-linux-musl.tar.gz \
+              anyharness-aarch64-unknown-linux-musl.tar.gz \
+              proliferate-self-hosted-aws-template.yaml \
+              proliferate-deploy.tar.gz \
+              > self-hosted-assets.SHA256SUMS
+          )
         working-directory: .
 
       - name: Ensure server release tag exists
@@ -272,4 +291,5 @@ jobs:
             artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz
             artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz
             artifacts/proliferate-self-hosted-aws-template.yaml
+            artifacts/proliferate-deploy.tar.gz
             artifacts/self-hosted-assets.SHA256SUMS

--- a/specs/developing/deploying/self-hosted-deploy.md
+++ b/specs/developing/deploying/self-hosted-deploy.md
@@ -59,6 +59,12 @@ server/deploy/
   wait-for-health.sh
 ```
 
+Every `server-v*` GitHub release also publishes this directory as a
+standalone bundle, `proliferate-deploy.tar.gz` (checksummed in
+`self-hosted-assets.SHA256SUMS`), so operators do not need to clone the
+monorepo. The bundle extracts to a `proliferate-deploy/` directory with the
+files above plus a `VERSION` file stamped with the release version.
+
 Services:
 
 - `caddy`: public HTTPS endpoint
@@ -101,8 +107,21 @@ The Proliferate API talks to the protected Bifrost management API through
 
 1. Provision a Linux host with Docker and Docker Compose v2.
 2. Point DNS for `api.company.com` at that host.
-3. Copy `server/deploy/.env.production.example` to `server/deploy/.env.static`.
-4. Fill in the required values:
+3. Fetch the deploy bundle for the release you want to run and create your
+   env file (no repo clone needed):
+
+```bash
+curl -fsSL https://github.com/proliferate-ai/proliferate/releases/download/server-vX.Y.Z/proliferate-deploy.tar.gz | tar xz
+cd proliferate-deploy
+cp .env.production.example .env.static
+```
+
+To verify the download first, fetch `self-hosted-assets.SHA256SUMS` from the
+same release and run `sha256sum -c` against it before extracting. Working from
+a monorepo checkout instead? `server/deploy/` is the same directory; run the
+steps below from there.
+
+4. Fill in the required values in `.env.static`:
    - `SITE_ADDRESS`
    - `PROLIFERATE_TELEMETRY_MODE`
    - `PROLIFERATE_HOST_BIN_DIR`
@@ -126,9 +145,9 @@ The Proliferate API talks to the protected Bifrost management API through
      overrides, add the extra env vars manually from
      [env-secrets-matrix.md](../reference/env-secrets-matrix.md)
 5. Leave `POSTGRES_PASSWORD`, `JWT_SECRET`, and `CLOUD_SECRET_KEY` blank if you
-   want `bootstrap.sh` to generate and persist them in
-   `server/deploy/.env.generated` on first startup.
-6. Optionally put host-local overrides in `server/deploy/.env.local`.
+   want `bootstrap.sh` to generate and persist them in `.env.generated`
+   (next to `.env.static`) on first startup.
+6. Optionally put host-local overrides in `.env.local` in the same directory.
    `ensure-secrets.sh` merges `.env.static` with `.env.local` into
    `.env.runtime`, and `.env.local` wins for non-secret operator settings. This
    is mainly useful for generated/self-hosted stacks where `.env.static` may be
@@ -160,10 +179,10 @@ after the local API passes health, also set:
 PROLIFERATE_PUBLIC_HEALTHCHECK_URL=https://api.company.com/health
 ```
 
-8. Run:
+8. Run, from the deploy directory:
 
 ```bash
-./server/deploy/bootstrap.sh
+./bootstrap.sh
 ```
 
 9. Give desktop users this config:
@@ -176,10 +195,10 @@ PROLIFERATE_PUBLIC_HEALTHCHECK_URL=https://api.company.com/health
 
 ## Update Flow
 
-The canonical self-hosted update flow is:
+The canonical self-hosted update flow is, from the deploy directory:
 
 ```bash
-./server/deploy/update.sh
+./update.sh
 ```
 
 That script runs:


### PR DESCRIPTION
C2 of the self-hosting stack (~/delete/self-hosting-execution.md; spec §3.1). The missing first command of every operator journey: server-v* releases now ship proliferate-deploy.tar.gz (server/deploy/** minus smoke/, + stamped VERSION, + basename SHA256SUMS entries).

Operator fetch (no monorepo clone):
curl -fsSL .../releases/download/server-vX.Y.Z/proliferate-deploy.tar.gz | tar xz && cd proliferate-deploy

Includes a real pre-existing bug fix: SHA256SUMS entries carried an artifacts/ path prefix but install-runtime.sh matches by basename, so RUNTIME_BINARY_SHA256_URL verification could never succeed. Docs updated to lead with the bundle. Verified locally: bundle built with the workflow's exact commands, extracted shape + exec bits confirmed; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)