### PR TITLE
fix(desktop): dev worker launch freshness + loud startup-crash surfacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/apps/desktop/src-tauri/src/commands/cloud_worker.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker.rs
@@ -11,7 +11,7 @@ use tauri::State;
 use tokio::{
     process::Child,
     sync::Mutex,
-    time::{sleep, Duration},
+    time::{sleep, Duration, Instant},
 };
 
 use crate::{app_config, sidecar::resolve_shell_path};
@@ -175,21 +175,50 @@ pub async fn ensure_desktop_dispatch_worker(
         pid = child.id(),
         "Proliferate Worker spawned"
     );
-    sleep(Duration::from_millis(150)).await;
-    if let Some(status) = child
-        .try_wait()
-        .map_err(|error| format!("Failed to inspect Proliferate Worker startup: {error}"))?
-    {
+    // Watch the worker across its first moments so an early crash surfaces as an
+    // error instead of a phantom "started". A fresh enrollment must survive the
+    // first cloud roundtrip — that's where an enroll-contract mismatch (e.g. a
+    // stale binary rejecting the request with a serde decode error) dies — so we
+    // give it a generous window; a plain re-attach only needs to clear the local
+    // spawn. A child still alive at the end of the window is a success: with a
+    // `cargo run` launcher the child is cargo, which may legitimately still be
+    // compiling, and we deliberately do NOT extend the window to wait it out.
+    let startup_window = if enrollment_token.is_some() {
+        Duration::from_millis(3000)
+    } else {
+        Duration::from_millis(500)
+    };
+    let startup_deadline = Instant::now() + startup_window;
+    let startup_exit = loop {
+        let status = child
+            .try_wait()
+            .map_err(|error| format!("Failed to inspect Proliferate Worker startup: {error}"))?;
+        if let Some(status) = status {
+            break Some(status);
+        }
+        if Instant::now() >= startup_deadline {
+            break None;
+        }
+        sleep(Duration::from_millis(100)).await;
+    };
+    if let Some(status) = startup_exit {
+        let log_tail = read_worker_log_tail(&paths.log, 12);
         tracing::error!(
             launcher = %launcher,
             %status,
             log_path = %paths.log.display(),
+            log_tail = %log_tail,
             "Proliferate Worker exited during startup"
         );
-        return Err(format!(
+        let mut message = format!(
             "Proliferate Worker exited during startup with {status}. See {} for output.",
             paths.log.display()
-        ));
+        );
+        if !log_tail.is_empty() {
+            message.push_str("\n\nLast worker log lines:\n");
+            message.push_str(&log_tail);
+        }
+        return Err(message);
     }
 
     let result = EnsureDesktopDispatchWorkerResult {
@@ -417,6 +446,19 @@ fn open_worker_log(path: &Path) -> Result<(std::fs::File, std::fs::File), String
     Ok((file, clone))
 }
 
+/// Reads the last `max_lines` lines of the worker log so a startup-crash cause
+/// (e.g. the serde enroll-contract decode error) can be attached to the failure
+/// surfaced to the caller instead of a bare "see log" pointer. Returns an empty
+/// string when the log is missing or unreadable — the tail is best-effort.
+fn read_worker_log_tail(path: &Path, max_lines: usize) -> String {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return String::new();
+    };
+    let lines: Vec<&str> = contents.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
+
 fn toml_string(value: &str) -> String {
     format!(
         "\"{}\"",
@@ -473,4 +515,53 @@ fn set_private_dir_permissions(path: &Path) -> Result<(), String> {
 #[cfg(not(unix))]
 fn set_private_dir_permissions(_path: &Path) -> Result<(), String> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_worker_log_tail;
+    use std::path::PathBuf;
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "proliferate-cloud-worker-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn read_worker_log_tail_returns_empty_when_missing() {
+        let path = unique_temp_path("missing");
+        assert!(!path.exists());
+        assert_eq!(read_worker_log_tail(&path, 12), "");
+    }
+
+    #[test]
+    fn read_worker_log_tail_returns_last_lines_only() {
+        let path = unique_temp_path("tail");
+        let body = (1..=20)
+            .map(|n| format!("line {n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, format!("{body}\n")).expect("write log");
+
+        let tail = read_worker_log_tail(&path, 3);
+        assert_eq!(tail, "line 18\nline 19\nline 20");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_worker_log_tail_returns_whole_file_when_shorter_than_limit() {
+        let path = unique_temp_path("short");
+        std::fs::write(&path, "only line").expect("write log");
+
+        assert_eq!(read_worker_log_tail(&path, 12), "only line");
+
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
@@ -69,6 +69,23 @@ pub(super) fn find_proliferate_worker_launcher() -> Option<WorkerLauncher> {
         }
     }
 
+    // In dev, prefer `cargo run` over any scanned binary: it guarantees the
+    // worker matches the checked-out enroll contract (a no-op rebuild when the
+    // tree is already fresh), whereas a `target/debug/proliferate-worker` picked
+    // up by the beside-exe / dev-candidate / PATH scans can be arbitrarily stale
+    // — a weeks-old build launched against a new server dies on enroll with a
+    // decode error. Fall through to the scans when cargo or the workspace root
+    // is unavailable. Release builds skip this and keep the scan-first order.
+    if cfg!(debug_assertions) {
+        if let (Some(cargo), Some(workspace_root)) = (which::which("cargo").ok(), workspace_root())
+        {
+            return Some(WorkerLauncher::CargoRun {
+                cargo,
+                workspace_root,
+            });
+        }
+    }
+
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
             let target = current_target_triple();
@@ -92,16 +109,6 @@ pub(super) fn find_proliferate_worker_launcher() -> Option<WorkerLauncher> {
     if let Ok(path) = which::which("proliferate-worker") {
         if let Some(path) = usable_worker_binary(&path) {
             return Some(WorkerLauncher::Binary(path));
-        }
-    }
-
-    if cfg!(debug_assertions) {
-        if let (Some(cargo), Some(workspace_root)) = (which::which("cargo").ok(), workspace_root())
-        {
-            return Some(WorkerLauncher::CargoRun {
-                cargo,
-                workspace_root,
-            });
         }
     }
 

--- a/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
+++ b/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
@@ -5,6 +5,12 @@ import {
   stopDesktopDispatchWorker,
 } from "@/lib/access/tauri/cloud-worker";
 import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+function describeWorkerError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.trim().length > 0 ? message.trim() : "unknown error";
+}
 
 // ensureDesktopWorker and teardownDesktopWorker both mutate the single
 // physical worker process, but their callers dispatch them fire-and-forget.
@@ -40,6 +46,14 @@ export function ensureDesktopWorker(): Promise<boolean> {
           domain: "cloud",
         },
       });
+      // The worker backs the integration-gateway MCP, so a silent failure
+      // strands local sessions without their integrations. Surface the cause
+      // (the Tauri command now appends the worker's crash log tail to its error)
+      // so a stale-binary / enroll-contract mismatch is visible instead of only
+      // landing in telemetry.
+      useToastStore
+        .getState()
+        .show(`Cloud integrations worker failed to start: ${describeWorkerError(error)}`, "error");
       return false;
     }
   });


### PR DESCRIPTION
## Root cause

In dev, the Tauri app resolved the desktop dispatch worker via `development_worker_candidates()` (a `target/debug` scan) **before** the `cargo run` fallback. So a stale `target/debug/proliferate-worker` built weeks ago (old enroll contract) got launched against a new server. It crashed on enroll with `missing field 'targetId'` — but only *after* the fixed 150ms startup death-watch window, so `ensure_desktop_dispatch_worker` reported `"started"` and the user silently lost the integration-gateway MCP (no dotfile written, and the failure never surfaced beyond telemetry).

## Changes

**1. Freshness-first launcher in debug builds** — `commands/cloud_worker/launcher.rs`
`PROLIFERATE_WORKER_BIN` still wins first (always). Then, **only under `cfg!(debug_assertions)`**, prefer `WorkerLauncher::CargoRun { cargo, workspace_root }` before the beside-exe / dev-candidate / PATH binary scans, falling through to those scans when `cargo` or the workspace root is unavailable. In dev, `cargo run` guarantees the worker matches the checked-out enroll contract (a no-op rebuild when the tree is fresh); a scanned `target/debug` binary can be arbitrarily stale. Release-build order is unchanged (the block is gated on `debug_assertions`, which was already where the old trailing `CargoRun` fallback lived, so this only reorders debug and removes a now-redundant block).

**2. Meaningful startup death-watch** — `commands/cloud_worker.rs`
Replaced the fixed `sleep(150ms)` + single `try_wait` with a ~100ms poll loop. Total window is **3000ms when `enrollment_token.is_some()`** (a fresh enrollment must survive the first cloud roundtrip — where contract mismatches die) and **500ms otherwise**. Breaks early on exit. On a detected exit it reads the last ~12 lines of the worker log at `paths.log` (`read_worker_log_tail`, tolerant of a missing/unreadable file) and appends that tail to both the `tracing::error!` and the returned `Err` string, so the real crash cause (e.g. the serde decode error) reaches the frontend instead of a bare "see log" pointer. A child still alive at the window end is success (`"started"`), same as before — with `CargoRun` the child is `cargo`, which may still be compiling, and the window is deliberately *not* extended to wait it out.

**3. Loud startup-crash surfacing (TS)** — `lib/workflows/cloud/ensure-desktop-worker.ts`
The caller chain is `useDesktopWorkerEnrollment` (hook) → `ensureDesktopWorker()` (workflow) → `ensureDesktopDispatchWorker()` (Tauri access). The workflow's `catch` previously routed the error to `captureTelemetryException` **only** — nothing user-visible; the hook just gets a `boolean`. It now also surfaces the failure via the app's existing toast store (`useToastStore.getState().show(msg, "error")` — the same escape-hatch used by `use-auth-orchestration-effects.ts`), combined with the richer error string from change 2. Access still lives in `lib/access`; the store lives in `@/stores` (workflows are permitted to import stores — precedent: `hot-session-ingest-manager.ts` — and the frontend-boundary gate confirms this). No component/access-boundary violation.

## Tests
- Added a `#[cfg(test)]` module covering `read_worker_log_tail` (missing file → empty, tail truncation, whole-file-when-shorter). The launcher preference is env-dependent with no existing seam, so it is left untested.

## Verification
- `cargo check -p proliferate` — clean.
- `cargo test -p proliferate` — **64 passed, 0 failed** (61 pre-existing + 3 new).
- `cargo clippy -p proliferate` — no new warnings in the touched code (remaining warnings are all pre-existing in untouched lines; clippy is not CI-gated with `-D warnings`).
- `npx tsc --noEmit` (apps/desktop) — the only errors are two pre-existing failures in `OrganizationIntegrationsPane.tsx` / `org-integrations-presentation.ts`, untouched by this PR (unrelated to cloud worker).
- `npx vitest run use-desktop-worker-enrollment.test.tsx` — **7 passed**.
- Shape gates from the repo root all pass, **no allowlist edits**: `check_max_lines.py` (cloud_worker.rs is 567 / 600), `check_server_boundaries.py`, `check_frontend_boundaries.py`, `check_proliferate_worker_structure.py`, `report_frontend_structure.py --strict` (TOTAL 0).

Note: `Cargo.lock` carries a one-line `proliferate` version sync (`0.3.3` → `0.3.4`); the lock on `main` was stale against the manifest (already `0.3.4` after `release: prepare release-2026-07-03`), and `cargo` re-syncs it on any invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
