### PR TITLE
fix(agent-auth): review fixes for runtime-bearer-enforcement

### DIFF
--- a/anyharness/crates/proliferate-supervisor/src/config.rs
+++ b/anyharness/crates/proliferate-supervisor/src/config.rs
@@ -50,3 +50,58 @@ fn dirs_fallback_home() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SupervisorConfig;
+
+    #[test]
+    fn parses_installer_config_with_bearer_enforcement() {
+        // Mirrors what install/proliferate-target-install.sh writes when
+        // PROLIFERATE_ANYHARNESS_BEARER_TOKEN is set.
+        let config: SupervisorConfig = toml::from_str(
+            r#"
+anyharness_binary = "/home/user/.proliferate/bin/anyharness"
+worker_binary = "/home/user/.proliferate/bin/proliferate-worker"
+worker_config = "/home/user/.proliferate/worker/config.toml"
+anyharness_args = ["serve", "--runtime-home", "/home/user/.proliferate/anyharness", "--port", "8457", "--require-bearer-auth"]
+restart_delay_seconds = 5
+
+[anyharness_env]
+ANYHARNESS_BEARER_TOKEN = "runtime-bearer"
+"#,
+        )
+        .expect("installer-shaped config parses");
+
+        assert!(config
+            .anyharness_args
+            .iter()
+            .any(|arg| arg == "--require-bearer-auth"));
+        assert_eq!(
+            config.anyharness_env.get("ANYHARNESS_BEARER_TOKEN"),
+            Some(&"runtime-bearer".to_string())
+        );
+        assert!(config.process_env.is_empty());
+        assert_eq!(config.restart_delay_seconds, 5);
+    }
+
+    #[test]
+    fn parses_installer_config_without_bearer() {
+        let config: SupervisorConfig = toml::from_str(
+            r#"
+anyharness_binary = "/home/user/.proliferate/bin/anyharness"
+worker_binary = "/home/user/.proliferate/bin/proliferate-worker"
+worker_config = "/home/user/.proliferate/worker/config.toml"
+anyharness_args = ["serve", "--runtime-home", "/home/user/.proliferate/anyharness", "--port", "8457"]
+restart_delay_seconds = 5
+"#,
+        )
+        .expect("installer-shaped config parses");
+
+        assert!(!config
+            .anyharness_args
+            .iter()
+            .any(|arg| arg == "--require-bearer-auth"));
+        assert!(config.anyharness_env.is_empty());
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod keychain;
 pub mod process;
 pub mod runtime;
 pub mod shell;
+pub mod ssh_common;
 pub mod ssh_install;
 pub mod ssh_tunnel;
 pub mod support;

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod keychain;
 pub mod process;
 pub mod runtime;
 pub mod shell;
+pub mod ssh_install;
 pub mod ssh_tunnel;
 pub mod support;
 pub mod window_chrome;

--- a/apps/desktop/src-tauri/src/commands/ssh_common.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_common.rs
@@ -1,0 +1,192 @@
+//! SSH plumbing shared by the tunnel and installer commands: connection
+//! parsing, common ssh(1) options, and child-process output collection with
+//! secret redaction.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const DEFAULT_SSH_PORT: u16 = 22;
+pub(crate) const DEFAULT_ANYHARNESS_PORT: u16 = 8457;
+const SSH_CONNECT_TIMEOUT_SECONDS: u16 = 12;
+
+#[derive(Debug)]
+pub(crate) struct SshConnection {
+    pub(crate) ssh_host: String,
+    pub(crate) ssh_user: String,
+    pub(crate) ssh_port: u16,
+    pub(crate) identity_file: Option<PathBuf>,
+}
+
+pub(crate) struct CommandOutput {
+    pub(crate) status: ExitStatus,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+pub(crate) fn parse_ssh_connection(
+    ssh_host: String,
+    ssh_user: String,
+    ssh_port: Option<u16>,
+    identity_file: Option<String>,
+) -> Result<SshConnection, String> {
+    let ssh_host = ssh_host.trim().to_string();
+    let ssh_user = ssh_user.trim().to_string();
+    if ssh_host.is_empty() || ssh_user.is_empty() {
+        return Err("SSH host and user are required.".to_string());
+    }
+    let identity_file = identity_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(expand_home_path)
+        .transpose()?;
+    Ok(SshConnection {
+        ssh_host,
+        ssh_user,
+        ssh_port: normalize_port(ssh_port, DEFAULT_SSH_PORT, "SSH port")?,
+        identity_file,
+    })
+}
+
+pub(crate) fn normalize_port(
+    value: Option<u16>,
+    fallback: u16,
+    label: &str,
+) -> Result<u16, String> {
+    match value {
+        Some(0) => Err(format!("{label} must be between 1 and 65535.")),
+        Some(port) => Ok(port),
+        None => Ok(fallback),
+    }
+}
+
+pub(crate) fn append_common_ssh_options(command: &mut Command, connection: &SshConnection) {
+    command
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("StrictHostKeyChecking=accept-new")
+        .arg("-o")
+        .arg(format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECONDS}"))
+        .arg("-o")
+        .arg("ServerAliveInterval=30")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3")
+        .arg("-p")
+        .arg(connection.ssh_port.to_string());
+
+    if let Some(identity_file) = &connection.identity_file {
+        command.arg("-i").arg(identity_file);
+    }
+}
+
+pub(crate) fn ssh_destination(connection: &SshConnection) -> String {
+    format!("{}@{}", connection.ssh_user, connection.ssh_host)
+}
+
+pub(crate) fn wait_for_child_output(
+    mut child: Child,
+    timeout: Duration,
+    context: &str,
+    tokens: &[&str],
+) -> Result<CommandOutput, String> {
+    let stdout_reader = spawn_reader(child.stdout.take());
+    let stderr_reader = spawn_reader(child.stderr.take());
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = stdout_reader.join().unwrap_or_default();
+                let stderr = stderr_reader.join().unwrap_or_default();
+                return Ok(CommandOutput {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = stdout_reader.join().unwrap_or_default();
+                let stderr = stderr_reader.join().unwrap_or_default();
+                let detail = command_output_error(context, &stdout, &stderr, tokens);
+                return Err(format!(
+                    "{context} timed out after {}s: {detail}",
+                    timeout.as_secs()
+                ));
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(100)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(format!("Failed to wait for {context}: {error}"));
+            }
+        }
+    }
+}
+
+fn spawn_reader<R>(reader: Option<R>) -> thread::JoinHandle<String>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let Some(mut reader) = reader else {
+            return String::new();
+        };
+        let mut output = String::new();
+        let _ = reader.read_to_string(&mut output);
+        output
+    })
+}
+
+pub(crate) fn redact_tokens(value: String, tokens: &[&str]) -> String {
+    tokens.iter().fold(value, |redacted, token| {
+        redacted.replace(token, "[redacted]")
+    })
+}
+
+pub(crate) fn command_output_error(
+    prefix: &str,
+    stdout: &str,
+    stderr: &str,
+    tokens: &[&str],
+) -> String {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+    let mut detail = String::new();
+    if !stderr.is_empty() {
+        detail.push_str(stderr);
+    }
+    if !stdout.is_empty() {
+        if !detail.is_empty() {
+            detail.push_str("\n\n");
+        }
+        detail.push_str(stdout);
+    }
+    detail = redact_tokens(detail, tokens);
+    if detail.is_empty() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}: {detail}")
+    }
+}
+
+fn expand_home_path(path: &str) -> Result<PathBuf, String> {
+    if path == "~" {
+        return std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME is not set.".to_string());
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| "HOME is not set.".to_string())?;
+        return Ok(home.join(rest));
+    }
+    Ok(PathBuf::from(path))
+}

--- a/apps/desktop/src-tauri/src/commands/ssh_install.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_install.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use super::ssh_tunnel::{
+use super::ssh_common::{
     append_common_ssh_options, command_output_error, normalize_port, parse_ssh_connection,
     redact_tokens, ssh_destination, wait_for_child_output, DEFAULT_ANYHARNESS_PORT,
 };

--- a/apps/desktop/src-tauri/src/commands/ssh_install.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_install.rs
@@ -1,0 +1,249 @@
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use super::ssh_tunnel::{
+    append_common_ssh_options, command_output_error, normalize_port, parse_ssh_connection,
+    redact_tokens, ssh_destination, wait_for_child_output, DEFAULT_ANYHARNESS_PORT,
+};
+
+const INSTALLER_SCRIPT: &str = include_str!("../../../../../install/proliferate-target-install.sh");
+const SSH_INSTALL_TIMEOUT: Duration = Duration::from_secs(600);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallSshTargetRuntimeInput {
+    ssh_host: String,
+    ssh_user: String,
+    ssh_port: Option<u16>,
+    identity_file: Option<String>,
+    remote_anyharness_port: Option<u16>,
+    cloud_base_url: String,
+    enrollment_token: String,
+    anyharness_bearer_token: Option<String>,
+    artifact_base_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallSshTargetRuntimeResult {
+    stdout: String,
+    stderr: String,
+}
+
+#[tauri::command]
+pub async fn install_ssh_target_runtime(
+    input: InstallSshTargetRuntimeInput,
+) -> Result<InstallSshTargetRuntimeResult, String> {
+    let cloud_base_url = input
+        .cloud_base_url
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    let enrollment_token = input.enrollment_token.trim().to_string();
+    if cloud_base_url.is_empty() {
+        return Err("Cloud base URL is required.".to_string());
+    }
+    if enrollment_token.is_empty() {
+        return Err("Enrollment token is required.".to_string());
+    }
+    let anyharness_bearer_token = input
+        .anyharness_bearer_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let artifact_base_url = input
+        .artifact_base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let remote_anyharness_port = normalize_port(
+        input.remote_anyharness_port,
+        DEFAULT_ANYHARNESS_PORT,
+        "Remote AnyHarness port",
+    )?;
+    let connection = parse_ssh_connection(
+        input.ssh_host,
+        input.ssh_user,
+        input.ssh_port,
+        input.identity_file,
+    )?;
+
+    tokio::task::spawn_blocking(move || {
+        let mut command = Command::new("ssh");
+        append_common_ssh_options(&mut command, &connection);
+        command
+            .arg("--")
+            .arg(ssh_destination(&connection))
+            .arg("sh")
+            .arg("-s")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("Failed to start SSH installer: {error}"))?;
+
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| "Failed to open SSH installer stdin.".to_string())?;
+            let payload = installer_payload(
+                &cloud_base_url,
+                &enrollment_token,
+                anyharness_bearer_token.as_deref(),
+                artifact_base_url.as_deref(),
+                remote_anyharness_port,
+            );
+            stdin
+                .write_all(payload.as_bytes())
+                .map_err(|error| format!("Failed to stream installer over SSH: {error}"))?;
+        }
+
+        let mut secret_tokens: Vec<&str> = vec![&enrollment_token];
+        if let Some(bearer) = anyharness_bearer_token.as_deref() {
+            secret_tokens.push(bearer);
+        }
+        let output =
+            wait_for_child_output(child, SSH_INSTALL_TIMEOUT, "SSH installer", &secret_tokens)?;
+        let stdout = redact_tokens(output.stdout, &secret_tokens);
+        let stderr = redact_tokens(output.stderr, &secret_tokens);
+        if output.status.success() {
+            Ok(InstallSshTargetRuntimeResult { stdout, stderr })
+        } else {
+            Err(command_output_error(
+                "SSH installer failed",
+                &stdout,
+                &stderr,
+                &secret_tokens,
+            ))
+        }
+    })
+    .await
+    .map_err(|error| format!("SSH installer task failed: {error}"))?
+}
+
+fn installer_payload(
+    cloud_base_url: &str,
+    enrollment_token: &str,
+    anyharness_bearer_token: Option<&str>,
+    artifact_base_url: Option<&str>,
+    remote_anyharness_port: u16,
+) -> String {
+    let mut payload = String::new();
+    payload.push_str("set -eu\n");
+    payload.push_str(&format!(
+        "PROLIFERATE_CLOUD_URL={}\n",
+        shell_quote(cloud_base_url),
+    ));
+    payload.push_str(&format!(
+        "PROLIFERATE_ENROLLMENT_TOKEN={}\n",
+        shell_quote(enrollment_token),
+    ));
+    if let Some(anyharness_bearer_token) = anyharness_bearer_token {
+        payload.push_str(&format!(
+            "PROLIFERATE_ANYHARNESS_BEARER_TOKEN={}\n",
+            shell_quote(anyharness_bearer_token),
+        ));
+    }
+    payload.push_str(&format!(
+        "PROLIFERATE_ANYHARNESS_PORT={}\n",
+        shell_quote(&remote_anyharness_port.to_string()),
+    ));
+    payload.push_str(&format!(
+        "PROLIFERATE_ANYHARNESS_BASE_URL={}\n",
+        shell_quote(&format!("http://127.0.0.1:{remote_anyharness_port}")),
+    ));
+    if let Some(artifact_base_url) = artifact_base_url {
+        payload.push_str(&format!(
+            "PROLIFERATE_ARTIFACT_BASE_URL={}\n",
+            shell_quote(artifact_base_url),
+        ));
+    }
+    payload.push('\n');
+    payload.push_str(INSTALLER_SCRIPT);
+    payload.push('\n');
+    payload
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{command_output_error, installer_payload, redact_tokens, INSTALLER_SCRIPT};
+
+    fn env_prelude(payload: &str) -> &str {
+        payload
+            .split(INSTALLER_SCRIPT)
+            .next()
+            .expect("payload embeds the installer script")
+    }
+
+    #[test]
+    fn installer_payload_includes_bearer_env_when_present() {
+        let payload = installer_payload(
+            "https://api.example.com",
+            "enroll-token",
+            Some("runtime-bearer"),
+            Some("https://artifacts.example.com/releases"),
+            18457,
+        );
+        assert!(payload.contains("PROLIFERATE_CLOUD_URL='https://api.example.com'\n"));
+        assert!(payload.contains("PROLIFERATE_ENROLLMENT_TOKEN='enroll-token'\n"));
+        assert!(payload.contains("PROLIFERATE_ANYHARNESS_BEARER_TOKEN='runtime-bearer'\n"));
+        assert!(payload.contains("PROLIFERATE_ANYHARNESS_PORT='18457'\n"));
+        assert!(payload.contains("PROLIFERATE_ANYHARNESS_BASE_URL='http://127.0.0.1:18457'\n"));
+        assert!(payload
+            .contains("PROLIFERATE_ARTIFACT_BASE_URL='https://artifacts.example.com/releases'\n"));
+    }
+
+    #[test]
+    fn installer_payload_omits_bearer_env_when_absent() {
+        let payload =
+            installer_payload("https://api.example.com", "enroll-token", None, None, 8457);
+        let prelude = env_prelude(&payload);
+        assert!(!prelude.contains("PROLIFERATE_ANYHARNESS_BEARER_TOKEN"));
+        assert!(!prelude.contains("PROLIFERATE_ARTIFACT_BASE_URL"));
+    }
+
+    #[test]
+    fn installer_payload_shell_quotes_bearer() {
+        let payload = installer_payload(
+            "https://api.example.com",
+            "enroll-token",
+            Some("bear'er"),
+            None,
+            8457,
+        );
+        assert!(payload.contains("PROLIFERATE_ANYHARNESS_BEARER_TOKEN='bear'\"'\"'er'\n"));
+    }
+
+    #[test]
+    fn redact_tokens_scrubs_every_secret() {
+        let redacted = redact_tokens(
+            "token=enroll-token bearer=runtime-bearer".to_string(),
+            &["enroll-token", "runtime-bearer"],
+        );
+        assert_eq!(redacted, "token=[redacted] bearer=[redacted]");
+    }
+
+    #[test]
+    fn command_output_error_redacts_secrets_in_detail() {
+        let error = command_output_error(
+            "SSH installer failed",
+            "stdout mentions enroll-token",
+            "stderr mentions runtime-bearer",
+            &["enroll-token", "runtime-bearer"],
+        );
+        assert!(!error.contains("enroll-token"));
+        assert!(!error.contains("runtime-bearer"));
+        assert!(error.contains("[redacted]"));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -9,12 +9,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tauri::State;
 
-const INSTALLER_SCRIPT: &str = include_str!("../../../../../install/proliferate-target-install.sh");
 const DEFAULT_SSH_PORT: u16 = 22;
-const DEFAULT_ANYHARNESS_PORT: u16 = 8457;
+pub(crate) const DEFAULT_ANYHARNESS_PORT: u16 = 8457;
 const SSH_CONNECT_TIMEOUT_SECONDS: u16 = 12;
 const SSH_PROBE_TIMEOUT: Duration = Duration::from_secs(25);
-const SSH_INSTALL_TIMEOUT: Duration = Duration::from_secs(600);
 const TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(12);
 const TUNNEL_READY_POLL: Duration = Duration::from_millis(150);
 const TUNNEL_HEALTH_REQUEST_TIMEOUT: Duration = Duration::from_millis(900);
@@ -77,26 +75,6 @@ pub struct ProbeSshTargetConnectionResult {
     ok: bool,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallSshTargetRuntimeInput {
-    ssh_host: String,
-    ssh_user: String,
-    ssh_port: Option<u16>,
-    identity_file: Option<String>,
-    remote_anyharness_port: Option<u16>,
-    cloud_base_url: String,
-    enrollment_token: String,
-    artifact_base_url: Option<String>,
-}
-
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallSshTargetRuntimeResult {
-    stdout: String,
-    stderr: String,
-}
-
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EnsureSshAnyHarnessTunnelResult {
@@ -105,17 +83,17 @@ pub struct EnsureSshAnyHarnessTunnelResult {
 }
 
 #[derive(Debug)]
-struct SshConnection {
+pub(crate) struct SshConnection {
     ssh_host: String,
     ssh_user: String,
     ssh_port: u16,
     identity_file: Option<PathBuf>,
 }
 
-struct CommandOutput {
-    status: ExitStatus,
-    stdout: String,
-    stderr: String,
+pub(crate) struct CommandOutput {
+    pub(crate) status: ExitStatus,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
 }
 
 #[tauri::command]
@@ -146,101 +124,12 @@ pub async fn probe_ssh_target_connection(
                 "SSH probe failed",
                 &output.stdout,
                 &output.stderr,
-                None,
+                &[],
             ))
         }
     })
     .await
     .map_err(|error| format!("SSH probe task failed: {error}"))?
-}
-
-#[tauri::command]
-pub async fn install_ssh_target_runtime(
-    input: InstallSshTargetRuntimeInput,
-) -> Result<InstallSshTargetRuntimeResult, String> {
-    let cloud_base_url = input
-        .cloud_base_url
-        .trim()
-        .trim_end_matches('/')
-        .to_string();
-    let enrollment_token = input.enrollment_token.trim().to_string();
-    if cloud_base_url.is_empty() {
-        return Err("Cloud base URL is required.".to_string());
-    }
-    if enrollment_token.is_empty() {
-        return Err("Enrollment token is required.".to_string());
-    }
-    let artifact_base_url = input
-        .artifact_base_url
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
-    let remote_anyharness_port = normalize_port(
-        input.remote_anyharness_port,
-        DEFAULT_ANYHARNESS_PORT,
-        "Remote AnyHarness port",
-    )?;
-    let connection = parse_ssh_connection(
-        input.ssh_host,
-        input.ssh_user,
-        input.ssh_port,
-        input.identity_file,
-    )?;
-
-    tokio::task::spawn_blocking(move || {
-        let mut command = Command::new("ssh");
-        append_common_ssh_options(&mut command, &connection);
-        command
-            .arg("--")
-            .arg(ssh_destination(&connection))
-            .arg("sh")
-            .arg("-s")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = command
-            .spawn()
-            .map_err(|error| format!("Failed to start SSH installer: {error}"))?;
-
-        {
-            let mut stdin = child
-                .stdin
-                .take()
-                .ok_or_else(|| "Failed to open SSH installer stdin.".to_string())?;
-            let payload = installer_payload(
-                &cloud_base_url,
-                &enrollment_token,
-                artifact_base_url.as_deref(),
-                remote_anyharness_port,
-            );
-            stdin
-                .write_all(payload.as_bytes())
-                .map_err(|error| format!("Failed to stream installer over SSH: {error}"))?;
-        }
-
-        let output = wait_for_child_output(
-            child,
-            SSH_INSTALL_TIMEOUT,
-            "SSH installer",
-            Some(&enrollment_token),
-        )?;
-        let stdout = redact_token(output.stdout, &enrollment_token);
-        let stderr = redact_token(output.stderr, &enrollment_token);
-        if output.status.success() {
-            Ok(InstallSshTargetRuntimeResult { stdout, stderr })
-        } else {
-            Err(command_output_error(
-                "SSH installer failed",
-                &stdout,
-                &stderr,
-                Some(&enrollment_token),
-            ))
-        }
-    })
-    .await
-    .map_err(|error| format!("SSH installer task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -496,7 +385,7 @@ fn allocate_local_port() -> Result<u16, String> {
         .map_err(|error| format!("Failed to read local tunnel port: {error}"))
 }
 
-fn parse_ssh_connection(
+pub(crate) fn parse_ssh_connection(
     ssh_host: String,
     ssh_user: String,
     ssh_port: Option<u16>,
@@ -521,7 +410,11 @@ fn parse_ssh_connection(
     })
 }
 
-fn normalize_port(value: Option<u16>, fallback: u16, label: &str) -> Result<u16, String> {
+pub(crate) fn normalize_port(
+    value: Option<u16>,
+    fallback: u16,
+    label: &str,
+) -> Result<u16, String> {
     match value {
         Some(0) => Err(format!("{label} must be between 1 and 65535.")),
         Some(port) => Ok(port),
@@ -529,7 +422,7 @@ fn normalize_port(value: Option<u16>, fallback: u16, label: &str) -> Result<u16,
     }
 }
 
-fn append_common_ssh_options(command: &mut Command, connection: &SshConnection) {
+pub(crate) fn append_common_ssh_options(command: &mut Command, connection: &SshConnection) {
     command
         .arg("-o")
         .arg("BatchMode=yes")
@@ -549,48 +442,8 @@ fn append_common_ssh_options(command: &mut Command, connection: &SshConnection) 
     }
 }
 
-fn ssh_destination(connection: &SshConnection) -> String {
+pub(crate) fn ssh_destination(connection: &SshConnection) -> String {
     format!("{}@{}", connection.ssh_user, connection.ssh_host)
-}
-
-fn installer_payload(
-    cloud_base_url: &str,
-    enrollment_token: &str,
-    artifact_base_url: Option<&str>,
-    remote_anyharness_port: u16,
-) -> String {
-    let mut payload = String::new();
-    payload.push_str("set -eu\n");
-    payload.push_str(&format!(
-        "PROLIFERATE_CLOUD_URL={}\n",
-        shell_quote(cloud_base_url),
-    ));
-    payload.push_str(&format!(
-        "PROLIFERATE_ENROLLMENT_TOKEN={}\n",
-        shell_quote(enrollment_token),
-    ));
-    payload.push_str(&format!(
-        "PROLIFERATE_ANYHARNESS_PORT={}\n",
-        shell_quote(&remote_anyharness_port.to_string()),
-    ));
-    payload.push_str(&format!(
-        "PROLIFERATE_ANYHARNESS_BASE_URL={}\n",
-        shell_quote(&format!("http://127.0.0.1:{remote_anyharness_port}")),
-    ));
-    if let Some(artifact_base_url) = artifact_base_url {
-        payload.push_str(&format!(
-            "PROLIFERATE_ARTIFACT_BASE_URL={}\n",
-            shell_quote(artifact_base_url),
-        ));
-    }
-    payload.push('\n');
-    payload.push_str(INSTALLER_SCRIPT);
-    payload.push('\n');
-    payload
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 fn spawn_and_wait_for_output(
@@ -601,14 +454,14 @@ fn spawn_and_wait_for_output(
     let child = command
         .spawn()
         .map_err(|error| format!("Failed to start {context}: {error}"))?;
-    wait_for_child_output(child, timeout, context, None)
+    wait_for_child_output(child, timeout, context, &[])
 }
 
-fn wait_for_child_output(
+pub(crate) fn wait_for_child_output(
     mut child: Child,
     timeout: Duration,
     context: &str,
-    token: Option<&str>,
+    tokens: &[&str],
 ) -> Result<CommandOutput, String> {
     let stdout_reader = spawn_reader(child.stdout.take());
     let stderr_reader = spawn_reader(child.stderr.take());
@@ -629,7 +482,7 @@ fn wait_for_child_output(
                 let _ = child.wait();
                 let stdout = stdout_reader.join().unwrap_or_default();
                 let stderr = stderr_reader.join().unwrap_or_default();
-                let detail = command_output_error(context, &stdout, &stderr, token);
+                let detail = command_output_error(context, &stdout, &stderr, tokens);
                 return Err(format!(
                     "{context} timed out after {}s: {detail}",
                     timeout.as_secs()
@@ -661,11 +514,18 @@ where
     })
 }
 
-fn redact_token(value: String, token: &str) -> String {
-    value.replace(token, "[redacted]")
+pub(crate) fn redact_tokens(value: String, tokens: &[&str]) -> String {
+    tokens.iter().fold(value, |redacted, token| {
+        redacted.replace(token, "[redacted]")
+    })
 }
 
-fn command_output_error(prefix: &str, stdout: &str, stderr: &str, token: Option<&str>) -> String {
+pub(crate) fn command_output_error(
+    prefix: &str,
+    stdout: &str,
+    stderr: &str,
+    tokens: &[&str],
+) -> String {
     let stdout = stdout.trim();
     let stderr = stderr.trim();
     let mut detail = String::new();
@@ -678,9 +538,7 @@ fn command_output_error(prefix: &str, stdout: &str, stderr: &str, token: Option<
         }
         detail.push_str(stdout);
     }
-    if let Some(token) = token {
-        detail = redact_token(detail, token);
-    }
+    detail = redact_tokens(detail, tokens);
     if detail.is_empty() {
         prefix.to_string()
     } else {

--- a/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
@@ -1,17 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Read;
 use std::net::TcpListener;
-use std::path::PathBuf;
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
-use std::thread;
 use std::time::{Duration, Instant};
 use tauri::State;
 
-const DEFAULT_SSH_PORT: u16 = 22;
-pub(crate) const DEFAULT_ANYHARNESS_PORT: u16 = 8457;
-const SSH_CONNECT_TIMEOUT_SECONDS: u16 = 12;
+use super::ssh_common::{
+    append_common_ssh_options, command_output_error, normalize_port, parse_ssh_connection,
+    ssh_destination, wait_for_child_output, CommandOutput, DEFAULT_ANYHARNESS_PORT,
+};
+
 const SSH_PROBE_TIMEOUT: Duration = Duration::from_secs(25);
 const TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(12);
 const TUNNEL_READY_POLL: Duration = Duration::from_millis(150);
@@ -58,6 +57,7 @@ pub struct EnsureSshAnyHarnessTunnelInput {
     ssh_port: Option<u16>,
     identity_file: Option<String>,
     remote_anyharness_port: Option<u16>,
+    anyharness_bearer_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,20 +80,6 @@ pub struct ProbeSshTargetConnectionResult {
 pub struct EnsureSshAnyHarnessTunnelResult {
     local_url: String,
     local_port: u16,
-}
-
-#[derive(Debug)]
-pub(crate) struct SshConnection {
-    ssh_host: String,
-    ssh_user: String,
-    ssh_port: u16,
-    identity_file: Option<PathBuf>,
-}
-
-pub(crate) struct CommandOutput {
-    pub(crate) status: ExitStatus,
-    pub(crate) stdout: String,
-    pub(crate) stderr: String,
 }
 
 #[tauri::command]
@@ -142,6 +128,14 @@ pub async fn ensure_ssh_anyharness_tunnel(
         return Err("target_id is required.".to_string());
     }
 
+    let anyharness_bearer_token = input
+        .anyharness_bearer_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let bearer = anyharness_bearer_token.as_deref();
+
     let connection = parse_ssh_connection(
         input.ssh_host,
         input.ssh_user,
@@ -164,7 +158,10 @@ pub async fn ensure_ssh_anyharness_tunnel(
     };
 
     if let Some(existing) = existing_tunnel_result(&state, &target_id, &connection_key)? {
-        if wait_for_anyharness(&existing.local_url).await.is_ok() {
+        if wait_for_anyharness(&existing.local_url, bearer)
+            .await
+            .is_ok()
+        {
             return Ok(existing);
         }
         remove_tunnel_for_port(&state, &target_id, existing.local_port);
@@ -199,7 +196,7 @@ pub async fn ensure_ssh_anyharness_tunnel(
         local_url.clone(),
         child,
     )? {
-        return match wait_for_anyharness(&existing.local_url).await {
+        return match wait_for_anyharness(&existing.local_url, bearer).await {
             Ok(()) => Ok(existing),
             Err(error) => {
                 remove_tunnel_for_port(&state, &target_id, existing.local_port);
@@ -208,7 +205,7 @@ pub async fn ensure_ssh_anyharness_tunnel(
         };
     }
 
-    match wait_for_anyharness(&local_url).await {
+    match wait_for_anyharness(&local_url, bearer).await {
         Ok(()) => Ok(EnsureSshAnyHarnessTunnelResult {
             local_url,
             local_port,
@@ -385,67 +382,6 @@ fn allocate_local_port() -> Result<u16, String> {
         .map_err(|error| format!("Failed to read local tunnel port: {error}"))
 }
 
-pub(crate) fn parse_ssh_connection(
-    ssh_host: String,
-    ssh_user: String,
-    ssh_port: Option<u16>,
-    identity_file: Option<String>,
-) -> Result<SshConnection, String> {
-    let ssh_host = ssh_host.trim().to_string();
-    let ssh_user = ssh_user.trim().to_string();
-    if ssh_host.is_empty() || ssh_user.is_empty() {
-        return Err("SSH host and user are required.".to_string());
-    }
-    let identity_file = identity_file
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(expand_home_path)
-        .transpose()?;
-    Ok(SshConnection {
-        ssh_host,
-        ssh_user,
-        ssh_port: normalize_port(ssh_port, DEFAULT_SSH_PORT, "SSH port")?,
-        identity_file,
-    })
-}
-
-pub(crate) fn normalize_port(
-    value: Option<u16>,
-    fallback: u16,
-    label: &str,
-) -> Result<u16, String> {
-    match value {
-        Some(0) => Err(format!("{label} must be between 1 and 65535.")),
-        Some(port) => Ok(port),
-        None => Ok(fallback),
-    }
-}
-
-pub(crate) fn append_common_ssh_options(command: &mut Command, connection: &SshConnection) {
-    command
-        .arg("-o")
-        .arg("BatchMode=yes")
-        .arg("-o")
-        .arg("StrictHostKeyChecking=accept-new")
-        .arg("-o")
-        .arg(format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECONDS}"))
-        .arg("-o")
-        .arg("ServerAliveInterval=30")
-        .arg("-o")
-        .arg("ServerAliveCountMax=3")
-        .arg("-p")
-        .arg(connection.ssh_port.to_string());
-
-    if let Some(identity_file) = &connection.identity_file {
-        command.arg("-i").arg(identity_file);
-    }
-}
-
-pub(crate) fn ssh_destination(connection: &SshConnection) -> String {
-    format!("{}@{}", connection.ssh_user, connection.ssh_host)
-}
-
 fn spawn_and_wait_for_output(
     mut command: Command,
     timeout: Duration,
@@ -457,96 +393,7 @@ fn spawn_and_wait_for_output(
     wait_for_child_output(child, timeout, context, &[])
 }
 
-pub(crate) fn wait_for_child_output(
-    mut child: Child,
-    timeout: Duration,
-    context: &str,
-    tokens: &[&str],
-) -> Result<CommandOutput, String> {
-    let stdout_reader = spawn_reader(child.stdout.take());
-    let stderr_reader = spawn_reader(child.stderr.take());
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let stdout = stdout_reader.join().unwrap_or_default();
-                let stderr = stderr_reader.join().unwrap_or_default();
-                return Ok(CommandOutput {
-                    status,
-                    stdout,
-                    stderr,
-                });
-            }
-            Ok(None) if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let stdout = stdout_reader.join().unwrap_or_default();
-                let stderr = stderr_reader.join().unwrap_or_default();
-                let detail = command_output_error(context, &stdout, &stderr, tokens);
-                return Err(format!(
-                    "{context} timed out after {}s: {detail}",
-                    timeout.as_secs()
-                ));
-            }
-            Ok(None) => thread::sleep(Duration::from_millis(100)),
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stdout_reader.join();
-                let _ = stderr_reader.join();
-                return Err(format!("Failed to wait for {context}: {error}"));
-            }
-        }
-    }
-}
-
-fn spawn_reader<R>(reader: Option<R>) -> thread::JoinHandle<String>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let Some(mut reader) = reader else {
-            return String::new();
-        };
-        let mut output = String::new();
-        let _ = reader.read_to_string(&mut output);
-        output
-    })
-}
-
-pub(crate) fn redact_tokens(value: String, tokens: &[&str]) -> String {
-    tokens.iter().fold(value, |redacted, token| {
-        redacted.replace(token, "[redacted]")
-    })
-}
-
-pub(crate) fn command_output_error(
-    prefix: &str,
-    stdout: &str,
-    stderr: &str,
-    tokens: &[&str],
-) -> String {
-    let stdout = stdout.trim();
-    let stderr = stderr.trim();
-    let mut detail = String::new();
-    if !stderr.is_empty() {
-        detail.push_str(stderr);
-    }
-    if !stdout.is_empty() {
-        if !detail.is_empty() {
-            detail.push_str("\n\n");
-        }
-        detail.push_str(stdout);
-    }
-    detail = redact_tokens(detail, tokens);
-    if detail.is_empty() {
-        prefix.to_string()
-    } else {
-        format!("{prefix}: {detail}")
-    }
-}
-
-async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
+async fn wait_for_anyharness(local_url: &str, bearer_token: Option<&str>) -> Result<(), String> {
     let deadline = Instant::now() + TUNNEL_READY_TIMEOUT;
     let client = reqwest::Client::builder()
         .timeout(TUNNEL_HEALTH_REQUEST_TIMEOUT)
@@ -556,7 +403,9 @@ async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
     let mut last_error = String::new();
     while Instant::now() < deadline {
         match client.get(&health_url).send().await {
-            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response) if response.status().is_success() => {
+                return verify_anyharness_access(&client, local_url, bearer_token).await;
+            }
             Ok(response) => {
                 last_error = format!("health returned {}", response.status());
             }
@@ -571,17 +420,33 @@ async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
     ))
 }
 
-fn expand_home_path(path: &str) -> Result<PathBuf, String> {
-    if path == "~" {
-        return std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set.".to_string());
+/// `/health` is registered outside the bearer middleware, so reachability
+/// alone does not prove Desktop can use the runtime. Probe an authenticated
+/// `/v1` route so enforcement mismatches fail here instead of on first use.
+async fn verify_anyharness_access(
+    client: &reqwest::Client,
+    local_url: &str,
+    bearer_token: Option<&str>,
+) -> Result<(), String> {
+    let verify_url = format!("{}/v1/workspaces", local_url.trim_end_matches('/'));
+    let mut request = client.get(&verify_url);
+    if let Some(bearer_token) = bearer_token {
+        request = request.bearer_auth(bearer_token);
     }
-    if let Some(rest) = path.strip_prefix("~/") {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set.".to_string())?;
-        return Ok(home.join(rest));
+    let response = request.send().await.map_err(|error| {
+        format!("AnyHarness became reachable, but the access check failed at {verify_url}: {error}")
+    })?;
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(if bearer_token.is_some() {
+            format!(
+                "AnyHarness rejected the stored runtime bearer ({status}). Reconnect the target from Compute settings to refresh its runtime credentials."
+            )
+        } else {
+            format!(
+                "AnyHarness requires a runtime bearer that Desktop does not have ({status}). Reconnect the target from Compute settings."
+            )
+        });
     }
-    Ok(PathBuf::from(path))
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,8 +13,8 @@ mod workspace_activity_indicator;
 
 use commands::{
     anonymous_telemetry, cloud_worker, config, diagnostics as diagnostics_commands,
-    google_workspace_mcp, keychain, process, runtime, shell, ssh_tunnel, support, window_chrome,
-    workspace_scratch,
+    google_workspace_mcp, keychain, process, runtime, shell, ssh_install, ssh_tunnel, support,
+    window_chrome, workspace_scratch,
 };
 use quit_flow::QuitFlowState;
 use tauri::Manager;
@@ -258,7 +258,7 @@ pub fn run() {
             window_chrome::apply_macos_window_chrome,
             window_chrome::set_webview_zoom,
             process::command_exists,
-            ssh_tunnel::install_ssh_target_runtime,
+            ssh_install::install_ssh_target_runtime,
             ssh_tunnel::probe_ssh_target_connection,
             ssh_tunnel::ensure_ssh_anyharness_tunnel,
             keychain::list_configured_env_var_names,

--- a/apps/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
@@ -102,7 +102,6 @@ export function useComputeTargetEnrollment() {
           kind: "ssh",
           ownerScope,
           organizationId: ownerScope === "organization" ? input.organizationId ?? null : null,
-          defaultWorkspaceRoot: input.defaultWorkspaceRoot ?? null,
         },
         existingEnrollmentRequest: input.existingTargetId ? {} : undefined,
         directAccess: {

--- a/apps/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-compute-target-enrollment.ts
@@ -72,7 +72,9 @@ export function useComputeTargetEnrollment() {
         targetId: string,
         body: CloudTargetExistingEnrollmentRequest,
       ) => createExistingTargetEnrollment({ targetId, body }),
-      saveDirectProfile: setSshDirectTargetProfile,
+      saveDirectProfile: async (profile) => {
+        await setSshDirectTargetProfile(profile);
+      },
       saveAppearance: setComputeTargetAppearancePreference,
       probeSsh: probeSshTargetConnection,
       installRuntime: installSshTargetRuntime,

--- a/apps/desktop/src/hooks/settings/workflows/use-ssh-direct-target-profile.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-ssh-direct-target-profile.ts
@@ -32,8 +32,7 @@ export function useSshDirectTargetProfile(targetId: string | null | undefined) {
   }, [reload]);
 
   const saveProfile = useCallback(async (next: SshDirectTargetProfile) => {
-    await setSshDirectTargetProfile(next);
-    setProfile(next);
+    setProfile(await setSshDirectTargetProfile(next));
   }, []);
 
   const testConnection = useCallback(async (next: SshDirectTargetProfile) => {
@@ -46,11 +45,14 @@ export function useSshDirectTargetProfile(targetId: string | null | undefined) {
         sshPort: next.sshPort,
         identityFile: next.identityFile ?? null,
         remoteAnyHarnessPort: next.remoteAnyHarnessPort,
+        anyharnessBearerToken: next.anyharnessBearerToken
+          ?? profile?.anyharnessBearerToken
+          ?? null,
       });
     } finally {
       setTesting(false);
     }
-  }, []);
+  }, [profile?.anyharnessBearerToken]);
 
   return {
     profile,

--- a/apps/desktop/src/lib/access/anyharness/runtime-target.ts
+++ b/apps/desktop/src/lib/access/anyharness/runtime-target.ts
@@ -4,6 +4,7 @@ import { resolveCloudSandboxGatewayConnectionForWorkspace } from "@/lib/access/c
 import { getCloudWorkspaceWithRetry } from "@/lib/access/cloud/workspace-connection-retry";
 import { ensureSshAnyHarnessTunnel } from "@/lib/access/tauri/ssh-tunnel";
 import { getSshDirectTargetProfile } from "@/lib/access/tauri/ssh-target-profile";
+import { resolveSshDirectTargetBearer } from "@/lib/access/anyharness/ssh-direct-bearer";
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { resolveCloudWorkspaceStatus } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
@@ -38,6 +39,7 @@ export async function resolveRuntimeTargetForWorkspace(
         "SSH direct access is not configured for this target. Add the SSH host, user, and key in Compute settings.",
       );
     }
+    const authToken = await resolveSshDirectTargetBearer(profile);
     const tunnel = await ensureSshAnyHarnessTunnel({
       targetId: profile.targetId,
       sshHost: profile.sshHost,
@@ -45,10 +47,12 @@ export async function resolveRuntimeTargetForWorkspace(
       sshPort: profile.sshPort,
       identityFile: profile.identityFile ?? null,
       remoteAnyHarnessPort: profile.remoteAnyHarnessPort,
+      anyharnessBearerToken: authToken,
     });
     return {
       location: "target",
       baseUrl: tunnel.localUrl,
+      authToken: authToken ?? undefined,
       anyharnessWorkspaceId: targetWorkspace.anyharnessWorkspaceId,
       runtimeGeneration: 0,
       targetId: targetWorkspace.targetId,

--- a/apps/desktop/src/lib/access/anyharness/ssh-direct-bearer.ts
+++ b/apps/desktop/src/lib/access/anyharness/ssh-direct-bearer.ts
@@ -1,0 +1,37 @@
+import { getTargetRuntimeAccess } from "@proliferate/cloud-sdk";
+import "@/lib/access/cloud/client";
+import {
+  setSshDirectTargetProfile,
+  type SshDirectTargetProfile,
+} from "@/lib/access/tauri/ssh-target-profile";
+
+/**
+ * Resolve the per-runtime AnyHarness bearer for a direct SSH attach.
+ *
+ * Enrollment caches the bearer on the local profile so attach works offline.
+ * Profiles saved before bearer enforcement lack it; recover it once from the
+ * owner-gated runtime-access endpoint and persist it back. Recovery failures
+ * (pre-bearer target, org-scoped target, Cloud unreachable) degrade to a
+ * tokenless attach, which unenforced runtimes still accept.
+ */
+export async function resolveSshDirectTargetBearer(
+  profile: SshDirectTargetProfile,
+): Promise<string | null> {
+  if (profile.anyharnessBearerToken) {
+    return profile.anyharnessBearerToken;
+  }
+  try {
+    const access = await getTargetRuntimeAccess(profile.targetId);
+    const bearer = access.anyharnessBearerToken.trim();
+    if (!bearer) {
+      return null;
+    }
+    await setSshDirectTargetProfile({
+      ...profile,
+      anyharnessBearerToken: bearer,
+    });
+    return bearer;
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/src/lib/access/tauri/ssh-target-profile.test.ts
+++ b/apps/desktop/src/lib/access/tauri/ssh-target-profile.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSshDirectTargetProfile,
+  setSshDirectTargetProfile,
+  type SshDirectTargetProfile,
+} from "./ssh-target-profile";
+
+const storeMocks = vi.hoisted(() => {
+  const values = new Map<string, unknown>();
+  const get = vi.fn(async (key: string) => values.get(key));
+  const set = vi.fn(async (key: string, value: unknown) => {
+    values.set(key, value);
+  });
+
+  return {
+    values,
+    get,
+    set,
+    getPreferencesStore: vi.fn(async () => ({ get, set })),
+  };
+});
+
+vi.mock("@/lib/access/tauri/store", () => ({
+  getPreferencesStore: storeMocks.getPreferencesStore,
+}));
+
+const profile = (
+  overrides: Partial<SshDirectTargetProfile> = {},
+): SshDirectTargetProfile => ({
+  targetId: "target-1",
+  sshHost: "box.example.com",
+  sshUser: "ubuntu",
+  sshPort: 22,
+  identityFile: "~/.ssh/id_ed25519",
+  remoteAnyHarnessPort: 18457,
+  workspaceRoot: null,
+  ...overrides,
+});
+
+describe("setSshDirectTargetProfile", () => {
+  beforeEach(() => {
+    storeMocks.values.clear();
+  });
+
+  it("stores and returns the runtime bearer", async () => {
+    const stored = await setSshDirectTargetProfile(
+      profile({ anyharnessBearerToken: "runtime-bearer" }),
+    );
+    expect(stored.anyharnessBearerToken).toBe("runtime-bearer");
+    const loaded = await getSshDirectTargetProfile("target-1");
+    expect(loaded?.anyharnessBearerToken).toBe("runtime-bearer");
+  });
+
+  it("preserves the stored bearer when a connection edit omits it", async () => {
+    await setSshDirectTargetProfile(
+      profile({ anyharnessBearerToken: "runtime-bearer" }),
+    );
+    const stored = await setSshDirectTargetProfile(
+      profile({ sshHost: "renamed.example.com" }),
+    );
+    expect(stored.sshHost).toBe("renamed.example.com");
+    expect(stored.anyharnessBearerToken).toBe("runtime-bearer");
+    const loaded = await getSshDirectTargetProfile("target-1");
+    expect(loaded?.anyharnessBearerToken).toBe("runtime-bearer");
+  });
+
+  it("normalizes a missing bearer to null", async () => {
+    const stored = await setSshDirectTargetProfile(profile());
+    expect(stored.anyharnessBearerToken).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/ssh-target-profile.ts
+++ b/apps/desktop/src/lib/access/tauri/ssh-target-profile.ts
@@ -17,6 +17,7 @@ export interface SshDirectTargetProfile {
   identityFile?: string | null;
   remoteAnyHarnessPort: number;
   workspaceRoot?: string | null;
+  anyharnessBearerToken?: string | null;
 }
 
 function normalizedPort(value: unknown, fallback: number): number {
@@ -42,6 +43,9 @@ function normalizeProfile(input: unknown): SshDirectTargetProfile | null {
   const workspaceRoot = typeof record.workspaceRoot === "string"
     ? record.workspaceRoot.trim()
     : "";
+  const anyharnessBearerToken = typeof record.anyharnessBearerToken === "string"
+    ? record.anyharnessBearerToken.trim()
+    : "";
   return {
     targetId,
     sshHost,
@@ -53,6 +57,7 @@ function normalizeProfile(input: unknown): SshDirectTargetProfile | null {
       DEFAULT_ANYHARNESS_PORT,
     ),
     workspaceRoot: workspaceRoot || null,
+    anyharnessBearerToken: anyharnessBearerToken || null,
   };
 }
 
@@ -82,14 +87,21 @@ export async function getSshDirectTargetProfile(
 
 export async function setSshDirectTargetProfile(
   profile: SshDirectTargetProfile,
-): Promise<void> {
+): Promise<SshDirectTargetProfile> {
   const normalized = normalizeProfile(profile);
   if (!normalized) {
     throw new Error("SSH host and user are required for direct target access.");
   }
   const profiles = await readProfiles();
+  // Only enrollment and runtime-access recovery write the bearer; connection
+  // edits omit it and must not drop the stored runtime credential.
+  if (!normalized.anyharnessBearerToken) {
+    normalized.anyharnessBearerToken =
+      profiles[normalized.targetId]?.anyharnessBearerToken ?? null;
+  }
   profiles[normalized.targetId] = normalized;
   await persistValue(SSH_DIRECT_TARGET_PROFILES_KEY, profiles);
+  return normalized;
 }
 
 export async function deleteSshDirectTargetProfile(targetId: string): Promise<void> {

--- a/apps/desktop/src/lib/access/tauri/ssh-tunnel.ts
+++ b/apps/desktop/src/lib/access/tauri/ssh-tunnel.ts
@@ -24,6 +24,7 @@ export interface InstallSshTargetRuntimeInput extends ProbeSshTargetConnectionIn
   remoteAnyHarnessPort?: number | null;
   cloudBaseUrl: string;
   enrollmentToken: string;
+  anyharnessBearerToken?: string | null;
   artifactBaseUrl?: string | null;
 }
 

--- a/apps/desktop/src/lib/access/tauri/ssh-tunnel.ts
+++ b/apps/desktop/src/lib/access/tauri/ssh-tunnel.ts
@@ -7,6 +7,7 @@ export interface EnsureSshAnyHarnessTunnelInput {
   sshPort?: number | null;
   identityFile?: string | null;
   remoteAnyHarnessPort?: number | null;
+  anyharnessBearerToken?: string | null;
 }
 
 export interface ProbeSshTargetConnectionInput {

--- a/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.test.ts
+++ b/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.test.ts
@@ -127,7 +127,13 @@ describe("runSshTargetConnectWorkflow", () => {
       "connected",
     ]);
     expect(workflowDeps.saveDirectProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ targetId: "target-1" }),
+      expect.objectContaining({
+        targetId: "target-1",
+        anyharnessBearerToken: "runtime-bearer",
+      }),
+    );
+    expect(workflowDeps.verifyTunnel).toHaveBeenCalledWith(
+      expect.objectContaining({ anyharnessBearerToken: "runtime-bearer" }),
     );
     expect(workflowDeps.installRuntime).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.test.ts
+++ b/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.test.ts
@@ -69,6 +69,7 @@ const connectedTarget = (
 const enrollment = (overrides: Partial<CloudTargetEnrollmentResponse> = {}): CloudTargetEnrollmentResponse => ({
   target: target(),
   enrollmentToken: "enroll-token",
+  anyharnessBearerToken: "runtime-bearer",
   installCommand: "curl -fsSL https://installer.example/install.sh | sh",
   artifactBaseUrl: "https://artifacts.example/releases/current",
   expiresAt: "2026-05-23T00:15:00Z",
@@ -106,7 +107,6 @@ describe("runSshTargetConnectWorkflow", () => {
         displayName: "SSH Box",
         kind: "ssh",
         ownerScope: "personal",
-        defaultWorkspaceRoot: "~/workspaces",
       },
       directAccess: profile(),
       cloudBaseUrl: "https://api.example.com",
@@ -134,6 +134,7 @@ describe("runSshTargetConnectWorkflow", () => {
         artifactBaseUrl: "https://artifacts.example/releases/current",
         cloudBaseUrl: "https://api.example.com",
         enrollmentToken: "enroll-token",
+        anyharnessBearerToken: "runtime-bearer",
         remoteAnyHarnessPort: 18457,
       }),
     );

--- a/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.ts
+++ b/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.ts
@@ -124,6 +124,7 @@ export async function runSshTargetConnectWorkflow(
     const profile = {
       ...input.directAccess,
       targetId: enrollment.target.id,
+      anyharnessBearerToken: enrollment.anyharnessBearerToken,
     };
 
     setPhase("saving_profile");

--- a/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.ts
+++ b/apps/desktop/src/lib/workflows/compute/ssh-target-connect-workflow.ts
@@ -144,6 +144,7 @@ export async function runSshTargetConnectWorkflow(
       remoteAnyHarnessPort: profile.remoteAnyHarnessPort,
       cloudBaseUrl: input.cloudBaseUrl,
       enrollmentToken: enrollment.enrollmentToken,
+      anyharnessBearerToken: enrollment.anyharnessBearerToken,
       artifactBaseUrl: enrollment.artifactBaseUrl ?? null,
     });
 

--- a/cloud/sdk/src/client/targets.ts
+++ b/cloud/sdk/src/client/targets.ts
@@ -5,6 +5,7 @@ import type {
   CloudTargetExistingEnrollmentRequest,
   CloudTargetEnrollmentRequest,
   CloudTargetEnrollmentResponse,
+  CloudTargetRuntimeAccessResponse,
   CloudTargetSummary,
 } from "../types/index.js";
 
@@ -48,6 +49,17 @@ export async function getTarget(
   return client.requestJson<CloudTargetDetail>({
     method: "GET",
     path: "/v1/cloud/targets/{target_id}",
+    pathParams: { target_id: targetId },
+  });
+}
+
+export async function getTargetRuntimeAccess(
+  targetId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<CloudTargetRuntimeAccessResponse> {
+  return client.requestJson<CloudTargetRuntimeAccessResponse>({
+    method: "GET",
+    path: "/v1/cloud/targets/{target_id}/runtime-access",
     pathParams: { target_id: targetId },
   });
 }

--- a/cloud/sdk/src/types/targets.ts
+++ b/cloud/sdk/src/types/targets.ts
@@ -70,6 +70,9 @@ export type CloudTargetEnrollmentResponse =
 export type CloudTargetExistingEnrollmentRequest =
   Schema<"CloudTargetExistingEnrollmentRequest">;
 
+export type CloudTargetRuntimeAccessResponse =
+  Schema<"CloudTargetRuntimeAccessResponse">;
+
 export type ArchiveCloudTargetResponse =
   Schema<"ArchiveCloudTargetResponse">;
 

--- a/install/proliferate-target-install.sh
+++ b/install/proliferate-target-install.sh
@@ -114,13 +114,25 @@ EOF
 fi
 chmod 600 "$WORKER_DIR/config.toml"
 
+anyharness_args="$(toml_string "serve"), $(toml_string "--runtime-home"), $(toml_string "$PROLIFERATE_HOME/anyharness"), $(toml_string "--port"), $(toml_string "$PROLIFERATE_ANYHARNESS_PORT")"
+if [ -n "${PROLIFERATE_ANYHARNESS_BEARER_TOKEN:-}" ]; then
+  anyharness_args="$anyharness_args, $(toml_string "--require-bearer-auth")"
+fi
+
 cat > "$SUPERVISOR_DIR/config.toml" <<EOF
 anyharness_binary = $(toml_string "$BIN_DIR/anyharness")
 worker_binary = $(toml_string "$BIN_DIR/proliferate-worker")
 worker_config = $(toml_string "$WORKER_DIR/config.toml")
-anyharness_args = [$(toml_string "serve"), $(toml_string "--runtime-home"), $(toml_string "$PROLIFERATE_HOME/anyharness"), $(toml_string "--port"), $(toml_string "$PROLIFERATE_ANYHARNESS_PORT")]
+anyharness_args = [$anyharness_args]
 restart_delay_seconds = 5
 EOF
+if [ -n "${PROLIFERATE_ANYHARNESS_BEARER_TOKEN:-}" ]; then
+  cat >> "$SUPERVISOR_DIR/config.toml" <<EOF
+
+[anyharness_env]
+ANYHARNESS_BEARER_TOKEN = $(toml_string "$PROLIFERATE_ANYHARNESS_BEARER_TOKEN")
+EOF
+fi
 chmod 600 "$SUPERVISOR_DIR/config.toml"
 
 if command -v systemctl >/dev/null 2>&1; then

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -27,7 +27,6 @@ anyharness/sdk-react/src/hooks/sessions.ts 653 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 759 existing generated cloud SDK type surface
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1880 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1575 existing SDK oversized file
-apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 646 existing desktop oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 632 existing desktop oversized test file


### PR DESCRIPTION
Enforces the per-target bearer end to end: the install script wires `--require-bearer-auth` and an env-delivered `ANYHARNESS_BEARER_TOKEN` into the supervisor config when the bearer is present, and the desktop installer exports the bearer (redacted from all output) with the connect workflow threading it through. Review fixes cache the bearer on the local SSH profile (recovering pre-bearer profiles via `/runtime-access`), set `RuntimeTarget.authToken` on the ssh-transport branch, and verify authenticated `/v1` access in the tunnel check so 401s surface during connect instead of after.

Stack: 3/6 — 16-gateway-target-scoping → 17-target-bearer → 18-runtime-bearer-enforcement → 19-direct-runtime-core → 20-direct-auth-sync → 21-direct-runtime-ui

Design: `specs/tbd/ssh-personal-target-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
