### PR TITLE
fix(agent-auth): native fallback for un-configured harnesses (unblock launches)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
@@ -63,11 +63,13 @@ pub struct GatewayProfile {
 /// - state present, has selection(s) for the harness: profile per route.
 ///   OpenCode merges ALL its selections into one composite profile
 ///   (spec §3.3); single-source harnesses error (typed) on more than one.
-/// - state present + scoped (`revision > 0`) but NO selection for the harness:
-///   fail-closed [`RouteAuthError::SelectionMissing`] (spec §3), mirroring the
-///   old `AGENT_AUTH_SELECTION_REQUIRED` semantics against the new model.
-/// - state present but NOT scoped (`revision == 0`) with no selection: legacy
-///   `Native` (bootstrapping state before any selection exists).
+/// - state present but NO selection for the harness (regardless of revision):
+///   legacy `Native`. A harness the user never configured uses its own native
+///   login — the least-surprising default, and safe (native = the user's own
+///   CLI sign-in, never ambient/leaked credentials). We deliberately do NOT
+///   fail-closed here: `revision` scoping is GLOBAL (any one selection bumps
+///   it), so fail-closing on a missing selection blocked launching every
+///   un-configured harness the moment a different one was configured.
 pub fn resolve_profile(
     state: Option<&AgentAuthState>,
     harness_kind: &str,
@@ -77,14 +79,7 @@ pub fn resolve_profile(
     };
     let selections = state.selections_for(harness_kind);
     if selections.is_empty() {
-        return if state.is_scoped() {
-            Err(RouteAuthError::SelectionMissing {
-                harness_kind: harness_kind.to_string(),
-                revision: state.revision,
-            })
-        } else {
-            Ok(AgentRuntimeAuthProfile::Native)
-        };
+        return Ok(AgentRuntimeAuthProfile::Native);
     }
     if harness_kind == OPENCODE_HARNESS {
         return resolve_opencode_composite(harness_kind, &selections, state.revision);
@@ -226,7 +221,10 @@ mod tests {
     }
 
     #[test]
-    fn scoped_missing_selection_fails_closed() {
+    fn missing_selection_falls_back_to_native_even_when_scoped() {
+        // Configuring a DIFFERENT harness (codex) bumps the global revision to
+        // 7, but claude — which the user never configured — must still launch
+        // on its own native login, not fail-closed.
         let state = state(
             7,
             vec![AuthSelection {
@@ -239,11 +237,8 @@ mod tests {
                 model_catalog: None,
             }],
         );
-        let error = resolve_profile(Some(&state), "claude").expect_err("fail-closed");
-        assert!(matches!(
-            error,
-            RouteAuthError::SelectionMissing { revision: 7, .. }
-        ));
+        let profile = resolve_profile(Some(&state), "claude").expect("resolve");
+        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -399,13 +399,16 @@ fn gemini_api_key_sets_only_gemini_key() {
 // --- fail-closed / missing / malformed / native ----------------------------
 
 #[test]
-fn scoped_state_without_selection_fails_closed_with_code() {
-    let home = TempHome::new("fail-closed");
+fn scoped_state_without_selection_renders_native_delta() {
+    // A scoped state (codex configured, revision bumped) must NOT block claude,
+    // which the user never configured — claude renders an empty (native) delta
+    // and launches on its own login.
+    let home = TempHome::new("missing-native");
     home.write_state_json(&gateway_state("codex", None)); // no claude selection
 
-    let error = resolve_launch_route_auth(home.path(), "claude").expect_err("fail-closed");
-    assert_eq!(error.code(), "AGENT_ROUTE_SELECTION_MISSING");
-    assert!(matches!(error, RouteAuthError::SelectionMissing { .. }));
+    let rendered = resolve_launch_route_auth(home.path(), "claude").expect("render");
+    assert!(rendered.set.is_empty());
+    assert!(rendered.remove.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Problem
Launching claude on `main` fails with `no agent-auth route selection for harness 'claude' at revision 1` (`AGENT_ROUTE_SELECTION_MISSING`). Once a user configures **any** harness, the shared `state.json` revision goes >0, and `resolve_profile` fail-closes on **every** harness that has no explicit selection — so unconfigured harnesses (claude here) can't launch at all.

## Fix
`resolve_profile`: a missing selection now resolves to `Native` (the harness's own login) regardless of revision, instead of `SelectionMissing`. `revision` scoping is global (any one selection bumps it), so per-harness fail-closing on "missing" is wrong. Native fallback is the least-surprising default and safe — native = the user's own CLI sign-in, never ambient/leaked creds. Explicit selections (gateway/api_key/native) are unaffected.

## Tests
Updated the two tests that asserted the old fail-closed to assert native fallback; `cargo test -p anyharness-lib route_auth` → 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)