### PR TITLE
ui: polish repo picker, actions suggestions, env vars, cloud/local switcher

### DIFF
--- a/apps/desktop/src/components/settings/panes/repo/RepoActionsPane.tsx
+++ b/apps/desktop/src/components/settings/panes/repo/RepoActionsPane.tsx
@@ -268,14 +268,14 @@ function SetupHintRows({
 
   return (
     <div className="space-y-1.5">
-      <p className="text-xs font-medium text-muted-foreground">{title}</p>
-      <div className="flex flex-col gap-1">
+      <p className="text-ui-sm font-medium text-muted-foreground">{title}</p>
+      <div className="flex flex-col gap-0.5">
         {hints.map((hint) => {
           const checked = isSetupHintEnabled(currentScript, hint.suggestedCommand);
           return (
             <Label
               key={hint.id}
-              className="mb-0 flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-foreground/5"
+              className="mb-0 flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-foreground/5"
             >
               <Checkbox
                 checked={checked}
@@ -286,10 +286,10 @@ function SetupHintRows({
                 ))}
                 className="size-3.5 shrink-0 accent-foreground"
               />
-              <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+              <span className="min-w-0 flex-1 truncate font-mono text-ui-sm text-foreground">
                 {hint.suggestedCommand}
               </span>
-              <span className="shrink-0 text-xs text-muted-foreground">
+              <span className="shrink-0 text-base text-muted-foreground">
                 {hint.detectedFile}
               </span>
             </Label>

--- a/apps/desktop/src/components/settings/panes/repo/RepoCloudGate.tsx
+++ b/apps/desktop/src/components/settings/panes/repo/RepoCloudGate.tsx
@@ -1,10 +1,18 @@
 import { type ReactNode } from "react";
 import { Cloud } from "lucide-react";
+import { GitHub } from "@proliferate/ui/icons";
+import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
 import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
 import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { Button } from "@proliferate/ui/primitives/Button";
+import { useGitHubAppUserAuthorization } from "@/hooks/settings/workflows/use-github-app-user-authorization";
 import { type CloudRepoEnvironmentEditor } from "@/hooks/settings/workflows/use-cloud-repo-environment-editor";
+
+// Land the GitHub authorization callback on the cloud environments settings
+// surface (the same return target the add-repo flow uses).
+const USER_AUTHORIZATION_RETURN_TO =
+  "proliferate://settings/environments?source=github_app_callback";
 
 interface RepoCloudGateProps {
   editor: CloudRepoEnvironmentEditor;
@@ -92,11 +100,17 @@ export function RepoCloudGate({
     );
   }
 
+  // Not authorized: block the cloud context entirely and show a single
+  // actionable connect prompt (or a clear admin/access message) instead of
+  // half-loading the page behind a passive notice.
   if (editor.authority.data && !editor.authority.data.authorized) {
     return (
-      <CloudEnvironmentNotice
-        label="GitHub App access needed"
-        description={editor.authority.data.message ?? repoAuthorityNotice(editor.authority.data.status)}
+      <RepoCloudAuthorizationRequired
+        status={editor.authority.data.status}
+        message={editor.authority.data.message ?? null}
+        onAuthorizationReturn={() => {
+          void editor.authority.refetch();
+        }}
       />
     );
   }
@@ -132,12 +146,89 @@ export function RepoCloudGate({
   return <>{children}</>;
 }
 
+/**
+ * The not-authorized branch of the gate. User-authorization gaps get an inline
+ * "Connect GitHub App" action (the shared authorize flow); installation and
+ * repo-access gaps a non-admin can't self-serve stay explanatory messages.
+ */
+function RepoCloudAuthorizationRequired({
+  status,
+  message,
+  onAuthorizationReturn,
+}: {
+  status: string;
+  message: string | null;
+  onAuthorizationReturn: () => void;
+}) {
+  const needsUserAuthorization =
+    status === "missing_user_authorization" || status === "expired_user_authorization";
+  const { authorize, authorizing, error } = useGitHubAppUserAuthorization({
+    returnTo: USER_AUTHORIZATION_RETURN_TO,
+    onAuthorizationReturn,
+  });
+
+  if (needsUserAuthorization) {
+    const reconnect = status === "expired_user_authorization";
+    const actionLabel = authorizing
+      ? "Opening GitHub…"
+      : reconnect
+        ? "Reconnect GitHub App"
+        : "Connect GitHub App";
+    return (
+      <SettingsEmptyState
+        icon={<GitHub aria-hidden="true" />}
+        title={reconnect ? "Reconnect GitHub App" : "Connect GitHub App"}
+        description={
+          message
+          ?? (reconnect
+            ? "Your GitHub App authorization expired. Reconnect it to configure cloud environments for this repository."
+            : "Authorize the Proliferate GitHub App to configure cloud environments for this repository.")
+        }
+        action={
+          <div className="flex flex-col items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              loading={authorizing}
+              disabled={authorizing}
+              onClick={authorize}
+            >
+              {!authorizing ? (
+                <ProviderBrandIcon provider="github" className="size-[13px]" />
+              ) : null}
+              {actionLabel}
+            </Button>
+            {error ? <p className="text-ui-sm text-destructive">{error}</p> : null}
+          </div>
+        }
+      />
+    );
+  }
+
+  return (
+    <SettingsEmptyState
+      icon={<GitHub aria-hidden="true" />}
+      title={authorizationRequiredTitle(status)}
+      description={message ?? repoAuthorityNotice(status)}
+    />
+  );
+}
+
+function authorizationRequiredTitle(status: string): string {
+  switch (status) {
+    case "missing_installation":
+      return "GitHub App not installed";
+    case "repo_not_covered":
+      return "Repository not covered";
+    case "missing_user_repo_access":
+      return "No access to this repository";
+    default:
+      return "GitHub App access needed";
+  }
+}
+
 function repoAuthorityNotice(status: string): string {
   switch (status) {
-    case "missing_user_authorization":
-      return "Authorize the Proliferate GitHub App in Account settings before configuring this cloud environment.";
-    case "expired_user_authorization":
-      return "Reauthorize the Proliferate GitHub App in Account settings before configuring this cloud environment.";
     case "missing_installation":
       return "An organization admin needs to install the Proliferate GitHub App for this repository.";
     case "repo_not_covered":

--- a/apps/desktop/src/hooks/settings/workflows/use-github-app-user-authorization.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-github-app-user-authorization.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { useStartGitHubAppUserAuthorization } from "@proliferate/cloud-sdk-react";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+
+// Same staggered refetch cadence the Account pane uses after opening the
+// GitHub authorization page: the callback deep-link may land on another
+// settings surface, so poll the caller's query for a while in case the user
+// returns to this view directly.
+const AUTHORIZATION_REFRESH_DELAYS_MS = [2_000, 5_000, 10_000, 20_000, 40_000, 80_000];
+
+export interface GitHubAppUserAuthorizationFlow {
+  authorize: () => void;
+  authorizing: boolean;
+  error: string | null;
+}
+
+/**
+ * Starts the GitHub App user-authorization flow — the same
+ * `useStartGitHubAppUserAuthorization` mutation + external-browser handoff the
+ * Account settings GitHub App section drives — and schedules a few refetches of
+ * the caller's authority query so a returning user self-heals out of the gate.
+ */
+export function useGitHubAppUserAuthorization({
+  returnTo,
+  onAuthorizationReturn,
+}: {
+  returnTo: string;
+  onAuthorizationReturn?: () => void;
+}): GitHubAppUserAuthorizationFlow {
+  const start = useStartGitHubAppUserAuthorization();
+  const { openExternal } = useTauriShellActions();
+  const [error, setError] = useState<string | null>(null);
+  const timersRef = useRef<number[]>([]);
+  const onReturnRef = useRef(onAuthorizationReturn);
+  onReturnRef.current = onAuthorizationReturn;
+
+  useEffect(() => () => {
+    for (const timerId of timersRef.current) {
+      window.clearTimeout(timerId);
+    }
+  }, []);
+
+  function authorize() {
+    setError(null);
+    void (async () => {
+      try {
+        const response = await start.mutateAsync({ returnTo });
+        await openExternal(response.authorizationUrl);
+        for (const timerId of timersRef.current) {
+          window.clearTimeout(timerId);
+        }
+        timersRef.current = AUTHORIZATION_REFRESH_DELAYS_MS.map((delayMs) =>
+          window.setTimeout(() => onReturnRef.current?.(), delayMs),
+        );
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : "GitHub App authorization failed.");
+      }
+    })();
+  }
+
+  return { authorize, authorizing: start.isPending, error };
+}

--- a/apps/packages/product-ui/src/environments/CloudEnvironmentList.tsx
+++ b/apps/packages/product-ui/src/environments/CloudEnvironmentList.tsx
@@ -126,7 +126,6 @@ function EnvironmentRow({
 }) {
   return (
     <SettingsRow
-      title={environment.description}
       label={(
         <span className="flex min-w-0 items-center gap-2">
           <Cloud size={14} className="shrink-0 text-muted-foreground" />

--- a/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
@@ -2,11 +2,11 @@ import { type FormEvent } from "react";
 import {
   Archive,
   Check,
-  Cloud,
   Lock,
   RotateCw,
   ShieldAlert,
 } from "lucide-react";
+import { GitHub } from "@proliferate/ui/icons";
 
 import {
   Dialog,
@@ -277,7 +277,7 @@ function RepositoryRow({
         {repo.ownerAvatarUrl ? (
           <img src={repo.ownerAvatarUrl} alt="" className="size-full object-cover" />
         ) : (
-          <Cloud size={12} aria-hidden />
+          <GitHub aria-hidden className="size-3" />
         )}
       </span>
       <span className="min-w-0 flex-1">

--- a/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
@@ -110,7 +110,7 @@ export function CloudRepoPicker({
       {error ? (
         <div
           role="alert"
-          className="mt-2 flex items-start gap-2 rounded-lg bg-destructive-subtle px-2.5 py-2 text-xs leading-[1.45] text-destructive"
+          className="mt-2 flex items-start gap-2 rounded-lg bg-destructive-subtle px-2.5 py-2 text-ui-sm leading-[1.45] text-destructive"
         >
           <ShieldAlert className="mt-px size-3.5 shrink-0" aria-hidden />
           <span className="min-w-0 flex-1">{error}</span>
@@ -196,7 +196,7 @@ function CloudRepoPickerBlocker({
         </span>
         <span className="min-w-0 flex-1">
           <h3 className="text-ui font-medium leading-5 text-foreground">{blocker.title}</h3>
-          <p className="mt-0.5 text-xs leading-[1.45] text-muted-foreground">
+          <p className="mt-0.5 text-ui-sm leading-[1.45] text-muted-foreground">
             {blocker.description}
           </p>
         </span>
@@ -241,7 +241,7 @@ function EmptyRepositoryState({ query }: { query: string }) {
       <div className="text-ui-sm font-medium text-foreground">
         {trimmedQuery ? "No matching repositories" : "No repositories found"}
       </div>
-      <p className="mx-auto mt-1 max-w-xs text-xs leading-[1.45] text-muted-foreground">
+      <p className="mx-auto mt-1 max-w-xs text-ui-sm leading-[1.45] text-muted-foreground">
         {trimmedQuery
           ? "Try another owner or repository name, or paste an owner/repo value below."
           : "Paste an owner/repo value below, or connect a GitHub account with repository access."}
@@ -291,7 +291,7 @@ function RepositoryRow({
             <Check className="size-3 shrink-0 text-success" aria-hidden />
           ) : null}
         </span>
-        <span className="block truncate text-xs leading-[1.45] text-muted-foreground">
+        <span className="block truncate text-ui-sm leading-[1.45] text-muted-foreground">
           {repo.disabledReason ? (
             <span className="text-warning">{repo.disabledReason}</span>
           ) : (

--- a/apps/packages/product-ui/src/settings/ModelConfigGrid.tsx
+++ b/apps/packages/product-ui/src/settings/ModelConfigGrid.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "@proliferate/ui/utils/tw-merge";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { GridTile } from "@proliferate/ui/primitives/GridTile";
 import { Switch } from "@proliferate/ui/primitives/Switch";
@@ -31,16 +31,16 @@ export function ModelConfigGrid({ models, onToggle, className }: ModelConfigGrid
         <GridTile key={model.id}>
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between gap-2">
-              <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
+              <span className="min-w-0 truncate text-ui font-medium leading-5 text-foreground">
                 {model.name}
               </span>
               <Badge tone="neutral">{model.provider}</Badge>
             </div>
             {model.version ? (
-              <span className="text-[12px] leading-[1.45] text-muted-foreground">{model.version}</span>
+              <span className="text-ui-sm leading-[1.45] text-muted-foreground">{model.version}</span>
             ) : null}
             <div className="mt-1 flex items-center justify-between gap-2 border-t border-border pt-2.5">
-              <span className="text-[12px] font-medium leading-[1.45] text-muted-foreground">Enabled</span>
+              <span className="text-ui-sm font-medium leading-[1.45] text-muted-foreground">Enabled</span>
               <Switch
                 checked={model.enabled}
                 disabled={model.disabled}

--- a/apps/packages/product-ui/src/settings/RepoPicker.tsx
+++ b/apps/packages/product-ui/src/settings/RepoPicker.tsx
@@ -40,7 +40,7 @@ export function RepoPicker({
           variant="unstyled"
           size="unstyled"
           aria-label="Select repository"
-          className="flex h-7 w-[200px] items-center gap-2 rounded-md border border-input bg-background pl-2 pr-2 text-ui-sm transition-colors hover:bg-accent data-[state=open]:bg-accent"
+          className="flex h-8 w-[200px] items-center gap-2 rounded-md border border-input bg-background px-2 text-ui-sm transition-colors hover:bg-accent data-[state=open]:bg-accent"
         >
           <RepoChip kind={selected?.kind ?? "local"} />
           <span className="min-w-0 flex-1 truncate text-left">

--- a/apps/packages/product-ui/src/settings/RepoPicker.tsx
+++ b/apps/packages/product-ui/src/settings/RepoPicker.tsx
@@ -1,4 +1,5 @@
-import { Check, ChevronsUpDown, Cloud, Folder, Plus } from "lucide-react";
+import { Check, ChevronsUpDown, Cloud, Plus } from "lucide-react";
+import { GitHub } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
 import {
   POPOVER_SURFACE_CLASS,
@@ -84,9 +85,11 @@ export function RepoPicker({
 }
 
 function RepoChip({ kind }: { kind: RepoPickerItem["kind"] }) {
-  const Icon = kind === "cloud" ? Cloud : Folder;
+  // GitHub-backed repos read as a GitHub mark; cloud environments stay a Cloud
+  // glyph. Neutral chip, not the old blue folder.
+  const Icon = kind === "cloud" ? Cloud : GitHub;
   return (
-    <span className="flex size-[15px] shrink-0 items-center justify-center rounded bg-special text-white [&>svg]:size-[9px]">
+    <span className="flex size-[15px] shrink-0 items-center justify-center rounded bg-surface-control text-muted-foreground [&>svg]:size-[10px]">
       <Icon />
     </span>
   );

--- a/apps/packages/ui/src/primitives/GridTile.tsx
+++ b/apps/packages/ui/src/primitives/GridTile.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "../utils/tw-merge";
 
 interface GridTileProps {
   children: ReactNode;

--- a/apps/packages/ui/src/primitives/RadioCardGroup.tsx
+++ b/apps/packages/ui/src/primitives/RadioCardGroup.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "../utils/tw-merge";
 import { Check } from "../icons/core";
 
 export interface RadioCardOption<Value extends string = string> {
@@ -60,11 +60,11 @@ export function RadioCardGroup<Value extends string>({
               </span>
             ) : null}
             <span className="min-w-0">
-              <span className="block text-[13px] font-medium leading-[1.3] text-foreground">
+              <span className="block text-ui font-medium leading-[1.3] text-foreground">
                 {option.label}
               </span>
               {option.description ? (
-                <span className="mt-[3px] block text-[12px] leading-[1.45] text-muted-foreground">
+                <span className="mt-[3px] block text-ui-sm leading-[1.45] text-muted-foreground">
                   {option.description}
                 </span>
               ) : null}


### PR DESCRIPTION
## Scope

Focused UI cleanup of the repo/environment-level **settings** surfaces in the desktop app ("Ugly settings pages #2"). Restrained polish onto the existing settings scaffold — no redesign. Two review rounds, **9 files, +186/−31** (GitHub shows the clean merge-base diff; ignore any raw two-dot count vs a diverged local `origin/main`).

## Round 1 — typography / control polish

- **RepoPicker** trigger height `h-7 → h-8` so it exactly matches the sibling Cloud/Local `SegmentedControl` (32px); tidied `pl-2 pr-2 → px-2`.
- **CloudRepoPicker** — lifted 8px (`text-xs`) secondary text to the 12px settings-description token (`text-ui-sm`) for the error alert, prerequisite blocker, empty state, and repo-row metadata.
- **RepoActionsPane** setup-hint suggestions — monospace 12px command, 11px muted detected-file, 12px group label (were 8–10px), roomier rows.
- **CloudEnvironmentList** — dropped a redundant native `title` tooltip.
- Pre-existing base design-check fixes (`GridTile`, `RadioCardGroup`, `ModelConfigGrid`): raw `tailwind-merge` → wrapper import, `text-[13px]`/`text-[12px]` → `text-ui`/`text-ui-sm`. Exact-equivalent, zero visual change; included only to keep `check:design` green.

## Round 2 — GitHub glyph + actionable cloud connect gate

**Repo chip (no more blue folder)**
- `RepoChip` (settings `RepoPicker`): dropped the `bg-special` blue folder chip. GitHub-backed repos now show the **owned GitHub mark** (`@proliferate/ui/icons`) on a neutral `bg-surface-control` chip; cloud repos keep the Cloud glyph.
- `CloudRepoPicker` rows: the no-avatar fallback is now the GitHub mark (was a Cloud icon), so both pickers read consistently.

**Cloud gate blocks unauthorized access with a real connect prompt**
- `RepoCloudGate`: when the GitHub App isn't authorized, the cloud context is blocked entirely (no half-loaded controls) and shows a single `SettingsEmptyState`:
  - `missing_user_authorization` / `expired_user_authorization` → **"Connect / Reconnect GitHub App"** with a button that drives the shared `useStartGitHubAppUserAuthorization` mutation + external-browser handoff (new `use-github-app-user-authorization` hook, reusing the exact flow the Account pane uses — no reimplementation, no "go to Account settings" dead-end).
  - `missing_installation` / `repo_not_covered` / `missing_user_repo_access` → clear explanatory messages (a non-admin can't self-serve an org install).
- Deleted the now-dead "authorize in Account settings" notice copy.
- **Switcher:** no change needed (option a) — the gate already fully owns the cloud content, so selecting Cloud shows only the connect prompt.
- **Happy path preserved:** when the App IS authorized, the `!authorized` block is skipped entirely and the gate falls through to `children` exactly as before (verified by build + structure).

Untouched: the secrets flow (`product-ui/src/secrets`), org/billing/SSO panes.

## Verify
- `pnpm check:design` ✅
- `pnpm build` (shared packages + tsc + vite) ✅
- product-ui vitest (`CloudEnvironments`, `AddRepoFlow`) ✅ 12/12
- desktop vitest (`SettingsSidebar`, `WorktreeStorageSection`, settings components/domain) ✅ (one unrelated `navigation.test.ts` failure is pre-existing on the base branch — those files are byte-identical to base and untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)