### PR TITLE
fix(ci): sync HarnessPane.test.tsx max-lines allowlist

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -25,7 +25,7 @@ cloud/sdk/src/types/generated.ts 759 existing generated cloud SDK type surface
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1880 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1575 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
-apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 546 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5)
+apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 618 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5)
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file


### PR DESCRIPTION
Main went red on the repo-shape gate: 2dc518ab grew HarnessPane.test.tsx to 618 lines against a 546 allowlist entry (exact-match gate). Sync the entry to observed reality; unblocks main CI and every open PR's merge preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)