### PR TITLE
fix(product-ui): repo-shape conformance for secrets dialog + icon barrel

### DIFF
--- a/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
+++ b/apps/packages/product-ui/src/secrets/SecretEditorDialog.tsx
@@ -226,9 +226,9 @@ export function SecretEditorDialog({
         )}
 
         <div className="space-y-1.5">
-          <label htmlFor="secret-name" className={fieldLabelClass}>
+          <Label htmlFor="secret-name" className={fieldLabelClass}>
             {nameLabel}
-          </label>
+          </Label>
           <Input
             id="secret-name"
             value={nameOrPath}
@@ -257,28 +257,32 @@ export function SecretEditorDialog({
         {kind === "env" ? (
           <div className="space-y-1.5">
             <div className="flex items-center justify-between gap-2">
-              <label htmlFor="secret-value" className={fieldLabelClass}>
+              <Label htmlFor="secret-value" className={fieldLabelClass}>
                 Value
-              </label>
+              </Label>
               <div className="flex items-center gap-0.5">
                 {multiline ? null : (
-                  <button
+                  <Button
                     type="button"
+                    variant="unstyled"
+                    size="unstyled"
                     className={toggleClass}
                     aria-label={revealed ? "Hide value" : "Show value"}
                     onClick={() => setRevealed((value) => !value)}
                   >
                     {revealed ? <EyeOff size={13} /> : <Eye size={13} />}
                     {revealed ? "Hide" : "Show"}
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
                   type="button"
+                  variant="unstyled"
+                  size="unstyled"
                   className={toggleClass}
                   onClick={() => setMultiline((value) => !value)}
                 >
                   {multiline ? "Single line" : "Multi-line"}
-                </button>
+                </Button>
               </div>
             </div>
             {multiline ? (

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -39,3 +39,4 @@ server/tests/integration/test_billing_accounting.py 872 existing server oversize
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
 apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx 492 existing markdown transcript renderer pending split
+apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pending split


### PR DESCRIPTION
Main carries 5 frontend-drift violations (raw label/button in SecretEditorDialog.tsx, 413-line icons/core.tsx) that fail the repo-shape gate on every open PR's merge preview.

- SecretEditorDialog: raw controls → the Label / unstyled-Button primitives the file already imports (identical classes/behavior)
- icons/core.tsx documented in the max-lines allowlist pending a split

Verified: check_max_lines + report_frontend_structure --strict both pass; product-ui builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)