### PR TITLE
ui: first-class add/edit secret flow

### DIFF
--- a/apps/packages/product-ui/src/secrets/SecretEditorDialog.test.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretEditorDialog.test.tsx
@@ -1,0 +1,78 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SecretEditorDialog, type SecretEditorDialogState } from "./SecretEditorDialog";
+
+// Radix (Dialog + Popover) touches a few DOM APIs jsdom doesn't implement.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = () => {};
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const CREATE_ENV: SecretEditorDialogState = { mode: "create", kind: "env" };
+
+function renderDialog(overrides: Partial<Parameters<typeof SecretEditorDialog>[0]> = {}) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <SecretEditorDialog
+      open
+      state={CREATE_ENV}
+      filePathMode="absolute"
+      onSave={onSave}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+  return { onSave, onClose };
+}
+
+describe("SecretEditorDialog", () => {
+  it("renders the type selector as our popover menu (no native <select>)", async () => {
+    renderDialog();
+
+    // Trigger reflects the current kind and is a button, not a native <select>.
+    const trigger = screen.getByRole("button", { name: /Environment variable/ });
+    expect(document.querySelector("select")).toBeNull();
+
+    // Opening it surfaces the styled popover menu with the other option.
+    fireEvent.click(trigger);
+    const fileOption = await screen.findByRole("button", { name: /^File$/ });
+
+    // Choosing "File" switches the form to the file flow (segmented source control).
+    fireEvent.click(fileOption);
+    await waitFor(() => {
+      expect(screen.getByText("Content source")).toBeTruthy();
+    });
+    expect(screen.getByRole("radio", { name: /Paste text/ })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: /Upload file/ })).toBeTruthy();
+    // Still no native select anywhere in the dialog.
+    expect(document.querySelector("select")).toBeNull();
+  });
+
+  it("flags a duplicate key and blocks save", () => {
+    renderDialog({ existingEnvKeys: ["API_TOKEN"] });
+
+    const name = screen.getByLabelText("Variable name");
+    fireEvent.change(name, { target: { value: "API_TOKEN" } });
+    fireEvent.blur(name);
+
+    expect(screen.getByText(/already exists/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add secret" })).toHaveProperty("disabled", true);
+  });
+
+  it("surfaces an empty-key error only after the field is touched", () => {
+    renderDialog();
+
+    expect(screen.queryByText("Enter a variable name.")).toBeNull();
+    fireEvent.blur(screen.getByLabelText("Variable name"));
+    expect(screen.getByText("Enter a variable name.")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
@@ -1,4 +1,5 @@
-import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { type ClipboardEvent, type FormEvent, useEffect, useMemo, useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
 
 import { CloudUpload } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -22,6 +23,12 @@ export interface SecretEditorDialogProps {
   open: boolean;
   state: SecretEditorDialogState | null;
   filePathMode: SecretFilePathMode;
+  /** Scope blurb (e.g. "Available in your cloud sandbox…") describing where the secret lives. */
+  scopeDescription?: string;
+  /** Existing env var names — used to flag duplicates before submit. */
+  existingEnvKeys?: readonly string[];
+  /** Existing file paths — used to flag duplicates before submit. */
+  existingFileKeys?: readonly string[];
   saving?: boolean;
   error?: string | null;
   onClose: () => void;
@@ -45,10 +52,17 @@ const FILE_CONTENT_SOURCE_LABELS: Record<SecretFileContentSource, string> = {
 };
 const FILE_CONTENT_SOURCE_OPTIONS: readonly SecretFileContentSource[] = ["text", "upload"];
 
+const fieldLabelClass = "text-sm font-medium text-foreground";
+const toggleClass =
+  "inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
 export function SecretEditorDialog({
   open,
   state,
   filePathMode,
+  scopeDescription,
+  existingEnvKeys = [],
+  existingFileKeys = [],
   saving = false,
   error = null,
   onClose,
@@ -56,7 +70,10 @@ export function SecretEditorDialog({
 }: SecretEditorDialogProps) {
   const [kind, setKind] = useState<SecretEditorKind>("env");
   const [nameOrPath, setNameOrPath] = useState("");
+  const [nameTouched, setNameTouched] = useState(false);
   const [secret, setSecret] = useState("");
+  const [revealed, setRevealed] = useState(false);
+  const [multiline, setMultiline] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [fileContentSource, setFileContentSource] = useState<SecretFileContentSource>("text");
 
@@ -66,26 +83,53 @@ export function SecretEditorDialog({
     }
     setKind(state.kind);
     setNameOrPath(state.nameOrPath ?? "");
+    setNameTouched(false);
     setSecret("");
+    setRevealed(false);
+    setMultiline(false);
     setSelectedFile(null);
     setFileContentSource("text");
   }, [open, state]);
 
   const editing = state?.mode === "edit";
-  const title = editing ? "Update secret" : "Add secret";
+  const trimmedName = nameOrPath.trim();
+  const kindNoun = kind === "env" ? "environment variable" : "file secret";
+  const title = editing ? `Edit ${kindNoun}` : `Add ${kindNoun}`;
   const pathLabel = filePathMode === "absolute" ? "Absolute path" : "Repo-relative path";
   const nameLabel = kind === "env" ? "Variable name" : pathLabel;
-  const hasSecretValue =
-    kind === "env" || fileContentSource === "text" ? secret.length > 0 : selectedFile !== null;
-  const canSave = nameOrPath.trim().length > 0 && hasSecretValue && !saving;
-  const description = useMemo(() => {
+
+  const siblingKeys = kind === "env" ? existingEnvKeys : existingFileKeys;
+  const duplicate = !editing && trimmedName.length > 0 && siblingKeys.includes(trimmedName);
+  const nameEmptyError = nameTouched && trimmedName.length === 0;
+  const nameError = duplicate
+    ? `A ${kindNoun} named “${trimmedName}” already exists.`
+    : nameEmptyError
+      ? kind === "env"
+        ? "Enter a variable name."
+        : "Enter a path."
+      : null;
+  const nameHint = useMemo(() => {
     if (kind === "env") {
-      return "Values are stored encrypted and shown only as metadata after saving.";
+      return "Use letters, numbers and underscores, e.g. API_TOKEN.";
     }
     return filePathMode === "absolute"
-      ? "File secrets are written to absolute paths in the cloud sandbox."
-      : "Workspace file secrets are written relative to this repo root.";
+      ? "Absolute path in the cloud sandbox, e.g. /home/user/.env."
+      : "Path relative to this repo root, e.g. .env.local.";
   }, [filePathMode, kind]);
+
+  const hasSecretValue =
+    kind === "env" || fileContentSource === "text" ? secret.length > 0 : selectedFile !== null;
+  const canSave = trimmedName.length > 0 && hasSecretValue && !duplicate && !saving;
+
+  const description = scopeDescription
+    ?? (kind === "env"
+      ? "Stored encrypted in your cloud sandbox."
+      : filePathMode === "absolute"
+        ? "Written to an absolute path in the cloud sandbox."
+        : "Written relative to this repo root.");
+  const handlingNote = kind === "env"
+    ? "Stored encrypted. Only the name and byte size are shown after saving."
+    : "Stored encrypted and written into the sandbox when it next materializes.";
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -93,23 +137,37 @@ export function SecretEditorDialog({
       return;
     }
     if (kind === "env") {
-      onSave({ kind, nameOrPath: nameOrPath.trim(), secret });
+      onSave({ kind, nameOrPath: trimmedName, secret });
       return;
     }
     if (fileContentSource === "text") {
-      onSave({ kind, nameOrPath: nameOrPath.trim(), content: secret });
+      onSave({ kind, nameOrPath: trimmedName, content: secret });
       return;
     }
     if (selectedFile) {
-      onSave({ kind, nameOrPath: nameOrPath.trim(), file: selectedFile });
+      onSave({ kind, nameOrPath: trimmedName, file: selectedFile });
     }
   }
 
   function handleKindChange(nextKind: SecretEditorKind) {
     setKind(nextKind);
     setSecret("");
+    setRevealed(false);
+    setMultiline(false);
     setSelectedFile(null);
     setFileContentSource("text");
+  }
+
+  function handleValuePaste(event: ClipboardEvent<HTMLInputElement>) {
+    if (multiline) {
+      return;
+    }
+    const pasted = event.clipboardData.getData("text");
+    if (pasted.includes("\n")) {
+      event.preventDefault();
+      setMultiline(true);
+      setSecret((prev) => prev + pasted);
+    }
   }
 
   function handleFileChange(file: File | null) {
@@ -140,15 +198,15 @@ export function SecretEditorDialog({
             Cancel
           </Button>
           <Button type="submit" form="secret-editor-form" loading={saving} disabled={!canSave}>
-            Save
+            {editing ? "Save changes" : "Add secret"}
           </Button>
         </>
       )}
     >
       <form id="secret-editor-form" className="space-y-4" onSubmit={submit}>
         {editing ? null : (
-          <div className="space-y-1.5">
-            <Label className="mb-0 text-sm font-medium text-foreground">Type</Label>
+          <Label className="block space-y-1.5 text-sm font-medium text-foreground">
+            <span className="block">Type</span>
             <Select
               value={kind}
               onChange={(event) =>
@@ -160,13 +218,21 @@ export function SecretEditorDialog({
                 </option>
               ))}
             </Select>
-          </div>
+          </Label>
         )}
-        <Label className="block space-y-1.5 text-sm font-medium text-foreground">
-          <span className="block">{nameLabel}</span>
+
+        <div className="space-y-1.5">
+          <label htmlFor="secret-name" className={fieldLabelClass}>
+            {nameLabel}
+          </label>
           <Input
+            id="secret-name"
             value={nameOrPath}
             disabled={editing}
+            autoComplete="off"
+            spellCheck={false}
+            aria-invalid={nameError ? true : undefined}
+            className={`font-mono${nameError ? " border-destructive/60 focus:ring-destructive" : ""}`}
             placeholder={
               kind === "env"
                 ? "API_TOKEN"
@@ -175,19 +241,68 @@ export function SecretEditorDialog({
                   : ".env.local"
             }
             onChange={(event) => setNameOrPath(event.currentTarget.value)}
+            onBlur={() => setNameTouched(true)}
           />
-        </Label>
+          {editing ? null : (
+            <p className={`text-xs ${nameError ? "text-destructive" : "text-muted-foreground"}`}>
+              {nameError ?? nameHint}
+            </p>
+          )}
+        </div>
+
         {kind === "env" ? (
-          <Label className="block space-y-1.5 text-sm font-medium text-foreground">
-            <span className="block">Value</span>
-            <Textarea
-              value={secret}
-              data-telemetry-mask
-              className="h-36 font-mono text-sm"
-              placeholder={editing ? "Replacement secret" : "Secret value"}
-              onChange={(event) => setSecret(event.currentTarget.value)}
-            />
-          </Label>
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <label htmlFor="secret-value" className={fieldLabelClass}>
+                Value
+              </label>
+              <div className="flex items-center gap-0.5">
+                {multiline ? null : (
+                  <button
+                    type="button"
+                    className={toggleClass}
+                    aria-label={revealed ? "Hide value" : "Show value"}
+                    onClick={() => setRevealed((value) => !value)}
+                  >
+                    {revealed ? <EyeOff size={13} /> : <Eye size={13} />}
+                    {revealed ? "Hide" : "Show"}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className={toggleClass}
+                  onClick={() => setMultiline((value) => !value)}
+                >
+                  {multiline ? "Single line" : "Multi-line"}
+                </button>
+              </div>
+            </div>
+            {multiline ? (
+              <Textarea
+                id="secret-value"
+                value={secret}
+                data-telemetry-mask
+                autoComplete="off"
+                spellCheck={false}
+                className="h-36 font-mono text-sm"
+                placeholder={editing ? "Replacement secret" : "Secret value"}
+                onChange={(event) => setSecret(event.currentTarget.value)}
+              />
+            ) : (
+              <Input
+                id="secret-value"
+                type={revealed ? "text" : "password"}
+                value={secret}
+                data-telemetry-mask
+                autoComplete="off"
+                spellCheck={false}
+                className="font-mono"
+                placeholder={editing ? "Replacement secret" : "Secret value"}
+                onChange={(event) => setSecret(event.currentTarget.value)}
+                onPaste={handleValuePaste}
+              />
+            )}
+          </div>
         ) : (
           <>
             <Label className="block space-y-1.5 text-sm font-medium text-foreground">
@@ -212,6 +327,7 @@ export function SecretEditorDialog({
                 <Textarea
                   value={secret}
                   data-telemetry-mask
+                  spellCheck={false}
                   className="h-52 font-mono text-sm"
                   placeholder={editing ? "Replacement file content" : "Secret file content"}
                   onChange={(event) => setSecret(event.currentTarget.value)}
@@ -242,6 +358,9 @@ export function SecretEditorDialog({
             )}
           </>
         )}
+
+        <p className="text-xs text-muted-foreground">{handlingNote}</p>
+
         {error ? (
           <div className="rounded-md border border-destructive/25 bg-destructive-subtle px-3 py-2 text-sm text-destructive">
             {error}

--- a/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
@@ -6,7 +6,8 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { Label } from "@proliferate/ui/primitives/Label";
 import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
-import { Select } from "@proliferate/ui/primitives/Select";
+import { SegmentedControl } from "@proliferate/ui/primitives/SegmentedControl";
+import { SettingsMenu } from "@proliferate/ui/primitives/SettingsMenu";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 
 export type SecretEditorKind = "env" | "file";
@@ -205,20 +206,23 @@ export function SecretEditorDialog({
     >
       <form id="secret-editor-form" className="space-y-4" onSubmit={submit}>
         {editing ? null : (
-          <Label className="block space-y-1.5 text-sm font-medium text-foreground">
-            <span className="block">Type</span>
-            <Select
-              value={kind}
-              onChange={(event) =>
-                handleKindChange(event.currentTarget.value as SecretEditorKind)}
-            >
-              {SECRET_KIND_OPTIONS.map((option) => (
-                <option key={option} value={option}>
-                  {SECRET_KIND_LABELS[option]}
-                </option>
-              ))}
-            </Select>
-          </Label>
+          <div className="space-y-1.5">
+            <div className={fieldLabelClass}>Type</div>
+            <SettingsMenu
+              label={SECRET_KIND_LABELS[kind]}
+              className="w-60"
+              menuClassName="w-60"
+              groups={[{
+                id: "kind",
+                options: SECRET_KIND_OPTIONS.map((option) => ({
+                  id: option,
+                  label: SECRET_KIND_LABELS[option],
+                  selected: kind === option,
+                  onSelect: () => handleKindChange(option),
+                })),
+              }]}
+            />
+          </div>
         )}
 
         <div className="space-y-1.5">
@@ -305,22 +309,18 @@ export function SecretEditorDialog({
           </div>
         ) : (
           <>
-            <Label className="block space-y-1.5 text-sm font-medium text-foreground">
-              <span className="block">Content source</span>
-              <Select
+            <div className="space-y-1.5">
+              <div className={fieldLabelClass}>Content source</div>
+              <SegmentedControl
+                ariaLabel="File content source"
+                items={FILE_CONTENT_SOURCE_OPTIONS.map((option) => ({
+                  id: option,
+                  label: FILE_CONTENT_SOURCE_LABELS[option],
+                }))}
                 value={fileContentSource}
-                onChange={(event) =>
-                  handleFileContentSourceChange(
-                    event.currentTarget.value as SecretFileContentSource,
-                  )}
-              >
-                {FILE_CONTENT_SOURCE_OPTIONS.map((option) => (
-                  <option key={option} value={option}>
-                    {FILE_CONTENT_SOURCE_LABELS[option]}
-                  </option>
-                ))}
-              </Select>
-            </Label>
+                onChange={handleFileContentSourceChange}
+              />
+            </div>
             {fileContentSource === "text" ? (
               <Label className="block space-y-1.5 text-sm font-medium text-foreground">
                 <span className="block">File content</span>

--- a/apps/packages/product-ui/src/secrets/SecretList.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretList.tsx
@@ -1,3 +1,6 @@
+import { KeyRound, Plus } from "lucide-react";
+
+import { Button } from "@proliferate/ui/primitives/Button";
 import { SecretRow } from "./SecretRow";
 
 export interface SecretListItem {
@@ -8,6 +11,9 @@ export interface SecretListItem {
 
 export interface SecretListProps {
   emptyLabel: string;
+  emptyDescription?: string;
+  addLabel?: string;
+  onAdd?: () => void;
   items: readonly SecretListItem[];
   canManage?: boolean;
   onEdit: (item: SecretListItem) => void;
@@ -16,6 +22,9 @@ export interface SecretListProps {
 
 export function SecretList({
   emptyLabel,
+  emptyDescription,
+  addLabel = "Add secret",
+  onAdd,
   items,
   canManage = true,
   onEdit,
@@ -23,8 +32,20 @@ export function SecretList({
 }: SecretListProps) {
   if (items.length === 0) {
     return (
-      <div className="rounded-md border border-dashed border-border-light px-3 py-4 text-sm text-muted-foreground">
-        {emptyLabel}
+      <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-light px-4 py-6 text-center">
+        <KeyRound size={16} className="text-muted-foreground" />
+        <div className="space-y-0.5">
+          <div className="text-sm text-foreground">{emptyLabel}</div>
+          {emptyDescription ? (
+            <div className="text-xs text-muted-foreground">{emptyDescription}</div>
+          ) : null}
+        </div>
+        {canManage && onAdd ? (
+          <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
+            <Plus size={14} />
+            {addLabel}
+          </Button>
+        ) : null}
       </div>
     );
   }

--- a/apps/packages/product-ui/src/secrets/SecretManagementPanel.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretManagementPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { KeyRound, Plus } from "lucide-react";
 
 import { Badge } from "@proliferate/ui/primitives/Badge";
@@ -64,6 +64,9 @@ export function SecretManagementPanel({
 }: SecretManagementPanelProps) {
   const [editorState, setEditorState] = useState<SecretEditorDialogState | null>(null);
   const [deleteState, setDeleteState] = useState<SecretDeleteDialogState | null>(null);
+  // Keep the editor open until a submitted save settles: close on success,
+  // stay open (showing the error) on failure so the user keeps their input.
+  const [submitPhase, setSubmitPhase] = useState<"idle" | "submitted" | "saving">("idle");
   const envItems = useMemo(
     () => envVars.map((item) => secretMetadataToListItem(item, item.name ?? "")),
     [envVars],
@@ -72,6 +75,8 @@ export function SecretManagementPanel({
     () => files.map((item) => secretMetadataToListItem(item, item.path ?? "")),
     [files],
   );
+  const existingEnvKeys = useMemo(() => envItems.map((item) => item.label), [envItems]);
+  const existingFileKeys = useMemo(() => fileItems.map((item) => item.label), [fileItems]);
   const status = error ? "error" : materialization?.status ?? "pending";
 
   function handleEditorSave(input: SecretEditorSaveInput) {
@@ -82,8 +87,27 @@ export function SecretManagementPanel({
     } else {
       onSaveFile(input.nameOrPath, { content: input.content });
     }
-    setEditorState(null);
+    setSubmitPhase("submitted");
   }
+
+  useEffect(() => {
+    if (submitPhase === "idle") {
+      return;
+    }
+    if (saving) {
+      // Wait until we've observed the in-flight save before deciding to close.
+      if (submitPhase !== "saving") {
+        setSubmitPhase("saving");
+      }
+      return;
+    }
+    if (submitPhase === "saving") {
+      setSubmitPhase("idle");
+      if (!error) {
+        setEditorState(null);
+      }
+    }
+  }, [submitPhase, saving, error]);
 
   function handleDeleteConfirm() {
     if (!deleteState) {
@@ -130,6 +154,9 @@ export function SecretManagementPanel({
         <div className="w-full max-w-xl">
           <SecretList
             emptyLabel="No environment variables yet."
+            emptyDescription="Add your first key to inject it into every cloud sandbox in this scope."
+            addLabel="Add variable"
+            onAdd={() => setEditorState({ mode: "create", kind: "env" })}
             items={envItems}
             canManage={canManage}
             onEdit={(item) => setEditorState({ mode: "edit", kind: "env", nameOrPath: item.label })}
@@ -142,6 +169,9 @@ export function SecretManagementPanel({
         <div className="w-full max-w-xl">
           <SecretList
             emptyLabel="No file secrets yet."
+            emptyDescription="Write a config or credential file straight into the sandbox filesystem."
+            addLabel="Add file"
+            onAdd={() => setEditorState({ mode: "create", kind: "file" })}
             items={fileItems}
             canManage={canManage}
             onEdit={(item) => setEditorState({ mode: "edit", kind: "file", nameOrPath: item.label })}
@@ -162,6 +192,9 @@ export function SecretManagementPanel({
         open={Boolean(editorState)}
         state={editorState}
         filePathMode={filePathMode}
+        scopeDescription={description}
+        existingEnvKeys={existingEnvKeys}
+        existingFileKeys={existingFileKeys}
         saving={saving}
         error={error}
         onClose={() => setEditorState(null)}

--- a/apps/packages/product-ui/src/secrets/SecretManagementPanel.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretManagementPanel.tsx
@@ -150,8 +150,11 @@ export function SecretManagementPanel({
         </div>
       </SettingsRow>
 
-      <SettingsRow label="Environment variables" className="sm:items-start">
-        <div className="w-full max-w-xl">
+      <SettingsRow
+        label="Environment variables"
+        className="sm:flex-col sm:items-stretch sm:justify-start"
+      >
+        <div className="w-full">
           <SecretList
             emptyLabel="No environment variables yet."
             emptyDescription="Add your first key to inject it into every cloud sandbox in this scope."
@@ -165,8 +168,11 @@ export function SecretManagementPanel({
         </div>
       </SettingsRow>
 
-      <SettingsRow label="Files" className="sm:items-start">
-        <div className="w-full max-w-xl">
+      <SettingsRow
+        label="Files"
+        className="sm:flex-col sm:items-stretch sm:justify-start"
+      >
+        <div className="w-full">
           <SecretList
             emptyLabel="No file secrets yet."
             emptyDescription="Write a config or credential file straight into the sandbox filesystem."


### PR DESCRIPTION
## What

Polishes the **add/edit secret flow** in Settings (personal + organization cloud secrets) into a first-class experience. Presentation and interaction only — no API/data logic changed.

### Dialog (`SecretEditorDialog`)
- Scope-aware header: title reads "Add/Edit environment variable" / "…file secret"; description now states **where the secret lives** (personal vs org blurb, threaded from the panel) plus a handling note ("Stored encrypted. Only the name and byte size are shown after saving.").
- **Key input** is monospace and carries a calm format hint ("Use letters, numbers and underscores, e.g. API_TOKEN") in a fixed slot that swaps to inline validation without layout jump.
- **Inline validation**: empty key (after blur) and duplicate key (checked against existing keys in scope) surface as a muted-red hint + red field border; Save stays disabled.
- **Value input**: masked single-line field with a Show/Hide reveal toggle, plus a Multi-line toggle. Pasting a multi-line secret auto-switches to a monospace textarea and preserves newlines.
- Submit label is action-aware ("Add secret" / "Save changes") with loading state on the shared Button.

### Flow fix (`SecretManagementPanel`)
- The dialog previously closed the instant you hit Save, so its error surface never showed and a failed save silently discarded your input. It now stays open until the mutation settles: closes on success, stays open showing the error on failure so you keep what you typed.

### Empty state (`SecretList`)
- Empty env/file lists now show a key glyph, an encouraging one-liner, and an inline "Add variable" / "Add file" button (respecting `canManage`).

## Scope
Kept the diff to the shared flow components in `apps/packages/product-ui/src/secrets/` — no changes to the panes' layout/table cosmetics (owned by another branch), the shared surface, or data hooks.

## Note on the diff
This branch is based on `tip/arc-test` (~12 commits ahead of `origin/main`), so the PR diff includes those. **Only the top two commits are this change** (`ui: first-class add/edit secret flow` + `ui: replace native selectors with popover/segmented + full-width secret sections`) — the shared secrets flow components in `apps/packages/product-ui/src/secrets/`.

## Round 2 (owner review)
- **Type selector** (env var / file): swapped the native `<select>` for our shared `SettingsMenu` popover — a codex-surface trigger showing the current selection that opens a styled menu with a check on the active option.
- **File content source** (paste text / upload): swapped the native `<select>` for the shared `SegmentedControl` binary toggle. No native `<select>` remains in the dialog (the `Select` primitive is untouched; other callers still use it).
- **Section widths**: the Environment variables and Files sections now stack their label as a full-width sub-heading with the list beneath it (dropped the `SettingsRow` label-left/content-right split and the `max-w-xl` cap), so both cards span the full content width and line up edge-to-edge with the hairline dividers.
- Added `SecretEditorDialog.test.tsx` (3 tests): verifies the popover Type menu opens inside the modal and switches the flow, the segmented source control renders, and duplicate/empty-key validation. Full product-ui suite: 106 passing.

## Verify
- `pnpm --filter @proliferate/product-ui build` — passes (tsc clean).
- `apps/desktop pnpm build` (packages + tsc + vite) — passes.
- `apps/desktop pnpm check:design` — the 3 failures it reports are pre-existing on `tip/arc-test` (RadioCardGroup, ModelConfigGrid, GridTile) and unrelated to these files; my files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

