### PR TITLE
fix(desktop): All-Models refresh for native routes uploads runtime-probed models

### DIFF
--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -8,6 +8,7 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import {
   useAgentGatewayModelsQuery,
+  useAgentLaunchOptionsQuery,
   useRefreshAgentGatewayModelsMutation,
 } from "@anyharness/sdk-react";
 import { RefreshCw } from "@proliferate/ui/icons";
@@ -19,6 +20,7 @@ import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-avail
 import { useToastStore } from "@/stores/toast/toast-store";
 import {
   buildEnabledOverridePatchJson,
+  buildRuntimeCatalogModelsJson,
   catalogRouteForSurface,
   normalizeCatalogModels,
   normalizeGatewayModels,
@@ -49,6 +51,11 @@ export function HarnessAllModelsSection({
   // instead of the cloud catalog snapshot, which never sees the runtime's own
   // gateway probes.
   const isRuntimeGateway = surface === "local" && route === "gateway";
+  // native/api_key routes probe on the client (catalog.py's refresh_catalog
+  // contract) — the server rejects a refresh with no uploaded payload for
+  // these routes, so Refresh sources one from the local AnyHarness runtime's
+  // already-resolved launch catalog instead (see buildRuntimeCatalogModelsJson).
+  const isRuntimeProbedRoute = route !== "gateway";
 
   const catalogQuery = useAgentCatalog(
     { harnessKind, surface, route },
@@ -61,6 +68,9 @@ export function HarnessAllModelsSection({
     enabled: isRuntimeGateway,
   });
   const refreshGatewayModels = useRefreshAgentGatewayModelsMutation();
+  const runtimeLaunchOptionsQuery = useAgentLaunchOptionsQuery({
+    enabled: isRuntimeProbedRoute,
+  });
 
   const models = useMemo(
     () =>
@@ -98,6 +108,25 @@ export function HarnessAllModelsSection({
           showToast(error.message || HARNESS_PANE_COPY.catalogRefreshError(displayName));
         },
       });
+      return;
+    }
+    if (isRuntimeProbedRoute) {
+      const modelsJson = buildRuntimeCatalogModelsJson(
+        harnessKind,
+        runtimeLaunchOptionsQuery.data,
+      );
+      if (modelsJson === null) {
+        showToast(HARNESS_PANE_COPY.catalogRefreshRuntimeUnavailable(displayName));
+        return;
+      }
+      refreshCatalog.mutate(
+        { harnessKind, body: { surface, route, modelsJson } },
+        {
+          onError: (error) => {
+            showToast(error.message || HARNESS_PANE_COPY.catalogRefreshError(displayName));
+          },
+        },
+      );
       return;
     }
     refreshCatalog.mutate(

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -66,6 +66,24 @@ const state = vi.hoisted(() => ({
       | undefined,
     isLoading: false,
   },
+  launchOptions: {
+    data: undefined as
+      | {
+        agents: Array<{
+          kind: string;
+          displayName: string;
+          defaultModelId: string | null;
+          models: Array<{
+            id: string;
+            displayName: string;
+            aliases?: string[];
+            isDefault: boolean;
+          }>;
+        }>;
+      }
+      | undefined,
+    isLoading: false,
+  },
 }));
 const putMutate = vi.hoisted(() => vi.fn());
 const createKeyMutate = vi.hoisted(() => vi.fn());
@@ -75,6 +93,7 @@ const refreshGatewayModelsMutate = vi.hoisted(() => vi.fn());
 const openAuthTerminal = vi.hoisted(() => vi.fn());
 const closeAuthTerminal = vi.hoisted(() => vi.fn());
 const handleTerminalExit = vi.hoisted(() => vi.fn());
+const showToast = vi.hoisted(() => vi.fn());
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
   useAgentGatewayCapabilities: () => state.capabilities,
@@ -97,6 +116,15 @@ vi.mock("@anyharness/sdk-react", () => ({
     mutate: refreshGatewayModelsMutate,
     isPending: false,
   }),
+  // native/api_key refreshes source their probe payload from the runtime's
+  // resolved launch catalog (the session model picker's data source) —
+  // mock stands in for that runtime read.
+  useAgentLaunchOptionsQuery: () => state.launchOptions,
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (s: { show: typeof showToast }) => unknown) =>
+    selector({ show: showToast }),
 }));
 
 // ModalShell (Radix Dialog) has no jsdom polyfills here — stub the picker to a
@@ -177,6 +205,8 @@ afterEach(() => {
   state.loginSessions = {};
   state.gatewayModels.data = undefined;
   state.gatewayModels.isLoading = false;
+  state.launchOptions.data = undefined;
+  state.launchOptions.isLoading = false;
 });
 
 describe("HarnessPane authentication", () => {
@@ -425,7 +455,7 @@ describe("HarnessPane all models", () => {
     expect(screen.getAllByRole("switch")).toHaveLength(2);
   });
 
-  it("refreshes the catalog for the current surface and route", () => {
+  it("refreshes the catalog for a native/api_key route using the runtime's resolved models", () => {
     state.catalog.data = {
       harnessKind: "claude",
       surface: "local",
@@ -436,14 +466,56 @@ describe("HarnessPane all models", () => {
       source: null,
       overrideApplied: false,
     };
+    state.launchOptions.data = {
+      agents: [
+        {
+          kind: "claude",
+          displayName: "Claude Code",
+          defaultModelId: "sonnet",
+          models: [{ id: "sonnet", displayName: "Sonnet 4.6", isDefault: true }],
+        },
+      ],
+    };
     renderPane("claude");
 
     fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
     fireEvent.click(screen.getByRole("button", { name: /Refresh/ }));
 
     expect(refreshMutate).toHaveBeenCalledWith(
-      { harnessKind: "claude", body: { surface: "local", route: "native" } },
+      {
+        harnessKind: "claude",
+        body: {
+          surface: "local",
+          route: "native",
+          modelsJson: JSON.stringify([{ id: "sonnet", displayName: "Sonnet 4.6" }]),
+        },
+      },
       expect.anything(),
+    );
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast and skips the server call when the local runtime has no models for this harness", () => {
+    state.catalog.data = {
+      harnessKind: "claude",
+      surface: "local",
+      route: "native",
+      models: [],
+      snapshotId: null,
+      probedAt: null,
+      source: null,
+      overrideApplied: false,
+    };
+    // No launchOptions data mocked: stands in for a runtime that is
+    // unreachable, or one with no ready models for this harness yet.
+    renderPane("claude");
+
+    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+    fireEvent.click(screen.getByRole("button", { name: /Refresh/ }));
+
+    expect(refreshMutate).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      "Local runtime unavailable — could not read Claude models.",
     );
   });
 

--- a/apps/desktop/src/copy/settings/harness-pane.ts
+++ b/apps/desktop/src/copy/settings/harness-pane.ts
@@ -40,6 +40,8 @@ export const HARNESS_PANE_COPY = {
     `Could not update ${displayName} authentication.`,
   catalogRefreshError: (displayName: string) =>
     `Could not refresh the ${displayName} model catalog.`,
+  catalogRefreshRuntimeUnavailable: (displayName: string) =>
+    `Local runtime unavailable — could not read ${displayName} models.`,
   catalogOverrideError: (displayName: string) =>
     `Could not update the ${displayName} model catalog.`,
   readyToast: (displayName: string) => `${displayName} is ready.`,

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
@@ -1,6 +1,8 @@
+import type { AgentLaunchOptionsResponse } from "@anyharness/sdk";
 import type { AgentAuthSelection } from "@proliferate/cloud-sdk";
 import { describe, expect, it } from "vitest";
 import {
+  buildRuntimeCatalogModelsJson,
   catalogRouteForSurface,
   defaultRouteForSurface,
   normalizeGatewayModels,
@@ -97,5 +99,68 @@ describe("normalizeGatewayModels", () => {
       },
     ]);
     expect(normalizeGatewayModels([])).toEqual([]);
+  });
+});
+
+describe("buildRuntimeCatalogModelsJson", () => {
+  function launchOptions(
+    agents: AgentLaunchOptionsResponse["agents"],
+  ): AgentLaunchOptionsResponse {
+    return { agents, workspaceId: null };
+  }
+
+  it("serializes the runtime's resolved models for the requested harness", () => {
+    const result = buildRuntimeCatalogModelsJson(
+      "claude",
+      launchOptions([
+        {
+          kind: "claude",
+          displayName: "Claude Code",
+          defaultModelId: "sonnet",
+          models: [
+            { id: "sonnet", displayName: "Sonnet 4.6", isDefault: true },
+            { id: "haiku", displayName: "Haiku 4.5", aliases: ["haiku-latest"], isDefault: false },
+          ],
+        },
+      ]),
+    );
+
+    expect(result).toBe(
+      JSON.stringify([
+        { id: "sonnet", displayName: "Sonnet 4.6" },
+        { id: "haiku", displayName: "Haiku 4.5", aliases: ["haiku-latest"] },
+      ]),
+    );
+  });
+
+  it("returns null when the runtime has no entry for the harness", () => {
+    const result = buildRuntimeCatalogModelsJson(
+      "codex",
+      launchOptions([
+        {
+          kind: "claude",
+          displayName: "Claude Code",
+          defaultModelId: null,
+          models: [{ id: "sonnet", displayName: "Sonnet 4.6", isDefault: true }],
+        },
+      ]),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the harness has zero ready models", () => {
+    const result = buildRuntimeCatalogModelsJson(
+      "claude",
+      launchOptions([
+        { kind: "claude", displayName: "Claude Code", defaultModelId: null, models: [] },
+      ]),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the runtime data is unavailable", () => {
+    expect(buildRuntimeCatalogModelsJson("claude", undefined)).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.ts
@@ -1,3 +1,4 @@
+import type { AgentLaunchOptionsResponse } from "@anyharness/sdk";
 import type {
   AgentAuthRoute,
   AgentAuthSelection,
@@ -57,6 +58,30 @@ export function normalizeGatewayModels(modelIds: readonly string[]): HarnessCata
       provider: null,
       enabled: true,
     }));
+}
+
+// native/api_key routes probe on the CLIENT (catalog.py's refresh_catalog
+// contract): rich live probing is deferred, so v1 sources the payload from the
+// local AnyHarness runtime's already-resolved launch catalog (the same
+// bundled catalog-v2 model list `useAgentLaunchOptionsQuery` feeds the session
+// model picker) instead of spawning a harness process. Returns null when the
+// runtime has no ready models for this harness — the caller should show a
+// "runtime unavailable" toast and skip the server call rather than upload an
+// empty snapshot.
+export function buildRuntimeCatalogModelsJson(
+  harnessKind: string,
+  launchOptions: AgentLaunchOptionsResponse | undefined,
+): string | null {
+  const agent = launchOptions?.agents.find((entry) => entry.kind === harnessKind);
+  if (!agent || agent.models.length === 0) {
+    return null;
+  }
+  const entries = agent.models.map((model) => ({
+    id: model.id,
+    displayName: model.displayName,
+    ...(model.aliases && model.aliases.length > 0 ? { aliases: model.aliases } : {}),
+  }));
+  return JSON.stringify(entries);
 }
 
 // Overrides have no GET endpoint, so the enabled-set is reconstructed from the


### PR DESCRIPTION
## What

Pressing **Refresh** on the All-Models tab for a harness on a native/api_key route always 400'd: the server (correctly) requires a client-probed `models_json` for non-gateway routes, but the desktop sent none — a known stub from the original agent-auth stack, hit live today.

Fix: for non-gateway routes the desktop now builds the payload from the local runtime's launch-options catalog (`GET /v1/agents/launch-options` — the same catalog-v2-backed, no-spawn source the session model picker uses) and passes it through the existing `modelsJson` field the SDK/API already supported. If the runtime has no ready models for the harness, the server call is skipped with a clear toast. The P3 local+gateway runtime-refresh path is untouched.

## Verification

- New unit coverage: `buildRuntimeCatalogModelsJson` (4 cases) + `HarnessPane` refresh-with-payload and runtime-unavailable-toast tests (the prior test asserting the bodyless call was itself encoding the bug — rewritten). 31 tests green across both files.
- Desktop `tsc --noEmit` green, mobile typecheck green, shared packages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)