### PR TITLE
feat(desktop): move workspace to cloud

### DIFF
--- a/apps/desktop/src/components/workspace/move/MoveProgress.tsx
+++ b/apps/desktop/src/components/workspace/move/MoveProgress.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@proliferate/ui/primitives/Button";
+import { CheckCircleFilled, Circle, CircleAlert, Spinner } from "@proliferate/ui/icons";
+import type { MovePhase } from "@/lib/domain/workspaces/move/move-model";
+import {
+  resolveMoveProgressSteps,
+  type MoveProgressStepStatus,
+} from "@/lib/domain/workspaces/move/move-progress";
+
+interface MoveProgressProps {
+  phase: MovePhase | "running";
+  /** Set when a post-cutover cleanup step failed -- the saga stays at phase "cutover"
+   *  server-side and the move is committed, so the only actions are retry (no abandon,
+   *  locked failure-semantics decision). */
+  error?: string | null;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}
+
+export function MoveProgress({ phase, error = null, onRetry, isRetrying = false }: MoveProgressProps) {
+  const steps = resolveMoveProgressSteps(phase);
+
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-2.5">
+        {steps.map((step) => (
+          <li key={step.key} className="flex items-center gap-2.5 text-ui">
+            <MoveProgressStepIcon status={error && step.status === "active" ? "error" : step.status} />
+            <span className={step.status === "pending" ? "text-muted-foreground" : "text-foreground"}>
+              {step.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {error && (
+        <div className="space-y-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-ui-sm text-destructive">{error}</p>
+          <p className="text-ui-sm text-muted-foreground">
+            {phase === "cutover"
+              ? "Moved. Cleanup is pending -- retry when ready."
+              : "Source untouched -- retry or cancel."}
+          </p>
+          {onRetry && (
+            <Button type="button" variant="outline" size="sm" loading={isRetrying} onClick={onRetry}>
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MoveProgressStepIcon({ status }: { status: MoveProgressStepStatus | "error" }) {
+  switch (status) {
+    case "done":
+      return <CheckCircleFilled className="size-4 shrink-0 text-git-green" />;
+    case "active":
+      return <Spinner className="size-4 shrink-0 text-foreground" />;
+    case "error":
+      return <CircleAlert className="size-4 shrink-0 text-destructive" />;
+    case "pending":
+      return <Circle className="size-4 shrink-0 text-muted-foreground/50" />;
+  }
+}

--- a/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.test.tsx
+++ b/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MoveWorkspaceDialog } from "./MoveWorkspaceDialog";
+
+const mocks = vi.hoisted(() => ({
+  workflow: null as ReturnType<typeof buildWorkflow> | null,
+  selectWorkspaceFromSurface: vi.fn(),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-move-workflow", () => ({
+  useWorkspaceMoveWorkflow: () => mocks.workflow!,
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    selectWorkspaceFromSurface: mocks.selectWorkspaceFromSurface,
+  }),
+}));
+
+beforeEach(() => {
+  mocks.selectWorkspaceFromSurface.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MoveWorkspaceDialog", () => {
+  it("shows the safe-move confirmation and calls startMove", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "readiness",
+        readiness: {
+          kind: "safe",
+          copy: {
+            headline: "Ready to move",
+            body: "This workspace is clean and published.",
+            primaryActionLabel: "Move to cloud",
+          },
+        },
+      },
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Ready to move")).toBeTruthy();
+    fireEvent.click(screen.getByText("Move to cloud"));
+    expect(mocks.workflow!.startMove).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows commit controls and disables the primary action until publish is ready", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "readiness",
+        readiness: {
+          kind: "prepare_required",
+          copy: {
+            headline: "Commit and push before moving",
+            body: "This workspace has uncommitted changes.",
+            primaryActionLabel: "Commit, push, and move",
+          },
+          includeUnstagedDefault: true,
+        },
+      },
+      publish: buildPublish({ disabledReason: "Enter a commit message." }),
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText("Commit message")).toBeTruthy();
+    const button = screen.getByText("Commit, push, and move").closest("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("offers resume/abandon when a pre-cutover move is already in progress", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "resume",
+        move: { id: "move-1", phase: "destination_ready" } as never,
+        postCutover: false,
+      },
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("Resume move"));
+    expect(mocks.workflow!.resumeMove).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Abandon move"));
+    expect(mocks.workflow!.abandonMove).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers open-vs-replace on a cloud_workspace_exists collision", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "collision",
+        gitOwner: "acme",
+        gitRepoName: "widgets",
+        branch: "feature/move",
+        collidingWorkspaceId: "cloud-ws-1",
+      },
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("Open the cloud workspace"));
+    expect(mocks.selectWorkspaceFromSurface).toHaveBeenCalledWith("cloud:cloud-ws-1", "workspace-move-dialog");
+
+    fireEvent.click(screen.getByText("Replace it with this local copy"));
+    expect(mocks.workflow!.replaceCollidingWorkspace).toHaveBeenCalledWith("cloud-ws-1");
+  });
+
+  it("renders the four-step progress list while the saga is running", () => {
+    mocks.workflow = buildWorkflow({
+      stage: { kind: "progress", phase: "destination_ready" },
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Prepare")).toBeTruthy();
+    expect(screen.getByText("Transfer sessions")).toBeTruthy();
+    expect(screen.getByText("Switch over")).toBeTruthy();
+    expect(screen.getByText("Clean up")).toBeTruthy();
+  });
+});
+
+interface PublishViewStateOverrides {
+  disabledReason?: string | null;
+  hasStagedChanges?: boolean;
+  hasUnstagedChanges?: boolean;
+}
+
+function buildPublish(overrides: PublishViewStateOverrides = {}) {
+  return {
+    commitDraft: { summary: "", includeUnstaged: false },
+    setCommitDraft: vi.fn(),
+    viewState: {
+      fileGroups: { staged: [], partial: [], unstaged: [] },
+      hasStagedChanges: true,
+      hasUnstagedChanges: false,
+      disabledReason: null,
+      ...overrides,
+    },
+    error: null,
+    submit: vi.fn(async () => true),
+    isLoading: false,
+    isSubmitting: false,
+  };
+}
+
+function buildWorkflow(overrides: {
+  stage: unknown;
+  publish?: ReturnType<typeof buildPublish>;
+}) {
+  return {
+    stage: overrides.stage,
+    readiness: (overrides.stage as { readiness?: unknown }).readiness ?? { kind: "blocked", copy: { headline: "", body: "", primaryActionLabel: "" }, blockerCode: "status_loading" },
+    publish: overrides.publish ?? buildPublish(),
+    error: null,
+    isLoading: false,
+    isSubmitting: false,
+    startMove: vi.fn(),
+    resumeMove: vi.fn(),
+    abandonMove: vi.fn(),
+    replaceCollidingWorkspace: vi.fn(),
+    reset: vi.fn(),
+  };
+}

--- a/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.test.tsx
+++ b/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.test.tsx
@@ -111,6 +111,42 @@ describe("MoveWorkspaceDialog", () => {
     expect(mocks.workflow!.replaceCollidingWorkspace).toHaveBeenCalledWith("cloud-ws-1");
   });
 
+  it("disables 'Open the cloud workspace' while a replace is in flight so it can't bypass it", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "collision",
+        gitOwner: "acme",
+        gitRepoName: "widgets",
+        branch: "feature/move",
+        collidingWorkspaceId: "cloud-ws-1",
+      },
+      isSubmitting: true,
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    const openButton = screen.getByText("Open the cloud workspace").closest("button") as HTMLButtonElement;
+    expect(openButton.disabled).toBe(true);
+    fireEvent.click(openButton);
+    expect(mocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+  });
+
+  it("offers a retry affordance when a post-cutover move is rediscovered stuck", () => {
+    mocks.workflow = buildWorkflow({
+      stage: {
+        kind: "resume",
+        move: { id: "move-1", phase: "cutover" } as never,
+        postCutover: true,
+      },
+    });
+
+    render(<MoveWorkspaceDialog open workspaceId="ws-1" workspaceKind="worktree" repoRoot={null} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("Retry cleanup"));
+    expect(mocks.workflow!.resumeMove).toHaveBeenCalledTimes(1);
+    expect(mocks.workflow!.abandonMove).not.toHaveBeenCalled();
+  });
+
   it("renders the four-step progress list while the saga is running", () => {
     mocks.workflow = buildWorkflow({
       stage: { kind: "progress", phase: "destination_ready" },
@@ -152,6 +188,7 @@ function buildPublish(overrides: PublishViewStateOverrides = {}) {
 function buildWorkflow(overrides: {
   stage: unknown;
   publish?: ReturnType<typeof buildPublish>;
+  isSubmitting?: boolean;
 }) {
   return {
     stage: overrides.stage,
@@ -159,7 +196,7 @@ function buildWorkflow(overrides: {
     publish: overrides.publish ?? buildPublish(),
     error: null,
     isLoading: false,
-    isSubmitting: false,
+    isSubmitting: overrides.isSubmitting ?? false,
     startMove: vi.fn(),
     resumeMove: vi.fn(),
     abandonMove: vi.fn(),

--- a/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.tsx
+++ b/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useId } from "react";
+import type { RepoRoot, WorkspaceKind } from "@anyharness/sdk";
+import { PublishChangedFiles } from "@/components/workspace/git/PublishChangedFiles";
+import { PublishSection } from "@/components/workspace/git/PublishSection";
+import { MoveProgress } from "@/components/workspace/move/MoveProgress";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Label } from "@proliferate/ui/primitives/Label";
+import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
+import { Switch } from "@proliferate/ui/primitives/Switch";
+import { Textarea } from "@proliferate/ui/primitives/Textarea";
+import { Spinner } from "@proliferate/ui/icons";
+import { useWorkspaceMoveWorkflow } from "@/hooks/workspaces/workflows/use-workspace-move-workflow";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+
+interface MoveWorkspaceDialogProps {
+  open: boolean;
+  workspaceId: string | null;
+  workspaceKind: WorkspaceKind | null;
+  repoRoot: Pick<RepoRoot, "remoteOwner" | "remoteRepoName" | "defaultBranch"> | null | undefined;
+  onClose: () => void;
+}
+
+export function MoveWorkspaceDialog({
+  open,
+  workspaceId,
+  workspaceKind,
+  repoRoot,
+  onClose,
+}: MoveWorkspaceDialogProps) {
+  const workflow = useWorkspaceMoveWorkflow({
+    workspaceId,
+    workspaceKind,
+    repoRoot,
+    enabled: open && Boolean(workspaceId),
+  });
+  const { stage, readiness, publish, error, isSubmitting } = workflow;
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
+
+  const commitSummaryId = useId();
+  const includeUnstagedId = useId();
+
+  const handleClose = useCallback(() => {
+    workflow.reset();
+    onClose();
+  }, [onClose, workflow]);
+
+  const handleOpenCollidingWorkspace = useCallback((collidingWorkspaceId: string) => {
+    selectWorkspaceFromSurface(cloudWorkspaceSyntheticId(collidingWorkspaceId), "workspace-move-dialog");
+    handleClose();
+  }, [handleClose, selectWorkspaceFromSurface]);
+
+  const disableClose = isSubmitting || stage.kind === "progress";
+
+  let title = "Move to cloud";
+  let primaryLabel: string | null = null;
+  let onPrimary: (() => void) | null = null;
+  let primaryDisabled = false;
+  let secondaryAction: { label: string; onClick: () => void } | null = null;
+
+  if (stage.kind === "readiness") {
+    title = readiness.copy.headline;
+    if (readiness.kind !== "blocked") {
+      primaryLabel = readiness.copy.primaryActionLabel;
+      onPrimary = () => void workflow.startMove();
+      primaryDisabled = readiness.kind === "prepare_required" && publish.viewState.disabledReason !== null;
+    }
+  } else if (stage.kind === "resume" && !stage.postCutover) {
+    title = "A move is already in progress";
+    primaryLabel = "Resume move";
+    onPrimary = () => void workflow.resumeMove();
+    secondaryAction = { label: "Abandon move", onClick: () => void workflow.abandonMove() };
+  } else if (stage.kind === "collision") {
+    title = "A cloud workspace already exists";
+  } else if (stage.kind === "not_configured") {
+    title = "Connect this repository to Proliferate Cloud";
+  } else if (stage.kind === "done") {
+    title = "Moved to cloud";
+    primaryLabel = "Done";
+    onPrimary = handleClose;
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={handleClose}
+      disableClose={disableClose}
+      title={title}
+      sizeClassName="max-w-md"
+      footer={(
+        <div className="flex w-full items-center justify-end gap-2">
+          {secondaryAction && (
+            <Button type="button" variant="outline" size="sm" disabled={isSubmitting} onClick={secondaryAction.onClick}>
+              {secondaryAction.label}
+            </Button>
+          )}
+          <Button type="button" variant="ghost" size="sm" onClick={handleClose} disabled={disableClose}>
+            {stage.kind === "done" ? "Close" : "Cancel"}
+          </Button>
+          {primaryLabel && onPrimary && (
+            <Button
+              type="button"
+              variant="inverted"
+              size="sm"
+              loading={isSubmitting}
+              disabled={primaryDisabled}
+              onClick={onPrimary}
+            >
+              {primaryLabel}
+            </Button>
+          )}
+        </div>
+      )}
+    >
+      <div className="space-y-4">
+        {stage.kind === "loading" && (
+          <div className="flex items-center gap-2 text-ui-sm text-muted-foreground">
+            <Spinner className="size-4" />
+            Checking workspace status…
+          </div>
+        )}
+
+        {stage.kind === "not_configured" && (
+          <p className="text-ui-sm text-muted-foreground">
+            This repository isn't connected to Proliferate Cloud yet. Configure it from
+            repository settings, then try moving this workspace again.
+          </p>
+        )}
+
+        {stage.kind === "resume" && !stage.postCutover && (
+          <p className="text-ui-sm text-muted-foreground">
+            A previous move for this workspace hasn't finished. Resume it, or abandon it
+            to unfreeze this workspace and start over.
+          </p>
+        )}
+
+        {stage.kind === "resume" && stage.postCutover && (
+          <MoveProgress
+            phase={stage.move.phase}
+            error={error}
+            isRetrying={isSubmitting}
+            onRetry={() => void workflow.resumeMove()}
+          />
+        )}
+
+        {stage.kind === "collision" && (
+          <MoveCollisionPanel
+            branch={stage.branch}
+            collidingWorkspaceId={stage.collidingWorkspaceId}
+            isSubmitting={isSubmitting}
+            onOpen={handleOpenCollidingWorkspace}
+            onReplace={(id) => void workflow.replaceCollidingWorkspace(id)}
+          />
+        )}
+
+        {stage.kind === "readiness" && (
+          <div className="space-y-4">
+            <p className="text-ui-sm text-muted-foreground">{readiness.copy.body}</p>
+
+            {readiness.kind === "prepare_required" && (
+              <>
+                {(publish.viewState.hasStagedChanges || publish.viewState.hasUnstagedChanges) && (
+                  <PublishSection flush>
+                    <p className="text-ui font-medium text-foreground">Changed files</p>
+                    <PublishChangedFiles groups={publish.viewState.fileGroups} scroll={false} />
+                  </PublishSection>
+                )}
+                <PublishSection flush>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-ui font-medium text-foreground">Commit message</p>
+                    {publish.viewState.hasUnstagedChanges && (
+                      <div className="flex items-center gap-2">
+                        <Switch
+                          id={includeUnstagedId}
+                          checked={publish.commitDraft.includeUnstaged}
+                          onChange={(includeUnstaged) =>
+                            publish.setCommitDraft({ ...publish.commitDraft, includeUnstaged })}
+                          disabled={isSubmitting}
+                        />
+                        <Label htmlFor={includeUnstagedId} className="mb-0">Include unstaged</Label>
+                      </div>
+                    )}
+                  </div>
+                  <Textarea
+                    id={commitSummaryId}
+                    aria-label="Commit message"
+                    rows={3}
+                    value={publish.commitDraft.summary}
+                    onChange={(event) =>
+                      publish.setCommitDraft({ ...publish.commitDraft, summary: event.target.value })}
+                    placeholder="Describe your changes"
+                    disabled={isSubmitting}
+                  />
+                </PublishSection>
+              </>
+            )}
+          </div>
+        )}
+
+        {stage.kind === "progress" && <MoveProgress phase={stage.phase} />}
+
+        {error && stage.kind !== "resume" && (
+          <p className="text-ui-sm text-destructive">{error}</p>
+        )}
+      </div>
+    </ModalShell>
+  );
+}
+
+function MoveCollisionPanel({
+  branch,
+  collidingWorkspaceId,
+  isSubmitting,
+  onOpen,
+  onReplace,
+}: {
+  branch: string;
+  collidingWorkspaceId: string | null;
+  isSubmitting: boolean;
+  onOpen: (collidingWorkspaceId: string) => void;
+  onReplace: (collidingWorkspaceId: string) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-ui-sm text-muted-foreground">
+        A cloud workspace for <span className="font-mono text-foreground">{branch}</span> already
+        exists with its own sessions. Open it instead, or replace it with this local copy.
+      </p>
+      <div className="flex flex-col gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!collidingWorkspaceId}
+          onClick={() => collidingWorkspaceId && onOpen(collidingWorkspaceId)}
+        >
+          Open the cloud workspace
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!collidingWorkspaceId || isSubmitting}
+          loading={isSubmitting}
+          onClick={() => collidingWorkspaceId && onReplace(collidingWorkspaceId)}
+        >
+          Replace it with this local copy
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.tsx
+++ b/apps/desktop/src/components/workspace/move/MoveWorkspaceDialog.tsx
@@ -70,6 +70,14 @@ export function MoveWorkspaceDialog({
     primaryLabel = "Resume move";
     onPrimary = () => void workflow.resumeMove();
     secondaryAction = { label: "Abandon move", onClick: () => void workflow.abandonMove() };
+  } else if (stage.kind === "resume" && stage.postCutover) {
+    // Cutover already committed the move -- only cleanup remains, so retry is the sole
+    // option (abandon is refused post-cutover). Freshly-rediscovered stuck moves land
+    // here with no `error`, so this branch (not MoveProgress's error-gated banner) must
+    // carry the retry affordance.
+    title = "Finishing the move to cloud";
+    primaryLabel = "Retry cleanup";
+    onPrimary = () => void workflow.resumeMove();
   } else if (stage.kind === "collision") {
     title = "A cloud workspace already exists";
   } else if (stage.kind === "not_configured") {
@@ -231,7 +239,7 @@ function MoveCollisionPanel({
           type="button"
           variant="outline"
           size="sm"
-          disabled={!collidingWorkspaceId}
+          disabled={!collidingWorkspaceId || isSubmitting}
           onClick={() => collidingWorkspaceId && onOpen(collidingWorkspaceId)}
         >
           Open the cloud workspace

--- a/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
 } from "react";
 import { PublishDialog } from "@/components/workspace/git/PublishDialog";
+import { MoveWorkspaceDialog } from "@/components/workspace/move/MoveWorkspaceDialog";
 import { ChatView } from "@/components/workspace/chat/ChatView";
 import { GlobalHeader } from "@/components/workspace/shell/topbar/GlobalHeader";
 import { WorkspaceContentView } from "@/components/workspace/shell/screen/WorkspaceContentView";
@@ -33,6 +34,9 @@ import { useWorkspaceOpenInWebActions } from "@/hooks/workspaces/workflows/remot
 import { useWorkspaceRemoteAccessActions } from "@/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
 import { useWorkspaceActivityAcknowledgement } from "@/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement";
+import { useWorkspaceMoveDialog } from "@/hooks/workspaces/facade/use-workspace-move-dialog";
+import { resolveWorkspaceLocationChip } from "@/lib/domain/workspaces/move/move-location-chip";
+import { useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
 import { resolveStandardWorkspaceChromeClasses } from "@/lib/domain/preferences/workspace-chrome";
 import { WorkspacePathProvider } from "@/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
@@ -167,8 +171,18 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     ? null
     : "Repository settings are unavailable.";
   const nativePortalOverlayOpen = useNativeOverlayOpen();
+  const moveDialog = useWorkspaceMoveDialog();
+  const openMoveDialog = useWorkspaceMoveStore((state) => state.openMoveDialog);
+  const workspaceLocationChip = useMemo(
+    () => resolveWorkspaceLocationChip(selectedWorkspaceId, isCloudWorkspaceSelected),
+    [isCloudWorkspaceSelected, selectedWorkspaceId],
+  );
+  const handleOpenMoveDialog = useCallback(() => {
+    if (selectedWorkspaceId) openMoveDialog(selectedWorkspaceId);
+  }, [openMoveDialog, selectedWorkspaceId]);
   const nativeWorkspaceOverlaysHidden = commandPaletteOpen
     || publishDialog.open
+    || moveDialog.open
     || nativePortalOverlayOpen;
   const handleTerminalActivationRequestHandled = useCallback(
     (request: NonNullable<typeof terminalActivationRequest>) => {
@@ -215,6 +229,13 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
   return (
     <DebugProfiler id="workspace-shell">
       <WorkspaceShellActionsProvider value={shellActions}>
+        <MoveWorkspaceDialog
+          open={moveDialog.open}
+          workspaceId={moveDialog.workspaceId}
+          workspaceKind={moveDialog.workspaceKind}
+          repoRoot={moveDialog.repoRoot}
+          onClose={moveDialog.onClose}
+        />
         <WorkspacePathProvider workspacePath={selectedWorkspace?.path ?? pendingWorkspacePath}>
           <WorkspaceHeaderTabsViewModelProvider
             enabled={hasWorkspaceShell && !hasLaunchIntentOnlyShell}
@@ -282,6 +303,8 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                             runLabel={runCommand.runLabel}
                             runTitle={runCommand.runTitle}
                             workspaceActions={workspaceActionsMenuProps}
+                            locationChip={workspaceLocationChip}
+                            onOpenMoveDialog={handleOpenMoveDialog}
                             onRun={runCommand.onRun}
                             onTogglePanel={actions.toggleRightPanel}
                           />

--- a/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -321,6 +321,7 @@ export const MainSidebar = memo(function MainSidebar() {
               onIndicatorAction={actions.handleSidebarIndicatorAction}
               onOpenPullRequest={actions.handleOpenPullRequest}
               onMarkWorkspaceDone={actions.handleMarkWorkspaceDone}
+              onMoveWorkspaceToCloud={actions.handleOpenMoveToCloud}
               onWorkspaceHover={handleWorkspaceHover}
               shortcutRevealVisible={shortcutRevealVisible}
               shortcutLabelByWorkspaceId={sidebarShortcutLabelById}

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -10,12 +10,29 @@ import {
 } from "@/lib/domain/workspaces/sidebar/sidebar-model";
 import { buildSidebarNewWorkspaceCommandScope } from "@/lib/domain/workspaces/creation/new-workspace-command";
 import { visibleSidebarGroupItems } from "@/lib/domain/workspaces/sidebar/sidebar-visible-items";
-import type { SidebarIndicatorAction } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type {
+  SidebarIndicatorAction,
+  SidebarStatusIndicator,
+} from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { SkeletonBlock } from "@/components/feedback/Skeleton";
 import { useWorkspaceCopyActions } from "@/hooks/workspaces/workflows/use-workspace-copy-actions";
+import { useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
 import { RepoGroup, type RepoGroupEnvironmentKind } from "./RepoGroup";
 import { SidebarShowToggleRow } from "./SidebarShowToggleRow";
 import { WorkspaceItem } from "./WorkspaceItem";
+
+// Status kinds that mean an agent turn is actively running or waiting on the user --
+// the sidebar-level approximation of the move dialog's own "blocked" readiness (spec
+// section 2.6 entry point: hidden while a turn is running). The full blocker set
+// (detached head, conflicts, behind-upstream, ...) is still surfaced by the dialog's
+// own readiness resolver once opened; this is just the cheap, already-computed signal
+// available per sidebar row without an extra query.
+const MOVE_TO_CLOUD_BLOCKING_STATUS_KINDS = new Set<SidebarStatusIndicator["kind"]>([
+  "iterating",
+  "waiting_input",
+  "waiting_plan",
+  "queued_prompt",
+]);
 
 interface SidebarWorkspaceContentProps {
   emptyState: SidebarEmptyState;
@@ -96,6 +113,7 @@ export function SidebarWorkspaceContent({
   onOpenRepoSettings,
 }: SidebarWorkspaceContentProps) {
   const { copyWorkspaceLocation, copyBranchName } = useWorkspaceCopyActions();
+  const activeMoveIdByWorkspaceId = useWorkspaceMoveStore((state) => state.activeMoveIdByWorkspaceId);
 
   if (isLoading && emptyState === "noWorkspaces") {
     return <SidebarLoadingState />;
@@ -242,6 +260,8 @@ export function SidebarWorkspaceContent({
                   (item.variant === "local" || item.variant === "worktree")
                     && !item.archived
                     && item.localWorkspaceId
+                    && !activeMoveIdByWorkspaceId[item.localWorkspaceId]
+                    && (!item.statusIndicator || !MOVE_TO_CLOUD_BLOCKING_STATUS_KINDS.has(item.statusIndicator.kind))
                     ? () => onMoveWorkspaceToCloud(item.localWorkspaceId!)
                     : undefined
                 }

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -40,6 +40,7 @@ interface SidebarWorkspaceContentProps {
   onIndicatorAction: (action: SidebarIndicatorAction) => void;
   onOpenPullRequest: (url: string) => void;
   onMarkWorkspaceDone: (workspaceId: string, logicalWorkspaceId: string) => void;
+  onMoveWorkspaceToCloud: (workspaceId: string) => void;
   onWorkspaceHover?: () => void;
   shortcutRevealVisible: boolean;
   shortcutLabelByWorkspaceId: ReadonlyMap<string, string>;
@@ -84,6 +85,7 @@ export function SidebarWorkspaceContent({
   onIndicatorAction,
   onOpenPullRequest,
   onMarkWorkspaceDone,
+  onMoveWorkspaceToCloud,
   onWorkspaceHover,
   shortcutRevealVisible,
   shortcutLabelByWorkspaceId,
@@ -234,6 +236,13 @@ export function SidebarWorkspaceContent({
                 onMarkDone={
                   item.variant === "worktree" && !item.archived && item.localWorkspaceId
                     ? () => onMarkWorkspaceDone(item.localWorkspaceId!, item.id)
+                    : undefined
+                }
+                onMoveToCloud={
+                  (item.variant === "local" || item.variant === "worktree")
+                    && !item.archived
+                    && item.localWorkspaceId
+                    ? () => onMoveWorkspaceToCloud(item.localWorkspaceId!)
                     : undefined
                 }
                 onHover={onWorkspaceHover}

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu.tsx
@@ -1,0 +1,41 @@
+import { Trash } from "@proliferate/ui/icons";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
+
+interface WorkspaceDeleteConfirmMenuProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Inline delete-confirmation step for the workspace row context menu. Explains
+ * exactly what the "Delete workspace" action removes (local worktree, record,
+ * chat history, agent artifacts) versus what it preserves (commits, branches,
+ * PRs), then offers the destructive confirm and a cancel.
+ */
+export function WorkspaceDeleteConfirmMenu({ onConfirm, onCancel }: WorkspaceDeleteConfirmMenuProps) {
+  return (
+    <>
+      <div className="px-2.5 py-2 text-sm text-foreground">
+        <div className="font-medium">Delete workspace?</div>
+        <div className="mt-1 text-xs leading-4 text-muted-foreground">
+          This removes the local worktree, workspace record, chat history, and local agent
+          artifacts for this workspace. Commits, branches, and pull requests are not deleted.
+        </div>
+        <div className="mt-1 text-xs leading-4 text-muted-foreground">
+          This cannot be undone from Proliferate.
+        </div>
+      </div>
+      <PopoverMenuItem
+        icon={<Trash className="size-3.5 shrink-0 text-muted-foreground" />}
+        label="Delete workspace"
+        variant="sidebar"
+        onClick={onConfirm}
+      />
+      <PopoverMenuItem
+        label="Cancel"
+        variant="sidebar"
+        onClick={onCancel}
+      />
+    </>
+  );
+}

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -82,6 +82,9 @@ interface WorkspaceItemProps {
   onArchive?: () => void;
   onUnarchive?: () => void;
   onMarkDone?: () => void;
+  /** Opens the move-to-cloud dialog for this workspace. Omit to hide the menu item
+   *  (cloud-backed workspaces, blocked workspaces, or a move already in flight). */
+  onMoveToCloud?: () => void;
   onIndicatorAction?: (action: SidebarIndicatorAction) => void;
   onHover?: () => void;
   /**
@@ -113,6 +116,7 @@ export function WorkspaceItem({
   onArchive,
   onUnarchive,
   onMarkDone,
+  onMoveToCloud,
   onIndicatorAction,
   onHover,
   workspaceLocationCopyLabel,
@@ -137,6 +141,7 @@ export function WorkspaceItem({
   const handleArchiveCommand = () => onArchive?.();
   const handleUnarchiveCommand = () => onUnarchive?.();
   const handleMarkDoneCommand = () => setDoneConfirmOpen(true);
+  const handleMoveToCloudCommand = () => onMoveToCloud?.();
   const { onContextMenuCapture } = useWorkspaceSidebarNativeContextMenu({
     canRename: !!onRename,
     canCopyWorkspaceLocation: !!onCopyWorkspaceLocation,
@@ -146,12 +151,14 @@ export function WorkspaceItem({
     canArchive: !!onArchive,
     canUnarchive: !!onUnarchive,
     canMarkDone: !!onMarkDone,
+    canMoveToCloud: !!onMoveToCloud,
     onRename: handleRenameCommand,
     onCopyWorkspaceLocation: handleCopyWorkspaceLocationCommand,
     onCopyBranchName: handleCopyBranchNameCommand,
     onArchive: handleArchiveCommand,
     onUnarchive: handleUnarchiveCommand,
     onMarkDone: handleMarkDoneCommand,
+    onMoveToCloud: handleMoveToCloudCommand,
   });
   const detail = detailIndicators.length > 0 || cloudStatusDefinition ? (
     <>

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -33,6 +33,7 @@ import {
   SidebarStatusIndicatorView,
 } from "./SidebarIndicators";
 import { SidebarWorkspaceGitGlyph } from "./SidebarWorkspaceGitGlyph";
+import { WorkspaceDeleteConfirmMenu } from "./WorkspaceDeleteConfirmMenu";
 import { WorkspaceItemMenu } from "./WorkspaceItemMenu";
 import { WorkspaceRenamePopover } from "./WorkspaceRenamePopover";
 import { ProductSidebarWorkspaceRow } from "@proliferate/product-ui/sidebar/ProductSidebarRepositories";
@@ -257,36 +258,10 @@ export function WorkspaceItem({
       {(close) => (
         <>
           {doneConfirmOpen ? (
-            <>
-              <div className="px-2.5 py-2 text-sm text-foreground">
-                <div className="font-medium">Delete workspace?</div>
-                <div className="mt-1 text-xs leading-4 text-muted-foreground">
-                  This removes the local worktree, workspace record, chat history, and local agent
-                  artifacts for this workspace. Commits, branches, and pull requests are not deleted.
-                </div>
-                <div className="mt-1 text-xs leading-4 text-muted-foreground">
-                  This cannot be undone from Proliferate.
-                </div>
-              </div>
-              <PopoverMenuItem
-                icon={<Trash className="size-3.5 shrink-0 text-muted-foreground" />}
-                label="Delete workspace"
-                variant="sidebar"
-                onClick={() => {
-                  close();
-                  setDoneConfirmOpen(false);
-                  onMarkDone?.();
-                }}
-              />
-              <PopoverMenuItem
-                label="Cancel"
-                variant="sidebar"
-                onClick={() => {
-                  close();
-                  setDoneConfirmOpen(false);
-                }}
-              />
-            </>
+            <WorkspaceDeleteConfirmMenu
+              onConfirm={() => { close(); setDoneConfirmOpen(false); onMarkDone?.(); }}
+              onCancel={() => { close(); setDoneConfirmOpen(false); }}
+            />
           ) : (
             <>
               {onRename && (

--- a/apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -11,6 +11,8 @@ import {
   WorkspaceActionsMenuContainer,
   type WorkspaceActionsMenuContainerProps,
 } from "@/components/workspace/shell/topbar/WorkspaceActionsMenuContainer";
+import { WorkspaceLocationChip } from "@/components/workspace/shell/topbar/WorkspaceLocationChip";
+import type { WorkspaceLocationChipView } from "@/lib/domain/workspaces/move/move-location-chip";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { DebugProfiler } from "@/components/diagnostics/DebugProfiler";
 import { SplitButton } from "@/components/workspace/open-target/SplitButton";
@@ -39,6 +41,8 @@ interface GlobalHeaderProps {
   runLabel?: string;
   runTitle?: string;
   workspaceActions: WorkspaceActionsMenuContainerProps;
+  locationChip?: WorkspaceLocationChipView | null;
+  onOpenMoveDialog?: () => void;
   onRun: () => void;
   onTogglePanel: () => void;
 }
@@ -52,6 +56,8 @@ export const GlobalHeader = memo(function GlobalHeader({
   runLabel = "Run",
   runTitle = "Run workspace command",
   workspaceActions,
+  locationChip = null,
+  onOpenMoveDialog,
   onRun,
   onTogglePanel,
 }: GlobalHeaderProps) {
@@ -94,6 +100,10 @@ export const GlobalHeader = memo(function GlobalHeader({
         >
           {title}
         </div>
+
+        {locationChip && onOpenMoveDialog && (
+          <WorkspaceLocationChip view={locationChip} onClick={onOpenMoveDialog} />
+        )}
 
         <WorkspaceActionsMenuContainer {...workspaceActions} />
 

--- a/apps/desktop/src/components/workspace/shell/topbar/WorkspaceLocationChip.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/WorkspaceLocationChip.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@proliferate/ui/primitives/Button";
+import type { WorkspaceLocationChipView } from "@/lib/domain/workspaces/move/move-location-chip";
+
+interface WorkspaceLocationChipProps {
+  view: WorkspaceLocationChipView;
+  onClick: () => void;
+}
+
+/** The workspace header's location indicator (spec section 2.6's entry point (b)):
+ *  clickable when the workspace is local, opening the same move-to-cloud dialog as the
+ *  sidebar context-menu item; a read-only badge for cloud/target workspaces until the
+ *  mirror direction lands. */
+export function WorkspaceLocationChip({ view, onClick }: WorkspaceLocationChipProps) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      disabled={!view.clickable}
+      onClick={onClick}
+      title={view.clickable ? "Move this workspace to the cloud" : view.label}
+      className="workspace-shell-icon-button shrink-0 gap-1 px-2 text-ui-sm text-muted-foreground disabled:opacity-100"
+    >
+      {view.label}
+    </Button>
+  );
+}

--- a/apps/desktop/src/hooks/access/anyharness/mobility/query-keys.ts
+++ b/apps/desktop/src/hooks/access/anyharness/mobility/query-keys.ts
@@ -1,0 +1,3 @@
+export function workspaceMobilityPreflightKey(runtimeUrl: string, workspaceId: string) {
+  return ["anyharness", "mobility", "preflight", runtimeUrl, workspaceId] as const;
+}

--- a/apps/desktop/src/hooks/access/anyharness/mobility/use-workspace-mobility-preflight-query.ts
+++ b/apps/desktop/src/hooks/access/anyharness/mobility/use-workspace-mobility-preflight-query.ts
@@ -1,0 +1,29 @@
+import type { WorkspaceMobilityPreflightResponse } from "@anyharness/sdk";
+import { useQuery } from "@tanstack/react-query";
+import { getWorkspaceMobilityPreflight } from "@/lib/access/anyharness/mobility";
+import { resolveWorkspaceConnection } from "@/lib/access/anyharness/resolve-workspace-connection";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import { workspaceMobilityPreflightKey } from "./query-keys";
+
+/**
+ * The source-side readiness signal for a workspace move (spec section 1/2.4): active
+ * turn / pending interaction, detached head, conflicts, dirty tree, and the estimated
+ * archive size. `move-readiness.ts` folds this together with git status into the four
+ * readiness outcomes.
+ */
+export function useWorkspaceMobilityPreflightQuery(
+  workspaceId: string | null,
+  options: { enabled?: boolean; refetchIntervalMs?: number | false } = {},
+) {
+  const { enabled = true, refetchIntervalMs = false } = options;
+  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  return useQuery<WorkspaceMobilityPreflightResponse>({
+    queryKey: workspaceMobilityPreflightKey(runtimeUrl, workspaceId ?? ""),
+    queryFn: async () => {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      return getWorkspaceMobilityPreflight(connection, connection.anyharnessWorkspaceId);
+    },
+    enabled: enabled && workspaceId !== null,
+    refetchInterval: refetchIntervalMs,
+  });
+}

--- a/apps/desktop/src/hooks/access/cloud/workspace-moves/query-keys.ts
+++ b/apps/desktop/src/hooks/access/cloud/workspace-moves/query-keys.ts
@@ -1,0 +1,4 @@
+export {
+  workspaceMoveKey,
+  workspaceMovesRootKey,
+} from "@proliferate/cloud-sdk-react/lib/query-keys";

--- a/apps/desktop/src/hooks/access/cloud/workspace-moves/use-start-workspace-move-mutation.ts
+++ b/apps/desktop/src/hooks/access/cloud/workspace-moves/use-start-workspace-move-mutation.ts
@@ -1,0 +1,7 @@
+import "@/lib/access/cloud/client";
+
+export { useStartWorkspaceMove } from "@proliferate/cloud-sdk-react/hooks/workspace-moves";
+// Typed 409 code thrown by `useStartWorkspaceMove` on collision (spec section 2,
+// "Collision"). Re-exported here so callers only need this access module, not the raw
+// cloud SDK, to build the open-vs-replace decision.
+export { WORKSPACE_MOVE_CLOUD_WORKSPACE_EXISTS_ERROR_CODE } from "@proliferate/cloud-sdk";

--- a/apps/desktop/src/hooks/access/cloud/workspace-moves/use-workspace-move-phase-mutations.ts
+++ b/apps/desktop/src/hooks/access/cloud/workspace-moves/use-workspace-move-phase-mutations.ts
@@ -1,0 +1,30 @@
+import "@/lib/access/cloud/client";
+import {
+  useCompleteWorkspaceMove,
+  useCutoverWorkspaceMove,
+  useExportWorkspaceMove,
+  useFailWorkspaceMove,
+  useInstallWorkspaceMove,
+} from "@proliferate/cloud-sdk-react/hooks/workspace-moves";
+
+/**
+ * Groups the mutations that advance an in-flight workspace_move through its phases
+ * after start -- install (local->cloud only; cloud->local uses `export` instead, spec
+ * section 2.3), cutover, complete, and fail. Mirrors the grouped-mutation shape of
+ * `useAutomationMutations` (hooks/access/cloud/automations/use-automation-mutations.ts).
+ */
+export function useWorkspaceMovePhaseMutations() {
+  const install = useInstallWorkspaceMove();
+  const exportMove = useExportWorkspaceMove();
+  const cutover = useCutoverWorkspaceMove();
+  const complete = useCompleteWorkspaceMove();
+  const fail = useFailWorkspaceMove();
+
+  return {
+    install,
+    export: exportMove,
+    cutover,
+    complete,
+    fail,
+  };
+}

--- a/apps/desktop/src/hooks/access/cloud/workspace-moves/use-workspace-move.ts
+++ b/apps/desktop/src/hooks/access/cloud/workspace-moves/use-workspace-move.ts
@@ -1,0 +1,6 @@
+import "@/lib/access/cloud/client";
+
+export {
+  useWorkspaceMove,
+  type UseWorkspaceMoveOptions,
+} from "@proliferate/cloud-sdk-react/hooks/workspace-moves";

--- a/apps/desktop/src/hooks/workspaces/facade/use-workspace-move-dialog.ts
+++ b/apps/desktop/src/hooks/workspaces/facade/use-workspace-move-dialog.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
+import { useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
+
+/**
+ * Groups the move-dialog's open/workspaceId state (owned by the dedicated
+ * `workspace-move-store`, since the dialog is opened from two independent entry points
+ * -- the sidebar context menu and the workspace header location chip -- that don't
+ * share a common parent) with the `Workspace`/`RepoRoot` lookup `MoveWorkspaceDialog`
+ * needs, so callers don't have to resolve the target workspace themselves.
+ */
+export function useWorkspaceMoveDialog() {
+  const open = useWorkspaceMoveStore((state) => state.dialogOpen);
+  const workspaceId = useWorkspaceMoveStore((state) => state.dialogWorkspaceId);
+  const onClose = useWorkspaceMoveStore((state) => state.closeMoveDialog);
+  const { data: collections } = useWorkspaces({ enabled: open });
+
+  const workspace = useMemo(
+    () => (workspaceId ? collections?.workspaces.find((entry) => entry.id === workspaceId) : undefined),
+    [collections?.workspaces, workspaceId],
+  );
+  const repoRoot = useMemo(
+    () => (workspace?.repoRootId
+      ? collections?.repoRoots.find((entry) => entry.id === workspace.repoRootId)
+      : undefined),
+    [collections?.repoRoots, workspace?.repoRootId],
+  );
+
+  return {
+    open,
+    workspaceId,
+    workspaceKind: workspace?.kind ?? null,
+    repoRoot: repoRoot ?? null,
+    onClose,
+  };
+}

--- a/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
+++ b/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
@@ -12,12 +12,14 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       canArchive: true,
       canUnarchive: false,
       canMarkDone: false,
+      canMoveToCloud: false,
       onRename: () => {},
       onCopyWorkspaceLocation: () => {},
       onCopyBranchName: () => {},
       onArchive: () => {},
       onUnarchive: () => {},
       onMarkDone: () => {},
+      onMoveToCloud: () => {},
     });
 
     expect(items).toMatchObject([
@@ -25,6 +27,33 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       { id: "copy-workspace-location", label: "Copy workspace path", accelerator: "CmdOrCtrl+Shift+C" },
       { id: "copy-branch-name", label: "Copy branch name", accelerator: "CmdOrCtrl+Alt+C" },
       { id: "archive", label: "Archive..." },
+    ]);
+  });
+
+  it("shows move to cloud for an eligible local workspace", () => {
+    const items = buildWorkspaceSidebarNativeContextMenuItems({
+      canRename: true,
+      canCopyWorkspaceLocation: false,
+      copyWorkspaceLocationLabel: "Copy workspace path",
+      canCopyBranchName: false,
+      archived: false,
+      canArchive: false,
+      canUnarchive: false,
+      canMarkDone: false,
+      canMoveToCloud: true,
+      onRename: () => {},
+      onCopyWorkspaceLocation: () => {},
+      onCopyBranchName: () => {},
+      onArchive: () => {},
+      onUnarchive: () => {},
+      onMarkDone: () => {},
+      onMoveToCloud: () => {},
+    });
+
+    expect(items).toMatchObject([
+      { id: "rename", label: "Rename" },
+      { kind: "separator" },
+      { id: "move-to-cloud", label: "Move to cloud…" },
     ]);
   });
 
@@ -38,12 +67,14 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       canArchive: false,
       canUnarchive: true,
       canMarkDone: false,
+      canMoveToCloud: false,
       onRename: () => {},
       onCopyWorkspaceLocation: () => {},
       onCopyBranchName: () => {},
       onArchive: () => {},
       onUnarchive: () => {},
       onMarkDone: () => {},
+      onMoveToCloud: () => {},
     });
 
     expect(items).toMatchObject([{ id: "unarchive", label: "Unarchive" }]);
@@ -59,12 +90,14 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       canArchive: true,
       canUnarchive: false,
       canMarkDone: true,
+      canMoveToCloud: false,
       onRename: () => {},
       onCopyWorkspaceLocation: () => {},
       onCopyBranchName: () => {},
       onArchive: () => {},
       onUnarchive: () => {},
       onMarkDone: () => {},
+      onMoveToCloud: () => {},
     });
 
     expect(items).toMatchObject([

--- a/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
+++ b/apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
@@ -12,12 +12,14 @@ export function useWorkspaceSidebarNativeContextMenu({
   canArchive,
   canUnarchive,
   canMarkDone,
+  canMoveToCloud,
   onRename,
   onCopyWorkspaceLocation,
   onCopyBranchName,
   onArchive,
   onUnarchive,
   onMarkDone,
+  onMoveToCloud,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -27,12 +29,14 @@ export function useWorkspaceSidebarNativeContextMenu({
   canArchive: boolean;
   canUnarchive: boolean;
   canMarkDone: boolean;
+  canMoveToCloud: boolean;
   onRename: () => void;
   onCopyWorkspaceLocation: () => void;
   onCopyBranchName: () => void;
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  onMoveToCloud: () => void;
 }) {
   return useNativeContextMenu(() =>
     buildWorkspaceSidebarNativeContextMenuItems({
@@ -44,12 +48,14 @@ export function useWorkspaceSidebarNativeContextMenu({
       canArchive,
       canUnarchive,
       canMarkDone,
+      canMoveToCloud,
       onRename,
       onCopyWorkspaceLocation,
       onCopyBranchName,
       onArchive,
       onUnarchive,
       onMarkDone,
+      onMoveToCloud,
     })
   );
 }
@@ -63,12 +69,14 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   canArchive,
   canUnarchive,
   canMarkDone,
+  canMoveToCloud,
   onRename,
   onCopyWorkspaceLocation,
   onCopyBranchName,
   onArchive,
   onUnarchive,
   onMarkDone,
+  onMoveToCloud,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -78,12 +86,14 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   canArchive: boolean;
   canUnarchive: boolean;
   canMarkDone: boolean;
+  canMoveToCloud: boolean;
   onRename: () => void;
   onCopyWorkspaceLocation: () => void;
   onCopyBranchName: () => void;
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  onMoveToCloud: () => void;
 }): NativeContextMenuItem[] {
   const items: NativeContextMenuItem[] = [];
   if (canRename) {
@@ -109,6 +119,17 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       label: "Copy branch name",
       accelerator: getShortcutNativeAccelerator(SHORTCUTS.copyBranchName) ?? undefined,
       onSelect: onCopyBranchName,
+    });
+  }
+
+  if (canMoveToCloud) {
+    if (items.length > 0) {
+      items.push({ kind: "separator" });
+    }
+    items.push({
+      id: "move-to-cloud",
+      label: "Move to cloud…",
+      onSelect: onMoveToCloud,
     });
   }
 

--- a/apps/desktop/src/hooks/workspaces/workflows/use-post-move-navigation.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-post-move-navigation.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { APP_ROUTES } from "@/config/app-routes";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { resolvePostMoveNavigation } from "@/lib/domain/workspaces/move/move-model";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+
+// A successful move may have just destroyed the source workspace (worktree source
+// fate), leaving the shell pointed at a dead id. Mirror useWorkspaceRetireActions.
+// markDone's clear-selection idiom and the collision panel's "Open the cloud
+// workspace" navigation: if this move's source is still the on-screen workspace, hand
+// off to the new cloud workspace (falling back to home when its id is unknown).
+export function usePostMoveNavigation(workspaceId: string | null) {
+  const navigate = useNavigate();
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
+  const clearSelection = useSessionSelectionStore((state) => state.clearSelection);
+  const setSelectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.setSelectedLogicalWorkspaceId,
+  );
+
+  return useCallback((destinationCloudWorkspaceId: string | null) => {
+    if (!workspaceId) return;
+    const navigation = resolvePostMoveNavigation({
+      movedWorkspaceId: workspaceId,
+      selectedWorkspaceId: useSessionSelectionStore.getState().selectedWorkspaceId,
+      destinationCloudWorkspaceId,
+    });
+    if (navigation.kind === "select_cloud") {
+      selectWorkspaceFromSurface(
+        cloudWorkspaceSyntheticId(navigation.cloudWorkspaceId),
+        "workspace-move-dialog",
+      );
+    } else if (navigation.kind === "home") {
+      clearSelection();
+      setSelectedLogicalWorkspaceId(null);
+      navigate(APP_ROUTES.home);
+    }
+  }, [clearSelection, navigate, selectWorkspaceFromSurface, setSelectedLogicalWorkspaceId, workspaceId]);
+}

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
@@ -1,0 +1,358 @@
+import type { GitStatusSnapshot, RepoRoot, WorkspaceKind } from "@anyharness/sdk";
+import { useGitStatusQuery } from "@anyharness/sdk-react";
+import type { WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
+import { useRepositories } from "@proliferate/cloud-sdk-react";
+import { useCallback, useMemo, useState } from "react";
+import {
+  useStartWorkspaceMove,
+  WORKSPACE_MOVE_CLOUD_WORKSPACE_EXISTS_ERROR_CODE,
+} from "@/hooks/access/cloud/workspace-moves/use-start-workspace-move-mutation";
+import { useWorkspaceMovePhaseMutations } from "@/hooks/access/cloud/workspace-moves/use-workspace-move-phase-mutations";
+import { useWorkspaceMove } from "@/hooks/access/cloud/workspace-moves/use-workspace-move";
+import { useWorkspaceMobilityPreflightQuery } from "@/hooks/access/anyharness/mobility/use-workspace-mobility-preflight-query";
+import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-workspace-actions";
+import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
+import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspacePublishWorkflow } from "@/hooks/workspaces/workflows/use-workspace-publish-workflow";
+import { getDesktopInstallId } from "@/lib/access/tauri/desktop-install-id";
+import {
+  destroyWorkspaceMobilitySource,
+  exportWorkspaceMobilityArchive,
+  freezeWorkspaceForHandoff,
+  markWorkspaceRemoteOwned,
+  unfreezeWorkspace,
+} from "@/lib/access/anyharness/mobility";
+import { resolveWorkspaceConnection } from "@/lib/access/anyharness/resolve-workspace-connection";
+import {
+  isMovePostCutover,
+  isNonTerminalMovePhase,
+  type MovePhase,
+  type MoveReadiness,
+} from "@/lib/domain/workspaces/move/move-model";
+import { resolveMoveReadiness } from "@/lib/domain/workspaces/move/move-readiness";
+import {
+  buildLocalToCloudMoveStartRequest,
+  findCollidingCloudWorkspace,
+  resolveRepoConfigIdForRepoRoot,
+} from "@/lib/domain/workspaces/move/move-start";
+import {
+  runWorkspaceMoveWorkflow,
+  type WorkspaceMoveWorkflowDeps,
+} from "@/lib/workflows/workspaces/run-workspace-move-workflow";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import { rememberActiveWorkspaceMoveId, useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
+
+export interface UseWorkspaceMoveWorkflowOptions {
+  workspaceId: string | null;
+  workspaceKind: WorkspaceKind | null;
+  repoRoot: Pick<RepoRoot, "remoteOwner" | "remoteRepoName" | "defaultBranch"> | null | undefined;
+  enabled: boolean;
+}
+
+export type MoveWorkflowStage =
+  | { kind: "loading" }
+  | { kind: "not_configured" }
+  | { kind: "resume"; move: WorkspaceMoveResponse; postCutover: boolean }
+  | {
+    kind: "collision";
+    gitOwner: string;
+    gitRepoName: string;
+    branch: string;
+    collidingWorkspaceId: string | null;
+  }
+  | { kind: "readiness"; readiness: MoveReadiness }
+  | { kind: "progress"; phase: MovePhase | "running" }
+  | { kind: "done" };
+
+interface CollisionState {
+  gitOwner: string;
+  gitRepoName: string;
+  branch: string;
+}
+
+// React wiring for the local->cloud workspace_move saga (spec section 2.3/5.4): composes
+// the publish-prep machinery (git-status-driven stage/commit/push, reused wholesale --
+// `initialIntent: "publish"` is exactly the local->cloud git-prep step) with the pure
+// readiness resolver and the pure `runWorkspaceMoveWorkflow` sequencer from stage 1.
+// Owns the one thing those pure layers can't: resolving live AnyHarness/cloud
+// connections and driving React Query mutations.
+export function useWorkspaceMoveWorkflow({
+  workspaceId,
+  workspaceKind,
+  repoRoot,
+  enabled,
+}: UseWorkspaceMoveWorkflowOptions) {
+  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const trackedMoveId = useWorkspaceMoveStore((state) =>
+    workspaceId ? state.activeMoveIdByWorkspaceId[workspaceId] ?? null : null);
+
+  const gitStatusQuery = useGitStatusQuery({ workspaceId, enabled });
+  const preflightQuery = useWorkspaceMobilityPreflightQuery(workspaceId, { enabled });
+  const repositoriesQuery = useRepositories(enabled);
+  const { data: workspaceCollections } = useWorkspaces({ enabled });
+
+  const [runningPhase, setRunningPhase] = useState<MovePhase | "running" | null>(null);
+  const activeMoveQuery = useWorkspaceMove(trackedMoveId, {
+    enabled: enabled && trackedMoveId !== null && runningPhase === null,
+  });
+  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
+
+  const publish = useWorkspacePublishWorkflow({
+    workspaceId,
+    initialIntent: "publish",
+    runtimeBlockedReason: null,
+    repoDefaultBranch: repoRoot?.defaultBranch ?? null,
+    enabled,
+  });
+
+  const startMoveMutation = useStartWorkspaceMove();
+  const phaseMutations = useWorkspaceMovePhaseMutations();
+  const { archiveCloudWorkspace, isArchivingCloudWorkspace } = useCloudWorkspaceActions();
+
+  const [error, setError] = useState<string | null>(null);
+  const [collision, setCollision] = useState<CollisionState | null>(null);
+  const [done, setDone] = useState(false);
+
+  const repoConfigId = useMemo(
+    () => resolveRepoConfigIdForRepoRoot(repoRoot, repositoriesQuery.data?.repositories ?? []),
+    [repoRoot, repositoriesQuery.data?.repositories],
+  );
+
+  const activeMove = activeMoveQuery.data && isNonTerminalMovePhase(activeMoveQuery.data.phase)
+    ? activeMoveQuery.data
+    : null;
+
+  const readiness = useMemo(
+    () => resolveMoveReadiness({
+      gitStatus: gitStatusQuery.data ?? null,
+      sourcePreflight: preflightQuery.data ?? null,
+      destinationState: null,
+      activeMove,
+    }),
+    [activeMove, gitStatusQuery.data, preflightQuery.data],
+  );
+
+  const stage: MoveWorkflowStage = useMemo(() => {
+    if (!workspaceId) return { kind: "loading" };
+    if (done) return { kind: "done" };
+    if (runningPhase !== null) return { kind: "progress", phase: runningPhase };
+    if (collision) {
+      const collidingWorkspace = workspaceCollections
+        ? findCollidingCloudWorkspace({ cloudWorkspaces: workspaceCollections.cloudWorkspaces, ...collision })
+        : null;
+      return { ...collision, kind: "collision", collidingWorkspaceId: collidingWorkspace?.id ?? null };
+    }
+    if (trackedMoveId && activeMoveQuery.isLoading) return { kind: "loading" };
+    if (activeMove) {
+      return { kind: "resume", move: activeMove, postCutover: isMovePostCutover(activeMove.phase) };
+    }
+    if (repositoriesQuery.isLoading) return { kind: "loading" };
+    if (!repoConfigId) return { kind: "not_configured" };
+    return { kind: "readiness", readiness };
+  }, [
+    activeMove,
+    activeMoveQuery.isLoading,
+    collision,
+    done,
+    readiness,
+    repoConfigId,
+    repositoriesQuery.isLoading,
+    runningPhase,
+    trackedMoveId,
+    workspaceCollections,
+    workspaceId,
+  ]);
+
+  const buildDeps = useCallback((status: GitStatusSnapshot): WorkspaceMoveWorkflowDeps => ({
+    startMove: async (request) => {
+      const move = await startMoveMutation.mutateAsync(request);
+      if (workspaceId) rememberActiveWorkspaceMoveId(workspaceId, move.id);
+      return move;
+    },
+    freezeSource: async (moveId) => {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      await freezeWorkspaceForHandoff(connection, connection.anyharnessWorkspaceId, moveId);
+    },
+    exportSourceArchive: async (moveId) => {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      return exportWorkspaceMobilityArchive(connection, connection.anyharnessWorkspaceId, {
+        requireCleanGitState: true,
+        expectedHandoffOpId: moveId,
+        expectedBaseCommitSha: status.headOid,
+        expectedBranchName: status.currentBranch ?? null,
+      });
+    },
+    installArchive: (moveId, archive) =>
+      phaseMutations.install.mutateAsync({ moveId, body: { archive } }),
+    cutover: (moveId) => phaseMutations.cutover.mutateAsync(moveId),
+    destroySource: async () => {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      await destroyWorkspaceMobilitySource(connection, connection.anyharnessWorkspaceId);
+    },
+    markSourceRemoteOwned: async () => {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      await markWorkspaceRemoteOwned(connection, connection.anyharnessWorkspaceId);
+    },
+    unfreezeSource: async (moveId) => {
+      if (!moveId) return;
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId!);
+      await unfreezeWorkspace(connection, connection.anyharnessWorkspaceId);
+    },
+    completeMove: (moveId) => phaseMutations.complete.mutateAsync(moveId),
+    failMove: async (moveId, failureCode, failureDetail) => {
+      await phaseMutations.fail.mutateAsync({ moveId, body: { failureCode, failureDetail } });
+    },
+    onPhaseChange: (phase) => setRunningPhase(phase),
+  }), [phaseMutations, runtimeUrl, startMoveMutation, workspaceId]);
+
+  /** Runs (or resumes) the saga against a known-fresh git status snapshot -- callers
+   *  that just pushed must pass the `refetch()` result, not the stale `gitStatusQuery.data`
+   *  closure, since a push doesn't re-render before this function's continuation runs.
+   *  `start` is always required (even when resuming): `runWorkspaceMoveWorkflow` only
+   *  reads it for the "not_started"/"started" phases, but a resume from the transient
+   *  "started" phase needs the *original* idempotencyKey to replay safely, so callers
+   *  reconstruct it from the known move rather than this function guessing. */
+  const runAndSettle = useCallback(async (input: {
+    status: GitStatusSnapshot;
+    start: Parameters<typeof buildLocalToCloudMoveStartRequest>[0];
+    resume?: { moveId: string; phase: MovePhase };
+  }) => {
+    if (!workspaceId || !workspaceKind) return;
+    setError(null);
+    setRunningPhase(input.resume?.phase ?? "running");
+    try {
+      const start = buildLocalToCloudMoveStartRequest(input.start);
+      const result = await runWorkspaceMoveWorkflow(
+        { start, sourceWorkspaceKind: workspaceKind, resume: input.resume },
+        buildDeps(input.status),
+      );
+      if (result.outcome === "failed") {
+        if (result.failureCode === WORKSPACE_MOVE_CLOUD_WORKSPACE_EXISTS_ERROR_CODE) {
+          rememberActiveWorkspaceMoveId(workspaceId, null);
+          setRunningPhase(null);
+          setCollision({ gitOwner: repoRoot?.remoteOwner ?? "", gitRepoName: repoRoot?.remoteRepoName ?? "", branch: start.branch });
+          return;
+        }
+        rememberActiveWorkspaceMoveId(workspaceId, null);
+        setRunningPhase(null);
+        setError(result.failureDetail ?? "The move failed.");
+        return;
+      }
+      rememberActiveWorkspaceMoveId(workspaceId, null);
+      await invalidateWorkspaceCollections();
+      setRunningPhase(null);
+      setDone(true);
+    } catch (caught) {
+      setRunningPhase(null);
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [buildDeps, invalidateWorkspaceCollections, repoRoot?.remoteOwner, repoRoot?.remoteRepoName, workspaceId, workspaceKind]);
+
+  const startMove = useCallback(async () => {
+    if (readiness.kind === "blocked") return;
+    let status = gitStatusQuery.data ?? null;
+    if (readiness.kind !== "safe") {
+      const didPrepare = await publish.submit();
+      if (!didPrepare) return;
+      const refetched = await gitStatusQuery.refetch();
+      status = refetched.data ?? null;
+    }
+    const branch = status?.currentBranch?.trim();
+    if (!status || !branch) {
+      setError(!status ? "Git status is still loading." : "This workspace has no current branch.");
+      return;
+    }
+    if (!repoConfigId) {
+      setError("Connect this repository to Proliferate Cloud first.");
+      return;
+    }
+    await runAndSettle({
+      status,
+      start: {
+        repoConfigId,
+        branch,
+        baseCommitSha: status.headOid,
+        desktopInstallId: await getDesktopInstallId(),
+        anyharnessWorkspaceId: workspaceId!,
+        idempotencyKey: crypto.randomUUID(),
+      },
+    });
+  }, [publish, readiness.kind, gitStatusQuery, repoConfigId, workspaceId, runAndSettle]);
+
+  const resumeMove = useCallback(async () => {
+    if (!activeMove || !gitStatusQuery.data || !workspaceId) return;
+    const sourceRef = activeMove.sourceRef as { desktopInstallId?: string; anyharnessWorkspaceId?: string };
+    await runAndSettle({
+      status: gitStatusQuery.data,
+      resume: { moveId: activeMove.id, phase: activeMove.phase },
+      start: {
+        repoConfigId: activeMove.repoConfigId,
+        branch: activeMove.branch,
+        baseCommitSha: activeMove.baseCommitSha,
+        desktopInstallId: sourceRef.desktopInstallId ?? "",
+        anyharnessWorkspaceId: sourceRef.anyharnessWorkspaceId ?? workspaceId,
+        idempotencyKey: activeMove.idempotencyKey,
+      },
+    });
+  }, [activeMove, gitStatusQuery.data, workspaceId, runAndSettle]);
+
+  const abandonMove = useCallback(async () => {
+    if (!activeMove || !workspaceId || isMovePostCutover(activeMove.phase)) return;
+    setError(null);
+    try {
+      const connection = await resolveWorkspaceConnection(runtimeUrl, workspaceId);
+      await unfreezeWorkspace(connection, connection.anyharnessWorkspaceId);
+      await phaseMutations.fail.mutateAsync({
+        moveId: activeMove.id,
+        body: { failureCode: "abandoned_by_user", failureDetail: null },
+      });
+      rememberActiveWorkspaceMoveId(workspaceId, null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [activeMove, phaseMutations.fail, runtimeUrl, workspaceId]);
+
+  const replaceCollidingWorkspace = useCallback(async (collidingWorkspaceId: string) => {
+    if (!collision || !workspaceId || !gitStatusQuery.data || !repoConfigId) return;
+    setError(null);
+    try {
+      await archiveCloudWorkspace(collidingWorkspaceId);
+      const startedCollision = collision;
+      setCollision(null);
+      await runAndSettle({
+        status: gitStatusQuery.data,
+        start: {
+          repoConfigId,
+          branch: startedCollision.branch,
+          baseCommitSha: gitStatusQuery.data.headOid,
+          desktopInstallId: await getDesktopInstallId(),
+          anyharnessWorkspaceId: workspaceId,
+          idempotencyKey: crypto.randomUUID(),
+        },
+      });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [archiveCloudWorkspace, collision, gitStatusQuery.data, repoConfigId, runAndSettle, workspaceId]);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setCollision(null);
+    setDone(false);
+    setRunningPhase(null);
+  }, []);
+
+  return {
+    stage,
+    readiness,
+    publish,
+    error: error ?? publish.error,
+    isLoading: gitStatusQuery.isLoading || preflightQuery.isLoading,
+    isSubmitting: runningPhase !== null || publish.isSubmitting || isArchivingCloudWorkspace,
+    startMove,
+    resumeMove,
+    abandonMove,
+    replaceCollidingWorkspace,
+    reset,
+  };
+}

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
@@ -3,6 +3,8 @@ import { useGitStatusQuery } from "@anyharness/sdk-react";
 import type { WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
 import { useRepositories } from "@proliferate/cloud-sdk-react";
 import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { APP_ROUTES } from "@/config/app-routes";
 import {
   useStartWorkspaceMove,
   WORKSPACE_MOVE_CLOUD_WORKSPACE_EXISTS_ERROR_CODE,
@@ -13,7 +15,9 @@ import { useWorkspaceMobilityPreflightQuery } from "@/hooks/access/anyharness/mo
 import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-workspace-actions";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 import { useWorkspacePublishWorkflow } from "@/hooks/workspaces/workflows/use-workspace-publish-workflow";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { getDesktopInstallId } from "@/lib/access/tauri/desktop-install-id";
 import {
   destroyWorkspaceMobilitySource,
@@ -27,6 +31,7 @@ import {
   isMovePostCutover,
   isNonTerminalMovePhase,
   resolveHandoffMoveId,
+  resolvePostMoveNavigation,
   type MovePhase,
   type MoveReadiness,
 } from "@/lib/domain/workspaces/move/move-model";
@@ -41,6 +46,7 @@ import {
   type WorkspaceMoveWorkflowDeps,
 } from "@/lib/workflows/workspaces/run-workspace-move-workflow";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { rememberActiveWorkspaceMoveId, useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
 
 export interface UseWorkspaceMoveWorkflowOptions {
@@ -84,6 +90,12 @@ export function useWorkspaceMoveWorkflow({
   enabled,
 }: UseWorkspaceMoveWorkflowOptions) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const navigate = useNavigate();
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
+  const clearSelection = useSessionSelectionStore((state) => state.clearSelection);
+  const setSelectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.setSelectedLogicalWorkspaceId,
+  );
   const storedMoveId = useWorkspaceMoveStore((state) =>
     workspaceId ? state.activeMoveIdByWorkspaceId[workspaceId] ?? null : null);
 
@@ -213,6 +225,30 @@ export function useWorkspaceMoveWorkflow({
     onPhaseChange: (phase) => setRunningPhase(phase),
   }), [phaseMutations, runtimeUrl, startMoveMutation, workspaceId]);
 
+  // A successful move may have just destroyed the source workspace (worktree source
+  // fate), leaving the shell pointed at a dead id. Mirror useWorkspaceRetireActions.
+  // markDone's clear-selection idiom and the collision panel's "Open the cloud
+  // workspace" navigation: if this move's source is still the on-screen workspace, hand
+  // off to the new cloud workspace (falling back to home when its id is unknown).
+  const navigateAfterMove = useCallback((destinationCloudWorkspaceId: string | null) => {
+    if (!workspaceId) return;
+    const navigation = resolvePostMoveNavigation({
+      movedWorkspaceId: workspaceId,
+      selectedWorkspaceId: useSessionSelectionStore.getState().selectedWorkspaceId,
+      destinationCloudWorkspaceId,
+    });
+    if (navigation.kind === "select_cloud") {
+      selectWorkspaceFromSurface(
+        cloudWorkspaceSyntheticId(navigation.cloudWorkspaceId),
+        "workspace-move-dialog",
+      );
+    } else if (navigation.kind === "home") {
+      clearSelection();
+      setSelectedLogicalWorkspaceId(null);
+      navigate(APP_ROUTES.home);
+    }
+  }, [clearSelection, navigate, selectWorkspaceFromSurface, setSelectedLogicalWorkspaceId, workspaceId]);
+
   /** Runs (or resumes) the saga against a known-fresh git status snapshot -- callers
    *  that just pushed must pass the `refetch()` result, not the stale `gitStatusQuery.data`
    *  closure, since a push doesn't re-render before this function's continuation runs.
@@ -250,11 +286,12 @@ export function useWorkspaceMoveWorkflow({
       await invalidateWorkspaceCollections();
       setRunningPhase(null);
       setDone(true);
+      navigateAfterMove(result.destinationCloudWorkspaceId);
     } catch (caught) {
       setRunningPhase(null);
       setError(caught instanceof Error ? caught.message : String(caught));
     }
-  }, [buildDeps, invalidateWorkspaceCollections, repoRoot?.remoteOwner, repoRoot?.remoteRepoName, workspaceId, workspaceKind]);
+  }, [buildDeps, invalidateWorkspaceCollections, navigateAfterMove, repoRoot?.remoteOwner, repoRoot?.remoteRepoName, workspaceId, workspaceKind]);
 
   const startMove = useCallback(async () => {
     if (readiness.kind === "blocked") return;

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
@@ -3,8 +3,6 @@ import { useGitStatusQuery } from "@anyharness/sdk-react";
 import type { WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
 import { useRepositories } from "@proliferate/cloud-sdk-react";
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { APP_ROUTES } from "@/config/app-routes";
 import {
   useStartWorkspaceMove,
   WORKSPACE_MOVE_CLOUD_WORKSPACE_EXISTS_ERROR_CODE,
@@ -15,9 +13,8 @@ import { useWorkspaceMobilityPreflightQuery } from "@/hooks/access/anyharness/mo
 import { useCloudWorkspaceActions } from "@/hooks/cloud/workflows/use-cloud-workspace-actions";
 import { useWorkspaces } from "@/hooks/workspaces/cache/use-workspaces";
 import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
-import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { usePostMoveNavigation } from "@/hooks/workspaces/workflows/use-post-move-navigation";
 import { useWorkspacePublishWorkflow } from "@/hooks/workspaces/workflows/use-workspace-publish-workflow";
-import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { getDesktopInstallId } from "@/lib/access/tauri/desktop-install-id";
 import {
   destroyWorkspaceMobilitySource,
@@ -31,7 +28,6 @@ import {
   isMovePostCutover,
   isNonTerminalMovePhase,
   resolveHandoffMoveId,
-  resolvePostMoveNavigation,
   type MovePhase,
   type MoveReadiness,
 } from "@/lib/domain/workspaces/move/move-model";
@@ -46,7 +42,6 @@ import {
   type WorkspaceMoveWorkflowDeps,
 } from "@/lib/workflows/workspaces/run-workspace-move-workflow";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
-import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { rememberActiveWorkspaceMoveId, useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
 
 export interface UseWorkspaceMoveWorkflowOptions {
@@ -90,12 +85,6 @@ export function useWorkspaceMoveWorkflow({
   enabled,
 }: UseWorkspaceMoveWorkflowOptions) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const navigate = useNavigate();
-  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
-  const clearSelection = useSessionSelectionStore((state) => state.clearSelection);
-  const setSelectedLogicalWorkspaceId = useSessionSelectionStore(
-    (state) => state.setSelectedLogicalWorkspaceId,
-  );
   const storedMoveId = useWorkspaceMoveStore((state) =>
     workspaceId ? state.activeMoveIdByWorkspaceId[workspaceId] ?? null : null);
 
@@ -225,29 +214,7 @@ export function useWorkspaceMoveWorkflow({
     onPhaseChange: (phase) => setRunningPhase(phase),
   }), [phaseMutations, runtimeUrl, startMoveMutation, workspaceId]);
 
-  // A successful move may have just destroyed the source workspace (worktree source
-  // fate), leaving the shell pointed at a dead id. Mirror useWorkspaceRetireActions.
-  // markDone's clear-selection idiom and the collision panel's "Open the cloud
-  // workspace" navigation: if this move's source is still the on-screen workspace, hand
-  // off to the new cloud workspace (falling back to home when its id is unknown).
-  const navigateAfterMove = useCallback((destinationCloudWorkspaceId: string | null) => {
-    if (!workspaceId) return;
-    const navigation = resolvePostMoveNavigation({
-      movedWorkspaceId: workspaceId,
-      selectedWorkspaceId: useSessionSelectionStore.getState().selectedWorkspaceId,
-      destinationCloudWorkspaceId,
-    });
-    if (navigation.kind === "select_cloud") {
-      selectWorkspaceFromSurface(
-        cloudWorkspaceSyntheticId(navigation.cloudWorkspaceId),
-        "workspace-move-dialog",
-      );
-    } else if (navigation.kind === "home") {
-      clearSelection();
-      setSelectedLogicalWorkspaceId(null);
-      navigate(APP_ROUTES.home);
-    }
-  }, [clearSelection, navigate, selectWorkspaceFromSurface, setSelectedLogicalWorkspaceId, workspaceId]);
+  const navigateAfterMove = usePostMoveNavigation(workspaceId);
 
   /** Runs (or resumes) the saga against a known-fresh git status snapshot -- callers
    *  that just pushed must pass the `refetch()` result, not the stale `gitStatusQuery.data`

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-move-workflow.ts
@@ -26,6 +26,7 @@ import { resolveWorkspaceConnection } from "@/lib/access/anyharness/resolve-work
 import {
   isMovePostCutover,
   isNonTerminalMovePhase,
+  resolveHandoffMoveId,
   type MovePhase,
   type MoveReadiness,
 } from "@/lib/domain/workspaces/move/move-model";
@@ -83,13 +84,20 @@ export function useWorkspaceMoveWorkflow({
   enabled,
 }: UseWorkspaceMoveWorkflowOptions) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const trackedMoveId = useWorkspaceMoveStore((state) =>
+  const storedMoveId = useWorkspaceMoveStore((state) =>
     workspaceId ? state.activeMoveIdByWorkspaceId[workspaceId] ?? null : null);
 
   const gitStatusQuery = useGitStatusQuery({ workspaceId, enabled });
   const preflightQuery = useWorkspaceMobilityPreflightQuery(workspaceId, { enabled });
   const repositoriesQuery = useRepositories(enabled);
   const { data: workspaceCollections } = useWorkspaces({ enabled });
+
+  // Falls back to the source's own frozen runtime-state when this app session never
+  // learned the move id (or forgot it across a restart) -- see resolveHandoffMoveId's
+  // docstring and the locked "resume/abandon" decision: reopening the dialog after
+  // Desktop was killed mid-move must still offer resume/abandon, not silently drop
+  // into a fresh "readiness" check against a still-frozen source.
+  const trackedMoveId = storedMoveId ?? resolveHandoffMoveId(preflightQuery.data?.runtimeState);
 
   const [runningPhase, setRunningPhase] = useState<MovePhase | "running" | null>(null);
   const activeMoveQuery = useWorkspaceMove(trackedMoveId, {

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/infra/measurement/latency-flow";
 import { useWorkspaceRetireActions } from "@/hooks/workspaces/workflows/use-workspace-retire-actions";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { useWorkspaceMoveStore } from "@/stores/workspaces/workspace-move-store";
 
 export function useWorkspaceSidebarActions() {
   const { openWorkspaceSession } = useWorkspaceActivationWorkflow();
@@ -33,6 +34,7 @@ export function useWorkspaceSidebarActions() {
     isCreatingCloudWorkspace,
   } = useCreateCloudWorkspace();
   const openAddRepoFlow = useAddRepoFlowStore((state) => state.openFlow);
+  const openMoveDialog = useWorkspaceMoveStore((state) => state.openMoveDialog);
   const showToast = useToastStore((state) => state.show);
   const { markDone, retryCleanup } = useWorkspaceRetireActions();
   const { openExternal } = useTauriShellActions();
@@ -40,6 +42,10 @@ export function useWorkspaceSidebarActions() {
   const handleAddRepo = useCallback(() => {
     openAddRepoFlow();
   }, [openAddRepoFlow]);
+
+  const handleOpenMoveToCloud = useCallback((workspaceId: string) => {
+    openMoveDialog(workspaceId);
+  }, [openMoveDialog]);
 
   const handleGoHome = useCallback(() => {
     goToTopLevelRoute(APP_ROUTES.home);
@@ -199,6 +205,7 @@ export function useWorkspaceSidebarActions() {
     handleCreateLocalWorkspace,
     handleCreateWorktreeWorkspace,
     handleCreateCloudWorkspace,
+    handleOpenMoveToCloud,
   };
 }
 

--- a/apps/desktop/src/lib/access/anyharness/mobility.ts
+++ b/apps/desktop/src/lib/access/anyharness/mobility.ts
@@ -1,0 +1,76 @@
+import type {
+  DestroyWorkspaceMobilitySourceRequest,
+  DestroyWorkspaceMobilitySourceResponse,
+  ExportWorkspaceMobilityArchiveRequest,
+  WorkspaceMobilityArchive,
+  WorkspaceMobilityPreflightResponse,
+  WorkspaceMobilityRuntimeState,
+} from "@anyharness/sdk";
+import { getAnyHarnessClient, type AnyHarnessClientConnection } from "@anyharness/sdk-react";
+
+// Raw AnyHarness mobility calls (preflight / freeze-unfreeze / export / destroy-source)
+// against a resolved runtime connection -- the engine surface the workspace_move
+// workflow drives on each side (specs/tbd/workspace-migration-v2.md section 2.3/2.4).
+// Desktop never calls the install endpoint from this flow: for local->cloud the server
+// forwards the exported archive to the destination sandbox's own AnyHarness install
+// route, and desktop only needs preflight/freeze/export/destroy-source here.
+
+export function getWorkspaceMobilityPreflight(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+): Promise<WorkspaceMobilityPreflightResponse> {
+  return getAnyHarnessClient(connection).mobility.preflight(workspaceId);
+}
+
+export function freezeWorkspaceForHandoff(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+  handoffOpId: string,
+): Promise<WorkspaceMobilityRuntimeState> {
+  return getAnyHarnessClient(connection).mobility.updateRuntimeState(workspaceId, {
+    mode: "frozen_for_handoff",
+    handoffOpId,
+  });
+}
+
+/** Unfreezes the source back to normal -- used on pre-cutover failure/abandon so the
+ *  source workspace isn't left stuck read-only. */
+export function unfreezeWorkspace(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+): Promise<WorkspaceMobilityRuntimeState> {
+  return getAnyHarnessClient(connection).mobility.updateRuntimeState(workspaceId, {
+    mode: "normal",
+    handoffOpId: null,
+  });
+}
+
+/** Post-cutover source-fate step for a plain local-directory workspace (source-fate
+ *  decision: mark remote_owned, never delete user files). */
+export function markWorkspaceRemoteOwned(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+): Promise<WorkspaceMobilityRuntimeState> {
+  return getAnyHarnessClient(connection).mobility.updateRuntimeState(workspaceId, {
+    mode: "remote_owned",
+    handoffOpId: null,
+  });
+}
+
+export function exportWorkspaceMobilityArchive(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+  input: ExportWorkspaceMobilityArchiveRequest,
+): Promise<WorkspaceMobilityArchive> {
+  return getAnyHarnessClient(connection).mobility.exportArchive(workspaceId, input);
+}
+
+/** Post-cutover source-fate step for a managed worktree (source-fate decision: destroy
+ *  the worktree). */
+export function destroyWorkspaceMobilitySource(
+  connection: AnyHarnessClientConnection,
+  workspaceId: string,
+  input?: DestroyWorkspaceMobilitySourceRequest,
+): Promise<DestroyWorkspaceMobilitySourceResponse> {
+  return getAnyHarnessClient(connection).mobility.destroySource(workspaceId, input);
+}

--- a/apps/desktop/src/lib/access/anyharness/runtime-target.ts
+++ b/apps/desktop/src/lib/access/anyharness/runtime-target.ts
@@ -7,13 +7,14 @@ import { getSshDirectTargetProfile } from "@/lib/access/tauri/ssh-target-profile
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { resolveCloudWorkspaceStatus } from "@/lib/domain/workspaces/cloud/cloud-workspace-status";
+import type { WorkspaceRuntimeLocation } from "@/lib/domain/workspaces/move/move-location-chip";
 
 type CloudWorkspaceCommandMetadata = CloudWorkspaceDetail & {
   targetId?: string | null;
 };
 
 export interface RuntimeTarget {
-  location: "local" | "cloud" | "target";
+  location: WorkspaceRuntimeLocation;
   baseUrl: string;
   authToken?: string;
   webSocketAuthTransport?: TerminalWebSocketAuthTransport;

--- a/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceLocationChip } from "./move-location-chip";
+
+describe("resolveWorkspaceLocationChip", () => {
+  it("returns null with no workspace selected", () => {
+    expect(resolveWorkspaceLocationChip(null, false)).toBeNull();
+  });
+
+  it("is clickable for a local workspace", () => {
+    expect(resolveWorkspaceLocationChip("workspace-1", false)).toEqual({
+      location: "local",
+      label: "This Mac",
+      clickable: true,
+    });
+  });
+
+  it("is a read-only badge for a cloud workspace", () => {
+    expect(resolveWorkspaceLocationChip("cloud:cloud-ws-1", true)).toEqual({
+      location: "cloud",
+      label: "Cloud",
+      clickable: false,
+    });
+  });
+
+  it("is a read-only badge for an SSH target workspace", () => {
+    expect(resolveWorkspaceLocationChip("target:target-1:ws-1", false)).toEqual({
+      location: "target",
+      label: "Remote target",
+      clickable: false,
+    });
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.ts
@@ -1,8 +1,12 @@
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
-import type { RuntimeTarget } from "@/lib/access/anyharness/runtime-target";
+
+/** The three-way location split a workspace id resolves to. Domain-owned so pure
+ *  modules can classify without reaching into lib/access; the access layer's
+ *  `RuntimeTarget.location` references this same union. */
+export type WorkspaceRuntimeLocation = "local" | "cloud" | "target";
 
 export interface WorkspaceLocationChipView {
-  location: RuntimeTarget["location"];
+  location: WorkspaceRuntimeLocation;
   label: string;
   /** Only local workspaces can open the move-to-cloud dialog in this PR (local->cloud
    *  only, spec section 0's "local<->E2B only" v1 gate); cloud/target chips render as a
@@ -10,7 +14,7 @@ export interface WorkspaceLocationChipView {
   clickable: boolean;
 }
 
-const LOCATION_LABELS: Record<RuntimeTarget["location"], string> = {
+const LOCATION_LABELS: Record<WorkspaceRuntimeLocation, string> = {
   local: "This Mac",
   cloud: "Cloud",
   target: "Remote target",
@@ -26,7 +30,7 @@ export function resolveWorkspaceLocationChip(
   isCloudWorkspaceSelected: boolean,
 ): WorkspaceLocationChipView | null {
   if (!workspaceId) return null;
-  const location: RuntimeTarget["location"] = isCloudWorkspaceSelected
+  const location: WorkspaceRuntimeLocation = isCloudWorkspaceSelected
     ? "cloud"
     : parseTargetWorkspaceSyntheticId(workspaceId)
       ? "target"

--- a/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-location-chip.ts
@@ -1,0 +1,39 @@
+import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
+import type { RuntimeTarget } from "@/lib/access/anyharness/runtime-target";
+
+export interface WorkspaceLocationChipView {
+  location: RuntimeTarget["location"];
+  label: string;
+  /** Only local workspaces can open the move-to-cloud dialog in this PR (local->cloud
+   *  only, spec section 0's "local<->E2B only" v1 gate); cloud/target chips render as a
+   *  read-only badge until the mirror direction (PR D) and SSH targets (M3) land. */
+  clickable: boolean;
+}
+
+const LOCATION_LABELS: Record<RuntimeTarget["location"], string> = {
+  local: "This Mac",
+  cloud: "Cloud",
+  target: "Remote target",
+};
+
+/**
+ * Cheap, synchronous classification of a workspace's location from its id shape alone
+ * -- the same three-way split `resolveRuntimeTargetForWorkspace` makes, without that
+ * function's async cloud-workspace-detail fetch (unneeded just to label a chip).
+ */
+export function resolveWorkspaceLocationChip(
+  workspaceId: string | null,
+  isCloudWorkspaceSelected: boolean,
+): WorkspaceLocationChipView | null {
+  if (!workspaceId) return null;
+  const location: RuntimeTarget["location"] = isCloudWorkspaceSelected
+    ? "cloud"
+    : parseTargetWorkspaceSyntheticId(workspaceId)
+      ? "target"
+      : "local";
+  return {
+    location,
+    label: LOCATION_LABELS[location],
+    clickable: location === "local",
+  };
+}

--- a/apps/desktop/src/lib/domain/workspaces/move/move-model.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-model.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveHandoffMoveId, sourceFateForWorkspaceKind } from "./move-model";
+
+describe("resolveHandoffMoveId", () => {
+  it("returns null when there is no runtime state", () => {
+    expect(resolveHandoffMoveId(null)).toBeNull();
+    expect(resolveHandoffMoveId(undefined)).toBeNull();
+  });
+
+  it("returns null for a workspace in normal mode", () => {
+    expect(resolveHandoffMoveId({ mode: "normal", handoffOpId: null })).toBeNull();
+  });
+
+  it("returns null for a remote_owned workspace (move already completed)", () => {
+    expect(resolveHandoffMoveId({ mode: "remote_owned", handoffOpId: null })).toBeNull();
+  });
+
+  it("recovers the move id from a frozen-for-handoff runtime state -- the 'Desktop was killed mid-move' recovery path", () => {
+    expect(resolveHandoffMoveId({ mode: "frozen_for_handoff", handoffOpId: "move-123" })).toBe(
+      "move-123",
+    );
+  });
+
+  it("returns null if frozen but the engine never recorded a handoff id", () => {
+    expect(resolveHandoffMoveId({ mode: "frozen_for_handoff", handoffOpId: null })).toBeNull();
+  });
+});
+
+describe("sourceFateForWorkspaceKind", () => {
+  it("destroys managed worktrees", () => {
+    expect(sourceFateForWorkspaceKind("worktree")).toBe("destroy");
+  });
+
+  it("only marks plain local-directory workspaces remote_owned", () => {
+    expect(sourceFateForWorkspaceKind("local")).toBe("mark_remote_owned");
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/move/move-model.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-model.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveHandoffMoveId, sourceFateForWorkspaceKind } from "./move-model";
+import {
+  resolveHandoffMoveId,
+  resolvePostMoveNavigation,
+  sourceFateForWorkspaceKind,
+} from "./move-model";
 
 describe("resolveHandoffMoveId", () => {
   it("returns null when there is no runtime state", () => {
@@ -23,6 +27,40 @@ describe("resolveHandoffMoveId", () => {
 
   it("returns null if frozen but the engine never recorded a handoff id", () => {
     expect(resolveHandoffMoveId({ mode: "frozen_for_handoff", handoffOpId: null })).toBeNull();
+  });
+});
+
+describe("resolvePostMoveNavigation", () => {
+  it("does nothing when the moved workspace is not the one on screen", () => {
+    expect(resolvePostMoveNavigation({
+      movedWorkspaceId: "ws-1",
+      selectedWorkspaceId: "ws-2",
+      destinationCloudWorkspaceId: "cloud-ws-1",
+    })).toEqual({ kind: "none" });
+  });
+
+  it("does nothing when nothing is selected", () => {
+    expect(resolvePostMoveNavigation({
+      movedWorkspaceId: "ws-1",
+      selectedWorkspaceId: null,
+      destinationCloudWorkspaceId: "cloud-ws-1",
+    })).toEqual({ kind: "none" });
+  });
+
+  it("hands off to the new cloud workspace when the moved workspace was on screen", () => {
+    expect(resolvePostMoveNavigation({
+      movedWorkspaceId: "ws-1",
+      selectedWorkspaceId: "ws-1",
+      destinationCloudWorkspaceId: "cloud-ws-1",
+    })).toEqual({ kind: "select_cloud", cloudWorkspaceId: "cloud-ws-1" });
+  });
+
+  it("falls back to home when the on-screen source moved but its destination id is unknown", () => {
+    expect(resolvePostMoveNavigation({
+      movedWorkspaceId: "ws-1",
+      selectedWorkspaceId: "ws-1",
+      destinationCloudWorkspaceId: null,
+    })).toEqual({ kind: "home" });
   });
 });
 

--- a/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
@@ -72,6 +72,30 @@ export function resolveHandoffMoveId(
   return runtimeState.handoffOpId ?? null;
 }
 
+/** Where the shell should point once a local->cloud move settles successfully. Only
+ *  redirects when the moved workspace is the one currently on screen -- a move kicked
+ *  off for a different workspace (e.g. from the sidebar) must never yank the user away
+ *  from what they're looking at. When the moved workspace *was* on screen the source may
+ *  have just been destroyed (worktree source fate, sourceFateForWorkspaceKind), so we
+ *  hand off to the freshly created cloud workspace, falling back to home only when its
+ *  id is somehow unknown (e.g. resuming an already-completed move). */
+export type PostMoveNavigation =
+  | { kind: "select_cloud"; cloudWorkspaceId: string }
+  | { kind: "home" }
+  | { kind: "none" };
+
+export function resolvePostMoveNavigation(input: {
+  movedWorkspaceId: string;
+  selectedWorkspaceId: string | null;
+  destinationCloudWorkspaceId: string | null;
+}): PostMoveNavigation {
+  if (input.selectedWorkspaceId !== input.movedWorkspaceId) return { kind: "none" };
+  if (input.destinationCloudWorkspaceId) {
+    return { kind: "select_cloud", cloudWorkspaceId: input.destinationCloudWorkspaceId };
+  }
+  return { kind: "home" };
+}
+
 // ---- Readiness (see move-readiness.ts for the resolver) ----
 
 export type MoveReadinessKind = "safe" | "push_required" | "prepare_required" | "blocked";

--- a/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
@@ -1,0 +1,95 @@
+import type { WorkspaceKind } from "@anyharness/sdk";
+import type {
+  WorkspaceMoveCanonicalSide,
+  WorkspaceMovePhase,
+  WorkspaceMoveRuntimeKind,
+} from "@proliferate/cloud-sdk";
+
+// Domain vocabulary for the workspace_move stack (specs/tbd/workspace-migration-v2.md
+// section 2.2/2.3). Re-exported under desktop's own domain names so callers depend on
+// this module rather than reaching into the cloud SDK's wire types directly.
+export type MovePhase = WorkspaceMovePhase;
+export type MoveCanonicalSide = WorkspaceMoveCanonicalSide;
+export type MoveRuntimeKind = WorkspaceMoveRuntimeKind;
+
+/** Phases in which the server saga is still actively driving the move. */
+export const ACTIVE_MOVE_PHASES: ReadonlySet<MovePhase> = new Set([
+  "started",
+  "destination_ready",
+  "installed",
+]);
+
+/** Phases that will never change again. */
+export const TERMINAL_MOVE_PHASES: ReadonlySet<MovePhase> = new Set([
+  "completed",
+  "failed",
+]);
+
+export function isNonTerminalMovePhase(phase: MovePhase): boolean {
+  return !TERMINAL_MOVE_PHASES.has(phase);
+}
+
+/** True once cutover has flipped canonical_side to the destination -- past this point,
+ *  failure semantics change from "unfreeze + fail" to "cleanup retries only" (spec
+ *  section 2.3, and the locked failure-semantics decision). */
+export function isMovePostCutover(phase: MovePhase): boolean {
+  return phase === "cutover" || phase === "completed";
+}
+
+/** One side of a move, resolved to the concrete runtime identity Desktop needs to drive
+ *  it. Mirrors the cloud SDK's `WorkspaceMoveEndpointRef` wire shape (kept separate so
+ *  domain code doesn't need to know which fields are meaningful for which `kind`). */
+export type MoveRuntimeRef =
+  | { kind: "local"; desktopInstallId: string; anyharnessWorkspaceId: string }
+  | { kind: "cloud"; cloudWorkspaceId?: string | null; anyharnessWorkspaceId?: string | null }
+  | { kind: "ssh"; targetId: string; anyharnessWorkspaceId: string };
+
+export type MoveSourceFate = "destroy" | "mark_remote_owned";
+
+/**
+ * Source-fate policy after cutover (locked product decision, "Source fate after
+ * cutover"): a managed worktree is destroyed; a workspace on the user's own plain
+ * directory is only marked `remote_owned` -- files on disk are never touched.
+ */
+export function sourceFateForWorkspaceKind(workspaceKind: WorkspaceKind): MoveSourceFate {
+  return workspaceKind === "worktree" ? "destroy" : "mark_remote_owned";
+}
+
+// ---- Readiness (see move-readiness.ts for the resolver) ----
+
+export type MoveReadinessKind = "safe" | "push_required" | "prepare_required" | "blocked";
+
+export interface MoveReadinessCopy {
+  headline: string;
+  body: string;
+  primaryActionLabel: string;
+}
+
+export interface MoveReadinessSafe {
+  kind: "safe";
+  copy: MoveReadinessCopy;
+}
+
+export interface MoveReadinessPushRequired {
+  kind: "push_required";
+  copy: MoveReadinessCopy;
+}
+
+export interface MoveReadinessPrepareRequired {
+  kind: "prepare_required";
+  copy: MoveReadinessCopy;
+  /** Whether the git-prep dialog should default "Include unstaged" to on. */
+  includeUnstagedDefault: boolean;
+}
+
+export interface MoveReadinessBlocked {
+  kind: "blocked";
+  copy: MoveReadinessCopy;
+  blockerCode: string;
+}
+
+export type MoveReadiness =
+  | MoveReadinessSafe
+  | MoveReadinessPushRequired
+  | MoveReadinessPrepareRequired
+  | MoveReadinessBlocked;

--- a/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-model.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceKind } from "@anyharness/sdk";
+import type { WorkspaceKind, WorkspaceMobilityRuntimeState } from "@anyharness/sdk";
 import type {
   WorkspaceMoveCanonicalSide,
   WorkspaceMovePhase,
@@ -53,6 +53,23 @@ export type MoveSourceFate = "destroy" | "mark_remote_owned";
  */
 export function sourceFateForWorkspaceKind(workspaceKind: WorkspaceKind): MoveSourceFate {
   return workspaceKind === "worktree" ? "destroy" : "mark_remote_owned";
+}
+
+/**
+ * Recovers a stale move id from the source workspace's own runtime-state when this
+ * app session's in-memory record of it (`workspace-move-store.ts`) has been lost --
+ * e.g. Desktop was killed mid-move and restarted. Mirrors spec section 2.2's recovery
+ * story: "a stale non-terminal row + engine preflight tells Desktop exactly what to
+ * offer". The source is only ever frozen (`{mode: frozen_for_handoff, handoffOpId}`)
+ * for the duration of its own in-flight move (step 3 of section 2.3's local->cloud
+ * flow, cleared by cutover cleanup), so a frozen runtime-state's `handoffOpId` is
+ * always that move's id.
+ */
+export function resolveHandoffMoveId(
+  runtimeState: Pick<WorkspaceMobilityRuntimeState, "mode" | "handoffOpId"> | null | undefined,
+): string | null {
+  if (!runtimeState || runtimeState.mode !== "frozen_for_handoff") return null;
+  return runtimeState.handoffOpId ?? null;
 }
 
 // ---- Readiness (see move-readiness.ts for the resolver) ----

--- a/apps/desktop/src/lib/domain/workspaces/move/move-progress.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-progress.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveMoveProgressSteps } from "./move-progress";
+
+describe("resolveMoveProgressSteps", () => {
+  it("marks prepare active and the rest pending while running/started", () => {
+    for (const phase of ["running", "started"] as const) {
+      const steps = resolveMoveProgressSteps(phase);
+      expect(steps.map((step) => step.status)).toEqual(["active", "pending", "pending", "pending"]);
+    }
+  });
+
+  it("marks prepare done and transfer active at destination_ready", () => {
+    const steps = resolveMoveProgressSteps("destination_ready");
+    expect(steps.map((step) => step.status)).toEqual(["done", "active", "pending", "pending"]);
+  });
+
+  it("marks switch_over active once installed", () => {
+    const steps = resolveMoveProgressSteps("installed");
+    expect(steps.map((step) => step.status)).toEqual(["done", "done", "active", "pending"]);
+  });
+
+  it("marks clean_up active at cutover", () => {
+    const steps = resolveMoveProgressSteps("cutover");
+    expect(steps.map((step) => step.status)).toEqual(["done", "done", "done", "active"]);
+  });
+
+  it("marks every step done once completed", () => {
+    const steps = resolveMoveProgressSteps("completed");
+    expect(steps.map((step) => step.status)).toEqual(["done", "done", "done", "done"]);
+  });
+
+  it("keeps the step labels stable and ordered", () => {
+    const steps = resolveMoveProgressSteps("running");
+    expect(steps.map((step) => step.label)).toEqual([
+      "Prepare",
+      "Transfer sessions",
+      "Switch over",
+      "Clean up",
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/move/move-progress.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-progress.ts
@@ -1,0 +1,51 @@
+import type { MovePhase } from "@/lib/domain/workspaces/move/move-model";
+
+export type MoveProgressStepStatus = "done" | "active" | "pending";
+
+export interface MoveProgressStep {
+  key: "prepare" | "transfer" | "switch_over" | "clean_up";
+  label: string;
+  status: MoveProgressStepStatus;
+}
+
+const STEP_ORDER: MoveProgressStep["key"][] = ["prepare", "transfer", "switch_over", "clean_up"];
+const STEP_LABELS: Record<MoveProgressStep["key"], string> = {
+  prepare: "Prepare",
+  transfer: "Transfer sessions",
+  switch_over: "Switch over",
+  clean_up: "Clean up",
+};
+
+/**
+ * Maps the saga's server-confirmed phase (plus the client-only "running" state fired
+ * before the first phase change lands) onto the four-step progress modal from the
+ * locked UI decision (spec section 2.6): Prepare -> Transfer sessions -> Switch over ->
+ * Clean up. `resume.phase` from a resumed move maps the same way, since resuming just
+ * re-enters this same phase sequence.
+ */
+export function resolveMoveProgressSteps(phase: MovePhase | "running"): MoveProgressStep[] {
+  const activeIndex = activeStepIndex(phase);
+  return STEP_ORDER.map((key, index) => ({
+    key,
+    label: STEP_LABELS[key],
+    status: index < activeIndex ? "done" : index === activeIndex ? "active" : "pending",
+  }));
+}
+
+function activeStepIndex(phase: MovePhase | "running"): number {
+  switch (phase) {
+    case "running":
+    case "started":
+    case "failed":
+      return 0;
+    case "destination_ready":
+      return 1;
+    case "installed":
+      return 2;
+    case "cutover":
+      return 3;
+    case "completed":
+      // One past the last step -- every step renders "done".
+      return STEP_ORDER.length;
+  }
+}

--- a/apps/desktop/src/lib/domain/workspaces/move/move-readiness.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-readiness.test.ts
@@ -1,0 +1,310 @@
+import type { GitStatusSnapshot, WorkspaceMobilityPreflightResponse } from "@anyharness/sdk";
+import type { WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
+import { describe, expect, it } from "vitest";
+import { resolveMoveReadiness, type MoveDestinationState } from "./move-readiness";
+
+describe("resolveMoveReadiness", () => {
+  it("resolves safe for a clean, published, up-to-date branch", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus(),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("safe");
+  });
+
+  it("resolves push_required when the branch is ahead of upstream", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ ahead: 2 }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("push_required");
+  });
+
+  it("resolves push_required when the branch has no upstream", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ upstreamBranch: null }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("push_required");
+  });
+
+  it("resolves prepare_required with includeUnstagedDefault=true for a dirty tree", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ clean: false }),
+      sourcePreflight: preflight({ canMove: false, blockers: [
+        { code: "workspace_dirty", message: "Workspace must be committed and clean before moving" },
+      ] }),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("prepare_required");
+    if (readiness.kind === "prepare_required") {
+      expect(readiness.includeUnstagedDefault).toBe(true);
+    }
+  });
+
+  it("does not treat a dirty-only preflight (workspace_dirty) as a strict blocker", () => {
+    // workspace_dirty always makes canMove=false on the engine (dirty must always be
+    // resolved before the archive can be exported), but it must downgrade to
+    // prepare_required rather than block outright -- that's the whole point of git prep.
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ clean: false }),
+      sourcePreflight: preflight({
+        canMove: false,
+        blockers: [{ code: "workspace_dirty", message: "dirty" }],
+      }),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("prepare_required");
+  });
+
+  it.each([
+    ["session_running", "A session is running"],
+    ["session_awaiting_interaction", "A session needs your input"],
+    ["pending_prompt", "A session needs your input"],
+  ] as const)("blocks on strict preflight blocker %s", (code, headline) => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus(),
+      sourcePreflight: preflight({
+        canMove: false,
+        blockers: [{ code, message: "blocked" }],
+      }),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe(code);
+      expect(readiness.copy.headline).toBe(headline);
+    }
+  });
+
+  it("blocks on a detached HEAD", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ detached: true }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("workspace_detached");
+    }
+  });
+
+  it("blocks on merge conflicts", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ conflicted: true }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("workspace_conflicted");
+    }
+  });
+
+  it("blocks on an in-progress git operation", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ operation: "rebase" }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("git_operation_in_progress");
+    }
+  });
+
+  it("blocks when behind upstream", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ behind: 1 }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("behind_upstream");
+    }
+  });
+
+  it("blocks when an active non-terminal move already exists", () => {
+    for (const phase of ["started", "destination_ready", "installed", "cutover"] as const) {
+      const readiness = resolveMoveReadiness({
+        gitStatus: gitStatus(),
+        sourcePreflight: preflight(),
+        destinationState: null,
+        activeMove: move({ phase }),
+      });
+      expect(readiness.kind).toBe("blocked");
+      if (readiness.kind === "blocked") {
+        expect(readiness.blockerCode).toBe("active_move");
+      }
+    }
+  });
+
+  it("ignores a terminal (completed/failed) prior move", () => {
+    for (const phase of ["completed", "failed"] as const) {
+      const readiness = resolveMoveReadiness({
+        gitStatus: gitStatus(),
+        sourcePreflight: preflight(),
+        destinationState: null,
+        activeMove: move({ phase }),
+      });
+      expect(readiness.kind).not.toBe("blocked");
+    }
+  });
+
+  it("active move takes precedence over other blockers", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus({ detached: true }),
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: move({ phase: "installed" }),
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("active_move");
+    }
+  });
+
+  it("blocks (status_loading) while git status hasn't loaded yet", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: null,
+      sourcePreflight: preflight(),
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("status_loading");
+    }
+  });
+
+  it("blocks (status_loading) while source preflight hasn't loaded yet", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus(),
+      sourcePreflight: null,
+      destinationState: null,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("status_loading");
+    }
+  });
+
+  it("blocks when the destination isn't ready", () => {
+    const destinationState: MoveDestinationState = {
+      ready: false,
+      blockerCode: "destination_head_mismatch",
+      blockerMessage: "The destination cannot check out the exact commit yet.",
+    };
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus(),
+      sourcePreflight: preflight(),
+      destinationState,
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("blocked");
+    if (readiness.kind === "blocked") {
+      expect(readiness.blockerCode).toBe("destination_head_mismatch");
+      expect(readiness.copy.body).toBe(destinationState.blockerMessage);
+    }
+  });
+
+  it("does not block when the destination reports ready", () => {
+    const readiness = resolveMoveReadiness({
+      gitStatus: gitStatus(),
+      sourcePreflight: preflight(),
+      destinationState: { ready: true, blockerCode: "", blockerMessage: "" },
+      activeMove: null,
+    });
+    expect(readiness.kind).toBe("safe");
+  });
+});
+
+function gitStatus(overrides: Partial<GitStatusSnapshot> = {}): GitStatusSnapshot {
+  return {
+    actions: {
+      canCommit: true,
+      canCreateBranchWorkspace: true,
+      canCreateDraftPullRequest: true,
+      canCreatePullRequest: true,
+      canPush: true,
+      pushLabel: "Push",
+      reasonIfBlocked: null,
+    },
+    ahead: 0,
+    behind: 0,
+    clean: true,
+    conflicted: false,
+    currentBranch: "feature/move",
+    detached: false,
+    files: [],
+    headOid: "abc123",
+    operation: "none",
+    repoRootPath: "/repo",
+    suggestedBaseBranch: null,
+    summary: { additions: 0, changedFiles: 0, conflictedFiles: 0, deletions: 0, includedFiles: 0 },
+    upstreamBranch: "origin/feature/move",
+    workspaceId: "workspace-1",
+    workspacePath: "/repo/worktree",
+    ...overrides,
+  };
+}
+
+function preflight(
+  overrides: Partial<WorkspaceMobilityPreflightResponse> = {},
+): WorkspaceMobilityPreflightResponse {
+  return {
+    canMove: true,
+    blockers: [],
+    warnings: [],
+    branchName: "feature/move",
+    baseCommitSha: "abc123",
+    archiveEstimatedBytes: 1024,
+    runtimeState: {
+      mode: "normal",
+      handoffOpId: null,
+      updatedAt: "2026-07-02T00:00:00Z",
+      workspaceId: "workspace-1",
+    },
+    sessions: [],
+    workspaceId: "workspace-1",
+    ...overrides,
+  };
+}
+
+function move(overrides: Partial<WorkspaceMoveResponse> = {}): WorkspaceMoveResponse {
+  return {
+    id: "move-1",
+    repoConfigId: "repo-1",
+    branch: "feature/move",
+    sourceKind: "local",
+    destinationKind: "cloud",
+    sourceRef: {},
+    destinationRef: {},
+    baseCommitSha: "abc123",
+    phase: "started",
+    canonicalSide: "source",
+    failureCode: null,
+    failureDetail: null,
+    idempotencyKey: "idem-1",
+    createdAt: "2026-07-02T00:00:00Z",
+    updatedAt: "2026-07-02T00:00:00Z",
+    cutoverAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/lib/domain/workspaces/move/move-readiness.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-readiness.ts
@@ -1,0 +1,175 @@
+import type { GitStatusSnapshot, WorkspaceMobilityPreflightResponse } from "@anyharness/sdk";
+import type { WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
+import {
+  isNonTerminalMovePhase,
+  type MoveReadiness,
+  type MoveReadinessCopy,
+} from "@/lib/domain/workspaces/move/move-model";
+
+/**
+ * AnyHarness mobility preflight blocker codes (anyharness-lib
+ * domains/mobility/service.rs::preflight_workspace) that must strictly block a move --
+ * the locked "Strict blockers" list: active turn / pending interaction. Everything else
+ * the engine can return (workspace_dirty, review_active, unsupported_session, ...) is
+ * either handled via the git-status fields below (dirty -> prepare_required) or is
+ * out of scope for this pure gate in v1 and stays informational on the raw preflight
+ * response for the UI to surface separately.
+ */
+const STRICT_PREFLIGHT_BLOCKER_CODES = new Set([
+  "session_running",
+  "session_awaiting_interaction",
+  "pending_prompt",
+]);
+
+const BLOCKER_COPY: Record<string, MoveReadinessCopy> = {
+  active_move: {
+    headline: "A move is already in progress",
+    body: "Resume or abandon the existing move before starting a new one.",
+    primaryActionLabel: "View move",
+  },
+  status_loading: {
+    headline: "Checking workspace status…",
+    body: "Hold on while we check whether this workspace is ready to move.",
+    primaryActionLabel: "Checking…",
+  },
+  session_running: {
+    headline: "A session is running",
+    body: "Wait for the active turn to finish before moving this workspace.",
+    primaryActionLabel: "Got it",
+  },
+  session_awaiting_interaction: {
+    headline: "A session needs your input",
+    body: "Answer the pending prompt before moving this workspace.",
+    primaryActionLabel: "Got it",
+  },
+  pending_prompt: {
+    headline: "A session needs your input",
+    body: "Answer the pending prompt before moving this workspace.",
+    primaryActionLabel: "Got it",
+  },
+  workspace_detached: {
+    headline: "Checked out at a detached commit",
+    body: "Switch to a branch before moving this workspace.",
+    primaryActionLabel: "Got it",
+  },
+  workspace_conflicted: {
+    headline: "Resolve conflicts first",
+    body: "This workspace has unresolved merge conflicts.",
+    primaryActionLabel: "Got it",
+  },
+  git_operation_in_progress: {
+    headline: "A Git operation is in progress",
+    body: "Finish or abort the current merge, rebase, or cherry-pick before moving.",
+    primaryActionLabel: "Got it",
+  },
+  behind_upstream: {
+    headline: "Sync this branch first",
+    body: "Pull the latest changes before moving this workspace.",
+    primaryActionLabel: "Open Git tools",
+  },
+};
+
+const SAFE_COPY: MoveReadinessCopy = {
+  headline: "Ready to move",
+  body: "This workspace is clean and published — it can move right away.",
+  primaryActionLabel: "Move to cloud",
+};
+
+const PUSH_REQUIRED_COPY: MoveReadinessCopy = {
+  headline: "Push before moving",
+  body: "This branch has local commits that haven't been pushed yet.",
+  primaryActionLabel: "Push and move",
+};
+
+const PREPARE_REQUIRED_COPY: MoveReadinessCopy = {
+  headline: "Commit and push before moving",
+  body: "This workspace has uncommitted changes. Commit and push them, then move.",
+  primaryActionLabel: "Commit, push, and move",
+};
+
+/**
+ * Destination-side readiness, checked before source freeze (durability plan's
+ * "Destination not at requested commit" case). Always `null` for a fresh local->cloud
+ * move -- the server materializes the destination as part of `start`, so there is
+ * nothing to check yet. Meaningful for the cloud->local mirror (PR D) when a prior
+ * round-trip's original worktree needs to be re-adopted.
+ */
+export interface MoveDestinationState {
+  ready: boolean;
+  blockerCode: string;
+  blockerMessage: string;
+}
+
+export interface MoveReadinessInput {
+  gitStatus: GitStatusSnapshot | null;
+  sourcePreflight: WorkspaceMobilityPreflightResponse | null;
+  destinationState: MoveDestinationState | null;
+  /** The identity's current non-terminal move, if any (spec section 2.2's partial-unique
+   *  "one non-terminal move per (user, repo, branch)" invariant, mirrored client-side). */
+  activeMove: WorkspaceMoveResponse | null;
+}
+
+/**
+ * Pure resolver: {gitStatus, sourcePreflight, destinationState, activeMove} -> exactly
+ * one of safe | push_required | prepare_required | blocked, with copy + primary action +
+ * blocker code (locked "Readiness" decision). Strict blockers: active turn / pending
+ * interaction (from preflight), detached head, conflicts, git op in progress, behind>0,
+ * active non-terminal move.
+ */
+export function resolveMoveReadiness(input: MoveReadinessInput): MoveReadiness {
+  if (input.activeMove && isNonTerminalMovePhase(input.activeMove.phase)) {
+    return blocked("active_move");
+  }
+
+  if (!input.gitStatus || !input.sourcePreflight) {
+    return blocked("status_loading");
+  }
+
+  const strictPreflightBlocker = input.sourcePreflight.blockers?.find((blocker) =>
+    STRICT_PREFLIGHT_BLOCKER_CODES.has(blocker.code));
+  if (strictPreflightBlocker) {
+    return blocked(strictPreflightBlocker.code, strictPreflightBlocker.message);
+  }
+
+  if (input.gitStatus.detached) {
+    return blocked("workspace_detached");
+  }
+  if (input.gitStatus.conflicted) {
+    return blocked("workspace_conflicted");
+  }
+  if (input.gitStatus.operation !== "none") {
+    return blocked("git_operation_in_progress");
+  }
+  if (input.gitStatus.behind > 0) {
+    return blocked("behind_upstream");
+  }
+
+  if (input.destinationState && !input.destinationState.ready) {
+    return blocked(input.destinationState.blockerCode, input.destinationState.blockerMessage);
+  }
+
+  if (!input.gitStatus.clean) {
+    return {
+      kind: "prepare_required",
+      copy: PREPARE_REQUIRED_COPY,
+      includeUnstagedDefault: true,
+    };
+  }
+
+  const needsPush = input.gitStatus.ahead > 0 || !input.gitStatus.upstreamBranch;
+  if (needsPush) {
+    return { kind: "push_required", copy: PUSH_REQUIRED_COPY };
+  }
+
+  return { kind: "safe", copy: SAFE_COPY };
+}
+
+function blocked(code: string, message?: string): MoveReadiness {
+  const knownCopy = BLOCKER_COPY[code];
+  const copy: MoveReadinessCopy = knownCopy ?? {
+    headline: "Can't move this workspace yet",
+    body: message ?? "This workspace can't be moved right now.",
+    primaryActionLabel: "Got it",
+  };
+  return { kind: "blocked", copy, blockerCode: code };
+}

--- a/apps/desktop/src/lib/domain/workspaces/move/move-start.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-start.test.ts
@@ -1,0 +1,119 @@
+import type { RepoRoot } from "@anyharness/sdk";
+import type { RepoConfigResponse } from "@proliferate/cloud-sdk";
+import { describe, expect, it } from "vitest";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+import {
+  buildLocalToCloudMoveStartRequest,
+  findCollidingCloudWorkspace,
+  resolveRepoConfigIdForRepoRoot,
+} from "./move-start";
+
+function repoConfig(overrides: Partial<RepoConfigResponse> = {}): RepoConfigResponse {
+  return {
+    id: "repo-config-1",
+    gitProvider: "github",
+    gitOwner: "acme",
+    gitRepoName: "widgets",
+    environments: [],
+    ...overrides,
+  };
+}
+
+function cloudWorkspace(overrides: Partial<CloudWorkspaceSummary> = {}): CloudWorkspaceSummary {
+  return {
+    id: "cloud-ws-1",
+    displayName: "widgets",
+    repo: {
+      provider: "github",
+      owner: "acme",
+      name: "widgets",
+      branch: "feature/move",
+      baseBranch: "main",
+    },
+    status: "ready",
+    workspaceStatus: "ready",
+    visibility: "private",
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    updatedAt: null,
+    createdAt: null,
+    readyAt: null,
+    postReadyPhase: "done",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("resolveRepoConfigIdForRepoRoot", () => {
+  it("matches a repo config by (gitOwner, gitRepoName)", () => {
+    const repoRoot: Pick<RepoRoot, "remoteOwner" | "remoteRepoName"> = {
+      remoteOwner: "acme",
+      remoteRepoName: "widgets",
+    };
+    const id = resolveRepoConfigIdForRepoRoot(repoRoot, [
+      repoConfig({ id: "other", gitRepoName: "gadgets" }),
+      repoConfig({ id: "repo-config-1" }),
+    ]);
+    expect(id).toBe("repo-config-1");
+  });
+
+  it("returns null when the repo root has no remote owner/name", () => {
+    expect(resolveRepoConfigIdForRepoRoot({ remoteOwner: null, remoteRepoName: null }, [repoConfig()]))
+      .toBeNull();
+  });
+
+  it("returns null when nothing matches", () => {
+    const repoRoot: Pick<RepoRoot, "remoteOwner" | "remoteRepoName"> = {
+      remoteOwner: "acme",
+      remoteRepoName: "unconfigured",
+    };
+    expect(resolveRepoConfigIdForRepoRoot(repoRoot, [repoConfig()])).toBeNull();
+  });
+});
+
+describe("findCollidingCloudWorkspace", () => {
+  it("finds a cloud workspace matching owner/name/branch", () => {
+    const found = findCollidingCloudWorkspace({
+      cloudWorkspaces: [cloudWorkspace({ id: "no-match", repo: { provider: "github", owner: "acme", name: "widgets", branch: "main", baseBranch: "main" } }), cloudWorkspace()],
+      gitOwner: "acme",
+      gitRepoName: "widgets",
+      branch: "feature/move",
+    });
+    expect(found?.id).toBe("cloud-ws-1");
+  });
+
+  it("returns null when no cloud workspace matches", () => {
+    const found = findCollidingCloudWorkspace({
+      cloudWorkspaces: [cloudWorkspace()],
+      gitOwner: "acme",
+      gitRepoName: "widgets",
+      branch: "unrelated-branch",
+    });
+    expect(found).toBeNull();
+  });
+});
+
+describe("buildLocalToCloudMoveStartRequest", () => {
+  it("builds a local source / cloud destination request", () => {
+    const request = buildLocalToCloudMoveStartRequest({
+      repoConfigId: "repo-config-1",
+      branch: "feature/move",
+      baseCommitSha: "abc123",
+      desktopInstallId: "install-1",
+      anyharnessWorkspaceId: "ws-1",
+      idempotencyKey: "idem-1",
+    });
+    expect(request).toEqual({
+      repoConfigId: "repo-config-1",
+      branch: "feature/move",
+      baseCommitSha: "abc123",
+      source: { kind: "local", desktopInstallId: "install-1", anyharnessWorkspaceId: "ws-1" },
+      destination: { kind: "cloud" },
+      idempotencyKey: "idem-1",
+    });
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/move/move-start.ts
+++ b/apps/desktop/src/lib/domain/workspaces/move/move-start.ts
@@ -1,0 +1,75 @@
+import type { RepoRoot } from "@anyharness/sdk";
+import type { RepoConfigResponse, StartWorkspaceMoveRequest } from "@proliferate/cloud-sdk";
+import { cloudRepositoryKey } from "@/lib/domain/settings/repositories";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+// Pure helpers for building the local->cloud `StartWorkspaceMoveRequest` (spec section
+// 5.2/5.3) and for the collision decision (spec section 2, "Collision"): resolving the
+// server-side repo identity from what Desktop already has cached, and -- since the SDK's
+// 409 error doesn't carry the colliding workspace's id (`ProliferateClientError` only
+// exposes `message`/`status`/`code`) -- finding it from the already-fetched workspace
+// collections cache instead of a second round trip.
+
+/**
+ * `StartWorkspaceMoveRequest.repoConfigId` identifies the repo server-side; Desktop only
+ * has the repo by (gitOwner, gitRepoName) locally. Requires the repo to already be
+ * connected to Proliferate Cloud (a `RepoConfigResponse` row exists) -- true by
+ * construction once a collision is possible, and gated earlier by the entry points
+ * otherwise (a repo with no cloud config can't have a colliding cloud workspace).
+ */
+export function resolveRepoConfigIdForRepoRoot(
+  repoRoot: Pick<RepoRoot, "remoteOwner" | "remoteRepoName"> | null | undefined,
+  repoConfigs: readonly RepoConfigResponse[],
+): string | null {
+  const gitOwner = repoRoot?.remoteOwner?.trim();
+  const gitRepoName = repoRoot?.remoteRepoName?.trim();
+  if (!gitOwner || !gitRepoName) {
+    return null;
+  }
+  const key = cloudRepositoryKey(gitOwner, gitRepoName);
+  return repoConfigs.find((config) =>
+    cloudRepositoryKey(config.gitOwner, config.gitRepoName) === key
+  )?.id ?? null;
+}
+
+/**
+ * Finds the cloud workspace a `cloud_workspace_exists` collision (409) refers to, by
+ * matching the move's own (gitOwner, gitRepoName, branch) against the already-cached
+ * workspace collections -- avoids depending on error response fields the SDK doesn't
+ * surface.
+ */
+export function findCollidingCloudWorkspace(input: {
+  cloudWorkspaces: readonly CloudWorkspaceSummary[];
+  gitOwner: string;
+  gitRepoName: string;
+  branch: string;
+}): CloudWorkspaceSummary | null {
+  const branch = input.branch.trim();
+  return input.cloudWorkspaces.find((workspace) =>
+    workspace.repo.owner === input.gitOwner
+    && workspace.repo.name === input.gitRepoName
+    && workspace.repo.branch.trim() === branch
+  ) ?? null;
+}
+
+export function buildLocalToCloudMoveStartRequest(input: {
+  repoConfigId: string;
+  branch: string;
+  baseCommitSha: string;
+  desktopInstallId: string;
+  anyharnessWorkspaceId: string;
+  idempotencyKey: string;
+}): StartWorkspaceMoveRequest {
+  return {
+    repoConfigId: input.repoConfigId,
+    branch: input.branch,
+    baseCommitSha: input.baseCommitSha,
+    source: {
+      kind: "local",
+      desktopInstallId: input.desktopInstallId,
+      anyharnessWorkspaceId: input.anyharnessWorkspaceId,
+    },
+    destination: { kind: "cloud" },
+    idempotencyKey: input.idempotencyKey,
+  };
+}

--- a/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.test.ts
+++ b/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.test.ts
@@ -1,0 +1,329 @@
+import type { WorkspaceMobilityArchive } from "@anyharness/sdk";
+import type { StartWorkspaceMoveRequest, WorkspaceMoveResponse, WorkspaceMovePhase } from "@proliferate/cloud-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { runWorkspaceMoveWorkflow } from "./run-workspace-move-workflow";
+
+const START_REQUEST: StartWorkspaceMoveRequest = {
+  repoConfigId: "repo-1",
+  branch: "feature/move",
+  baseCommitSha: "abc123",
+  source: { kind: "local", desktopInstallId: "install-1", anyharnessWorkspaceId: "ws-1" },
+  destination: { kind: "cloud" },
+  idempotencyKey: "idem-1",
+};
+
+const ARCHIVE: WorkspaceMobilityArchive = {
+  baseCommitSha: "abc123",
+  files: [],
+  repoRootPath: "/repo",
+  sourceWorkspacePath: "/repo/worktree",
+};
+
+describe("runWorkspaceMoveWorkflow", () => {
+  it("runs the full happy path and destroys a managed-worktree source", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    const result = await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    );
+
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(calls).toEqual([
+      "startMove",
+      "freezeSource",
+      "exportSourceArchive",
+      "installArchive",
+      "cutover",
+      "destroySource",
+      "completeMove",
+    ]);
+    expect(deps.markSourceRemoteOwned).not.toHaveBeenCalled();
+    expect(deps.unfreezeSource).not.toHaveBeenCalled();
+    expect(deps.failMove).not.toHaveBeenCalled();
+  });
+
+  it("marks a plain local-directory source remote_owned instead of destroying it", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "local" },
+      deps,
+    );
+
+    expect(calls).toContain("markSourceRemoteOwned");
+    expect(calls).not.toContain("destroySource");
+    expect(deps.destroySource).not.toHaveBeenCalled();
+  });
+
+  it("reports phase transitions via onPhaseChange", async () => {
+    const deps = depsMock();
+    await runWorkspaceMoveWorkflow({ start: START_REQUEST, sourceWorkspaceKind: "worktree" }, deps);
+
+    expect(deps.onPhaseChange).toHaveBeenNthCalledWith(1, "destination_ready");
+    expect(deps.onPhaseChange).toHaveBeenNthCalledWith(2, "installed");
+    expect(deps.onPhaseChange).toHaveBeenNthCalledWith(3, "cutover");
+    expect(deps.onPhaseChange).toHaveBeenNthCalledWith(4, "completed");
+  });
+
+  it("resumes from destination_ready without re-calling startMove", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    const result = await runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "destination_ready" },
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(calls).toEqual([
+      "freezeSource",
+      "exportSourceArchive",
+      "installArchive",
+      "cutover",
+      "destroySource",
+      "completeMove",
+    ]);
+    expect(deps.startMove).not.toHaveBeenCalled();
+  });
+
+  it("resumes from installed, skipping freeze/export/install", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    await runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "installed" },
+      },
+      deps,
+    );
+
+    expect(calls).toEqual(["cutover", "destroySource", "completeMove"]);
+    expect(deps.freezeSource).not.toHaveBeenCalled();
+    expect(deps.exportSourceArchive).not.toHaveBeenCalled();
+    expect(deps.installArchive).not.toHaveBeenCalled();
+  });
+
+  it("resumes from cutover, only running cleanup + complete", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    const result = await runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "cutover" },
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(calls).toEqual(["destroySource", "completeMove"]);
+    expect(deps.cutover).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits immediately when resuming an already-completed move", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    const result = await runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "completed" },
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(calls).toEqual([]);
+  });
+
+  it("refuses to resume a failed move", async () => {
+    const deps = depsMock();
+    await expect(runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "failed" },
+      },
+      deps,
+    )).rejects.toThrow(/Cannot resume a failed move/);
+  });
+
+  it("re-issues startMove (idempotent) when resuming a stalled 'started' row", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+
+    await runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "started" },
+      },
+      deps,
+    );
+
+    expect(deps.startMove).toHaveBeenCalledOnce();
+    expect(calls[0]).toBe("startMove");
+  });
+
+  it("on pre-cutover failure, unfreezes the source and fails the move without cutting over", async () => {
+    const calls: string[] = [];
+    const deps = depsMock(calls);
+    const error = Object.assign(new Error("export refused: dirty tree"), { code: "workspace_dirty" });
+    deps.exportSourceArchive.mockRejectedValueOnce(error);
+
+    const result = await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    );
+
+    expect(result).toEqual({
+      outcome: "failed",
+      moveId: "move-1",
+      failureCode: "workspace_dirty",
+      failureDetail: "export refused: dirty tree",
+    });
+    expect(deps.unfreezeSource).toHaveBeenCalledWith("move-1");
+    expect(deps.failMove).toHaveBeenCalledWith("move-1", "workspace_dirty", "export refused: dirty tree");
+    expect(deps.cutover).not.toHaveBeenCalled();
+    expect(deps.installArchive).not.toHaveBeenCalled();
+  });
+
+  it("unfreezes but does not call failMove when startMove itself fails (no moveId yet)", async () => {
+    const deps = depsMock();
+    deps.startMove.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    );
+
+    expect(result).toEqual({
+      outcome: "failed",
+      moveId: null,
+      failureCode: "move_workflow_error",
+      failureDetail: "network error",
+    });
+    expect(deps.unfreezeSource).toHaveBeenCalledWith(null);
+    expect(deps.failMove).not.toHaveBeenCalled();
+  });
+
+  it("does not mask the triggering error when unfreeze/failMove cleanup itself throws", async () => {
+    const deps = depsMock();
+    deps.exportSourceArchive.mockRejectedValueOnce(new Error("export failed"));
+    deps.unfreezeSource.mockRejectedValueOnce(new Error("unfreeze failed too"));
+    deps.failMove.mockRejectedValueOnce(new Error("fail-move failed too"));
+
+    const result = await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    );
+
+    expect(result.outcome).toBe("failed");
+    if (result.outcome === "failed") {
+      expect(result.failureDetail).toBe("export failed");
+    }
+  });
+
+  it("on post-cutover failure, propagates the error and does not unfreeze or fail the move", async () => {
+    const deps = depsMock();
+    deps.destroySource.mockRejectedValueOnce(new Error("destroy-source unreachable"));
+
+    await expect(runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    )).rejects.toThrow("destroy-source unreachable");
+
+    expect(deps.unfreezeSource).not.toHaveBeenCalled();
+    expect(deps.failMove).not.toHaveBeenCalled();
+    expect(deps.completeMove).not.toHaveBeenCalled();
+  });
+
+  it("post-cutover failure on resume from cutover also propagates without touching failMove", async () => {
+    const deps = depsMock();
+    deps.completeMove.mockRejectedValueOnce(new Error("complete unreachable"));
+
+    await expect(runWorkspaceMoveWorkflow(
+      {
+        start: START_REQUEST,
+        sourceWorkspaceKind: "worktree",
+        resume: { moveId: "move-1", phase: "cutover" },
+      },
+      deps,
+    )).rejects.toThrow("complete unreachable");
+
+    expect(deps.unfreezeSource).not.toHaveBeenCalled();
+    expect(deps.failMove).not.toHaveBeenCalled();
+  });
+});
+
+function depsMock(calls: string[] = []) {
+  const moveAt = (phase: WorkspaceMovePhase): WorkspaceMoveResponse => ({
+    id: "move-1",
+    repoConfigId: "repo-1",
+    branch: "feature/move",
+    sourceKind: "local",
+    destinationKind: "cloud",
+    sourceRef: {},
+    destinationRef: {},
+    baseCommitSha: "abc123",
+    phase,
+    canonicalSide: phase === "cutover" || phase === "completed" ? "destination" : "source",
+    failureCode: null,
+    failureDetail: null,
+    idempotencyKey: "idem-1",
+    createdAt: "2026-07-02T00:00:00Z",
+    updatedAt: "2026-07-02T00:00:00Z",
+    cutoverAt: null,
+    completedAt: null,
+  });
+
+  return {
+    startMove: vi.fn(async () => {
+      calls.push("startMove");
+      return moveAt("destination_ready");
+    }),
+    freezeSource: vi.fn(async () => {
+      calls.push("freezeSource");
+    }),
+    exportSourceArchive: vi.fn(async () => {
+      calls.push("exportSourceArchive");
+      return ARCHIVE;
+    }),
+    installArchive: vi.fn(async () => {
+      calls.push("installArchive");
+      return moveAt("installed");
+    }),
+    cutover: vi.fn(async () => {
+      calls.push("cutover");
+      return moveAt("cutover");
+    }),
+    destroySource: vi.fn(async () => {
+      calls.push("destroySource");
+    }),
+    markSourceRemoteOwned: vi.fn(async () => {
+      calls.push("markSourceRemoteOwned");
+    }),
+    unfreezeSource: vi.fn(async () => {
+      calls.push("unfreezeSource");
+    }),
+    completeMove: vi.fn(async () => {
+      calls.push("completeMove");
+      return moveAt("completed");
+    }),
+    failMove: vi.fn(async () => {
+      calls.push("failMove");
+    }),
+    onPhaseChange: vi.fn(),
+  };
+}

--- a/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.test.ts
+++ b/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.test.ts
@@ -29,7 +29,7 @@ describe("runWorkspaceMoveWorkflow", () => {
       deps,
     );
 
-    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1", destinationCloudWorkspaceId: null });
     expect(calls).toEqual([
       "startMove",
       "freezeSource",
@@ -81,7 +81,7 @@ describe("runWorkspaceMoveWorkflow", () => {
       deps,
     );
 
-    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1", destinationCloudWorkspaceId: null });
     expect(calls).toEqual([
       "freezeSource",
       "exportSourceArchive",
@@ -125,7 +125,7 @@ describe("runWorkspaceMoveWorkflow", () => {
       deps,
     );
 
-    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1", destinationCloudWorkspaceId: null });
     expect(calls).toEqual(["destroySource", "completeMove"]);
     expect(deps.cutover).not.toHaveBeenCalled();
   });
@@ -143,8 +143,26 @@ describe("runWorkspaceMoveWorkflow", () => {
       deps,
     );
 
-    expect(result).toEqual({ outcome: "completed", moveId: "move-1" });
+    expect(result).toEqual({ outcome: "completed", moveId: "move-1", destinationCloudWorkspaceId: null });
     expect(calls).toEqual([]);
+  });
+
+  it("threads the destination cloud workspace id from the server's move rows", async () => {
+    const deps = depsMock();
+    deps.startMove.mockResolvedValueOnce(
+      moveAt("destination_ready", { cloudWorkspaceId: "cloud-ws-9" }),
+    );
+
+    const result = await runWorkspaceMoveWorkflow(
+      { start: START_REQUEST, sourceWorkspaceKind: "worktree" },
+      deps,
+    );
+
+    expect(result).toEqual({
+      outcome: "completed",
+      moveId: "move-1",
+      destinationCloudWorkspaceId: "cloud-ws-9",
+    });
   });
 
   it("refuses to resume a failed move", async () => {
@@ -267,15 +285,18 @@ describe("runWorkspaceMoveWorkflow", () => {
   });
 });
 
-function depsMock(calls: string[] = []) {
-  const moveAt = (phase: WorkspaceMovePhase): WorkspaceMoveResponse => ({
+function moveAt(
+  phase: WorkspaceMovePhase,
+  destinationRef: Record<string, unknown> = {},
+): WorkspaceMoveResponse {
+  return {
     id: "move-1",
     repoConfigId: "repo-1",
     branch: "feature/move",
     sourceKind: "local",
     destinationKind: "cloud",
     sourceRef: {},
-    destinationRef: {},
+    destinationRef,
     baseCommitSha: "abc123",
     phase,
     canonicalSide: phase === "cutover" || phase === "completed" ? "destination" : "source",
@@ -286,8 +307,10 @@ function depsMock(calls: string[] = []) {
     updatedAt: "2026-07-02T00:00:00Z",
     cutoverAt: null,
     completedAt: null,
-  });
+  };
+}
 
+function depsMock(calls: string[] = []) {
   return {
     startMove: vi.fn(async () => {
       calls.push("startMove");

--- a/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.ts
+++ b/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.ts
@@ -1,0 +1,142 @@
+import type { WorkspaceKind, WorkspaceMobilityArchive } from "@anyharness/sdk";
+import type { StartWorkspaceMoveRequest, WorkspaceMoveResponse } from "@proliferate/cloud-sdk";
+import {
+  sourceFateForWorkspaceKind,
+  type MovePhase,
+} from "@/lib/domain/workspaces/move/move-model";
+
+// Pure step sequencer for the local<->cloud workspace_move saga (pattern:
+// run-workspace-publish-workflow.ts). Models spec section 2.3's step order plus the
+// locked source-fate branching and failure semantics:
+//   pre-cutover failure  -> unfreeze the source + fail the move
+//   post-cutover failure -> cleanup retries only (no unfreeze/fail; caller resumes by
+//                            re-invoking this function with `resume.phase: "cutover"`)
+//
+// Reaches the world only through `deps` -- the caller (a workflow hook) resolves the
+// concrete AnyHarness/cloud connections and binds them into these callbacks.
+
+export interface WorkspaceMoveWorkflowDeps {
+  startMove: (request: StartWorkspaceMoveRequest) => Promise<WorkspaceMoveResponse>;
+  freezeSource: (moveId: string) => Promise<void>;
+  exportSourceArchive: (moveId: string) => Promise<WorkspaceMobilityArchive>;
+  installArchive: (moveId: string, archive: WorkspaceMobilityArchive) => Promise<WorkspaceMoveResponse>;
+  cutover: (moveId: string) => Promise<WorkspaceMoveResponse>;
+  /** Managed-worktree source fate (sourceFateForWorkspaceKind === "destroy"). */
+  destroySource: (moveId: string) => Promise<void>;
+  /** Plain local-directory source fate (sourceFateForWorkspaceKind === "mark_remote_owned"). */
+  markSourceRemoteOwned: (moveId: string) => Promise<void>;
+  /** Best-effort pre-cutover recovery: returns the source runtime to normal mode. */
+  unfreezeSource: (moveId: string | null) => Promise<void>;
+  completeMove: (moveId: string) => Promise<WorkspaceMoveResponse>;
+  failMove: (moveId: string, failureCode: string, failureDetail: string | null) => Promise<void>;
+  /** Optional progress callback -- fired after every phase transition the server
+   *  confirms, so a progress modal can render Prepare/Transfer/Switch/Clean-up. */
+  onPhaseChange?: (phase: MovePhase) => void;
+}
+
+export interface RunWorkspaceMoveWorkflowInput {
+  start: StartWorkspaceMoveRequest;
+  /** Drives source-fate cleanup after cutover (locked "Source fate after cutover"
+   *  decision: managed worktrees are destroyed, plain local directories are only
+   *  marked remote_owned). Required on every call, including resumes, since cleanup
+   *  is recomputed fresh each time rather than persisted mid-saga. */
+  sourceWorkspaceKind: WorkspaceKind;
+  /** Present when resuming an existing non-terminal (or post-cutover, pre-complete)
+   *  move instead of starting a fresh one. `phase` is the move's last known phase. */
+  resume?: { moveId: string; phase: MovePhase };
+}
+
+export type WorkspaceMoveWorkflowResult =
+  | { outcome: "completed"; moveId: string }
+  | { outcome: "failed"; moveId: string | null; failureCode: string; failureDetail: string | null };
+
+export async function runWorkspaceMoveWorkflow(
+  input: RunWorkspaceMoveWorkflowInput,
+  deps: WorkspaceMoveWorkflowDeps,
+): Promise<WorkspaceMoveWorkflowResult> {
+  let moveId = input.resume?.moveId ?? null;
+  let phase: MovePhase | "not_started" = input.resume?.phase ?? "not_started";
+
+  if (phase === "completed") {
+    return { outcome: "completed", moveId: moveId! };
+  }
+  if (phase === "failed") {
+    throw new Error("Cannot resume a failed move -- start a new move instead.");
+  }
+
+  try {
+    // "started" is a transient server-side row state that normally flips to
+    // "destination_ready" within the same start() call; a resume that observes it
+    // (e.g. the server crashed mid-saga) just re-issues start, which is idempotent via
+    // idempotencyKey.
+    if (phase === "not_started" || phase === "started") {
+      const move = await deps.startMove(input.start);
+      moveId = move.id;
+      phase = move.phase;
+      deps.onPhaseChange?.(phase);
+    }
+
+    if (phase === "destination_ready") {
+      await deps.freezeSource(moveId!);
+      const archive = await deps.exportSourceArchive(moveId!);
+      const move = await deps.installArchive(moveId!, archive);
+      phase = move.phase;
+      deps.onPhaseChange?.(phase);
+    }
+
+    if (phase === "installed") {
+      const move = await deps.cutover(moveId!);
+      phase = move.phase;
+      deps.onPhaseChange?.(phase);
+    }
+  } catch (error) {
+    const { code, detail } = describeFailure(error);
+    await safely(() => deps.unfreezeSource(moveId));
+    if (moveId) {
+      await safely(() => deps.failMove(moveId!, code, detail));
+    }
+    return { outcome: "failed", moveId, failureCode: code, failureDetail: detail };
+  }
+
+  // Post-cutover: cleanup retries only. Errors here propagate as-is -- the move stays
+  // in "cutover" phase server-side and the caller resumes by re-invoking with
+  // `resume: { moveId, phase: "cutover" }`.
+  if (phase === "cutover") {
+    const fate = sourceFateForWorkspaceKind(input.sourceWorkspaceKind);
+    if (fate === "destroy") {
+      await deps.destroySource(moveId!);
+    } else {
+      await deps.markSourceRemoteOwned(moveId!);
+    }
+    const move = await deps.completeMove(moveId!);
+    phase = move.phase;
+    deps.onPhaseChange?.(phase);
+  }
+
+  if (phase !== "completed") {
+    throw new Error(`Unexpected terminal phase after cutover: ${phase}`);
+  }
+  return { outcome: "completed", moveId: moveId! };
+}
+
+async function safely(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch {
+    // Best-effort: cleanup calls in the failure path must never mask the triggering error.
+  }
+}
+
+function describeFailure(error: unknown): { code: string; detail: string | null } {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" && code.length > 0) {
+      return { code, detail: errorMessage(error) };
+    }
+  }
+  return { code: "move_workflow_error", detail: errorMessage(error) };
+}
+
+function errorMessage(error: unknown): string | null {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.ts
+++ b/apps/desktop/src/lib/workflows/workspaces/run-workspace-move-workflow.ts
@@ -47,7 +47,7 @@ export interface RunWorkspaceMoveWorkflowInput {
 }
 
 export type WorkspaceMoveWorkflowResult =
-  | { outcome: "completed"; moveId: string }
+  | { outcome: "completed"; moveId: string; destinationCloudWorkspaceId: string | null }
   | { outcome: "failed"; moveId: string | null; failureCode: string; failureDetail: string | null };
 
 export async function runWorkspaceMoveWorkflow(
@@ -56,9 +56,13 @@ export async function runWorkspaceMoveWorkflow(
 ): Promise<WorkspaceMoveWorkflowResult> {
   let moveId = input.resume?.moveId ?? null;
   let phase: MovePhase | "not_started" = input.resume?.phase ?? "not_started";
+  // Threaded back to the caller so a completed move can redirect the shell onto the new
+  // cloud workspace (the source worktree may have just been destroyed). Populated from
+  // the server's move rows, which carry it from the "destination_ready" transition on.
+  let destinationCloudWorkspaceId: string | null = null;
 
   if (phase === "completed") {
-    return { outcome: "completed", moveId: moveId! };
+    return { outcome: "completed", moveId: moveId!, destinationCloudWorkspaceId };
   }
   if (phase === "failed") {
     throw new Error("Cannot resume a failed move -- start a new move instead.");
@@ -73,6 +77,7 @@ export async function runWorkspaceMoveWorkflow(
       const move = await deps.startMove(input.start);
       moveId = move.id;
       phase = move.phase;
+      destinationCloudWorkspaceId = destinationCloudWorkspaceIdFromMove(move) ?? destinationCloudWorkspaceId;
       deps.onPhaseChange?.(phase);
     }
 
@@ -81,12 +86,14 @@ export async function runWorkspaceMoveWorkflow(
       const archive = await deps.exportSourceArchive(moveId!);
       const move = await deps.installArchive(moveId!, archive);
       phase = move.phase;
+      destinationCloudWorkspaceId = destinationCloudWorkspaceIdFromMove(move) ?? destinationCloudWorkspaceId;
       deps.onPhaseChange?.(phase);
     }
 
     if (phase === "installed") {
       const move = await deps.cutover(moveId!);
       phase = move.phase;
+      destinationCloudWorkspaceId = destinationCloudWorkspaceIdFromMove(move) ?? destinationCloudWorkspaceId;
       deps.onPhaseChange?.(phase);
     }
   } catch (error) {
@@ -110,13 +117,24 @@ export async function runWorkspaceMoveWorkflow(
     }
     const move = await deps.completeMove(moveId!);
     phase = move.phase;
+    destinationCloudWorkspaceId = destinationCloudWorkspaceIdFromMove(move) ?? destinationCloudWorkspaceId;
     deps.onPhaseChange?.(phase);
   }
 
   if (phase !== "completed") {
     throw new Error(`Unexpected terminal phase after cutover: ${phase}`);
   }
-  return { outcome: "completed", moveId: moveId! };
+  return { outcome: "completed", moveId: moveId!, destinationCloudWorkspaceId };
+}
+
+/** The destination cloud workspace id the server recorded on a local->cloud move.
+ *  Populated on the move row's `destinationRef` from the "destination_ready" transition
+ *  onward (see workspace_moves/service.py); null before then or for non-cloud
+ *  destinations. */
+function destinationCloudWorkspaceIdFromMove(move: WorkspaceMoveResponse): string | null {
+  if (move.destinationKind !== "cloud") return null;
+  const id = (move.destinationRef as { cloudWorkspaceId?: unknown }).cloudWorkspaceId;
+  return typeof id === "string" && id.length > 0 ? id : null;
 }
 
 async function safely(fn: () => Promise<void>): Promise<void> {

--- a/apps/desktop/src/stores/workspaces/workspace-move-store.ts
+++ b/apps/desktop/src/stores/workspaces/workspace-move-store.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+
+// UI state for the workspace-move dialog (open/workspaceId, pattern:
+// add-repo-flow-store.ts) plus a session-scoped memory of "which move id is this
+// workspace's in-flight move" (spec section 2.2's recovery story: "a stale non-terminal
+// row + engine preflight tells Desktop exactly what to offer"). There is no
+// list-active-move-by-identity server endpoint (PR B's API is start/get-by-id/phase
+// transitions only, spec section 5.2), so remembering the id locally is what lets the
+// dialog re-offer resume/abandon after being closed and reopened. Deliberately
+// in-memory only, not written to the persisted workspace-ui-store: losing it across an
+// app restart just means the resume prompt doesn't come back automatically, and the
+// user can still see the workspace is stuck via the normal preflight/runtime-state
+// checks and start a fresh move.
+
+interface WorkspaceMoveUiState {
+  dialogOpen: boolean;
+  dialogWorkspaceId: string | null;
+  activeMoveIdByWorkspaceId: Record<string, string>;
+  openMoveDialog: (workspaceId: string) => void;
+  closeMoveDialog: () => void;
+  setActiveMoveId: (workspaceId: string, moveId: string | null) => void;
+}
+
+export const useWorkspaceMoveStore = create<WorkspaceMoveUiState>((set, get) => ({
+  dialogOpen: false,
+  dialogWorkspaceId: null,
+  activeMoveIdByWorkspaceId: {},
+
+  openMoveDialog: (workspaceId) => set({ dialogOpen: true, dialogWorkspaceId: workspaceId }),
+  closeMoveDialog: () => set({ dialogOpen: false, dialogWorkspaceId: null }),
+
+  setActiveMoveId: (workspaceId, moveId) => {
+    const current = get().activeMoveIdByWorkspaceId;
+    if (moveId === null) {
+      if (!(workspaceId in current)) return;
+      const next = { ...current };
+      delete next[workspaceId];
+      set({ activeMoveIdByWorkspaceId: next });
+      return;
+    }
+    if (current[workspaceId] === moveId) return;
+    set({ activeMoveIdByWorkspaceId: { ...current, [workspaceId]: moveId } });
+  },
+}));
+
+export function rememberActiveWorkspaceMoveId(workspaceId: string, moveId: string | null) {
+  useWorkspaceMoveStore.getState().setActiveMoveId(workspaceId, moveId);
+}


### PR DESCRIPTION
Part of the **workspace-migration v2** stack (A→B→C→D). Stacked on #914. Spec: `specs/tbd/workspace-migration-v2.md`.

## What
The desktop **local → cloud** move experience.

- A pure **readiness resolver** (`safe | push_required | prepare_required | blocked`) over git status + source preflight + destination state, and a pure workflow sequencer for the saga (freeze → export → install → cutover → cleanup) with correct pre-/post-cutover failure semantics.
- `MoveWorkspaceDialog` + `MoveProgress`, reusing the existing publish (commit/push) machinery — which already routes to a cloud workspace via the runtime gateway, so git-prep works against either side with no new plumbing.
- Entry points: a workspace context-menu verb + a clickable location chip. Source-fate on cleanup respects workspace kind (managed worktree → destroy; plain local dir → mark remote_owned, never delete user files). Mid-move resume/abandon if a move is already in flight.

## Evidence
Move domain/workflow/component suite green (61+ tests); typecheck clean; part of the 6-green-live-round-trip stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
