### PR TITLE
ui: match transcript message body size to composer input

### DIFF
--- a/apps/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/apps/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -129,7 +129,7 @@ function FileLinkedText({ text }: { text: string }) {
   const tokens = tokenizeSerializedFileLinks(text);
 
   return (
-    <div className="whitespace-pre-wrap break-words text-chat leading-[var(--text-chat--line-height)]">
+    <div className="whitespace-pre-wrap break-words text-[length:var(--prose-text-size,var(--text-chat))] leading-[var(--prose-text-line-height,var(--text-chat--line-height))]">
       {tokens.map((token, index) => {
         if (token.type === "text") {
           return <Fragment key={`text-${index}`}>{token.text}</Fragment>;

--- a/apps/desktop/src/components/workspace/chat/transcript/UserMessage.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/UserMessage.tsx
@@ -84,7 +84,7 @@ export function UserMessage({
           >
             <div
               ref={textRef}
-              className={`break-words select-text${
+              className={`[--prose-text-size:var(--text-message)] [--prose-text-line-height:var(--text-message--line-height)] break-words select-text${
                 !expanded ? " line-clamp-5" : ""
               }`}
             >

--- a/apps/packages/design/src/css/dom.css
+++ b/apps/packages/design/src/css/dom.css
@@ -48,6 +48,15 @@
      chat font size — including runtime text-scale changes — but always sits
      one step below it. */
   --text-chat-meta: calc(var(--text-chat, 12px) - 2px);
+  /* Message body prose (assistant + user transcript bodies) reads at the
+     composer size, so typed text and sent text match. Secondary chrome
+     (tool/action rows, plans, work history) stays on --text-chat. Declared as
+     an alias of --text-composer rather than a separate scale entry so it
+     tracks the composer across every appearance preset with no drift lock to
+     keep in sync. Message surfaces opt in via --prose-text-size (below);
+     everything else falls back to --text-chat. */
+  --text-message: var(--text-composer);
+  --text-message--line-height: var(--text-composer--line-height);
 }
 
 * {

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
@@ -31,7 +31,10 @@ export function AssistantMessage({
   renderCodeBlock,
 }: AssistantMessageProps) {
   return (
-    <div className="text-chat leading-[var(--text-chat--line-height)] select-text text-foreground">
+    // Opt this message body into the composer-matched prose size. Both the
+    // stable and live MarkdownBody below inherit --prose-text-size from here,
+    // so the reserved height is identical between streaming and settled states.
+    <div className="[--prose-text-size:var(--text-message)] [--prose-text-line-height:var(--text-message--line-height)] text-[length:var(--prose-text-size)] leading-[var(--prose-text-line-height)] select-text text-foreground">
       <AssistantMessageContent
         content={content}
         isStreaming={isStreaming}

--- a/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
@@ -36,7 +36,7 @@ export function CloudChatUserMessage({
           >
             <div
               ref={textRef}
-              className={`break-words select-text text-chat leading-[var(--text-chat--line-height)]${
+              className={`break-words select-text text-[length:var(--text-message)] leading-[var(--text-message--line-height)]${
                 !expanded ? " line-clamp-5" : ""
               }`}
             >

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -87,7 +87,15 @@ type MdCodeProps = MdElementProps & {
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 };
 
-const LI_CLASSNAME = "pl-0.5 text-chat leading-[var(--text-chat--line-height)]";
+// Message prose reads at --prose-text-size, which the assistant/user message
+// wrappers set to --text-message (the composer size). Every other MarkdownBody
+// context — tool-row detail bodies, plan cards, work history — leaves the var
+// unset, so the fallback keeps that secondary chrome on --text-chat while
+// conversation bodies grow to match the composer.
+const PROSE_TEXT =
+  "text-[length:var(--prose-text-size,var(--text-chat))] leading-[var(--prose-text-line-height,var(--text-chat--line-height))]";
+
+const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 
 // Markdown component overrides are the React element *types* for every
 // rendered node. They must be referentially stable across renders: a fresh
@@ -108,17 +116,17 @@ const STATIC_MARKDOWN_COMPONENTS = {
   h6: (props: MdElementProps) =>
     mdHtmlElement("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground", props),
   p: (props: MdElementProps) =>
-    mdHtmlElement("p", "mb-[0.6875rem] mt-0 text-chat leading-[var(--text-chat--line-height)] text-foreground", props),
+    mdHtmlElement("p", `mb-[0.6875rem] mt-0 ${PROSE_TEXT} text-foreground`, props),
   ul: (props: MdElementProps) =>
-    mdHtmlElement("ul", "my-0 list-disc pl-[1.3125rem] text-chat leading-[var(--text-chat--line-height)] text-foreground [&>li+li]:mt-2", props),
+    mdHtmlElement("ul", `my-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`, props),
   ol: (props: MdElementProps) =>
-    mdHtmlElement("ol", "my-0 list-decimal pl-[1.3125rem] text-chat leading-[var(--text-chat--line-height)] text-foreground [&>li+li]:mt-2", props),
+    mdHtmlElement("ol", `my-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`, props),
   li: (props: MdElementProps) =>
     mdHtmlElement("li", LI_CLASSNAME, props),
   blockquote: (props: MdElementProps) =>
     mdHtmlElement(
       "blockquote",
-      "my-3 border-l-2 border-border pl-4 text-chat italic leading-[var(--text-chat--line-height)] text-foreground",
+      `my-3 border-l-2 border-border pl-4 ${PROSE_TEXT} italic text-foreground`,
       props,
     ),
   hr: () => <hr className="my-3 border-border" />,
@@ -131,16 +139,16 @@ const STATIC_MARKDOWN_COMPONENTS = {
       <div className="overflow-x-auto">
         {mdHtmlElement(
           "table",
-          "w-max min-w-full border-collapse text-chat leading-[var(--text-chat--line-height)] [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.02] [&_tbody_tr:last-child_td]:border-b-0",
+          `w-max min-w-full border-collapse ${PROSE_TEXT} [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.02] [&_tbody_tr:last-child_td]:border-b-0`,
           props,
         )}
       </div>
     </div>
   ),
   th: (props: MdElementProps) =>
-    mdHtmlElement("th", "border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left text-chat font-semibold leading-[var(--text-chat--line-height)] text-foreground", props),
+    mdHtmlElement("th", `border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left ${PROSE_TEXT} font-semibold text-foreground`, props),
   td: (props: MdElementProps) =>
-    mdHtmlElement("td", "border-b border-border px-2.5 py-1.5 align-top text-chat leading-[var(--text-chat--line-height)]", props),
+    mdHtmlElement("td", `border-b border-border px-2.5 py-1.5 align-top ${PROSE_TEXT}`, props),
   pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
@@ -290,7 +298,7 @@ export const MarkdownBody = memo(function MarkdownBody({
   taskListItems = "inline",
 }: MarkdownBodyProps) {
   const markdownClassName = [
-    "text-chat leading-[var(--text-chat--line-height)] text-foreground break-words",
+    `${PROSE_TEXT} text-foreground break-words`,
     "[&_li>p]:my-0",
     "[&_li>ol]:mt-2",
     "[&_li>ul]:mt-2",


### PR DESCRIPTION
## What

Makes the chat **transcript message body** (assistant + user prose) read at the
composer input size — **14px / 22px** at the default preset instead of 12px / 20px —
so typed text and sent text match. Secondary tool/action chrome stays at 12px.

> Based on `tip/arc-test`, so the PR diff includes those upstream commits. Only the
> top commit (`ui: match transcript message body size to composer input`) is mine —
> 6 files.

## How

- **New token** (`apps/packages/design/src/css/dom.css`):
  `--text-message: var(--text-composer)` and
  `--text-message--line-height: var(--text-composer--line-height)`.
  Declared as an **alias of the composer token** (next to the existing derived
  `--text-chat-meta`) rather than a new scale entry, so it tracks the composer
  across every appearance preset automatically — no `UI_FONT_SCALES` / `tokens.ts`
  / `tw-merge` drift lock to keep in sync.

- **Ambient opt-in, not a global bump.** `MarkdownBody` is shared with secondary
  chrome (cloud tool-row detail bodies, plan cards, work history), so its prose
  renderers can't be bumped globally without enlarging that chrome. Instead the
  shared renderers read `text-[length:var(--prose-text-size,var(--text-chat))]`
  (+ matching line-height). Only the message wrappers set `--prose-text-size:
  var(--text-message)`; every other context falls back to `--text-chat` (12px) and
  is untouched.
  - `MarkdownBody.tsx` — `p / ul / ol / li / blockquote / table / th / td` + the
    wrapper now use the ambient prose var (via one shared `PROSE_TEXT` constant).
    Headings, inline `code`/`pre`, and code blocks are left on their own scales.
  - `AssistantMessage.tsx` — wrapper sets the ambient var; both the stable and live
    `MarkdownBody` inherit it.
  - `CloudChatUserMessage.tsx` — cloud user bubble uses `--text-message` directly.
  - `UserMessage.tsx` (desktop) + `PromptContentRenderer.tsx` — desktop user bubble
    sets the ambient var; the shared `FileLinkedText` reads it with a `--text-chat`
    fallback, so other `PromptContentRenderer` callers are unchanged.

- `PlanMarkdownBody` is intentionally **left at chat size** — plan cards are
  structured secondary content and no ancestor sets the opt-in var.

## CLS / no-scroll-bump

`--text-chat` is untouched, so `TRAILING_STATUS_MIN_HEIGHT`
(`calc(var(--text-chat--line-height)+1.5rem)`) — the reserved streaming/status slot —
is unaffected. The stable and live `MarkdownBody` are siblings under the same wrapper
and inherit identical `--prose-text-size` / `--prose-text-line-height`, so a run of
prose renders at byte-identical metrics whether it's in the live tail or after it
flushes into the stable prefix. The `+8` line-height relationship is preserved
(14+8=22, mirroring 12+8=20). **A streaming message's height is identical live vs
settled.**

## Verification

- `pnpm check:design` — clean for this diff (the 3 failures — `ModelConfigGrid`,
  `GridTile`, `RadioCardGroup` — are pre-existing on the base branch, none of them
  mine).
- `apps/desktop` `pnpm build` (`tsc && vite build`) — passes.
- Vitest: `appearance-css-drift` (4), `TranscriptItemBlock` (6), and all
  product-ui transcript tests (36) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
