### PR TITLE
feat(agent-auth): direct-runtime family core — attach state machine + authed tunnel resolver

### DIFF
--- a/apps/desktop/src/lib/access/anyharness/direct-runtime-connection.test.ts
+++ b/apps/desktop/src/lib/access/anyharness/direct-runtime-connection.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetDirectRuntimeBearerCacheForTest,
+  resolveDirectRuntimeConnection,
+} from "./direct-runtime-connection";
+import {
+  loopbackDirectRuntimeRef,
+  sshDirectRuntimeRef,
+} from "@/lib/domain/compute/direct-runtime";
+import type { SshDirectTargetProfile } from "@/lib/access/tauri/ssh-target-profile";
+import {
+  getDirectRuntimeConnectionSnapshot,
+  useDirectRuntimeConnectionStore,
+} from "@/stores/compute/direct-runtime-connection-store";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+const mocks = vi.hoisted(() => ({
+  getSshDirectTargetProfile: vi.fn(),
+  ensureSshAnyHarnessTunnel: vi.fn(),
+  resolveSshDirectTargetBearer: vi.fn(),
+  refreshSshDirectTargetBearer: vi.fn(),
+}));
+
+vi.mock("@/lib/access/tauri/ssh-target-profile", () => ({
+  getSshDirectTargetProfile: mocks.getSshDirectTargetProfile,
+}));
+
+vi.mock("@/lib/access/tauri/ssh-tunnel", () => ({
+  ensureSshAnyHarnessTunnel: mocks.ensureSshAnyHarnessTunnel,
+}));
+
+vi.mock("@/lib/access/anyharness/ssh-direct-bearer", () => ({
+  resolveSshDirectTargetBearer: mocks.resolveSshDirectTargetBearer,
+  refreshSshDirectTargetBearer: mocks.refreshSshDirectTargetBearer,
+}));
+
+const profile = (
+  overrides: Partial<SshDirectTargetProfile> = {},
+): SshDirectTargetProfile => ({
+  targetId: "target-1",
+  sshHost: "box.example.com",
+  sshUser: "ubuntu",
+  sshPort: 22,
+  identityFile: null,
+  remoteAnyHarnessPort: 8457,
+  workspaceRoot: null,
+  anyharnessBearerToken: "runtime-bearer",
+  ...overrides,
+});
+
+const tunnel = { localUrl: "http://127.0.0.1:52001", localPort: 52001 };
+
+beforeEach(() => {
+  mocks.getSshDirectTargetProfile.mockReset();
+  mocks.ensureSshAnyHarnessTunnel.mockReset();
+  mocks.resolveSshDirectTargetBearer.mockReset();
+  mocks.refreshSshDirectTargetBearer.mockReset();
+  resetDirectRuntimeBearerCacheForTest();
+  useDirectRuntimeConnectionStore.setState({ connectionsByKey: {} });
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "http://127.0.0.1:8457",
+    connectionState: "healthy",
+    error: null,
+  });
+});
+
+describe("resolveDirectRuntimeConnection (loopback)", () => {
+  it("resolves the local harness runtime with no token", async () => {
+    await expect(
+      resolveDirectRuntimeConnection(loopbackDirectRuntimeRef()),
+    ).resolves.toEqual({
+      baseUrl: "http://127.0.0.1:8457",
+      authToken: null,
+    });
+    expect(mocks.getSshDirectTargetProfile).not.toHaveBeenCalled();
+    expect(mocks.ensureSshAnyHarnessTunnel).not.toHaveBeenCalled();
+    expect(useDirectRuntimeConnectionStore.getState().connectionsByKey).toEqual({});
+  });
+
+  it("derives the loopback snapshot from harness bootstrap health", () => {
+    expect(getDirectRuntimeConnectionSnapshot(null)).toEqual({
+      connectionState: "attached",
+      baseUrl: "http://127.0.0.1:8457",
+      authToken: null,
+      lastError: null,
+    });
+    useHarnessConnectionStore.setState({
+      connectionState: "failed",
+      error: "sidecar exited",
+    });
+    expect(getDirectRuntimeConnectionSnapshot(null)).toEqual({
+      connectionState: "unreachable",
+      baseUrl: null,
+      authToken: null,
+      lastError: "sidecar exited",
+    });
+  });
+});
+
+describe("resolveDirectRuntimeConnection (ssh)", () => {
+  it("ensures the tunnel with the profile bearer and marks the target attached", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(profile());
+    mocks.ensureSshAnyHarnessTunnel.mockResolvedValue(tunnel);
+
+    await expect(
+      resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1")),
+    ).resolves.toEqual({
+      baseUrl: tunnel.localUrl,
+      authToken: "runtime-bearer",
+    });
+    expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenCalledWith({
+      targetId: "target-1",
+      sshHost: "box.example.com",
+      sshUser: "ubuntu",
+      sshPort: 22,
+      identityFile: null,
+      remoteAnyHarnessPort: 8457,
+      anyharnessBearerToken: "runtime-bearer",
+    });
+    expect(mocks.resolveSshDirectTargetBearer).not.toHaveBeenCalled();
+    expect(getDirectRuntimeConnectionSnapshot("target-1")).toEqual({
+      connectionState: "attached",
+      baseUrl: tunnel.localUrl,
+      authToken: "runtime-bearer",
+      lastError: null,
+    });
+  });
+
+  it("reports connecting while the tunnel ensure is in flight", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(profile());
+    let finishEnsure: (value: typeof tunnel) => void = () => undefined;
+    mocks.ensureSshAnyHarnessTunnel.mockImplementation(
+      () => new Promise((resolve) => {
+        finishEnsure = resolve;
+      }),
+    );
+
+    const pending = resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1"));
+    await vi.waitFor(() => {
+      expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenCalled();
+    });
+    expect(getDirectRuntimeConnectionSnapshot("target-1").connectionState).toBe(
+      "connecting",
+    );
+
+    finishEnsure(tunnel);
+    await pending;
+    expect(getDirectRuntimeConnectionSnapshot("target-1").connectionState).toBe(
+      "attached",
+    );
+  });
+
+  it("fails as unreachable when no profile is configured", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(null);
+
+    await expect(
+      resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1")),
+    ).rejects.toThrow("SSH direct access is not configured");
+    expect(getDirectRuntimeConnectionSnapshot("target-1")).toMatchObject({
+      connectionState: "unreachable",
+      lastError: expect.stringContaining("not configured"),
+    });
+  });
+
+  it("marks the target unreachable when the tunnel fails", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(profile());
+    mocks.ensureSshAnyHarnessTunnel.mockRejectedValue(
+      "Failed to start ssh tunnel: connection refused",
+    );
+
+    await expect(
+      resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1")),
+    ).rejects.toBe("Failed to start ssh tunnel: connection refused");
+    expect(mocks.refreshSshDirectTargetBearer).not.toHaveBeenCalled();
+    expect(getDirectRuntimeConnectionSnapshot("target-1")).toEqual({
+      connectionState: "unreachable",
+      baseUrl: null,
+      authToken: null,
+      lastError: "Failed to start ssh tunnel: connection refused",
+    });
+  });
+
+  it("refetches the bearer and retries once when the runtime rejects it", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(
+      profile({ anyharnessBearerToken: "stale-bearer" }),
+    );
+    mocks.ensureSshAnyHarnessTunnel
+      .mockRejectedValueOnce(
+        "AnyHarness rejected the stored runtime bearer (401 Unauthorized).",
+      )
+      .mockResolvedValueOnce(tunnel);
+    mocks.refreshSshDirectTargetBearer.mockResolvedValue("fresh-bearer");
+
+    await expect(
+      resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1")),
+    ).resolves.toEqual({
+      baseUrl: tunnel.localUrl,
+      authToken: "fresh-bearer",
+    });
+    expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ anyharnessBearerToken: "fresh-bearer" }),
+    );
+    expect(getDirectRuntimeConnectionSnapshot("target-1")).toMatchObject({
+      connectionState: "attached",
+      authToken: "fresh-bearer",
+    });
+  });
+
+  it("rethrows the rejection when the refetched bearer is unchanged", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(
+      profile({ anyharnessBearerToken: "stale-bearer" }),
+    );
+    mocks.ensureSshAnyHarnessTunnel.mockRejectedValue(
+      "AnyHarness rejected the stored runtime bearer (401 Unauthorized).",
+    );
+    mocks.refreshSshDirectTargetBearer.mockResolvedValue("stale-bearer");
+
+    await expect(
+      resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1")),
+    ).rejects.toBe(
+      "AnyHarness rejected the stored runtime bearer (401 Unauthorized).",
+    );
+    expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenCalledTimes(1);
+    expect(getDirectRuntimeConnectionSnapshot("target-1").connectionState).toBe(
+      "unreachable",
+    );
+  });
+
+  it("caches a bearerless resolution in memory across resolves", async () => {
+    mocks.getSshDirectTargetProfile.mockResolvedValue(
+      profile({ anyharnessBearerToken: null }),
+    );
+    mocks.resolveSshDirectTargetBearer.mockResolvedValue(null);
+    mocks.ensureSshAnyHarnessTunnel.mockResolvedValue(tunnel);
+
+    await resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1"));
+    await resolveDirectRuntimeConnection(sshDirectRuntimeRef("target-1"));
+
+    expect(mocks.resolveSshDirectTargetBearer).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ anyharnessBearerToken: null }),
+    );
+  });
+});

--- a/apps/desktop/src/lib/access/anyharness/direct-runtime-connection.ts
+++ b/apps/desktop/src/lib/access/anyharness/direct-runtime-connection.ts
@@ -1,0 +1,150 @@
+import type { DirectRuntimeRef } from "@/lib/domain/compute/direct-runtime";
+import {
+  refreshSshDirectTargetBearer,
+  resolveSshDirectTargetBearer,
+} from "@/lib/access/anyharness/ssh-direct-bearer";
+import {
+  getSshDirectTargetProfile,
+  type SshDirectTargetProfile,
+} from "@/lib/access/tauri/ssh-target-profile";
+import {
+  ensureSshAnyHarnessTunnel,
+  type EnsureSshAnyHarnessTunnelResult,
+} from "@/lib/access/tauri/ssh-tunnel";
+import { useDirectRuntimeConnectionStore } from "@/stores/compute/direct-runtime-connection-store";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+export interface DirectRuntimeConnection {
+  baseUrl: string;
+  authToken: string | null;
+}
+
+// Per-target runtime bearer, resolved at most once per app run outside the
+// rejection-refresh path. `null` records a target that has no bearer (never
+// enforced or Cloud unreachable) so resolves stay offline-safe and do not
+// re-hit the runtime-access endpoint on every workspace resolution.
+const bearerByTargetId = new Map<string, string | null>();
+
+export function resetDirectRuntimeBearerCacheForTest(): void {
+  bearerByTargetId.clear();
+}
+
+/**
+ * The single place transport resolution happens for the direct-runtime
+ * family. Loopback resolves to the local harness runtime; ssh resolves to an
+ * ensured tunnel plus the per-runtime bearer. Remote attach outcomes are
+ * reported to the direct-runtime connection store (connecting -> attached /
+ * unreachable); loopback state derives from the harness bootstrap instead.
+ */
+export async function resolveDirectRuntimeConnection(
+  ref: DirectRuntimeRef,
+): Promise<DirectRuntimeConnection> {
+  if (ref.transport === "loopback") {
+    return {
+      baseUrl: useHarnessConnectionStore.getState().runtimeUrl,
+      authToken: null,
+    };
+  }
+  if (ref.targetId === null) {
+    throw new Error("A remote direct runtime requires a target id.");
+  }
+  return resolveSshTransportConnection(ref.targetId);
+}
+
+async function resolveSshTransportConnection(
+  targetId: string,
+): Promise<DirectRuntimeConnection> {
+  const dispatch = useDirectRuntimeConnectionStore.getState().dispatchConnectionEvent;
+  dispatch(targetId, { type: "connect_started" });
+
+  const profile = await getSshDirectTargetProfile(targetId);
+  if (!profile) {
+    const message =
+      "SSH direct access is not configured for this target. "
+      + "Add the SSH host, user, and key in Compute settings.";
+    dispatch(targetId, { type: "attach_failed", error: message });
+    throw new Error(message);
+  }
+
+  try {
+    const { tunnel, authToken } = await ensureTunnelWithBearer(targetId, profile);
+    dispatch(targetId, {
+      type: "attached",
+      baseUrl: tunnel.localUrl,
+      authToken,
+    });
+    return { baseUrl: tunnel.localUrl, authToken };
+  } catch (error) {
+    dispatch(targetId, { type: "attach_failed", error: errorMessage(error) });
+    throw error;
+  }
+}
+
+async function ensureTunnelWithBearer(
+  targetId: string,
+  profile: SshDirectTargetProfile,
+): Promise<{ tunnel: EnsureSshAnyHarnessTunnelResult; authToken: string | null }> {
+  // The profile bearer is authoritative (enrollment writes it); the memory
+  // cache only stands in for the runtime-access fetch when the profile
+  // predates bearer enforcement.
+  let authToken: string | null;
+  if (profile.anyharnessBearerToken) {
+    authToken = profile.anyharnessBearerToken;
+  } else {
+    const cached = bearerByTargetId.get(targetId);
+    authToken = cached !== undefined
+      ? cached
+      : await resolveSshDirectTargetBearer(profile);
+  }
+  bearerByTargetId.set(targetId, authToken);
+
+  try {
+    const tunnel = await ensureTunnel(profile, authToken);
+    return { tunnel, authToken };
+  } catch (error) {
+    if (!isRuntimeBearerRejection(error)) {
+      throw error;
+    }
+    // The runtime rejected the bearer Desktop holds (re-enrollment rotates
+    // it). Re-fetch from the runtime-access endpoint and retry once.
+    const refreshed = await refreshSshDirectTargetBearer(profile);
+    if (!refreshed || refreshed === authToken) {
+      throw error;
+    }
+    bearerByTargetId.set(targetId, refreshed);
+    const tunnel = await ensureTunnel(profile, refreshed);
+    return { tunnel, authToken: refreshed };
+  }
+}
+
+function ensureTunnel(
+  profile: SshDirectTargetProfile,
+  authToken: string | null,
+): Promise<EnsureSshAnyHarnessTunnelResult> {
+  return ensureSshAnyHarnessTunnel({
+    targetId: profile.targetId,
+    sshHost: profile.sshHost,
+    sshUser: profile.sshUser,
+    sshPort: profile.sshPort,
+    identityFile: profile.identityFile ?? null,
+    remoteAnyHarnessPort: profile.remoteAnyHarnessPort,
+    anyharnessBearerToken: authToken,
+  });
+}
+
+// Mirrors the unauthorized-access messages produced by
+// ssh_tunnel.rs::verify_anyharness_access — the tunnel-ensure command is the
+// authed probe, so its error string is the only 401/403 signal Desktop gets.
+function isRuntimeBearerRejection(error: unknown): boolean {
+  return errorMessage(error).includes("runtime bearer");
+}
+
+function errorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/apps/desktop/src/lib/access/anyharness/runtime-target.ts
+++ b/apps/desktop/src/lib/access/anyharness/runtime-target.ts
@@ -1,10 +1,9 @@
 import type { CloudAgentKind, CloudWorkspaceDetail } from "@/lib/access/cloud/client";
 import type { TerminalWebSocketAuthTransport } from "@anyharness/sdk";
+import { resolveDirectRuntimeConnection } from "@/lib/access/anyharness/direct-runtime-connection";
 import { resolveCloudSandboxGatewayConnectionForWorkspace } from "@/lib/access/cloud/cloud-sandbox-gateway";
 import { getCloudWorkspaceWithRetry } from "@/lib/access/cloud/workspace-connection-retry";
-import { ensureSshAnyHarnessTunnel } from "@/lib/access/tauri/ssh-tunnel";
-import { getSshDirectTargetProfile } from "@/lib/access/tauri/ssh-target-profile";
-import { resolveSshDirectTargetBearer } from "@/lib/access/anyharness/ssh-direct-bearer";
+import { sshDirectRuntimeRef } from "@/lib/domain/compute/direct-runtime";
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { resolveCloudWorkspaceStatus } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
@@ -13,6 +12,14 @@ type CloudWorkspaceCommandMetadata = CloudWorkspaceDetail & {
   targetId?: string | null;
 };
 
+/**
+ * `"local"` and `"target"` are both members of the direct-runtime family
+ * (user-owned AnyHarness that Desktop attaches to); the two literals survive
+ * only as wire-compatible transport aliases for loopback vs ssh. No consumer
+ * may branch on local-vs-target for anything except presentation — transport
+ * resolution lives solely in resolveDirectRuntimeConnection
+ * (specs/tbd/ssh-personal-target-design.md §3.2).
+ */
 export interface RuntimeTarget {
   location: "local" | "cloud" | "target";
   baseUrl: string;
@@ -33,26 +40,13 @@ export async function resolveRuntimeTargetForWorkspace(
 ): Promise<RuntimeTarget> {
   const targetWorkspace = parseTargetWorkspaceSyntheticId(workspaceId);
   if (targetWorkspace) {
-    const profile = await getSshDirectTargetProfile(targetWorkspace.targetId);
-    if (!profile) {
-      throw new Error(
-        "SSH direct access is not configured for this target. Add the SSH host, user, and key in Compute settings.",
-      );
-    }
-    const authToken = await resolveSshDirectTargetBearer(profile);
-    const tunnel = await ensureSshAnyHarnessTunnel({
-      targetId: profile.targetId,
-      sshHost: profile.sshHost,
-      sshUser: profile.sshUser,
-      sshPort: profile.sshPort,
-      identityFile: profile.identityFile ?? null,
-      remoteAnyHarnessPort: profile.remoteAnyHarnessPort,
-      anyharnessBearerToken: authToken,
-    });
+    const connection = await resolveDirectRuntimeConnection(
+      sshDirectRuntimeRef(targetWorkspace.targetId),
+    );
     return {
       location: "target",
-      baseUrl: tunnel.localUrl,
-      authToken: authToken ?? undefined,
+      baseUrl: connection.baseUrl,
+      authToken: connection.authToken ?? undefined,
       anyharnessWorkspaceId: targetWorkspace.anyharnessWorkspaceId,
       runtimeGeneration: 0,
       targetId: targetWorkspace.targetId,

--- a/apps/desktop/src/lib/access/anyharness/ssh-direct-bearer.ts
+++ b/apps/desktop/src/lib/access/anyharness/ssh-direct-bearer.ts
@@ -20,6 +20,17 @@ export async function resolveSshDirectTargetBearer(
   if (profile.anyharnessBearerToken) {
     return profile.anyharnessBearerToken;
   }
+  return refreshSshDirectTargetBearer(profile);
+}
+
+/**
+ * Re-fetch the runtime bearer from Cloud, bypassing the profile cache, and
+ * persist the result. Used when the runtime rejects the bearer Desktop holds
+ * (the target was re-enrolled with a fresh credential).
+ */
+export async function refreshSshDirectTargetBearer(
+  profile: SshDirectTargetProfile,
+): Promise<string | null> {
   try {
     const access = await getTargetRuntimeAccess(profile.targetId);
     const bearer = access.anyharnessBearerToken.trim();

--- a/apps/desktop/src/lib/domain/compute/direct-runtime.test.ts
+++ b/apps/desktop/src/lib/domain/compute/direct-runtime.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  DETACHED_DIRECT_RUNTIME_CONNECTION,
+  directRuntimeConnectionKey,
+  directRuntimeTransport,
+  loopbackDirectRuntimeConnectionState,
+  loopbackDirectRuntimeRef,
+  reduceDirectRuntimeConnection,
+  sshDirectRuntimeRef,
+  type DirectRuntimeConnectionSnapshot,
+} from "./direct-runtime";
+
+describe("direct runtime refs", () => {
+  it("derives loopback transport from a null target id", () => {
+    expect(directRuntimeTransport(null)).toBe("loopback");
+    expect(directRuntimeTransport("target-1")).toBe("ssh");
+  });
+
+  it("builds a loopback ref for this machine", () => {
+    expect(loopbackDirectRuntimeRef()).toEqual({
+      targetId: null,
+      transport: "loopback",
+      displayName: "This Mac",
+    });
+  });
+
+  it("builds an ssh ref with the target id as the fallback display name", () => {
+    expect(sshDirectRuntimeRef("target-1")).toEqual({
+      targetId: "target-1",
+      transport: "ssh",
+      displayName: "target-1",
+    });
+    expect(sshDirectRuntimeRef("target-1", "Home server").displayName).toBe(
+      "Home server",
+    );
+  });
+
+  it("keys loopback and targets without collisions", () => {
+    expect(directRuntimeConnectionKey(null)).toBe("loopback");
+    expect(directRuntimeConnectionKey("loopback")).toBe("target:loopback");
+    expect(directRuntimeConnectionKey("target-1")).toBe("target:target-1");
+  });
+});
+
+describe("loopbackDirectRuntimeConnectionState", () => {
+  it("maps harness bootstrap health onto the direct connection states", () => {
+    expect(loopbackDirectRuntimeConnectionState("healthy")).toBe("attached");
+    expect(loopbackDirectRuntimeConnectionState("connecting")).toBe("connecting");
+    expect(loopbackDirectRuntimeConnectionState("failed")).toBe("unreachable");
+  });
+});
+
+describe("reduceDirectRuntimeConnection", () => {
+  const attached: DirectRuntimeConnectionSnapshot = {
+    connectionState: "attached",
+    baseUrl: "http://127.0.0.1:52001",
+    authToken: "bearer-1",
+    lastError: null,
+  };
+
+  it("moves detached to connecting on connect_started", () => {
+    expect(
+      reduceDirectRuntimeConnection(DETACHED_DIRECT_RUNTIME_CONNECTION, {
+        type: "connect_started",
+      }),
+    ).toEqual({
+      connectionState: "connecting",
+      baseUrl: null,
+      authToken: null,
+      lastError: null,
+    });
+  });
+
+  it("keeps the last resolved connection while reconnecting", () => {
+    expect(
+      reduceDirectRuntimeConnection(attached, { type: "connect_started" }),
+    ).toEqual({ ...attached, connectionState: "connecting" });
+  });
+
+  it("records the resolved connection and clears errors on attach", () => {
+    const unreachable = reduceDirectRuntimeConnection(
+      DETACHED_DIRECT_RUNTIME_CONNECTION,
+      { type: "attach_failed", error: "tunnel failed" },
+    );
+    expect(
+      reduceDirectRuntimeConnection(unreachable, {
+        type: "attached",
+        baseUrl: "http://127.0.0.1:52001",
+        authToken: "bearer-1",
+      }),
+    ).toEqual(attached);
+  });
+
+  it("drops the resolved connection and records the error on failure", () => {
+    expect(
+      reduceDirectRuntimeConnection(attached, {
+        type: "attach_failed",
+        error: "tunnel failed",
+      }),
+    ).toEqual({
+      connectionState: "unreachable",
+      baseUrl: null,
+      authToken: null,
+      lastError: "tunnel failed",
+    });
+  });
+
+  it("resets fully on detach", () => {
+    expect(
+      reduceDirectRuntimeConnection(attached, { type: "detached" }),
+    ).toEqual(DETACHED_DIRECT_RUNTIME_CONNECTION);
+  });
+});

--- a/apps/desktop/src/lib/domain/compute/direct-runtime.ts
+++ b/apps/desktop/src/lib/domain/compute/direct-runtime.ts
@@ -1,0 +1,111 @@
+/**
+ * The direct-runtime family: persistent, user-owned AnyHarness runtimes that
+ * Desktop attaches to instead of provisioning. "Local" is the degenerate case
+ * where the transport is loopback; an SSH target is the identical thing where
+ * the transport is a tunnel. Transport is a property derived from the ref —
+ * never a category — and may only influence connection resolution and
+ * presentation (specs/tbd/ssh-personal-target-design.md §0, §3.2).
+ */
+
+export type DirectRuntimeTransport = "loopback" | "ssh";
+
+export type DirectRuntimeConnectionState =
+  | "attached"
+  | "connecting"
+  | "unreachable"
+  | "detached";
+
+export interface DirectRuntimeRef {
+  /** null identifies this machine's loopback runtime. */
+  targetId: string | null;
+  transport: DirectRuntimeTransport;
+  displayName: string;
+}
+
+export function directRuntimeTransport(targetId: string | null): DirectRuntimeTransport {
+  return targetId === null ? "loopback" : "ssh";
+}
+
+export function loopbackDirectRuntimeRef(displayName = "This Mac"): DirectRuntimeRef {
+  return { targetId: null, transport: "loopback", displayName };
+}
+
+export function sshDirectRuntimeRef(
+  targetId: string,
+  displayName?: string,
+): DirectRuntimeRef {
+  return {
+    targetId,
+    transport: directRuntimeTransport(targetId),
+    displayName: displayName ?? targetId,
+  };
+}
+
+export function directRuntimeConnectionKey(targetId: string | null): string {
+  return targetId === null ? "loopback" : `target:${targetId}`;
+}
+
+/**
+ * The loopback runtime has no attach machinery of its own: its connection
+ * state derives from the local harness bootstrap health.
+ */
+export function loopbackDirectRuntimeConnectionState(
+  harnessConnectionState: "connecting" | "healthy" | "failed",
+): DirectRuntimeConnectionState {
+  switch (harnessConnectionState) {
+    case "healthy":
+      return "attached";
+    case "connecting":
+      return "connecting";
+    case "failed":
+      return "unreachable";
+  }
+}
+
+export interface DirectRuntimeConnectionSnapshot {
+  connectionState: DirectRuntimeConnectionState;
+  baseUrl: string | null;
+  authToken: string | null;
+  lastError: string | null;
+}
+
+export type DirectRuntimeConnectionEvent =
+  | { type: "connect_started" }
+  | { type: "attached"; baseUrl: string; authToken: string | null }
+  | { type: "attach_failed"; error: string }
+  | { type: "detached" };
+
+export const DETACHED_DIRECT_RUNTIME_CONNECTION: DirectRuntimeConnectionSnapshot = {
+  connectionState: "detached",
+  baseUrl: null,
+  authToken: null,
+  lastError: null,
+};
+
+export function reduceDirectRuntimeConnection(
+  previous: DirectRuntimeConnectionSnapshot,
+  event: DirectRuntimeConnectionEvent,
+): DirectRuntimeConnectionSnapshot {
+  switch (event.type) {
+    case "connect_started":
+      // Keep the last resolved connection while re-ensuring so an already
+      // attached runtime does not flash-drop its address mid-refresh.
+      return { ...previous, connectionState: "connecting" };
+    case "attached":
+      return {
+        connectionState: "attached",
+        baseUrl: event.baseUrl,
+        authToken: event.authToken,
+        lastError: null,
+      };
+    case "attach_failed":
+      return {
+        connectionState: "unreachable",
+        baseUrl: null,
+        authToken: null,
+        lastError: event.error,
+      };
+    case "detached":
+      return DETACHED_DIRECT_RUNTIME_CONNECTION;
+  }
+}

--- a/apps/desktop/src/stores/compute/direct-runtime-connection-store.ts
+++ b/apps/desktop/src/stores/compute/direct-runtime-connection-store.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+import {
+  DETACHED_DIRECT_RUNTIME_CONNECTION,
+  directRuntimeConnectionKey,
+  loopbackDirectRuntimeConnectionState,
+  reduceDirectRuntimeConnection,
+  type DirectRuntimeConnectionEvent,
+  type DirectRuntimeConnectionSnapshot,
+} from "@/lib/domain/compute/direct-runtime";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+interface DirectRuntimeConnectionStoreState {
+  connectionsByKey: Record<string, DirectRuntimeConnectionSnapshot>;
+  dispatchConnectionEvent: (
+    targetId: string | null,
+    event: DirectRuntimeConnectionEvent,
+  ) => void;
+  resetConnections: () => void;
+}
+
+export const useDirectRuntimeConnectionStore = create<DirectRuntimeConnectionStoreState>(
+  (set) => ({
+    connectionsByKey: {},
+    dispatchConnectionEvent: (targetId, event) => {
+      // Loopback state derives from the harness bootstrap; only remote
+      // direct runtimes carry an attach machine of their own.
+      if (targetId === null) {
+        return;
+      }
+      const key = directRuntimeConnectionKey(targetId);
+      set((state) => ({
+        connectionsByKey: {
+          ...state.connectionsByKey,
+          [key]: reduceDirectRuntimeConnection(
+            state.connectionsByKey[key] ?? DETACHED_DIRECT_RUNTIME_CONNECTION,
+            event,
+          ),
+        },
+      }));
+    },
+    resetConnections: () => set({ connectionsByKey: {} }),
+  }),
+);
+
+export function getDirectRuntimeConnectionSnapshot(
+  targetId: string | null,
+): DirectRuntimeConnectionSnapshot {
+  if (targetId === null) {
+    const { runtimeUrl, connectionState, error } = useHarnessConnectionStore.getState();
+    const derived = loopbackDirectRuntimeConnectionState(connectionState);
+    return {
+      connectionState: derived,
+      baseUrl: derived === "attached" ? runtimeUrl : null,
+      authToken: null,
+      lastError: error,
+    };
+  }
+  const key = directRuntimeConnectionKey(targetId);
+  return (
+    useDirectRuntimeConnectionStore.getState().connectionsByKey[key]
+    ?? DETACHED_DIRECT_RUNTIME_CONNECTION
+  );
+}


### PR DESCRIPTION
Desktop core for the direct-runtime family: a pure domain model (`DirectRuntimeRef` with loopback|ssh transport derived from targetId, plus a connection-state reducer) and a per-target zustand connection store whose loopback entry derives from harness bootstrap health. `resolveDirectRuntimeConnection` becomes the single transport-resolution point — ssh attaches via profile + tunnel + the per-runtime bearer (in-memory cached, refetched and retried once on rejection) — and the `runtime-target.ts` 'target' branch delegates to it, with 'local'/'target' documented as wire-compat aliases of the direct family.

Stack: 4/6 — 16-gateway-target-scoping → 17-target-bearer → 18-runtime-bearer-enforcement → 19-direct-runtime-core → 20-direct-auth-sync → 21-direct-runtime-ui

Design: `specs/tbd/ssh-personal-target-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
