### PR TITLE
feat(gateway): real xAI upstream + LiteLLM in production compose

### DIFF
--- a/.github/workflows/_deploy-litellm.yml
+++ b/.github/workflows/_deploy-litellm.yml
@@ -14,7 +14,8 @@
 #            LITELLM_DEPLOY_ENABLED (set "true" once the RDS + ECS service exist)
 #   secrets: LITELLM_DATABASE_URL, LITELLM_MASTER_KEY,
 #            AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY,
-#            AGENT_GATEWAY_MANAGED_OPENAI_API_KEY
+#            AGENT_GATEWAY_MANAGED_OPENAI_API_KEY,
+#            AGENT_GATEWAY_MANAGED_XAI_API_KEY
 name: Deploy LiteLLM
 
 on:
@@ -62,6 +63,7 @@ jobs:
       LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
       AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY: ${{ secrets.AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY }}
       AGENT_GATEWAY_MANAGED_OPENAI_API_KEY: ${{ secrets.AGENT_GATEWAY_MANAGED_OPENAI_API_KEY }}
+      AGENT_GATEWAY_MANAGED_XAI_API_KEY: ${{ secrets.AGENT_GATEWAY_MANAGED_XAI_API_KEY }}
       DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
       GIT_SHA: ${{ inputs.git_sha }}
     steps:
@@ -91,6 +93,7 @@ jobs:
           : "${LITELLM_MASTER_KEY:?Set the LITELLM_MASTER_KEY secret on the GitHub environment.}"
           : "${AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY:?Set the AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY secret on the GitHub environment.}"
           : "${AGENT_GATEWAY_MANAGED_OPENAI_API_KEY:?Set the AGENT_GATEWAY_MANAGED_OPENAI_API_KEY secret on the GitHub environment.}"
+          : "${AGENT_GATEWAY_MANAGED_XAI_API_KEY:?Set the AGENT_GATEWAY_MANAGED_XAI_API_KEY secret on the GitHub environment.}"
 
       - name: Configure AWS credentials
         if: ${{ steps.switch.outputs.deploy == 'true' }}
@@ -152,6 +155,8 @@ jobs:
             --type SecureString --value "$AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY" --overwrite >/dev/null
           aws ssm put-parameter --name "${parameter_prefix}/openai-api-key" \
             --type SecureString --value "$AGENT_GATEWAY_MANAGED_OPENAI_API_KEY" --overwrite >/dev/null
+          aws ssm put-parameter --name "${parameter_prefix}/xai-api-key" \
+            --type SecureString --value "$AGENT_GATEWAY_MANAGED_XAI_API_KEY" --overwrite >/dev/null
 
           jq -n \
             '[]' > env-updates.json
@@ -162,7 +167,8 @@ jobs:
               {"name":"DATABASE_URL","valueFrom":($prefix + "/database-url")},
               {"name":"LITELLM_MASTER_KEY","valueFrom":($prefix + "/master-key")},
               {"name":"ANTHROPIC_API_KEY","valueFrom":($prefix + "/anthropic-api-key")},
-              {"name":"OPENAI_API_KEY","valueFrom":($prefix + "/openai-api-key")}
+              {"name":"OPENAI_API_KEY","valueFrom":($prefix + "/openai-api-key")},
+              {"name":"XAI_API_KEY","valueFrom":($prefix + "/xai-api-key")}
             ]' > secret-updates.json
 
           jq \
@@ -174,7 +180,7 @@ jobs:
               def merge_environment($updates):
                 (.environment // []) as $current
                 | ($updates[0] | map(.name)) as $updated_names
-                | ["DATABASE_URL", "LITELLM_MASTER_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"] as $secret_names
+                | ["DATABASE_URL", "LITELLM_MASTER_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"] as $secret_names
                 | ($current | map(select(
                     .name as $name
                     | ($updated_names | index($name) | not)

--- a/scripts/agent-gateway-smoke/README.md
+++ b/scripts/agent-gateway-smoke/README.md
@@ -86,6 +86,7 @@ Per-harness notes:
   one-shot answer, so the runner detects the marker and kills the process
   group instead of waiting for exit.
 - **grok** — isolated `HOME`, `GROK_MODELS_BASE_URL=<proxy>/v1`,
-  `XAI_API_KEY=<vk>`. The CLI discovers models via `GET /v1/models`, so
-  `grok-4-fast`/`grok-build` are aliased to Anthropic Haiku in
-  `server/litellm/config.yaml` (the CLI doesn't care about the upstream).
+  `XAI_API_KEY=<vk>`. The CLI discovers models via `GET /v1/models`; the
+  gateway serves `grok-4-fast`/`grok-4`/`grok-code-fast-1`/`grok-build`
+  against real xAI upstreams in `server/litellm/config.yaml` (the CLI itself
+  doesn't care which upstream backs the model_name it was told to use).

--- a/server/deploy/docker-compose.production.yml
+++ b/server/deploy/docker-compose.production.yml
@@ -30,6 +30,53 @@ services:
       timeout: 3s
       retries: 10
 
+  # litellm-db and litellm are both `profiles: [agent-gateway]`: only needed
+  # when AGENT_GATEWAY_ENABLED=true. Bare `up -d`/`pull` (what bootstrap.sh
+  # and update.sh run) skip profiled services entirely, so self-hosters who
+  # leave the gateway disabled never pull or start these. Bring the gateway
+  # up explicitly with:
+  #   docker compose --profile agent-gateway -f docker-compose.production.yml up -d
+  litellm-db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    profiles: ["agent-gateway"]
+    environment:
+      POSTGRES_DB: ${LITELLM_POSTGRES_DB:-litellm}
+      POSTGRES_USER: ${LITELLM_POSTGRES_USER:-litellm}
+      POSTGRES_PASSWORD: ${LITELLM_POSTGRES_PASSWORD}
+    volumes:
+      - litellmpgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  litellm:
+    image: ${PROLIFERATE_LITELLM_IMAGE:-ghcr.io/proliferate-ai/proliferate-litellm}:${PROLIFERATE_LITELLM_IMAGE_TAG:-stable}
+    restart: unless-stopped
+    profiles: ["agent-gateway"]
+    environment:
+      DATABASE_URL: postgresql://${LITELLM_POSTGRES_USER:-litellm}:${LITELLM_POSTGRES_PASSWORD}@litellm-db:5432/${LITELLM_POSTGRES_DB:-litellm}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+    depends_on:
+      litellm-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness', timeout=3)",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   migrate:
     image: ${PROLIFERATE_SERVER_IMAGE:-ghcr.io/proliferate-ai/proliferate-server}:${PROLIFERATE_SERVER_IMAGE_TAG:-stable}
     restart: "no"
@@ -70,6 +117,7 @@ services:
 
 volumes:
   pgdata:
+  litellmpgdata:
   caddy_data:
   caddy_config:
   setup_state:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-proliferate-local-dev}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
     volumes:
       - ./litellm/config.yaml:/app/config.yaml:ro
     command: ["--config", "/app/config.yaml", "--port", "4000"]

--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -11,6 +11,16 @@
 # Provider keys come from the container environment:
 #   ANTHROPIC_API_KEY  (deploy: from AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY)
 #   OPENAI_API_KEY     (deploy: from AGENT_GATEWAY_MANAGED_OPENAI_API_KEY)
+#   XAI_API_KEY        (deploy: from AGENT_GATEWAY_MANAGED_XAI_API_KEY)
+#
+# Aliasing rule: a model_name may only be re-pointed at a different upstream
+# model id when both are served by the SAME provider (e.g. grok-build below
+# aliases to a cheaper xAI model, same as the dated/bare Anthropic pairs
+# above). Never alias one provider's model_name to another provider's
+# upstream — that silently swaps the model a harness thinks it is talking to.
+# This file is the one deployed config (dev and prod both run it as-is): any
+# dev-only shim/mock (LiteLLM `mock_response`, cross-provider test aliases)
+# belongs in a docker-compose dev overlay, never here.
 
 model_list:
   # Anthropic
@@ -57,18 +67,33 @@ model_list:
       model: openai/gpt-5-mini
       api_key: os.environ/OPENAI_API_KEY
 
-  # Grok CLI aliases. The grok CLI discovers models via GET /v1/models and
-  # speaks plain chat/completions, so grok-named entries can point at any
-  # upstream; we alias them to Anthropic Haiku (see HARNESS-MATRIX.md).
-  # grok-build is the CLI's interactive/title-gen model — cheap to keep.
+  # xAI. The grok CLI discovers models via GET /v1/models and speaks plain
+  # chat/completions, so it will send whatever model_name we advertise here —
+  # these ids are ours to choose, but litellm_params.model must be a REAL id
+  # LiteLLM's xai provider serves (verified against LiteLLM's own
+  # model_prices_and_context_window.json; never invented):
+  #   - xai/grok-4 exists as-is.
+  #   - there is no plain "xai/grok-4-fast"; xai/grok-4-1-fast is the current
+  #     (non-deprecated) fast-tier model, so grok-4-fast resolves there.
+  #   - xai/grok-code-fast-1 exists as-is.
+  - model_name: grok-4
+    litellm_params:
+      model: xai/grok-4
+      api_key: os.environ/XAI_API_KEY
   - model_name: grok-4-fast
     litellm_params:
-      model: anthropic/claude-haiku-4-5-20251001
-      api_key: os.environ/ANTHROPIC_API_KEY
+      model: xai/grok-4-1-fast
+      api_key: os.environ/XAI_API_KEY
+  - model_name: grok-code-fast-1
+    litellm_params:
+      model: xai/grok-code-fast-1
+      api_key: os.environ/XAI_API_KEY
+  # grok-build is the CLI's interactive/title-gen model — cheap to keep.
+  # Same-provider alias only (never cross-provider): a small xAI model.
   - model_name: grok-build
     litellm_params:
-      model: anthropic/claude-haiku-4-5-20251001
-      api_key: os.environ/ANTHROPIC_API_KEY
+      model: xai/grok-3-mini-latest
+      api_key: os.environ/XAI_API_KEY
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
## What

- `server/litellm/config.yaml`: grok CLI aliases now point at real xAI models instead of the placeholder Anthropic Haiku swap:
  - `grok-4` -> `xai/grok-4`
  - `grok-4-fast` -> `xai/grok-4-1-fast` (there is no plain `grok-4-fast` id upstream; `grok-4-1-fast` is the current non-deprecated fast-tier model)
  - `grok-code-fast-1` -> `xai/grok-code-fast-1`
  - `grok-build` -> `xai/grok-3-mini-latest` (same-provider alias only, per the new documented rule: a `model_name` may only be re-pointed at a different upstream model id when both are served by the same provider)
  - All ids verified against LiteLLM's own `model_prices_and_context_window.json`, not invented.
- `XAI_API_KEY` plumbed end to end:
  - `server/docker-compose.yml` (dev) passes it through to the litellm container.
  - `.github/workflows/_deploy-litellm.yml` adds `AGENT_GATEWAY_MANAGED_XAI_API_KEY` as a required secret, pushes it to SSM, and wires it into the ECS task definition alongside the existing Anthropic/OpenAI keys.
- `server/deploy/docker-compose.production.yml`: adds `litellm` + `litellm-db` services behind the `agent-gateway` compose profile, so self-hosters opt in with `docker compose --profile agent-gateway -f docker-compose.production.yml up -d`. Bare `up -d`/`pull` (what `bootstrap.sh`/`update.sh` run) skip profiled services entirely, so operators who leave the gateway disabled are unaffected.
- `scripts/agent-gateway-smoke/README.md` updated to describe the real upstreams instead of the old Haiku-aliasing note.

### Why the production litellm service still uses a baked image, not a bind mount

The dev compose bind-mounts `../litellm/config.yaml` into the upstream `ghcr.io/berriai/litellm` image. I checked whether production could mirror that, and it can't: `server-ci.yml`'s release-bundling step only does `cp -R server/deploy/. proliferate-deploy/` into `proliferate-deploy.tar.gz` — `server/litellm/` lives outside `server/deploy/` and never reaches a standalone self-hosted install (only files already inside `server/deploy/`, like `Caddyfile`, survive that way, which is why `caddy` can bind-mount it and `litellm` can't). So production keeps referencing the baked `ghcr.io/proliferate-ai/proliferate-litellm:stable` image with the config built in.

**Known follow-up required:** no CI job publishes `ghcr.io/proliferate-ai/proliferate-litellm` anywhere. `server-ci.yml` only publishes `ghcr.io/proliferate-ai/proliferate-server`; the only pipeline that builds a LiteLLM image (`_deploy-litellm.yml`) pushes to a private ECR repo for Proliferate's own ECS deployment, not GHCR. A self-hoster who sets `AGENT_GATEWAY_ENABLED=true` and runs `--profile agent-gateway up -d` today would hit a missing image on pull. This PR does not add that publish job (out of scope here) — filing/landing a GHCR publish step for `server/litellm/Dockerfile` (mirroring the `proliferate-server` GHCR job in `server-ci.yml`) is a required follow-up before self-hosted agent-gateway is actually usable.

## Verification

- `docker compose -f server/deploy/docker-compose.production.yml --profile agent-gateway config -q` with a dummy env passes cleanly; rendered `litellm` service resolves to `image: ghcr.io/proliferate-ai/proliferate-litellm:stable` with `XAI_API_KEY` wired through.
- Live dev smoke against the real xAI upstream (already run in a prior pass, not re-run here):
  - `GET /v1/models` through the proxy lists all 14 configured `model_names`, including `grok-4`, `grok-4-fast`, `grok-code-fast-1`, `grok-build`.
  - A completion request for `xai grok-4-fast` returned a real `200` through the proxy.

## Known external blocker

`openai gpt-5-mini` returns a `404 organization must be verified` through the gateway. Confirmed this is OpenAI account state, not a gateway/config bug: the identical error reproduces calling `api.openai.com` directly with the same key, and `gpt-4o-mini` works fine through the same proxy path. Fix is at https://platform.openai.com/settings/organization/general — config is untouched by this PR, and the working `gpt-4o-mini` path confirms gateway wiring is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)