### PR TITLE
fix(cloud/github-app): verify installation ownership in install callback (IDOR)

### DIFF
--- a/server/proliferate/db/store/github_app.py
+++ b/server/proliferate/db/store/github_app.py
@@ -23,6 +23,16 @@ from proliferate.utils.time import utcnow
 _CACHE_FRESHNESS_SECONDS = 600
 
 
+class GitHubAppInstallationOrganizationConflict(Exception):
+    """Raised when an installation would be rebound to a different organization.
+
+    Defense in depth against cross-tenant IDOR: an installation row that is
+    already owned by one organization must not be silently reassigned to a
+    different organization unless the caller has independently proven the actor
+    controls the installation (``allow_organization_rebind=True``).
+    """
+
+
 @dataclass(frozen=True, repr=False)
 class GitHubAppAuthorizationValue:
     id: UUID
@@ -231,6 +241,7 @@ async def upsert_github_app_installation(
     installation: GitHubAppInstallationPayload,
     organization_id: UUID | None = None,
     installed_by_user_id: UUID | None = None,
+    allow_organization_rebind: bool = False,
 ) -> GitHubAppInstallationValue:
     now = utcnow()
     row = (
@@ -255,6 +266,18 @@ async def upsert_github_app_installation(
             updated_at=now,
         )
         db.add(row)
+    # Never let one organization silently claim an installation already bound to
+    # another. Callers that rebind (e.g. a verified re-install / ownership
+    # transfer) must opt in explicitly after proving control of the installation.
+    if (
+        organization_id is not None
+        and row.organization_id is not None
+        and row.organization_id != organization_id
+        and not allow_organization_rebind
+    ):
+        raise GitHubAppInstallationOrganizationConflict(
+            "GitHub App installation is already bound to a different organization."
+        )
     row.account_login = installation.account_login
     row.account_type = installation.account_type
     row.repository_selection = installation.repository_selection

--- a/server/proliferate/integrations/github/__init__.py
+++ b/server/proliferate/integrations/github/__init__.py
@@ -8,6 +8,7 @@ from proliferate.integrations.github.app_installations import (
     fetch_installation_repo_coverage_from_github,
     get_github_app_installation,
     list_github_app_installations,
+    list_github_app_user_installations,
     verify_github_app_user_repo_access,
     verify_github_webhook_signature,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "fetch_installation_repo_coverage_from_github",
     "httpx",
     "list_github_app_installations",
+    "list_github_app_user_installations",
     "list_branches",
     "list_github_repositories",
     "refresh_github_app_user_authorization",

--- a/server/proliferate/integrations/github/app_installations.py
+++ b/server/proliferate/integrations/github/app_installations.py
@@ -146,6 +146,52 @@ async def list_github_app_installations() -> tuple[GitHubAppInstallationInfo, ..
     return tuple(installations)
 
 
+async def list_github_app_user_installations(
+    *,
+    user_access_token: str,
+) -> tuple[GitHubAppInstallationInfo, ...]:
+    """List the app installations the authenticated user can access.
+
+    Uses the user-to-server OAuth token (NOT the app JWT), so the result is
+    scoped to installations the user actually controls/belongs to. This is the
+    basis for proving that a caller controls a given installation before we bind
+    it to their organization.
+    """
+    installations: list[GitHubAppInstallationInfo] = []
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            page = 1
+            while True:
+                response = await client.get(
+                    "https://api.github.com/user/installations",
+                    headers=_user_headers(user_access_token),
+                    params={"per_page": 100, "page": page},
+                )
+                if response.status_code >= 300:
+                    raise GitHubIntegrationError(
+                        "Could not list GitHub App installations for the user."
+                    )
+                payload = response.json()
+                items = payload.get("installations") if isinstance(payload, dict) else None
+                if not isinstance(items, list):
+                    raise GitHubIntegrationError(
+                        "Could not list GitHub App installations for the user."
+                    )
+                for item in items:
+                    if isinstance(item, dict):
+                        installation = _installation_from_payload(item)
+                        if installation is not None:
+                            installations.append(installation)
+                if len(items) < 100:
+                    break
+                page += 1
+    except httpx.HTTPError as exc:
+        raise GitHubIntegrationError(
+            "Could not list GitHub App installations for the user."
+        ) from exc
+    return tuple(installations)
+
+
 async def get_github_app_installation(
     *,
     installation_id: str,

--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -21,6 +21,7 @@ from proliferate.integrations.github import (
     exchange_github_app_code,
     get_github_app_installation,
     list_github_app_installations,
+    list_github_app_user_installations,
 )
 from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_service
 from proliferate.server.cloud.errors import CloudApiError
@@ -390,11 +391,23 @@ async def complete_github_app_installation_callback(
             "Could not verify GitHub App installation.",
             status_code=502,
         ) from exc
+    # `get_github_app_installation` authenticates as the App itself (app JWT), so
+    # it succeeds for ANY installation of the Proliferate App regardless of who
+    # is asking. Before binding this installation to the actor's organization we
+    # must prove the actor actually controls it — otherwise an org admin could
+    # claim (and hijack) another tenant's installation by supplying its
+    # enumerable installation_id (cross-tenant IDOR).
+    await _verify_actor_controls_installation(
+        db,
+        actor_user_id=actor_user_id,
+        installation=installation,
+    )
     await github_app_store.upsert_github_app_installation(
         db,
         installation=installation,
         organization_id=organization_id,
         installed_by_user_id=actor_user_id,
+        allow_organization_rebind=True,
     )
     repo_environments = await repositories_store.list_cloud_repo_environments_for_git_owner(
         db,
@@ -406,6 +419,50 @@ async def complete_github_app_installation_callback(
             repo_environment_id=repo_environment.id,
         )
     return return_to or _default_return_after_callback("organization")
+
+
+async def _verify_actor_controls_installation(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    installation: GitHubAppInstallationInfo,
+) -> None:
+    """Confirm the acting user actually controls the GitHub App installation.
+
+    Uses the actor's own user-to-server OAuth token (never the app JWT) to list
+    the installations the user can access and requires the target installation
+    to be one of them, matching both installation id and account. This closes
+    the cross-tenant IDOR where a signed installation `state` for org A is
+    replayed against another tenant's `installation_id`.
+    """
+    authorization = await ensure_fresh_github_app_authorization(db, user_id=actor_user_id)
+    if authorization.access_token is None:
+        raise CloudApiError(
+            "github_app_authorization_required",
+            "Connect your GitHub account before installing the Proliferate GitHub App.",
+            status_code=409,
+        )
+    try:
+        accessible = await list_github_app_user_installations(
+            user_access_token=authorization.access_token,
+        )
+    except GitHubIntegrationError as exc:
+        raise CloudApiError(
+            "github_app_installation_ownership_check_failed",
+            "Could not verify control of this GitHub App installation.",
+            status_code=502,
+        ) from exc
+    for candidate in accessible:
+        if (
+            candidate.github_installation_id == installation.github_installation_id
+            and candidate.account_login.lower() == installation.account_login.lower()
+        ):
+            return
+    raise CloudApiError(
+        "github_app_installation_forbidden",
+        "You do not have access to this GitHub App installation.",
+        status_code=403,
+    )
 
 
 async def get_github_app_installation_status(

--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -435,13 +435,22 @@ async def _verify_actor_controls_installation(
     the cross-tenant IDOR where a signed installation `state` for org A is
     replayed against another tenant's `installation_id`.
     """
-    authorization = await ensure_fresh_github_app_authorization(db, user_id=actor_user_id)
-    if authorization.access_token is None:
-        raise CloudApiError(
+    try:
+        authorization = await ensure_fresh_github_app_authorization(db, user_id=actor_user_id)
+    except CloudApiError as exc:
+        # `ensure_fresh_github_app_authorization` raises with generic
+        # "GitHub Cloud repos" copy; surface an install-context message when the
+        # actor simply has no (or an expired) user authorization.
+        if exc.code in {
             "github_app_authorization_required",
-            "Connect your GitHub account before installing the Proliferate GitHub App.",
-            status_code=409,
-        )
+            "github_app_authorization_expired",
+        }:
+            raise CloudApiError(
+                "github_app_authorization_required",
+                "Connect your GitHub account before installing the Proliferate GitHub App.",
+                status_code=409,
+            ) from exc
+        raise
     try:
         accessible = await list_github_app_user_installations(
             user_access_token=authorization.access_token,

--- a/server/tests/unit/test_github_app_service.py
+++ b/server/tests/unit/test_github_app_service.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
+from proliferate.db.store import github_app as github_app_store
+from proliferate.db.store.github_app import GitHubAppInstallationOrganizationConflict
 from proliferate.integrations.github.app_installations import GitHubAppInstallationInfo
 from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthorization
 from proliferate.server.cloud.errors import CloudApiError
@@ -133,7 +136,7 @@ async def test_complete_github_app_installation_callback_links_installation_to_o
         repository_selection="selected",
         permissions={"contents": "read"},
     )
-    calls: list[tuple[str, uuid.UUID, uuid.UUID]] = []
+    calls: list[tuple[str, uuid.UUID, uuid.UUID, bool]] = []
 
     async def fake_get_github_app_installation(
         *,
@@ -142,17 +145,30 @@ async def test_complete_github_app_installation_callback_links_installation_to_o
         assert installation_id == "142900805"
         return installation
 
+    async def fake_ensure_fresh_github_app_authorization(db: object, *, user_id: uuid.UUID):
+        del db
+        assert user_id == actor_user_id
+        return SimpleNamespace(access_token="ghu_actor")
+
+    async def fake_list_github_app_user_installations(
+        *,
+        user_access_token: str,
+    ) -> tuple[GitHubAppInstallationInfo, ...]:
+        assert user_access_token == "ghu_actor"
+        return (installation,)
+
     async def fake_upsert_github_app_installation(
         db: object,
         *,
         installation: GitHubAppInstallationInfo,
         organization_id: uuid.UUID | None = None,
         installed_by_user_id: uuid.UUID | None = None,
+        allow_organization_rebind: bool = False,
     ) -> None:
         del db, installation
         assert organization_id is not None
         assert installed_by_user_id is not None
-        calls.append(("upsert", organization_id, installed_by_user_id))
+        calls.append(("upsert", organization_id, installed_by_user_id, allow_organization_rebind))
 
     async def fake_list_cloud_repo_environments_for_git_owner(db: object, *, git_owner: str):
         del db
@@ -163,6 +179,16 @@ async def test_complete_github_app_installation_callback_links_installation_to_o
         service,
         "get_github_app_installation",
         fake_get_github_app_installation,
+    )
+    monkeypatch.setattr(
+        service,
+        "ensure_fresh_github_app_authorization",
+        fake_ensure_fresh_github_app_authorization,
+    )
+    monkeypatch.setattr(
+        service,
+        "list_github_app_user_installations",
+        fake_list_github_app_user_installations,
     )
     monkeypatch.setattr(
         service.github_app_store,
@@ -183,7 +209,131 @@ async def test_complete_github_app_installation_callback_links_installation_to_o
     )
 
     assert redirect_url == "https://app.example.test/settings/organization"
-    assert calls == [("upsert", organization_id, actor_user_id)]
+    assert calls == [("upsert", organization_id, actor_user_id, True)]
+
+
+@pytest.mark.asyncio
+async def test_complete_github_app_installation_callback_rejects_foreign_installation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The IDOR fix: an actor cannot bind an installation they do not control."""
+    monkeypatch.setattr(service.settings, "cloud_secret_key", "test-secret")
+    monkeypatch.setattr(service.settings, "frontend_base_url", "https://app.example.test")
+
+    attacker_user_id = uuid.uuid4()
+    attacker_org_id = uuid.uuid4()
+    state = service._state_for_installation(
+        user_id=attacker_user_id,
+        organization_id=attacker_org_id,
+        return_to=None,
+    )
+    victim_installation = GitHubAppInstallationInfo(
+        github_installation_id="99999999",
+        account_login="victim-org",
+        account_type="Organization",
+        repository_selection="all",
+        permissions={"contents": "read"},
+    )
+
+    async def fake_get_github_app_installation(
+        *,
+        installation_id: str,
+    ) -> GitHubAppInstallationInfo:
+        # App-JWT lookup succeeds for ANY installation — this is why it cannot
+        # be trusted for ownership.
+        assert installation_id == "99999999"
+        return victim_installation
+
+    async def fake_ensure_fresh_github_app_authorization(db: object, *, user_id: uuid.UUID):
+        del db
+        assert user_id == attacker_user_id
+        return SimpleNamespace(access_token="ghu_attacker")
+
+    async def fake_list_github_app_user_installations(
+        *,
+        user_access_token: str,
+    ) -> tuple[GitHubAppInstallationInfo, ...]:
+        # The attacker only controls their own installation, never the victim's.
+        return (
+            GitHubAppInstallationInfo(
+                github_installation_id="11111111",
+                account_login="attacker-org",
+                account_type="Organization",
+                repository_selection="all",
+                permissions={},
+            ),
+        )
+
+    async def fail_upsert_github_app_installation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("installation must not be bound when ownership is unverified")
+
+    monkeypatch.setattr(
+        service,
+        "get_github_app_installation",
+        fake_get_github_app_installation,
+    )
+    monkeypatch.setattr(
+        service,
+        "ensure_fresh_github_app_authorization",
+        fake_ensure_fresh_github_app_authorization,
+    )
+    monkeypatch.setattr(
+        service,
+        "list_github_app_user_installations",
+        fake_list_github_app_user_installations,
+    )
+    monkeypatch.setattr(
+        service.github_app_store,
+        "upsert_github_app_installation",
+        fail_upsert_github_app_installation,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await service.complete_github_app_installation_callback(
+            object(),
+            installation_id="99999999",
+            setup_action="install",
+            state=state,
+        )
+    assert excinfo.value.code == "github_app_installation_forbidden"
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_upsert_github_app_installation_rejects_cross_org_rebind() -> None:
+    """Defense in depth: the store refuses to reassign an installation's org."""
+    existing_org_id = uuid.uuid4()
+    attacker_org_id = uuid.uuid4()
+    existing_row = SimpleNamespace(organization_id=existing_org_id)
+
+    class _Result:
+        def scalar_one_or_none(self) -> object:
+            return existing_row
+
+    class _FakeSession:
+        async def execute(self, *_args: object, **_kwargs: object) -> _Result:
+            return _Result()
+
+        def add(self, _row: object) -> None:
+            raise AssertionError("existing row must not be re-added")
+
+        async def flush(self) -> None:
+            raise AssertionError("must not flush a rejected cross-org rebind")
+
+    payload = GitHubAppInstallationInfo(
+        github_installation_id="142900805",
+        account_login="victim-org",
+        account_type="Organization",
+        repository_selection="all",
+        permissions={},
+    )
+
+    with pytest.raises(GitHubAppInstallationOrganizationConflict):
+        await github_app_store.upsert_github_app_installation(
+            _FakeSession(),
+            installation=payload,
+            organization_id=attacker_org_id,
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_github_app_service.py
+++ b/server/tests/unit/test_github_app_service.py
@@ -300,6 +300,77 @@ async def test_complete_github_app_installation_callback_rejects_foreign_install
 
 
 @pytest.mark.asyncio
+async def test_complete_github_app_installation_callback_surfaces_install_context_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unconnected actor gets the install-context 409, not the generic copy."""
+    monkeypatch.setattr(service.settings, "cloud_secret_key", "test-secret")
+    monkeypatch.setattr(service.settings, "frontend_base_url", "https://app.example.test")
+
+    actor_user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    state = service._state_for_installation(
+        user_id=actor_user_id,
+        organization_id=organization_id,
+        return_to=None,
+    )
+    installation = GitHubAppInstallationInfo(
+        github_installation_id="142900805",
+        account_login="proliferate-ai",
+        account_type="Organization",
+        repository_selection="selected",
+        permissions={"contents": "read"},
+    )
+
+    async def fake_get_github_app_installation(
+        *,
+        installation_id: str,
+    ) -> GitHubAppInstallationInfo:
+        assert installation_id == "142900805"
+        return installation
+
+    async def fake_ensure_fresh_github_app_authorization(db: object, *, user_id: uuid.UUID):
+        del db
+        assert user_id == actor_user_id
+        # The helper raises with generic "GitHub Cloud repos" copy.
+        raise CloudApiError(
+            "github_app_authorization_required",
+            "Connect the Proliferate GitHub App before using GitHub Cloud repos.",
+            status_code=409,
+        )
+
+    async def fail_upsert_github_app_installation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("installation must not be bound when actor is unauthorized")
+
+    monkeypatch.setattr(
+        service,
+        "get_github_app_installation",
+        fake_get_github_app_installation,
+    )
+    monkeypatch.setattr(
+        service,
+        "ensure_fresh_github_app_authorization",
+        fake_ensure_fresh_github_app_authorization,
+    )
+    monkeypatch.setattr(
+        service.github_app_store,
+        "upsert_github_app_installation",
+        fail_upsert_github_app_installation,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await service.complete_github_app_installation_callback(
+            object(),
+            installation_id="142900805",
+            setup_action="install",
+            state=state,
+        )
+    assert excinfo.value.code == "github_app_authorization_required"
+    assert excinfo.value.status_code == 409
+    assert "installing the Proliferate GitHub App" in excinfo.value.message
+
+
+@pytest.mark.asyncio
 async def test_upsert_github_app_installation_rejects_cross_org_rebind() -> None:
     """Defense in depth: the store refuses to reassign an installation's org."""
     existing_org_id = uuid.uuid4()


### PR DESCRIPTION
## Security fix: cross-tenant IDOR in GitHub App installation callback

**Severity:** Medium · **Class:** Broken authorization / org-boundary crossing (IDOR)

### The bug
`complete_github_app_installation_callback` bound an installation to the actor's org using only two attacker-influenced inputs: the `installation_id` query param and the `organization_id` decoded from the signed `state`. Because `get_github_app_installation` authenticates as the **App itself** (app JWT), it resolves *any* installation of the Proliferate App, and `upsert_github_app_installation` looked rows up solely by `github_installation_id` and unconditionally overwrote `organization_id`/`installed_by_user_id`.

**Impact:** an org admin could mint a valid `state` for their own org (`/installation/start`) and replay it against a victim's enumerable `installation_id`, rebinding the victim's installation cross-tenant — DoS the victim (their integration shows "not installed") while the attacker's org falsely shows the victim's GitHub account connected. `state` was also replayable within its ~10-min window.

### The fix (ownership proof + defense in depth)
1. **Ownership verification (primary)** — new `_verify_actor_controls_installation` fetches the actor's own **user-to-server** OAuth token (`ensure_fresh_github_app_authorization`) and calls the new `list_github_app_user_installations` (`GET /user/installations`). The target installation must appear in that *user-scoped* list with a matching account, else `403 github_app_installation_forbidden`. An attacker not in the victim's GitHub org simply won't see the victim's installation, so the IDOR **and** any `state` replay are neutralized. Actors without a connected GitHub account get a recoverable `409` rather than a silent bind.
2. **Cross-org overwrite refusal (defense in depth)** — `upsert_github_app_installation` now raises `GitHubAppInstallationOrganizationConflict` if an existing row is owned by a *different* org, unless `allow_organization_rebind=True`. The callback passes that flag only *after* ownership is verified, preserving the legitimate re-install / transfer path.

### Testing
`ruff` clean; `mypy` net-new errors = 0 (verified against pre-change baseline). Targeted tests: `test_github_app_service.py` → **7 passed** (incl. new foreign-installation-rejection + store cross-org-rebind-rejection tests), `test_github_integration.py` → **12 passed**.

### Behavior change to note
Completing an org installation now requires the acting user to have connected their personal GitHub account (already required for repo listing/authority in practice). Worth a quick UI check that the install button surfaces the `409` gracefully / prompts to connect first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
