### PR TITLE
ui: polish org/billing/secrets/SSO settings panes

### DIFF
--- a/apps/desktop/src/components/settings/panes/organization/OrganizationAgentPolicySection.tsx
+++ b/apps/desktop/src/components/settings/panes/organization/OrganizationAgentPolicySection.tsx
@@ -8,6 +8,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
 import { Label } from "@proliferate/ui/primitives/Label";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
+import { SettingsEyebrow } from "@proliferate/product-ui/settings/SettingsEyebrow";
 
 const ROUTE_OPTIONS = [
   { value: "native", label: "Native (harness sign-in)" },
@@ -109,17 +110,17 @@ export function OrganizationAgentPolicySection({
       title="Agent policy"
       description="Allowed auth routes and harnesses for members. Conflicts are flagged only — nothing is blocked."
     >
-      <div className="space-y-4 py-3">
+      <div className="space-y-5 py-1">
         {policy.isLoading ? (
-          <div className="text-sm text-muted-foreground">Loading agent policy...</div>
+          <div className="text-ui-sm text-muted-foreground">Loading agent policy…</div>
         ) : policy.isError ? (
-          <div className="text-sm text-muted-foreground">
+          <div className="text-ui-sm text-muted-foreground">
             Agent policy could not be loaded.
           </div>
         ) : (
           <>
             {!editable ? (
-              <div className="text-sm text-muted-foreground">
+              <div className="text-ui-sm text-muted-foreground">
                 Editing the agent policy requires a paid plan.
               </div>
             ) : null}
@@ -140,7 +141,7 @@ export function OrganizationAgentPolicySection({
               />
             </div>
             {updatePolicy.isError ? (
-              <div className="text-sm text-destructive">
+              <div className="text-ui-sm text-destructive">
                 {updatePolicy.error instanceof Error
                   ? updatePolicy.error.message
                   : "Agent policy could not be saved."}
@@ -162,45 +163,56 @@ export function OrganizationAgentPolicySection({
         )}
       </div>
 
-      <div className="border-t border-border py-3">
-        <div className="mb-2 text-sm font-semibold text-foreground">Conflicts</div>
-        {violations.isLoading ? (
-          <div className="text-sm text-muted-foreground">Checking member selections...</div>
-        ) : violations.isError ? (
-          <div className="text-sm text-muted-foreground">
-            Conflicts could not be loaded.
-          </div>
-        ) : violationRows.length === 0 ? (
-          <div className="text-sm text-muted-foreground">
-            No member selections conflict with this policy.
-          </div>
-        ) : (
-          <table className="w-full text-left text-sm">
-            <thead>
-              <tr className="text-muted-foreground">
-                <th className="py-1 pr-4 font-medium">Member</th>
-                <th className="py-1 pr-4 font-medium">Harness</th>
-                <th className="py-1 pr-4 font-medium">Surface</th>
-                <th className="py-1 font-medium">Route</th>
-              </tr>
-            </thead>
-            <tbody>
-              {violationRows.map((violation) => (
-                <tr
-                  key={`${violation.userId}-${violation.harnessKind}-${violation.surface}`}
-                  className="border-t border-border-light"
-                >
-                  <td className="py-1.5 pr-4 text-foreground">
-                    {violation.displayName ?? violation.email ?? violation.userId}
-                  </td>
-                  <td className="py-1.5 pr-4">{harnessLabel(violation.harnessKind)}</td>
-                  <td className="py-1.5 pr-4 capitalize">{violation.surface}</td>
-                  <td className="py-1.5">{routeLabel(violation.route)}</td>
+      <div className="border-t border-border pt-4">
+        <SettingsEyebrow>Conflicts</SettingsEyebrow>
+        <p className="mt-1 text-ui-sm leading-[1.45] text-muted-foreground">
+          Member selections that fall outside this policy. Flagged only — nothing is blocked.
+        </p>
+        <div className="mt-3">
+          {violations.isLoading ? (
+            <div className="text-ui-sm text-muted-foreground">Checking member selections…</div>
+          ) : violations.isError ? (
+            <div className="text-ui-sm text-muted-foreground">
+              Conflicts could not be loaded.
+            </div>
+          ) : violationRows.length === 0 ? (
+            <div className="text-ui-sm text-muted-foreground">
+              No member selections conflict with this policy.
+            </div>
+          ) : (
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-border">
+                  <SettingsEyebrow as="th" className="pb-2 pr-4 text-left">Member</SettingsEyebrow>
+                  <SettingsEyebrow as="th" className="pb-2 pr-4 text-left">Harness</SettingsEyebrow>
+                  <SettingsEyebrow as="th" className="pb-2 pr-4 text-left">Surface</SettingsEyebrow>
+                  <SettingsEyebrow as="th" className="pb-2 text-left">Route</SettingsEyebrow>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+              </thead>
+              <tbody>
+                {violationRows.map((violation) => (
+                  <tr
+                    key={`${violation.userId}-${violation.harnessKind}-${violation.surface}`}
+                    className="border-b border-border last:border-b-0"
+                  >
+                    <td className="py-2.5 pr-4 text-ui text-foreground">
+                      {violation.displayName ?? violation.email ?? violation.userId}
+                    </td>
+                    <td className="py-2.5 pr-4 text-ui-sm text-muted-foreground">
+                      {harnessLabel(violation.harnessKind)}
+                    </td>
+                    <td className="py-2.5 pr-4 text-ui-sm capitalize text-muted-foreground">
+                      {violation.surface}
+                    </td>
+                    <td className="py-2.5 text-ui-sm text-muted-foreground">
+                      {routeLabel(violation.route)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
       </div>
     </SettingsSection>
   );
@@ -220,12 +232,12 @@ function PolicyChecklist({
   onToggle: (value: string) => void;
 }) {
   return (
-    <fieldset className="space-y-2">
-      <legend className="text-sm font-semibold text-foreground">{legend}</legend>
+    <fieldset className="space-y-2.5">
+      <SettingsEyebrow as="legend">{legend}</SettingsEyebrow>
       {options.map((option) => (
         <Label
           key={option.value}
-          className="flex items-center gap-2 text-sm text-foreground"
+          className="flex items-center gap-2 text-ui text-foreground"
         >
           <Checkbox
             checked={checked.has(option.value)}

--- a/apps/desktop/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx
@@ -44,7 +44,7 @@ export function OrganizationInvitationsSection({
           description="Share this link with people who already have an invitation for this organization."
         >
           <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-            <div className="flex h-9 min-w-0 flex-1 items-center rounded-md border border-input bg-background px-3 text-sm text-foreground">
+            <div className="flex h-9 min-w-0 flex-1 items-center rounded-md border border-input bg-background px-3 text-ui text-foreground">
               <span className="min-w-0 truncate font-mono text-ui-sm">
                 {inviteLinkUrl || (copyingInviteLink ? "Loading invite link…" : "Invite link unavailable")}
               </span>

--- a/apps/packages/product-surfaces/src/settings/BillingManagementCards.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingManagementCards.tsx
@@ -1,4 +1,5 @@
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
+import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
 import { ExternalLink } from "@proliferate/ui/icons";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -27,38 +28,37 @@ export function BillingPlanCard({
   actionError: string | null;
   onManage: () => void;
 }) {
+  const context = organizationLoading
+    ? "Billing details for this organization."
+    : organization
+      ? `Billing for ${organization.name}.`
+      : "Shared billing and credits for this workspace.";
+
   return (
-    <SettingsSection>
-      <div className="space-y-4 p-5">
-        <h2 className="text-lg font-semibold text-foreground">Plan</h2>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 space-y-1">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-base font-medium text-foreground">{plan.name}</span>
-              <span className="text-base font-medium text-muted-foreground">· {plan.price}</span>
-              <Badge tone={plan.badgeTone}>{plan.badge}</Badge>
-            </div>
-            <p className="text-sm leading-5 text-muted-foreground">
-              {organizationLoading
-                ? "Billing details for this organization."
-                : organization
-                  ? `Billing for ${organization.name}.`
-                  : "Shared billing and credits for this workspace."}
-            </p>
-            {actionError ? <p className="text-sm text-destructive">{actionError}</p> : null}
-          </div>
-          <Button
-            type="button"
-            variant="primary"
-            loading={loading}
-            disabled={organizationLoading}
-            onClick={onManage}
-            className="w-full sm:w-auto"
-          >
-            Manage
-          </Button>
-        </div>
-      </div>
+    <SettingsSection title="Plan">
+      <SettingsRow
+        label={(
+          <span className="flex flex-wrap items-center gap-2">
+            {plan.name}
+            <span className="font-normal text-muted-foreground">{plan.price}</span>
+            <Badge tone={plan.badgeTone}>{plan.badge}</Badge>
+          </span>
+        )}
+        description={context}
+      >
+        <Button
+          type="button"
+          variant="primary"
+          loading={loading}
+          disabled={organizationLoading}
+          onClick={onManage}
+        >
+          Manage
+        </Button>
+      </SettingsRow>
+      {actionError ? (
+        <p className="pt-2 text-ui-sm text-destructive">{actionError}</p>
+      ) : null}
     </SettingsSection>
   );
 }
@@ -75,39 +75,35 @@ export function BillingAutoTopUpCard({
   onEnabledChange: (value: boolean) => void;
 }) {
   return (
-    <SettingsSection>
-      <div className="space-y-6 p-5">
-        <div className="space-y-1.5">
-          <h2 className="text-lg font-semibold text-foreground">Auto top-up</h2>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            Automatically replenish compute units and LLM credits from their own thresholds.
-          </p>
-        </div>
-
-        <div className="flex items-center gap-3">
+    <SettingsSection
+      title="Auto top-up"
+      description="Automatically replenish compute units and LLM credits from their own thresholds."
+    >
+      <SettingsRow
+        label="Enable auto top-up"
+        description="Replenish balances automatically when they fall below the configured threshold."
+      >
+        <div className="flex items-center gap-2">
+          {saving ? <span className="text-ui-sm text-muted-foreground">Saving…</span> : null}
           <Switch
             checked={enabled}
             onChange={onEnabledChange}
             disabled={disabled}
             aria-label="Auto top-up"
           />
-          <span className="text-sm font-medium text-foreground">Enable auto top-up</span>
-          {saving ? <span className="text-xs text-muted-foreground">Saving...</span> : null}
         </div>
-
-        <div className="grid gap-3 sm:grid-cols-2">
-          <AutoTopUpSummary
-            label="Compute auto top-up"
-            description="Replenish compute units when runtime capacity falls below the configured threshold."
-          />
-          <AutoTopUpSummary
-            label="LLM credit auto top-up"
-            description="Replenish LLM credits when model usage balance falls below the configured threshold."
-          />
-        </div>
-
-        <p className="text-sm text-muted-foreground">Last auto top-up: not yet run.</p>
-      </div>
+      </SettingsRow>
+      <SettingsRow
+        label="Compute auto top-up"
+        description="Replenish compute units when runtime capacity falls below the configured threshold."
+      />
+      <SettingsRow
+        label="LLM credit auto top-up"
+        description="Replenish LLM credits when model usage balance falls below the configured threshold."
+      />
+      <SettingsRow label="Last auto top-up">
+        <span className="text-ui-sm text-muted-foreground">Not yet run</span>
+      </SettingsRow>
     </SettingsSection>
   );
 }
@@ -122,35 +118,25 @@ export function BillingPortalCard({
   onOpenPortal: () => void;
 }) {
   return (
-    <SettingsSection>
-      <div className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0 space-y-1.5">
-          <h2 className="text-lg font-semibold text-foreground">Billing</h2>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            View invoices, update payment methods, and manage cancellation in Stripe.
-          </p>
-        </div>
+    <SettingsSection
+      title="Billing portal"
+      description="View invoices, update payment methods, and manage cancellation in Stripe."
+    >
+      <SettingsRow
+        label="Stripe billing portal"
+        description="Open the Stripe-hosted portal to manage payment details for this organization."
+      >
         <Button
           type="button"
           variant="primary"
           loading={loading}
           disabled={disabled}
           onClick={onOpenPortal}
-          className="w-full sm:w-auto"
         >
           Access billing portal
           <ExternalLink className="size-3.5" />
         </Button>
-      </div>
+      </SettingsRow>
     </SettingsSection>
-  );
-}
-
-function AutoTopUpSummary({ label, description }: { label: string; description: string }) {
-  return (
-    <div className="rounded-lg border border-border-light bg-foreground/[0.02] p-3">
-      <div className="text-sm font-medium text-foreground">{label}</div>
-      <div className="mt-1 text-sm leading-5 text-muted-foreground">{description}</div>
-    </div>
   );
 }

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
@@ -118,7 +118,7 @@ describe("BillingSettingsSurface", () => {
     );
 
     expect(screen.getAllByRole("heading", { name: "Billing" }).length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Plan" })).toBeTruthy();
+    expect(screen.getByText("Plan")).toBeTruthy();
     expect(screen.getByText(/tracked, budgeted, and topped up separately/)).toBeTruthy();
     expect(screen.getByText("360 PCUs")).toBeTruthy();
     expect(screen.getByText("12,000 LLM credits")).toBeTruthy();

--- a/apps/packages/product-surfaces/src/settings/BillingUsageUnitsSection.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingUsageUnitsSection.tsx
@@ -26,25 +26,19 @@ export function BillingUsageUnitsSection({
   addCreditsDisabled: boolean;
 }) {
   return (
-    <SettingsSection>
-      <div className="space-y-6 p-5">
-        <div className="space-y-1.5">
-          <h2 className="text-lg font-semibold text-foreground">Usage units</h2>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            Compute units and LLM credits are tracked, budgeted, and topped up separately.
-          </p>
-        </div>
-
-        <div className="grid gap-4">
-          {unitBalances.map((unitBalance) => (
-            <BillingUnitPoolCard
-              key={unitBalance.kind}
-              unitBalance={unitBalance}
-              addCreditsLoading={addCreditsLoading}
-              addCreditsDisabled={addCreditsDisabled}
-            />
-          ))}
-        </div>
+    <SettingsSection
+      title="Usage units"
+      description="Compute units and LLM credits are tracked, budgeted, and topped up separately."
+    >
+      <div className="grid gap-4 pt-1">
+        {unitBalances.map((unitBalance) => (
+          <BillingUnitPoolCard
+            key={unitBalance.kind}
+            unitBalance={unitBalance}
+            addCreditsLoading={addCreditsLoading}
+            addCreditsDisabled={addCreditsDisabled}
+          />
+        ))}
       </div>
     </SettingsSection>
   );
@@ -61,10 +55,10 @@ function BillingUnitPoolCard({
 }) {
   return (
     <section className="overflow-hidden rounded-lg border border-border-light bg-foreground/[0.02]">
-      <div className="space-y-5 p-4">
+      <div className="space-y-4 p-4">
         <div className="space-y-1">
-          <h3 className="text-base font-semibold text-foreground">{unitBalance.title}</h3>
-          <p className="text-sm leading-5 text-muted-foreground">{unitBalance.description}</p>
+          <h3 className="text-ui font-medium text-foreground">{unitBalance.title}</h3>
+          <p className="text-ui-sm leading-[1.45] text-muted-foreground">{unitBalance.description}</p>
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
@@ -75,37 +69,30 @@ function BillingUnitPoolCard({
 
         <ProgressBar
           value={unitBalance.availablePercent ?? 0}
-          className="h-4 overflow-hidden rounded-full border border-border-light bg-foreground/5 p-0.5"
+          className="h-2.5 overflow-hidden rounded-full bg-foreground/10"
           indicatorClassName="h-full rounded-full bg-primary/70"
           aria-label={`${unitBalance.title} available`}
         />
       </div>
 
-      <div className="border-t border-border-light bg-background/40 p-4">
-        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-          <div className="min-w-0">
-            <h4 className="text-sm font-medium text-foreground">
-              Top up {unitBalance.title.toLowerCase()}
-            </h4>
-            <p className="mt-1 text-sm leading-5 text-muted-foreground">
-              {unitBalance.lowBalanceCopy}
-            </p>
+      <div className="flex flex-col gap-2 border-t border-border-light bg-background/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="text-ui font-medium text-foreground">
+            Top up {unitBalance.title.toLowerCase()}
           </div>
-        </div>
-        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-ui-sm leading-[1.45] text-muted-foreground">
             Credit pack checkout for organizations is coming soon.
           </p>
-          <Button
-            type="button"
-            variant="secondary"
-            loading={addCreditsLoading}
-            disabled={addCreditsDisabled}
-            className="w-full sm:w-auto"
-          >
-            {unitBalance.topUpLabel}
-          </Button>
         </div>
+        <Button
+          type="button"
+          variant="secondary"
+          loading={addCreditsLoading}
+          disabled={addCreditsDisabled}
+          className="w-full sm:w-auto"
+        >
+          {unitBalance.topUpLabel}
+        </Button>
       </div>
     </section>
   );
@@ -114,10 +101,8 @@ function BillingUnitPoolCard({
 function BillingMetric({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="mb-1 text-sm text-muted-foreground">{label}</p>
-      <p className="break-words text-xl font-semibold leading-tight text-foreground sm:text-2xl">
-        {value}
-      </p>
+      <p className="mb-1 text-ui-sm text-muted-foreground">{label}</p>
+      <p className="break-words text-lg font-semibold leading-tight text-foreground">{value}</p>
     </div>
   );
 }

--- a/apps/packages/product-ui/src/settings/ModelConfigGrid.tsx
+++ b/apps/packages/product-ui/src/settings/ModelConfigGrid.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "@proliferate/ui/utils/tw-merge";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { GridTile } from "@proliferate/ui/primitives/GridTile";
 import { Switch } from "@proliferate/ui/primitives/Switch";
@@ -31,16 +31,16 @@ export function ModelConfigGrid({ models, onToggle, className }: ModelConfigGrid
         <GridTile key={model.id}>
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between gap-2">
-              <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
+              <span className="min-w-0 truncate text-ui font-medium leading-5 text-foreground">
                 {model.name}
               </span>
               <Badge tone="neutral">{model.provider}</Badge>
             </div>
             {model.version ? (
-              <span className="text-[12px] leading-[1.45] text-muted-foreground">{model.version}</span>
+              <span className="text-ui-sm leading-[1.45] text-muted-foreground">{model.version}</span>
             ) : null}
             <div className="mt-1 flex items-center justify-between gap-2 border-t border-border pt-2.5">
-              <span className="text-[12px] font-medium leading-[1.45] text-muted-foreground">Enabled</span>
+              <span className="text-ui-sm font-medium leading-[1.45] text-muted-foreground">Enabled</span>
               <Switch
                 checked={model.enabled}
                 disabled={model.disabled}

--- a/apps/packages/product-ui/src/settings/OrganizationSsoSettingsSurface.tsx
+++ b/apps/packages/product-ui/src/settings/OrganizationSsoSettingsSurface.tsx
@@ -1,5 +1,5 @@
-import { Copy, RotateCw, ShieldCheck, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { Copy, RefreshCw, ShieldCheckFilled, Trash } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
@@ -75,7 +75,7 @@ export function OrganizationSsoSettingsSurface({
   const statusActionDisabled = busy || hasUnsavedChanges;
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <SettingsPageHeader
         title="Single sign-on"
         description="Configure organization OIDC sign-in for managed cloud users."
@@ -87,13 +87,13 @@ export function OrganizationSsoSettingsSurface({
             disabled={busy}
             loading={loading}
           >
-            <RotateCw size={14} />
+            <RefreshCw className="size-3.5" />
             Refresh
           </Button>
         )}
       />
       {error ? (
-        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-ui-sm leading-[1.45] text-destructive">
           {error}
         </div>
       ) : null}
@@ -212,7 +212,7 @@ export function OrganizationSsoSettingsSurface({
               disabled={!connection || busy}
               onClick={onCopyRedirectUri}
             >
-              <Copy size={14} />
+              <Copy className="size-3.5" />
             </Button>
           </div>
         </SettingsRow>
@@ -226,7 +226,7 @@ export function OrganizationSsoSettingsSurface({
             disabled={busy}
             onClick={() => setDeleteConfirmOpen(true)}
           >
-            <Trash2 size={14} />
+            <Trash className="size-3.5" />
             Delete
           </Button>
         ) : null}
@@ -259,7 +259,7 @@ export function OrganizationSsoSettingsSurface({
             disabled={statusActionDisabled}
             onClick={onEnable}
           >
-            <ShieldCheck size={14} />
+            <ShieldCheckFilled className="size-3.5" />
             Enable
           </Button>
         ) : null}
@@ -274,7 +274,7 @@ export function OrganizationSsoSettingsSurface({
         </Button>
       </div>
       {connection?.lastError ? (
-        <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning">
+        <div className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-ui-sm leading-[1.45] text-warning">
           {connection.lastError}
         </div>
       ) : null}

--- a/apps/packages/ui/src/primitives/GridTile.tsx
+++ b/apps/packages/ui/src/primitives/GridTile.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "../utils/tw-merge";
 
 interface GridTileProps {
   children: ReactNode;

--- a/apps/packages/ui/src/primitives/RadioCardGroup.tsx
+++ b/apps/packages/ui/src/primitives/RadioCardGroup.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
+import { twMerge } from "../utils/tw-merge";
 import { Check } from "../icons/core";
 
 export interface RadioCardOption<Value extends string = string> {
@@ -60,11 +60,11 @@ export function RadioCardGroup<Value extends string>({
               </span>
             ) : null}
             <span className="min-w-0">
-              <span className="block text-[13px] font-medium leading-[1.3] text-foreground">
+              <span className="block text-ui font-medium leading-[1.3] text-foreground">
                 {option.label}
               </span>
               {option.description ? (
-                <span className="mt-[3px] block text-[12px] leading-[1.45] text-muted-foreground">
+                <span className="mt-[3px] block text-ui-sm leading-[1.45] text-muted-foreground">
                   {option.description}
                 </span>
               ) : null}


### PR DESCRIPTION
## What

UI cleanup pass on the org-level settings panes ("Ugly settings pages #1"). Normalizes Billing, SSO, Org policies/members, and adjacent shared primitives onto the flat `SettingsSection`/`SettingsRow`/`SettingsEyebrow` scaffold and semantic type tokens, so the surfaces read as one intentional system.

### Changes
- **Billing** (`product-surfaces/settings/BillingManagementCards.tsx`, `BillingUsageUnitsSection.tsx`): flattened the boxed `p-5` cards with `text-lg` `<h2>` headers onto `SettingsSection` mono eyebrows + `SettingsRow` rows — matching the sibling Budgets pane. Plan / Auto top-up / Billing-portal are now flat rows; the compute/LLM balance pools stay as subtle inner cards. Token-clean typography throughout.
- **SSO** (`product-ui/settings/OrganizationSsoSettingsSurface.tsx`): standard `space-y-6` rhythm, migrated `lucide-react` icons to `@proliferate/ui/icons` (Refresh/Copy/Enable/Delete), and token-cleaned the error / last-error notices (`text-ui-sm`, consistent radius/padding).
- **Agent policy** (`OrganizationAgentPolicySection.tsx`): retired raw `text-sm` for `text-ui`/`text-ui-sm`, eyebrow sub-headings + legends, and gave the conflicts table real row heights + hairline separators (was a cramped ad-hoc table).
- **Members invite-link chip**: `text-sm` → `text-ui`.
- **Pre-existing design-check fixes** (unblock the gate — the base branch was already red): `RadioCardGroup`/`ModelConfigGrid` `text-[Npx]` → semantic tokens; `GridTile`/`RadioCardGroup`/`ModelConfigGrid` now route `tailwind-merge` through `@proliferate/ui/utils/tw-merge`.

Org secrets pane was left as-is (already on the scaffold; the add/edit-secret flow is owned by another branch).

## Note on the diff
This branch is based on `tip/arc-test`, which is ~12 commits ahead of `origin/main`, so the PR diff includes those commits. **Only the top commit (`ui: polish org/billing/secrets/SSO settings panes`) is this change.**

## Verification
- `pnpm check:design` passes.
- `pnpm build` (shared packages + tsc + vite) passes.
- `product-surfaces` billing test passes (the "Plan" heading assertion was updated to `getByText` since the plan header is now a flat eyebrow, not an `<h2>`). Remaining desktop/product-surfaces test failures are pre-existing on `tip/arc-test` and unrelated (syntax highlighting, keyboard shortcuts, settings routing, first-run auth hooks, support-surface mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
