### PR TITLE
fix(cloud/agent-run-config): require org membership for org-scoped listing (IDOR)

### DIFF
--- a/server/proliferate/server/cloud/agent_run_config/service.py
+++ b/server/proliferate/server/cloud/agent_run_config/service.py
@@ -154,13 +154,17 @@ async def list_agent_run_configs(
     usable_in: str | None = None,
     status: str | None = CLOUD_AGENT_RUN_CONFIG_STATUS_ACTIVE,
 ) -> list[CloudAgentRunConfigRecord]:
-    if owner_scope == CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_ORGANIZATION:
-        if organization_id is None:
-            raise CloudApiError(
-                "organization_required",
-                "organizationId is required for organization configs.",
-                status_code=400,
-            )
+    if owner_scope == CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_ORGANIZATION and organization_id is None:
+        raise CloudApiError(
+            "organization_required",
+            "organizationId is required for organization configs.",
+            status_code=400,
+        )
+    # Require membership whenever an organization is scoped, regardless of owner_scope.
+    # The store ORs org-scoped rows into results for any non-None organization_id, so the
+    # guard must run even when owner_scope is omitted (otherwise a non-member could
+    # enumerate a victim org's configs via `?organizationId=<uuid>` with no ownerScope).
+    if organization_id is not None:
         await _require_org_member(db, user_id=user.id, organization_id=organization_id)
     return list(
         await config_store.list_configs(

--- a/server/tests/unit/test_cloud_agent_run_config_service.py
+++ b/server/tests/unit/test_cloud_agent_run_config_service.py
@@ -315,6 +315,72 @@ async def test_org_default_allows_system_config(
     assert upserted["organization_id"] == default_org_id
 
 
+@pytest.mark.asyncio
+async def test_list_requires_org_membership_when_organization_id_without_owner_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IDOR guard: passing organizationId (no ownerScope) must assert membership."""
+    user_id = uuid.uuid4()
+    victim_org_id = uuid.uuid4()
+
+    async def fake_get_active_membership(*args: object, **kwargs: object) -> None:
+        # Actor is not a member of the requested organization.
+        return None
+
+    async def fail_list_configs(*args: object, **kwargs: object) -> tuple[object, ...]:
+        raise AssertionError("store must not be reached for a non-member")
+
+    monkeypatch.setattr(
+        service.organization_store, "get_active_membership", fake_get_active_membership
+    )
+    monkeypatch.setattr(service.config_store, "list_configs", fail_list_configs)
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await service.list_agent_run_configs(
+            None,  # type: ignore[arg-type]
+            SimpleNamespace(id=user_id),  # type: ignore[arg-type]
+            owner_scope=None,
+            organization_id=victim_org_id,
+        )
+
+    assert exc_info.value.code == "organization_not_found"
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_allows_org_member_scoped_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A member passing organizationId reaches the store exactly once."""
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    calls: dict[str, int] = {"membership": 0, "list": 0}
+
+    async def fake_get_active_membership(*args: object, **kwargs: object) -> SimpleNamespace:
+        calls["membership"] += 1
+        return SimpleNamespace(role="member")
+
+    async def fake_list_configs(*args: object, **kwargs: object) -> tuple[object, ...]:
+        calls["list"] += 1
+        assert kwargs["organization_id"] == org_id
+        return ()
+
+    monkeypatch.setattr(
+        service.organization_store, "get_active_membership", fake_get_active_membership
+    )
+    monkeypatch.setattr(service.config_store, "list_configs", fake_list_configs)
+
+    result = await service.list_agent_run_configs(
+        None,  # type: ignore[arg-type]
+        SimpleNamespace(id=user_id),  # type: ignore[arg-type]
+        owner_scope=CLOUD_AGENT_RUN_CONFIG_OWNER_SCOPE_ORGANIZATION,
+        organization_id=org_id,
+    )
+
+    assert result == []
+    assert calls == {"membership": 1, "list": 1}
+
+
 def test_execution_scope_rejects_archived_config() -> None:
     issue = validate_config_execution_scope(
         _config(status="archived"),


### PR DESCRIPTION
## Security fix: cross-org IDOR in agent-run-config listing

**Severity:** Medium · **Class:** Broken authorization / org-boundary crossing (IDOR)

### The bug
`GET /agent-run-configs` (`server/proliferate/server/cloud/agent_run_config`) exposes `ownerScope` and `organizationId` as independent query params. In `list_agent_run_configs`, the membership guard `_require_org_member` was nested inside `if owner_scope == ORGANIZATION`. So a request that supplied `organizationId` but **omitted** `ownerScope` (default `None`) skipped the guard entirely — yet `organization_id` was still forwarded to the store, whose `list_configs` unconditionally ORs org-scoped rows into the result for any non-`None` `organization_id`.

**Impact:** any authenticated user could call `GET /agent-run-configs?organizationId=<victim-org-uuid>` (no `ownerScope`) and enumerate all of a victim org's active org-scoped agent run configs — disclosing name, agent_kind, model_id, `control_values_json`, `created_by_user_id`, and usable flags. Read-only metadata disclosure; no secrets/keys leaked. There is no RLS backstop on `cloud_agent_run_config`.

### The fix
Restructured the guard so `_require_org_member(db, user.id, organization_id)` runs for **any** non-`None` `organization_id`, regardless of `owner_scope`. The `owner_scope == ORGANIZATION and organization_id is None` → 400 validation is preserved, and the legitimate member path calls the guard exactly once.

Sibling handlers (`get`/`update`/`archive`/`create`/`defaults`/`set-default`) were audited: they route through membership-enforced paths (`_visible_config` / `_require_org_admin`) and were already safe.

### Testing
`ruff` + `mypy` clean on changed files. `pytest tests/unit/test_cloud_agent_run_config_service.py` → **10 passed** (8 existing + 2 new regression tests asserting a non-member is rejected).

### Follow-up (optional, not required here)
Defense-in-depth: add a store-level "membership asserted" guard and an RLS policy on `cloud_agent_run_config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
