### PR TITLE
fix(agent-auth): review fixes for target-bearer

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1049,6 +1049,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Targets Endpoint */
+        get: operations["list_targets_endpoint_v1_cloud_targets_get"];
+        put?: never;
+        /** Create Target Enrollment Endpoint */
+        post: operations["create_target_enrollment_endpoint_v1_cloud_targets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}/enrollments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Existing Target Enrollment Endpoint */
+        post: operations["create_existing_target_enrollment_endpoint_v1_cloud_targets__target_id__enrollments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Target Endpoint */
+        get: operations["get_target_endpoint_v1_cloud_targets__target_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/targets/{target_id}/runtime-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Target Runtime Access Endpoint */
+        get: operations["get_target_runtime_access_endpoint_v1_cloud_targets__target_id__runtime_access_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workspaces": {
         parameters: {
             query?: never;
@@ -3277,6 +3346,96 @@ export interface components {
             /** Files */
             files: components["schemas"]["CloudSecretFileMetadata"][];
             materialization?: components["schemas"]["CloudSecretsMaterializationResponse"] | null;
+        };
+        /** CloudTargetDetail */
+        CloudTargetDetail: {
+            /** Id */
+            id: string;
+            /** Displayname */
+            displayName: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Archivedat */
+            archivedAt?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+            /** Owneruserid */
+            ownerUserId?: string | null;
+            /** Createdbyuserid */
+            createdByUserId: string;
+        };
+        /** CloudTargetEnrollmentRequest */
+        CloudTargetEnrollmentRequest: {
+            /** Displayname */
+            displayName: string;
+            /**
+             * Kind
+             * @default ssh
+             */
+            kind: string;
+            /**
+             * Ownerscope
+             * @default personal
+             * @enum {string}
+             */
+            ownerScope: "personal" | "organization";
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Ttlseconds */
+            ttlSeconds?: number | null;
+        };
+        /** CloudTargetEnrollmentResponse */
+        CloudTargetEnrollmentResponse: {
+            target: components["schemas"]["CloudTargetDetail"];
+            /** Enrollmenttoken */
+            enrollmentToken: string;
+            /** Anyharnessbearertoken */
+            anyharnessBearerToken: string;
+            /** Installcommand */
+            installCommand: string;
+            /** Artifactbaseurl */
+            artifactBaseUrl?: string | null;
+            /** Expiresat */
+            expiresAt: string;
+        };
+        /** CloudTargetExistingEnrollmentRequest */
+        CloudTargetExistingEnrollmentRequest: {
+            /** Ttlseconds */
+            ttlSeconds?: number | null;
+        };
+        /** CloudTargetRuntimeAccessResponse */
+        CloudTargetRuntimeAccessResponse: {
+            /** Anyharnessbearertoken */
+            anyharnessBearerToken: string;
+        };
+        /** CloudTargetSummary */
+        CloudTargetSummary: {
+            /** Id */
+            id: string;
+            /** Displayname */
+            displayName: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Ownerscope */
+            ownerScope: string;
+            /** Organizationid */
+            organizationId?: string | null;
+            /** Archivedat */
+            archivedAt?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
         };
         /** CloudWorkspaceRuntimeStatusResponse */
         CloudWorkspaceRuntimeStatusResponse: {
@@ -7033,6 +7192,156 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CloudSandboxResponse"];
+                };
+            };
+        };
+    };
+    list_targets_endpoint_v1_cloud_targets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetSummary"][];
+                };
+            };
+        };
+    };
+    create_target_enrollment_endpoint_v1_cloud_targets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CloudTargetEnrollmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetEnrollmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_existing_target_enrollment_endpoint_v1_cloud_targets__target_id__enrollments_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CloudTargetExistingEnrollmentRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetEnrollmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_target_endpoint_v1_cloud_targets__target_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_target_runtime_access_endpoint_v1_cloud_targets__target_id__runtime_access_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CloudTargetRuntimeAccessResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/server/alembic/versions/d4c5b6a79801_cloud_target_anyharness_bearer.py
+++ b/server/alembic/versions/d4c5b6a79801_cloud_target_anyharness_bearer.py
@@ -1,0 +1,37 @@
+"""cloud target anyharness bearer
+
+Adds ``anyharness_bearer_token_ciphertext`` to ``cloud_targets``: the
+per-runtime AnyHarness bearer minted at enrollment (ssh/personal-target
+design §3.3), stored as recoverable Fernet ciphertext keyed by the cloud
+secret key — the same pattern as ``cloud_sandbox.runtime_token_ciphertext``,
+because both the Desktop direct-attach path and re-installs need the
+plaintext back.
+
+Revision ID: d4c5b6a79801
+Revises: b8c9d0e1f2a3
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d4c5b6a79801"
+down_revision: str | Sequence[str] | None = "b8c9d0e1f2a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "cloud_targets"
+_COLUMN = "anyharness_bearer_token_ciphertext"
+
+
+def upgrade() -> None:
+    op.add_column(_TABLE, sa.Column(_COLUMN, sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column(_TABLE, _COLUMN)

--- a/server/alembic/versions/e2a3b4c5d6f7_cloud_target_single_active_dispatch.py
+++ b/server/alembic/versions/e2a3b4c5d6f7_cloud_target_single_active_dispatch.py
@@ -1,0 +1,62 @@
+"""cloud target single active desktop dispatch
+
+Backs the enrollment reuse rule with a real invariant: at most one active
+personal ``desktop_dispatch`` target per user. The reuse path in
+``create_target_enrollment`` was a plain check-then-insert, so concurrent
+enrollments (Desktop double-submit, retries) could each insert a row — the
+extra row was never reused or rotated but stayed visible and selectable as
+an agent-auth scope. Duplicates are archived down to the oldest row (the one
+the reuse path deterministically picked) before the partial unique index is
+created; the service recovers from the index's IntegrityError by taking the
+reuse branch.
+
+Revision ID: e2a3b4c5d6f7
+Revises: d4c5b6a79801
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e2a3b4c5d6f7"
+down_revision: str | Sequence[str] | None = "d4c5b6a79801"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "cloud_targets"
+_INDEX = "uq_cloud_targets_personal_desktop_dispatch_active"
+_ACTIVE_DISPATCH = "owner_scope = 'personal' AND kind = 'desktop_dispatch' AND archived_at IS NULL"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {_TABLE}
+            SET archived_at = NOW(), status = 'archived'
+            WHERE {_ACTIVE_DISPATCH}
+              AND id NOT IN (
+                SELECT DISTINCT ON (owner_user_id) id
+                FROM {_TABLE}
+                WHERE {_ACTIVE_DISPATCH}
+                ORDER BY owner_user_id, created_at, id
+              )
+            """
+        )
+    )
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["owner_user_id"],
+        unique=True,
+        postgresql_where=sa.text(_ACTIVE_DISPATCH),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX, table_name=_TABLE)

--- a/server/proliferate/db/models/cloud/targets.py
+++ b/server/proliferate/db/models/cloud/targets.py
@@ -13,7 +13,7 @@ stack.
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from proliferate.constants.cloud import (
@@ -47,6 +47,17 @@ class CloudTarget(Base):
         ),
         Index("ix_cloud_targets_owner_user_status", "owner_user_id", "status"),
         Index("ix_cloud_targets_organization_status", "organization_id", "status"),
+        # One active personal desktop_dispatch row per user: the enrollment
+        # reuse rule as a DB invariant, so concurrent enrollments cannot
+        # each insert their own row (service recovers via the reuse branch).
+        Index(
+            "uq_cloud_targets_personal_desktop_dispatch_active",
+            "owner_user_id",
+            unique=True,
+            postgresql_where=text(
+                "owner_scope = 'personal' AND kind = 'desktop_dispatch' AND archived_at IS NULL"
+            ),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/server/proliferate/db/models/cloud/targets.py
+++ b/server/proliferate/db/models/cloud/targets.py
@@ -5,14 +5,15 @@ ssh/personal-target design (specs/tbd/ssh-personal-target-design.md §3.1)
 brings the enrollment record back as the ownership anchor for per-target
 agent-auth scoping: a ``CloudTarget`` row is a user-owned direct runtime that
 target-scoped route selections reference. Only the ownership/identity columns
-live here; enrollment transport state (workers, inventory, heartbeats,
-bearer ciphertext) returns with the enrollment slice of the stack.
+plus the per-runtime AnyHarness bearer (§3.3) live here; enrollment transport
+state (workers, inventory, heartbeats) returns with the worker slice of the
+stack.
 """
 
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from proliferate.constants.cloud import (
@@ -67,6 +68,11 @@ class CloudTarget(Base):
         ForeignKey("user.id", ondelete="CASCADE"),
         index=True,
     )
+    # Per-runtime AnyHarness bearer, Fernet-encrypted with the cloud secret key
+    # (same recoverable-ciphertext pattern as CloudSandbox.runtime_token_ciphertext,
+    # NOT the one-way HMAC used for enrollment tokens): the plaintext must be
+    # re-readable for direct attach (runtime-access endpoint) and re-install.
+    anyharness_bearer_token_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
     archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/server/proliferate/db/store/cloud_sync/targets.py
+++ b/server/proliferate/db/store/cloud_sync/targets.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import and_, exists, or_, select
+from sqlalchemy import and_, exists, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -21,6 +21,9 @@ from proliferate.db.models.cloud.targets import CloudTarget
 from proliferate.db.models.organizations import OrganizationMembership
 
 
+# Deliberately excludes anyharness_bearer_token_ciphertext: snapshots feed
+# list/detail payload builders, and the bearer must never ride along. Read it
+# through get_target_anyharness_bearer_ciphertext instead.
 @dataclass(frozen=True)
 class CloudTargetSnapshot:
     id: UUID
@@ -90,3 +93,103 @@ async def get_visible_target_by_id(
     if row is None:
         return None
     return _target_snapshot(row)
+
+
+async def list_visible_targets(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> list[CloudTargetSnapshot]:
+    rows = (
+        await db.execute(
+            select(CloudTarget)
+            .where(_visible_target_filter(user_id))
+            .order_by(CloudTarget.created_at, CloudTarget.id)
+        )
+    ).scalars()
+    return [_target_snapshot(row) for row in rows]
+
+
+async def get_active_personal_target_by_kind(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    kind: str,
+) -> CloudTargetSnapshot | None:
+    row = (
+        await db.execute(
+            select(CloudTarget)
+            .where(CloudTarget.owner_scope == "personal")
+            .where(CloudTarget.owner_user_id == owner_user_id)
+            .where(CloudTarget.kind == kind)
+            .where(CloudTarget.archived_at.is_(None))
+            .order_by(CloudTarget.created_at)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return _target_snapshot(row)
+
+
+async def create_target(
+    db: AsyncSession,
+    *,
+    display_name: str,
+    kind: str,
+    owner_scope: str,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+    created_by_user_id: UUID,
+    anyharness_bearer_token_ciphertext: str,
+) -> CloudTargetSnapshot:
+    target = CloudTarget(
+        display_name=display_name,
+        kind=kind,
+        owner_scope=owner_scope,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+        anyharness_bearer_token_ciphertext=anyharness_bearer_token_ciphertext,
+    )
+    db.add(target)
+    await db.flush()
+    return _target_snapshot(target)
+
+
+async def set_target_status(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    status_value: str,
+) -> None:
+    await db.execute(
+        update(CloudTarget).where(CloudTarget.id == target_id).values(status=status_value)
+    )
+
+
+async def set_target_anyharness_bearer_ciphertext(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    ciphertext: str,
+) -> None:
+    await db.execute(
+        update(CloudTarget)
+        .where(CloudTarget.id == target_id)
+        .values(anyharness_bearer_token_ciphertext=ciphertext)
+    )
+
+
+async def get_target_anyharness_bearer_ciphertext(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+) -> str | None:
+    return (
+        await db.execute(
+            select(CloudTarget.anyharness_bearer_token_ciphertext).where(
+                CloudTarget.id == target_id
+            )
+        )
+    ).scalar_one_or_none()

--- a/server/proliferate/db/store/cloud_sync/targets.py
+++ b/server/proliferate/db/store/cloud_sync/targets.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import and_, exists, or_, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -154,6 +155,35 @@ async def create_target(
     )
     db.add(target)
     await db.flush()
+    return _target_snapshot(target)
+
+
+async def create_single_active_personal_target(
+    db: AsyncSession,
+    *,
+    display_name: str,
+    kind: str,
+    owner_user_id: UUID,
+    anyharness_bearer_token_ciphertext: str,
+) -> CloudTargetSnapshot | None:
+    """Insert a personal target guarded by the one-active-row-per-user unique
+    index (uq_cloud_targets_personal_desktop_dispatch_active); returns None
+    when a concurrent enrollment already holds the slot."""
+    target = CloudTarget(
+        display_name=display_name,
+        kind=kind,
+        owner_scope="personal",
+        owner_user_id=owner_user_id,
+        organization_id=None,
+        created_by_user_id=owner_user_id,
+        anyharness_bearer_token_ciphertext=anyharness_bearer_token_ciphertext,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(target)
+            await db.flush()
+    except IntegrityError:
+        return None
     return _target_snapshot(target)
 
 

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -14,13 +14,16 @@ from proliferate.server.cloud.mcp_catalog.api import router as mcp_catalog_route
 from proliferate.server.cloud.repos.api import router as repos_router
 from proliferate.server.cloud.repositories.api import router as repositories_router
 from proliferate.server.cloud.secrets.api import router as secrets_router
+from proliferate.server.cloud.targets.api import router as targets_router
 from proliferate.server.cloud.webhooks.api import router as webhooks_router
 from proliferate.server.cloud.workspaces.api import router as workspaces_router
 from proliferate.server.cloud.worktree_policy.api import router as worktree_policy_router
 
-# Legacy cloud domains (commands, targets, claims, mobility, live sync,
-# runtime config, plugins, skills, slack) are parked: their tables were
-# removed in the model cleanup and their routers are intentionally unmounted.
+# Legacy cloud domains (commands, claims, mobility, live sync, runtime
+# config, plugins, skills, slack) are parked: their tables were removed in
+# the model cleanup and their routers are intentionally unmounted. Targets
+# returned as a minimal direct-runtime slice (enrollment + per-runtime
+# AnyHarness bearer); the worker plane stays parked.
 
 router = APIRouter(prefix="/cloud", tags=["cloud"])
 router.include_router(repos_router)
@@ -29,6 +32,7 @@ router.include_router(github_app_router)
 router.include_router(github_app_organization_router)
 router.include_router(secrets_router)
 router.include_router(cloud_sandboxes_router)
+router.include_router(targets_router)
 router.include_router(workspaces_router)
 router.include_router(worktree_policy_router)
 router.include_router(agent_gateway_router)

--- a/server/proliferate/server/cloud/targets/api.py
+++ b/server/proliferate/server/cloud/targets/api.py
@@ -1,4 +1,10 @@
-"""HTTP routes for cloud compute targets."""
+"""HTTP routes for cloud compute targets (minimal direct-runtime slice).
+
+Enrollment mints the per-runtime AnyHarness bearer; it surfaces exactly
+twice — in the enrollment response (once, for the Desktop installer flow)
+and via the owner-gated runtime-access endpoint (direct attach). List and
+detail payloads never carry it.
+"""
 
 from __future__ import annotations
 
@@ -12,27 +18,27 @@ from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.targets.models import (
-    ArchiveCloudTargetResponse,
     CloudTargetDetail,
     CloudTargetEnrollmentRequest,
     CloudTargetEnrollmentResponse,
     CloudTargetExistingEnrollmentRequest,
+    CloudTargetRuntimeAccessResponse,
     CloudTargetSummary,
     target_detail_payload,
     target_summary_payload,
 )
 from proliferate.server.cloud.targets.service import (
-    archive_target,
     create_target_enrollment,
     create_target_enrollment_for_existing_target,
     get_target_detail,
+    get_target_runtime_access,
     list_targets,
 )
 
 router = APIRouter(prefix="/targets", tags=["cloud-targets"])
 
 
-@router.post("/enrollments", response_model=CloudTargetEnrollmentResponse)
+@router.post("", response_model=CloudTargetEnrollmentResponse)
 async def create_target_enrollment_endpoint(
     body: CloudTargetEnrollmentRequest,
     db: AsyncSession = Depends(get_async_session),
@@ -84,14 +90,14 @@ async def get_target_endpoint(
     return target_detail_payload(value)
 
 
-@router.post("/{target_id}/archive", response_model=ArchiveCloudTargetResponse)
-async def archive_target_endpoint(
+@router.get("/{target_id}/runtime-access", response_model=CloudTargetRuntimeAccessResponse)
+async def get_target_runtime_access_endpoint(
     target_id: UUID,
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
-) -> ArchiveCloudTargetResponse:
+) -> CloudTargetRuntimeAccessResponse:
     try:
-        value = await archive_target(db, target_id=target_id, user=user)
+        bearer = await get_target_runtime_access(db, target_id=target_id, user_id=user.id)
     except CloudApiError as error:
         raise_cloud_error(error)
-    return ArchiveCloudTargetResponse(target=target_detail_payload(value))
+    return CloudTargetRuntimeAccessResponse(anyharness_bearer_token=bearer)

--- a/server/proliferate/server/cloud/targets/domain/rules.py
+++ b/server/proliferate/server/cloud/targets/domain/rules.py
@@ -9,7 +9,6 @@ from proliferate.constants.cloud import (
     CLOUD_TARGET_DEFAULT_ENROLLMENT_TTL_SECONDS,
     CLOUD_TARGET_MAX_ENROLLMENT_TTL_SECONDS,
     SUPPORTED_ENROLLABLE_CLOUD_TARGET_KINDS,
-    CloudTargetKind,
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.targets.domain.types import CloudTargetOwnerScope
@@ -78,27 +77,18 @@ def clamp_enrollment_ttl_seconds(value: int | None) -> int:
     return min(value, CLOUD_TARGET_MAX_ENROLLMENT_TTL_SECONDS)
 
 
-def default_workspace_root_for_kind(kind: str, supplied_root: str | None) -> str | None:
-    root = supplied_root.strip() if supplied_root is not None else ""
-    if root:
-        return root
-    if kind == CloudTargetKind.ssh.value:
-        return "~/proliferate-workspaces"
-    if kind == CloudTargetKind.desktop_dispatch.value:
-        return "~/Proliferate/workspaces"
-    return None
-
-
 def build_install_command(
     *,
     installer_url: str,
     cloud_base_url: str,
     enrollment_token: str,
+    anyharness_bearer_token: str,
     artifact_base_url: str | None,
 ) -> str:
     env_parts = [
         f"PROLIFERATE_CLOUD_URL={shlex.quote(cloud_base_url)}",
         f"PROLIFERATE_ENROLLMENT_TOKEN={shlex.quote(enrollment_token)}",
+        f"PROLIFERATE_ANYHARNESS_BEARER_TOKEN={shlex.quote(anyharness_bearer_token)}",
     ]
     if artifact_base_url:
         env_parts.append(f"PROLIFERATE_ARTIFACT_BASE_URL={shlex.quote(artifact_base_url)}")

--- a/server/proliferate/server/cloud/targets/models.py
+++ b/server/proliferate/server/cloud/targets/models.py
@@ -1,98 +1,28 @@
-"""Request and response models for cloud compute targets."""
+"""Request and response models for cloud compute targets.
+
+Minimal direct-runtime reintroduction: only the ownership/identity shape of
+the minimal ``cloud_targets`` registry is exposed. Inventory, worker status,
+and update-channel payloads return with the worker slice of the stack.
+
+The per-runtime AnyHarness bearer appears in exactly two payloads — the
+enrollment response (once, alongside the enrollment token, so it can reach
+the Desktop installer flow) and the runtime-access response (owner-gated
+direct attach). It must never be added to summary/detail payloads.
+"""
 
 from __future__ import annotations
 
-import json
 from datetime import datetime
-from typing import Literal, cast
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from proliferate.constants.cloud import CloudTargetUpdateChannel, CloudTargetUpdateStatus
-from proliferate.db.store.cloud_sync.targets import (
-    CloudTargetCurrentVersionsSnapshot,
-    CloudTargetInventorySnapshot,
-    CloudTargetSnapshot,
-    CloudTargetStatusSnapshot,
-)
+from proliferate.db.store.cloud_sync.targets import CloudTargetSnapshot
 
 
 def _to_iso(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
-
-
-def _parse_json(value: str | None) -> dict[str, object] | None:
-    if value is None:
-        return None
-    parsed = cast(object, json.loads(value))
-    return parsed if isinstance(parsed, dict) else {"value": parsed}
-
-
-class CloudTargetInventoryModel(BaseModel):
-    os: str | None = None
-    arch: str | None = None
-    distro: str | None = None
-    shell: str | None = None
-    git: dict[str, object] | None = None
-    node: dict[str, object] | None = None
-    python: dict[str, object] | None = None
-    browser: dict[str, object] | None = None
-    capabilities: dict[str, object] | None = None
-    providers: dict[str, object] | None = None
-    mcp: dict[str, object] | None = None
-    updated_at: str = Field(serialization_alias="updatedAt")
-
-
-class CloudTargetStatusModel(BaseModel):
-    status: str
-    status_detail: str | None = Field(default=None, serialization_alias="statusDetail")
-    last_seen_at: str | None = Field(default=None, serialization_alias="lastSeenAt")
-    last_heartbeat_at: str | None = Field(default=None, serialization_alias="lastHeartbeatAt")
-    updated_at: str | None = Field(default=None, serialization_alias="updatedAt")
-
-
-class CloudTargetDesiredVersionsModel(BaseModel):
-    anyharness_version: str | None = Field(
-        default=None,
-        serialization_alias="anyharnessVersion",
-    )
-    worker_version: str | None = Field(default=None, serialization_alias="workerVersion")
-    supervisor_version: str | None = Field(
-        default=None,
-        serialization_alias="supervisorVersion",
-    )
-
-
-class CloudTargetCurrentVersionsModel(BaseModel):
-    worker_id: str = Field(serialization_alias="workerId")
-    anyharness_version: str | None = Field(
-        default=None,
-        serialization_alias="anyharnessVersion",
-    )
-    worker_version: str | None = Field(default=None, serialization_alias="workerVersion")
-    supervisor_version: str | None = Field(
-        default=None,
-        serialization_alias="supervisorVersion",
-    )
-    reported_at: str | None = Field(default=None, serialization_alias="reportedAt")
-
-
-class CloudTargetUpdateModel(BaseModel):
-    channel: CloudTargetUpdateChannel
-    generation: int
-    desired_versions: CloudTargetDesiredVersionsModel = Field(
-        serialization_alias="desiredVersions",
-    )
-    current_versions: CloudTargetCurrentVersionsModel | None = Field(
-        default=None,
-        serialization_alias="currentVersions",
-    )
-    status: CloudTargetUpdateStatus | None = None
-    status_detail: str | None = Field(default=None, serialization_alias="statusDetail")
-    component: Literal["anyharness", "worker", "supervisor"] | None = None
-    version: str | None = None
-    reported_at: str | None = Field(default=None, serialization_alias="reportedAt")
 
 
 class CloudTargetSummary(BaseModel):
@@ -101,19 +31,7 @@ class CloudTargetSummary(BaseModel):
     kind: str
     status: str
     owner_scope: str = Field(serialization_alias="ownerScope")
-    sandbox_profile_id: str | None = Field(default=None, serialization_alias="sandboxProfileId")
-    profile_target_role: str = Field(serialization_alias="profileTargetRole")
     organization_id: str | None = Field(default=None, serialization_alias="organizationId")
-    default_workspace_root: str | None = Field(
-        default=None,
-        serialization_alias="defaultWorkspaceRoot",
-    )
-    inventory: CloudTargetInventoryModel | None = None
-    status_detail: CloudTargetStatusModel | None = Field(
-        default=None,
-        serialization_alias="statusDetail",
-    )
-    update: CloudTargetUpdateModel
     archived_at: str | None = Field(default=None, serialization_alias="archivedAt")
     created_at: str = Field(serialization_alias="createdAt")
     updated_at: str = Field(serialization_alias="updatedAt")
@@ -132,7 +50,6 @@ class CloudTargetEnrollmentRequest(BaseModel):
         alias="ownerScope",
     )
     organization_id: UUID | None = Field(default=None, alias="organizationId")
-    default_workspace_root: str | None = Field(default=None, alias="defaultWorkspaceRoot")
     ttl_seconds: int | None = Field(default=None, alias="ttlSeconds")
 
 
@@ -143,80 +60,14 @@ class CloudTargetExistingEnrollmentRequest(BaseModel):
 class CloudTargetEnrollmentResponse(BaseModel):
     target: CloudTargetDetail
     enrollment_token: str = Field(serialization_alias="enrollmentToken")
+    anyharness_bearer_token: str = Field(serialization_alias="anyharnessBearerToken")
     install_command: str = Field(serialization_alias="installCommand")
     artifact_base_url: str | None = Field(default=None, serialization_alias="artifactBaseUrl")
     expires_at: str = Field(serialization_alias="expiresAt")
 
 
-class ArchiveCloudTargetResponse(BaseModel):
-    target: CloudTargetDetail
-
-
-def inventory_payload(
-    value: CloudTargetInventorySnapshot | None,
-) -> CloudTargetInventoryModel | None:
-    if value is None:
-        return None
-    return CloudTargetInventoryModel(
-        os=value.os,
-        arch=value.arch,
-        distro=value.distro,
-        shell=value.shell,
-        git=_parse_json(value.git_json),
-        node=_parse_json(value.node_json),
-        python=_parse_json(value.python_json),
-        browser=_parse_json(value.browser_json),
-        capabilities=_parse_json(value.capabilities_json),
-        providers=_parse_json(value.providers_json),
-        mcp=_parse_json(value.mcp_json),
-        updated_at=_to_iso(value.updated_at),
-    )
-
-
-def status_payload(
-    value: CloudTargetStatusSnapshot | None,
-) -> CloudTargetStatusModel | None:
-    if value is None:
-        return None
-    return CloudTargetStatusModel(
-        status=value.status,
-        status_detail=value.status_detail,
-        last_seen_at=_to_iso(value.last_seen_at),
-        last_heartbeat_at=_to_iso(value.last_heartbeat_at),
-        updated_at=_to_iso(value.updated_at),
-    )
-
-
-def current_versions_payload(
-    value: CloudTargetCurrentVersionsSnapshot | None,
-) -> CloudTargetCurrentVersionsModel | None:
-    if value is None:
-        return None
-    return CloudTargetCurrentVersionsModel(
-        worker_id=str(value.worker_id),
-        anyharness_version=value.anyharness_version,
-        worker_version=value.worker_version,
-        supervisor_version=value.supervisor_version,
-        reported_at=_to_iso(value.reported_at),
-    )
-
-
-def update_payload(value: CloudTargetSnapshot) -> CloudTargetUpdateModel:
-    return CloudTargetUpdateModel(
-        channel=value.update_channel,
-        generation=value.update_generation,
-        desired_versions=CloudTargetDesiredVersionsModel(
-            anyharness_version=value.desired_anyharness_version,
-            worker_version=value.desired_worker_version,
-            supervisor_version=value.desired_supervisor_version,
-        ),
-        current_versions=current_versions_payload(value.current_versions),
-        status=value.update_status,
-        status_detail=value.update_status_detail,
-        component=value.update_component,
-        version=value.update_version,
-        reported_at=_to_iso(value.update_reported_at),
-    )
+class CloudTargetRuntimeAccessResponse(BaseModel):
+    anyharness_bearer_token: str = Field(serialization_alias="anyharnessBearerToken")
 
 
 def target_summary_payload(value: CloudTargetSnapshot) -> CloudTargetSummary:
@@ -226,13 +77,7 @@ def target_summary_payload(value: CloudTargetSnapshot) -> CloudTargetSummary:
         kind=value.kind,
         status=value.status,
         owner_scope=value.owner_scope,
-        sandbox_profile_id=str(value.sandbox_profile_id) if value.sandbox_profile_id else None,
-        profile_target_role=value.profile_target_role,
         organization_id=str(value.organization_id) if value.organization_id else None,
-        default_workspace_root=value.default_workspace_root,
-        inventory=inventory_payload(value.inventory),
-        status_detail=status_payload(value.status_record),
-        update=update_payload(value),
         archived_at=_to_iso(value.archived_at),
         created_at=_to_iso(value.created_at),
         updated_at=_to_iso(value.updated_at),

--- a/server/proliferate/server/cloud/targets/service.py
+++ b/server/proliferate/server/cloud/targets/service.py
@@ -1,9 +1,16 @@
-"""Application service for cloud compute targets."""
+"""Application service for cloud compute targets.
+
+Minimal direct-runtime reintroduction (ssh/personal-target design §3.3, §4):
+enrollment creates/refreshes a target row, mints the per-runtime AnyHarness
+bearer (stored as recoverable Fernet ciphertext on the row), and hands
+Desktop a self-contained install command. Worker-side redemption of the
+enrollment token (the ``/worker/enroll`` plane) is parked and returns with
+the worker slice of the stack; the token is minted here so the install
+command contract — and the installer's required env — stays stable.
+"""
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import secrets
 from datetime import timedelta
 from uuid import UUID
@@ -12,27 +19,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.authorization import ActorIdentity
 from proliferate.config import settings
-from proliferate.constants.cloud import (
-    CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN,
-    CloudTargetKind,
-    CloudTargetStatus,
-)
+from proliferate.constants.cloud import CloudTargetKind, CloudTargetStatus
 from proliferate.db.store import organizations as organizations_store
-from proliferate.db.store.cloud_sync import inventory as inventory_store
 from proliferate.db.store.cloud_sync import targets as targets_store
-from proliferate.db.store.cloud_sync import worker_auth as worker_auth_store
-from proliferate.db.store.cloud_sync import worker_control as worker_control_store
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.live.service import (
-    publish_target_patch_after_commit,
-    publish_worker_control_after_commit,
-)
-from proliferate.server.cloud.target_git_identity.service import require_user_github_auth
 from proliferate.server.cloud.targets.domain.policy import require_target_admin_membership
 from proliferate.server.cloud.targets.domain.rules import (
     build_install_command,
     clamp_enrollment_ttl_seconds,
-    default_workspace_root_for_kind,
     normalize_target_display_name,
     validate_enrollable_kind,
     validate_owner_scope,
@@ -43,15 +37,8 @@ from proliferate.server.cloud.targets.models import (
     CloudTargetExistingEnrollmentRequest,
     target_detail_payload,
 )
+from proliferate.utils.crypto import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
-
-
-def _hash_token(*, domain: str, token: str) -> str:
-    return hmac.new(
-        settings.cloud_secret_key.encode("utf-8"),
-        f"{domain}:{token}".encode(),
-        hashlib.sha256,
-    ).hexdigest()
 
 
 def _cloud_base_url() -> str:
@@ -66,43 +53,50 @@ def _cloud_base_url() -> str:
     return "http://localhost:8000"
 
 
-async def _create_enrollment_response_for_target(
-    db: AsyncSession,
+def _mint_anyharness_bearer() -> str:
+    # Same recipe as the managed-sandbox runtime token
+    # (runtime/provisioning/launch.py): urlsafe, 32 bytes of entropy.
+    return secrets.token_urlsafe(32)
+
+
+def _enrollment_response_for_target(
     *,
     target: targets_store.CloudTargetSnapshot,
-    user: ActorIdentity,
+    anyharness_bearer_token: str,
     ttl_seconds: int | None,
 ) -> CloudTargetEnrollmentResponse:
-    token = secrets.token_urlsafe(48)
+    enrollment_token = secrets.token_urlsafe(48)
     ttl = clamp_enrollment_ttl_seconds(ttl_seconds)
     expires_at = utcnow() + timedelta(seconds=ttl)
-    await worker_auth_store.create_enrollment(
-        db,
-        target_id=target.id,
-        token_hash=_hash_token(domain=CLOUD_TARGET_ENROLLMENT_TOKEN_DOMAIN, token=token),
-        created_by_user_id=user.id,
-        expires_at=expires_at,
-    )
     install_command = build_install_command(
         installer_url=settings.proliferate_target_installer_url,
         cloud_base_url=_cloud_base_url(),
-        enrollment_token=token,
+        enrollment_token=enrollment_token,
+        anyharness_bearer_token=anyharness_bearer_token,
         artifact_base_url=settings.proliferate_target_artifact_base_url or None,
     )
-    refreshed = await targets_store.get_target_by_id(db, target.id)
-    if refreshed is None:
-        raise CloudApiError(
-            "cloud_target_not_found",
-            "Target was not created.",
-            status_code=500,
-        )
     return CloudTargetEnrollmentResponse(
-        target=target_detail_payload(refreshed),
-        enrollment_token=token,
+        target=target_detail_payload(target),
+        enrollment_token=enrollment_token,
+        anyharness_bearer_token=anyharness_bearer_token,
         install_command=install_command,
         artifact_base_url=settings.proliferate_target_artifact_base_url or None,
         expires_at=expires_at.isoformat(),
     )
+
+
+async def _require_org_target_admin(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    user_id: UUID,
+) -> None:
+    membership = await organizations_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    require_target_admin_membership(membership)
 
 
 async def create_target_enrollment(
@@ -119,14 +113,9 @@ async def create_target_enrollment(
     display_name = normalize_target_display_name(body.display_name)
     organization_id = body.organization_id if owner_scope == "organization" else None
     if organization_id is not None:
-        membership = await organizations_store.get_active_membership(
-            db,
-            organization_id=organization_id,
-            user_id=user.id,
-        )
-        require_target_admin_membership(membership)
+        await _require_org_target_admin(db, organization_id=organization_id, user_id=user.id)
     owner_user_id = user.id if owner_scope == "personal" else None
-    await require_user_github_auth(db, user_id=user.id)
+    bearer = _mint_anyharness_bearer()
     target = None
     if kind == CloudTargetKind.desktop_dispatch.value and owner_scope == "personal":
         target = await targets_store.get_active_personal_target_by_kind(
@@ -143,15 +132,18 @@ async def create_target_enrollment(
             owner_user_id=owner_user_id,
             organization_id=organization_id,
             created_by_user_id=user.id,
-            default_workspace_root=default_workspace_root_for_kind(
-                kind,
-                body.default_workspace_root,
-            ),
+            anyharness_bearer_token_ciphertext=encrypt_text(bearer),
         )
-    return await _create_enrollment_response_for_target(
-        db,
+    else:
+        # Reusing an existing row is a re-install: rotate its bearer.
+        await targets_store.set_target_anyharness_bearer_ciphertext(
+            db,
+            target_id=target.id,
+            ciphertext=encrypt_text(bearer),
+        )
+    return _enrollment_response_for_target(
         target=target,
-        user=user,
+        anyharness_bearer_token=bearer,
         ttl_seconds=body.ttl_seconds,
     )
 
@@ -165,43 +157,35 @@ async def create_target_enrollment_for_existing_target(
 ) -> CloudTargetEnrollmentResponse:
     target = await get_target_detail(db, target_id=target_id, user_id=user.id)
     validate_enrollable_kind(target.kind)
-    if target.archived_at is not None or target.status == "archived":
+    if target.archived_at is not None or target.status == CloudTargetStatus.archived.value:
         raise CloudApiError(
             "cloud_target_archived",
             "Target is archived.",
             status_code=409,
         )
     if target.organization_id is not None:
-        membership = await organizations_store.get_active_membership(
+        await _require_org_target_admin(
             db,
             organization_id=target.organization_id,
             user_id=user.id,
         )
-        require_target_admin_membership(membership)
-    await require_user_github_auth(db, user_id=user.id)
-    now = utcnow()
-    await worker_auth_store.revoke_pending_enrollments_for_target(
+    # A re-enrollment is a re-install: the runtime gets a fresh identity, so
+    # the bearer rotates rather than resurfacing the old secret.
+    bearer = _mint_anyharness_bearer()
+    await targets_store.set_target_anyharness_bearer_ciphertext(
         db,
         target_id=target.id,
-        now=now,
-    )
-    await worker_auth_store.archive_workers_for_target(db, target_id=target.id, now=now)
-    await inventory_store.upsert_target_status(
-        db,
-        target_id=target.id,
-        worker_id=None,
-        status_value=CloudTargetStatus.enrolling.value,
-        status_detail="Waiting for worker re-enrollment.",
+        ciphertext=encrypt_text(bearer),
     )
     await targets_store.set_target_status(
         db,
         target_id=target.id,
         status_value=CloudTargetStatus.enrolling.value,
     )
-    return await _create_enrollment_response_for_target(
-        db,
-        target=target,
-        user=user,
+    refreshed = await get_target_detail(db, target_id=target.id, user_id=user.id)
+    return _enrollment_response_for_target(
+        target=refreshed,
+        anyharness_bearer_token=bearer,
         ttl_seconds=body.ttl_seconds,
     )
 
@@ -211,7 +195,7 @@ async def list_targets(
     *,
     user_id: UUID,
 ) -> list[targets_store.CloudTargetSnapshot]:
-    return list(await targets_store.list_visible_targets(db, user_id=user_id))
+    return await targets_store.list_visible_targets(db, user_id=user_id)
 
 
 async def get_target_detail(
@@ -234,37 +218,38 @@ async def get_target_detail(
     return target
 
 
-async def archive_target(
+async def get_target_runtime_access(
     db: AsyncSession,
     *,
     target_id: UUID,
-    user: ActorIdentity,
-) -> targets_store.CloudTargetSnapshot:
-    target = await get_target_detail(db, target_id=target_id, user_id=user.id)
-    if target.organization_id is not None:
-        membership = await organizations_store.get_active_membership(
-            db,
-            organization_id=target.organization_id,
-            user_id=user.id,
-        )
-        require_target_admin_membership(membership)
-    archived = await targets_store.archive_target(db, target_id=target.id)
-    if archived is None:
+    user_id: UUID,
+) -> str:
+    """Return the decrypted per-runtime bearer for direct attach.
+
+    Personal, caller-owned targets only: the bearer is raw access material
+    for a machine the user owns, so visibility (org membership) is not
+    enough. Foreign, org-scoped, and unknown ids all read as 404 to avoid
+    leaking target existence.
+    """
+    target = await targets_store.get_visible_target_by_id(
+        db,
+        target_id=target_id,
+        user_id=user_id,
+    )
+    if target is None or target.owner_scope != "personal" or target.owner_user_id != user_id:
         raise CloudApiError(
             "cloud_target_not_found",
             "Target not found.",
             status_code=404,
         )
-    await worker_auth_store.archive_workers_for_target(
+    ciphertext = await targets_store.get_target_anyharness_bearer_ciphertext(
         db,
         target_id=target.id,
-        now=utcnow(),
     )
-    await worker_control_store.bump_control_revision(db, target_id=target.id)
-    await publish_target_patch_after_commit(db, archived)
-    await publish_worker_control_after_commit(
-        db,
-        target_id=target.id,
-        reason="state_changed",
-    )
-    return archived
+    if ciphertext is None:
+        raise CloudApiError(
+            "cloud_target_runtime_access_unavailable",
+            "No runtime bearer has been minted for this target.",
+            status_code=404,
+        )
+    return decrypt_text(ciphertext)

--- a/server/proliferate/server/cloud/targets/service.py
+++ b/server/proliferate/server/cloud/targets/service.py
@@ -85,6 +85,32 @@ def _enrollment_response_for_target(
     )
 
 
+async def _rotate_target_for_reinstall(
+    db: AsyncSession,
+    *,
+    target_id: UUID,
+    user_id: UUID,
+) -> tuple[targets_store.CloudTargetSnapshot, str]:
+    """Re-enrollment of an existing row is a re-install: the runtime gets a
+    fresh identity, so the bearer rotates rather than resurfacing the old
+    secret, and the row returns to 'enrolling' until the new install
+    registers (the old bearer stops matching the running runtime the moment
+    it rotates, so the row must not keep claiming 'online')."""
+    bearer = _mint_anyharness_bearer()
+    await targets_store.set_target_anyharness_bearer_ciphertext(
+        db,
+        target_id=target_id,
+        ciphertext=encrypt_text(bearer),
+    )
+    await targets_store.set_target_status(
+        db,
+        target_id=target_id,
+        status_value=CloudTargetStatus.enrolling.value,
+    )
+    refreshed = await get_target_detail(db, target_id=target_id, user_id=user_id)
+    return refreshed, bearer
+
+
 async def _require_org_target_admin(
     db: AsyncSession,
     *,
@@ -115,15 +141,8 @@ async def create_target_enrollment(
     if organization_id is not None:
         await _require_org_target_admin(db, organization_id=organization_id, user_id=user.id)
     owner_user_id = user.id if owner_scope == "personal" else None
-    bearer = _mint_anyharness_bearer()
-    target = None
-    if kind == CloudTargetKind.desktop_dispatch.value and owner_scope == "personal":
-        target = await targets_store.get_active_personal_target_by_kind(
-            db,
-            owner_user_id=user.id,
-            kind=kind,
-        )
-    if target is None:
+    if kind != CloudTargetKind.desktop_dispatch.value or owner_scope != "personal":
+        bearer = _mint_anyharness_bearer()
         target = await targets_store.create_target(
             db,
             display_name=display_name,
@@ -134,13 +153,52 @@ async def create_target_enrollment(
             created_by_user_id=user.id,
             anyharness_bearer_token_ciphertext=encrypt_text(bearer),
         )
-    else:
-        # Reusing an existing row is a re-install: rotate its bearer.
-        await targets_store.set_target_anyharness_bearer_ciphertext(
-            db,
-            target_id=target.id,
-            ciphertext=encrypt_text(bearer),
+        return _enrollment_response_for_target(
+            target=target,
+            anyharness_bearer_token=bearer,
+            ttl_seconds=body.ttl_seconds,
         )
+    # Personal desktop_dispatch enrolls into the user's single active row,
+    # enforced by uq_cloud_targets_personal_desktop_dispatch_active: a lost
+    # insert race lands in the reuse branch instead of a duplicate row.
+    existing = await targets_store.get_active_personal_target_by_kind(
+        db,
+        owner_user_id=user.id,
+        kind=kind,
+    )
+    if existing is None:
+        bearer = _mint_anyharness_bearer()
+        created = await targets_store.create_single_active_personal_target(
+            db,
+            display_name=display_name,
+            kind=kind,
+            owner_user_id=user.id,
+            anyharness_bearer_token_ciphertext=encrypt_text(bearer),
+        )
+        if created is not None:
+            return _enrollment_response_for_target(
+                target=created,
+                anyharness_bearer_token=bearer,
+                ttl_seconds=body.ttl_seconds,
+            )
+        existing = await targets_store.get_active_personal_target_by_kind(
+            db,
+            owner_user_id=user.id,
+            kind=kind,
+        )
+    if existing is None:
+        # The concurrent winner's row vanished between the failed insert and
+        # the re-read; surface as retryable rather than looping.
+        raise CloudApiError(
+            "cloud_target_enrollment_conflict",
+            "A concurrent enrollment is in progress. Retry.",
+            status_code=409,
+        )
+    target, bearer = await _rotate_target_for_reinstall(
+        db,
+        target_id=existing.id,
+        user_id=user.id,
+    )
     return _enrollment_response_for_target(
         target=target,
         anyharness_bearer_token=bearer,
@@ -169,20 +227,11 @@ async def create_target_enrollment_for_existing_target(
             organization_id=target.organization_id,
             user_id=user.id,
         )
-    # A re-enrollment is a re-install: the runtime gets a fresh identity, so
-    # the bearer rotates rather than resurfacing the old secret.
-    bearer = _mint_anyharness_bearer()
-    await targets_store.set_target_anyharness_bearer_ciphertext(
+    refreshed, bearer = await _rotate_target_for_reinstall(
         db,
         target_id=target.id,
-        ciphertext=encrypt_text(bearer),
+        user_id=user.id,
     )
-    await targets_store.set_target_status(
-        db,
-        target_id=target.id,
-        status_value=CloudTargetStatus.enrolling.value,
-    )
-    refreshed = await get_target_detail(db, target_id=target.id, user_id=user.id)
     return _enrollment_response_for_target(
         target=refreshed,
         anyharness_bearer_token=bearer,

--- a/server/tests/integration/test_cloud_targets_api.py
+++ b/server/tests/integration/test_cloud_targets_api.py
@@ -1,0 +1,225 @@
+"""Integration tests: minimal cloud-targets slice with per-target bearer.
+
+Covers the ssh/personal-target design §3.3: the per-runtime AnyHarness
+bearer is minted at enrollment and stored as recoverable ciphertext, a
+re-enrollment rotates it, the install command carries it, the owner-gated
+runtime-access endpoint returns it (404 for foreign callers and unminted
+rows), and list/detail payloads never leak it.
+"""
+
+from __future__ import annotations
+
+import shlex
+import uuid
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.targets import CloudTarget
+from proliferate.utils.crypto import decrypt_text
+from tests.integration.test_agent_gateway_api import _authed_user
+
+_TARGETS = "/v1/cloud/targets"
+
+
+async def _enroll(
+    client: AsyncClient,
+    headers: dict[str, str],
+    *,
+    display_name: str = "ssh-box",
+    kind: str = "ssh",
+) -> Response:
+    return await client.post(
+        _TARGETS,
+        headers=headers,
+        json={"displayName": display_name, "kind": kind},
+    )
+
+
+async def _stored_ciphertext(db_session: AsyncSession, target_id: str) -> str | None:
+    row = (
+        await db_session.execute(select(CloudTarget).where(CloudTarget.id == uuid.UUID(target_id)))
+    ).scalar_one()
+    return row.anyharness_bearer_token_ciphertext
+
+
+def _iter_keys(value: object) -> list[str]:
+    keys: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            keys.append(str(key))
+            keys.extend(_iter_keys(child))
+    elif isinstance(value, list):
+        for child in value:
+            keys.extend(_iter_keys(child))
+    return keys
+
+
+class TestEnrollmentBearer:
+    @pytest.mark.asyncio
+    async def test_enroll_mints_encrypted_bearer(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        response = await _enroll(client, headers)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        bearer = body["anyharnessBearerToken"]
+        assert bearer
+        assert body["enrollmentToken"]
+        assert body["target"]["kind"] == "ssh"
+        assert body["target"]["status"] == "enrolling"
+
+        ciphertext = await _stored_ciphertext(db_session, body["target"]["id"])
+        assert ciphertext is not None
+        # Recoverable ciphertext, never the plaintext at rest.
+        assert bearer not in ciphertext
+        assert decrypt_text(ciphertext) == bearer
+
+    @pytest.mark.asyncio
+    async def test_install_command_carries_bearer_env(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        response = await _enroll(client, headers)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        install_command = body["installCommand"]
+        quoted_bearer = shlex.quote(body["anyharnessBearerToken"])
+        bearer_env = f"PROLIFERATE_ANYHARNESS_BEARER_TOKEN={quoted_bearer}"
+        token_env = f"PROLIFERATE_ENROLLMENT_TOKEN={shlex.quote(body['enrollmentToken'])}"
+        assert bearer_env in install_command
+        assert token_env in install_command
+        assert "PROLIFERATE_CLOUD_URL=" in install_command
+
+    @pytest.mark.asyncio
+    async def test_reenroll_rotates_bearer(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        first = await _enroll(client, headers)
+        assert first.status_code == 200, first.text
+        target_id = first.json()["target"]["id"]
+        first_bearer = first.json()["anyharnessBearerToken"]
+
+        second = await client.post(f"{_TARGETS}/{target_id}/enrollments", headers=headers)
+        assert second.status_code == 200, second.text
+        body = second.json()
+        second_bearer = body["anyharnessBearerToken"]
+        assert second_bearer
+        assert second_bearer != first_bearer
+        assert (
+            f"PROLIFERATE_ANYHARNESS_BEARER_TOKEN={shlex.quote(second_bearer)}"
+            in body["installCommand"]
+        )
+        assert body["target"]["status"] == "enrolling"
+
+        ciphertext = await _stored_ciphertext(db_session, target_id)
+        assert ciphertext is not None
+        assert decrypt_text(ciphertext) == second_bearer
+
+    @pytest.mark.asyncio
+    async def test_reenroll_foreign_target_is_404(self, client: AsyncClient) -> None:
+        _, owner_headers = await _authed_user(client)
+        enrolled = await _enroll(client, owner_headers)
+        target_id = enrolled.json()["target"]["id"]
+
+        _, other_headers = await _authed_user(client)
+        response = await client.post(
+            f"{_TARGETS}/{target_id}/enrollments",
+            headers=other_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "cloud_target_not_found"
+
+
+class TestRuntimeAccess:
+    @pytest.mark.asyncio
+    async def test_owner_reads_bearer(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        enrolled = await _enroll(client, headers)
+        assert enrolled.status_code == 200, enrolled.text
+        target_id = enrolled.json()["target"]["id"]
+        bearer = enrolled.json()["anyharnessBearerToken"]
+
+        response = await client.get(f"{_TARGETS}/{target_id}/runtime-access", headers=headers)
+        assert response.status_code == 200, response.text
+        assert response.json() == {"anyharnessBearerToken": bearer}
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_404(self, client: AsyncClient) -> None:
+        _, owner_headers = await _authed_user(client)
+        enrolled = await _enroll(client, owner_headers)
+        target_id = enrolled.json()["target"]["id"]
+
+        _, other_headers = await _authed_user(client)
+        response = await client.get(
+            f"{_TARGETS}/{target_id}/runtime-access",
+            headers=other_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "cloud_target_not_found"
+
+    @pytest.mark.asyncio
+    async def test_unknown_target_is_404(self, client: AsyncClient) -> None:
+        _, headers = await _authed_user(client)
+        response = await client.get(
+            f"{_TARGETS}/{uuid.uuid4()}/runtime-access",
+            headers=headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "cloud_target_not_found"
+
+    @pytest.mark.asyncio
+    async def test_unminted_bearer_is_404(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        user_id, headers = await _authed_user(client)
+        target = CloudTarget(
+            display_name="pre-bearer-box",
+            kind="ssh",
+            status="online",
+            owner_scope="personal",
+            owner_user_id=uuid.UUID(user_id),
+            created_by_user_id=uuid.UUID(user_id),
+        )
+        db_session.add(target)
+        await db_session.commit()
+
+        response = await client.get(f"{_TARGETS}/{target.id}/runtime-access", headers=headers)
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "cloud_target_runtime_access_unavailable"
+
+
+class TestNoBearerLeakage:
+    @pytest.mark.asyncio
+    async def test_list_and_detail_never_carry_the_bearer(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        enrolled = await _enroll(client, headers)
+        assert enrolled.status_code == 200, enrolled.text
+        target_id = enrolled.json()["target"]["id"]
+        bearer = enrolled.json()["anyharnessBearerToken"]
+
+        listed = await client.get(_TARGETS, headers=headers)
+        assert listed.status_code == 200
+        detail = await client.get(f"{_TARGETS}/{target_id}", headers=headers)
+        assert detail.status_code == 200
+        assert [entry["id"] for entry in listed.json()] == [target_id]
+
+        for response in (listed, detail):
+            assert bearer not in response.text
+            for key in _iter_keys(response.json()):
+                for fragment in ("token", "bearer", "ciphertext"):
+                    assert fragment not in key.lower(), f"response leaks field {key}"

--- a/server/tests/integration/test_cloud_targets_api.py
+++ b/server/tests/integration/test_cloud_targets_api.py
@@ -14,10 +14,12 @@ import uuid
 
 import pytest
 from httpx import AsyncClient, Response
-from sqlalchemy import select
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.cloud.targets import CloudTarget
+from proliferate.db.store.cloud_sync import targets as targets_store
 from proliferate.utils.crypto import decrypt_text
 from tests.integration.test_agent_gateway_api import _authed_user
 
@@ -124,6 +126,104 @@ class TestEnrollmentBearer:
         ciphertext = await _stored_ciphertext(db_session, target_id)
         assert ciphertext is not None
         assert decrypt_text(ciphertext) == second_bearer
+
+    @pytest.mark.asyncio
+    async def test_repeat_dispatch_enroll_reuses_row_rotates_and_marks_enrolling(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        first = await _enroll(client, headers, display_name="this-mac", kind="desktop_dispatch")
+        assert first.status_code == 200, first.text
+        target_id = first.json()["target"]["id"]
+        first_bearer = first.json()["anyharnessBearerToken"]
+
+        # Simulate the completed install so the reused row reads online.
+        await db_session.execute(
+            update(CloudTarget)
+            .where(CloudTarget.id == uuid.UUID(target_id))
+            .values(status="online")
+        )
+        await db_session.commit()
+
+        second = await _enroll(client, headers, display_name="this-mac", kind="desktop_dispatch")
+        assert second.status_code == 200, second.text
+        body = second.json()
+        # Same row reused, but the response reflects the post-rotation state:
+        # back to enrolling until the re-install registers.
+        assert body["target"]["id"] == target_id
+        assert body["target"]["status"] == "enrolling"
+        second_bearer = body["anyharnessBearerToken"]
+        assert second_bearer != first_bearer
+
+        ciphertext = await _stored_ciphertext(db_session, target_id)
+        assert ciphertext is not None
+        assert decrypt_text(ciphertext) == second_bearer
+
+    @pytest.mark.asyncio
+    async def test_duplicate_active_personal_dispatch_rows_rejected_by_db(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        user_id, _ = await _authed_user(client)
+
+        def dispatch_row() -> CloudTarget:
+            return CloudTarget(
+                display_name="this-mac",
+                kind="desktop_dispatch",
+                status="online",
+                owner_scope="personal",
+                owner_user_id=uuid.UUID(user_id),
+                created_by_user_id=uuid.UUID(user_id),
+            )
+
+        db_session.add(dispatch_row())
+        await db_session.commit()
+
+        db_session.add(dispatch_row())
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+        await db_session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_lost_dispatch_insert_race_lands_in_reuse_branch(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _, headers = await _authed_user(client)
+        first = await _enroll(client, headers, display_name="this-mac", kind="desktop_dispatch")
+        assert first.status_code == 200, first.text
+        target_id = first.json()["target"]["id"]
+        first_bearer = first.json()["anyharnessBearerToken"]
+
+        # Simulate losing the check-then-insert race: the pre-insert read
+        # misses the concurrent winner's committed row, so the insert hits
+        # the unique index and the service must recover into the reuse path.
+        real_lookup = targets_store.get_active_personal_target_by_kind
+        reads = {"count": 0}
+
+        async def lose_first_read(db, *, owner_user_id, kind):  # type: ignore[no-untyped-def]
+            reads["count"] += 1
+            if reads["count"] == 1:
+                return None
+            return await real_lookup(db, owner_user_id=owner_user_id, kind=kind)
+
+        monkeypatch.setattr(
+            targets_store,
+            "get_active_personal_target_by_kind",
+            lose_first_read,
+        )
+
+        second = await _enroll(client, headers, display_name="this-mac", kind="desktop_dispatch")
+        assert second.status_code == 200, second.text
+        body = second.json()
+        assert body["target"]["id"] == target_id
+        assert body["target"]["status"] == "enrolling"
+        assert body["anyharnessBearerToken"] != first_bearer
+        assert reads["count"] >= 2
 
     @pytest.mark.asyncio
     async def test_reenroll_foreign_target_is_404(self, client: AsyncClient) -> None:


### PR DESCRIPTION
Mints a per-target AnyHarness bearer at enrollment (design §3.3), stored encrypted at rest with the recoverable-ciphertext pattern, and revives the targets domain as a minimal mounted slice: enroll mints the bearer, re-enroll rotates it, and a new `GET /v1/cloud/targets/{id}/runtime-access` returns it for caller-owned personal targets only. `build_install_command` now emits `PROLIFERATE_ANYHARNESS_BEARER_TOKEN` and store snapshots exclude the ciphertext so list/detail payloads cannot leak it. Review fixes close a check-then-insert enrollment race with a partial unique index and make the reuse branch rotate + flip status like re-enrollment.

Stack: 2/6 — 16-gateway-target-scoping → 17-target-bearer → 18-runtime-bearer-enforcement → 19-direct-runtime-core → 20-direct-auth-sync → 21-direct-runtime-ui

Design: `specs/tbd/ssh-personal-target-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
