### PR TITLE
fix(cloud): kill E2B sandbox on destroy + rewrite provisioning specs

### DIFF
--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -8,6 +8,7 @@ ORM stack.
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 from uuid import UUID
 
@@ -17,8 +18,11 @@ from proliferate.db.store import billing_subjects
 from proliferate.db.store import cloud_sandboxes as sandbox_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+from proliferate.integrations.sandbox import get_sandbox_provider
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.utils.crypto import decrypt_text
+
+logger = logging.getLogger(__name__)
 
 
 class _UserWithId(Protocol):
@@ -75,6 +79,17 @@ async def destroy_cloud_sandbox(
     # Retire the sandbox's worker + gateway token so a destroyed sandbox can
     # never keep authenticating back to Cloud.
     await runtime_workers_store.revoke_active_workers_for_identity(db, cloud_sandbox_id=sandbox.id)
+    if sandbox.e2b_sandbox_id:
+        provider = get_sandbox_provider(sandbox.e2b_template_ref)
+        try:
+            await provider.destroy_sandbox(sandbox.e2b_sandbox_id)
+        except Exception:
+            logger.warning(
+                "cloud sandbox provider destroy failed sandbox_id=%s e2b_sandbox_id=%s",
+                sandbox.id,
+                sandbox.e2b_sandbox_id,
+                exc_info=True,
+            )
     return await sandbox_store.mark_cloud_sandbox_destroyed(db, sandbox.id)
 
 

--- a/specs/codebase/primitives/cloud-commands.md
+++ b/specs/codebase/primitives/cloud-commands.md
@@ -1,1384 +1,243 @@
-# 04 — Cloud Running Alignment
+# Cloud Commands
 
-Status: implementation-ready spec.
+> Rewritten 2026-07-02 to replace a description of the pre-cutover architecture (PR #809, commit 4b54c9f2b) with the current `cloud_sandbox` model.
 
-Date: 2026-06-05 (collapsed-identity revision; command leasing/results
-correlate by `target_id`, no slot fence).
+Status: Describes shipped, current behavior. The materialization section is
+fully verified; the live-session forwarding section is also verified but
+scoped narrowly (see caveats).
+
+Date: 2026-07-02.
 
 Depends on: [`sandbox-provisioning.md`](sandbox-provisioning.md),
-[`mcp-skills.md`](mcp-skills.md),
-[`agent-auth.md`](agent-auth.md).
+[`workspace-lifecycle.md`](workspace-lifecycle.md).
 
-The cloud command queue, worker dispatcher, event tail, and session
-projection substrate is mostly shipped. This spec is cleanup and
-alignment: thread the spec 00 fields through, add the runtime-config
-preflight peer of the existing agent-auth preflight, fill in the
-missing exposure/projection admission model, add a wake gate, and
-strip the direct-access reads from `cloud_workspace`.
+## There Is No Async Command Queue
 
-## 1. Purpose & Scope
-
-In scope:
-
-- Thread `cloud_workspace_id` and `sandbox_profile_id`
-  through cloud_commands, the worker wire contract, command leasing,
-  delivery, result ingest, and event ingest.
-- Correlate command leasing and result ingest by `target_id` per spec 00 §5.8
-  (no slot id, no `slot_generation`, no fence — `target_id` is the epoch).
-- `_validate_runtime_config_preflight()` peer of the existing
-  `_validate_agent_auth_preflight()` (per spec 01).
-- Worker dispatcher synthesizes `AgentAuthExternalScope` from
-  `sandboxProfileId` on `start_session` (per spec 02 §5.2).
-- New `cloud_workspace_exposure` table; existing
-  `cloud_session_projection` (table name: `cloud_sessions`) extended
-  with `exposure_id`, `projection_level`, `commandable`,
-  `gap_state_json`, `last_uploaded_seq`.
-- Worker `worker_projection_cursor` SQLite mirror; worker tail is
-  exposure-gated.
-- Wake gate before delivery for wake-required command kinds. Cloud
-  performs the Proliferate-owned E2B operation; worker never wakes
-  itself.
-- Workspace `origin` made an explicit column (kept narrow to the
-  spec-03 vocabulary). `exposure_state` and `sandbox_type` are
-  derived, not stored.
-- Remove all managed-cloud reads of `cloud_workspace.runtime_url`,
-  `runtime_token_ciphertext`, `active_sandbox_id` (spec 00 dropped
-  the columns; spec 04 closes the call sites at
-  `config_sync/repo_config.py`, `liveness/ensure_running.py`, and
-  runtime `service.py`; AnyHarness protocol calls live under
-  `integrations/anyharness/**`).
-- "Passive UI" invariant: list workspace/session/transcript state
-  from Cloud DB without waking the sandbox. Enforced by review +
-  tests.
-
-Out of scope:
-
-- Claim policy and claimable lists (→ spec 05). Spec 04 lays the
-  `cloud_workspace_exposure.visibility = 'shared_unclaimed'`
-  scaffolding but spec 05 owns the claim API and claim tokens.
-- Slack inbound webhook handling (→ spec 07). Spec 04's command
-  source enum already has `'slack'`; spec 07 wires the producer.
-- Automation runner internals (→ spec 06). Spec 04 ensures the
-  existing automation cloud-execution caller carries the new
-  envelope fields, but the automation lifecycle is owned by spec 06.
-- Web/mobile UI shells (→ spec 08).
-- Billing wake-gate decisions (→ spec 09). Spec 04 defines the wake
-  hook; spec 09 owns "is this billing subject allowed to wake right
-  now?".
-- Migration / move (→ spec 10).
-
-## 2. Mental Model
+This corrects a previously mis-stated fact. There is no `cloud_commands`
+table and no `CloudCommand` model:
 
 ```text
-client (Desktop / Web / Mobile / Slack / Automation / API)
-  -> Cloud control plane
-       enqueue_command (preflight + idempotency + auth gate)
-       persist cloud_workspace + cloud_workspace_exposure +
-       cloud_session_projection rows BEFORE worker dispatch
-       wake the target's sandbox if the command requires it
-  -> Proliferate Worker
-       leases command (correlated by target_id)
-       preflights local runtime state
-       calls local AnyHarness
-       reports result + echoes cloud_workspace_id
-  -> AnyHarness
-       runs session
-  -> Worker tailer (exposure-gated)
-       uploads events for active exposures only
-  -> Cloud event ingest
-       writes cloud_session_event, updates projection rows
-  -> clients
-       read from Cloud DB; no E2B wake required for passive views
+$ grep -rn "class CloudCommand" server/proliferate/db/models/
+(no matches)
 ```
 
-The invariant set:
+The old architecture (described in a stale prior version of this file) had
+a queue + worker-lease model with command rows, leasing, delivery, and
+result ingest. That is gone from this worktree. What actually executes
+commands inside a sandbox today is synchronous and RPC-style, driven
+directly by the requesting HTTP handler's call stack.
+
+## Materialization: The Synchronous, Redis-Locked RPC Model
+
+### Entry points
+
+Callers that trigger sandbox materialization work call one of the
+`schedule_materialize_*` functions in
+`server/proliferate/server/cloud/materialization/service.py:22-58`
+(`schedule_materialize_sandbox`, `schedule_materialize_repo_environment`,
+`schedule_materialize_secret_set`). Each schedules its work via
+`runner.run_after_commit`
+(`server/proliferate/server/cloud/materialization/runner.py:19-33`), which:
+
+- registers a callback that fires only after the current DB transaction
+  commits (`db_run_after_commit`, from `proliferate.db.engine`);
+- on commit, spawns the actual work with `asyncio.create_task(_run())` —
+  this is in-process, best-effort scheduling. Exceptions are caught and
+  logged (`logger.exception(...)`), not retried. **There is no durable,
+  persisted queue row backing this** — if the process crashes between
+  commit and task completion, the scheduled materialization is simply
+  lost; nothing re-drives it. This is consistent with "no async command
+  queue," but worth calling out explicitly since it means materialization
+  scheduling itself is not crash-safe today.
+
+One caller — `create_cloud_workspace_for_user`
+(`server/proliferate/server/cloud/workspaces/service.py:182-185`) — instead
+calls `materialization_service.materialize_repo_environment(...)` directly
+and `await`s it inline (not via `schedule_*`/`run_after_commit`), so
+workspace creation synchronously blocks on materialization completing
+before returning to the caller.
+
+### The shared operation skeleton
+
+`run_cloud_sandbox_operation`
+(`server/proliferate/server/cloud/materialization/operation.py:24-38`) is
+the single shared entrypoint used by every materialization operation:
+
+```python
+async def run_cloud_sandbox_operation(db, *, sandbox, operation_key, ..., run):
+    async with locks.redis_materialization_lock(f"cloud-sandbox:{sandbox.id}", ...):
+        target = await sandbox_io.connect_ready_sandbox(db, sandbox=sandbox)
+        await run(MaterializationContext(sandbox=sandbox, target=target))
+```
+
+- **Synchronization is a Redis lock, not a queue.** `redis_materialization_lock`
+  (`server/proliferate/server/cloud/materialization/locks.py:56-98`) does a
+  `SET NX EX` on a key derived from `cloud-sandbox:{sandbox.id}`
+  (namespaced further by `settings.redbeat_key_prefix`,
+  `locks.py:22-23`), busy-waits up to `wait_timeout_seconds` (default 300s,
+  polling every 0.5s) if already held, and raises
+  `CloudMaterializationLockTimeout` on timeout. While held, a background
+  task renews the TTL periodically (`_renew_lock`, `locks.py:24-46`). This
+  guarantees at most one materialization operation runs against a given
+  sandbox at a time; it does not queue or order pending callers beyond
+  simple first-to-acquire-wins polling.
+- Note `operation_key` is accepted by `run_cloud_sandbox_operation` but
+  immediately discarded (`del operation_key`, `operation.py:32`) — it is
+  not currently used for anything (not part of the lock key, not logged
+  here). Callers still pass distinct-looking values
+  (e.g. `f"secrets:workspace:{repo_environment.id}"` in
+  `materialize/secret_set.py:47`), but as of this file those values have no
+  effect I could find.
+- Inside the lock, `connect_ready_sandbox` (see `sandbox-provisioning.md`)
+  ensures the E2B sandbox exists and AnyHarness is healthy, lazily
+  provisioning if needed, then the caller's `run(ctx)` callback executes
+  with a `MaterializationContext(sandbox, target)`.
+
+### Callers of `run_cloud_sandbox_operation` (verified by grep)
 
 ```text
-1. Cloud creates cloud_workspace + (where relevant) exposure +
-   projection rows BEFORE worker dispatch.
-2. Wake-required commands wake the target's sandbox through Proliferate,
-   not through raw E2B URLs.
-3. Command leasing, delivery, and result ingest correlate by `target_id`;
-   reports from an archived (replaced) target are inert.
-4. Worker results never auto-create cloud_workspace rows (spec 00
-   acceptance #23 echoed here).
-5. Workspace materialization results must echo cloud_workspace_id.
-6. Worker event tailer projects only sessions with active exposure +
-   projection. No exposure -> no upload.
-7. Passive UI reads come from Cloud DB only. Mutation/launch reads go
-   through Cloud commands.
+server/proliferate/server/cloud/materialization/materialize/sandbox.py
+server/proliferate/server/cloud/materialization/materialize/repo_environment.py
+server/proliferate/server/cloud/materialization/materialize/secret_set.py
 ```
 
-## 3. Dependencies
+I grepped the whole `server/proliferate/server/cloud/` tree for
+`run_cloud_sandbox_operation` and these three (plus `operation.py` itself)
+are the only matches. There is no `materialize/agent_auth.py` in this
+worktree, but that is not because agent-auth materialization work hasn't
+started — a large agent-auth command/materialization layer already exists
+at `server/proliferate/server/cloud/agent_auth/` (`worker_materialization.py`,
+`reconciler.py`, `sharing.py`, `grant_freshness.py`, and 40+ other modules,
+using `CloudCommandKind`/`CloudCommandStatus`/lease vocabulary). It is
+parked, not deleted: commit `073cea282` ("fix(server): align test suite +
+finish deletion sweep after #803/#809 cutover", PR #846) removed store
+modules it depends on (`db/store/cloud_agent_auth/mappers.py` and friends,
+plus all of `db/store/cloud_sync/`), and its reconciler import is
+commented out in `main.py:52` under an "AGENT AUTH PARKED" note —
+importing `worker_materialization.py` fails with `ModuleNotFoundError`
+against this worktree's dependencies. So the module is dead/unreachable
+code, not evidence that no async command queue work has begun; it just
+isn't wired into `run_cloud_sandbox_operation` or mounted anywhere live.
 
-Hard:
+- `materialize_sandbox` (`materialize/sandbox.py:21-28`) — the
+  personal-sandbox bootstrap: inside one locked operation it materializes
+  GitHub credentials, global secrets, and every configured repo
+  environment for the user (`materialize/sandbox.py:31-51`).
+- `materialize_repo_environment` (`materialize/repo_environment.py`, not
+  fully read in this pass beyond its call site) — clones/checks out one
+  repo into the sandbox.
+- `materialize_secret_set` (`materialize/secret_set.py:20-51`) — resolves
+  personal/organization/workspace-scoped secrets and writes them as env
+  files + individual secret files inside the sandbox
+  (`materialize_global_secrets_for_user`,
+  `materialize_workspace_secrets_for_repo_environment`), tracking an
+  applied-manifest row via `sandbox_secret_store` so unused files from a
+  previous version get removed (`_reconcile_secret_files`,
+  `secret_set.py:266-289`) rather than left behind.
 
-- Spec 00: `sandbox_profile`, `cloud_targets.profile_target_role`,
-  the ephemeral managed target (= sandbox), `sandbox_profile_target_state`,
-  `cloud_target_runtime_access`, plus the new envelope/result wire
-  fields.
-- Spec 01: `sandbox_profile_runtime_config_current.current_sequence`
-  and `current_revision_id`; the
-  `applied_runtime_config_sequence`/`applied_runtime_config_revision_id`
-  columns on `sandbox_profile_target_state`. The `materialize_environment`
-  command carrying a `runtime_config` fragment.
-- Spec 02: agent-auth preflight already shipped; spec 04 doesn't
-  redo it, but the dispatcher synthesizes `AgentAuthExternalScope`
-  per spec 02 §5.2.
+### How commands actually run inside the sandbox
 
-Soft:
+Two layers, both ultimately calling the sandbox provider's `run_command`:
 
-- Spec 05 (claiming) and spec 06 (automations) consume the exposure
-  / projection model defined here.
-- Spec 09 (billing) owns the actual wake-allow check inside the
-  wake hook.
+- `run_sandbox_command_logged`
+  (`server/proliferate/server/cloud/runtime/sandbox_exec.py:161-201+`) —
+  the low-level wrapper: logs a structured "command started"/"failed"
+  event via `log_cloud_event`, times the call, and calls
+  `provider.run_command(sandbox, command, user=, cwd=, envs=, background=,
+  timeout_seconds=)`. This is what `connect_ready_sandbox` uses directly to
+  chmod and launch the AnyHarness binary itself
+  (`materialization/sandbox_io/connect.py:172-197`).
+- `run_materialization_script`
+  (`server/proliferate/server/cloud/materialization/sandbox_io/commands.py:19-46`)
+  — a higher-level helper used by materializers: wraps an arbitrary script
+  as `bash -lc <script>`, calls `run_sandbox_command_logged` with it, and
+  raises `CloudMaterializationCommandError` if the exit code is non-zero.
 
-## 4. Current Repo State
+Both are direct provider calls against the E2B sandbox (i.e. `provider` is
+the `SandboxProvider` for `e2b`,
+`server/proliferate/integrations/sandbox/e2b.py`) — there is no
+intermediate lease/result-ingest round trip; the calling coroutine awaits
+the command and gets the result back in the same call stack.
 
-Verified against the current repository worktree on 2026-05-20.
+## Live-Session Command Forwarding (Verified, Separate Path)
 
-### 4.1 What is shipped
+This is a distinct path from materialization, used once a sandbox is
+`ready` and a client (Desktop/Web/etc.) wants to talk to AnyHarness
+directly for a live chat/agent session, terminal, etc.
 
-**`cloud_commands` table** (`db/models/cloud/commands.py`):
+Router: `server/proliferate/server/cloud/gateway/api.py`, mounted as
+`gateway_router` at prefix `{api_prefix}/v1/gateway`
+(`server/proliferate/main.py:57,231`) — so the effective paths are under
+`/v1/gateway/cloud-sandbox/anyharness/...`.
+
+- `proxy_cloud_sandbox_anyharness_http`
+  (`gateway/api.py:26-40`) — catch-all HTTP route
+  `/cloud-sandbox/anyharness/{path:path}` for `GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS`.
+- `proxy_cloud_sandbox_anyharness_websocket`
+  (`gateway/api.py:43-63`) — the same path as a WebSocket route, with its
+  own auth (`authenticate_product_user_for_gateway_websocket`, since
+  WebSocket upgrade requests can't carry a normal `Authorization` header).
+
+Both resolve `ensure_cloud_sandbox_gateway_access`
+(`server/proliferate/server/cloud/gateway/service.py:75-89`), which:
+
+1. checks a 60-second in-process cache keyed by `user_id`
+   (`_GATEWAY_ACCESS_CACHE_TTL_SECONDS = 60.0`, `gateway/service.py:38`);
+2. on a miss, calls `ensure_cloud_sandbox_ready` (the Step-A DB-row-only
+   path from `sandbox-provisioning.md` — this does **not** itself
+   provision the E2B VM) and decrypts the runtime token via
+   `load_cloud_sandbox_runtime_access`.
+
+Then `proxy_http_to_anyharness` / `proxy_websocket_to_anyharness`
+(`server/proliferate/server/cloud/gateway/proxy.py`) forward the request or
+WebSocket byte-for-byte to `anyharness_base_url`, injecting the decrypted
+bearer token and stripping hop-by-hop/auth headers
+(`_STRIP_REQUEST_HEADERS`/`_STRIP_RESPONSE_HEADERS`, `proxy.py:23-40`).
+Gateway code here does not parse or reinterpret AnyHarness's command
+payloads — it is a byte-level reverse proxy.
+
+### What is confirmed vs. not
+
+**Confirmed by direct read:** the route exists, is mounted, resolves
+sandbox access, and reverse-proxies to `anyharness_base_url` for both HTTP
+and WebSocket.
+
+**Not verified in this pass / caveats:**
+- I did not verify what happens if the gateway proxies a request while
+  `connect_ready_sandbox` has not yet been run for this sandbox in this
+  process lifetime (i.e. whether `ensure_cloud_sandbox_gateway_access`'s
+  call to `ensure_cloud_sandbox_ready` is sufficient to guarantee AnyHarness
+  is actually up, given that function only does the cheap DB-row-ensure
+  step, not the E2B-provisioning step). If a sandbox row exists with a
+  stale `anyharness_base_url` from a previous VM lifetime (e.g. after an
+  E2B pause/resume cycle where the process died), I did not trace whether
+  the gateway proxy would successfully reach a live AnyHarness or fail —
+  that reconciliation (`connect_ready_sandbox`'s health-check-then-relaunch
+  logic) is only invoked from the materialization path, not from the
+  gateway path, as far as I traced.
+- I did not verify client-side (Desktop/Web) code that decides when to use
+  this gateway path vs. a local Tauri/AnyHarness runtime — out of scope for
+  this pass.
+- The 60-second access cache means a sandbox recycled (e.g. destroyed and
+  a new row created) could serve stale `upstream_base_url`/token to a
+  client for up to 60s after the change; I did not find any cache
+  invalidation hook tied to sandbox destroy/recreate.
+
+## Code Map
 
 ```text
-id, target_id (fk), organization_id, actor_user_id,
-actor_kind        user | automation | slack | api_key | system
-source            web | mobile | slack | api | automation | desktop_cloud_view
-workspace_id      text (AnyHarness id), nullable
-session_id        text, nullable
-kind              command kind enum
-payload_json
-observed_event_seq
-preconditions_json
-authorization_context_json    { actorUserId, targetOwnerScope,
-                                targetOrganizationId, cloudWorkspaceId }
-status            queued | leased | delivered | accepted |
-                  accepted_but_queued | rejected | expired |
-                  superseded | failed_delivery
-lease_id, leased_by_worker_id, lease_expires_at, attempt_count
-delivered_at, accepted_at, rejected_at, expired_at
-error_code, error_message, result_json
-```
-
-`authorization_context_json` already carries `cloudWorkspaceId`. Spec
-00 promotes it to a first-class column.
-
-**Command service** (`server/proliferate/server/cloud/commands/service.py`):
-
-```text
-enqueue_command(...)
-  - idempotency scope key: org/user : target : workspace : session : kind
-  - validates target status, kind, payload shape
-  - calls _validate_agent_auth_preflight()
-  - stores authorization_context_json
-
-_validate_agent_auth_preflight(...)
-  - reads sandboxProfileId + requiredAgentAuthRevision from payload
-  - loads sandbox_profile_agent_auth_target_state for (profile, target)
-  - rejects if profile missing / belongs to other target / applied <
-    required
-```
-
-**Command API**:
-
-```text
-POST /v1/cloud/commands              enqueue_command_endpoint
-GET  /v1/cloud/commands/{command_id} get_command_status_endpoint
-
-POST /v1/cloud/worker/commands/lease
-POST /v1/cloud/worker/commands/{command_id}/result
-POST /v1/cloud/worker/commands/{command_id}/delivery
-```
-
-**Worker dispatcher**
-(`anyharness/crates/proliferate-worker/src/commands/dispatcher.rs`):
-
-```text
-run_loop()
-  flush_pending_command_results()
-  lease_command(supported_kinds)
-  process_command(envelope)
-
-process_command branches per kind:
-  configure_git_identity, ensure_repo_checkout, materialize_environment,
-  sync_existing_workspace, refresh_agent_auth_config,
-  + everything else routed via dispatch_anyharness() after
-    map_cloud_command(envelope).
-
-Preconditions: validated server-side at enqueue; worker honors
-observed_event_seq if the precondition payload demands it.
-```
-
-**Session projection / event upload** (`db/models/cloud/sync.py`):
-
-```text
-cloud_session_events
-  id, target_id, session_id, anyharness_seq (uniq per session),
-  event_type, payload_json, payload_hash (dedup), payload_ref,
-  payload_size_bytes, created_at
-
-cloud_event_ingest_state
-  target_id, session_id, last_contiguous_seq, updated_at
-
-cloud_synced_workspaces
-  target_id, cloud_workspace_id (fk), workspace_id (AnyHarness)
-
-cloud_sessions       (the table is named cloud_sessions, model
-                      class is CloudSessionProjection)
-  id, target_id, session_id, cloud_workspace_id (nullable),
-  workspace_id (AnyHarness), status, phase, live_config_json,
-  last_event_seq, last_event_at, started_at, ended_at
-
-cloud_transcript_items
-  target_id, session_id, item_id, turn_id, kind, status,
-  first_seq, last_seq, completed_seq, timestamps
-
-cloud_pending_interactions
-  target_id, session_id, request_id, kind, status, requested_seq,
-  resolved_seq, timestamps
-```
-
-**Event upload endpoint**:
-
-```text
-POST /v1/cloud/worker/events/batches    worker_event_batch_endpoint
-  body: WorkerEventBatchRequest with list of WorkerSessionEventEnvelope
-  resp: { accepted_events, duplicate_events, live_only_events,
-          session_acks: [{ session_id, last_contiguous_seq }] }
-  dedup: UNIQUE (target_id, session_id, anyharness_seq) + payload_hash
-```
-
-**Worker tailer**
-(`anyharness/crates/proliferate-worker/src/sync/tailer.rs`):
-
-```text
-run_loop()  every 500ms
-  for each session in store.list_sync_sessions():
-    fetch list_session_events(session_id, last_uploaded_seq)
-    POST /worker/events/batches
-    update local cursor on session_acks
-```
-
-`store.list_sync_sessions()` returns every session the worker knows
-about. **It is not exposure-gated today.**
-
-**`cloud_workspace.origin_json`** is nullable and free-form. Used
-informally by automation runners. There is no enum-typed `origin`
-column today.
-
-**Direct-access reads on `cloud_workspace`** (call sites today):
-
-```text
-cloud_workspace.active_sandbox_id   server/cloud/runtime/config_sync/repo_config.py
-cloud_workspace.runtime_url         server/cloud/runtime/service.py,
-                                    server/cloud/runtime/liveness/ensure_running.py
-cloud_workspace.runtime_token_ciphertext  server/cloud/runtime/service.py
-cloud_workspace/runtime_environment direct-access fields are also read
-  through db/store/cloud_workspaces.py, runtime/liveness/ensure_running.py,
-  repo_config/service.py, runtime/provision.py, and runtime/setup_monitor.py.
-
-Raw AnyHarness protocol access is not owned by these product paths; it lives
-under server/proliferate/integrations/anyharness/**.
-```
-
-These columns are dropped by spec 00. Spec 04 closes the call sites
-by routing through `cloud_target_runtime_access`.
-
-**Callers of `POST /v1/cloud/commands`**:
-
-```text
-Desktop                 source = desktop_cloud_view
-Web                     source = web (via cloud-sdk-react useEnqueueCloudCommand)
-Mobile                  source = mobile (same SDK)
-Automation              source = automation (cloud_executor_commands.py)
-API                     source = api (agent_auth service)
-Slack                   no caller in repo yet (spec 07 adds)
-```
-
-### 4.2 Gaps spec 04 closes
-
-- `cloud_commands.cloud_workspace_id` is in
-  `authorization_context_json` but not a column. Spec 00 promotes it.
-  Spec 04 makes every caller stamp it and every reader use it.
-- Command leasing correlates only by `target_id`; spec 00 removed the slot
-  fence, so there are no `leased_cloud_sandbox_id`/`leased_slot_generation`
-  columns to implement.
-- `_validate_runtime_config_preflight()` does not exist; spec 04 adds
-  it as the peer of `_validate_agent_auth_preflight()`.
-- Worker dispatcher does not synthesize `AgentAuthExternalScope` from
-  `sandboxProfileId`; spec 04 wires it per spec 02 §5.2.
-- `cloud_workspace_exposure` table does not exist; spec 04 creates it.
-- `cloud_sessions` (the projection table) does not carry
-  `exposure_id`, `projection_level`, `commandable`, `gap_state_json`,
-  `last_uploaded_seq`. Spec 04 adds them.
-- `worker_projection_cursor` does not exist locally on the worker.
-  Spec 04 adds it.
-- Worker tailer is not exposure-gated. Spec 04 gates it.
-- Wake-on-command logic does not exist. Spec 04 adds the wake hook
-  inside `enqueue_command` (or a sibling delivery-time gate).
-- No `origin` enum column on `cloud_workspace`. Spec 04 adds one
-  using the spec-03 vocabulary.
-
-## 5. Target Model
-
-### 5.1 Command envelope, result, and lease — wire the spec-00 fields
-
-Server (`cloud_commands` table) — already extended by spec 00:
-
-```text
-cloud_workspace_id        uuid fk cloud_workspace.id   nullable
-```
-
-There are no `leased_cloud_sandbox_id` / `leased_slot_generation` columns —
-leasing correlates by `target_id` alone (spec 00 §5.8).
-
-Spec 04 enforces:
-
-```text
-enqueue_command writes:
-  cloud_workspace_id  (always set for managed-cloud commands; null
-                       for non-managed targets like SSH/local)
-
-lease / result / delivery / event ingest correlate by target_id:
-  worker.target_id MUST equal command.target_id, and the command's target
-  MUST NOT be archived. If the target was replaced (archived):
-    - the report is inert; no projection / workspace / billing state is
-      updated from a retired target
-    - the command is marked superseded (status = 'superseded')
-  target_id is the epoch — there is no slot id or slot_generation to compare,
-  and no "mark worker stale" step: a replaced sandbox is a brand-new target
-  with a brand-new worker that never shared identity with the old one.
-```
-
-Worker wire (already added by spec 00 contract change):
-
-```text
-CloudCommandEnvelope:
-  cloud_workspace_id    Option<Uuid>
-  sandbox_profile_id    Option<Uuid>
-
-CommandResultRequest:
-  cloud_workspace_id        Option<Uuid>
-  anyharness_workspace_id   Option<String>    -- echoed on materialize
-
-CommandDeliveryRequest:
-  cloud_workspace_id    Option<Uuid>
-```
-
-No `slot_generation` on any of these — `target_id` (already present) is the
-identity.
-
-Where the worker fills in these fields:
-
-```text
-On materialize_workspace result:
-  - echo cloud_workspace_id from the inbound envelope
-  - on success: set anyharness_workspace_id = the created/resolved
-    AnyHarness workspace id
-  - server verifies cloud_workspace_id resolves to a row + matches
-    the command's cloud_workspace_id, and the command's target is the
-    active (non-archived) primary; then updates
-    cloud_workspace.anyharness_workspace_id + materialized_target_id
-
-On every other command result:
-  - echo cloud_workspace_id when known
-```
-
-### 5.2 Runtime config preflight
-
-New peer of `_validate_agent_auth_preflight()`:
-
-```text
-server/proliferate/server/cloud/commands/service.py
-
-_validate_runtime_config_preflight(db, payload, target, profile):
-  required_seq      = payload.get('requiredRuntimeConfigSequence')
-  required_rev_id   = payload.get('requiredRuntimeConfigRevisionId')
-  if both None:
-    return  # caller did not assert any preflight
-  state = load sandbox_profile_target_state(profile.id, target.id)
-  if state is None:
-    reject 'runtime_config_not_applied'
-  if state.applied_runtime_config_sequence < required_seq:
-    reject 'runtime_config_stale'
-  if required_rev_id and state.applied_runtime_config_revision_id != required_rev_id:
-    reject 'runtime_config_revision_mismatch'
-  # validity is per active target: the state row is loaded for the profile's
-  # active primary target. A replaced target gets a fresh state row, so there
-  # is no slot generation to compare.
-```
-
-Called from `enqueue_command` for kinds that require it:
-
-```text
-start_session, send_prompt, resolve_interaction, update_session_config,
-materialize_workspace (target-applied check before re-materializing
-                       on a target whose runtime config is behind)
-```
-
-`materialize_environment` is the apply command itself, not gated by
-this preflight. It carries the new revision; the preflight gates
-*subsequent* commands.
-
-When preflight fails with `runtime_config_stale` (the common case),
-the caller's choice is either:
-
-```text
-(a) auto-cascade
-    enqueue materialize_environment first with the current revision,
-    and enqueue the requested command after that. The server stitches
-    them with idempotency keys so a retry collapses.
-(b) fail fast
-    return the stale error to the caller; caller re-fetches state and
-    decides what to do.
-```
-
-Default behavior: **fail fast**. The "configure your sandbox before launching"
-flow is the user-visible contract. Auto-cascade requires an explicit UI
-materialize step before it can become part of the command contract.
-
-### 5.3 Exposure model
-
-New table:
-
-```text
-cloud_workspace_exposure
-  id                              uuid pk
-  target_id                       uuid fk cloud_targets.id            not null
-  cloud_workspace_id              uuid fk cloud_workspace.id          not null
-  anyharness_workspace_id         text                                nullable
-
-  owner_scope                     text   'personal' | 'organization'
-  owner_user_id                   uuid fk user.id                     nullable
-  organization_id                 uuid fk organization.id             nullable
-
-  visibility                      text   'private' | 'shared_unclaimed'
-                                          | 'claimed' | 'archived'
-  claimed_by_user_id              uuid fk user.id                     nullable
-
-  default_projection_level        text   'index_only' | 'session_summaries'
-                                          | 'transcript' | 'live'
-  commandable                     boolean                             not null default true
-
-  status                          text   'active' | 'paused' | 'stale' | 'revoked'
-  revision                        integer                             not null default 1
-  last_projected_at               timestamptz                         nullable
-
-  origin                          text                                nullable
-                                  (matches spec-03 Origin vocabulary)
-
-  created_at, updated_at, archived_at
-
-  CHECK ck_cloud_workspace_exposure_owner_fields
-  CHECK ck_cloud_workspace_exposure_visibility
-  CHECK ck_cloud_workspace_exposure_projection_level
-  CHECK ck_cloud_workspace_exposure_claimed_user
-    (claimed_by_user_id IS NOT NULL -> visibility = 'claimed')
-    -- visibility='claimed' may have claimed_by_user_id NULL after user
-       deletion; spec 05 treats that as orphan-claimed audit state.
-
-  UNIQUE PARTIAL ux_cloud_workspace_exposure_active
-    (target_id, cloud_workspace_id) WHERE archived_at IS NULL
-```
-
-A workspace has at most one active exposure at a time. Archiving an
-exposure does not delete the workspace; it just stops Cloud from
-projecting/commanding.
-
-### 5.4 Session projection extension
-
-Extend the existing `cloud_sessions` table (model class
-`CloudSessionProjection`):
-
-```text
-ADD COLUMN exposure_id           uuid fk cloud_workspace_exposure.id   nullable
-ADD COLUMN projection_level      text                                  not null default 'live'
-                                 'session_summaries' | 'transcript' | 'live'
-ADD COLUMN commandable           boolean                               not null default true
-ADD COLUMN gap_state_json        text                                  nullable
-                                 { last_gap_seq, last_repair_attempt_at, kind }
-ADD COLUMN last_uploaded_seq     integer                               nullable
-                                 mirror of cloud_event_ingest_state for fast reads
-ADD COLUMN agent_run_config_snapshot_json  jsonb                       nullable
-                                 -- resolved cloud_agent_run_config
-                                    values at session-creation time;
-                                    spec 06 §5.3 snapshot pattern.
-                                    Set by the launch caller (Desktop /
-                                    web / mobile / cowork) on
-                                    start_session; immutable thereafter.
-
-backfill:
-  default projection_level = 'live'
-  default commandable      = true
-  exposure_id              = NULL until exposure rows exist; populated
-                             as exposures are created by spec 04's
-                             managed_profile_launch service
-```
-
-Behavior:
-
-```text
-projection_level = 'session_summaries'
-  -> Cloud lists session, status, title; does not store transcript rows
-  -> commandable = false typically; not enforced by DB
-
-projection_level = 'transcript'
-  -> Cloud stores cloud_transcript_item, cloud_pending_interaction rows
-  -> commandable may be true (read+write) or false (read-only)
-
-projection_level = 'live'
-  -> as transcript, plus live-fanout SSE / websocket feed
-```
-
-`gap_state_json` is set when event ingest detects a sequence gap (a
-missing `anyharness_seq`). The worker tailer's
-`backfill_exposed_workspace` command kind re-fetches the missing seq
-range; on success, `gap_state_json` is cleared.
-
-### 5.5 Worker projection cursor
-
-New worker SQLite table:
-
-```text
-worker_projection_cursor
-  session_projection_id    text primary key
-  exposure_id              text                  not null
-  anyharness_workspace_id  text                  not null
-  anyharness_session_id    text                  not null
-  projection_level         text                  not null
-  commandable              boolean               not null
-  last_uploaded_seq        integer               not null default 0
-  last_ack_seq             integer               not null default 0
-  status                   text                  not null default 'active'
-  gap_state_json           text                  nullable
-  updated_at               text                  not null
-```
-
-The cursor is keyed by `session_projection_id`, not `exposure_id`. One
-workspace exposure can have multiple sessions; keying by exposure would
-silently collapse all but one active session. Worker responses may also
-include workspace-only exposure rows with no session projection; those
-rows are status/readiness input only and are not stored as tail cursors.
-
-Worker tailer reconciliation:
-
-```text
-worker pulls active exposures + projections from Cloud:
-  GET /v1/cloud/worker/exposures      (worker-token-only)
-  -> list of { exposure_id, target_id, cloud_workspace_id,
-               anyharness_workspace_id, anyharness_session_id,
-               projection_level, commandable, status, revision,
-               last_uploaded_seq }
-
-worker upserts worker_projection_cursor rows for active session projections.
-worker removes rows for revoked/paused exposures (or marks them
-inactive).
-
-tailer.run_loop iterates only over active worker_projection_cursor
-rows. Sessions outside the active set are NOT tailed.
-```
-
-When a new session starts on the worker side (e.g. `start_session`
-arrives, the AnyHarness session id is known after creation), the
-worker reports it back to Cloud via the command result; Cloud
-upserts the corresponding `cloud_session_projection` row and worker
-re-fetches active exposures on the next reconciliation tick.
-
-### 5.6 Wake gate
-
-A wake-required command is one that needs the AnyHarness process to
-be running. Wake-required kinds:
-
-```text
-materialize_workspace
-materialize_environment              (target apply; needs the runtime)
-refresh_agent_auth_config            (needs PUT /v1/agents/auth-config)
-start_session
-send_prompt
-resolve_interaction
-update_session_config
-cancel_turn       (when the runtime must observe; close_session same)
-close_session
-backfill_exposed_workspace
-```
-
-Non-wake-required:
-
-```text
-configure_git_identity     (idempotent; can run on next wake naturally
-                            unless caller wants it now)
-ensure_repo_checkout       (same)
-```
-
-**Wake is async.** `enqueue_command` does not block on E2B. The
-command row is persisted immediately; if the target's sandbox needs to be
-woken, a background wake job is kicked off and the command stays in
-`queued` status until the worker (after the sandbox resumes) leases it.
-
-Web and mobile callers already poll for command status; the wake
-latency becomes visible as time-in-`queued` without any new polling
-surface. UI can surface "Your cloud is starting up" by reading
-`GET /v1/cloud/sandbox-profiles/{id}/target-state` (existing) which
-includes the sandbox status.
-
-Wake control flow:
-
-```text
-server/proliferate/server/cloud/commands/service.py
-  enqueue_command(...):
-    ... existing preflight (agent_auth + runtime_config) ...
-    persist cloud_commands row (status='queued')
-    if kind in WAKE_REQUIRED_KINDS and target.kind == 'managed_cloud':
-        kick_off_managed_sandbox_wake(target_id, command_id)
-    return command_id   # NEVER blocks on E2B
-
-server/proliferate/server/cloud/runtime/wake.py        (new)
-  kick_off_managed_sandbox_wake(target_id, command_id):
-    # synchronous portion: just enqueue the background job.
-    # idempotent under concurrent callers via advisory lock per
-    # target id; only one wake job is in-flight per target.
-    advisory_lock_try(target_id)
-    if wake_job_already_running(target_id):
-        return                           # piggy-back on the in-flight job
-    enqueue_wake_job(target_id)
-
-  run_managed_sandbox_wake_job(target_id):
-    # background worker function
-    lock (target_id) advisory
-    load the target's sandbox (1:1 with the active primary target)
-    if sandbox.status == 'running':
-        return  # nothing to do (a sibling command already woke it)
-    consult spec-09 billing hook (deny if blocked):
-        if denied:
-            mark all queued wake-required commands for this target as
-              failed_delivery with error_code='sandbox_wake_blocked'
-            return
-    if sandbox.status in ('paused', 'blocked'):
-        perform_proliferate_owned_e2b_resume(sandbox)
-        sandbox.status = 'resuming'
-        record wake event for audit
-    if sandbox.status == 'creating':
-        await bounded for the in-flight create
-    wait_for_worker_heartbeat(target_id, timeout)
-    if sandbox.status != 'running' after timeout:
-        mark all queued wake-required commands as failed_delivery
-          with error_code='sandbox_wake_failed'
-        return
-    # worker is now polling; it will pick up the queued commands
-    # naturally on its next lease tick.
-```
-
-The worker side does not change: when the sandbox is paused, the worker
-process is suspended (no polling); after wake the worker resumes and
-leases the queued commands. (The poll transport itself — the control
-long-poll — is owned by the worker contract, not this section.)
-
-**Fail-fast for terminal wake failures.** If the wake job runs out of
-bounded retries or billing denies, queued wake-required commands for
-that target transition to `failed_delivery` immediately with a typed
-`error_code`. They do not loiter in `queued` waiting for hope:
-
-```text
-sandbox_wake_failed     E2B SDK returned a terminal error,
-                        or worker did not heartbeat after wake.
-
-sandbox_wake_blocked    spec-09 billing/policy denied the wake
-                        (e.g. compute exhausted, billing block).
-
-sandbox_wake_timeout    wake_timeout exceeded without the sandbox reaching
-                        'running'. Same UX as failed; separate code
-                        for diagnostics.
-```
-
-Callers polling `GET /v1/cloud/commands/{id}` see the transition from
-`queued` → `failed_delivery` and surface a typed error. There is no
-"queued forever" state.
-
-**Explicit wake action** (for "warm up my cloud before I type"):
-
-```text
-POST /v1/cloud/sandbox-profiles/{profile_id}/wake
-  body: { target_id? }   (defaults to the primary target)
-  behavior: idempotent kick_off_managed_sandbox_wake;
-            returns immediately with current sandbox state
-  response: { sandbox_profile_id, target_id, sandbox_status,
-              wake_in_flight, last_wake_started_at }
-  errors:
-    sandbox_wake_blocked  if billing denies (no row created)
-    profile_not_active    if profile.status not in
-                           ('active','provisioning')
-```
-
-This is a UX convenience. It does the same work `enqueue_command`
-would, but without persisting a command. Mobile/web's "Resume
-session" or "Wake cloud" button calls it before the user starts
-typing so the latency happens behind a progress affordance.
-
-Idempotency: `kick_off_managed_sandbox_wake` is safe to call
-concurrently. The advisory lock + sandbox status re-read makes parallel
-callers converge on one in-flight wake job.
-
-Spec 09 owns the billing gate inside the wake job; spec 04 wires the
-call hook. Spec 04's wake job uses a stub that returns "allow" until
-spec 09 lands.
-
-### 5.7 Workspace metadata
-
-Add a typed `origin` column to `cloud_workspace`:
-
-```text
-ALTER TABLE cloud_workspace
-  ADD COLUMN origin text NOT NULL DEFAULT 'manual_desktop'
-
-CHECK ck_cloud_workspace_origin:
-  origin IN ('manual_desktop','manual_web','manual_mobile',
-             'automation','slack','cowork_api')
-```
-
-Mapping current data:
-
-```text
-existing rows: stamp origin from origin_json.kind where available,
-                else default 'manual_desktop'.
-```
-
-`origin_json` stays for free-form metadata (originator details that
-don't fit the enum) but is no longer the primary key for "where did
-this come from."
-
-`exposure_state` and `sandbox_type` are **derived**, not stored:
-
-```text
-exposure_state
-  derived from cloud_workspace_exposure rows + their status/visibility
-  values defined in spec-03 §5.3 Exposure vocabulary
-  returned from GET /v1/cloud/workspaces/{id} as a computed field
-
-sandbox_type
-  derived from cloud_targets.kind + sandbox_profile.owner_scope:
-    kind='local'                       -> 'local'
-    kind='ssh'                         -> 'ssh'
-    kind='managed_cloud'
-      AND profile.owner_scope='personal'    -> 'managed_personal'
-      AND profile.owner_scope='organization' -> 'managed_shared'
-  returned from GET /v1/cloud/workspaces/{id} as a computed field
-```
-
-Derived fields are read-only on the API; they have no UPDATE path.
-
-### 5.8 Worker dispatcher updates
-
-```text
-anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
-
-process_command(envelope):
-  - if envelope.kind in agent_auth_scoped_kinds:
-      synthesize AgentAuthExternalScope {
-        provider: "proliferate-cloud",
-        id: envelope.sandbox_profile_id?.to_string(),
-        target_id: Some(envelope.target_id.to_string())
-      }
-      attach to AnyHarness CreateSessionRequest /
-      ResumeSessionRequest
-      (per spec 02 §5.2)
-
-  - if envelope.kind in runtime_config_scoped_kinds:
-      attach expected_runtime_config_revision {
-        revision_id, content_hash, external_scope: { provider:
-        "proliferate-cloud", id: sandbox_profile_id, target_id }
-      } from envelope payload to AnyHarness create/resume request
-      (per spec 01 §5.10)
-
-  - on materialize_workspace result success:
-      include anyharness_workspace_id and echo cloud_workspace_id
-```
-
-Worker reads new envelope fields from the contract; no version
-gating (spec-03 migration-posture rule).
-
-### 5.9 Passive UI rule
-
-Cloud-mediated lists, summaries, and status reads NEVER trigger a
-sandbox wake. The cloud_workspace + cloud_workspace_exposure +
-cloud_session_projection + cloud_transcript_item rows are the
-authoritative source.
-
-Concretely:
-
-```text
-GET /v1/cloud/workspaces
-GET /v1/cloud/workspaces/{id}
-GET /v1/cloud/workspaces/{id}/sessions
-GET /v1/cloud/sessions/{id}
-GET /v1/cloud/sessions/{id}/transcript
-GET /v1/cloud/sessions/{id}/pending-interactions
-GET /v1/cloud/sandbox-profiles/{id}/target-state
-GET /v1/cloud/sandbox-profiles/{id}/exposures      (new; admin & owner)
-
-These endpoints:
-  - read from Cloud DB only
-  - never call kick_off_managed_sandbox_wake
-  - never read cloud_target_runtime_access
-  - return cached transcript / pending-interaction rows even if the
-    sandbox is paused
-```
-
-A test in `server/tests/cloud/test_passive_ui_does_not_wake.py`
-asserts that calling the GET endpoints above on a workspace whose
-sandbox is paused does not mutate `cloud_sandbox.status` and does not
-emit a wake event.
-
-### 5.10 Removing direct-access reads from cloud_workspace
-
-Spec 00 drops `cloud_workspace.active_sandbox_id`, `runtime_url`,
-`runtime_token_ciphertext`. Spec 04 closes the callers:
-
-```text
-server/proliferate/server/cloud/runtime/config_sync/repo_config.py
-  - read active_sandbox_id from cloud_target_runtime_access
-  - read anyharness_base_url from cloud_target_runtime_access
-  - decrypt runtime_token_ciphertext from cloud_target_runtime_access
-
-server/proliferate/server/cloud/runtime/service.py
-  - same; all direct-access reads route through
-    cloud_target_runtime_access
-
-server/proliferate/server/cloud/runtime/liveness/ensure_running.py
-server/proliferate/server/cloud/runtime/config_sync/runtime_config.py
-  - runtime access arrives through cloud_target_runtime_access-backed callers;
-    raw AnyHarness protocol access stays in integrations/anyharness/**
-```
-
-Boundary rule (matches spec 00 §5.5):
-
-```text
-cloud_target_runtime_access is for:
-  managed provisioning bootstrap
-  allowlisted health checks
-  diagnostics
-
-Production Cloud -> AnyHarness mutations go through
-cloud_commands -> worker -> AnyHarness.
-```
-
-A grep `rg "cloud_workspace\.(active_sandbox_id|runtime_url|runtime_token_ciphertext|anyharness_data_key_ciphertext)" server/proliferate`
-returns no hits after spec 04 lands.
-
-### 5.11 API surface added by this spec
-
-User/admin:
-
-```text
-GET  /v1/cloud/workspaces/{cloud_workspace_id}/exposure
-POST /v1/cloud/workspaces/{cloud_workspace_id}/exposure
-PATCH /v1/cloud/workspace-exposures/{exposure_id}
-       body: { default_projection_level?, commandable?,
-               visibility?: requires admin/claim policy ok }
-DELETE /v1/cloud/workspace-exposures/{exposure_id}     (archives)
-
-GET  /v1/cloud/sandbox-profiles/{id}/exposures
-       owner/admin view of active exposures across the profile
-
-POST /v1/cloud/sessions/{session_id}/projection
-       upgrade/downgrade projection_level (or create from a session
-       discovered by backfill_exposed_workspace)
-
-POST /v1/cloud/sandbox-profiles/{id}/wake
-       body: { target_id? }
-       idempotent; kicks off the async wake job; returns immediately
-       with current sandbox state. Used by mobile/web "warm up cloud"
-       affordances and any UX that wants to surface "starting up"
-       before the first command is sent.
-```
-
-Worker (worker-token-only):
-
-```text
-GET /v1/cloud/worker/exposures
-       returns active exposures + projections for the worker's target
-       plus revision metadata so the worker can detect changes
-```
-
-Existing endpoints:
-
-```text
-POST /v1/cloud/commands                      (existing; payloads gain
-                                              requiredRuntimeConfig*)
-GET  /v1/cloud/commands/{id}                 (existing)
-POST /v1/cloud/worker/commands/lease         (existing; target-correlated)
-POST /v1/cloud/worker/commands/{id}/result   (existing; echo fields)
-POST /v1/cloud/worker/commands/{id}/delivery (existing)
-POST /v1/cloud/worker/events/batches         (existing; exposure-gated
-                                              by Cloud-side check)
-```
-
-Cloud event ingest accepts batches only for sessions whose
-projection has `projection_status = 'active'`. Batches for revoked/archived
-projections are accepted but discarded with a structured warning
-(useful for diagnostics) — see the per-event ack list.
-Event ingest MUST look up the active exposure/projection before applying
-events and MUST NOT auto-create `cloud_sessions` / projection rows from worker
-event batches.
-
-## 6. Files To Change
-
-Server (Python):
-
-```text
-server/proliferate/db/models/cloud/commands.py
-  - the column adds are owned by spec 00; spec 04 imports the new
-    fields and uses them in service code
-
-server/proliferate/db/models/cloud/workspaces.py
-  - add origin enum column + CHECK
-  - remove direct-access columns (already owned by spec 00; spec 04
-    just confirms removal in migration ordering)
-
-server/proliferate/db/models/cloud/sync.py
-  - CloudSessionProjection (table cloud_sessions):
-      add exposure_id, projection_level, commandable, gap_state_json,
-      last_uploaded_seq columns + CHECKs
-
-server/proliferate/db/models/cloud/exposures.py        (new)
-  CloudWorkspaceExposure
-  CloudWorkspaceExposureRevision (optional audit ring; defer if not
-                                  needed by spec 05)
-
-server/alembic/versions/<NEW>_exposure_projection_and_wake.py
-  - cloud_workspace_exposure
-  - cloud_sessions projection columns
-  - cloud_workspace.origin column
-
-server/proliferate/db/store/cloud_sync/
-  exposures.py                    (new) snapshot loaders/upserts
-  projections.py                  (new) cloud_sessions projection upserts
-                                        and gap_state writes
-  events.py                       update ingest to set
-                                        last_uploaded_seq on
-                                        cloud_session_projection
-  workspaces.py                   write origin enum
-
-server/proliferate/server/cloud/commands/service.py
-  - thread cloud_workspace_id into every enqueue (already in
-    authorization_context_json; promote to column)
-  - _validate_runtime_config_preflight()
-  - call kick_off_managed_sandbox_wake for wake-required kinds (async,
-    fire-and-forget; command is persisted in 'queued' immediately)
-  - on lease/result/delivery: correlate by target_id; reject (mark
-    superseded) when the command's target is archived; emit observability
-    event
-
-server/proliferate/server/cloud/commands/api.py
-  - response shape: include exposure_id, projection_id, target identity
-    where helpful
-
-server/proliferate/server/cloud/workspaces/service.py
-  - rewrite create_cloud_workspace to use the new managed_profile_launch
-    helper (signature below)
-  - stamp origin enum from caller (web/desktop/automation/slack)
-
-managed_profile_launch signature (canonical; every caller imports here):
-
-  def managed_profile_launch(
-      db: AsyncSession,
-      *,
-      owner_scope: str,                    # 'personal' | 'organization'
-      owner_user_id: UUID | None,
-      organization_id: UUID | None,
-      normalized_repo_key: str,
-      git_branch: str | None,
-      worktree_path: str | None,
-      origin: str,                         # spec 03 §5.3 Origin enum value
-      source_kind: str,                    # spec 05 §5.1 source_kind for
-                                           # claim provenance; matches origin
-                                           # for most callers; 'manual' for
-                                           # Desktop dispatch
-      exposure_visibility: str,            # spec 04 §5.3 visibility enum
-      exposure_commandable: bool,
-      default_projection_level: str,       # 'live' | 'transcript' |
-                                           # 'session_summaries'
-      required_runtime_config_revision_id: str | None,   # spec 01
-      required_agent_auth_revision: int | None,          # spec 02
-      actor_user_id: UUID,
-      idempotency_key: str | None = None,
-  ) -> ManagedProfileLaunchResult:
-      ...
-
-  class ManagedProfileLaunchResult:
-      sandbox_profile_id:        UUID
-      target_id:                 UUID
-      active_sandbox_id:         UUID    # the cloud_sandbox row, 1:1 with target
-      cloud_workspace_id:        UUID
-      cloud_workspace_exposure_id: UUID
-      cloud_session_projection_id: UUID | None   # set later on start_session
-      already_exists:            bool   # idempotency: True if same key
-                                         # resolved to existing rows
-
-The helper is transactional: ensure_*_sandbox_profile,
-ensure_primary_profile_target, provision_managed_target (background-
-provisioned), cloud_workspace INSERT, cloud_workspace_exposure
-INSERT or revision bump, all in one server-side flow. On
-failure before exposure insert, the cloud_workspace row is rolled
-back.
-
-Sandbox provisioning runs in the background (spec 00 §2.1); the
-helper returns once the cloud_workspace + exposure rows exist
-even if the sandbox is still `creating`. Wake-required commands
-that arrive against a creating sandbox use the spec 04 §5.6 async
-wake path.
-
-Sensible exposure defaults per caller (callers pass these
-explicitly; the helper does not infer):
-  personal launch            visibility='private', commandable=true
-  automation personal        visibility='private', commandable=true
-  automation team            visibility='shared_unclaimed', commandable=true
-  slack team                 visibility='shared_unclaimed', commandable=true
-  desktop dispatch           visibility='private', commandable=true
-  - create or upsert cloud_session_projection on session start
-
-server/proliferate/server/cloud/runtime/wake.py     (new)
-  kick_off_managed_sandbox_wake(target_id, command_id?)   (sync; enqueues
-                                                           background job)
-  run_managed_sandbox_wake_job(target_id)                 (background)
-  perform_proliferate_owned_e2b_resume(sandbox)
-
-server/proliferate/server/cloud/runtime/config_sync/repo_config.py
-server/proliferate/server/cloud/runtime/service.py
-server/proliferate/server/cloud/runtime/liveness/ensure_running.py
-server/proliferate/server/cloud/runtime/config_sync/runtime_config.py
-  - read from cloud_target_runtime_access instead of cloud_workspace
-
-server/proliferate/server/cloud/workspaces/api.py
-  - GET /workspaces/{id} returns computed exposure_state + sandbox_type
-  - POST /workspaces/{id}/exposure
-  - PATCH /workspace-exposures/{id}
-  - DELETE /workspace-exposures/{id}
-
-server/proliferate/server/cloud/sandbox_profiles/api.py
-  - GET /sandbox-profiles/{id}/exposures   (admin & owner)
-
-server/proliferate/server/cloud/worker/api.py
-  - GET /worker/exposures
-  - event ingest: discard events for inactive projections with a
-    structured per-event ack
-
-server/proliferate/server/automations/worker/cloud_execution/**
-  - automation runner uses the new managed_profile_launch helper
-  - origin = 'automation' on workspace + exposure
-```
-
-Worker (Rust):
-
-```text
-anyharness/crates/proliferate-worker/src/commands/dispatcher.rs
-  - synthesize AgentAuthExternalScope on agent-auth-scoped kinds
-  - attach expected_runtime_config_revision on runtime-config-scoped kinds
-  - echo cloud_workspace_id on results
-
-anyharness/crates/proliferate-worker/src/commands/mapping.rs
-  - propagate envelope fields through to AnyHarness contract types
-
-anyharness/crates/proliferate-worker/src/cloud_client/exposures.rs   (new)
-  GET /v1/cloud/worker/exposures
-  Snapshot dataclasses
-
-anyharness/crates/proliferate-worker/src/store/
-  worker_projection_cursor schema + DAO
-
-anyharness/crates/proliferate-worker/src/sync/tailer.rs
-  - replace store.list_sync_sessions() with
-    store.list_active_projection_cursors()
-  - on reconcile tick, refresh active exposures from Cloud
-  - record gaps via projection cursor; surface to Cloud on next ingest
-
-anyharness/crates/proliferate-worker/src/sync/backfill.rs
-  - sync_existing_workspace is renamed to backfill_exposed_workspace
-    in the same PR (server enum, worker supported_kinds, DB CHECK,
-    payload type, SDK regen). Becomes the explicit backfill-when-
-    exposure-is-new flow.
-```
-
-SDK regeneration:
-
-```text
-anyharness/sdk         (no contract change in spec 04 beyond what
-                        spec 00/01/02 already shipped)
-cloud/sdk              (add exposures/projection clients, new fields
-                        on workspace responses)
-```
-
-Desktop:
-
-```text
-apps/desktop/src/hooks/access/cloud/workspaces/                    extend
-  - returns exposure_state and sandbox_type from server payload
-apps/desktop/src/hooks/access/cloud/exposures/                     (new)
-  use-workspace-exposure.ts, use-exposure-mutations.ts
-apps/desktop/src/hooks/access/cloud/projections/                   (new)
-  use-session-projection.ts
-apps/desktop/src/components/cloud/                                 add passive
-  workspace sidebar row uses exposure_state + sandbox_type from
-  vocabulary.ts (spec 03)
-```
-
-## 7. Implementation Chunks
-
-```text
-Chunk A  cloud_workspace_id + target correlation on commands
-  - command service stamps cloud_workspace_id at enqueue
-  - lease/result/delivery/event ingest correlate by target_id
-  - reports from an archived (replaced) target are inert; command superseded
-  - tests: archived-target result discarded; superseded marker
-
-Chunk B  Runtime config preflight
-  - _validate_runtime_config_preflight()
-  - enqueue rejects stale; fail-fast V1
-  - test: start_session with stale requiredRuntimeConfigSequence
-    is rejected before reaching the worker
-
-Chunk C  Exposure + projection model
-  - cloud_workspace_exposure table
-  - cloud_sessions projection columns
-  - upsert exposure + projection on managed_profile_launch
-  - worker /worker/exposures endpoint
-  - worker projection cursor + tailer rewrite
-  - event ingest gated by projection.status='active'
-
-Chunk D  Async wake job
-  - kick_off_managed_sandbox_wake (sync; advisory lock; enqueues job)
-  - run_managed_sandbox_wake_job (background; consults billing hook;
-    E2B resume; waits for heartbeat)
-  - WAKE_REQUIRED_KINDS constant
-  - POST /v1/cloud/sandbox-profiles/{id}/wake endpoint
-  - failed wake transitions queued wake-required commands for the
-    target to failed_delivery with typed error_code
-  - tests: enqueue never blocks; wake runs in background; command
-    transitions queued -> leased after wake; wake fail -> queued ->
-    failed_delivery
-
-Chunk E  Workspace metadata + derived fields
-  - origin enum column with CHECK
-  - origin stamped by every caller (web/desktop/automation/slack)
-  - workspace API computes exposure_state + sandbox_type
-  - desktop reads via use-workspace
-
-Chunk F  Direct-access cleanup
-  - repo_config_apply, runtime service, anyharness_api, ensure_running,
-    credential_freshness, provision, setup_monitor, repo_config/service.py,
-    db/store/cloud_runtime_environments.py, and db/store/cloud_workspaces.py
-    stop reading/writing cloud_workspace/runtime_environment direct-access
-    fields on managed-cloud launch paths
-  - cloud_target_runtime_access is the only home
-  - grep verifies zero matches
-
-Chunk G  Passive UI invariant tests
-  - integration test that calls every passive GET endpoint with a
-    paused sandbox and asserts no sandbox mutation, no E2B SDK call
-```
-
-Preferred implementation is one PR per spec. Chunks are review checkpoints inside that PR and may be split only when the split does not leave duplicate models, dead paths, partially wired security checks, or visible inert UI.
-
-## 8. Acceptance Criteria
-
-1. Every managed-cloud `cloud_commands` row carries
-   `cloud_workspace_id`. Non-managed (SSH, local) rows leave it NULL.
-2. Command leasing correlates by `target_id` only; there is no
-   `leased_cloud_sandbox_id` / `leased_slot_generation`.
-3. Result, delivery, and event ingest reject reports from an archived
-   (replaced) target. Affected commands are marked `superseded`. There is
-   no slot generation and no "mark worker stale" step — a replaced sandbox
-   is a brand-new target with a brand-new worker.
-4. `_validate_runtime_config_preflight()` exists in
-   `commands/service.py` and is called from `enqueue_command` for
-   `start_session`, `send_prompt`, `resolve_interaction`,
-   `update_session_config`, and `materialize_workspace`.
-5. Preflight behavior is **fail fast** on stale runtime config. Auto-cascade
-   is outside this command contract.
-6. `cloud_workspace_exposure` exists with the schema in §5.3.
-   Active exposure is unique per `(target_id, cloud_workspace_id)`.
-7. `cloud_sessions` (CloudSessionProjection) has `exposure_id`,
-   `projection_level`, `commandable`, `gap_state_json`,
-   `last_uploaded_seq` columns.
-8. Worker tailer is exposure-gated: it tails only sessions whose
-   `cloud_session_projection.projection_status = 'active'` AND parent
-   exposure is active. Sessions outside the active set are not
-   uploaded.
-9. `enqueue_command` never blocks on E2B. Wake-required commands
-   are persisted in `queued` status; if the sandbox is not running,
-   `kick_off_managed_sandbox_wake` is called and the wake job runs in
-   the background. The command transitions to `leased` after the
-   sandbox reaches `running` and the worker picks it up.
-10. The async wake job consults the spec-09 billing hook (a stub
-    returning "allow" is fine in this spec; spec 09 fills it in).
-    Wake denials transition queued commands to `failed_delivery`
-    with `error_code='sandbox_wake_blocked'` and never let them
-    loiter in `queued`.
-10a. Bounded wake retry exhaustion transitions queued commands to
-    `failed_delivery` with `error_code='sandbox_wake_failed'` (E2B
-    terminal) or `'sandbox_wake_timeout'` (no heartbeat after
-    timeout). Same caller-visible failure surface; separate codes
-    for diagnostics.
-10b. `POST /v1/cloud/sandbox-profiles/{id}/wake` is idempotent.
-    Concurrent callers converge on one in-flight wake job per
-    target via an advisory lock.
-11. `cloud_workspace.origin` is a typed column constrained to the
-    spec-03 Origin vocabulary. Every workspace-create caller sets
-    it.
-12. `GET /v1/cloud/workspaces/{id}` returns computed `exposure_state`
-    and `sandbox_type` fields using the spec-03 vocabulary string
-    values. Neither is a stored column.
-13. Worker dispatcher synthesizes `AgentAuthExternalScope` on
-    agent-auth-scoped kinds (spec 02 §5.2) and attaches
-    `expected_runtime_config_revision` on runtime-config-scoped
-    kinds (spec 01 §5.10).
-14. Managed-cloud launch paths no longer read/write
-    `cloud_workspace.active_sandbox_id`, `cloud_workspace.runtime_url`,
-    `cloud_workspace.runtime_token_ciphertext`, `cloud_runtime_environment`
-    direct-access fields, or runtime access copied through
-    `db/store/cloud_workspaces.py`. Runtime access reads route through
-    `cloud_target_runtime_access`.
-15. Passive UI endpoints (§5.9 list) never call
-    `kick_off_managed_sandbox_wake` and never trigger a wake event.
-    Integration test asserts this for a paused sandbox.
-16. Cloud event ingest discards (with a per-event ack) events for
-    projections whose status is not `active`. The discard is
-    observable in the ack list but does not mutate transcript or
-    pending-interaction rows.
-17. `GET /v1/cloud/worker/exposures` exists and is worker-token-only.
-    The worker projection cursor table reconciles to its response.
-18. `materialize_workspace` worker result echoes `cloud_workspace_id`
-    and (on success) `anyharness_workspace_id`. The server rejects
-    results whose `cloud_workspace_id` does not match an existing
-    row (spec 00 acceptance #23 enforced here).
-19. The automation runner and Slack workspace launch (when spec 07
-    lands) call the same `managed_profile_launch` helper.
-20. Worker tailer's `backfill_exposed_workspace` (renamed from
-    `sync_existing_workspace` in this PR; same-PR rename, no alias)
-    fires only when an exposure is newly active or after a gap is
-    detected. It is not used for routine ingest.
-
-## 9. Verification / Tests
-
-Server:
-
-```bash
-cd server && uv run pytest -q
-```
-
-Targeted tests:
-
-```text
-server/tests/cloud/commands/test_cloud_workspace_id_promoted_to_column.py
-server/tests/cloud/commands/test_target_correlation_lease.py
-server/tests/cloud/commands/test_archived_target_result_rejection.py
-server/tests/cloud/commands/test_superseded_on_archived_target.py
-server/tests/cloud/commands/test_runtime_config_preflight_stale.py
-server/tests/cloud/commands/test_runtime_config_preflight_revision_mismatch.py
-server/tests/cloud/commands/test_runtime_config_preflight_ok.py
-server/tests/cloud/commands/test_enqueue_does_not_block_on_e2b.py
-server/tests/cloud/commands/test_wake_kicked_off_for_wake_required_kinds.py
-server/tests/cloud/commands/test_no_wake_for_non_wake_required.py
-server/tests/cloud/commands/test_wake_job_consults_billing_hook.py
-server/tests/cloud/commands/test_wake_failure_transitions_queued_to_failed.py
-server/tests/cloud/commands/test_wake_idempotent_under_concurrent_kicks.py
-server/tests/cloud/sandbox_profiles/test_wake_action_endpoint.py
-server/tests/cloud/exposures/test_exposure_unique_per_workspace.py
-server/tests/cloud/exposures/test_exposure_visibility_check.py
-server/tests/cloud/exposures/test_exposure_default_for_personal_launch.py
-server/tests/cloud/exposures/test_exposure_default_for_automation.py
-server/tests/cloud/exposures/test_exposure_default_for_slack_launch.py
-server/tests/cloud/projections/test_projection_columns_present.py
-server/tests/cloud/projections/test_event_ingest_discards_inactive.py
-server/tests/cloud/projections/test_gap_state_repair_flow.py
-server/tests/cloud/workspaces/test_origin_enum_check.py
-server/tests/cloud/workspaces/test_sandbox_type_derivation.py
-server/tests/cloud/workspaces/test_exposure_state_derivation.py
-server/tests/cloud/runtime/test_no_direct_access_reads_cloud_workspace.py
-server/tests/cloud/passive_ui/test_passive_ui_does_not_wake.py
-server/tests/automations/test_automation_uses_managed_profile_launch.py
-```
-
-Worker / AnyHarness:
-
-```bash
-cargo test -p proliferate-worker
-```
-
-Targeted Rust tests:
-
-```text
-anyharness/crates/proliferate-worker/src/sync/tailer.rs#tests
-  - tailer tails only active projection cursors
-  - inactive cursors are skipped
-  - reconciliation refreshes from /worker/exposures
-  - gap detection records gap_state and stops uploads until repair
-
-anyharness/crates/proliferate-worker/src/commands/dispatcher.rs#tests
-  - agent_auth_scope synthesized on start_session
-  - expected_runtime_config_revision attached on start_session/send_prompt
-  - materialize_workspace result echoes cloud_workspace_id
-  - non-wake-required commands proceed even on a paused-status slot
-    (worker side; the server-side wake gate is the policy authority)
-```
-
-Manual smoke:
-
-```text
-1. Personal workspace launch end-to-end
-   - managed_profile_launch creates cloud_workspace + exposure (private)
-     + projection
-   - enqueue_command stamps cloud_workspace_id and required_*_revision;
-     returns command_id immediately (no E2B block)
-   - if sandbox is paused: kick_off_managed_sandbox_wake fires in background;
-     UI polls /sandbox-profiles/{id}/target-state for "Cloud starting up"
-   - sandbox transitions paused -> resuming -> running; worker heartbeats
-   - worker leases the queued command, materializes, echoes ids
-   - tailer picks up the new session via /worker/exposures
-   - cloud_session_projection becomes active
-
-1a. Mobile "warm up cloud" before typing
-   - mobile calls POST /v1/cloud/sandbox-profiles/{id}/wake
-   - server returns immediately with current sandbox state
-   - background wake job runs; mobile polls target-state
-   - by the time user finishes typing, the sandbox is running; first
-     send_prompt has no wake latency
-
-1b. Wake failure (billing block)
-   - billing hook denies wake
-   - all queued wake-required commands for the target transition
-     queued -> failed_delivery with error_code='sandbox_wake_blocked'
-   - caller's command-status poll surfaces the typed error
-   - no commands loiter in queued forever
-
-2. Slack-style team launch (preparation for spec 07)
-   - managed_profile_launch with origin='slack' and visibility='shared_unclaimed'
-   - exposure visible to org members
-   - projection active; commandable=true
-   - workspace listing for org members shows it without waking
-
-3. Target replacement mid-flight
-   - active session running
-   - replace the managed target (archive old target + sandbox, provision new)
-   - worker on the old target reports a result -> inert/superseded
-     (the old target is archived; nothing routes to it)
-   - the new target gets a fresh sandbox_profile_target_state row
-   - cloud_workspace.materialized_target_id invalidated -> rematerialize-required
-   - new launches re-materialize before send_prompt
-
-4. Stale runtime config
-   - bump sandbox_profile_runtime_config_current to N+1
-   - start_session with requiredRuntimeConfigSequence=N is rejected
-     by the preflight as 'runtime_config_stale'
-   - re-enqueue with requiredRuntimeConfigSequence=N+1 after
-     materialize_environment applies; succeeds
-
-5. Passive UI on paused sandbox
-   - pause the sandbox
-   - GET /workspaces, /sessions, /transcript all succeed without
-     waking; cloud_sandbox.status stays paused
-
-6. Direct-access cleanup
-   - rg returns no cloud_workspace.runtime_* reads
-   - runtime endpoints work via cloud_target_runtime_access
+server/proliferate/server/cloud/materialization/service.py
+server/proliferate/server/cloud/materialization/runner.py
+server/proliferate/server/cloud/materialization/operation.py
+server/proliferate/server/cloud/materialization/locks.py
+server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+server/proliferate/server/cloud/materialization/sandbox_io/commands.py
+server/proliferate/server/cloud/materialization/materialize/sandbox.py
+server/proliferate/server/cloud/materialization/materialize/repo_environment.py
+server/proliferate/server/cloud/materialization/materialize/secret_set.py
+server/proliferate/server/cloud/runtime/sandbox_exec.py
+server/proliferate/server/cloud/gateway/api.py
+server/proliferate/server/cloud/gateway/service.py
+server/proliferate/server/cloud/gateway/proxy.py
+server/proliferate/server/cloud/gateway/access.py
 ```

--- a/specs/codebase/primitives/sandbox-provisioning.md
+++ b/specs/codebase/primitives/sandbox-provisioning.md
@@ -1,314 +1,283 @@
 # Sandbox Provisioning
 
-Status: Stack 1 implementation contract.
+> Rewritten 2026-07-02 to replace a description of the pre-cutover architecture (PR #809, commit 4b54c9f2b) with the current `cloud_sandbox` model.
 
-Date: 2026-06-24.
+Status: Describes shipped, current behavior.
 
-This spec describes the managed cloud sandbox foundation after the Stack 1
-cutover. The control plane provisions a single E2B-backed sandbox for a user,
-starts AnyHarness inside that sandbox, records the minimal runtime access
-material needed by the server, and treats AnyHarness SQLite inside the sandbox
-as the source of truth for runtime workspaces and sessions.
+Date: 2026-07-02.
 
-Daytona support has been removed. The managed sandbox provider is E2B.
+Depends on: none.
 
-## Goals
-
-- Keep the sandbox primitive small enough to reason about.
-- Provision one active personal cloud sandbox per user for now.
-- Keep cloud repo configuration in the control plane, but materialize configured
-  repos into the sandbox when a sandbox exists.
-- Preserve runtime truth inside AnyHarness rather than projecting every runtime
-  workspace into Cloud DB.
-- Store enough encrypted access metadata for the upcoming gateway to authenticate
-  a user once and proxy through to the sandbox-local AnyHarness instance.
+This spec describes the current managed cloud sandbox: one E2B microVM per
+owner, a `cloud_sandbox` Postgres row per sandbox, lazy two-step
+provisioning, E2B webhook reconciliation, and the destroy path.
 
 ## Data Model
 
-### `managed_sandbox`
+### `cloud_sandbox`
 
-One row represents one provider sandbox owned by a personal user or
-organization. The product currently uses the personal path; organization fields
-exist so the model does not need another migration when shared sandboxes are
-enabled.
+Model: `CloudSandbox`
+(`server/proliferate/db/models/cloud/sandboxes.py:29`).
 
-Important columns:
+Columns:
 
-- `owner_scope`: `personal` or `organization`.
-- `owner_user_id` / `organization_id`: exactly one is set, matching
-  `owner_scope`.
-- `created_by_user_id`: the user who first requested the sandbox.
-- `billing_subject_id`: billing subject used for provisioning and future
-  wake/start gating.
-- `status`: `creating`, `starting`, `ready`, `paused`, `error`, `destroying`,
-  or `destroyed`.
-- `last_error`: last provisioning or lifecycle error surfaced to the UI.
-- `e2b_sandbox_id`: provider sandbox id.
-- `e2b_template_ref`: E2B template ref used for this sandbox.
-- `anyharness_base_url`: private/public E2B host URL for the sandbox
-  AnyHarness server.
-- `anyharness_bearer_token_ciphertext`: encrypted runtime bearer token accepted
-  by sandbox AnyHarness.
-- `anyharness_data_key_ciphertext`: encrypted AnyHarness data key used by the
-  runtime.
-- `runtime_generation`: increments when the provider sandbox or AnyHarness
-  access tuple changes.
-- `ready_at`, `last_health_at`, `destroyed_at`: lifecycle timestamps.
+- `id` (`sandboxes.py:54`)
+- `owner_user_id` — FK to `user.id`, `ondelete="CASCADE"` (`sandboxes.py:55-58`)
+- `sandbox_type` — enum, currently constrained to exactly one value, `'e2b'`,
+  by both a Python `CloudSandboxType` enum
+  (`server/proliferate/constants/cloud.py:355-356`) and a DB check
+  constraint `ck_cloud_sandbox_type` (`sandboxes.py:35-38`)
+- `provider_sandbox_id` — the E2B sandbox id, nullable (`sandboxes.py:63-66`)
+- `status` — enum with exactly five values, enforced by both the Python
+  `CloudSandboxStatus` enum (`constants/cloud.py:359-364`) and a DB check
+  constraint `ck_cloud_sandbox_status` (`sandboxes.py:31-34`): `creating`,
+  `ready`, `paused`, `error`, `destroyed`
+- `anyharness_base_url` (`sandboxes.py:68`)
+- `runtime_token_ciphertext` (`sandboxes.py:69`)
+- `anyharness_data_key_ciphertext` (`sandboxes.py:70`)
+- `ready_at`, `last_health_at`, `destroyed_at` (`sandboxes.py:71-76`)
+- `created_at`, `updated_at` (`sandboxes.py:77-82`)
 
-Active uniqueness is enforced with partial indexes:
+There is no `organization_id` column on the ORM model — I read the full
+model and it is not there. The store-layer value type
+`CloudSandboxValue` (`server/proliferate/db/store/cloud_sandboxes.py:23-44`)
+does carry an `organization_id` field, but `cloud_sandbox_value()`
+(`cloud_sandboxes.py:47-70`) always sets it to the literal `None`
+(`cloud_sandboxes.py:56`) rather than reading it from a column — it is a
+leftover shape from an older value type, not live schema.
 
-- one non-destroyed personal sandbox per `owner_user_id`;
-- one non-destroyed organization sandbox per `organization_id`.
+Indexes (`sandboxes.py:39-51`):
 
-Destroyed rows remain as audit history. A later ensure creates a fresh row.
+- `ux_cloud_sandbox_personal_active`: unique partial index on
+  `owner_user_id` where `destroyed_at IS NULL` — enforces at most one
+  non-destroyed sandbox per owner.
+- `ux_cloud_sandbox_provider_sandbox_id`: unique partial index on
+  `provider_sandbox_id` where it is not null.
+- `ix_cloud_sandbox_owner_user_status`: lookup index.
 
-### `managed_sandbox_repo_materialization`
+## Ownership / Isolation Unit
 
-One row tracks the application of a configured `cloud_repo_config` into a
-managed sandbox.
+**Implemented today:** exactly one E2B microVM per user (`owner_user_id`).
+There is no shared/org-level sandbox mode in this codebase.
 
-Important columns:
+- `ensure_organization_cloud_sandbox` unconditionally raises
+  `ValueError("Organization cloud sandboxes are not supported.")`
+  (`server/proliferate/db/store/cloud_sandboxes.py:177-183`).
+- `load_organization_cloud_sandbox` is a stub that discards its arguments
+  and always returns `None` (`cloud_sandboxes.py:109-116`).
+- `acquire_cloud_sandbox_owner_lock` raises unless
+  `owner_scope == "personal"` (`cloud_sandboxes.py:74-88`).
+- The only creation path, `ensure_personal_cloud_sandbox`
+  (`cloud_sandboxes.py:146-172`), takes `user_id` and always writes
+  `owner_user_id`.
 
-- `managed_sandbox_id`
-- `cloud_repo_config_id`
-- `sandbox_generation`: generation of the sandbox runtime this attempt applies
-  to.
-- `status`: `pending`, `running`, `ready`, `error`, or `disabled`.
-- `repo_path`: canonical path inside the sandbox, currently
-  `/home/user/workspace/repos/{owner}/{repo}`.
-- `anyharness_repo_root_id`
-- `anyharness_workspace_id`
-- `applied_files_version`
-- `applied_setup_script_version`
-- `applied_env_vars_version`
-- `last_error`, `last_attempted_at`, `materialized_at`
+**Designed-for invariant** (reserved, not built): the schema is shaped so
+that "owner" could later mean an organization instead of a user, with the
+same guarantee — exactly one non-destroyed sandbox per owner, never many
+sandboxes per owner, never a sandbox shared across owners. The
+`organization_id` field surviving in `CloudSandboxValue` and the
+`owner_scope: "personal" | ...` branching in the store functions are the
+visible seams for that future mode; they are not wired to anything today.
 
-The unique key is `(managed_sandbox_id, cloud_repo_config_id)`.
+Why one-VM-per-owner: it keeps credential/secret isolation simple — the
+isolation boundary is the process/VM boundary, so there's no need for a
+second, in-VM multi-tenancy scheme to keep one user's secrets or agent
+session state away from another's. It also maps 1:1 to E2B's own billing
+unit (a microVM), and it avoids noisy-neighbor problems between unrelated
+users' agent sessions sharing one VM's CPU/RAM.
 
-## Provisioning Flow
+## Provisioning Is Lazy, In Two Distinct Steps
 
-### 1. Template
+### Step A — DB row creation (cheap, no cloud cost)
 
-The E2B template is built out of band and referenced by `E2B_TEMPLATE_NAME`.
-The template should include:
+`POST /v1/cloud-sandbox/ensure`
+(`server/proliferate/server/cloud/cloud_sandboxes/api.py:34-38`) calls
+`ensure_cloud_sandbox_ready`, which calls
+`ensure_personal_cloud_sandbox_exists`
+(`server/proliferate/server/cloud/cloud_sandboxes/service.py:45-62`), which:
 
-- AnyHarness runtime binary;
-- proliferate worker/supervisor binaries when required by later stacks;
-- agent installations and seed assets that are safe to pre-bake;
-- a blank writable workspace area.
+1. takes a Postgres advisory lock keyed by owner via
+   `acquire_cloud_sandbox_owner_lock`
+   (`db/store/cloud_sandboxes.py:74-88`, lock key
+   `f"cloud-sandbox:personal:{owner_user_id}"`);
+2. ensures a personal billing subject exists;
+3. calls `sandbox_store.ensure_personal_cloud_sandbox`
+   (`db/store/cloud_sandboxes.py:146-172`): reuses the existing
+   non-destroyed row if one is found (`load_personal_cloud_sandbox`,
+   `lock_row=True`), otherwise inserts a new row with
+   `status="creating"`, `provider_sandbox_id=None`.
 
-Self-hosted deployments use the same `E2B_TEMPLATE_NAME` config shape. There is
-no `SANDBOX_PROVIDER` switch.
+No E2B API call happens in this path. `POST .../wake` shares the same code
+path (`cloud_sandboxes/service.py:65-66`: `wake_cloud_sandbox` just calls
+`ensure_cloud_sandbox_ready`).
 
-### 2. Ensure Sandbox
+### Step B — actual E2B provisioning (real cloud cost)
 
-The user-facing ensure endpoint is:
+This happens on first real use of the sandbox, not on `ensure`. The
+function is `connect_ready_sandbox`
+(`server/proliferate/server/cloud/materialization/sandbox_io/connect.py:56-141`):
 
-```text
-POST /v1/cloud/managed-sandbox/ensure
-```
+1. If `sandbox.destroyed_at` is set or `status == "destroyed"`, raises
+   `CloudMaterializationCommandError` (`connect.py:61-62`).
+2. If `provider_sandbox_id` is `None`, calls `provider.create_sandbox()`
+   — the real E2B call — then persists the id via
+   `record_cloud_sandbox_provider_sandbox` and commits (`connect.py:66-79`).
+3. Calls `provider.resume_sandbox()` and resolves the runtime endpoint/context
+   (`connect.py:81-83`).
+4. If a runtime token/data key are already recorded, tries a health check
+   plus an auth-enforcement check against the existing `anyharness_base_url`
+   (`connect.py:87-97`); on any exception (e.g. a stale/dead process after
+   an E2B pause/resume) it falls through to relaunching AnyHarness. If no
+   token/data key exist yet, it generates fresh ones and launches directly
+   (`connect.py:115-127`).
+5. `_launch_anyharness_runtime` (`connect.py:153-227`) writes the launch
+   script, `chmod 700`s it, starts AnyHarness detached, waits for health,
+   verifies auth is enforced, then also boots a "worker sidecar" process in
+   the VM (`launch_worker_sidecar`, see note below), and finally calls
+   `mark_cloud_sandbox_ready` and commits.
+6. Back in `connect_ready_sandbox`, if the resolved `anyharness_base_url`
+   changed, `mark_cloud_sandbox_ready` is called again and committed
+   (`connect.py:129-141`).
 
-The server:
+`mark_cloud_sandbox_ready` (`db/store/cloud_sandboxes.py:222-246`) sets
+`status="ready"`, stores `provider_sandbox_id`, `anyharness_base_url`,
+the encrypted token/data-key ciphertexts, and `ready_at`/`last_health_at`.
 
-1. authenticates the user with the normal product JWT;
-2. ensures the user's personal billing subject;
-3. acquires an owner advisory lock for the DB claim phase;
-4. reuses the non-destroyed `managed_sandbox` row if one exists, otherwise
-   inserts a `creating` row;
-5. claims provisioning by committing a fresh `starting` status before provider
-   work; concurrent ensure calls wait on that fresh row instead of creating
-   another E2B sandbox;
-6. reuses a healthy recorded AnyHarness runtime when possible;
-7. otherwise creates or resumes an E2B sandbox from `E2B_TEMPLATE_NAME`;
-8. stores `e2b_sandbox_id` immediately after provider creation so later failure
-   paths can retry or clean up the sandbox;
-9. uploads/executes the AnyHarness launch script;
-10. waits for AnyHarness health and auth to pass;
-11. encrypts and stores runtime access metadata;
-12. marks the row `ready` and increments `runtime_generation` when the runtime
-    tuple changed;
-13. best-effort reconciles configured GitHub repos into the sandbox.
+This is invoked from `run_cloud_sandbox_operation`
+(`server/proliferate/server/cloud/materialization/operation.py:24-38`),
+the shared entrypoint for every materialization operation: it acquires a
+Redis lock scoped to `cloud-sandbox:{sandbox.id}`, then calls
+`connect_ready_sandbox`, then runs the caller's callback. See
+`cloud-commands.md` for the materialization/command-execution side of this.
 
-Long-running provisioning is currently request-driven. Service code commits at
-phase boundaries so provider work is not held inside one database transaction;
-fresh `starting`/`destroying` rows are the durable lifecycle claim between those
-transactions. If/when this moves to a background job, keep the same state
-transitions and owner claim semantics.
+Note on the "worker sidecar": this is a separate in-VM process
+(`server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py:1-9`)
+that enrolls back to Cloud, heartbeats, and writes an integration-gateway
+dotfile AnyHarness reads at session launch. Its own docstring says booting
+is best-effort — "the sandbox is fully usable over its direct AnyHarness
+bearer token even if the worker never comes up." Do not confuse this
+"worker" with a command queue worker; there is no queue (see
+`cloud-commands.md`).
 
-### 3. Wake
+## E2B Webhook Reconciliation
 
-The wake endpoint is:
+`handle_e2b_webhook`
+(`server/proliferate/server/cloud/webhooks/service.py:156-249`) is the only
+path in this codebase that reacts to E2B-side state changes Cloud didn't
+itself initiate (E2B auto-pausing an idle VM, E2B confirming a kill, etc).
 
-```text
-POST /v1/cloud/managed-sandbox/wake
-```
+- Verifies the webhook signature (`webhooks/service.py:158`,
+  `_verify_e2b_signature`).
+- Dedupes by event id via `remember_sandbox_event_receipt` ->
+  `remember_cloud_sandbox_event_receipt` (`webhooks/service.py:164-170`);
+  a duplicate delivery returns an empty receipt and does nothing else.
+- Resolves the `cloud_sandbox` row by provider sandbox id, falling back to
+  a `cloud_sandbox_id` in the event's metadata (`webhooks/service.py:175-183`).
+- Applies `_should_ignore_sandbox_event` guard logic (`webhooks/service.py:75-89`)
+  — e.g. ignores non-`killed` events for an already-destroyed sandbox, and
+  ignores stale `created`/`resumed` events that predate a more recent
+  `paused` transition.
+- Updates `CloudSandbox.status` via `mark_cloud_sandbox_provider_state`
+  (`db/store/cloud_sandboxes.py:249-271`).
+- Opens/closes billing usage segments
+  (`record_cloud_sandbox_usage_started` / `record_cloud_sandbox_usage_stopped`,
+  imported at `webhooks/service.py:32-35`) for `created`/`resumed` (open) and
+  `paused`/`timeout`/`killed` (close) events (`webhooks/service.py:200-249`).
+- **Billing enforcement in the webhook itself:** on `created`/`resumed`, if
+  the owner has an active spend hold (checked via
+  `get_billing_snapshot_for_subject`), the handler calls
+  `provider.pause_sandbox()` directly, closes the usage segment with
+  `USAGE_SEGMENT_CLOSED_BY_QUOTA_ENFORCEMENT`, and marks the sandbox
+  `paused` — rather than letting the resumed/created VM keep running
+  (`webhooks/service.py:203-220`).
 
-It shares the ensure flow, but callers should treat it as "make the existing
-sandbox usable again" rather than "create a product workspace." Wake may resume
-the E2B sandbox, relaunch AnyHarness, update runtime access, and reconcile repos.
+## Destroy Path
 
-### 4. Destroy
+`DELETE /v1/cloud-sandbox`
+(`server/proliferate/server/cloud/cloud_sandboxes/api.py:52-60`) calls
+`destroy_cloud_sandbox`
+(`server/proliferate/server/cloud/cloud_sandboxes/service.py:73-92`). As of
+this worktree it:
 
-The destroy endpoint is:
+1. Loads the sandbox row with `lock_row=True`; returns `None` (204, no-op)
+   if there is none (`service.py:76-78`).
+2. Revokes active workers/gateway tokens for the sandbox identity via
+   `runtime_workers_store.revoke_active_workers_for_identity(db,
+   cloud_sandbox_id=sandbox.id)` (`service.py:82`) — this revokes every
+   non-`revoked` `CloudRuntimeWorker` row (and its gateway token) scoped to
+   the sandbox
+   (`server/proliferate/db/store/runtime_workers.py:189-209`), so a
+   destroyed sandbox can never re-authenticate to Cloud.
+3. If the sandbox actually reached E2B (`sandbox.e2b_sandbox_id` is set),
+   calls `provider.destroy_sandbox()` to kill the real microVM. Failure is
+   caught and logged as a warning (`logger.warning(...,
+   exc_info=True)`), not raised (`service.py:84-91`).
+4. Marks the DB row `destroyed` via `mark_cloud_sandbox_destroyed`
+   (`db/store/cloud_sandboxes.py:287-302`), which sets `status="destroyed"`
+   and `destroyed_at`.
 
-```text
-DELETE /v1/cloud/managed-sandbox
-```
+This is the fixed/current behavior: an earlier version of this path was
+missing step 3 entirely, so a "destroyed" DB row could leave the real E2B
+VM running (and billing) until E2B's own idle timeout — that gap is closed
+in this worktree. One known soft spot remains: the failure-handling choice
+in step 3 is log-and-continue with no retry and no reconciler behind it —
+if `provider.destroy_sandbox()` fails, nothing currently re-attempts it.
+The next `ensure` for that user will create a brand-new DB row (the unique
+partial index only excludes destroyed rows), so a leaked E2B VM from a
+failed destroy would become orphaned from any DB row rather than blocking
+the user.
 
-The server claims `destroying`, asks E2B to kill the sandbox when an E2B id is
-present, then marks the row `destroyed` only after provider deletion succeeds.
-The next ensure creates a new row because active uniqueness excludes destroyed
-rows.
+## Superseded / Dead Code
 
-## Repo Configuration And Materialization
+Two modules that a stale prior audit pass mis-identified as live
+alternate paths were fully **deleted** by PR #823 ("delete parked cloud
+domains and dead consumers") — they do not exist in this worktree at all:
 
-`cloud_repo_config` remains the control-plane object for "this GitHub repo is
-enabled for cloud use." The same DB object supports:
+- `server/proliferate/server/cloud/workspaces/lifecycle/api.py` — verified
+  gone (`git log --all -- <path>` shows it last touched by the PR #823
+  deletion commits; `find` for `lifecycle/api.py` under
+  `server/proliferate/server/cloud/workspaces/` returns nothing).
+- `server/proliferate/server/cloud/runtime/provision.py`
+  (`create_and_connect_sandbox`) — same: deleted by PR #823, not present.
 
-- local only: repo exists on disk, no configured cloud repo row;
-- local + cloud: local repo root matches a configured cloud repo row;
-- cloud only: configured cloud repo row exists with no local checkout.
+If you are reading an older spec or an old audit note that references
+either path, treat it as historical — the current live workspace CRUD
+router is `server/proliferate/server/cloud/workspaces/api.py`, mounted as
+`workspaces_router` in `server/proliferate/server/cloud/api.py:22,32`
+(see `workspace-lifecycle.md`), and the current provisioning entrypoint is
+`connect_ready_sandbox` documented above.
 
-Desktop settings builds repository entries from both local repo roots and cloud
-repo configs. A configured cloud repo with no local checkout is represented as a
-cloud-only repository entry and does not expose local file-picking controls.
+## Live Runtime Access (Gateway)
 
-When a repo config is saved, bootstrapped, or a tracked file changes, the server
-schedules a post-commit best-effort materialization if the user has a ready
-managed sandbox and a ready GitHub grant.
-
-Materialization currently:
-
-1. clones or fetches the GitHub repo inside the sandbox;
-2. uses a temporary `GIT_ASKPASS` script and never persists the token in the
-   remote URL;
-3. checks out the configured default branch when available, but refuses to
-   reset an existing checkout with local changes or overwrite a non-git
-   directory;
-4. writes tracked file contents from `cloud_repo_config`;
-5. resolves a runtime workspace in AnyHarness for the repo path;
-6. optionally starts setup through AnyHarness when setup is configured;
-7. records applied file/setup/env versions in
-   `managed_sandbox_repo_materialization`.
-
-Manual git setup is acceptable during this Stack 1 transition, but the DB rows
-must still be able to reconcile later when a sandbox is created after repo
-configuration already exists.
-
-## Runtime Truth
-
-Cloud DB does not own runtime workspace/session truth for managed sandboxes.
-AnyHarness SQLite in the sandbox is the source of truth for:
-
-- runtime workspaces;
-- sessions;
-- transcript/event streams;
-- terminal and command execution state.
-
-Cloud DB owns product/account configuration, authentication, billing gates, and
-the minimal runtime access pointer needed to reach AnyHarness.
-
-This is why the managed sandbox API does not create `cloud_workspace` rows.
-Gateway routes should authenticate the user in the control plane, authorize
-access to the user's sandbox, then proxy the AnyHarness request without
-reinterpreting AnyHarness commands.
-
-## Gateway Handoff
-
-The future gateway should use `managed_sandbox` as its routing source:
-
-```text
-user JWT
-  -> load active managed_sandbox for user/org
-  -> decrypt runtime token
-  -> proxy to anyharness_base_url with sandbox runtime auth
-```
-
-Gateway code should not parse AnyHarness command payloads. The client should be
-able to use the same AnyHarness SDK shape locally and in cloud, with only the
-base URL/auth resolver differing.
-
-The current managed sandbox API is intentionally small:
-
-```text
-GET    /v1/cloud/managed-sandbox
-POST   /v1/cloud/managed-sandbox/ensure
-POST   /v1/cloud/managed-sandbox/wake
-DELETE /v1/cloud/managed-sandbox
-```
-
-## Deleted Paths
-
-The Stack 1 cutover removes active Daytona support. The old cloud-workspace
-router remains mounted as a compatibility surface for current Desktop/Web
-workspace flows until gateway-backed AnyHarness workspace creation replaces
-those clients. It is not the managed sandbox provisioning contract.
-
-Deleted/obsolete concepts:
-
-- `SANDBOX_PROVIDER`;
-- `DAYTONA_API_KEY`, `DAYTONA_SERVER_URL`, `DAYTONA_TARGET`;
-- provider-polymorphic sandbox selection for managed cloud;
-- active workspace repo-config status/resync/setup routes scoped by
-  `/v1/cloud/workspaces/{workspace_id}`.
+Once a sandbox is `ready`, `/v1/gateway/cloud-sandbox/anyharness/{path}`
+(HTTP and WebSocket, mounted at `server/proliferate/main.py:57,231` with
+prefix `{api_prefix}/v1/gateway`) authenticates the product user, resolves
+`ensure_cloud_sandbox_gateway_access`
+(`server/proliferate/server/cloud/gateway/service.py:75-99` — this itself
+calls `ensure_cloud_sandbox_ready` then decrypts the runtime token via
+`load_cloud_sandbox_runtime_access`), and proxies the request/websocket
+directly to `anyharness_base_url` (`server/proliferate/server/cloud/gateway/proxy.py`)
+without reinterpreting AnyHarness's command payloads. Gateway access is
+cached in-process per user for 60 seconds
+(`gateway/service.py:38,75-83`). See `cloud-commands.md` for how this
+differs from the materialization command path.
 
 ## Code Map
 
-Server:
-
 ```text
-server/proliferate/db/models/cloud/managed_sandboxes.py
-server/proliferate/db/store/managed_sandboxes.py
-server/proliferate/db/store/managed_sandbox_repo_materializations.py
-server/proliferate/server/cloud/managed_sandboxes/api.py
-server/proliferate/server/cloud/managed_sandboxes/models.py
-server/proliferate/server/cloud/managed_sandboxes/service.py
-server/proliferate/server/cloud/managed_sandboxes/repo_materialization.py
-server/proliferate/server/cloud/repo_config/service.py
-```
-
-SDK:
-
-```text
-cloud/sdk/src/client/managed-sandboxes.ts
-cloud/sdk-react/src/hooks/managed-sandboxes.ts
-```
-
-Desktop repository projection:
-
-```text
-apps/desktop/src/lib/domain/settings/repositories.ts
-apps/desktop/src/hooks/settings/derived/use-settings-repositories.ts
-apps/desktop/src/hooks/home/derived/use-home-next-repository-selection.ts
-apps/desktop/src/hooks/cloud/workflows/use-save-cloud-repo-config.ts
-```
-
-## Verification
-
-Targeted server checks:
-
-```bash
-cd server
-uv run --extra dev pytest -q \
-  tests/integration/test_managed_sandbox_store.py \
-  tests/integration/test_desktop_auth_gate.py \
-  tests/integration/test_cloud_startup.py
-```
-
-Generated cloud SDK:
-
-```bash
-make cloud-client-generate
-pnpm --filter @proliferate/cloud-sdk build
-pnpm --filter @proliferate/cloud-sdk-react build
-```
-
-Desktop checks:
-
-```bash
-pnpm --dir apps/desktop exec tsc --noEmit
-pnpm --dir apps/desktop exec vitest run \
-  src/lib/domain/settings/repositories.test.ts \
-  src/components/settings/panes/EnvironmentsPane.test.tsx \
-  src/hooks/cloud/workflows/use-save-cloud-repo-config.test.ts
+server/proliferate/db/models/cloud/sandboxes.py
+server/proliferate/db/store/cloud_sandboxes.py
+server/proliferate/server/cloud/cloud_sandboxes/api.py
+server/proliferate/server/cloud/cloud_sandboxes/service.py
+server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py
+server/proliferate/server/cloud/materialization/operation.py
+server/proliferate/server/cloud/materialization/locks.py
+server/proliferate/server/cloud/webhooks/service.py
+server/proliferate/server/cloud/webhooks/api.py
+server/proliferate/server/cloud/gateway/api.py
+server/proliferate/server/cloud/gateway/service.py
+server/proliferate/server/cloud/gateway/proxy.py
+server/proliferate/integrations/sandbox/e2b.py
+server/proliferate/integrations/sandbox/base.py
 ```

--- a/specs/codebase/primitives/workspace-lifecycle.md
+++ b/specs/codebase/primitives/workspace-lifecycle.md
@@ -1,1264 +1,206 @@
-# Workspace Pruning And Worktree Management Spec
+# Workspace Lifecycle
 
-Status: implementation spec with V1 archive-prune slice implemented.
+> Rewritten 2026-07-02 to replace a description of the pre-cutover architecture (PR #809, commit 4b54c9f2b) with the current `cloud_workspace` model.
 
-Date: 2026-05-25
+Status: Describes shipped, current behavior.
 
-## Purpose
+Date: 2026-07-02.
 
-This spec defines the product and implementation model for workspace pruning,
-worktree cleanup, archive/restore, and on-demand rehydration across Desktop,
-Cloud, Web, Mobile, and worker-managed targets.
+Depends on: [`sandbox-provisioning.md`](sandbox-provisioning.md).
 
-The central distinction is:
+This spec describes `CloudWorkspace`: the lightweight product row that
+represents one repo+branch pair inside a user's `cloud_sandbox`, and its
+live create/read/archive/restore/delete surface. It intentionally does not
+describe `server/proliferate/server/cloud/workspaces/lifecycle/` — that
+package was deleted by PR #823 and is not part of the live system (see the
+"Superseded / dead code" note in `sandbox-provisioning.md`).
 
-```text
-Workspace = durable product record.
-Worktree = filesystem materialization where runtime work happens.
-```
+## Data Model
 
-Worktree cleanup must never mean "delete the chat." A user should be able to
-keep a workspace active while its checkout is currently absent, and a user
-should be able to archive a workspace without losing history, repo identity,
-branch/ref, sessions, or cloud refs.
+### `cloud_workspace`
 
-## V1 Implementation Boundary
+Model: `CloudWorkspace`
+(`server/proliferate/db/models/cloud/workspaces.py:12`). Verified directly
+in this worktree — the model is minimal:
 
-The implemented V1 slice covers the first end-to-end storage-management path:
+- `id` (`workspaces.py:36`)
+- `owner_user_id` — FK to `user.id`, `ondelete="CASCADE"` (`workspaces.py:37-40`)
+- `repo_environment_id` — FK to `repo_environment.id`, `ondelete="RESTRICT"`
+  (`workspaces.py:41-43`)
+- `display_name` (`workspaces.py:44`)
+- `git_branch` (`workspaces.py:45`)
+- `git_base_branch`, nullable (`workspaces.py:46`)
+- `anyharness_workspace_id` — nullable pointer into AnyHarness, indexed
+  (`workspaces.py:47-51`)
+- `created_at`, `updated_at` (`workspaces.py:52-57`)
+- `archived_at` — nullable; presence means archived (`workspaces.py:58`)
 
-- Cloud workspace responses expose product lifecycle, runtime target,
-  cloud-access, and primary-materialization state separately.
-- Desktop selection and sidebar logic distinguish "Cloud access enabled" from
-  "managed cloud runtime", so a cloud-synced local workspace continues to route
-  to local Tauri/AnyHarness when it has a local materialization.
-- Cloud archive/restore/purge are durable product APIs.
-- Archiving a materialized target workspace queues a
-  `prune_workspace_worktree` command.
-- The worker handles that command by asking AnyHarness to run the existing safe
-  retire/preflight path, then reports materialization state and cleanup status
-  back to Cloud.
-- Cloud stores the report, preserves the workspace record/history, and removes
-  inactive worker exposure from active sync after successful dehydration.
-- Desktop exposes an environment pressure indicator in the chat composer:
-  local runtimes compare materialized managed worktree count against the ideal
-  per-repo limit, while cloud sandboxes compare CPU/RAM pressure against the
-  runtime ideal maximum. The indicator opens the runtime worktree inventory and
-  cleanup surface.
-- Automatic AnyHarness retention passes are disabled by default. Cleanup runs
-  from explicit user actions unless an operator opts into automatic worktree
-  retention for a runtime.
-- AnyHarness worktree inventory rows include lightweight git status and
-  approximate storage estimates for the checkout plus runtime SQLite history.
-  These estimates are advisory UI inputs, not billing-grade accounting.
-- Explicit workspace deletion from the pruning inventory is a purge operation:
-  it removes the checkout, workspace record, sessions, raw runtime events,
-  normalized events, and local agent artifacts. This path must stay distinct
-  from safe checkout pruning.
+It does **not** carry `worktree_path`, `active_sandbox_id`, or
+`cleanup_state` — I read the current file and none of those fields exist.
+Those existed in the pre-cutover model and are gone; AnyHarness (running
+inside the sandbox) owns that filesystem/worktree state internally now.
+Cloud DB just holds `anyharness_workspace_id` as an opaque pointer into it.
 
-Full active lazy rehydration and cache cleanup depend on the AnyHarness
-materialization contract described below: either identity-preserving
-dehydrate/rehydrate APIs, or a generation-remapping contract that can recreate a
-target worktree and bridge session projections under the same Cloud workspace
-id.
+Indexes / constraints (`workspaces.py:14-33`):
 
-## End-State UX
+- `ux_cloud_workspace_anyharness_workspace`: unique partial index on
+  `(owner_user_id, anyharness_workspace_id)` where
+  `archived_at IS NULL AND anyharness_workspace_id IS NOT NULL`.
+- `ix_cloud_workspace_repo_environment_id`: lookup index.
+- `ux_cloud_workspace_active_repo_environment_branch`: unique partial index
+  on `(owner_user_id, repo_environment_id, git_branch)` where
+  `archived_at IS NULL` — this is what makes "one active workspace per
+  branch per repo per owner" an enforced DB invariant, not just an
+  application-level check.
 
-### Active Workspaces
+## Relationship To The Owning Sandbox
 
-Most active workspaces can have their worktrees silently pruned in the
-background when they are clean, old enough, not pinned, and not running work.
-They remain visible in the normal workspace list.
+A `CloudWorkspace` has no foreign key to `cloud_sandbox` at all — it is
+scoped to `owner_user_id`, and the owner's single `cloud_sandbox` (see
+`sandbox-provisioning.md`) is looked up separately wherever runtime state
+is needed. E.g. `_workspace_payload`
+(`server/proliferate/server/cloud/workspaces/service.py:473-512`) loads
+`workspace.owner_user_id`'s sandbox via
+`cloud_sandbox_store.load_personal_cloud_sandbox` to compute a
+`runtime_status` for the response, and `get_cloud_workspace_runtime_status`
+(`workspaces/service.py:302-315`) does the same to build
+`CloudWorkspaceRuntimeStatusResponse`.
 
-When the user selects an active workspace whose worktree has been pruned:
+`_runtime_status` (`workspaces/service.py:523-534`) maps sandbox status to
+a workspace-facing runtime status: `sandbox is None -> "disabled"`,
+`"ready" -> "running"`, `{"creating","provisioning"} -> "pending"`,
+`{"paused","stopped"} -> "paused"`, `{"error","destroyed"} -> "error"`,
+default `"pending"`. Note this function checks for the strings
+`"provisioning"` and `"stopped"`, which are not in the current
+`CloudSandboxStatus` enum (`creating|ready|paused|error|destroyed` — see
+`sandbox-provisioning.md`); those branches currently appear unreachable
+given the sandbox model's actual status values, but I'm reporting the code
+as written rather than guessing at intent.
 
-```text
-1. The transcript and session history load immediately from durable state.
-2. Files, terminal, and new agent actions show a restorable/dehydrated state.
-3. No checkout is created only because the chat was selected.
-4. The first runtime-demand action rehydrates the checkout from repo +
-   branch/ref + workspace config.
-5. The original action resumes after hydration.
-```
+`_workspace_status` (`workspaces/service.py:515-520`, independent of
+sandbox state) is: `archived_at is not None -> "archived"`, else
+`not anyharness_workspace_id -> "materializing"`, else `"ready"`.
 
-The user should see "restoring workspace" only once hydration is actually
-needed. They should not see a dead workspace, a missing folder error, or a
-cloud-sandbox resume screen when the selected runtime is the local desktop
-target.
+## Live Workspace CRUD
 
-### Archive
+Router: `server/proliferate/server/cloud/workspaces/api.py`, mounted as
+`workspaces_router` in `server/proliferate/server/cloud/api.py:22,32`
+(prefixed with `/cloud` and the global `/v1` prefix from
+`server/proliferate/main.py:230`). This is the only live workspace CRUD
+surface — verified by grepping `cloud/api.py`'s `include_router` calls,
+which do not reference the deleted `workspaces/lifecycle/` package.
 
-Archive is explicit user intent. It is not just a sidebar filter.
+Routes (`workspaces/api.py`):
 
-When the user archives a workspace:
+- `GET /workspaces?lifecycle=active|archived|all` — list
+  (`workspaces/api.py:36-49`, default `lifecycle="active"`)
+- `POST /workspaces` — create (`workspaces/api.py:52-61`)
+- `GET /workspaces/{workspace_id}` — detail (`workspaces/api.py:64-73`)
+- `GET /workspaces/{workspace_id}/runtime-status` — runtime status
+  (`workspaces/api.py:76-89`)
+- `PATCH /workspaces/{workspace_id}/display-name` — rename
+  (`workspaces/api.py:92-108`)
+- `POST /workspaces/{workspace_id}/archive` — archive
+  (`workspaces/api.py:111-120`)
+- `POST /workspaces/{workspace_id}/restore` — restore
+  (`workspaces/api.py:123-132`)
+- `DELETE /workspaces/{workspace_id}` — hard delete, 204
+  (`workspaces/api.py:135-143`)
 
-```text
-1. The workspace immediately leaves the active workspace list.
-2. The workspace appears in the Archived chats settings page.
-3. The workspace record, sessions, transcript, repo identity, branch/ref,
-   cloud refs, and ownership remain durable.
-4. The system attempts to prune the worktree.
-```
+All routes are scoped to the authenticated user
+(`current_product_user`) and load via
+`get_cloud_workspace_for_user(db, user_id, workspace_id)`
+(`db/store/cloud_workspaces.py:93-105`), which filters by
+`owner_user_id`, so a user cannot address another user's workspace by id.
 
-If the worktree is safe to remove, the checkout is deleted and the workspace is
-archived + dehydrated.
+### Create
 
-If the worktree is not safe to remove, the workspace still remains archived, but
-Archived chats shows a cleanup attention state with the blocker. Examples:
+`create_cloud_workspace_for_user`
+(`server/proliferate/server/cloud/workspaces/service.py:82-224`):
 
-- uncommitted changes
-- conflicts
-- live session
-- active terminal
-- queued prompt
-- running operation
+1. Validates `git_owner`/`git_repo_name`/`branch_name` are non-empty.
+2. Looks up the `repo_environment` row for that owner+repo; 404s
+   (`cloud_repo_environment_not_found`) if the repo hasn't been configured
+   as a cloud environment.
+3. Requires GitHub App repo authority (`require_github_cloud_repo_authority`)
+   and fetches live branches from GitHub via
+   `get_repo_branches_for_credentials`.
+4. Resolves the base branch (explicit `base_branch`, else the repo
+   environment's default, else GitHub's default) and 400s if it doesn't
+   exist on GitHub.
+5. Computes the set of branch names already in use (GitHub branches +
+   active `cloud_workspace` rows for that repo environment via
+   `list_active_workspace_branches_for_repo_environment`); if
+   `generated_name` is set, auto-generates a free branch name
+   (`resolve_generated_branch_name`), else 409s on collision
+   (`github_branch_already_exists` / `cloud_branch_already_exists`).
+6. Calls `materialization_service.materialize_repo_environment(db,
+   repo_environment_id=...)` — this is what actually ensures the sandbox
+   exists/is ready and the repo is checked out inside it (see
+   `cloud-commands.md`); this is a synchronous await, not fire-and-forget,
+   so workspace creation blocks on sandbox+repo materialization.
+7. Inserts the `cloud_workspace` row with retry-on-branch-collision via
+   `_create_workspace_row_with_branch_retry`
+   (`workspaces/service.py:385-431`), which relies on
+   `create_cloud_workspace` returning `None` on an `IntegrityError` from the
+   unique partial index rather than raising, and regenerates a branch name
+   up to 5 times if `generated_name` was requested.
+8. Loads ready runtime access for the owner's sandbox
+   (`_load_ready_runtime_access`, `workspaces/service.py:318-330` — 409s
+   `cloud_sandbox_missing` if there is no sandbox row at all), resolves the
+   repo root inside AnyHarness (`resolve_runtime_workspace`), then calls
+   `create_remote_worktree_workspace` directly against AnyHarness over
+   HTTP (via `runtime_url`/`runtime_token`, not through the gateway proxy)
+   to create the actual worktree and get back an
+   `anyharness_workspace_id`.
+9. Stores that id on the `cloud_workspace` row via
+   `update_workspace_anyharness_workspace_id`.
 
-This keeps the product semantics clear: archive hides the workspace from normal
-work, while cleanup safety remains strict and visible.
+The worktree path handed to AnyHarness is computed client-side
+(`_worktree_path`, `workspaces/service.py:537-547`):
+`{SANDBOX_WORKSPACE_ROOT}/worktrees/{owner}/{repo}/{branch-segment}-{workspace_id[:8]}`.
 
-### Restore
+### Archive / Restore / Delete — what "lifecycle" means here
 
-Restoring an archived workspace:
+This is a product-record lifecycle, distinct from sandbox lifecycle
+(`sandbox-provisioning.md`) — archiving or deleting a workspace does not
+touch the owner's `cloud_sandbox` row or the E2B VM at all; it only
+changes the `cloud_workspace` row.
 
-```text
-1. Moves it back to active workspaces.
-2. Keeps the same durable workspace id and history.
-3. Rehydrates the worktree on demand when the user opens files, starts a
-   terminal, sends a prompt, or otherwise needs runtime access.
-```
+- **Archive** (`archive_cloud_workspace_for_user`,
+  `workspaces/service.py:255-262`): sets `archived_at = now()` via
+  `archive_cloud_workspace` (`db/store/cloud_workspaces.py:168-176`). This
+  frees the `(owner_user_id, repo_environment_id, git_branch)` unique slot
+  (the partial index excludes archived rows), so a new workspace can be
+  created on the same branch. I found **no code path that tells AnyHarness
+  to clean up or dehydrate the underlying worktree on archive** — archive
+  here is purely a Cloud DB state change. If AnyHarness independently prunes
+  worktrees for archived workspaces, I did not find that wiring in this
+  pass; treat that as **unverified**.
+- **Restore** (`restore_cloud_workspace_for_user`,
+  `workspaces/service.py:265-290`): checks the branch isn't already taken
+  by another active workspace for the same repo environment (409
+  `cloud_branch_already_exists` if so), then clears `archived_at` via
+  `restore_cloud_workspace` (`db/store/cloud_workspaces.py:178-190`), which
+  itself also guards against the unique-index collision with a nested
+  transaction and returns `None` on `IntegrityError` (translated back to
+  the same 409).
+- **Delete** (`delete_cloud_workspace_for_user`,
+  `workspaces/service.py:293-299`): hard-deletes the row via
+  `delete_cloud_workspace` (`db/store/cloud_workspaces.py:193-198`,
+  `await db.delete(row)`). No archived-only guard is enforced in the
+  service function I read — delete is callable on an active workspace too.
+  As with archive, I found no code here that reaches into AnyHarness to
+  clean up the worktree/session state before deleting the pointer row;
+  **unverified** whether anything reconciles that server-side.
 
-Restore should feel like "bring this workspace back" rather than "create a new
-workspace from scratch."
-
-### Delete / Purge
-
-Delete/purge is the only destructive product operation. It requires explicit
-confirmation and removes the product record and durable history according to
-the relevant retention policy.
-
-Prune, archive, and restore must not be overloaded to mean delete.
-
-## Non-Goals
-
-Do not automatically delete workspace records or chat/session history.
-
-Do not auto-prune dirty work unless a separate reliable checkpoint/snapshot
-system exists and the product has adopted it explicitly.
-
-Do not prune arbitrary user folders outside Proliferate-managed worktree roots.
-
-Do not make Desktop local sidebar archive a local-only preference long term.
-Archive needs to become durable product lifecycle state.
-
-Do not make Cloud directly delete target files. Cloud owns intent and policy;
-the target runtime owns filesystem safety and execution.
-
-## Local QA Requirement
-
-This feature must be QA'd in a profile-isolated full-stack worktree, not only
-through unit tests or a shared `main` dev profile.
-
-Use the profile-aware workflow:
-
-```bash
-make dev-init PROFILE=<name>
-make dev PROFILE=<name>
-```
-
-For a worktree-specific QA pass, copy the developer's local env files into the
-worktree before startup:
-
-```text
-.env
-.env.local
-.env.prod
-server/.env
-server/.env.local
-```
-
-These files contain local secrets and must remain uncommitted.
-
-After startup, the user should log in through the worktree's local app/web
-surface. The resulting auth/session state is part of the QA fixture. This is
-important because the highest-risk bugs are not pure UI states; they involve
-authenticated Cloud records, local Desktop runtime state, cloud access exposure,
-and target selection.
-
-The minimum manual QA profile should cover:
-
-- enabling Cloud access for a local Desktop workspace
-- reloading that cloud-synced local workspace
-- confirming the UI reconnects to local Tauri/AnyHarness, not a managed cloud
-  sandbox
-- confirming cloud-access indicators do not imply cloud-sandbox execution
-- archiving a workspace and seeing it move to Archived immediately
-- restoring the same workspace id and history from Archived
-- exercising a cleanup blocker with dirty work, if practical
-
-Profile state should live under:
-
-```text
-~/.proliferate-local/dev/profiles/<name>/
-~/.proliferate-local/runtimes/<name>/
-```
-
-## Current Code Anchors
-
-These are the existing pieces this spec should build on rather than bypass.
-Line references were checked against `main` at `dcd18490` on 2026-05-25.
-
-### Cloud Workspace Record
-
-`server/proliferate/db/models/cloud/workspaces.py`
-
-- `CloudWorkspace` is the durable cloud workspace table at line 22.
-- It already stores display name, Git provider/owner/repo, branch/base branch,
-  `worktree_path`, runtime ids, `archived_at`, and cleanup state.
-- Active uniqueness today is usually expressed as `archived_at IS NULL`.
-
-Important current rows:
+## Code Map
 
 ```text
-CloudWorkspace.display_name
-CloudWorkspace.git_provider / git_owner / git_repo_name
-CloudWorkspace.git_branch / git_base_branch
-CloudWorkspace.worktree_path
-CloudWorkspace.active_sandbox_id
-CloudWorkspace.anyharness_workspace_id
-CloudWorkspace.archived_at
-CloudWorkspace.cleanup_state
+server/proliferate/db/models/cloud/workspaces.py
+server/proliferate/db/store/cloud_workspaces.py
+server/proliferate/server/cloud/workspaces/api.py
+server/proliferate/server/cloud/workspaces/service.py
+server/proliferate/server/cloud/workspaces/models.py
+server/proliferate/server/cloud/api.py
 ```
-
-Useful current lines:
-
-```text
-22   class CloudWorkspace
-108  display_name
-109  git_provider
-115  worktree_path
-133  active_sandbox_id
-179  archived_at
-180  cleanup_state
-```
-
-`server/proliferate/db/store/cloud_workspaces.py`
-
-- `archive_cloud_workspace_record(...)` starts at line 562.
-- It currently marks `archived_at`, status
-  `archived`, and cleanup state `pending`.
-- This is close to the desired product archive path, but cleanup semantics need
-  to become materialization-specific and report blocker states clearly.
-
-### Cloud Worktree Policy
-
-`server/proliferate/constants/cloud.py`
-
-- `DEFAULT_MAX_MATERIALIZED_WORKTREES_PER_REPO = 20` at line 349.
-
-`server/proliferate/db/models/cloud/worktree_policy.py`
-
-- `CloudWorktreeRetentionPolicy` starts at line 12.
-- It stores
-  `max_materialized_worktrees_per_repo` with a 10-100 bounds check.
-
-`server/proliferate/server/cloud/worktree_policy/**`
-
-- Cloud already exposes get/set APIs for the user policy.
-- This should remain the policy owner for cloud-visible product limits.
-
-### AnyHarness Worktree Safety And Retention
-
-`specs/codebase/structures/anyharness/src/workspaces.md`
-
-- AnyHarness treats workspace records as durable execution-surface identity.
-- It already distinguishes local workspaces and worktree workspaces.
-- It already states that worktree retention is enforced by AnyHarness and that
-  control planes sync desired policy through the runtime API.
-
-`anyharness/crates/anyharness-lib/src/api/router.rs`
-
-- Existing worktree endpoints include:
-
-```text
-83   /worktrees/inventory
-87   /worktrees/orphans/prune
-91   /worktrees/retention-policy
-95   /worktrees/retention/run
-```
-
-`anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs`
-
-- Current retention groups standard active worktree workspaces by repo.
-- It enforces the materialized-worktree limit.
-- It preflights, rechecks under operation lock, then removes the worktree.
-- Key lines:
-
-```text
-142  list_standard_active_worktrees_by_activity
-210  first preflight check
-284  preflight recheck before deletion
-347  retire_worktree_materialization call
-```
-
-`anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs`
-
-- Current preflight blocks unsafe cleanup for dirty work, conflicts, live
-  sessions, active terminals, pending prompts, pending interactions, and running
-  operations.
-- Key lines:
-
-```text
-182  dirty work blocker
-188  conflicted work blocker
-277  live execution blocker gate
-333  live session / terminal / prompt blockers
-403  running operation blockers
-```
-
-`anyharness/crates/anyharness-lib/src/domains/workspaces/runtime/materialization.rs`
-
-- `retire_worktree_materialization(...)` is the current safe materialization
-  deletion workflow and delegates `git worktree remove --force` to the git
-  adapter.
-
-### Current Desktop Archive Gap
-
-`apps/desktop/src/stores/preferences/workspace-ui-sidebar-actions.ts`
-
-- Desktop sidebar archive currently stores ids in `archivedWorkspaceIds`
-  starting at line 32.
-- That is local UI preference state, not durable product lifecycle.
-
-This spec replaces that long-term meaning with server/runtime-backed archive
-state while preserving local responsiveness in the UI.
-
-## Concepts
-
-### Workspace
-
-A workspace is a durable product record.
-
-It owns:
-
-- chat history
-- session history and transcript projections
-- repo identity
-- branch/ref
-- display metadata
-- ownership and sharing state
-- target/cloud refs
-- last activity
-- archive/delete lifecycle
-- materialization summary
-
-A workspace can be active even when no runnable checkout currently exists.
-
-For Cloud-backed workspaces, `CloudWorkspace.id` is the stable product id.
-Local-only workspaces use the same durable product lifecycle concept instead
-of relying on sidebar preference ids.
-
-### Worktree
-
-A worktree is a filesystem checkout/materialization of a workspace on a target.
-
-It owns:
-
-- checkout path
-- current file tree
-- git worktree state
-- generated dependency caches under that checkout
-- terminal/session execution root
-
-Pruning a worktree deletes the checkout/materialized files, not the workspace
-record and not chat/session history.
-
-### Materialization
-
-A materialization is the binding between a durable workspace and a target's
-runtime/filesystem state.
-
-It owns:
-
-- target id
-- runtime kind
-- AnyHarness workspace id, if one is currently registered
-- worktree path, if hydrated
-- materialization generation
-- last reported state
-- cleanup status, blockers, and errors
-- measured storage usage
-
-Cloud access/exposure is related but separate. A workspace can have a Cloud
-record and a Cloud exposure while still executing on the local Desktop target.
-
-### Cache
-
-Cache cleanup is separate from worktree pruning.
-
-Safe generated paths can be pruned inside a hydrated worktree without changing
-workspace lifecycle or materialization state. Examples:
-
-```text
-node_modules
-target
-dist/build caches
-package manager caches
-tool caches under Proliferate-managed roots
-```
-
-Cache cleanup should report reclaimed bytes and should not affect chat/session
-continuity.
-
-### Archive
-
-Archive is a durable product lifecycle state.
-
-Archived workspaces are hidden from active work views and shown in an Archived
-area. They remain recoverable and searchable.
-
-Archive requests should also request worktree pruning, but filesystem safety can
-block the cleanup step without undoing the archive.
-
-### Rehydrate
-
-Rehydrate restores a filesystem materialization for a workspace from durable
-state:
-
-```text
-repo provider/owner/name
-repo root or checkout origin
-branch/base branch/ref
-workspace config
-cloud/target materialization config
-AnyHarness workspace identity or a new materialization generation
-```
-
-Rehydration should be lazy. Selecting a dehydrated workspace should load
-transcript and metadata without forcing checkout creation. Runtime-demand
-actions trigger hydration:
-
-- opening files
-- starting a terminal
-- sending a prompt
-- explicit "restore worktree" action
-
-If the user sends a prompt while dehydrated, the prompt should become a visible
-queued prompt with copy like "restoring workspace to send", then dispatch after
-hydration succeeds.
-
-## State Model
-
-### Product Lifecycle
-
-Product lifecycle answers: "Should this workspace appear as usable work?"
-
-```text
-active
-archived
-deleted
-```
-
-`active`
-
-- Shows in normal workspace lists.
-- Can be hydrated or dehydrated.
-- Can receive prompts after rehydration if needed.
-
-`archived`
-
-- Hidden from normal active lists.
-- Shown in Settings -> Archived chats.
-- Does not receive new prompts unless restored first.
-- Can still have cleanup attention if its worktree could not yet be pruned.
-
-`deleted`
-
-- Product record and history are removed or tombstoned according to retention.
-- Only explicit destructive user action should enter this state.
-
-### Materialization State
-
-Materialization state answers: "Does a runnable checkout exist right now?"
-
-```text
-hydrated
-dehydrated
-hydrating
-unknown
-inconsistent
-```
-
-`hydrated`
-
-- A target has a usable checkout/worktree.
-- Runtime actions can use this materialization immediately.
-
-`dehydrated`
-
-- Durable workspace exists but the checkout is absent.
-- Transcript/history can load.
-- Files/terminal/prompt dispatch require hydration first.
-
-`hydrating`
-
-- A target is currently restoring checkout and runtime context.
-
-`unknown`
-
-- Cloud has not yet received a fresh report from the owning target.
-
-`inconsistent`
-
-- Cloud and target disagree in a way that requires reconciliation. Examples:
-  stale AnyHarness id, missing path for a supposedly hydrated workspace, or an
-  exposure that points at a materialization the worker no longer recognizes.
-
-### Cleanup Status
-
-Cleanup status answers: "What happened when we tried to remove storage?"
-
-```text
-idle
-pruning
-blocked
-failed
-skipped
-completed
-```
-
-`blocked`
-
-- Cleanup was not safe. Store structured blockers and show attention in the
-  Archived chats settings page or workspace details.
-
-`failed`
-
-- Cleanup attempted and failed due to an operational error, not a safety
-  blocker. Store last error and retry affordance.
-
-`skipped`
-
-- Cleanup did not run because the policy did not select this materialization or
-  because another operation superseded it.
-
-### Runtime Target
-
-Runtime target answers: "Where will runtime work execute?"
-
-Required normalized shape:
-
-```text
-executionTarget.kind = local_desktop | managed_cloud | ssh | self_hosted
-executionTarget.targetId
-selectedMaterializationId
-cloudAccess.state = disabled | enabled | enabling | error
-```
-
-Surfaces must not infer runtime target from "has cloud workspace record",
-`cloudWorkspaceId`, or exposure existence.
-
-### Why This Split Matters
-
-The current AnyHarness `retired` lifecycle combines two ideas:
-
-```text
-not active as an execution workspace
-cleanup requested/completed for a worktree path
-```
-
-For product UX, those must split:
-
-```text
-CloudWorkspace.product_lifecycle = active | archived | deleted
-WorkspaceMaterialization.materialization_state = hydrated | dehydrated | ...
-WorkspaceMaterialization.cleanup_status = idle | pruning | blocked | ...
-```
-
-An active workspace can be dehydrated.
-An archived workspace can be cleanup-blocked.
-A deleted workspace is the only product-destructive state.
-
-## Required AnyHarness Materialization Contract
-
-Active dehydration is not implementable by simply reusing today's AnyHarness
-retirement path.
-
-Current behavior:
-
-- `retention.rs` ultimately calls `retire_worktree_materialization(...)`.
-- The current retention path marks the AnyHarness workspace as `retired`.
-- `access_gate.rs` blocks mutation for retired workspaces.
-
-That is correct for today's "remove this worktree execution workspace" behavior,
-but it does not represent "this product workspace is still active, with chat
-available, and can be rehydrated later."
-
-V1 must choose one of these runtime contracts before active auto-pruning ships:
-
-1. Add explicit AnyHarness materialization APIs that dehydrate and rehydrate a
-   worktree while preserving an active durable runtime workspace identity.
-2. Treat Cloud as the stable product identity, allow rehydration to create a new
-   AnyHarness workspace/materialization generation, and make transcript/session
-   projections bridge old and new runtime ids under the same Cloud workspace.
-
-Option 1 is cleaner long term. Option 2 may be faster if the existing
-`ensure_repo_checkout`, `materialize_workspace`, and environment materialization
-paths are used carefully. Either way, the spec must not assume that current
-`retired` state can stand in for active dehydration.
-
-Required AnyHarness capabilities:
-
-- structured preflight for prune/cache cleanup
-- operation lock and immediate pre-delete recheck
-- managed-root path validation
-- dehydrate worktree without deleting durable product history
-- rehydrate or materialize from repo/ref/config
-- report stale/missing/inconsistent materializations
-- preserve or explicitly remap session/runtime identity
-
-## Services Touched
-
-| Area | Responsibility | Required Changes |
-| --- | --- | --- |
-| Cloud workspace service | Product lifecycle, archive/restore/delete, response shape | Add lifecycle fields, materialization summary, explicit archive/restore/purge APIs |
-| Cloud command service | Target commands for runtime actions | Add version-gated materialization/cache command kinds only after worker support exists |
-| Worker | Target orchestration | Poll policy/commands, sync policy to AnyHarness, report inventory/materialization/cleanup results |
-| AnyHarness | Filesystem/runtime safety | Add or formalize active dehydrate/rehydrate semantics; keep prune safety local to target |
-| SDK / SDK React | Typed product model | Expose lifecycle, target, cloud access, and materialization fields without raw endpoint leakage |
-| Desktop / Web / Mobile | UX and action routing | Use product model fields; stop using cloud existence as runtime-target signal |
-
-## Ownership
-
-### Cloud / Server Owns
-
-Cloud owns canonical product state and policy for Cloud-backed workspaces:
-
-- workspace lifecycle: active, archived, deleted
-- materialization desired state
-- max hydrated worktrees per user/profile/target/repo
-- pinned state
-- archive/restore/delete user intents
-- product-visible blocker and last-error summaries
-- storage usage summaries reported by targets
-- command queueing for target actions
-
-Cloud does not directly manipulate target filesystem paths.
-
-### Proliferate Worker Owns
-
-The worker owns background orchestration on a target:
-
-- polling Cloud for commands
-- polling/syncing policy
-- reporting target liveness and inventory
-- asking AnyHarness to run preflight, prune, rehydrate, cache cleanup
-- uploading materialization status, blockers, bytes, and command results
-
-Automatic pruning is owned by the worker loop, but v1 candidate selection and
-filesystem safety should remain inside AnyHarness after the worker syncs Cloud's
-desired retention policy. If Cloud ever needs to select exact candidates, a new
-candidate-scoped AnyHarness prune API is required so the runtime can still
-validate and reject unsafe candidates.
-
-### AnyHarness Owns
-
-AnyHarness owns filesystem and runtime safety:
-
-- managed worktree root boundaries
-- canonical path checks
-- dirty/conflict detection
-- live session, terminal, prompt, and operation blockers
-- operation locking and preflight recheck
-- worktree deletion
-- workspace/worktree registration
-- local runtime materialization
-
-AnyHarness should expose enough structured results for Cloud and Desktop to
-show product-level state without reimplementing filesystem safety.
-
-### Desktop / Web / Mobile Own
-
-Surfaces own presentation and user interactions:
-
-- active vs archived navigation
-- lazy restore/dehydrated UI
-- archive, restore, prune now, retry cleanup actions
-- blocker resolution affordances
-- local-vs-cloud target clarity
-
-Surfaces should not infer cloud sandbox execution from "has cloud workspace
-record." Runtime selection must come from target/materialization ownership.
-
-## Data Model Additions
-
-Use a separate materialization table in v1 if feasible. It is the least
-ambiguous representation because one durable workspace can have materializations
-on multiple targets.
-
-Recommended shape:
-
-```text
-cloud_workspaces
-  id
-  owner_scope / owner_id
-  product_lifecycle: active | archived | deleted
-  archived_at
-  deleted_at
-  pinned_at
-  last_opened_at
-  last_activity_at
-  git_provider / git_owner / git_repo_name / normalized_repo_key
-  git_branch / git_base_branch / git_ref
-  display_name
-  durable workspace/session metadata...
-
-cloud_workspace_materializations
-  id
-  cloud_workspace_id
-  target_id
-  exposure_id nullable
-  anyharness_workspace_id nullable
-  worktree_path nullable
-  execution_target_kind: local_desktop | managed_cloud | ssh | self_hosted
-  materialization_state: hydrated | dehydrated | hydrating | unknown | inconsistent
-  cleanup_status: idle | pruning | blocked | failed | skipped | completed
-  desired_state: hydrated | dehydrated
-  generation
-  last_command_id nullable
-  state_reason
-  blockers_json
-  error_code
-  error_message
-  retryable
-  last_reported_at
-  last_hydrated_at
-  last_dehydrated_at
-  last_prune_attempted_at
-  last_prune_completed_at
-  reclaimed_bytes
-  storage_bytes
-  cache_bytes
-  measured_at
-```
-
-Recommended uniqueness:
-
-```text
-cloud_workspaces(owner_scope, owner_id, normalized_repo_key, git_branch)
-  WHERE product_lifecycle = 'active'
-
-cloud_workspace_materializations(target_id, anyharness_workspace_id)
-  WHERE anyharness_workspace_id IS NOT NULL
-
-cloud_workspace_materializations(target_id, worktree_path)
-  WHERE materialization_state = 'hydrated' AND worktree_path IS NOT NULL
-```
-
-Compatibility rules:
-
-- Existing `archived_at` is already used for active uniqueness and list
-  filtering. `product_lifecycle` is the canonical field; `archived_at` is an
-  indexed compatibility mirror for archived workspaces.
-- Existing `cleanup_state` is a compatibility projection. Service code derives
-  UI state from materialization `cleanup_status`.
-- If primary materialization storage lives on `cloud_workspaces`, the service
-  and SDK response must still expose the shape described below so UI and mobile
-  stay coupled to the canonical response contract.
-
-Exposure/projection rule:
-
-- Dehydrating a worktree must not revoke Cloud access by itself.
-- Dehydrating a worktree must not erase transcript projections.
-- Exposure state answers whether cloud surfaces can reach a target.
-- Materialization state answers whether runtime actions can execute immediately.
-
-## API And Response Contract
-
-Workspace list/detail responses should expose product, materialization, target,
-and cloud-access state explicitly.
-
-Representative shape:
-
-```json
-{
-  "id": "cloud_workspace_id",
-  "displayName": "proliferate",
-  "productLifecycle": "active",
-  "pinned": false,
-  "repo": {
-    "provider": "github",
-    "owner": "proliferate-ai",
-    "name": "proliferate",
-    "branch": "main",
-    "ref": null
-  },
-  "executionTarget": {
-    "kind": "local_desktop",
-    "targetId": "target_id",
-    "label": "Pablo's MacBook Pro",
-    "online": true
-  },
-  "cloudAccess": {
-    "state": "enabled",
-    "exposureId": "exposure_id",
-    "exposureRevision": 1
-  },
-  "primaryMaterialization": {
-    "id": "materialization_id",
-    "targetId": "target_id",
-    "anyharnessWorkspaceId": "optional_runtime_id",
-    "state": "dehydrated",
-    "desiredState": "hydrated",
-    "cleanupStatus": "idle",
-    "generation": 3,
-    "blockers": [],
-    "lastError": null,
-    "storageBytes": 123456
-  },
-  "materializations": []
-}
-```
-
-Compatibility fields such as `workspaceStatus`, `visibility`, and top-level
-`archivedAt` are not lifecycle truth. New UI must use the explicit lifecycle,
-materialization, target, and cloud-access fields.
-
-Required product APIs:
-
-```text
-GET    /v1/cloud/workspaces?lifecycle=active|archived|all
-POST   /v1/cloud/workspaces/{workspace_id}/archive
-POST   /v1/cloud/workspaces/{workspace_id}/restore
-POST   /v1/cloud/workspaces/{workspace_id}/purge
-POST   /v1/cloud/worker/materialization-reports
-```
-
-Future materialization APIs, after the identity-preserving hydrate contract is
-implemented:
-
-```text
-POST   /v1/cloud/workspaces/{workspace_id}/materializations/{id}/prune
-POST   /v1/cloud/workspaces/{workspace_id}/materializations/{id}/hydrate
-POST   /v1/cloud/workspaces/{workspace_id}/materializations/{id}/clean-caches
-```
-
-API requirements:
-
-- Archive/restore/purge are idempotent for repeated client retries.
-- Archive/restore/purge authorize against workspace ownership/sharing, not only
-  target reachability.
-- Restore handles active uniqueness conflicts explicitly. If a restored
-  workspace collides with an active workspace, return a structured conflict
-  instead of silently creating a duplicate.
-- SDK React invalidates active, archived, all, workspace detail, command, and
-  cloud exposure query keys after mutations.
-- `deleteCloudWorkspace` must be migrated or wrapped so callers choose between
-  archive, restore, and purge intentionally.
-
-## Interfaces And Commands
-
-Do not add product command names unless both Cloud and worker understand them.
-Unknown `CloudCommandKind` values are rejected by the current dispatch/mapping
-path.
-
-Potential CloudCommand kinds after worker support exists:
-
-```text
-prune_workspace_worktree
-clean_workspace_caches
-hydrate_workspace_materialization
-```
-
-`hydrate_workspace_materialization`
-
-- input: workspace id, materialization id, target id, repo identity/ref,
-  desired path/worktree mode, materialization config version
-- output: AnyHarness workspace id or remapped generation, worktree path,
-  materialization state, storage summary
-
-`prune_workspace_worktree`
-
-- input: workspace id, materialization id, target id, expected AnyHarness
-  workspace id/path, reason `auto_retention | archive | manual`
-- output: materialization state, cleanup status, blockers or error, reclaimed
-  bytes
-
-`clean_workspace_caches`
-
-- input: workspace id, materialization id, target id, safe path policy version
-- output: reclaimed bytes, cleaned paths summary, blockers or error
-
-Inventory and materialization status are worker report endpoints/events, not
-commands. The worker reports what exists on the target; Cloud commands express
-user or policy intent.
-
-Phase-one rehydration can be a product flow that uses existing runtime APIs:
-
-```text
-ensure_repo_checkout
-materialize_workspace
-materialize_environment
-```
-
-That phase must still report the resulting materialization id/generation back to
-Cloud.
-
-## Policies
-
-### Automatic Worktree Pruning
-
-Automatic pruning selects candidates only from active workspaces whose
-materialization is safe to remove.
-
-V1 policy split:
-
-- Cloud stores desired policy and product-visible limits.
-- Worker syncs desired policy to AnyHarness.
-- AnyHarness computes and enforces candidates for its managed target.
-- Worker reports results and blockers back to Cloud.
-
-Keep hydrated:
-
-- live sessions
-- active terminals
-- queued prompts or pending interactions
-- running operations
-- pinned workspaces
-- recently used workspaces
-- dirty or conflicted workspaces
-- workspaces outside Proliferate-managed roots
-- workspaces with unresolved cleanup blockers
-
-Eligible:
-
-- active
-- clean
-- not live
-- not recently used
-- not pinned
-- under a managed worktree root
-- over the configured per-repo/per-target hydration limit
-
-Result:
-
-- product lifecycle remains `active`
-- materialization state becomes `dehydrated`
-- cleanup status becomes `completed`
-- transcript/session history remain available
-
-### Archive Pruning
-
-Archive pruning is requested immediately when the product lifecycle becomes
-`archived`.
-
-If cleanup succeeds:
-
-```text
-product_lifecycle = archived
-materialization_state = dehydrated
-cleanup_status = completed
-```
-
-If cleanup is blocked:
-
-```text
-product_lifecycle = archived
-materialization_state = hydrated
-cleanup_status = blocked
-blockers = structured safety blockers
-```
-
-If cleanup fails operationally:
-
-```text
-product_lifecycle = archived
-materialization_state = hydrated | unknown
-cleanup_status = failed
-last_error = structured operational error
-```
-
-### Cache Cleanup
-
-Cache cleanup may run on hydrated active or archived workspaces when safe.
-
-It must not change product lifecycle or materialization state. It updates
-storage metrics and last cache cleanup result only.
-
-## Flows
-
-### 1. Automatic Active Worktree Prune
-
-```text
-1. Worker reports inventory and target liveness.
-2. Worker loads Cloud worktree retention policy.
-3. Worker syncs desired retention policy to AnyHarness.
-4. AnyHarness computes candidate active workspaces over the hydrated limit.
-5. AnyHarness preflights candidates.
-6. AnyHarness rejects unsafe candidates with structured blockers.
-7. AnyHarness rechecks safe candidates under operation lock.
-8. AnyHarness deletes the worktree checkout.
-9. Worker reports materialization_state=dehydrated, cleanup_status=completed,
-   blockers/failures, and reclaimed bytes.
-10. Cloud updates product-visible materialization summary.
-```
-
-Invariant:
-
-```text
-The workspace remains active the whole time.
-```
-
-### 2. Select Dehydrated Active Workspace
-
-```text
-1. User selects active workspace.
-2. Surface loads transcript/session history from durable Cloud/Desktop state.
-3. Surface notices materialization_state=dehydrated.
-4. Surface shows files/terminal/runtime controls in a restorable state.
-5. No checkout is created solely because the user selected the workspace.
-```
-
-Runtime destination must come from `executionTarget` and selected
-materialization, not from whether the workspace also has a Cloud sync record.
-
-### 3. Runtime Action On Dehydrated Workspace
-
-```text
-1. User opens files, starts terminal, sends prompt, or clicks restore worktree.
-2. Surface marks the action as waiting on hydration.
-3. Cloud queues hydrate command for the selected target, or Desktop calls local
-   AnyHarness directly for local-only work.
-4. Worker ensures repo checkout, worktree, AnyHarness workspace registration,
-   environment config, and materialization summary.
-5. Worker reports materialization_state=hydrated.
-6. Surface resumes the original action.
-```
-
-For a prompt, the user should see the prompt in the conversation immediately as
-queued or pending, not lose text while hydration runs.
-
-### 4. Archive Workspace
-
-```text
-1. User clicks Archive.
-2. Cloud marks product_lifecycle=archived.
-3. Workspace leaves active lists and appears in Archived chats under Settings.
-4. A prune intent is created for the relevant materialization.
-5. Worker/AnyHarness attempts safe prune.
-6. Archived item shows either clean archived state, cleanup blocker, or cleanup
-   failure.
-```
-
-Archive is immediate from the product point of view. Cleanup may lag or need
-attention.
-
-### 5. Restore Archived Workspace
-
-```text
-1. User opens Settings -> Archived chats and clicks Unarchive.
-2. Cloud checks active uniqueness for the repo/branch/owner scope.
-3. Cloud marks product_lifecycle=active or returns a structured conflict.
-4. Workspace returns to active lists.
-5. If materialization_state=dehydrated, runtime access triggers hydration.
-6. Rehydration uses saved repo identity, branch/ref, workspace config, and
-   target materialization config.
-```
-
-No new product workspace should be created unless the old one was deleted.
-
-### 6. Manual Prune Now
-
-```text
-1. User chooses Prune worktree now.
-2. Surface shows preflight result if blocked.
-3. If safe, target prunes worktree.
-4. Active workspace remains active but becomes dehydrated.
-```
-
-Manual prune is not archive. It is a storage action.
-
-### 7. Delete / Purge
-
-```text
-1. User chooses Delete/Purge.
-2. Surface explains destructive consequence.
-3. User confirms.
-4. Cloud deletes or tombstones workspace product records and schedules
-   filesystem cleanup.
-5. Pending commands for the workspace are cancelled or ignored by generation.
-```
-
-Delete/purge can include stronger cleanup behavior because the user explicitly
-asked for destruction.
-
-## Surface State Matrix
-
-| State | Placement | Primary Copy | Enabled Actions | Disabled Actions | Badge |
-| --- | --- | --- | --- | --- | --- |
-| active + hydrated | Active list | Normal workspace name | open files, terminal, prompt, archive, prune now | none | optional target icon |
-| active + dehydrated | Active list | Normal name; runtime controls say "restore worktree" | transcript, archive, hydrate | files/terminal/prompt until hydration starts | subtle storage/restorable dot |
-| active + hydrating | Active list | "Restoring workspace..." | transcript, cancel if supported | destructive prune | spinner/progress |
-| active + pruning | Active list | "Cleaning up worktree..." | transcript | files/terminal/prompt until result | cleanup progress |
-| archived + dehydrated | Archived chats settings page | Normal name, archived | unarchive, purge | prompt/terminal | archived icon plus restorable |
-| archived + cleanup blocked | Archived chats settings page | "Cleanup needs attention" | unarchive, view blockers, retry prune, purge | prompt until restore | attention badge |
-| archived + cleanup failed | Archived chats settings page | "Cleanup failed" | retry cleanup, unarchive, purge | prompt until restore | attention badge |
-
-## Sidebar And Runtime Target Contract
-
-Sidebar and workspace-shell view models should come from one shared product
-model, not duplicated inference in Desktop and Web.
-
-Required view-model fields:
-
-```text
-workspaceId
-productLifecycle
-listPlacement: active | archived | hidden
-archivedCount
-executionTarget.kind
-executionTarget.label
-cloudAccess.state
-primaryMaterialization.state
-primaryMaterialization.cleanupStatus
-cleanupAttention
-enabledActions
-selectedArchivedReadOnly
-```
-
-UI rules:
-
-- Cloud access enabled should remain visible as an access indicator.
-- Cloud access enabled must not use the same icon/copy as managed cloud runtime.
-- Active/dehydrated workspaces stay in the active list.
-- Archived workspaces move to the Archived chats settings page, not a mere
-  filter or top-level daily navigation item.
-- Local preference ids can provide optimistic latency hiding, but must reconcile
-  to durable product lifecycle.
-
-## Permissions And Identity
-
-Lifecycle mutations require workspace ownership or an explicit permission grant.
-
-Runtime actions require:
-
-- a selected materialization target
-- target online or command queued semantics
-- worker version support for the requested command
-- active product lifecycle unless the action is restore/purge/cleanup
-
-Identity requirements:
-
-- `CloudWorkspace.id` remains stable across archive/restore/dehydrate/rehydrate.
-- Materialization `generation` increments when runtime identity/path is remapped.
-- Worker command results include the expected generation or command id to avoid
-  stale reports reviving old state.
-- Sessions/transcript projections remain attached to the stable Cloud workspace
-  even if the AnyHarness workspace id changes.
-
-## Failure Model
-
-Persist failures as structured state, not only log lines.
-
-Required categories:
-
-```text
-blocked_dirty_work
-blocked_conflicts
-blocked_live_session
-blocked_active_terminal
-blocked_pending_prompt
-blocked_running_operation
-target_offline
-command_expired
-missing_runtime_workspace
-stale_materialization_generation
-restore_conflict
-path_outside_managed_root
-operation_failed
-inconsistent_report
-```
-
-Required behavior:
-
-- Target offline: show queued/offline state; do not mark prune failed until the
-  command expires or policy decides to skip.
-- Command expiry: keep product lifecycle intact and expose retry.
-- Open while pruning: allow transcript; runtime actions wait for prune result
-  and then hydrate if needed.
-- Delete racing commands: command results must be ignored if workspace is
-  deleted or generation no longer matches.
-- Stale AnyHarness id: report `inconsistent`, then reconcile by inventory or
-  explicit rematerialization.
-- Restore conflict: return a user-actionable conflict instead of creating a new
-  workspace silently.
-
-## Safety Rules
-
-Never auto-prune:
-
-- uncommitted work
-- conflicted work
-- ambiguous git operation state
-- live sessions
-- active terminals
-- pending prompts
-- pending interactions
-- running operations
-- worktrees outside Proliferate-managed roots
-- arbitrary user folders
-
-Always:
-
-- preflight before cleanup
-- recheck under operation lock immediately before deletion
-- preserve durable workspace/session history for prune/archive
-- report blockers structurally
-- make delete/purge explicit
-
-## Verification
-
-Automated tests:
-
-- Implemented V1 tests cover Cloud active/archived lifecycle, restore
-  conflicts, archive/purge command superseding, response lifecycle fields,
-  Desktop archive/restore query invalidation, worker prune command reporting,
-  and AnyHarness retire cleanup safety.
-- Materialization contract tests must cover stale generation reports, target
-  offline transitions, command expiry, cache cleanup, and identity-preserving
-  hydrate.
-- Dirty-work fixtures must continue proving archive cleanup preserves user work
-  and surfaces blockers.
-
-Manual profile QA:
-
-- Use `make dev-init PROFILE=<name>` and `make dev PROFILE=<name>` from a
-  separate worktree with copied local env files.
-- Enable Cloud access for a local Desktop workspace.
-- Reload that cloud-synced local workspace and confirm local Tauri/AnyHarness is
-  the runtime target, not managed cloud.
-- Archive a clean workspace and confirm it leaves Active immediately and lands
-  in Archived.
-- Archive a dirty workspace and confirm archive succeeds while cleanup attention
-  explains the blocker.
-- Restore an archived workspace and confirm the same Cloud workspace id/history
-  returns to Active.
-- Hydration QA: select a dehydrated active workspace and confirm transcript
-  loads without checkout hydration until a file/terminal/prompt action.
-- Hydration QA: send a prompt while dehydrated and confirm the prompt is
-  visibly queued during hydration.
-
-## Implementation Notes
-
-The existing AnyHarness retention path uses `retired` terminology. Avoid
-leaking that wording into product UX. Treat it as the current cleanup mechanism,
-not as sufficient active-dehydration semantics.
-
-The current cloud archive path already sets cleanup pending. Keep that useful
-intent, but split the user-visible archive state from the filesystem cleanup
-result.
-
-The current Desktop sidebar archive preference is an optimistic local UI cache
-that reconciles to durable workspace lifecycle state.
-
-The worktree policy UI should continue to speak about storage cleanup, not
-workspace deletion. Copy should make clear that history remains unless the user
-deletes the workspace.


### PR DESCRIPTION
## Summary

- **Bug fix**: `destroy_cloud_sandbox` revoked worker/gateway tokens and marked the DB row destroyed, but never told E2B to kill the actual microVM — the real sandbox kept running (and billing) until E2B's own idle timeout. No reconciler or webhook path covered this gap. Now calls `provider.destroy_sandbox()` when the sandbox actually reached E2B, logging (not raising) on failure so destroy still succeeds from the user's perspective.
- **Docs**: `sandbox-provisioning.md`, `workspace-lifecycle.md`, and `cloud-commands.md` described the pre-cutover architecture (`sandbox_profile`/`cloud_targets`/`managed_sandbox`, an async `cloud_commands` queue) that PR #809 replaced. Rewritten and adversarially fact-checked line-by-line against current code — notably corrects a prior claim that an async command queue exists (it doesn't; materialization is synchronous and Redis-lock-guarded, and not crash-safe) and documents the one-E2B-VM-per-owner isolation invariant.

## Test plan

- [ ] `destroy_cloud_sandbox` unit/integration test asserting `provider.destroy_sandbox` is called when `e2b_sandbox_id` is set (no existing coverage for this function)
- [x] Python syntax/import check on the modified service module
- [x] Every factual claim in the three rewritten specs verified against this worktree's code (draft → 3 independent adversarial fact-checks → corrections applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)