### PR TITLE
fix(desktop): repo-shape conformance for streaming-UI leftovers

### DIFF
--- a/apps/desktop/src/components/workspace/chat/input/ComposerAttachedPanel.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerAttachedPanel.tsx
@@ -140,9 +140,11 @@ export function ComposerCardFooter({
     <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 px-3 pb-3 pt-1.5">
       <div className="flex flex-wrap items-center gap-2">
         {secondaryActions.map((action) => (
-          <button
+          <Button
             key={action.label}
             type="button"
+            variant="unstyled"
+            size="unstyled"
             disabled={action.disabled}
             onClick={action.onSelect}
             className={twMerge(
@@ -151,12 +153,14 @@ export function ComposerCardFooter({
             )}
           >
             {action.label}
-          </button>
+          </Button>
         ))}
       </div>
       {primaryAction && (
-        <button
+        <Button
           type="button"
+          variant="unstyled"
+          size="unstyled"
           disabled={primaryAction.disabled}
           onClick={primaryAction.onSelect}
           className={twMerge(
@@ -165,7 +169,7 @@ export function ComposerCardFooter({
           )}
         >
           {primaryAction.label}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -41,3 +41,4 @@ server/tests/integration/test_auth_flow.py 2052 existing server oversized integr
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
+apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx 492 existing markdown transcript renderer pending split


### PR DESCRIPTION
The streaming UI overhaul (#871) landed two raw `<button>`s in `ComposerAttachedPanel` and a 492-line `MarkdownBody.tsx`, which the repo-shape frontend-drift gate now flags on every open PR's merge preview.

- Footer chips switch to the sanctioned `Button variant="unstyled"` primitive (identical classes/behavior)
- `MarkdownBody.tsx` documented in `max_lines_allowlist.txt` pending a proper split

Verified locally: `check_max_lines` and `report_frontend_structure --strict` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)