### PR TITLE
feat(activity): SessionActivity contract v1 (loops, processes, subagents, feed)

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/activity.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/activity.rs
@@ -1,0 +1,198 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::{Goal, Loop};
+
+/// One normalized, strictly-typed, per-session aggregate: the single answer
+/// to "what is this agent doing right now" (session-activity-architecture,
+/// locked 2026-07-02). Two element classes: mirrors with write paths
+/// (`goal`, `loops`) and read-only rosters (`processes`, `agents`), each
+/// roster element carrying an opaque [`FeedRef`] for its live content
+/// stream — the UI never learns the transport.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionActivity {
+    pub turn: TurnState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goal: Option<Goal>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub loops: Vec<Loop>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub processes: Vec<ActivityProcess>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<ActivitySubagent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum TurnState {
+    Running {
+        turn_id: String,
+        started_at: String,
+    },
+    Idle,
+}
+
+/// A harness-owned or client-executed process the agent is running in the
+/// background (Claude background bash, Cursor detached terminals, …).
+/// Read-only roster element — never externally settable.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityProcess {
+    pub id: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    pub status: ProcessStatus,
+    /// Cursor provides a real pid; Claude does not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    pub started_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed: Option<FeedRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ProcessStatus {
+    Running,
+    Exited {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exit_code: Option<i32>,
+    },
+}
+
+/// A harness-native subagent (Claude Task agent, Codex collab child thread,
+/// Cursor `cursor/task`). Read-only roster element; the ⑂ chip routes to the
+/// existing delegated-work surfaces.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivitySubagent {
+    /// Claude `task_id` / Codex child `threadId` / Cursor `agentId`.
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub background: bool,
+    pub status: SubagentStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<ActivityUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feed: Option<FeedRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "status", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum SubagentStatus {
+    Running,
+    Completed {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+    },
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityUsage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens_used: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_seconds: Option<i64>,
+}
+
+/// An opaque handle to a roster element's live content stream. The UI never
+/// learns the transport (`tail_file` / `acp_child_demux` / `http_sse`) — that
+/// detail stays inside the runtime's `FeedBinding` table and is resolved
+/// lazily by the `FeedService` only while a panel watches it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedRef {
+    pub feed_id: String,
+    pub kind: FeedKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FeedKind {
+    TerminalBytes,
+    Transcript,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_state_serializes_running_and_idle() {
+        let running = TurnState::Running {
+            turn_id: "turn-1".to_string(),
+            started_at: "2026-07-02T00:00:00Z".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_value(&running).expect("serialize running"),
+            serde_json::json!({
+                "status": "running",
+                "turnId": "turn-1",
+                "startedAt": "2026-07-02T00:00:00Z"
+            })
+        );
+
+        let idle = TurnState::Idle;
+        assert_eq!(
+            serde_json::to_value(&idle).expect("serialize idle"),
+            serde_json::json!({ "status": "idle" })
+        );
+    }
+
+    #[test]
+    fn process_status_serializes_running_and_exited() {
+        assert_eq!(
+            serde_json::to_value(ProcessStatus::Running).expect("serialize running"),
+            serde_json::json!({ "status": "running" })
+        );
+        assert_eq!(
+            serde_json::to_value(ProcessStatus::Exited { exit_code: Some(0) })
+                .expect("serialize exited"),
+            serde_json::json!({ "status": "exited", "exitCode": 0 })
+        );
+    }
+
+    #[test]
+    fn feed_ref_round_trips() {
+        let feed = FeedRef {
+            feed_id: "feed-1".to_string(),
+            kind: FeedKind::TerminalBytes,
+        };
+        let json = serde_json::to_value(&feed).expect("serialize feed ref");
+        assert_eq!(
+            json,
+            serde_json::json!({ "feedId": "feed-1", "kind": "terminal_bytes" })
+        );
+        let round_tripped: FeedRef = serde_json::from_value(json).expect("deserialize feed ref");
+        assert_eq!(round_tripped, feed);
+    }
+
+    #[test]
+    fn session_activity_round_trips_with_empty_rosters() {
+        let activity = SessionActivity {
+            turn: TurnState::Idle,
+            goal: None,
+            loops: Vec::new(),
+            processes: Vec::new(),
+            agents: Vec::new(),
+        };
+        let json = serde_json::to_value(&activity).expect("serialize session activity");
+        assert_eq!(
+            json,
+            serde_json::json!({ "turn": { "status": "idle" } })
+        );
+    }
+}

--- a/anyharness/crates/anyharness-contract/src/v1/events.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/events.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::activity::{ActivityProcess, ActivitySubagent};
 use super::goals::Goal;
 use super::interactions::{InteractionRequestedEvent, InteractionResolvedEvent};
+use super::loops::Loop;
 use super::SessionLiveConfigSnapshot;
 
 // ---------------------------------------------------------------------------
@@ -59,6 +61,17 @@ pub enum SessionEvent {
     GoalUpdated(GoalUpdatedPayload),
     GoalMet(GoalMetPayload),
     GoalCleared(GoalClearedPayload),
+    LoopUpserted(LoopUpsertedPayload),
+    LoopRemoved(LoopRemovedPayload),
+    LoopFired(LoopFiredPayload),
+    // Renamed off the default snake_case of the variant name so the `"type"`
+    // tag matches the wire's tagged-chunk `transcriptEvent` vocabulary
+    // (`NON_TRANSCRIPT_CHUNK_EVENTS`) verbatim — same string as
+    // `event_type()` below.
+    #[serde(rename = "process_upserted")]
+    ActivityProcessUpserted(ActivityProcessUpsertedPayload),
+    #[serde(rename = "subagent_upserted")]
+    ActivitySubagentUpserted(ActivitySubagentUpsertedPayload),
 
     PendingPromptAdded(PendingPromptAddedPayload),
     PendingPromptUpdated(PendingPromptUpdatedPayload),
@@ -93,6 +106,11 @@ impl SessionEvent {
             Self::GoalUpdated(_) => "goal_updated",
             Self::GoalMet(_) => "goal_met",
             Self::GoalCleared(_) => "goal_cleared",
+            Self::LoopUpserted(_) => "loop_upserted",
+            Self::LoopRemoved(_) => "loop_removed",
+            Self::LoopFired(_) => "loop_fired",
+            Self::ActivityProcessUpserted(_) => "process_upserted",
+            Self::ActivitySubagentUpserted(_) => "subagent_upserted",
             Self::PendingPromptAdded(_) => "pending_prompt_added",
             Self::PendingPromptUpdated(_) => "pending_prompt_updated",
             Self::PendingPromptRemoved(_) => "pending_prompt_removed",
@@ -709,6 +727,41 @@ pub struct GoalClearedPayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct LoopUpsertedPayload {
+    #[serde(rename = "loop")]
+    pub r#loop: Loop,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopRemovedPayload {
+    pub loop_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopFiredPayload {
+    #[serde(rename = "loop")]
+    pub r#loop: Loop,
+    pub fired_at_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityProcessUpsertedPayload {
+    pub process: ActivityProcess,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivitySubagentUpsertedPayload {
+    pub agent: ActivitySubagent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct UsageUpdatePayload {
     pub used: u64,
     pub size: u64,
@@ -975,5 +1028,102 @@ mod tests {
             payload.status,
             super::super::reviews::ReviewRunStatus::ParentRevising
         );
+    }
+
+    fn sample_loop() -> super::super::loops::Loop {
+        use super::super::loops::{Loop, LoopSchedule, LoopScheduleKind, LoopStatus};
+        Loop {
+            loop_id: "cron-1".to_string(),
+            prompt: "ping".to_string(),
+            schedule: LoopSchedule {
+                kind: LoopScheduleKind::Cron,
+                expr: "*/1 * * * *".to_string(),
+            },
+            recurring: true,
+            status: LoopStatus::Active,
+            native: true,
+            last_fired_at_ms: None,
+            fire_count: 0,
+            updated_at_ms: 1,
+        }
+    }
+
+    #[test]
+    fn loop_upserted_event_round_trips_with_loop_tag() {
+        let event = SessionEvent::LoopUpserted(LoopUpsertedPayload {
+            r#loop: sample_loop(),
+        });
+        let json = serde_json::to_value(&event).expect("serialize loop upserted event");
+        assert_eq!(json["type"], "loop_upserted");
+        assert_eq!(json["loop"]["loopId"], "cron-1");
+
+        let round_tripped: SessionEvent =
+            serde_json::from_value(json).expect("deserialize loop upserted event");
+        assert_eq!(round_tripped.event_type(), "loop_upserted");
+    }
+
+    #[test]
+    fn loop_removed_and_fired_events_round_trip() {
+        let removed = SessionEvent::LoopRemoved(LoopRemovedPayload {
+            loop_id: "cron-1".to_string(),
+        });
+        assert_eq!(removed.event_type(), "loop_removed");
+        let json = serde_json::to_value(&removed).expect("serialize loop removed event");
+        assert_eq!(json, serde_json::json!({ "type": "loop_removed", "loopId": "cron-1" }));
+
+        let fired = SessionEvent::LoopFired(LoopFiredPayload {
+            r#loop: sample_loop(),
+            fired_at_ms: 2,
+            turn_id: Some("turn-1".to_string()),
+        });
+        assert_eq!(fired.event_type(), "loop_fired");
+        let json = serde_json::to_value(&fired).expect("serialize loop fired event");
+        assert_eq!(json["type"], "loop_fired");
+        assert_eq!(json["firedAtMs"], 2);
+        assert_eq!(json["turnId"], "turn-1");
+    }
+
+    #[test]
+    fn activity_events_serialize_with_wire_matching_type_tags() {
+        use super::super::activity::{ActivityProcess, ActivitySubagent, ProcessStatus, SubagentStatus};
+
+        let process_event = SessionEvent::ActivityProcessUpserted(ActivityProcessUpsertedPayload {
+            process: ActivityProcess {
+                id: "proc-1".to_string(),
+                command: "sleep 30 && echo OK > out.txt".to_string(),
+                cwd: None,
+                status: ProcessStatus::Running,
+                pid: None,
+                started_at: "2026-07-02T00:00:00Z".to_string(),
+                ended_at: None,
+                feed: None,
+            },
+        });
+        assert_eq!(process_event.event_type(), "process_upserted");
+        let json = serde_json::to_value(&process_event).expect("serialize process event");
+        assert_eq!(json["type"], "process_upserted");
+        let round_tripped: SessionEvent =
+            serde_json::from_value(json).expect("deserialize process event");
+        assert_eq!(round_tripped.event_type(), "process_upserted");
+
+        let subagent_event =
+            SessionEvent::ActivitySubagentUpserted(ActivitySubagentUpsertedPayload {
+                agent: ActivitySubagent {
+                    id: "agent-1".to_string(),
+                    agent_type: Some("reviewer".to_string()),
+                    description: None,
+                    model: None,
+                    background: true,
+                    status: SubagentStatus::Running,
+                    usage: None,
+                    feed: None,
+                },
+            });
+        assert_eq!(subagent_event.event_type(), "subagent_upserted");
+        let json = serde_json::to_value(&subagent_event).expect("serialize subagent event");
+        assert_eq!(json["type"], "subagent_upserted");
+        let round_tripped: SessionEvent =
+            serde_json::from_value(json).expect("deserialize subagent event");
+        assert_eq!(round_tripped.event_type(), "subagent_upserted");
     }
 }

--- a/anyharness/crates/anyharness-contract/src/v1/loops.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/loops.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A recurring in-session prompt on a schedule: a strict mirror of native
+/// harness state where it exists (Claude session crons) and a
+/// runtime-emulated equivalent where it doesn't (Codex — `native: false`).
+/// Unlike [`super::Goal`], **multiple loops per session are allowed**, keyed
+/// by `loop_id` (LoopPort wire contract v1).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Loop {
+    pub loop_id: String,
+    pub prompt: String,
+    pub schedule: LoopSchedule,
+    pub recurring: bool,
+    pub status: LoopStatus,
+    pub native: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_fired_at_ms: Option<i64>,
+    pub fire_count: i64,
+    pub updated_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopSchedule {
+    pub kind: LoopScheduleKind,
+    /// `"5m"` sugar or a raw cron expression, per `kind`.
+    pub expr: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopScheduleKind {
+    Interval,
+    Cron,
+}
+
+/// Normalized loop status across harnesses (LoopPort wire contract v1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopStatus {
+    Active,
+    Cleared,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_serializes_camel_case_and_round_trips() {
+        let value = Loop {
+            loop_id: "cron-1".to_string(),
+            prompt: "append ping + timestamp to PING.log".to_string(),
+            schedule: LoopSchedule {
+                kind: LoopScheduleKind::Cron,
+                expr: "*/1 * * * *".to_string(),
+            },
+            recurring: true,
+            status: LoopStatus::Active,
+            native: true,
+            last_fired_at_ms: Some(1_780_000_000_000),
+            fire_count: 2,
+            updated_at_ms: 1_780_000_000_001,
+        };
+
+        let json = serde_json::to_value(&value).expect("serialize loop");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "loopId": "cron-1",
+                "prompt": "append ping + timestamp to PING.log",
+                "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+                "recurring": true,
+                "status": "active",
+                "native": true,
+                "lastFiredAtMs": 1_780_000_000_000i64,
+                "fireCount": 2,
+                "updatedAtMs": 1_780_000_000_001i64
+            })
+        );
+
+        let round_tripped: Loop = serde_json::from_value(json).expect("deserialize loop");
+        assert_eq!(round_tripped.loop_id, "cron-1");
+        assert_eq!(round_tripped.status, LoopStatus::Active);
+    }
+
+    #[test]
+    fn loop_omits_absent_last_fired_at() {
+        let value = Loop {
+            loop_id: "cron-2".to_string(),
+            prompt: "check every 5m".to_string(),
+            schedule: LoopSchedule {
+                kind: LoopScheduleKind::Interval,
+                expr: "5m".to_string(),
+            },
+            recurring: true,
+            status: LoopStatus::Active,
+            native: false,
+            last_fired_at_ms: None,
+            fire_count: 0,
+            updated_at_ms: 1,
+        };
+        let json = serde_json::to_value(&value).expect("serialize loop");
+        assert!(json.get("lastFiredAtMs").is_none());
+    }
+}

--- a/anyharness/crates/anyharness-contract/src/v1/mod.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod agent_auth;
 pub mod agents;
 pub mod auth;
@@ -11,6 +12,7 @@ pub mod goals;
 pub mod health;
 pub mod hosting;
 pub mod interactions;
+pub mod loops;
 pub mod mcp;
 pub mod mobility;
 pub mod origin;
@@ -25,6 +27,7 @@ pub mod terminals;
 pub mod workspaces;
 pub mod worktrees;
 
+pub use activity::*;
 pub use agent_auth::*;
 pub use agents::*;
 pub use auth::*;
@@ -38,6 +41,7 @@ pub use goals::*;
 pub use health::*;
 pub use hosting::*;
 pub use interactions::*;
+pub use loops::*;
 pub use mcp::*;
 pub use mobility::*;
 pub use origin::*;

--- a/anyharness/crates/anyharness-contract/src/v1/sessions.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/sessions.rs
@@ -6,7 +6,7 @@ use utoipa::ToSchema;
 use super::OriginContext;
 use super::{
     ContentPart, Goal, InteractionKind, McpElicitationInteractionPayload,
-    PermissionInteractionContext, PermissionInteractionOption, PromptProvenance,
+    PermissionInteractionContext, PermissionInteractionOption, PromptProvenance, SessionActivity,
     SessionLiveConfigSnapshot, SessionMcpBindingSummary, UserInputQuestion,
 };
 
@@ -123,8 +123,15 @@ pub struct Session {
     pub pending_prompts: Vec<PendingPromptSummary>,
     #[serde(default)]
     pub action_capabilities: SessionActionCapabilities,
+    /// Deprecated in favor of `activity.goal` — kept for existing SDK
+    /// consumers; every write still moves this field too.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_goal: Option<Goal>,
+    /// `SessionActivity` (turn/goal/loops/processes/agents) — the
+    /// session-activity-architecture aggregate. `None` when the runtime has
+    /// not yet assembled it for this read path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activity: Option<SessionActivity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<OriginContext>,
 }
@@ -138,6 +145,13 @@ pub struct SessionActionCapabilities {
     pub targeted_fork: bool,
     #[serde(default)]
     pub supports_goals: bool,
+    #[serde(default)]
+    pub supports_loops: bool,
+    /// Whether loops ride native harness state (Claude session crons) or are
+    /// runtime-emulated (Codex `LoopSchedulerExtension`). Meaningless when
+    /// `supports_loops` is `false`.
+    #[serde(default)]
+    pub loops_native: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -718,6 +732,7 @@ mod tests {
             dismissed_at: None,
             pending_prompts: vec![],
             active_goal: None,
+            activity: None,
             origin: None,
         };
 

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -15,6 +15,8 @@ use crate::domains::agents::catalog::sync::CatalogSyncService;
 use crate::domains::agents::installer::reconcile::execution::AgentReconcileService;
 use crate::domains::agents::installer::seed::AgentSeedStore;
 use crate::domains::agents::runtime::AgentRuntime;
+use crate::domains::activity::service::ActivityService;
+use crate::domains::activity::store::ActivityStore;
 use crate::domains::artifacts::protection::ArtifactProtectionService;
 use crate::domains::artifacts::runtime::ArtifactRuntime;
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
@@ -27,6 +29,8 @@ use crate::domains::goals::hooks::GoalSessionHooks;
 use crate::domains::goals::runtime::GoalRuntime;
 use crate::domains::goals::service::GoalService;
 use crate::domains::goals::store::GoalStore;
+use crate::domains::loops::service::LoopService;
+use crate::domains::loops::store::LoopStore;
 use crate::domains::mobility::service::MobilityService;
 use crate::domains::mobility::store::MobilityStore;
 use crate::domains::plans::runtime::PlanRuntime;
@@ -136,6 +140,8 @@ pub struct AppState {
     pub plan_runtime: Arc<PlanRuntime>,
     pub goal_service: Arc<GoalService>,
     pub goal_runtime: Arc<GoalRuntime>,
+    pub loop_service: Arc<LoopService>,
+    pub activity_service: Arc<ActivityService>,
     pub acp_manager: LiveSessionManager,
     pub terminal_service: Arc<TerminalService>,
     pub agent_login_terminal_service: Arc<AgentLoginTerminalService>,
@@ -219,6 +225,8 @@ impl AppState {
         ));
         let plan_service = Arc::new(PlanService::new(PlanStore::new(db.clone())));
         let goal_service = Arc::new(GoalService::new(GoalStore::new(db.clone())));
+        let loop_service = Arc::new(LoopService::new(LoopStore::new(db.clone())));
+        let activity_service = Arc::new(ActivityService::new(ActivityStore::new(db.clone())));
         let terminal_service = Arc::new(TerminalService::new(
             TerminalStore::new(db.clone()),
             runtime_home.clone(),
@@ -259,6 +267,8 @@ impl AppState {
             plan_service: plan_service.clone(),
             review_service: review_service.clone(),
             goal_service: goal_service.clone(),
+            loop_service: loop_service.clone(),
+            activity_service: activity_service.clone(),
         });
         let cowork_delegation_service = CoworkDelegationService::new(
             (*cowork_service).clone(),
@@ -333,6 +343,8 @@ impl AppState {
             plan_service.clone(),
             gateway_model_resolver.clone(),
             goal_service.clone(),
+            loop_service.clone(),
+            activity_service.clone(),
         ));
         let retire_preflight_checker = Arc::new(RetirePreflightChecker::new(
             workspace_runtime.clone(),
@@ -472,6 +484,8 @@ impl AppState {
             plan_runtime,
             goal_service,
             goal_runtime,
+            loop_service,
+            activity_service,
             acp_manager,
             terminal_service,
             agent_login_terminal_service,

--- a/anyharness/crates/anyharness-lib/src/app/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/app/sessions.rs
@@ -6,8 +6,12 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::domains::activity::service::ActivityService;
+use crate::domains::activity::session_observer::ActivitySessionObserver;
 use crate::domains::goals::service::GoalService;
 use crate::domains::goals::session_observer::GoalSessionObserver;
+use crate::domains::loops::service::LoopService;
+use crate::domains::loops::session_observer::LoopSessionObserver;
 use crate::domains::plans::permission_advisor::PlanPermissionAdvisor;
 use crate::domains::plans::service::PlanService;
 use crate::domains::plans::session_observer::PlanSessionObserver;
@@ -26,12 +30,17 @@ pub(super) struct LiveSessionsWiringDeps {
     pub plan_service: Arc<PlanService>,
     pub review_service: Arc<ReviewService>,
     pub goal_service: Arc<GoalService>,
+    pub loop_service: Arc<LoopService>,
+    pub activity_service: Arc<ActivityService>,
 }
 
 /// Registration order is the observer dispatch order: plans must run before
 /// reviews (reviews consumes the proposed-plan envelopes the plans observer
 /// emits, via in-pass feed-forward). Goals consume and feed nothing in-pass,
-/// so they run last.
+/// so they run after plans/reviews; loops and activity are registered after
+/// goals per the session-activity-architecture build order (both also
+/// consume and feed nothing in-pass, so their relative order is
+/// unconstrained beyond "after goals").
 pub(super) fn wire_live_sessions(deps: &LiveSessionsWiringDeps) -> LiveSessionManager {
     let observers: Vec<Arc<dyn SessionEventObserver>> = vec![
         Arc::new(PlanSessionObserver::new(deps.plan_service.clone())),
@@ -40,6 +49,8 @@ pub(super) fn wire_live_sessions(deps: &LiveSessionsWiringDeps) -> LiveSessionMa
             deps.plan_service.clone(),
         )),
         Arc::new(GoalSessionObserver::new(deps.goal_service.clone())),
+        Arc::new(LoopSessionObserver::new(deps.loop_service.clone())),
+        Arc::new(ActivitySessionObserver::new(deps.activity_service.clone())),
     ];
     let permission_advisor: Option<Arc<dyn PermissionAdvisor>> = Some(Arc::new(
         PlanPermissionAdvisor::new(deps.plan_service.clone()),

--- a/anyharness/crates/anyharness-lib/src/domains/activity/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/mod.rs
@@ -1,0 +1,9 @@
+pub mod model;
+pub mod service;
+pub mod session_observer;
+mod session_ports;
+pub mod store;
+pub mod wire;
+
+#[cfg(test)]
+mod service_tests;

--- a/anyharness/crates/anyharness-lib/src/domains/activity/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/model.rs
@@ -1,0 +1,171 @@
+use anyharness_contract::v1::{
+    ActivityProcess, ActivitySubagent, ActivityUsage, FeedKind, FeedRef, ProcessStatus,
+    SubagentStatus,
+};
+
+/// Read-only roster element: a harness-owned or client-executed background
+/// process. Never externally settable — records transition only through
+/// observer-ingested native notifications
+/// ([`super::session_observer::ActivitySessionObserver`]).
+#[derive(Debug, Clone)]
+pub struct ActivityProcessRecord {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub process_id: String,
+    pub command: String,
+    pub cwd: Option<String>,
+    pub status: ProcessRunStatus,
+    pub exit_code: Option<i32>,
+    pub pid: Option<u32>,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub feed_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessRunStatus {
+    Running,
+    Exited,
+}
+
+impl ActivityProcessRecord {
+    /// Background processes always stream raw bytes — the `feed_id` (when
+    /// bound) resolves to a [`FeedKind::TerminalBytes`] feed.
+    pub fn to_contract(&self) -> ActivityProcess {
+        ActivityProcess {
+            id: self.process_id.clone(),
+            command: self.command.clone(),
+            cwd: self.cwd.clone(),
+            status: match self.status {
+                ProcessRunStatus::Running => ProcessStatus::Running,
+                ProcessRunStatus::Exited => ProcessStatus::Exited {
+                    exit_code: self.exit_code,
+                },
+            },
+            pid: self.pid,
+            started_at: self.started_at.clone(),
+            ended_at: self.ended_at.clone(),
+            feed: self.feed_id.clone().map(|feed_id| FeedRef {
+                feed_id,
+                kind: FeedKind::TerminalBytes,
+            }),
+        }
+    }
+}
+
+/// Read-only roster element: a harness-native subagent (Claude Task agent,
+/// Codex collab child thread, Cursor `cursor/task`). Never externally
+/// settable.
+#[derive(Debug, Clone)]
+pub struct ActivitySubagentRecord {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub subagent_id: String,
+    pub agent_type: Option<String>,
+    pub description: Option<String>,
+    pub model: Option<String>,
+    pub background: bool,
+    pub status: SubagentRunStatus,
+    pub summary: Option<String>,
+    pub tokens_used: Option<i64>,
+    pub tool_calls: Option<i64>,
+    pub duration_seconds: Option<i64>,
+    pub feed_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubagentRunStatus {
+    Running,
+    Completed,
+    Failed,
+}
+
+impl ActivitySubagentRecord {
+    /// Subagents always stream a nested transcript — the `feed_id` (when
+    /// bound) resolves to a [`FeedKind::Transcript`] feed.
+    pub fn to_contract(&self) -> ActivitySubagent {
+        let usage = if self.tokens_used.is_some()
+            || self.tool_calls.is_some()
+            || self.duration_seconds.is_some()
+        {
+            Some(ActivityUsage {
+                tokens_used: self.tokens_used,
+                tool_calls: self.tool_calls,
+                duration_seconds: self.duration_seconds,
+            })
+        } else {
+            None
+        };
+        ActivitySubagent {
+            id: self.subagent_id.clone(),
+            agent_type: self.agent_type.clone(),
+            description: self.description.clone(),
+            model: self.model.clone(),
+            background: self.background,
+            status: match self.status {
+                SubagentRunStatus::Running => SubagentStatus::Running,
+                SubagentRunStatus::Completed => SubagentStatus::Completed {
+                    summary: self.summary.clone(),
+                },
+                SubagentRunStatus::Failed => SubagentStatus::Failed,
+            },
+            usage,
+            feed: self.feed_id.clone().map(|feed_id| FeedRef {
+                feed_id,
+                kind: FeedKind::Transcript,
+            }),
+        }
+    }
+}
+
+/// Which roster element owns a [`FeedBindingRecord`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeedOwnerKind {
+    Process,
+    Subagent,
+}
+
+impl FeedOwnerKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Subagent => "subagent",
+        }
+    }
+}
+
+/// The transport detail a `FeedRef` resolves to — internal-only, never
+/// serialized to the contract. `tail_file` / `acp_child_demux` / `http_sse`
+/// per the session-activity-architecture membrane framework.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeedTransport {
+    TailFile { path: String },
+    AcpChildDemux { thread_id: String },
+    HttpSse { url: String },
+}
+
+/// One row per roster element's live content stream: the opaque `feed_id`
+/// exposed as [`FeedRef`] plus the transport detail that never leaves the
+/// runtime.
+#[derive(Debug, Clone)]
+pub struct FeedBindingRecord {
+    pub feed_id: String,
+    pub session_id: String,
+    pub kind: FeedKind,
+    pub owner_kind: FeedOwnerKind,
+    pub owner_id: String,
+    pub transport: FeedTransport,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl FeedBindingRecord {
+    pub fn to_feed_ref(&self) -> FeedRef {
+        FeedRef {
+            feed_id: self.feed_id.clone(),
+            kind: self.kind,
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/service.rs
@@ -1,0 +1,292 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::{
+    ActivityProcess, ActivityProcessUpsertedPayload, ActivitySubagent,
+    ActivitySubagentUpsertedPayload, FeedKind, SessionEvent, SessionEventEnvelope,
+};
+
+use super::model::{
+    ActivityProcessRecord, ActivitySubagentRecord, FeedBindingRecord, FeedOwnerKind,
+    FeedTransport, ProcessRunStatus, SubagentRunStatus,
+};
+use super::store::ActivityStore;
+use super::wire::{
+    ActivityProcessStatusWire, ActivityProcessWire, ActivitySubagentStatusWire,
+    ActivitySubagentWire, FeedTransportWire,
+};
+use crate::domains::sessions::model::SessionEventRecord;
+
+#[derive(Debug, Clone)]
+pub struct ActivityEventContext {
+    pub workspace_id: String,
+    pub session_id: String,
+    pub source_agent_kind: String,
+    pub turn_id: Option<String>,
+    pub next_seq: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ActivityEventBatch {
+    pub envelopes: Vec<SessionEventEnvelope>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ActivityIngestError {
+    #[error(transparent)]
+    Store(#[from] anyhow::Error),
+}
+
+/// Mirror-keeping over the read-only activity rosters (background processes
+/// + harness-native subagents). Unlike goals/loops there is no external
+/// write path at all — every record transitions ONLY through the
+/// native-notification ingest paths here
+/// ([`super::session_observer::ActivitySessionObserver`]).
+#[derive(Clone)]
+pub struct ActivityService {
+    store: ActivityStore,
+}
+
+impl ActivityService {
+    pub fn new(store: ActivityStore) -> Self {
+        Self { store }
+    }
+
+    pub fn store(&self) -> &ActivityStore {
+        &self.store
+    }
+
+    pub fn current_processes(&self, session_id: &str) -> anyhow::Result<Vec<ActivityProcess>> {
+        Ok(self
+            .store
+            .list_processes(session_id)?
+            .iter()
+            .map(ActivityProcessRecord::to_contract)
+            .collect())
+    }
+
+    pub fn current_agents(&self, session_id: &str) -> anyhow::Result<Vec<ActivitySubagent>> {
+        Ok(self
+            .store
+            .list_subagents(session_id)?
+            .iter()
+            .map(ActivitySubagentRecord::to_contract)
+            .collect())
+    }
+
+    pub fn current_roster(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<(Vec<ActivityProcess>, Vec<ActivitySubagent>)> {
+        Ok((
+            self.current_processes(session_id)?,
+            self.current_agents(session_id)?,
+        ))
+    }
+
+    pub fn current_rosters_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, (Vec<ActivityProcess>, Vec<ActivitySubagent>)>> {
+        Ok(self
+            .store
+            .list_rosters_for_sessions(session_ids)?
+            .into_iter()
+            .map(|(session_id, (processes, subagents))| {
+                (
+                    session_id,
+                    (
+                        processes.iter().map(ActivityProcessRecord::to_contract).collect(),
+                        subagents.iter().map(ActivitySubagentRecord::to_contract).collect(),
+                    ),
+                )
+            })
+            .collect())
+    }
+
+    /// Ingests one `process_upserted` tagged-chunk payload: upserts the
+    /// process row (and its feed binding, if a transport was carried) and
+    /// persists the matching contract event in one transaction.
+    pub fn ingest_process_upserted(
+        &self,
+        context: ActivityEventContext,
+        wire: ActivityProcessWire,
+    ) -> Result<ActivityEventBatch, ActivityIngestError> {
+        self.store
+            .with_tx_anyhow(|tx| {
+                let feed_id = wire
+                    .feed
+                    .clone()
+                    .map(|transport| {
+                        bind_feed(
+                            tx,
+                            &context,
+                            FeedOwnerKind::Process,
+                            &wire.id,
+                            FeedKind::TerminalBytes,
+                            transport,
+                        )
+                    })
+                    .transpose()?;
+
+                let record = ActivityProcessRecord {
+                    session_id: context.session_id.clone(),
+                    workspace_id: context.workspace_id.clone(),
+                    process_id: wire.id.clone(),
+                    command: wire.command.clone(),
+                    cwd: wire.cwd.clone(),
+                    status: match wire.status {
+                        ActivityProcessStatusWire::Running => ProcessRunStatus::Running,
+                        ActivityProcessStatusWire::Exited => ProcessRunStatus::Exited,
+                    },
+                    exit_code: wire.exit_code,
+                    pid: wire.pid,
+                    started_at: wire.started_at.clone(),
+                    ended_at: wire.ended_at.clone(),
+                    feed_id,
+                    updated_at: chrono::Utc::now().to_rfc3339(),
+                };
+                ActivityStore::upsert_process(tx, &record)?;
+
+                let envelope = envelope(
+                    &context,
+                    context.next_seq,
+                    SessionEvent::ActivityProcessUpserted(ActivityProcessUpsertedPayload {
+                        process: record.to_contract(),
+                    }),
+                );
+                ActivityStore::insert_event(tx, &event_record(&envelope)?)?;
+                Ok(ActivityEventBatch {
+                    envelopes: vec![envelope],
+                })
+            })
+            .map_err(ActivityIngestError::Store)
+    }
+
+    /// Ingests one `subagent_upserted` tagged-chunk payload.
+    pub fn ingest_subagent_upserted(
+        &self,
+        context: ActivityEventContext,
+        wire: ActivitySubagentWire,
+    ) -> Result<ActivityEventBatch, ActivityIngestError> {
+        self.store
+            .with_tx_anyhow(|tx| {
+                let feed_id = wire
+                    .feed
+                    .clone()
+                    .map(|transport| {
+                        bind_feed(
+                            tx,
+                            &context,
+                            FeedOwnerKind::Subagent,
+                            &wire.id,
+                            FeedKind::Transcript,
+                            transport,
+                        )
+                    })
+                    .transpose()?;
+
+                let record = ActivitySubagentRecord {
+                    session_id: context.session_id.clone(),
+                    workspace_id: context.workspace_id.clone(),
+                    subagent_id: wire.id.clone(),
+                    agent_type: wire.agent_type.clone(),
+                    description: wire.description.clone(),
+                    model: wire.model.clone(),
+                    background: wire.background,
+                    status: match wire.status {
+                        ActivitySubagentStatusWire::Running => SubagentRunStatus::Running,
+                        ActivitySubagentStatusWire::Completed => SubagentRunStatus::Completed,
+                        ActivitySubagentStatusWire::Failed => SubagentRunStatus::Failed,
+                    },
+                    summary: wire.summary.clone(),
+                    tokens_used: wire.tokens_used,
+                    tool_calls: wire.tool_calls,
+                    duration_seconds: wire.duration_seconds,
+                    feed_id,
+                    updated_at: chrono::Utc::now().to_rfc3339(),
+                };
+                ActivityStore::upsert_subagent(tx, &record)?;
+
+                let envelope = envelope(
+                    &context,
+                    context.next_seq,
+                    SessionEvent::ActivitySubagentUpserted(ActivitySubagentUpsertedPayload {
+                        agent: record.to_contract(),
+                    }),
+                );
+                ActivityStore::insert_event(tx, &event_record(&envelope)?)?;
+                Ok(ActivityEventBatch {
+                    envelopes: vec![envelope],
+                })
+            })
+            .map_err(ActivityIngestError::Store)
+    }
+}
+
+/// Resolves the stable opaque `feed_id` for one roster element, minting a
+/// fresh id on first sight and reusing it (updating the transport in place)
+/// on subsequent upserts — a feed with no watcher costs nothing, and the
+/// contract never learns the transport.
+fn bind_feed(
+    tx: &rusqlite::Connection,
+    context: &ActivityEventContext,
+    owner_kind: FeedOwnerKind,
+    owner_id: &str,
+    kind: FeedKind,
+    transport_wire: FeedTransportWire,
+) -> rusqlite::Result<String> {
+    let existing =
+        ActivityStore::find_feed_binding_tx(tx, &context.session_id, owner_kind, owner_id)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let feed_id = existing
+        .as_ref()
+        .map(|binding| binding.feed_id.clone())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let record = FeedBindingRecord {
+        feed_id: feed_id.clone(),
+        session_id: context.session_id.clone(),
+        kind,
+        owner_kind,
+        owner_id: owner_id.to_string(),
+        transport: transport_from_wire(transport_wire),
+        created_at: existing.map(|binding| binding.created_at).unwrap_or_else(|| now.clone()),
+        updated_at: now,
+    };
+    ActivityStore::upsert_feed_binding(tx, &record)?;
+    Ok(feed_id)
+}
+
+fn transport_from_wire(wire: FeedTransportWire) -> FeedTransport {
+    match wire {
+        FeedTransportWire::TailFile { path } => FeedTransport::TailFile { path },
+        FeedTransportWire::AcpChildDemux { thread_id } => {
+            FeedTransport::AcpChildDemux { thread_id }
+        }
+        FeedTransportWire::HttpSse { url } => FeedTransport::HttpSse { url },
+    }
+}
+
+fn envelope(context: &ActivityEventContext, seq: i64, event: SessionEvent) -> SessionEventEnvelope {
+    SessionEventEnvelope {
+        session_id: context.session_id.clone(),
+        seq,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        turn_id: context.turn_id.clone(),
+        item_id: None,
+        event,
+    }
+}
+
+fn event_record(envelope: &SessionEventEnvelope) -> rusqlite::Result<SessionEventRecord> {
+    Ok(SessionEventRecord {
+        id: 0,
+        session_id: envelope.session_id.clone(),
+        seq: envelope.seq,
+        timestamp: envelope.timestamp.clone(),
+        event_type: envelope.event.event_type().to_string(),
+        turn_id: envelope.turn_id.clone(),
+        item_id: envelope.item_id.clone(),
+        payload_json: serde_json::to_string(&envelope.event)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/service_tests.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use anyharness_contract::v1::{FeedKind, ProcessStatus, SessionEvent, SubagentStatus};
+use serde_json::json;
+
+use super::service::{ActivityEventContext, ActivityService};
+use super::session_observer::ActivitySessionObserver;
+use super::store::ActivityStore;
+use super::wire::{ActivityProcessStatusWire, ActivityProcessWire, ActivitySubagentStatusWire, ActivitySubagentWire, FeedTransportWire};
+use crate::app::test_support;
+use crate::live::sessions::model::{
+    AcpChunkPayload, SessionEventObserver, SessionObservation, SessionObserverContext,
+};
+use crate::persistence::Db;
+
+fn test_service() -> ActivityService {
+    let db = Db::open_in_memory().expect("open db");
+    test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+    db.with_conn(|conn| {
+        conn.execute(
+            "INSERT INTO sessions (
+                id, workspace_id, agent_kind, status, created_at, updated_at
+             ) VALUES ('session-1', 'workspace-1', 'claude', 'idle', 'now', 'now')",
+            [],
+        )?;
+        Ok(())
+    })
+    .expect("seed db");
+    ActivityService::new(ActivityStore::new(db))
+}
+
+fn context(next_seq: i64) -> ActivityEventContext {
+    ActivityEventContext {
+        workspace_id: "workspace-1".to_string(),
+        session_id: "session-1".to_string(),
+        source_agent_kind: "claude".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        next_seq,
+    }
+}
+
+fn process_wire(id: &str, status: ActivityProcessStatusWire) -> ActivityProcessWire {
+    ActivityProcessWire {
+        id: id.to_string(),
+        command: "sleep 30 && echo OK > out.txt".to_string(),
+        cwd: None,
+        status,
+        exit_code: None,
+        pid: None,
+        started_at: "2026-07-02T00:00:00Z".to_string(),
+        ended_at: None,
+        feed: None,
+    }
+}
+
+#[test]
+fn ingest_process_upserted_creates_the_roster_row() {
+    let service = test_service();
+    let batch = service
+        .ingest_process_upserted(context(1), process_wire("proc-1", ActivityProcessStatusWire::Running))
+        .expect("ingest process");
+
+    assert_eq!(batch.envelopes.len(), 1);
+    assert_eq!(batch.envelopes[0].event.event_type(), "process_upserted");
+    let SessionEvent::ActivityProcessUpserted(payload) = &batch.envelopes[0].event else {
+        panic!("expected process_upserted event");
+    };
+    assert_eq!(payload.process.id, "proc-1");
+    assert_eq!(payload.process.status, ProcessStatus::Running);
+
+    let processes = service.current_processes("session-1").expect("load processes");
+    assert_eq!(processes.len(), 1);
+    assert_eq!(processes[0].id, "proc-1");
+}
+
+#[test]
+fn ingest_process_upserted_transitions_running_to_exited() {
+    let service = test_service();
+    service
+        .ingest_process_upserted(context(1), process_wire("proc-1", ActivityProcessStatusWire::Running))
+        .expect("ingest running");
+
+    let mut exited = process_wire("proc-1", ActivityProcessStatusWire::Exited);
+    exited.exit_code = Some(0);
+    exited.ended_at = Some("2026-07-02T00:00:30Z".to_string());
+    service
+        .ingest_process_upserted(context(2), exited)
+        .expect("ingest exited");
+
+    let processes = service.current_processes("session-1").expect("load processes");
+    assert_eq!(processes.len(), 1);
+    assert_eq!(
+        processes[0].status,
+        ProcessStatus::Exited { exit_code: Some(0) }
+    );
+}
+
+#[test]
+fn ingest_process_upserted_binds_a_stable_feed_ref_across_updates() {
+    let service = test_service();
+    let mut wire = process_wire("proc-1", ActivityProcessStatusWire::Running);
+    wire.feed = Some(FeedTransportWire::TailFile {
+        path: "/tmp/out.txt".to_string(),
+    });
+    let first = service
+        .ingest_process_upserted(context(1), wire.clone())
+        .expect("ingest with feed");
+    let SessionEvent::ActivityProcessUpserted(first_payload) = &first.envelopes[0].event else {
+        panic!("expected process_upserted event");
+    };
+    let feed = first_payload.process.feed.clone().expect("feed ref");
+    assert_eq!(feed.kind, FeedKind::TerminalBytes);
+
+    wire.status = ActivityProcessStatusWire::Exited;
+    wire.exit_code = Some(0);
+    let second = service.ingest_process_upserted(context(2), wire).expect("ingest again");
+    let SessionEvent::ActivityProcessUpserted(second_payload) = &second.envelopes[0].event else {
+        panic!("expected process_upserted event");
+    };
+    let second_feed = second_payload.process.feed.clone().expect("feed ref still present");
+    assert_eq!(second_feed.feed_id, feed.feed_id);
+}
+
+#[test]
+fn ingest_subagent_upserted_creates_the_roster_row_with_usage() {
+    let service = test_service();
+    let wire = ActivitySubagentWire {
+        id: "agent-1".to_string(),
+        agent_type: Some("reviewer".to_string()),
+        description: Some("Reviewing the diff".to_string()),
+        model: Some("claude-sonnet".to_string()),
+        background: true,
+        status: ActivitySubagentStatusWire::Running,
+        summary: None,
+        tokens_used: Some(1200),
+        tool_calls: Some(3),
+        duration_seconds: Some(42),
+        feed: None,
+    };
+    let batch = service
+        .ingest_subagent_upserted(context(1), wire)
+        .expect("ingest subagent");
+
+    assert_eq!(batch.envelopes.len(), 1);
+    assert_eq!(batch.envelopes[0].event.event_type(), "subagent_upserted");
+    let SessionEvent::ActivitySubagentUpserted(payload) = &batch.envelopes[0].event else {
+        panic!("expected subagent_upserted event");
+    };
+    assert_eq!(payload.agent.status, SubagentStatus::Running);
+    let usage = payload.agent.usage.clone().expect("usage present");
+    assert_eq!(usage.tokens_used, Some(1200));
+
+    let agents = service.current_agents("session-1").expect("load agents");
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].id, "agent-1");
+}
+
+// ---------------------------------------------------------------------------
+// Observer ingestion (fixture chunks)
+// ---------------------------------------------------------------------------
+
+fn observer_context(next_seq: i64) -> SessionObserverContext {
+    SessionObserverContext {
+        session_id: "session-1".to_string(),
+        workspace_id: "workspace-1".to_string(),
+        agent_kind: "claude".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        next_seq,
+    }
+}
+
+fn activity_chunk(meta: serde_json::Value) -> AcpChunkPayload {
+    AcpChunkPayload {
+        content: json!({ "type": "text", "text": "" }),
+        meta: Some(meta),
+        message_id: None,
+    }
+}
+
+#[test]
+fn observer_ingests_process_upserted_chunk() {
+    let service = Arc::new(test_service());
+    let observer = ActivitySessionObserver::new(service.clone());
+
+    let payload = activity_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "process_upserted",
+            "process": {
+                "id": "proc-1",
+                "command": "sleep 30 && echo OK > out.txt",
+                "status": "running",
+                "startedAt": "2026-07-02T00:00:00Z",
+                "feed": { "kind": "tail_file", "path": "/tmp/out.txt" }
+            }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&payload),
+    );
+
+    assert_eq!(effects.persisted_events.len(), 1);
+    assert_eq!(effects.persisted_events[0].event.event_type(), "process_upserted");
+    let processes = service.current_processes("session-1").expect("load processes");
+    assert_eq!(processes.len(), 1);
+    assert!(processes[0].feed.is_some());
+}
+
+#[test]
+fn observer_ingests_subagent_upserted_chunk() {
+    let service = Arc::new(test_service());
+    let observer = ActivitySessionObserver::new(service.clone());
+
+    let payload = activity_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "subagent_upserted",
+            "agent": {
+                "id": "agent-1",
+                "background": false,
+                "status": "completed",
+                "summary": "Found 2 bugs",
+                "feed": { "kind": "acp_child_demux", "threadId": "child-thread-1" }
+            }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&payload),
+    );
+
+    assert_eq!(effects.persisted_events.len(), 1);
+    assert_eq!(effects.persisted_events[0].event.event_type(), "subagent_upserted");
+    let agents = service.current_agents("session-1").expect("load agents");
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].status,
+        SubagentStatus::Completed {
+            summary: Some("Found 2 bugs".to_string())
+        }
+    );
+    let feed = agents[0].feed.clone().expect("feed ref");
+    assert_eq!(feed.kind, FeedKind::Transcript);
+}
+
+#[test]
+fn observer_ignores_unrelated_and_malformed_chunks() {
+    let service = Arc::new(test_service());
+    let observer = ActivitySessionObserver::new(service.clone());
+
+    let plan_chunk = activity_chunk(json!({
+        "anyharness": { "transcriptEvent": "proposed_plan_completed" }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&plan_chunk),
+    );
+    assert!(effects.persisted_events.is_empty());
+
+    let malformed = activity_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "process_upserted",
+            "process": { "id": "proc-1", "status": "not-a-status" }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&malformed),
+    );
+    assert!(effects.persisted_events.is_empty());
+    assert!(service
+        .current_processes("session-1")
+        .expect("load processes")
+        .is_empty());
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/session_observer.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/session_observer.rs
@@ -1,0 +1,224 @@
+//! Activity-roster ingestion as a [`SessionEventObserver`].
+//!
+//! The sidecars/integration modules emit background-process and subagent
+//! state as zero-length `AgentMessageChunk` updates tagged
+//! `meta.anyharness.transcriptEvent = process_upserted | subagent_upserted`
+//! with the normalized wire payload in `meta.anyharness.process` /
+//! `meta.anyharness.agent`. The dispatcher keeps these chunks out of the
+//! transcript (`NON_TRANSCRIPT_CHUNK_EVENTS`) and surfaces them here as
+//! [`SessionObservation::NonTranscriptChunk`].
+//!
+//! These rosters are strictly read-only: there is no write path at all, only
+//! this ingest.
+//!
+//! # Dispatch contract
+//!
+//! Registered after the goal observer in the ordered pass (see
+//! `app/sessions.rs`): activity consumes and feeds nothing in-pass.
+//!
+//! # Threading contract
+//!
+//! `observe` runs synchronously under the sink lock, on the per-session
+//! thread. All event-emitting work happens inline; no async hand-off.
+
+use std::sync::Arc;
+
+use super::service::{ActivityEventContext, ActivityService};
+use super::wire::{
+    ActivityProcessWire, ActivitySubagentWire, PROCESS_UPSERTED_TRANSCRIPT_EVENT,
+    SUBAGENT_UPSERTED_TRANSCRIPT_EVENT,
+};
+use crate::live::sessions::model::{
+    AcpChunkPayload, ObserverEffects, SessionEventObserver, SessionObservation,
+    SessionObserverContext,
+};
+
+pub struct ActivitySessionObserver {
+    activity: Arc<ActivityService>,
+}
+
+impl ActivitySessionObserver {
+    pub fn new(activity: Arc<ActivityService>) -> Self {
+        Self { activity }
+    }
+
+    fn observe_activity_chunk(
+        &self,
+        ctx: &SessionObserverContext,
+        payload: &AcpChunkPayload,
+    ) -> ObserverEffects {
+        let meta = parse_activity_chunk_meta(payload.meta.as_ref());
+        let Some(anyharness_meta) = meta.anyharness else {
+            return ObserverEffects::default();
+        };
+        let context = ActivityEventContext {
+            workspace_id: ctx.workspace_id.clone(),
+            session_id: ctx.session_id.clone(),
+            source_agent_kind: ctx.agent_kind.clone(),
+            turn_id: ctx.turn_id.clone(),
+            next_seq: ctx.next_seq,
+        };
+        match anyharness_meta.transcript_event.as_deref() {
+            Some(PROCESS_UPSERTED_TRANSCRIPT_EVENT) => {
+                let Some(value) = anyharness_meta.process else {
+                    return ObserverEffects::default();
+                };
+                let wire = match serde_json::from_value::<ActivityProcessWire>(value) {
+                    Ok(wire) => wire,
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = %ctx.session_id,
+                            error = %error,
+                            "malformed activity process wire payload on tagged chunk"
+                        );
+                        return ObserverEffects::default();
+                    }
+                };
+                match self.activity.ingest_process_upserted(context, wire) {
+                    Ok(batch) => ObserverEffects {
+                        persisted_events: batch.envelopes,
+                    },
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = %ctx.session_id,
+                            error = %error,
+                            "failed to ingest native process notification"
+                        );
+                        ObserverEffects::default()
+                    }
+                }
+            }
+            Some(SUBAGENT_UPSERTED_TRANSCRIPT_EVENT) => {
+                let Some(value) = anyharness_meta.agent else {
+                    return ObserverEffects::default();
+                };
+                let wire = match serde_json::from_value::<ActivitySubagentWire>(value) {
+                    Ok(wire) => wire,
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = %ctx.session_id,
+                            error = %error,
+                            "malformed activity subagent wire payload on tagged chunk"
+                        );
+                        return ObserverEffects::default();
+                    }
+                };
+                match self.activity.ingest_subagent_upserted(context, wire) {
+                    Ok(batch) => ObserverEffects {
+                        persisted_events: batch.envelopes,
+                    },
+                    Err(error) => {
+                        tracing::warn!(
+                            session_id = %ctx.session_id,
+                            error = %error,
+                            "failed to ingest native subagent notification"
+                        );
+                        ObserverEffects::default()
+                    }
+                }
+            }
+            _ => ObserverEffects::default(),
+        }
+    }
+}
+
+impl SessionEventObserver for ActivitySessionObserver {
+    fn observe(
+        &self,
+        ctx: &SessionObserverContext,
+        obs: SessionObservation<'_>,
+    ) -> ObserverEffects {
+        match obs {
+            SessionObservation::NonTranscriptChunk(payload) => {
+                self.observe_activity_chunk(ctx, payload)
+            }
+            // Roster state arrives only on tagged protocol chunks.
+            SessionObservation::ToolCall { .. }
+            | SessionObservation::AssistantMessageCompleted(_)
+            | SessionObservation::Event(_) => ObserverEffects::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ActivityChunkAnyHarnessMeta {
+    transcript_event: Option<String>,
+    /// Kept raw so a malformed wire payload is diagnosed per-event instead
+    /// of silently voiding the whole meta parse.
+    #[serde(default)]
+    process: Option<serde_json::Value>,
+    #[serde(default)]
+    agent: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct ActivityChunkMeta {
+    #[serde(default)]
+    anyharness: Option<ActivityChunkAnyHarnessMeta>,
+}
+
+fn parse_activity_chunk_meta(meta: Option<&serde_json::Value>) -> ActivityChunkMeta {
+    meta.and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_activity_chunk_meta_reads_process_payload() {
+        let meta = parse_activity_chunk_meta(Some(&json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "transcriptEvent": "process_upserted",
+                "process": {
+                    "id": "proc-1",
+                    "command": "sleep 30",
+                    "status": "running",
+                    "startedAt": "2026-07-02T00:00:00Z"
+                }
+            }
+        })));
+        let anyharness = meta.anyharness.expect("anyharness meta");
+        assert_eq!(
+            anyharness.transcript_event.as_deref(),
+            Some("process_upserted")
+        );
+        let wire: ActivityProcessWire =
+            serde_json::from_value(anyharness.process.expect("process payload"))
+                .expect("parse process wire");
+        assert_eq!(wire.id, "proc-1");
+    }
+
+    #[test]
+    fn parse_activity_chunk_meta_reads_agent_payload() {
+        let meta = parse_activity_chunk_meta(Some(&json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "transcriptEvent": "subagent_upserted",
+                "agent": {
+                    "id": "agent-1",
+                    "background": true,
+                    "status": "running"
+                }
+            }
+        })));
+        let anyharness = meta.anyharness.expect("anyharness meta");
+        assert_eq!(
+            anyharness.transcript_event.as_deref(),
+            Some("subagent_upserted")
+        );
+        assert!(anyharness.agent.is_some());
+    }
+
+    #[test]
+    fn parse_activity_chunk_meta_defaults_on_missing_or_malformed_meta() {
+        assert!(parse_activity_chunk_meta(None).anyharness.is_none());
+        assert!(parse_activity_chunk_meta(Some(&json!("not an object")))
+            .anyharness
+            .is_none());
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/session_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/session_ports.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::{ActivityProcess, ActivitySubagent};
+
+use super::service::ActivityService;
+use crate::domains::sessions::active_activity_roster::ActivityRosterResolver;
+
+impl ActivityRosterResolver for ActivityService {
+    fn activity_roster(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<(Vec<ActivityProcess>, Vec<ActivitySubagent>)> {
+        self.current_roster(session_id)
+    }
+
+    fn activity_rosters_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, (Vec<ActivityProcess>, Vec<ActivitySubagent>)>> {
+        self.current_rosters_for_sessions(session_ids)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/store.rs
@@ -1,0 +1,424 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::FeedKind;
+use rusqlite::{params, types::Type, Connection, OptionalExtension, Row};
+
+use super::model::{
+    ActivityProcessRecord, ActivitySubagentRecord, FeedBindingRecord, FeedOwnerKind,
+    FeedTransport, ProcessRunStatus, SubagentRunStatus,
+};
+use crate::domains::sessions::model::SessionEventRecord;
+use crate::persistence::Db;
+
+#[derive(Clone)]
+pub struct ActivityStore {
+    db: Db,
+}
+
+impl ActivityStore {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+
+    pub fn with_tx_anyhow<F, T>(&self, f: F) -> anyhow::Result<T>
+    where
+        F: FnOnce(&Connection) -> anyhow::Result<T>,
+    {
+        self.db.with_tx_anyhow(f)
+    }
+
+    // -- processes ----------------------------------------------------------
+
+    pub fn find_process_tx(
+        tx: &Connection,
+        session_id: &str,
+        process_id: &str,
+    ) -> rusqlite::Result<Option<ActivityProcessRecord>> {
+        tx.query_row(
+            "SELECT * FROM activity_processes WHERE session_id = ?1 AND process_id = ?2",
+            params![session_id, process_id],
+            map_process,
+        )
+        .optional()
+    }
+
+    pub fn list_processes(&self, session_id: &str) -> anyhow::Result<Vec<ActivityProcessRecord>> {
+        self.db.with_conn(|conn| {
+            let mut statement = conn.prepare(
+                "SELECT * FROM activity_processes WHERE session_id = ?1 ORDER BY started_at ASC",
+            )?;
+            let rows = statement
+                .query_map([session_id], map_process)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    pub fn upsert_process(tx: &Connection, record: &ActivityProcessRecord) -> rusqlite::Result<()> {
+        tx.execute(
+            "INSERT INTO activity_processes (
+                session_id, workspace_id, process_id, command, cwd, status, exit_code, pid,
+                started_at, ended_at, feed_id, updated_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(session_id, process_id) DO UPDATE SET
+                command = excluded.command,
+                cwd = excluded.cwd,
+                status = excluded.status,
+                exit_code = excluded.exit_code,
+                pid = excluded.pid,
+                ended_at = excluded.ended_at,
+                feed_id = excluded.feed_id,
+                updated_at = excluded.updated_at",
+            params![
+                record.session_id,
+                record.workspace_id,
+                record.process_id,
+                record.command,
+                record.cwd,
+                process_status_to_db(record.status),
+                record.exit_code,
+                record.pid,
+                record.started_at,
+                record.ended_at,
+                record.feed_id,
+                record.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    // -- subagents ------------------------------------------------------------
+
+    pub fn find_subagent_tx(
+        tx: &Connection,
+        session_id: &str,
+        subagent_id: &str,
+    ) -> rusqlite::Result<Option<ActivitySubagentRecord>> {
+        tx.query_row(
+            "SELECT * FROM activity_subagents WHERE session_id = ?1 AND subagent_id = ?2",
+            params![session_id, subagent_id],
+            map_subagent,
+        )
+        .optional()
+    }
+
+    pub fn list_subagents(&self, session_id: &str) -> anyhow::Result<Vec<ActivitySubagentRecord>> {
+        self.db.with_conn(|conn| {
+            let mut statement = conn.prepare(
+                "SELECT * FROM activity_subagents WHERE session_id = ?1 ORDER BY updated_at ASC",
+            )?;
+            let rows = statement
+                .query_map([session_id], map_subagent)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    pub fn upsert_subagent(
+        tx: &Connection,
+        record: &ActivitySubagentRecord,
+    ) -> rusqlite::Result<()> {
+        tx.execute(
+            "INSERT INTO activity_subagents (
+                session_id, workspace_id, subagent_id, agent_type, description, model,
+                background, status, summary, tokens_used, tool_calls, duration_seconds,
+                feed_id, updated_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             ON CONFLICT(session_id, subagent_id) DO UPDATE SET
+                agent_type = excluded.agent_type,
+                description = excluded.description,
+                model = excluded.model,
+                background = excluded.background,
+                status = excluded.status,
+                summary = excluded.summary,
+                tokens_used = excluded.tokens_used,
+                tool_calls = excluded.tool_calls,
+                duration_seconds = excluded.duration_seconds,
+                feed_id = excluded.feed_id,
+                updated_at = excluded.updated_at",
+            params![
+                record.session_id,
+                record.workspace_id,
+                record.subagent_id,
+                record.agent_type,
+                record.description,
+                record.model,
+                record.background,
+                subagent_status_to_db(record.status),
+                record.summary,
+                record.tokens_used,
+                record.tool_calls,
+                record.duration_seconds,
+                record.feed_id,
+                record.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    // -- feed bindings --------------------------------------------------------
+
+    /// Returns the existing binding for this roster element if one exists;
+    /// callers use this to keep `feed_id` stable across repeated upserts of
+    /// the same owner instead of minting a new opaque id every time.
+    pub fn find_feed_binding_tx(
+        tx: &Connection,
+        session_id: &str,
+        owner_kind: FeedOwnerKind,
+        owner_id: &str,
+    ) -> rusqlite::Result<Option<FeedBindingRecord>> {
+        tx.query_row(
+            "SELECT * FROM feed_bindings WHERE session_id = ?1 AND owner_kind = ?2 AND owner_id = ?3",
+            params![session_id, owner_kind.as_str(), owner_id],
+            map_feed_binding,
+        )
+        .optional()
+    }
+
+    pub fn upsert_feed_binding(tx: &Connection, record: &FeedBindingRecord) -> rusqlite::Result<()> {
+        let (transport_kind, path, thread_id, url) = transport_to_db(&record.transport);
+        tx.execute(
+            "INSERT INTO feed_bindings (
+                feed_id, session_id, kind, owner_kind, owner_id, transport_kind,
+                transport_path, transport_thread_id, transport_url, created_at, updated_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             ON CONFLICT(session_id, owner_kind, owner_id) DO UPDATE SET
+                kind = excluded.kind,
+                transport_kind = excluded.transport_kind,
+                transport_path = excluded.transport_path,
+                transport_thread_id = excluded.transport_thread_id,
+                transport_url = excluded.transport_url,
+                updated_at = excluded.updated_at",
+            params![
+                record.feed_id,
+                record.session_id,
+                feed_kind_to_db(record.kind),
+                record.owner_kind.as_str(),
+                record.owner_id,
+                transport_kind,
+                path,
+                thread_id,
+                url,
+                record.created_at,
+                record.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_event(tx: &Connection, record: &SessionEventRecord) -> rusqlite::Result<()> {
+        tx.execute(
+            "INSERT INTO session_events (session_id, seq, timestamp, event_type, turn_id, item_id, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                record.session_id,
+                record.seq,
+                record.timestamp,
+                record.event_type,
+                record.turn_id,
+                record.item_id,
+                record.payload_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Batch roster read for a page of sessions — one query per table (not
+    /// one per session), grouped client-side. Used by `SessionView`'s
+    /// batched assembly path.
+    pub fn list_rosters_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, (Vec<ActivityProcessRecord>, Vec<ActivitySubagentRecord>)>>
+    {
+        let mut grouped: HashMap<String, (Vec<ActivityProcessRecord>, Vec<ActivitySubagentRecord>)> =
+            HashMap::new();
+        if session_ids.is_empty() {
+            return Ok(grouped);
+        }
+        self.db.with_conn(|conn| {
+            for session_id in session_ids {
+                let mut process_statement = conn.prepare(
+                    "SELECT * FROM activity_processes WHERE session_id = ?1 ORDER BY started_at ASC",
+                )?;
+                let processes = process_statement
+                    .query_map([session_id], map_process)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                let mut subagent_statement = conn.prepare(
+                    "SELECT * FROM activity_subagents WHERE session_id = ?1 ORDER BY updated_at ASC",
+                )?;
+                let subagents = subagent_statement
+                    .query_map([session_id], map_subagent)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                if !processes.is_empty() || !subagents.is_empty() {
+                    grouped.insert(session_id.clone(), (processes, subagents));
+                }
+            }
+            Ok(())
+        })?;
+        Ok(grouped)
+    }
+}
+
+fn process_status_to_db(status: ProcessRunStatus) -> &'static str {
+    match status {
+        ProcessRunStatus::Running => "running",
+        ProcessRunStatus::Exited => "exited",
+    }
+}
+
+fn process_status_from_db(value: &str) -> rusqlite::Result<ProcessRunStatus> {
+    match value {
+        "running" => Ok(ProcessRunStatus::Running),
+        "exited" => Ok(ProcessRunStatus::Exited),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown activity process status: {other}").into(),
+        )),
+    }
+}
+
+fn subagent_status_to_db(status: SubagentRunStatus) -> &'static str {
+    match status {
+        SubagentRunStatus::Running => "running",
+        SubagentRunStatus::Completed => "completed",
+        SubagentRunStatus::Failed => "failed",
+    }
+}
+
+fn subagent_status_from_db(value: &str) -> rusqlite::Result<SubagentRunStatus> {
+    match value {
+        "running" => Ok(SubagentRunStatus::Running),
+        "completed" => Ok(SubagentRunStatus::Completed),
+        "failed" => Ok(SubagentRunStatus::Failed),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown activity subagent status: {other}").into(),
+        )),
+    }
+}
+
+fn feed_kind_to_db(kind: FeedKind) -> &'static str {
+    match kind {
+        FeedKind::TerminalBytes => "terminal_bytes",
+        FeedKind::Transcript => "transcript",
+    }
+}
+
+fn feed_kind_from_db(value: &str) -> rusqlite::Result<FeedKind> {
+    match value {
+        "terminal_bytes" => Ok(FeedKind::TerminalBytes),
+        "transcript" => Ok(FeedKind::Transcript),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown feed kind: {other}").into(),
+        )),
+    }
+}
+
+fn transport_to_db(
+    transport: &FeedTransport,
+) -> (&'static str, Option<&str>, Option<&str>, Option<&str>) {
+    match transport {
+        FeedTransport::TailFile { path } => ("tail_file", Some(path.as_str()), None, None),
+        FeedTransport::AcpChildDemux { thread_id } => {
+            ("acp_child_demux", None, Some(thread_id.as_str()), None)
+        }
+        FeedTransport::HttpSse { url } => ("http_sse", None, None, Some(url.as_str())),
+    }
+}
+
+fn transport_from_db(
+    kind: &str,
+    path: Option<String>,
+    thread_id: Option<String>,
+    url: Option<String>,
+) -> rusqlite::Result<FeedTransport> {
+    match kind {
+        "tail_file" => Ok(FeedTransport::TailFile {
+            path: path.unwrap_or_default(),
+        }),
+        "acp_child_demux" => Ok(FeedTransport::AcpChildDemux {
+            thread_id: thread_id.unwrap_or_default(),
+        }),
+        "http_sse" => Ok(FeedTransport::HttpSse {
+            url: url.unwrap_or_default(),
+        }),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown feed transport kind: {other}").into(),
+        )),
+    }
+}
+
+fn map_process(row: &Row<'_>) -> rusqlite::Result<ActivityProcessRecord> {
+    Ok(ActivityProcessRecord {
+        session_id: row.get("session_id")?,
+        workspace_id: row.get("workspace_id")?,
+        process_id: row.get("process_id")?,
+        command: row.get("command")?,
+        cwd: row.get("cwd")?,
+        status: process_status_from_db(row.get::<_, String>("status")?.as_str())?,
+        exit_code: row.get("exit_code")?,
+        pid: row.get("pid")?,
+        started_at: row.get("started_at")?,
+        ended_at: row.get("ended_at")?,
+        feed_id: row.get("feed_id")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn map_subagent(row: &Row<'_>) -> rusqlite::Result<ActivitySubagentRecord> {
+    Ok(ActivitySubagentRecord {
+        session_id: row.get("session_id")?,
+        workspace_id: row.get("workspace_id")?,
+        subagent_id: row.get("subagent_id")?,
+        agent_type: row.get("agent_type")?,
+        description: row.get("description")?,
+        model: row.get("model")?,
+        background: row.get("background")?,
+        status: subagent_status_from_db(row.get::<_, String>("status")?.as_str())?,
+        summary: row.get("summary")?,
+        tokens_used: row.get("tokens_used")?,
+        tool_calls: row.get("tool_calls")?,
+        duration_seconds: row.get("duration_seconds")?,
+        feed_id: row.get("feed_id")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn map_feed_binding(row: &Row<'_>) -> rusqlite::Result<FeedBindingRecord> {
+    let owner_kind = match row.get::<_, String>("owner_kind")?.as_str() {
+        "process" => FeedOwnerKind::Process,
+        "subagent" => FeedOwnerKind::Subagent,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                Type::Text,
+                format!("unknown feed owner kind: {other}").into(),
+            ))
+        }
+    };
+    Ok(FeedBindingRecord {
+        feed_id: row.get("feed_id")?,
+        session_id: row.get("session_id")?,
+        kind: feed_kind_from_db(row.get::<_, String>("kind")?.as_str())?,
+        owner_kind,
+        owner_id: row.get("owner_id")?,
+        transport: transport_from_db(
+            row.get::<_, String>("transport_kind")?.as_str(),
+            row.get("transport_path")?,
+            row.get("transport_thread_id")?,
+            row.get("transport_url")?,
+        )?,
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/activity/wire.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/activity/wire.rs
@@ -1,0 +1,160 @@
+//! ActivityPort wire contract v1 (session-activity-architecture, locked
+//! 2026-07-02): the normalized shapes the sidecars/integration modules speak
+//! for the read-only activity rosters — `ActivityProcessWire` /
+//! `ActivitySubagentWire` payloads on tagged notification chunks
+//! (`process_upserted` / `subagent_upserted`). The `feed` transport
+//! (`tail_file` / `acp_child_demux` / `http_sse`) travels membrane→runtime
+//! ONLY on this wire type — it is swapped for an opaque
+//! [`super::model::FeedBindingRecord`] / `FeedRef` before anything leaves
+//! the runtime.
+
+use serde::Deserialize;
+
+pub const PROCESS_UPSERTED_TRANSCRIPT_EVENT: &str = "process_upserted";
+pub const SUBAGENT_UPSERTED_TRANSCRIPT_EVENT: &str = "subagent_upserted";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityProcessWire {
+    pub id: String,
+    pub command: String,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    pub status: ActivityProcessStatusWire,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    #[serde(default)]
+    pub pid: Option<u32>,
+    pub started_at: String,
+    #[serde(default)]
+    pub ended_at: Option<String>,
+    #[serde(default)]
+    pub feed: Option<FeedTransportWire>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityProcessStatusWire {
+    Running,
+    Exited,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivitySubagentWire {
+    pub id: String,
+    #[serde(default)]
+    pub agent_type: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub background: bool,
+    pub status: ActivitySubagentStatusWire,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub tokens_used: Option<i64>,
+    #[serde(default)]
+    pub tool_calls: Option<i64>,
+    #[serde(default)]
+    pub duration_seconds: Option<i64>,
+    #[serde(default)]
+    pub feed: Option<FeedTransportWire>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivitySubagentStatusWire {
+    Running,
+    Completed,
+    Failed,
+}
+
+/// The feed transport as parsed off the wire — membrane→runtime only, per
+/// the ActivityPort framework. Tag values match
+/// `harness-runtime-mechanics.md`'s vocabulary verbatim
+/// (`tail_file(path)` / `acp_child_demux(thread_id)` / `http_sse(url)`).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FeedTransportWire {
+    TailFile { path: String },
+    AcpChildDemux {
+        #[serde(rename = "threadId")]
+        thread_id: String,
+    },
+    HttpSse { url: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activity_process_wire_parses_running_and_exited() {
+        let running: ActivityProcessWire = serde_json::from_value(serde_json::json!({
+            "id": "proc-1",
+            "command": "sleep 30 && echo OK > out.txt",
+            "status": "running",
+            "startedAt": "2026-07-02T00:00:00Z"
+        }))
+        .expect("parse running process wire");
+        assert_eq!(running.status, ActivityProcessStatusWire::Running);
+        assert!(running.feed.is_none());
+
+        let exited: ActivityProcessWire = serde_json::from_value(serde_json::json!({
+            "id": "proc-1",
+            "command": "sleep 30 && echo OK > out.txt",
+            "status": "exited",
+            "exitCode": 0,
+            "pid": 4242,
+            "startedAt": "2026-07-02T00:00:00Z",
+            "endedAt": "2026-07-02T00:00:30Z",
+            "feed": { "kind": "tail_file", "path": "/tmp/out.txt" }
+        }))
+        .expect("parse exited process wire");
+        assert_eq!(exited.status, ActivityProcessStatusWire::Exited);
+        assert_eq!(exited.exit_code, Some(0));
+        assert_eq!(
+            exited.feed,
+            Some(FeedTransportWire::TailFile {
+                path: "/tmp/out.txt".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn activity_subagent_wire_parses_feed_transports() {
+        let acp: ActivitySubagentWire = serde_json::from_value(serde_json::json!({
+            "id": "child-1",
+            "background": true,
+            "status": "running",
+            "feed": { "kind": "acp_child_demux", "threadId": "child-thread-1" }
+        }))
+        .expect("parse acp_child_demux subagent wire");
+        assert_eq!(
+            acp.feed,
+            Some(FeedTransportWire::AcpChildDemux {
+                thread_id: "child-thread-1".to_string()
+            })
+        );
+
+        let sse: ActivitySubagentWire = serde_json::from_value(serde_json::json!({
+            "id": "child-2",
+            "background": false,
+            "status": "completed",
+            "summary": "done",
+            "feed": { "kind": "http_sse", "url": "http://127.0.0.1:9000/session/child-2/events" }
+        }))
+        .expect("parse http_sse subagent wire");
+        assert_eq!(sse.status, ActivitySubagentStatusWire::Completed);
+        assert_eq!(sse.summary.as_deref(), Some("done"));
+        assert_eq!(
+            sse.feed,
+            Some(FeedTransportWire::HttpSse {
+                url: "http://127.0.0.1:9000/session/child-2/events".to_string()
+            })
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs
@@ -37,6 +37,13 @@ use crate::live::sessions::{
 /// adapter's transcript tail, which can lag the ext-method response).
 const GOAL_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// `nativeStatus` the sidecar stamps on a `goal/set` response it has DEFERRED
+/// to the streaming turn boundary (claude-agent-acp: a `/goal` issued mid-turn
+/// is queued and only arms — emitting its `goal_updated` — once the turn ends).
+/// A deferred set therefore has no notification within the confirmation window
+/// and must not be blocked on / cleared like a normal synchronous set.
+const GOAL_PENDING_INJECTION_NATIVE_STATUS: &str = "pending_injection";
+
 #[derive(Debug, thiserror::Error)]
 pub enum GoalOpError {
     #[error("session not found")]
@@ -139,12 +146,30 @@ impl GoalRuntime {
         };
         // The response is the sidecar's confirmation that the NATIVE write
         // landed; the mirror still transitions only via the notification.
-        if let Err(error) = serde_json::from_value::<GoalWireEnvelope>(response) {
-            tracing::warn!(
-                session_id,
-                error = %error,
-                "goal/set returned an unexpected result shape"
-            );
+        let response_goal = match serde_json::from_value::<GoalWireEnvelope>(response) {
+            Ok(envelope) => envelope.goal,
+            Err(error) => {
+                tracing::warn!(
+                    session_id,
+                    error = %error,
+                    "goal/set returned an unexpected result shape"
+                );
+                None
+            }
+        };
+
+        // A DEFERRED set (`nativeStatus == pending_injection`) has not armed
+        // yet — the sidecar queued it to the turn boundary and will emit its
+        // `goal_updated` only after the streaming turn ends, which routinely
+        // outlasts GOAL_CONFIRMATION_TIMEOUT. Blocking here would time out,
+        // clear the pending(Set) marker, and make the late notification
+        // classify as a Drop against a cleared mirror (permanently invisible
+        // goal). Instead: keep the pending(Set) marker so the eventual
+        // notification is an Insert, and hand the caller the provisional
+        // pending goal now. The async notification drives the mirror — no
+        // optimistic local transition, preserving the strict mirror.
+        if let Some(pending) = deferred_pending_injection(response_goal.as_ref()) {
+            return Ok(provisional_goal_from_wire(pending));
         }
 
         // Correlate the confirmation to THIS write by objective (when one was
@@ -377,6 +402,36 @@ fn goal_event_objective(event: &SessionEvent) -> Option<&str> {
     }
 }
 
+/// Returns the response goal iff the sidecar deferred the set to the turn
+/// boundary (`nativeStatus == pending_injection`), meaning no confirming
+/// notification will arrive within the confirmation window.
+fn deferred_pending_injection(response_goal: Option<&GoalWire>) -> Option<&GoalWire> {
+    response_goal.filter(|goal| {
+        goal.native_status.as_deref() == Some(GOAL_PENDING_INJECTION_NATIVE_STATUS)
+    })
+}
+
+/// A transient contract goal for a deferred set — returned to the caller so it
+/// sees the pending goal immediately. Never persisted: the mirror is still
+/// written only by the eventual `goal_updated` notification.
+fn provisional_goal_from_wire(wire: &GoalWire) -> Goal {
+    let now = chrono::Utc::now().to_rfc3339();
+    Goal {
+        objective: wire.objective.clone(),
+        status: wire.status.to_contract(),
+        native_status: wire.native_status.clone(),
+        token_budget: wire.token_budget,
+        tokens_used: wire.tokens_used,
+        time_used_seconds: wire.time_used_seconds,
+        met_reason: wire.met_reason.clone(),
+        iterations: wire.iterations,
+        native: wire.native,
+        revision: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
 /// The `Box<dyn Any + Send>` produced by [`GoalReconcileOp`] downcasts to
 /// this.
 struct GoalReconcileOpOutput {
@@ -424,6 +479,7 @@ fn goal_event_context(ctx: &SessionObserverContext) -> GoalEventContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domains::goals::wire::GoalWireStatus;
     use anyharness_contract::v1::{Goal, GoalStatus, GoalUpdatedPayload};
 
     const GOAL_EVENT_TYPES: &[&str] = &["goal_updated", "goal_met", "goal_cleared"];
@@ -469,5 +525,52 @@ mod tests {
         // edit to a new objective; only the edit's own echo does.
         assert!(!goal_event_matches(&stale, GOAL_EVENT_TYPES, Some("new objective")));
         assert!(goal_event_matches(&fresh, GOAL_EVENT_TYPES, Some("new objective")));
+    }
+
+    fn pending_injection_wire(objective: &str) -> GoalWire {
+        GoalWire {
+            objective: objective.to_string(),
+            status: GoalWireStatus::Active,
+            native_status: Some(GOAL_PENDING_INJECTION_NATIVE_STATUS.to_string()),
+            token_budget: None,
+            tokens_used: None,
+            time_used_seconds: None,
+            met_reason: None,
+            iterations: None,
+            native: true,
+            updated_at_ms: None,
+        }
+    }
+
+    #[test]
+    fn deferred_pending_injection_detects_only_the_deferred_native_status() {
+        let deferred = pending_injection_wire("ship it");
+        assert!(deferred_pending_injection(Some(&deferred)).is_some());
+
+        let armed = GoalWire {
+            native_status: Some("active".to_string()),
+            ..pending_injection_wire("ship it")
+        };
+        assert!(deferred_pending_injection(Some(&armed)).is_none());
+
+        let no_native = GoalWire {
+            native_status: None,
+            ..pending_injection_wire("ship it")
+        };
+        assert!(deferred_pending_injection(Some(&no_native)).is_none());
+
+        assert!(deferred_pending_injection(None).is_none());
+    }
+
+    #[test]
+    fn provisional_goal_from_wire_carries_pending_status_without_revision() {
+        let goal = provisional_goal_from_wire(&pending_injection_wire("ship it"));
+        assert_eq!(goal.objective, "ship it");
+        assert_eq!(goal.status, GoalStatus::Active);
+        assert_eq!(goal.native_status.as_deref(), Some("pending_injection"));
+        // Provisional (never persisted): revision starts at 0 and the real
+        // revision is minted by the eventual notification-driven insert.
+        assert_eq!(goal.revision, 0);
+        assert!(goal.native);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/loops/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/mod.rs
@@ -1,0 +1,9 @@
+pub mod model;
+pub mod service;
+pub mod session_observer;
+mod session_ports;
+pub mod store;
+pub mod wire;
+
+#[cfg(test)]
+mod service_tests;

--- a/anyharness/crates/anyharness-lib/src/domains/loops/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/model.rs
@@ -1,0 +1,45 @@
+use anyharness_contract::v1::{Loop, LoopSchedule, LoopScheduleKind, LoopStatus};
+
+/// The persisted loop mirror: one row per `(session_id, loop_id)`. Unlike
+/// [`crate::domains::goals::model::GoalRecord`], **multiple loops per
+/// session are allowed** (the native Claude `CronList` shape) — there is no
+/// single-head-row lifecycle here, just keyed upserts. Records transition
+/// only through observer-ingested native notifications
+/// ([`super::session_observer::LoopSessionObserver`]); the write path
+/// (`_anyharness/loop/set|clear`) lands with the loop runtime PR.
+#[derive(Debug, Clone)]
+pub struct LoopRecord {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub loop_id: String,
+    pub prompt: String,
+    pub schedule_kind: LoopScheduleKind,
+    pub schedule_expr: String,
+    pub recurring: bool,
+    pub status: LoopStatus,
+    pub native: bool,
+    pub last_fired_at_ms: Option<i64>,
+    pub fire_count: i64,
+    pub native_state_json: Option<String>,
+    pub created_at: String,
+    pub updated_at_ms: i64,
+}
+
+impl LoopRecord {
+    pub fn to_contract(&self) -> Loop {
+        Loop {
+            loop_id: self.loop_id.clone(),
+            prompt: self.prompt.clone(),
+            schedule: LoopSchedule {
+                kind: self.schedule_kind,
+                expr: self.schedule_expr.clone(),
+            },
+            recurring: self.recurring,
+            status: self.status,
+            native: self.native,
+            last_fired_at_ms: self.last_fired_at_ms,
+            fire_count: self.fire_count,
+            updated_at_ms: self.updated_at_ms,
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/service.rs
@@ -1,0 +1,264 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::{
+    LoopFiredPayload, LoopRemovedPayload, LoopStatus, LoopUpsertedPayload, SessionEvent,
+    SessionEventEnvelope,
+};
+
+use super::model::LoopRecord;
+use super::store::LoopStore;
+use super::wire::LoopWire;
+use crate::domains::sessions::model::SessionEventRecord;
+
+pub const MAX_LOOP_PROMPT_BYTES: usize = 16 * 1024;
+
+/// The tagged-chunk kinds the sidecars (and, on Codex, the runtime-emulated
+/// `LoopSchedulerExtension`) emit — `loop_upserted | loop_removed |
+/// loop_fired` (session-activity-architecture up-path vocabulary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopNativeEventKind {
+    Upserted,
+    Removed,
+    Fired,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoopEventContext {
+    pub workspace_id: String,
+    pub session_id: String,
+    pub source_agent_kind: String,
+    pub turn_id: Option<String>,
+    pub next_seq: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoopEventBatch {
+    pub r#loop: Option<LoopRecord>,
+    pub envelopes: Vec<SessionEventEnvelope>,
+}
+
+impl LoopEventBatch {
+    fn unchanged(r#loop: Option<LoopRecord>) -> Self {
+        Self {
+            r#loop,
+            envelopes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoopIngestError {
+    #[error("loop notification payload is missing its loop")]
+    MissingLoopPayload,
+    #[error("loop_removed notification is missing its loopId")]
+    MissingLoopId,
+    #[error("loop prompt exceeds {MAX_LOOP_PROMPT_BYTES} bytes")]
+    PromptTooLarge,
+    #[error(transparent)]
+    Store(#[from] anyhow::Error),
+}
+
+/// Mirror-keeping over the loops table. Unlike
+/// [`crate::domains::goals::service::GoalService`] there is no single-head
+/// lifecycle: each notification names its own `loop_id`, so ingestion is a
+/// plain keyed upsert. Records transition ONLY through the native-event
+/// ingest path here; the write path (`_anyharness/loop/set|clear`) lands
+/// with the loop runtime PR.
+#[derive(Clone)]
+pub struct LoopService {
+    store: LoopStore,
+}
+
+impl LoopService {
+    pub fn new(store: LoopStore) -> Self {
+        Self { store }
+    }
+
+    pub fn store(&self) -> &LoopStore {
+        &self.store
+    }
+
+    pub fn current_loops(&self, session_id: &str) -> anyhow::Result<Vec<LoopRecord>> {
+        self.store.list_active(session_id)
+    }
+
+    pub fn current_loops_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, Vec<LoopRecord>>> {
+        self.store.list_active_for_sessions(session_ids)
+    }
+
+    /// Ingests one sidecar loop notification: upserts the mirror row and
+    /// persists the matching contract event row in a single transaction,
+    /// returning every committed envelope (the observer partial-failure
+    /// contract). Idempotent: a notification that changes nothing commits
+    /// nothing and returns no envelopes.
+    pub fn ingest_native_event(
+        &self,
+        context: LoopEventContext,
+        kind: LoopNativeEventKind,
+        wire: Option<LoopWire>,
+        loop_id: Option<String>,
+    ) -> Result<LoopEventBatch, LoopIngestError> {
+        if let Some(wire) = wire.as_ref() {
+            if wire.prompt.len() > MAX_LOOP_PROMPT_BYTES {
+                return Err(LoopIngestError::PromptTooLarge);
+            }
+        }
+        match kind {
+            LoopNativeEventKind::Upserted => {
+                let wire = wire.ok_or(LoopIngestError::MissingLoopPayload)?;
+                self.apply_upsert(context, wire, false)
+                    .map_err(LoopIngestError::Store)
+            }
+            LoopNativeEventKind::Fired => {
+                let wire = wire.ok_or(LoopIngestError::MissingLoopPayload)?;
+                self.apply_upsert(context, wire, true)
+                    .map_err(LoopIngestError::Store)
+            }
+            LoopNativeEventKind::Removed => {
+                let loop_id = loop_id
+                    .or_else(|| wire.map(|wire| wire.loop_id))
+                    .ok_or(LoopIngestError::MissingLoopId)?;
+                self.apply_removed(context, loop_id)
+                    .map_err(LoopIngestError::Store)
+            }
+        }
+    }
+
+    fn apply_upsert(
+        &self,
+        context: LoopEventContext,
+        wire: LoopWire,
+        fired: bool,
+    ) -> anyhow::Result<LoopEventBatch> {
+        self.store.with_tx_anyhow(|tx| {
+            let now = chrono::Utc::now().to_rfc3339();
+            let existing = LoopStore::find_one_tx(tx, &context.session_id, &wire.loop_id)?;
+            let native_state_json = Some(serde_json::to_string(&wire)?);
+            let next = LoopRecord {
+                session_id: context.session_id.clone(),
+                workspace_id: context.workspace_id.clone(),
+                loop_id: wire.loop_id.clone(),
+                prompt: wire.prompt.clone(),
+                schedule_kind: wire.schedule.kind.to_contract(),
+                schedule_expr: wire.schedule.expr.clone(),
+                recurring: wire.recurring,
+                status: wire.status.to_contract(),
+                native: wire.native,
+                last_fired_at_ms: wire.last_fired_at_ms,
+                fire_count: wire.fire_count,
+                native_state_json,
+                created_at: existing
+                    .as_ref()
+                    .map(|existing| existing.created_at.clone())
+                    .unwrap_or_else(|| now.clone()),
+                updated_at_ms: wire.updated_at_ms,
+            };
+
+            if !fired {
+                if let Some(existing) = existing.as_ref() {
+                    if loop_content_unchanged(existing, &next) {
+                        return Ok(LoopEventBatch::unchanged(Some(existing.clone())));
+                    }
+                }
+            }
+
+            LoopStore::upsert_loop(tx, &next)?;
+
+            let event = if fired {
+                SessionEvent::LoopFired(LoopFiredPayload {
+                    r#loop: next.to_contract(),
+                    fired_at_ms: next.last_fired_at_ms.unwrap_or(next.updated_at_ms),
+                    turn_id: context.turn_id.clone(),
+                })
+            } else {
+                SessionEvent::LoopUpserted(LoopUpsertedPayload {
+                    r#loop: next.to_contract(),
+                })
+            };
+            let envelope = envelope(&context, context.next_seq, event);
+            LoopStore::insert_event(tx, &event_record(&envelope)?)?;
+            Ok(LoopEventBatch {
+                r#loop: Some(next),
+                envelopes: vec![envelope],
+            })
+        })
+    }
+
+    fn apply_removed(
+        &self,
+        context: LoopEventContext,
+        loop_id: String,
+    ) -> anyhow::Result<LoopEventBatch> {
+        self.store.with_tx_anyhow(|tx| {
+            let Some(existing) = LoopStore::find_one_tx(tx, &context.session_id, &loop_id)? else {
+                return Ok(LoopEventBatch::unchanged(None));
+            };
+            if existing.status == LoopStatus::Cleared {
+                return Ok(LoopEventBatch::unchanged(Some(existing)));
+            }
+            let removed = LoopRecord {
+                status: LoopStatus::Cleared,
+                updated_at_ms: now_ms(),
+                ..existing
+            };
+            LoopStore::upsert_loop(tx, &removed)?;
+            let envelope = envelope(
+                &context,
+                context.next_seq,
+                SessionEvent::LoopRemoved(LoopRemovedPayload {
+                    loop_id: removed.loop_id.clone(),
+                }),
+            );
+            LoopStore::insert_event(tx, &event_record(&envelope)?)?;
+            Ok(LoopEventBatch {
+                r#loop: Some(removed),
+                envelopes: vec![envelope],
+            })
+        })
+    }
+}
+
+/// Content equality for idempotent ingest: everything the wire can move,
+/// excluding bookkeeping (`created_at`).
+fn loop_content_unchanged(existing: &LoopRecord, next: &LoopRecord) -> bool {
+    existing.prompt == next.prompt
+        && existing.schedule_kind == next.schedule_kind
+        && existing.schedule_expr == next.schedule_expr
+        && existing.recurring == next.recurring
+        && existing.status == next.status
+        && existing.native == next.native
+        && existing.last_fired_at_ms == next.last_fired_at_ms
+        && existing.fire_count == next.fire_count
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn envelope(context: &LoopEventContext, seq: i64, event: SessionEvent) -> SessionEventEnvelope {
+    SessionEventEnvelope {
+        session_id: context.session_id.clone(),
+        seq,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        turn_id: context.turn_id.clone(),
+        item_id: None,
+        event,
+    }
+}
+
+fn event_record(envelope: &SessionEventEnvelope) -> rusqlite::Result<SessionEventRecord> {
+    Ok(SessionEventRecord {
+        id: 0,
+        session_id: envelope.session_id.clone(),
+        seq: envelope.seq,
+        timestamp: envelope.timestamp.clone(),
+        event_type: envelope.event.event_type().to_string(),
+        turn_id: envelope.turn_id.clone(),
+        item_id: envelope.item_id.clone(),
+        payload_json: serde_json::to_string(&envelope.event)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/service_tests.rs
@@ -1,0 +1,430 @@
+use std::sync::Arc;
+
+use anyharness_contract::v1::{LoopScheduleKind, LoopStatus, SessionEvent};
+use serde_json::json;
+
+use super::service::{LoopEventContext, LoopNativeEventKind, LoopService};
+use super::session_observer::LoopSessionObserver;
+use super::store::LoopStore;
+use super::wire::{LoopScheduleKindWire, LoopScheduleWire, LoopWire, LoopWireStatus};
+use crate::app::test_support;
+use crate::live::sessions::model::{
+    AcpChunkPayload, SessionEventObserver, SessionObservation, SessionObserverContext,
+};
+use crate::persistence::Db;
+
+fn test_service() -> LoopService {
+    let db = Db::open_in_memory().expect("open db");
+    test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+    db.with_conn(|conn| {
+        conn.execute(
+            "INSERT INTO sessions (
+                id, workspace_id, agent_kind, status, created_at, updated_at
+             ) VALUES ('session-1', 'workspace-1', 'claude', 'idle', 'now', 'now')",
+            [],
+        )?;
+        Ok(())
+    })
+    .expect("seed db");
+    LoopService::new(LoopStore::new(db))
+}
+
+fn context(next_seq: i64) -> LoopEventContext {
+    LoopEventContext {
+        workspace_id: "workspace-1".to_string(),
+        session_id: "session-1".to_string(),
+        source_agent_kind: "claude".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        next_seq,
+    }
+}
+
+fn wire(loop_id: &str, prompt: &str, status: LoopWireStatus) -> LoopWire {
+    LoopWire {
+        loop_id: loop_id.to_string(),
+        prompt: prompt.to_string(),
+        schedule: LoopScheduleWire {
+            kind: LoopScheduleKindWire::Cron,
+            expr: "*/1 * * * *".to_string(),
+        },
+        recurring: true,
+        status,
+        native: true,
+        last_fired_at_ms: None,
+        fire_count: 0,
+        updated_at_ms: 1,
+    }
+}
+
+#[test]
+fn ingest_upserted_creates_the_mirror_and_emits_loop_upserted() {
+    let service = test_service();
+
+    let batch = service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop");
+
+    let record = batch.r#loop.expect("loop record");
+    assert_eq!(record.loop_id, "cron-1");
+    assert_eq!(record.status, LoopStatus::Active);
+    assert_eq!(record.schedule_kind, LoopScheduleKind::Cron);
+    assert_eq!(batch.envelopes.len(), 1);
+    assert_eq!(batch.envelopes[0].event.event_type(), "loop_upserted");
+    let SessionEvent::LoopUpserted(payload) = &batch.envelopes[0].event else {
+        panic!("expected loop_upserted event");
+    };
+    assert_eq!(payload.r#loop.loop_id, "cron-1");
+}
+
+#[test]
+fn ingest_upserted_edits_in_place() {
+    let service = test_service();
+    service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop");
+
+    let mut edited = wire("cron-1", "ping twice", LoopWireStatus::Active);
+    edited.updated_at_ms = 2;
+    service
+        .ingest_native_event(context(2), LoopNativeEventKind::Upserted, Some(edited), None)
+        .expect("ingest edit");
+
+    let current = service
+        .current_loops("session-1")
+        .expect("load current")
+        .into_iter()
+        .find(|record| record.loop_id == "cron-1")
+        .expect("loop present");
+    assert_eq!(current.prompt, "ping twice");
+}
+
+#[test]
+fn ingest_duplicate_upsert_is_idempotent() {
+    let service = test_service();
+    service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop");
+
+    let repeat = service
+        .ingest_native_event(
+            context(2),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest duplicate");
+
+    assert!(repeat.envelopes.is_empty());
+}
+
+#[test]
+fn multiple_loops_coexist_per_session() {
+    let service = test_service();
+    service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop 1");
+    service
+        .ingest_native_event(
+            context(2),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-2", "pong", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop 2");
+
+    let mut current = service
+        .current_loops("session-1")
+        .expect("load current");
+    current.sort_by(|a, b| a.loop_id.cmp(&b.loop_id));
+    assert_eq!(current.len(), 2);
+    assert_eq!(current[0].loop_id, "cron-1");
+    assert_eq!(current[1].loop_id, "cron-2");
+}
+
+#[test]
+fn ingest_fired_updates_counters_and_emits_loop_fired() {
+    let service = test_service();
+    service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop");
+
+    let mut fired = wire("cron-1", "ping", LoopWireStatus::Active);
+    fired.fire_count = 1;
+    fired.last_fired_at_ms = Some(1_780_000_000_000);
+    fired.updated_at_ms = 1_780_000_000_000;
+    let batch = service
+        .ingest_native_event(context(2), LoopNativeEventKind::Fired, Some(fired), None)
+        .expect("ingest fired");
+
+    assert_eq!(batch.envelopes.len(), 1);
+    assert_eq!(batch.envelopes[0].event.event_type(), "loop_fired");
+    let SessionEvent::LoopFired(payload) = &batch.envelopes[0].event else {
+        panic!("expected loop_fired event");
+    };
+    assert_eq!(payload.fired_at_ms, 1_780_000_000_000);
+    assert_eq!(payload.turn_id.as_deref(), Some("turn-1"));
+    assert_eq!(
+        service
+            .current_loops("session-1")
+            .expect("load current")
+            .into_iter()
+            .find(|record| record.loop_id == "cron-1")
+            .expect("loop present")
+            .fire_count,
+        1
+    );
+}
+
+#[test]
+fn ingest_removed_transitions_and_emits_loop_removed() {
+    let service = test_service();
+    service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Upserted,
+            Some(wire("cron-1", "ping", LoopWireStatus::Active)),
+            None,
+        )
+        .expect("ingest loop");
+
+    let batch = service
+        .ingest_native_event(
+            context(2),
+            LoopNativeEventKind::Removed,
+            None,
+            Some("cron-1".to_string()),
+        )
+        .expect("ingest removed");
+
+    assert_eq!(batch.envelopes.len(), 1);
+    assert_eq!(batch.envelopes[0].event.event_type(), "loop_removed");
+    assert!(service
+        .current_loops("session-1")
+        .expect("load current")
+        .is_empty());
+
+    let repeat = service
+        .ingest_native_event(
+            context(3),
+            LoopNativeEventKind::Removed,
+            None,
+            Some("cron-1".to_string()),
+        )
+        .expect("ingest duplicate removal");
+    assert!(repeat.envelopes.is_empty());
+}
+
+#[test]
+fn removing_unknown_loop_is_a_noop() {
+    let service = test_service();
+    let batch = service
+        .ingest_native_event(
+            context(1),
+            LoopNativeEventKind::Removed,
+            None,
+            Some("cron-missing".to_string()),
+        )
+        .expect("ingest removal of unknown loop");
+    assert!(batch.envelopes.is_empty());
+    assert!(batch.r#loop.is_none());
+}
+
+#[test]
+fn missing_wire_payload_on_upsert_is_an_error() {
+    let service = test_service();
+    let error = service
+        .ingest_native_event(context(1), LoopNativeEventKind::Upserted, None, None)
+        .expect_err("upsert without loop payload must fail");
+    assert!(error.to_string().contains("missing its loop"));
+}
+
+#[test]
+fn missing_loop_id_on_removed_is_an_error() {
+    let service = test_service();
+    let error = service
+        .ingest_native_event(context(1), LoopNativeEventKind::Removed, None, None)
+        .expect_err("removed without loopId must fail");
+    assert!(error.to_string().contains("missing its loopId"));
+}
+
+// ---------------------------------------------------------------------------
+// Observer ingestion (fixture chunks)
+// ---------------------------------------------------------------------------
+
+fn observer_context(next_seq: i64) -> SessionObserverContext {
+    SessionObserverContext {
+        session_id: "session-1".to_string(),
+        workspace_id: "workspace-1".to_string(),
+        agent_kind: "claude".to_string(),
+        turn_id: Some("turn-1".to_string()),
+        next_seq,
+    }
+}
+
+fn loop_chunk(meta: serde_json::Value) -> AcpChunkPayload {
+    AcpChunkPayload {
+        content: json!({ "type": "text", "text": "" }),
+        meta: Some(meta),
+        message_id: None,
+    }
+}
+
+#[test]
+fn observer_ingests_loop_upserted_chunk() {
+    let service = Arc::new(test_service());
+    let observer = LoopSessionObserver::new(service.clone());
+
+    let payload = loop_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "loop_upserted",
+            "loop": {
+                "loopId": "cron-1",
+                "prompt": "append ping + timestamp to PING.log",
+                "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+                "recurring": true,
+                "status": "active",
+                "native": true,
+                "lastFiredAtMs": null,
+                "fireCount": 0,
+                "updatedAtMs": 1
+            }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&payload),
+    );
+
+    assert_eq!(effects.persisted_events.len(), 1);
+    assert_eq!(effects.persisted_events[0].event.event_type(), "loop_upserted");
+    let loops = service.current_loops("session-1").expect("load current");
+    assert_eq!(loops.len(), 1);
+    assert_eq!(loops[0].loop_id, "cron-1");
+}
+
+#[test]
+fn observer_ingests_loop_fired_and_removed_chunks() {
+    let service = Arc::new(test_service());
+    let observer = LoopSessionObserver::new(service.clone());
+
+    let upserted = loop_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "loop_upserted",
+            "loop": {
+                "loopId": "cron-1",
+                "prompt": "ping",
+                "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+                "recurring": true,
+                "status": "active",
+                "native": true,
+                "fireCount": 0,
+                "updatedAtMs": 1
+            }
+        }
+    }));
+    observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&upserted),
+    );
+
+    let fired = loop_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "loop_fired",
+            "loop": {
+                "loopId": "cron-1",
+                "prompt": "ping",
+                "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+                "recurring": true,
+                "status": "active",
+                "native": true,
+                "lastFiredAtMs": 2,
+                "fireCount": 1,
+                "updatedAtMs": 2
+            }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(2),
+        SessionObservation::NonTranscriptChunk(&fired),
+    );
+    assert_eq!(effects.persisted_events.len(), 1);
+    assert_eq!(effects.persisted_events[0].event.event_type(), "loop_fired");
+
+    let removed = loop_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "loop_removed",
+            "loopId": "cron-1"
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(3),
+        SessionObservation::NonTranscriptChunk(&removed),
+    );
+    assert_eq!(effects.persisted_events.len(), 1);
+    assert_eq!(effects.persisted_events[0].event.event_type(), "loop_removed");
+    assert!(service
+        .current_loops("session-1")
+        .expect("load current")
+        .is_empty());
+}
+
+#[test]
+fn observer_ignores_unrelated_and_malformed_chunks() {
+    let service = Arc::new(test_service());
+    let observer = LoopSessionObserver::new(service.clone());
+
+    let plan_chunk = loop_chunk(json!({
+        "anyharness": { "transcriptEvent": "proposed_plan_completed" }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&plan_chunk),
+    );
+    assert!(effects.persisted_events.is_empty());
+
+    let malformed = loop_chunk(json!({
+        "anyharness": {
+            "schemaVersion": 1,
+            "transcriptEvent": "loop_upserted",
+            "loop": { "loopId": "cron-1", "status": "paused" }
+        }
+    }));
+    let effects = observer.observe(
+        &observer_context(1),
+        SessionObservation::NonTranscriptChunk(&malformed),
+    );
+    assert!(effects.persisted_events.is_empty());
+    assert!(service
+        .current_loops("session-1")
+        .expect("load current")
+        .is_empty());
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/session_observer.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/session_observer.rs
@@ -1,0 +1,193 @@
+//! Loop-mirror ingestion as a [`SessionEventObserver`].
+//!
+//! The sidecar LoopPorts (and, on Codex, the runtime-emulated
+//! `LoopSchedulerExtension`) emit loop state as zero-length
+//! `AgentMessageChunk` updates tagged `meta.anyharness.transcriptEvent =
+//! loop_upserted | loop_removed | loop_fired` with the normalized
+//! [`LoopWire`] payload in `meta.anyharness.loop` (`loop_removed` carries
+//! only `meta.anyharness.loopId`). The dispatcher keeps these chunks out of
+//! the transcript (`NON_TRANSCRIPT_CHUNK_EVENTS`) and surfaces them here as
+//! [`SessionObservation::NonTranscriptChunk`].
+//!
+//! # Dispatch contract
+//!
+//! Registered after the goal observer in the ordered pass (see
+//! `app/sessions.rs`): loops consume and feed nothing in-pass, so ordering
+//! relative to goals is unconstrained beyond "after goals" per the task
+//! sequencing note.
+//!
+//! # Threading contract
+//!
+//! `observe` runs synchronously under the sink lock, on the per-session
+//! thread. All event-emitting work happens inline; no async hand-off.
+
+use std::sync::Arc;
+
+use super::service::{LoopEventContext, LoopNativeEventKind, LoopService};
+use super::wire::{
+    LoopWire, LOOP_FIRED_TRANSCRIPT_EVENT, LOOP_REMOVED_TRANSCRIPT_EVENT,
+    LOOP_UPSERTED_TRANSCRIPT_EVENT,
+};
+use crate::live::sessions::model::{
+    AcpChunkPayload, ObserverEffects, SessionEventObserver, SessionObservation,
+    SessionObserverContext,
+};
+
+pub struct LoopSessionObserver {
+    loops: Arc<LoopService>,
+}
+
+impl LoopSessionObserver {
+    pub fn new(loops: Arc<LoopService>) -> Self {
+        Self { loops }
+    }
+
+    fn observe_loop_chunk(
+        &self,
+        ctx: &SessionObserverContext,
+        payload: &AcpChunkPayload,
+    ) -> ObserverEffects {
+        let meta = parse_loop_chunk_meta(payload.meta.as_ref());
+        let Some(anyharness_meta) = meta.anyharness else {
+            return ObserverEffects::default();
+        };
+        let kind = match anyharness_meta.transcript_event.as_deref() {
+            Some(LOOP_UPSERTED_TRANSCRIPT_EVENT) => LoopNativeEventKind::Upserted,
+            Some(LOOP_REMOVED_TRANSCRIPT_EVENT) => LoopNativeEventKind::Removed,
+            Some(LOOP_FIRED_TRANSCRIPT_EVENT) => LoopNativeEventKind::Fired,
+            _ => return ObserverEffects::default(),
+        };
+        let wire = match anyharness_meta.r#loop {
+            Some(value) => match serde_json::from_value::<LoopWire>(value) {
+                Ok(wire) => Some(wire),
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %ctx.session_id,
+                        error = %error,
+                        "malformed loop wire payload on tagged chunk"
+                    );
+                    return ObserverEffects::default();
+                }
+            },
+            None => None,
+        };
+        let context = LoopEventContext {
+            workspace_id: ctx.workspace_id.clone(),
+            session_id: ctx.session_id.clone(),
+            source_agent_kind: ctx.agent_kind.clone(),
+            turn_id: ctx.turn_id.clone(),
+            next_seq: ctx.next_seq,
+        };
+        match self
+            .loops
+            .ingest_native_event(context, kind, wire, anyharness_meta.loop_id)
+        {
+            Ok(batch) => ObserverEffects {
+                persisted_events: batch.envelopes,
+            },
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %ctx.session_id,
+                    error = %error,
+                    "failed to ingest native loop notification"
+                );
+                ObserverEffects::default()
+            }
+        }
+    }
+}
+
+impl SessionEventObserver for LoopSessionObserver {
+    fn observe(
+        &self,
+        ctx: &SessionObserverContext,
+        obs: SessionObservation<'_>,
+    ) -> ObserverEffects {
+        match obs {
+            SessionObservation::NonTranscriptChunk(payload) => self.observe_loop_chunk(ctx, payload),
+            // Loop state arrives only on tagged protocol chunks.
+            SessionObservation::ToolCall { .. }
+            | SessionObservation::AssistantMessageCompleted(_)
+            | SessionObservation::Event(_) => ObserverEffects::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoopChunkAnyHarnessMeta {
+    transcript_event: Option<String>,
+    /// Kept raw so a malformed wire payload is diagnosed per-event instead
+    /// of silently voiding the whole meta parse. Present for
+    /// upserted/fired; absent for removed.
+    r#loop: Option<serde_json::Value>,
+    /// Present on `loop_removed` (and, redundantly, on the others).
+    #[serde(default)]
+    loop_id: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct LoopChunkMeta {
+    #[serde(default)]
+    anyharness: Option<LoopChunkAnyHarnessMeta>,
+}
+
+fn parse_loop_chunk_meta(meta: Option<&serde_json::Value>) -> LoopChunkMeta {
+    meta.and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_loop_chunk_meta_reads_event_and_wire_payload() {
+        let meta = parse_loop_chunk_meta(Some(&json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "transcriptEvent": "loop_upserted",
+                "loop": {
+                    "loopId": "cron-1",
+                    "prompt": "ping",
+                    "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+                    "recurring": true,
+                    "status": "active",
+                    "native": true,
+                    "lastFiredAtMs": null,
+                    "fireCount": 0,
+                    "updatedAtMs": 1
+                }
+            }
+        })));
+        let anyharness = meta.anyharness.expect("anyharness meta");
+        assert_eq!(anyharness.transcript_event.as_deref(), Some("loop_upserted"));
+        let wire: LoopWire = serde_json::from_value(anyharness.r#loop.expect("loop payload"))
+            .expect("parse loop wire");
+        assert_eq!(wire.loop_id, "cron-1");
+    }
+
+    #[test]
+    fn parse_loop_chunk_meta_tolerates_removed_without_loop() {
+        let meta = parse_loop_chunk_meta(Some(&json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "transcriptEvent": "loop_removed",
+                "loopId": "cron-1"
+            }
+        })));
+        let anyharness = meta.anyharness.expect("anyharness meta");
+        assert_eq!(anyharness.transcript_event.as_deref(), Some("loop_removed"));
+        assert!(anyharness.r#loop.is_none());
+        assert_eq!(anyharness.loop_id.as_deref(), Some("cron-1"));
+    }
+
+    #[test]
+    fn parse_loop_chunk_meta_defaults_on_missing_or_malformed_meta() {
+        assert!(parse_loop_chunk_meta(None).anyharness.is_none());
+        assert!(parse_loop_chunk_meta(Some(&json!("not an object")))
+            .anyharness
+            .is_none());
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/session_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/session_ports.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::Loop;
+
+use super::model::LoopRecord;
+use super::service::LoopService;
+use crate::domains::sessions::active_loops::LoopsResolver;
+
+impl LoopsResolver for LoopService {
+    fn active_loops(&self, session_id: &str) -> anyhow::Result<Vec<Loop>> {
+        Ok(self
+            .current_loops(session_id)?
+            .iter()
+            .map(LoopRecord::to_contract)
+            .collect())
+    }
+
+    fn active_loops_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, Vec<Loop>>> {
+        Ok(self
+            .current_loops_for_sessions(session_ids)?
+            .into_iter()
+            .map(|(session_id, loops)| {
+                (
+                    session_id,
+                    loops.iter().map(LoopRecord::to_contract).collect(),
+                )
+            })
+            .collect())
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/store.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::{LoopScheduleKind, LoopStatus};
+use rusqlite::{params, types::Type, Connection, OptionalExtension, Row};
+
+use super::model::LoopRecord;
+use crate::domains::sessions::model::SessionEventRecord;
+use crate::persistence::Db;
+
+#[derive(Clone)]
+pub struct LoopStore {
+    db: Db,
+}
+
+impl LoopStore {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+
+    pub fn with_tx_anyhow<F, T>(&self, f: F) -> anyhow::Result<T>
+    where
+        F: FnOnce(&Connection) -> anyhow::Result<T>,
+    {
+        self.db.with_tx_anyhow(f)
+    }
+
+    pub fn find_one(&self, session_id: &str, loop_id: &str) -> anyhow::Result<Option<LoopRecord>> {
+        self.db
+            .with_conn(|conn| Self::find_one_tx(conn, session_id, loop_id))
+    }
+
+    pub fn find_one_tx(
+        tx: &Connection,
+        session_id: &str,
+        loop_id: &str,
+    ) -> rusqlite::Result<Option<LoopRecord>> {
+        tx.query_row(
+            "SELECT * FROM loops WHERE session_id = ?1 AND loop_id = ?2",
+            params![session_id, loop_id],
+            map_loop,
+        )
+        .optional()
+    }
+
+    /// Active loops for one session, most-recently-updated first (the
+    /// composer chip / loops panel read model).
+    pub fn list_active(&self, session_id: &str) -> anyhow::Result<Vec<LoopRecord>> {
+        self.db.with_conn(|conn| {
+            let mut statement = conn.prepare(
+                "SELECT * FROM loops
+                 WHERE session_id = ?1 AND status = 'active'
+                 ORDER BY updated_at_ms DESC",
+            )?;
+            let rows = statement
+                .query_map([session_id], map_loop)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    pub fn list_active_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, Vec<LoopRecord>>> {
+        let mut grouped: HashMap<String, Vec<LoopRecord>> = HashMap::new();
+        if session_ids.is_empty() {
+            return Ok(grouped);
+        }
+        self.db.with_conn(|conn| {
+            for session_id in session_ids {
+                let mut statement = conn.prepare(
+                    "SELECT * FROM loops
+                     WHERE session_id = ?1 AND status = 'active'
+                     ORDER BY updated_at_ms DESC",
+                )?;
+                let rows = statement
+                    .query_map([session_id], map_loop)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                if !rows.is_empty() {
+                    grouped.insert(session_id.clone(), rows);
+                }
+            }
+            Ok(())
+        })?;
+        Ok(grouped)
+    }
+
+    pub fn upsert_loop(tx: &Connection, record: &LoopRecord) -> rusqlite::Result<()> {
+        tx.execute(
+            "INSERT INTO loops (
+                session_id, workspace_id, loop_id, prompt, schedule_kind, schedule_expr,
+                recurring, status, native, last_fired_at_ms, fire_count, native_state_json,
+                created_at, updated_at_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             ON CONFLICT(session_id, loop_id) DO UPDATE SET
+                prompt = excluded.prompt,
+                schedule_kind = excluded.schedule_kind,
+                schedule_expr = excluded.schedule_expr,
+                recurring = excluded.recurring,
+                status = excluded.status,
+                native = excluded.native,
+                last_fired_at_ms = excluded.last_fired_at_ms,
+                fire_count = excluded.fire_count,
+                native_state_json = excluded.native_state_json,
+                updated_at_ms = excluded.updated_at_ms",
+            params![
+                record.session_id,
+                record.workspace_id,
+                record.loop_id,
+                record.prompt,
+                schedule_kind_to_db(record.schedule_kind),
+                record.schedule_expr,
+                record.recurring,
+                status_to_db(record.status),
+                record.native,
+                record.last_fired_at_ms,
+                record.fire_count,
+                record.native_state_json,
+                record.created_at,
+                record.updated_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_event(tx: &Connection, record: &SessionEventRecord) -> rusqlite::Result<()> {
+        tx.execute(
+            "INSERT INTO session_events (session_id, seq, timestamp, event_type, turn_id, item_id, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                record.session_id,
+                record.seq,
+                record.timestamp,
+                record.event_type,
+                record.turn_id,
+                record.item_id,
+                record.payload_json,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+pub fn status_to_db(status: LoopStatus) -> &'static str {
+    match status {
+        LoopStatus::Active => "active",
+        LoopStatus::Cleared => "cleared",
+    }
+}
+
+fn status_from_db(value: &str) -> rusqlite::Result<LoopStatus> {
+    match value {
+        "active" => Ok(LoopStatus::Active),
+        "cleared" => Ok(LoopStatus::Cleared),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown loop status: {other}").into(),
+        )),
+    }
+}
+
+fn schedule_kind_to_db(kind: LoopScheduleKind) -> &'static str {
+    match kind {
+        LoopScheduleKind::Interval => "interval",
+        LoopScheduleKind::Cron => "cron",
+    }
+}
+
+fn schedule_kind_from_db(value: &str) -> rusqlite::Result<LoopScheduleKind> {
+    match value {
+        "interval" => Ok(LoopScheduleKind::Interval),
+        "cron" => Ok(LoopScheduleKind::Cron),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            Type::Text,
+            format!("unknown loop schedule kind: {other}").into(),
+        )),
+    }
+}
+
+fn map_loop(row: &Row<'_>) -> rusqlite::Result<LoopRecord> {
+    Ok(LoopRecord {
+        session_id: row.get("session_id")?,
+        workspace_id: row.get("workspace_id")?,
+        loop_id: row.get("loop_id")?,
+        prompt: row.get("prompt")?,
+        schedule_kind: schedule_kind_from_db(row.get::<_, String>("schedule_kind")?.as_str())?,
+        schedule_expr: row.get("schedule_expr")?,
+        recurring: row.get("recurring")?,
+        status: status_from_db(row.get::<_, String>("status")?.as_str())?,
+        native: row.get("native")?,
+        last_fired_at_ms: row.get("last_fired_at_ms")?,
+        fire_count: row.get("fire_count")?,
+        native_state_json: row.get("native_state_json")?,
+        created_at: row.get("created_at")?,
+        updated_at_ms: row.get("updated_at_ms")?,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/loops/wire.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/wire.rs
@@ -1,0 +1,116 @@
+//! LoopPort wire contract v1 (pinned 2026-07-02, tagged-chunk vocabulary per
+//! `codex/session-activity-architecture.md`): the normalized shapes the
+//! sidecars speak — `LoopWire` payloads on tagged notification chunks and
+//! (once the loop runtime PR lands) `_anyharness/loop/*` ext-method
+//! responses. Status/schedule vocabulary arrives already normalized by the
+//! sidecar membranes.
+
+use anyharness_contract::v1::{LoopScheduleKind, LoopStatus};
+use serde::{Deserialize, Serialize};
+
+pub const LOOP_UPSERTED_TRANSCRIPT_EVENT: &str = "loop_upserted";
+pub const LOOP_REMOVED_TRANSCRIPT_EVENT: &str = "loop_removed";
+pub const LOOP_FIRED_TRANSCRIPT_EVENT: &str = "loop_fired";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopWire {
+    pub loop_id: String,
+    pub prompt: String,
+    pub schedule: LoopScheduleWire,
+    pub recurring: bool,
+    pub status: LoopWireStatus,
+    #[serde(default = "default_native")]
+    pub native: bool,
+    #[serde(default)]
+    pub last_fired_at_ms: Option<i64>,
+    #[serde(default)]
+    pub fire_count: i64,
+    #[serde(default)]
+    pub updated_at_ms: i64,
+}
+
+fn default_native() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopScheduleWire {
+    pub kind: LoopScheduleKindWire,
+    pub expr: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopScheduleKindWire {
+    Interval,
+    Cron,
+}
+
+impl LoopScheduleKindWire {
+    pub fn to_contract(self) -> LoopScheduleKind {
+        match self {
+            Self::Interval => LoopScheduleKind::Interval,
+            Self::Cron => LoopScheduleKind::Cron,
+        }
+    }
+}
+
+/// The normalized status vocabulary on the wire — identical to the contract
+/// [`LoopStatus`], kept as its own type so an unrecognized sidecar value
+/// fails deserialization loudly instead of leaking into the mirror.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopWireStatus {
+    Active,
+    Cleared,
+}
+
+impl LoopWireStatus {
+    pub fn to_contract(self) -> LoopStatus {
+        match self {
+            Self::Active => LoopStatus::Active,
+            Self::Cleared => LoopStatus::Cleared,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_wire_parses_pinned_contract_shape() {
+        let wire: LoopWire = serde_json::from_value(serde_json::json!({
+            "loopId": "cron-1",
+            "prompt": "append ping + timestamp to PING.log",
+            "schedule": { "kind": "cron", "expr": "*/1 * * * *" },
+            "recurring": true,
+            "status": "active",
+            "native": true,
+            "lastFiredAtMs": 1_780_000_000_000i64,
+            "fireCount": 2,
+            "updatedAtMs": 1_780_000_000_001i64
+        }))
+        .expect("parse loop wire");
+
+        assert_eq!(wire.loop_id, "cron-1");
+        assert_eq!(wire.status, LoopWireStatus::Active);
+        assert_eq!(wire.schedule.kind, LoopScheduleKindWire::Cron);
+        assert_eq!(wire.fire_count, 2);
+    }
+
+    #[test]
+    fn loop_wire_rejects_unknown_status() {
+        let error = serde_json::from_value::<LoopWire>(serde_json::json!({
+            "loopId": "cron-1",
+            "prompt": "x",
+            "schedule": { "kind": "interval", "expr": "5m" },
+            "recurring": true,
+            "status": "paused"
+        }))
+        .expect_err("raw harness statuses outside active|cleared must not parse");
+        assert!(error.to_string().contains("paused"));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mod.rs
@@ -1,7 +1,9 @@
+pub mod activity;
 pub mod agents;
 pub mod artifacts;
 pub mod cowork;
 pub mod goals;
+pub mod loops;
 pub mod mobility;
 pub mod plans;
 pub mod repo_roots;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/active_activity_roster.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/active_activity_roster.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::{ActivityProcess, ActivitySubagent};
+
+/// Read port for the session read-side: resolves the read-only activity
+/// rosters (background processes + harness-native subagents) the activity
+/// domain keeps, without the sessions domain depending on activity
+/// internals. Mirrors [`super::active_goals::ActiveGoalResolver`].
+pub trait ActivityRosterResolver: Send + Sync {
+    fn activity_roster(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<(Vec<ActivityProcess>, Vec<ActivitySubagent>)>;
+
+    #[allow(clippy::type_complexity)]
+    fn activity_rosters_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, (Vec<ActivityProcess>, Vec<ActivitySubagent>)>>;
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/active_loops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/active_loops.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use anyharness_contract::v1::Loop;
+
+/// Read port for the session read-side: resolves the active-loop mirror the
+/// loops domain keeps, without the sessions domain depending on loop
+/// internals. Mirrors [`super::active_goals::ActiveGoalResolver`]; unlike
+/// goals, a session may have many active loops.
+pub trait LoopsResolver: Send + Sync {
+    fn active_loops(&self, session_id: &str) -> anyhow::Result<Vec<Loop>>;
+
+    fn active_loops_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> anyhow::Result<HashMap<String, Vec<Loop>>>;
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
@@ -1,4 +1,6 @@
+pub mod active_activity_roster;
 pub mod active_goals;
+pub mod active_loops;
 pub mod attachment_storage;
 pub mod delegation;
 pub mod deletion;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
@@ -108,6 +108,7 @@ impl SessionRecord {
                 self.action_capabilities_json.as_deref(),
             ),
             active_goal: None,
+            activity: None,
             origin: self.origin.as_ref().map(OriginContext::to_contract),
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -6,7 +6,9 @@ use anyharness_contract::v1::{
     McpElicitationSubmittedField, SessionMcpBindingSummary, UserInputSubmittedAnswer,
 };
 
+use super::active_activity_roster::ActivityRosterResolver;
 use super::active_goals::ActiveGoalResolver;
+use super::active_loops::LoopsResolver;
 use super::links::model::SessionLinkRecord;
 use super::links::service::SessionLinkService;
 use super::mcp_bindings::crypto::SessionDataCipher;
@@ -52,6 +54,8 @@ pub struct SessionRuntime {
     /// plane's [`GatewayModelPlan`] and schedules launch-time lazy probes.
     gateway_model_resolver: Arc<dyn GatewayModelResolve>,
     active_goal_resolver: Arc<dyn ActiveGoalResolver>,
+    loops_resolver: Arc<dyn LoopsResolver>,
+    activity_roster_resolver: Arc<dyn ActivityRosterResolver>,
 }
 
 impl SessionRuntime {
@@ -275,6 +279,8 @@ impl SessionRuntime {
         plan_interaction_link_resolver: Arc<dyn PlanInteractionLinkResolver>,
         gateway_model_resolver: Arc<dyn GatewayModelResolve>,
         active_goal_resolver: Arc<dyn ActiveGoalResolver>,
+        loops_resolver: Arc<dyn LoopsResolver>,
+        activity_roster_resolver: Arc<dyn ActivityRosterResolver>,
     ) -> Self {
         Self {
             session_service,
@@ -290,6 +296,8 @@ impl SessionRuntime {
             plan_interaction_link_resolver,
             gateway_model_resolver,
             active_goal_resolver,
+            loops_resolver,
+            activity_roster_resolver,
         }
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs
@@ -8,7 +8,8 @@
 use std::collections::HashMap;
 
 use anyharness_contract::v1::{
-    Goal, Session, SessionExecutionSummary, SessionLinkSummary, SessionLiveConfigSnapshot,
+    ActivityProcess, ActivitySubagent, Goal, Loop, Session, SessionActivity,
+    SessionExecutionSummary, SessionLinkSummary, SessionLiveConfigSnapshot, TurnState,
     WorkspaceExecutionSummary,
 };
 
@@ -28,6 +29,9 @@ pub struct SessionView {
     pub execution_summary: SessionExecutionSummary,
     pub pending_prompts: Vec<PendingPromptRecord>,
     pub active_goal: Option<Goal>,
+    pub loops: Vec<Loop>,
+    pub processes: Vec<ActivityProcess>,
+    pub agents: Vec<ActivitySubagent>,
 }
 
 impl SessionView {
@@ -41,7 +45,19 @@ impl SessionView {
             .iter()
             .map(PendingPromptRecord::to_contract)
             .collect();
-        session.active_goal = self.active_goal;
+        session.active_goal = self.active_goal.clone();
+        session.activity = Some(SessionActivity {
+            // TODO(activity-runtime): source `turn_id`/`started_at` from the
+            // live sink's `current_turn_id` once the loop/activity runtime
+            // PR threads it through `LiveSessionExecutionSnapshot` — the
+            // no-optimistic-state rule means this scaffolding reports Idle
+            // rather than fabricate a turn id.
+            turn: TurnState::Idle,
+            goal: self.active_goal,
+            loops: self.loops,
+            processes: self.processes,
+            agents: self.agents,
+        });
         session
     }
 }
@@ -64,12 +80,17 @@ impl SessionRuntime {
             .store()
             .list_pending_prompts(&record.id)?;
         let active_goal = self.active_goal_resolver.active_goal(&record.id)?;
+        let loops = self.loops_resolver.active_loops(&record.id)?;
+        let (processes, agents) = self.activity_roster_resolver.activity_roster(&record.id)?;
         Ok(SessionView {
             record: record.clone(),
             live_config,
             execution_summary,
             pending_prompts,
             active_goal,
+            loops,
+            processes,
+            agents,
         })
     }
 
@@ -92,15 +113,25 @@ impl SessionRuntime {
         let mut active_goals = self
             .active_goal_resolver
             .active_goals_for_sessions(&session_ids)?;
+        let mut loops_by_session = self.loops_resolver.active_loops_for_sessions(&session_ids)?;
+        let mut rosters_by_session = self
+            .activity_roster_resolver
+            .activity_rosters_for_sessions(&session_ids)?;
 
         let mut views = Vec::with_capacity(records.len());
         for record in records {
+            let (processes, agents) = rosters_by_session
+                .remove(&record.id)
+                .unwrap_or_default();
             views.push(SessionView {
                 record: record.clone(),
                 live_config: live_configs.remove(&record.id),
                 execution_summary: self.session_execution_summary(record).await,
                 pending_prompts: pending_prompts.remove(&record.id).unwrap_or_default(),
                 active_goal: active_goals.remove(&record.id),
+                loops: loops_by_session.remove(&record.id).unwrap_or_default(),
+                processes,
+                agents,
             });
         }
         Ok(views)
@@ -235,6 +266,16 @@ mod tests {
                 .iter()
                 .map(PendingPromptRecord::to_contract)
                 .collect();
+            // `into_contract` always assembles `activity` now (empty rosters
+            // when the resolvers have nothing for this session) — mirror
+            // that here so the byte-for-byte comparison stays meaningful.
+            legacy.activity = Some(SessionActivity {
+                turn: TurnState::Idle,
+                goal: None,
+                loops: Vec::new(),
+                processes: Vec::new(),
+                agents: Vec::new(),
+            });
 
             let view = SessionView {
                 record: record.clone(),
@@ -242,6 +283,9 @@ mod tests {
                 execution_summary: execution_summary.clone(),
                 pending_prompts: pending_prompts.clone(),
                 active_goal: None,
+                loops: Vec::new(),
+                processes: Vec::new(),
+                agents: Vec::new(),
             };
 
             assert_eq!(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -487,10 +487,13 @@ pub(in crate::live::sessions::actor) fn action_capabilities_from_acp(
             "agent advertises edit-safe targeted fork metadata; public targeted fork remains disabled until runtime target dispatch is implemented"
         );
     }
+    let (supports_loops, loops_native) = loops_capability_from_init_meta(init_response.meta.as_ref());
     SessionActionCapabilities {
         fork,
         targeted_fork: false,
         supports_goals: supports_goals_from_init_meta(init_response.meta.as_ref()),
+        supports_loops,
+        loops_native,
     }
 }
 
@@ -517,6 +520,45 @@ fn supports_goals_from_init_meta(meta: Option<&acp::schema::Meta>) -> bool {
         .and_then(|goals| goals.get("supported"))
         .and_then(|value| value.as_bool())
         .unwrap_or(false)
+}
+
+/// `InitializeResponse._meta.anyharness.loops` — the LoopPort capability
+/// advertisement (wire contract v1: `{ supported, native }`). Same
+/// degrade-to-unsupported rule as goals: anything short of an explicit
+/// `{ schemaVersion: 1, loops: { supported: true } }` reports
+/// `(false, false)` so a stale sidecar never breaks. `native` is only
+/// meaningful when `supported` is true — claude-agent-acp advertises
+/// `native: true` (session crons); codex-acp omits `loops` entirely in v1
+/// (runtime-emulated by `LoopSchedulerExtension`, not the sidecar).
+fn loops_capability_from_init_meta(meta: Option<&acp::schema::Meta>) -> (bool, bool) {
+    let Some(anyharness) = meta
+        .and_then(|meta| meta.get("anyharness"))
+        .and_then(|value| value.as_object())
+    else {
+        return (false, false);
+    };
+    if anyharness
+        .get("schemaVersion")
+        .and_then(|value| value.as_u64())
+        != Some(1)
+    {
+        return (false, false);
+    }
+    let Some(loops) = anyharness.get("loops").and_then(|value| value.as_object()) else {
+        return (false, false);
+    };
+    let supported = loops
+        .get("supported")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    if !supported {
+        return (false, false);
+    }
+    let native = loops
+        .get("native")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    (true, native)
 }
 
 #[cfg(all(test, unix))]
@@ -586,5 +628,78 @@ mod tests {
             })
         ))));
         assert!(!supports_goals_from_init_meta(None));
+    }
+
+    #[test]
+    fn loops_capability_requires_schema_version_and_supported_flag() {
+        // claude-agent-acp: native loops.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": true, "native": true }
+                }
+            })))),
+            (true, true)
+        );
+        // codex-acp v1: loops omitted entirely (runtime-emulated, not the
+        // sidecar) — degrades to unsupported.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "goals": { "supported": true, "native": true }
+                }
+            })))),
+            (false, false)
+        );
+        // Wrong schema version degrades to unsupported even if the flag is set.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 2,
+                    "loops": { "supported": true, "native": true }
+                }
+            })))),
+            (false, false)
+        );
+        // Explicitly unsupported.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": false }
+                }
+            })))),
+            (false, false)
+        );
+        // Supported but not native (a future runtime-emulated-by-sidecar case).
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": true, "native": false }
+                }
+            })))),
+            (true, false)
+        );
+        assert_eq!(loops_capability_from_init_meta(None), (false, false));
+    }
+
+    #[test]
+    fn action_capabilities_from_acp_wires_loops_capability_into_session_capabilities() {
+        let mut init_response =
+            acp::schema::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+        init_response.meta = Some(init_meta(serde_json::json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "goals": { "supported": true, "native": true },
+                "loops": { "supported": true, "native": true }
+            }
+        })));
+        let capabilities = action_capabilities_from_acp(&init_response);
+        assert!(capabilities.supports_goals);
+        assert!(capabilities.supports_loops);
+        assert!(capabilities.loops_native);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/ingest.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/ingest.rs
@@ -235,9 +235,11 @@ const NON_TRANSCRIPT_CHUNK_EVENTS: &[&str] = &[
     "goal_updated",
     "goal_met",
     "goal_cleared",
-    "loop_updated",
+    "loop_upserted",
+    "loop_removed",
     "loop_fired",
-    "loop_cleared",
+    "process_upserted",
+    "subagent_upserted",
 ];
 
 fn is_non_transcript_chunk(meta: Option<&serde_json::Value>) -> bool {

--- a/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
@@ -194,6 +194,8 @@ pub(super) const MIGRATIONS: &[(&str, &str)] = &[
         include_str!("sql/0051_gateway_model_probe.sql"),
     ),
     ("0052_goals", include_str!("sql/0052_goals.sql")),
+    ("0053_loops", include_str!("sql/0053_loops.sql")),
+    ("0054_activity", include_str!("sql/0054_activity.sql")),
 ];
 
 pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0053_loops.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0053_loops.sql
@@ -1,0 +1,23 @@
+-- Loops: recurring in-session prompts on a schedule. Unlike goals, multiple
+-- loops per session are allowed (native Claude `CronList` shape) — keyed by
+-- (session_id, loop_id) rather than a single mirror row per session.
+CREATE TABLE loops (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    loop_id TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    schedule_kind TEXT NOT NULL,
+    schedule_expr TEXT NOT NULL,
+    recurring INTEGER NOT NULL DEFAULT 1,
+    status TEXT NOT NULL,
+    native INTEGER NOT NULL DEFAULT 1,
+    last_fired_at_ms INTEGER,
+    fire_count INTEGER NOT NULL DEFAULT 0,
+    native_state_json TEXT,
+    created_at TEXT NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (session_id, loop_id)
+);
+
+CREATE INDEX idx_loops_session_status
+    ON loops(session_id, status);

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0054_activity.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0054_activity.sql
@@ -1,0 +1,56 @@
+-- Activity rosters: read-only mirrors of harness-native background
+-- processes and subagents (session-activity-architecture). Never externally
+-- settable — records transition only through observer-ingested native
+-- notifications. `feed_bindings` holds the transport detail
+-- (tail_file|acp_child_demux|http_sse) that never leaves the runtime; the
+-- contract only ever sees the opaque `feed_id` it mints.
+CREATE TABLE activity_processes (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    process_id TEXT NOT NULL,
+    command TEXT NOT NULL,
+    cwd TEXT,
+    status TEXT NOT NULL,
+    exit_code INTEGER,
+    pid INTEGER,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    feed_id TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, process_id)
+);
+
+CREATE TABLE activity_subagents (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    subagent_id TEXT NOT NULL,
+    agent_type TEXT,
+    description TEXT,
+    model TEXT,
+    background INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL,
+    summary TEXT,
+    tokens_used INTEGER,
+    tool_calls INTEGER,
+    duration_seconds INTEGER,
+    feed_id TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, subagent_id)
+);
+
+CREATE TABLE feed_bindings (
+    feed_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    owner_kind TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    transport_kind TEXT NOT NULL,
+    transport_path TEXT,
+    transport_thread_id TEXT,
+    transport_url TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_feed_bindings_owner
+    ON feed_bindings(session_id, owner_kind, owner_id);

--- a/specs/generated/anyharness-db-schema.sql
+++ b/specs/generated/anyharness-db-schema.sql
@@ -4,6 +4,42 @@ CREATE TABLE _migrations (
             applied_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
 
+-- table: activity_processes
+CREATE TABLE activity_processes (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    process_id TEXT NOT NULL,
+    command TEXT NOT NULL,
+    cwd TEXT,
+    status TEXT NOT NULL,
+    exit_code INTEGER,
+    pid INTEGER,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    feed_id TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, process_id)
+);
+
+-- table: activity_subagents
+CREATE TABLE activity_subagents (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    subagent_id TEXT NOT NULL,
+    agent_type TEXT,
+    description TEXT,
+    model TEXT,
+    background INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL,
+    summary TEXT,
+    tokens_used INTEGER,
+    tool_calls INTEGER,
+    duration_seconds INTEGER,
+    feed_id TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, subagent_id)
+);
+
 -- table: agent_model_registry_snapshots
 CREATE TABLE agent_model_registry_snapshots (
     id TEXT PRIMARY KEY,
@@ -54,6 +90,21 @@ CREATE TABLE cowork_threads (
     created_at TEXT NOT NULL
 , workspace_delegation_enabled INTEGER NOT NULL DEFAULT 1);
 
+-- table: feed_bindings
+CREATE TABLE feed_bindings (
+    feed_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    owner_kind TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    transport_kind TEXT NOT NULL,
+    transport_path TEXT,
+    transport_thread_id TEXT,
+    transport_url TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
 -- table: gateway_model_probe
 CREATE TABLE gateway_model_probe (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -82,6 +133,25 @@ CREATE TABLE goals (
     native_state_json TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
+);
+
+-- table: loops
+CREATE TABLE loops (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    loop_id TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    schedule_kind TEXT NOT NULL,
+    schedule_expr TEXT NOT NULL,
+    recurring INTEGER NOT NULL DEFAULT 1,
+    status TEXT NOT NULL,
+    native INTEGER NOT NULL DEFAULT 1,
+    last_fired_at_ms INTEGER,
+    fire_count INTEGER NOT NULL DEFAULT 0,
+    native_state_json TEXT,
+    created_at TEXT NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (session_id, loop_id)
 );
 
 -- table: mobility_archive_installs
@@ -575,6 +645,10 @@ CREATE INDEX idx_cowork_threads_session_id ON cowork_threads(session_id);
 -- index: idx_cowork_threads_workspace_id
 CREATE INDEX idx_cowork_threads_workspace_id ON cowork_threads(workspace_id);
 
+-- index: idx_feed_bindings_owner
+CREATE UNIQUE INDEX idx_feed_bindings_owner
+    ON feed_bindings(session_id, owner_kind, owner_id);
+
 -- index: idx_gateway_model_probe_lookup
 CREATE INDEX idx_gateway_model_probe_lookup
     ON gateway_model_probe(harness_kind, revision, probed_at);
@@ -587,6 +661,10 @@ CREATE INDEX idx_goals_session_created
 CREATE UNIQUE INDEX idx_goals_single_open_per_session
     ON goals(session_id)
     WHERE status IN ('active', 'paused', 'blocked');
+
+-- index: idx_loops_session_status
+CREATE INDEX idx_loops_session_status
+    ON loops(session_id, status);
 
 -- index: idx_plan_handoffs_plan
 CREATE INDEX idx_plan_handoffs_plan


### PR DESCRIPTION
## What

First slice of the loops/rosters track: the `anyharness-contract` v1 types for session activity (`Loop`/`LoopSchedule`/`LoopStatus`, `ActivityProcess`/`ActivitySubagent`, `FeedRef`/`FeedKind`, the `SessionActivity` aggregate) plus the new `SessionEvent` variants and their wire tags. Also includes a goals fix that landed alongside this slice: `goal/set` no longer blocks or clears the mirror when the native response is `pending_injection` — it now keeps the pending marker and returns a provisional goal without tripping the 15s clock.

## Why

Loops and rosters (processes/subagents/feed) need a stable wire contract before the runtime (`02`) and desktop (`03`) layers can build on it. This PR is contract-only plus the one goals correctness fix that was needed to keep the deferred-injection mirror consistent for the layers stacked on top.

## Gate verdict

**partial** — not covered in this pass: Codex collab-subagent child feed demux wire mechanics; OpenCode/Cursor "no loop affordance" checks (out of scope for Phase B/C); product/UI (pdev) layer verification (this run scoped to protocol layer); Codex child-thread re-list on reattach (blocked by no subagent ever spawning in the harness used for verification).

## Dependencies

Stacks on `goals/phase-a`. This track (and the sibling fork PRs) stacks on the in-flight native-goals train — proliferate#909, claude-agent-acp#24, codex-acp#12 — the pin dance across those three covers all of it.

Part of a stack: **01-contract** (this PR) → 02-runtime → 03-desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
