### PR TITLE
fix(desktop): prevent path traversal in support attachment staging

### DIFF
--- a/apps/desktop/src-tauri/src/commands/support.rs
+++ b/apps/desktop/src-tauri/src/commands/support.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
@@ -133,9 +133,18 @@ pub fn stage_support_report_attachment(
     let bytes = STANDARD
         .decode(input.data_base64)
         .map_err(|error| format!("Failed to decode attachment: {error}"))?;
-    let path = support_attachment_dir()?
-        .join(safe_path_segment(&input.client_file_id))
-        .join(safe_file_name(&input.file_name));
+    // Canonicalize the staging root (which exists) so the containment check below
+    // resolves any symlinks in the app-dir prefix before comparing.
+    let root = support_attachment_dir()?;
+    fs::create_dir_all(&root)
+        .map_err(|error| format!("Failed to create {}: {error}", root.display()))?;
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|error| format!("Failed to resolve support attachment directory: {error}"))?;
+    // Resolve + contain the write path so a crafted client_file_id / file_name can
+    // never escape the staging directory (path traversal → arbitrary overwrite).
+    let path =
+        resolve_staged_attachment_write_path(&canonical_root, &input.client_file_id, &input.file_name)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| format!("Failed to create {}: {error}", parent.display()))?;
@@ -176,6 +185,47 @@ fn support_attachment_dir() -> Result<PathBuf, String> {
     Ok(app_dir_path()?.join("support-report-attachments"))
 }
 
+/// Build the on-disk write path for a staged attachment and guarantee it stays
+/// inside `canonical_root`. `canonical_root` must already be canonicalized.
+///
+/// This is defense-in-depth: `safe_path_segment` / `safe_file_name` already strip
+/// any parent-dir component, and this containment check catches anything that
+/// slips through (e.g. via a normalization quirk) before we touch the filesystem.
+fn resolve_staged_attachment_write_path(
+    canonical_root: &Path,
+    client_file_id: &str,
+    file_name: &str,
+) -> Result<PathBuf, String> {
+    let path = canonical_root
+        .join(safe_path_segment(client_file_id))
+        .join(safe_file_name(file_name));
+    if !is_within(canonical_root, &path) {
+        return Err("Attachment path is outside support staging.".to_string());
+    }
+    Ok(normalize_lexically(&path))
+}
+
+/// Lexically resolve `.` and `..` components without touching the filesystem, so
+/// containment can be checked even when the leaf does not exist yet.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+/// True when `path`, once `.`/`..` are lexically resolved, stays under `root`.
+fn is_within(root: &Path, path: &Path) -> bool {
+    normalize_lexically(path).starts_with(root)
+}
+
 fn validate_staged_attachment_path(path: &str) -> Result<PathBuf, String> {
     let candidate = PathBuf::from(path);
     let root = support_attachment_dir()?
@@ -200,7 +250,7 @@ fn safe_file_name(file_name: &str) -> String {
 }
 
 fn safe_path_segment(value: &str) -> String {
-    value
+    let sanitized = value
         .chars()
         .map(|character| {
             if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_' | ' ') {
@@ -211,5 +261,96 @@ fn safe_path_segment(value: &str) -> String {
         })
         .collect::<String>()
         .trim()
-        .to_string()
+        .to_string();
+
+    // Collapse dot-only segments (".", "..", "...") — anything with no non-dot
+    // character — to a placeholder so a parent-dir component can never be
+    // produced. Legitimate ids (which always contain a non-dot character) pass
+    // through unchanged.
+    if sanitized.is_empty() || sanitized.chars().all(|character| character == '.') {
+        return "_".to_string();
+    }
+
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contains_parent_component(value: &str) -> bool {
+        Path::new(value)
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    }
+
+    #[test]
+    fn safe_path_segment_collapses_dot_only_segments() {
+        // The exact bytes used in the exploit must never survive as a
+        // parent-dir component.
+        for input in ["..", ".", "...", "   ..   ", "./", "../"] {
+            let segment = safe_path_segment(input);
+            assert!(
+                !contains_parent_component(&segment),
+                "segment {input:?} sanitized to {segment:?} which still traverses",
+            );
+        }
+        assert_eq!(safe_path_segment(".."), "_");
+        assert_eq!(safe_path_segment("."), "_");
+    }
+
+    #[test]
+    fn safe_path_segment_keeps_legitimate_ids() {
+        assert_eq!(safe_path_segment("legit-id_123"), "legit-id_123");
+        assert_eq!(safe_path_segment("report.log"), "report.log");
+        assert_eq!(safe_path_segment(".hidden"), ".hidden");
+        // Slashes are neutralized to underscores, so no component boundary is
+        // introduced.
+        let segment = safe_path_segment("a/../../etc");
+        assert!(!contains_parent_component(&segment));
+        assert!(!segment.contains('/'));
+    }
+
+    #[test]
+    fn is_within_rejects_lexical_escape() {
+        let root = PathBuf::from("/home/user/.app/support-report-attachments");
+        // Belt-and-suspenders: even a raw "../secret" (which the sanitizer would
+        // never produce) is caught by the containment guard.
+        assert!(!is_within(&root, &root.join("..").join("auth-session.json")));
+        assert!(!is_within(&root, &root.join("..").join("..").join("etc")));
+        assert!(is_within(&root, &root.join("client-1").join("file.txt")));
+    }
+
+    #[test]
+    fn resolve_write_path_contains_parent_dir_client_id() {
+        let root = PathBuf::from("/home/user/.app/support-report-attachments");
+        // The reported exploit: clientFileId "..", fileName "auth-session.json"
+        // must resolve to a path INSIDE the staging root, never app_dir/auth-session.json.
+        let resolved =
+            resolve_staged_attachment_write_path(&root, "..", "auth-session.json").unwrap();
+        assert!(
+            resolved.starts_with(&root),
+            "resolved path {resolved:?} escaped staging root",
+        );
+        assert_ne!(resolved, PathBuf::from("/home/user/.app/auth-session.json"));
+        assert!(!contains_parent_component(resolved.to_str().unwrap()));
+    }
+
+    #[test]
+    fn resolve_write_path_contains_nested_traversal() {
+        let root = PathBuf::from("/home/user/.app/support-report-attachments");
+        for (client_file_id, file_name) in [
+            ("../../etc", "passwd"),
+            ("..", "env-secrets.json"),
+            ("../..", "pending-auth.json"),
+        ] {
+            let resolved =
+                resolve_staged_attachment_write_path(&root, client_file_id, file_name).unwrap();
+            assert!(
+                resolved.starts_with(&root),
+                "clientFileId {client_file_id:?} escaped to {resolved:?}",
+            );
+            assert!(!contains_parent_component(resolved.to_str().unwrap()));
+        }
+    }
 }


### PR DESCRIPTION
## Security fix: path traversal in support-attachment staging (Tauri)

**Severity:** Medium · **Class:** Path traversal → arbitrary file overwrite

### The bug
The `stage_support_report_attachment` IPC command in `apps/desktop/src-tauri/src/commands/support.rs` built its write path as
`support_attachment_dir()?.join(safe_path_segment(&client_file_id)).join(safe_file_name(&file_name))`
and called `fs::write` with **no containment check** — unlike the sibling read/delete commands, which enforce containment via `validate_staged_attachment_path`.

`safe_path_segment` explicitly permitted `.`, so a `client_file_id` of `".."` survived sanitization and produced `support-report-attachments/../<file_name>`, resolving into the app directory that holds the 0600 secret files `auth-session.json`, `env-secrets.json`, `pending-auth.json`.

**Impact:** a caller passing an untrusted `clientFileId` could overwrite `auth-session.json` with attacker-chosen tokens (session fixation) or `env-secrets.json` to plant provider API keys injected into the sidecar.

### The fix (two independent layers)
1. **Containment guard on the write path** — new `resolve_staged_attachment_write_path` canonicalizes the (existing) staging root and lexically normalizes the joined path, rejecting anything that escapes the root (`Attachment path is outside support staging.`). Robust to the leaf not yet existing.
2. **Sanitizer hardening** — `safe_path_segment` now collapses any dot-only / non-`.`-free segment to `_`, so a parent-dir component can never be produced. Legitimate ids pass through unchanged.

### Testing
`cargo test -p proliferate support::` → **5 passed**, including the exact reported exploit (`clientFileId ".."`, `fileName "auth-session.json"`) plus nested-traversal cases. `cargo clippy` clean for `support.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
