### PR TITLE
feat(cloud): org-scoped worker identity + gateway org-policy enforcement (restore #894)

### DIFF
--- a/apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.test.tsx
+++ b/apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OrganizationRecord } from "@/lib/domain/organizations/organization-records";
+import { OrganizationSwitchDialog } from "./OrganizationSwitchDialog";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+const switchMock = vi.fn<(organizationId: string) => Promise<void>>();
+
+vi.mock("@/hooks/organizations/workflows/use-organization-switch-action", () => ({
+  useOrganizationSwitchAction: () => ({
+    switchOrganization: switchMock,
+    switchingOrganization: false,
+  }),
+}));
+
+// Stub the modal primitive with a minimal confirm/cancel surface so the test
+// exercises the dialog's onConfirm wiring rather than Radix portal internals.
+vi.mock("@proliferate/ui/primitives/ConfirmationDialog", () => ({
+  ConfirmationDialog: ({
+    open,
+    confirmLabel,
+    onConfirm,
+    onClose,
+  }: {
+    open: boolean;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) =>
+    open ? (
+      <div>
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+        <button type="button" onClick={onClose}>
+          cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
+function organization(id: string, name: string): OrganizationRecord {
+  return { id, name } as OrganizationRecord;
+}
+
+describe("OrganizationSwitchDialog", () => {
+  beforeEach(() => {
+    switchMock.mockReset();
+    useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("closes the dialog after a successful switch without a toast", async () => {
+    switchMock.mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <OrganizationSwitchDialog target={organization("org-2", "Acme")} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch organization" }));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(switchMock).toHaveBeenCalledWith("org-2");
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it("surfaces an error toast and keeps the dialog open when the switch fails", async () => {
+    switchMock.mockRejectedValue(new Error("worker teardown failed"));
+    const onClose = vi.fn();
+    render(
+      <OrganizationSwitchDialog target={organization("org-2", "Acme")} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch organization" }));
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+    });
+    const [toast] = useToastStore.getState().toasts;
+    expect(toast.message).toBe("worker teardown failed");
+    expect(toast.type).toBe("error");
+    // The switch failed, so the dialog stays open for a retry.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.tsx
+++ b/apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.tsx
@@ -1,0 +1,51 @@
+import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
+import { useOrganizationSwitchAction } from "@/hooks/organizations/workflows/use-organization-switch-action";
+import type { OrganizationRecord } from "@/lib/domain/organizations/organization-records";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+/**
+ * Confirmation for the semi-destructive org->org switch: the desktop worker's
+ * (user, org) identity rotates, so running local sessions are closed first.
+ * Users with a single organization never reach this dialog — the switcher
+ * only lists organizations they belong to, and clicking the already-active
+ * one is a no-op. Org-less users gaining their first organization adopt it in
+ * place without confirmation.
+ */
+export function OrganizationSwitchDialog({
+  target,
+  onClose,
+}: {
+  target: OrganizationRecord | null;
+  onClose: () => void;
+}) {
+  const { switchOrganization, switchingOrganization } = useOrganizationSwitchAction();
+  const showToast = useToastStore((state) => state.show);
+
+  return (
+    <ConfirmationDialog
+      open={target !== null}
+      title={target ? `Switch to ${target.name}?` : "Switch organization?"}
+      description="Switching organizations closes your running local sessions."
+      confirmLabel="Switch organization"
+      loading={switchingOrganization}
+      disableClose={switchingOrganization}
+      onClose={onClose}
+      onConfirm={() => {
+        if (!target) {
+          return;
+        }
+        // switchOrganization resets its own loading flag in a finally, but a
+        // failed switch (e.g. worker teardown or the selection write throwing)
+        // must not be swallowed: surface it and keep the dialog open so the
+        // user can retry, instead of silently leaving the old org active.
+        void switchOrganization(target.id).then(onClose, (error) => {
+          showToast(
+            error instanceof Error
+              ? error.message
+              : `Could not switch to ${target.name}.`,
+          );
+        });
+      }}
+    />
+  );
+}

--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -32,15 +32,20 @@ import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
 import { useCloudBilling } from "@/hooks/cloud/facade/use-cloud-billing";
 import { useCurrentUserOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-current-user-organization-invitations";
 import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
+import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
-import type { OrganizationInvitationRecord } from "@/lib/domain/organizations/organization-records";
+import type {
+  OrganizationInvitationRecord,
+  OrganizationRecord,
+} from "@/lib/domain/organizations/organization-records";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "@/stores/toast/toast-store";
+import { OrganizationSwitchDialog } from "./OrganizationSwitchDialog";
 
 const PROLIFERATE_CHANGELOG_URL = "https://proliferate.com/changelog";
 const PROLIFERATE_DISCORD_URL = "https://discord.gg/7b5afMTqW";
@@ -72,8 +77,11 @@ export function SidebarAccountFooter() {
     authStatus === "authenticated",
   );
   const actions = useOrganizationActions(activeOrganizationId);
+  const { activateJoinedOrganization, activatingJoinedOrganization } =
+    useJoinedOrganizationActivation();
   const pendingInvitations = pendingInvitationsQuery.data?.invitations ?? [];
   const [acceptTarget, setAcceptTarget] = useState<OrganizationInvitationRecord | null>(null);
+  const [switchTarget, setSwitchTarget] = useState<OrganizationRecord | null>(null);
 
   const displayName = user?.display_name?.trim() || user?.email || "Account";
   const initials = displayName.trim().slice(0, 2).toUpperCase() || "PR";
@@ -94,7 +102,7 @@ export function SidebarAccountFooter() {
     }
     try {
       const response = await actions.acceptCurrentInvitation(acceptTarget.id);
-      setActiveOrganizationId(response.organization.id);
+      await activateJoinedOrganization(response.organization.id);
       setAcceptTarget(null);
       showToast(`Joined ${response.organization.name}.`, "info");
     } catch {
@@ -195,7 +203,16 @@ export function SidebarAccountFooter() {
                           : undefined
                       }
                       onClick={() => {
-                        setActiveOrganizationId(organization.id);
+                        // Org->org is semi-destructive (worker identity
+                        // rotates), so it confirms first; gaining a first
+                        // organization adopts it in place.
+                        if (organization.id !== activeOrganizationId) {
+                          if (activeOrganizationId) {
+                            setSwitchTarget(organization);
+                          } else {
+                            setActiveOrganizationId(organization.id);
+                          }
+                        }
                         close();
                       }}
                     />
@@ -318,15 +335,20 @@ export function SidebarAccountFooter() {
         description={
           acceptTarget
             ? `Accept this invitation for ${acceptTarget.email} and join as ${acceptTarget.role}.`
+              + (activeOrganizationId ? " Joining switches your active organization and closes your running local sessions." : "")
             : "Accept this invitation and join the organization."
         }
         confirmLabel="Accept invitation"
-        loading={actions.acceptingCurrentInvitation}
-        disableClose={actions.acceptingCurrentInvitation}
+        loading={actions.acceptingCurrentInvitation || activatingJoinedOrganization}
+        disableClose={actions.acceptingCurrentInvitation || activatingJoinedOrganization}
         onClose={() => setAcceptTarget(null)}
         onConfirm={() => {
           void handleAcceptInvitation();
         }}
+      />
+      <OrganizationSwitchDialog
+        target={switchTarget}
+        onClose={() => setSwitchTarget(null)}
       />
     </div>
   );

--- a/apps/desktop/src/components/settings/panes/OrganizationMembersPane.tsx
+++ b/apps/desktop/src/components/settings/panes/OrganizationMembersPane.tsx
@@ -15,6 +15,7 @@ import { useOrganizationMembers } from "@/hooks/access/cloud/organizations/use-o
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useOrganizationJoinInvitationFlow } from "@/hooks/organizations/workflows/use-organization-join-invitation-flow";
+import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION } from "@/config/settings";
 import {
   type OrganizationInvitationRecord,
@@ -35,7 +36,6 @@ export function OrganizationMembersPane() {
     activeOrganizationId,
     organizations,
     organizationsQuery,
-    setActiveOrganizationId,
   } = useActiveOrganization();
   const actions = useOrganizationActions(activeOrganizationId);
   const admin = useIsAdmin(activeOrganizationId);
@@ -53,6 +53,7 @@ export function OrganizationMembersPane() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
   const joinFlow = useOrganizationJoinInvitationFlow();
+  const { activateJoinedOrganization } = useJoinedOrganizationActivation();
 
   const members = membersQuery.data?.members ?? EMPTY_MEMBERS;
   const invitations = invitationsQuery.data?.invitations ?? EMPTY_INVITATIONS;
@@ -68,7 +69,7 @@ export function OrganizationMembersPane() {
     joinFlow.setStatusMessage(null);
     try {
       const response = await actions.acceptCurrentInvitation(invitationId);
-      setActiveOrganizationId(response.organization.id);
+      await activateJoinedOrganization(response.organization.id);
       joinFlow.clearJoinTarget();
       joinFlow.setStatusMessage(`Joined ${response.organization.name}.`);
       showToast(`Joined ${response.organization.name}.`, "info");

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthUser } from "@/lib/domain/auth/auth-user";
 
 const workflowMocks = vi.hoisted(() => ({
-  ensureDesktopWorker: vi.fn<() => Promise<boolean>>(),
+  ensureDesktopWorker: vi.fn<(organizationId: string | null) => Promise<boolean>>(),
   teardownDesktopWorker: vi.fn<() => Promise<void>>(),
 }));
 
@@ -19,10 +19,11 @@ function authUser(id: string): AuthUser {
 }
 
 // The enrollment guard is module-level state, so each test loads the hook
-// (and the auth store it observes) from a fresh module registry.
+// (and the stores it observes) from a fresh module registry.
 async function loadEnrollmentHarness() {
   vi.resetModules();
   const { useAuthStore } = await import("@/stores/auth/auth-store");
+  const { useOrganizationStore } = await import("@/stores/organizations/organization-store");
   const { useDesktopWorkerEnrollment } = await import("./use-desktop-worker-enrollment");
   useAuthStore.setState({
     status: "bootstrapping",
@@ -30,13 +31,20 @@ async function loadEnrollmentHarness() {
     user: null,
     error: null,
   });
+  useOrganizationStore.setState({
+    activeOrganizationId: null,
+    activeOrganizationValidated: false,
+  });
   const rendered = renderHook(() => useDesktopWorkerEnrollment());
   return {
     ...rendered,
     signIn: (id: string) =>
       useAuthStore.setState({ status: "authenticated", user: authUser(id) }),
     signOut: () => useAuthStore.setState({ status: "anonymous", user: null }),
-    bootstrap: () => useAuthStore.setState({ status: "bootstrapping" }),
+    setOrganization: (organizationId: string | null) =>
+      useOrganizationStore.getState().setActiveOrganizationId(organizationId, {
+        validated: true,
+      }),
     nudgeRender: () => useAuthStore.setState({ error: "nudge a re-render" }),
   };
 }
@@ -95,9 +103,68 @@ describe("useDesktopWorkerEnrollment", () => {
     });
   });
 
+  it("re-enrolls when a different user signs in under the same organization", async () => {
+    const harness = await loadEnrollmentHarness();
+
+    harness.setOrganization("org-1");
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
+    });
+
+    harness.signIn("user-b");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+    });
+    expect(workflowMocks.teardownDesktopWorker).not.toHaveBeenCalled();
+  });
+
+  it("re-enrolls on an org->org change without tearing down itself", async () => {
+    // The destructive part of an org->org switch (confirm dialog, closing
+    // local sessions, teardownDesktopWorker) runs in the organization switch
+    // action before the store changes; the guard only re-enrolls.
+    const harness = await loadEnrollmentHarness();
+
+    harness.setOrganization("org-1");
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
+    });
+
+    harness.setOrganization("org-2");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+    });
+    expect(workflowMocks.ensureDesktopWorker).toHaveBeenLastCalledWith("org-2");
+    expect(workflowMocks.teardownDesktopWorker).not.toHaveBeenCalled();
+  });
+
+  it("adopts a first organization in place: plain re-enroll, no teardown", async () => {
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
+    });
+
+    // Org-less user gains their first organization: the guard key updates
+    // and the worker re-enrolls without disturbing anything.
+    harness.setOrganization("org-1");
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+    });
+    expect(workflowMocks.teardownDesktopWorker).not.toHaveBeenCalled();
+
+    // Same (user, org) again is a no-op.
+    harness.setOrganization("org-1");
+    await flushEffects();
+    expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+  });
+
   it("tears down on sign-out and re-enrolls on the next login", async () => {
     const harness = await loadEnrollmentHarness();
 
+    harness.setOrganization("org-1");
     harness.signIn("user-a");
     await waitFor(() => {
       expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
@@ -133,46 +200,26 @@ describe("useDesktopWorkerEnrollment", () => {
     expect(workflowMocks.teardownDesktopWorker).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the guard when enrollment fails so the next effect run retries", async () => {
-    const harness = await loadEnrollmentHarness();
-    // First enrollment fails silently (ensureDesktopWorker swallows the error
-    // and resolves false); every attempt after that succeeds.
-    workflowMocks.ensureDesktopWorker.mockResolvedValueOnce(false);
+  it("clears the guard and retries when enrollment fails", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker.mockResolvedValueOnce(false);
+      const harness = await loadEnrollmentHarness();
 
-    harness.signIn("user-a");
-    await waitFor(() => {
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
       expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
-    });
-    // Let the false result settle so the guard is reset back to null.
-    await flushEffects();
 
-    // A re-bootstrap (e.g. token refresh) re-runs the effect for the SAME user;
-    // because the failed attempt cleared the guard, enrollment is retried
-    // instead of being wedged until sign-out.
-    harness.bootstrap();
-    await flushEffects();
-    harness.signIn("user-a");
-    await waitFor(() => {
+      // The failed attempt cleared the guard and scheduled a retry; once the
+      // delay elapses the effect re-runs and enrolls again.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
       expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
-    });
-    expect(workflowMocks.teardownDesktopWorker).not.toHaveBeenCalled();
-  });
-
-  it("does not retry the same user after a successful enrollment", async () => {
-    const harness = await loadEnrollmentHarness();
-
-    harness.signIn("user-a");
-    await waitFor(() => {
-      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
-    });
-    await flushEffects();
-
-    // Re-bootstrap for the same user: a successful enrollment kept the guard,
-    // so no re-enrollment fires.
-    harness.bootstrap();
-    await flushEffects();
-    harness.signIn("user-a");
-    await flushEffects();
-    expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -1,54 +1,99 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   ensureDesktopWorker,
   teardownDesktopWorker,
 } from "@/lib/workflows/cloud/ensure-desktop-worker";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { useOrganizationStore } from "@/stores/organizations/organization-store";
 
-// User id the desktop worker is currently enrolled for. Module-level so
-// remounts (or StrictMode double-effects) don't re-enroll for the same user,
-// but keyed by user so switching accounts in one app process rotates the
-// worker + integration-gateway identity instead of silently keeping the
-// previous user's credentials.
-let enrolledUserId: string | null = null;
+// (user, org) key the desktop worker is currently enrolled for. Module-level
+// so remounts (or StrictMode double-effects) don't re-enroll for the same
+// identity, but keyed so switching accounts or organizations in one app
+// process rotates the worker + integration-gateway identity instead of
+// silently keeping the previous identity's credentials.
+let enrolledIdentityKey: string | null = null;
 
+// Delay before retrying a failed enrollment. Long enough not to hammer an
+// unreachable control plane, short enough that integrations recover without
+// a restart.
+const ENROLLMENT_RETRY_DELAY_MS = 15_000;
+
+function identityKey(userId: string, organizationId: string | null): string {
+  return `${userId}::${organizationId ?? ""}`;
+}
+
+// Enrollment guard transitions:
+// - user change: plain re-enroll — ticket consumption rotates the worker
+//   identity server-side, no teardown needed.
+// - org change from a non-null org: the destructive part (confirm, closing
+//   running local sessions, teardownDesktopWorker) already ran in the
+//   organization switch action BEFORE the store changed; here we only
+//   re-enroll under the new org.
+// - org change from null (org-less user gaining their first org): adopt in
+//   place — a plain re-enroll rotates the worker token without disturbing
+//   running sessions.
+// - sign-out: teardown (stop the local worker + delete the gateway dotfile;
+//   the server-side revoke ran in sign-out orchestration while the session
+//   was still valid).
+//
+// The organization is the store's activeOrganizationId without requiring the
+// validated flag: the server membership-validates the organization on
+// enrollment anyway, and waiting for validation would enroll org-less first
+// and then re-enroll once the organizations query resolves on every cold
+// start. A stale selection 404s server-side and the guard re-enrolls once the
+// selection lifecycle falls back to a real membership.
 export function useDesktopWorkerEnrollment(): void {
   const authStatus = useAuthStore((state) => state.status);
   const authUserId = useAuthStore((state) => state.user?.id ?? null);
+  const activeOrganizationId = useOrganizationStore(
+    (state) => state.activeOrganizationId,
+  );
+  const [retryNonce, setRetryNonce] = useState(0);
   useEffect(() => {
     if (authStatus === "bootstrapping") {
       return;
     }
     if (authStatus !== "authenticated" || !authUserId) {
-      // Signed out: revoke + stop the worker and clear the guard so the next
-      // login (any user) re-enrolls with a fresh identity.
-      if (enrolledUserId !== null) {
-        enrolledUserId = null;
+      // Signed out: stop the worker and clear the guard so the next login
+      // (any user) re-enrolls with a fresh identity.
+      if (enrolledIdentityKey !== null) {
+        enrolledIdentityKey = null;
         void teardownDesktopWorker();
       }
       return;
     }
-    if (enrolledUserId === authUserId) {
+    const nextIdentityKey = identityKey(authUserId, activeOrganizationId);
+    if (enrolledIdentityKey === nextIdentityKey) {
       return;
     }
-    // Fresh login or a different user in the same app process: enrolling hands
-    // the Tauri command a new ticket, which rotates the worker identity and
-    // (server-side) revokes the predecessor worker + gateway token.
-    //
-    // Claim the guard synchronously so concurrent renders don't double-enroll,
-    // but ensureDesktopWorker swallows its own errors — if it fails silently we
-    // must clear the guard, otherwise a single transient failure wedges this
-    // user out of a worker until sign-out/in. Reset only when the guard still
-    // holds the id we set: a newer sign-out or user switch may have already
-    // claimed it, and clobbering that would strand the newer identity. This is
-    // not a retry loop — one reset per failed attempt; the next effect run
-    // (re-bootstrap, status change, or user switch) retries.
-    const enrollingUserId = authUserId;
-    enrolledUserId = enrollingUserId;
-    void ensureDesktopWorker().then((ok) => {
-      if (!ok && enrolledUserId === enrollingUserId) {
-        enrolledUserId = null;
+    // Enrolling hands the Tauri command a new ticket, which rotates the
+    // worker identity and (server-side) revokes the predecessor worker +
+    // gateway token under the new (user, org) scope. The effect-captured
+    // organization is passed through so the enrolled org always matches the
+    // guard key, even if the store changes mid-flight.
+    enrolledIdentityKey = nextIdentityKey;
+    let cancelled = false;
+    let retryTimer: number | null = null;
+    void ensureDesktopWorker(activeOrganizationId).then((enrolled) => {
+      if (enrolled || enrolledIdentityKey !== nextIdentityKey) {
+        return;
+      }
+      // Enrollment failed (e.g. a network blip right after an org switch's
+      // deliberate teardown). Leaving the guard set would make the app
+      // believe a worker exists until the next identity change or restart,
+      // so clear it and schedule a retry (timer only while still mounted).
+      enrolledIdentityKey = null;
+      if (!cancelled) {
+        retryTimer = window.setTimeout(() => {
+          setRetryNonce((nonce) => nonce + 1);
+        }, ENROLLMENT_RETRY_DELAY_MS);
       }
     });
-  }, [authStatus, authUserId]);
+    return () => {
+      cancelled = true;
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer);
+      }
+    };
+  }, [authStatus, authUserId, activeOrganizationId, retryNonce]);
 }

--- a/apps/desktop/src/hooks/organizations/workflows/use-joined-organization-activation.ts
+++ b/apps/desktop/src/hooks/organizations/workflows/use-joined-organization-activation.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { useOrganizationSelectionActions } from "@/hooks/organizations/workflows/use-organization-selection-actions";
+import { useOrganizationSwitchAction } from "@/hooks/organizations/workflows/use-organization-switch-action";
+import { useOrganizationStore } from "@/stores/organizations/organization-store";
+
+// Activates an organization the user just joined (e.g. by accepting an
+// invitation). Joining while already active in another org is the same
+// semi-destructive transition as the org switcher, so it runs the switch
+// action (close running local sessions + tear down the worker) BEFORE the
+// store change — the (user, org) enrollment guard then re-enrolls cleanly
+// instead of rotating the worker underneath running sessions. A first
+// organization (or re-activating the current one) is adopted in place.
+export function useJoinedOrganizationActivation() {
+  const activeOrganizationId = useOrganizationStore(
+    (state) => state.activeOrganizationId,
+  );
+  const { setActiveOrganizationId } = useOrganizationSelectionActions();
+  const { switchOrganization, switchingOrganization } = useOrganizationSwitchAction();
+
+  const activateJoinedOrganization = useCallback(async (organizationId: string) => {
+    if (activeOrganizationId && activeOrganizationId !== organizationId) {
+      await switchOrganization(organizationId);
+      return;
+    }
+    setActiveOrganizationId(organizationId);
+  }, [activeOrganizationId, setActiveOrganizationId, switchOrganization]);
+
+  return {
+    activateJoinedOrganization,
+    activatingJoinedOrganization: switchingOrganization,
+  };
+}

--- a/apps/desktop/src/hooks/organizations/workflows/use-organization-switch-action.ts
+++ b/apps/desktop/src/hooks/organizations/workflows/use-organization-switch-action.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from "react";
+import { useOrganizationSelectionActions } from "@/hooks/organizations/workflows/use-organization-selection-actions";
+import { useSessionDismissActions } from "@/hooks/sessions/workflows/use-session-dismiss-actions";
+import { collectRunningLocalSessionIds } from "@/lib/domain/sessions/running-local-sessions";
+import { teardownDesktopWorker } from "@/lib/workflows/cloud/ensure-desktop-worker";
+import { getSessionRecords } from "@/stores/sessions/session-records";
+
+// The semi-destructive org->org switch: close running LOCAL sessions (via the
+// same per-session dismiss action the session UI uses — there is no bulk
+// close workflow), tear down the desktop worker (revoke + stop + delete the
+// gateway dotfile), then record the new active organization. The
+// (user, org)-keyed enrollment guard observes the store change and re-enrolls
+// the worker under the new organization.
+export function useOrganizationSwitchAction() {
+  const { dismissSession } = useSessionDismissActions();
+  const { setActiveOrganizationId } = useOrganizationSelectionActions();
+  const [switchingOrganization, setSwitchingOrganization] = useState(false);
+
+  const switchOrganization = useCallback(async (organizationId: string) => {
+    setSwitchingOrganization(true);
+    try {
+      const runningLocalSessionIds = collectRunningLocalSessionIds(getSessionRecords());
+      for (const sessionId of runningLocalSessionIds) {
+        // dismissSession swallows its own failures; a session that could not
+        // be dismissed must not block rotating the worker identity.
+        await dismissSession(sessionId);
+      }
+      await teardownDesktopWorker();
+      setActiveOrganizationId(organizationId);
+    } finally {
+      setSwitchingOrganization(false);
+    }
+  }, [dismissSession, setActiveOrganizationId]);
+
+  return { switchOrganization, switchingOrganization };
+}

--- a/apps/desktop/src/lib/domain/sessions/running-local-sessions.test.ts
+++ b/apps/desktop/src/lib/domain/sessions/running-local-sessions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectRunningLocalSessionIds,
+  isLocalWorkspaceId,
+  type RunningLocalSessionCandidate,
+} from "./running-local-sessions";
+
+function candidate(
+  workspaceId: string | null,
+  status: "running" | "idle" | "closed",
+  options?: { pendingInteraction?: boolean },
+): RunningLocalSessionCandidate {
+  return {
+    workspaceId,
+    status,
+    transcript: {
+      isStreaming: false,
+      pendingInteractions: options?.pendingInteraction ? [{ requestId: "req-1" }] : [],
+    },
+  };
+}
+
+describe("isLocalWorkspaceId", () => {
+  it("treats plain workspace ids as local", () => {
+    expect(isLocalWorkspaceId("ws-1")).toBe(true);
+  });
+
+  it("rejects cloud and target synthetic ids and missing ids", () => {
+    expect(isLocalWorkspaceId("cloud:cw-1")).toBe(false);
+    expect(isLocalWorkspaceId("target:tgt-1:ws-1")).toBe(false);
+    expect(isLocalWorkspaceId(null)).toBe(false);
+    expect(isLocalWorkspaceId(undefined)).toBe(false);
+  });
+});
+
+describe("collectRunningLocalSessionIds", () => {
+  it("collects only live local sessions", () => {
+    const sessions: Record<string, RunningLocalSessionCandidate> = {
+      "local-working": candidate("ws-1", "running"),
+      "local-needs-input": candidate("ws-1", "idle", { pendingInteraction: true }),
+      "local-idle": candidate("ws-1", "idle"),
+      "local-closed": candidate("ws-1", "closed"),
+      "cloud-working": candidate("cloud:cw-1", "running"),
+      "target-working": candidate("target:tgt-1:ws-9", "running"),
+      "unassigned-working": candidate(null, "running"),
+    };
+
+    expect(collectRunningLocalSessionIds(sessions)).toEqual([
+      "local-working",
+      "local-needs-input",
+    ]);
+  });
+
+  it("returns an empty list when nothing is running locally", () => {
+    expect(collectRunningLocalSessionIds({})).toEqual([]);
+    expect(
+      collectRunningLocalSessionIds({ idle: candidate("ws-1", "idle") }),
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/domain/sessions/running-local-sessions.ts
+++ b/apps/desktop/src/lib/domain/sessions/running-local-sessions.ts
@@ -1,0 +1,39 @@
+import { resolveSessionViewState } from "@proliferate/product-domain/sessions/activity";
+import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
+import { isCloudWorkspaceId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+
+type SessionActivitySnapshot = NonNullable<Parameters<typeof resolveSessionViewState>[0]>;
+
+export type RunningLocalSessionCandidate = SessionActivitySnapshot & {
+  workspaceId?: string | null;
+};
+
+// A plain workspace id (neither the cloud: nor the target: synthetic form)
+// runs on the local AnyHarness runtime.
+export function isLocalWorkspaceId(workspaceId: string | null | undefined): boolean {
+  if (!workspaceId) {
+    return false;
+  }
+  return !isCloudWorkspaceId(workspaceId)
+    && parseTargetWorkspaceSyntheticId(workspaceId) === null;
+}
+
+// Sessions an organization switch must close before the desktop worker is
+// torn down: live agent loops on the LOCAL runtime. Cloud/target sessions do
+// not run through the desktop worker's integration-gateway identity, so they
+// are left alone.
+export function collectRunningLocalSessionIds(
+  sessions: Record<string, RunningLocalSessionCandidate>,
+): string[] {
+  const runningSessionIds: string[] = [];
+  for (const [sessionId, record] of Object.entries(sessions)) {
+    if (!isLocalWorkspaceId(record.workspaceId)) {
+      continue;
+    }
+    const viewState = resolveSessionViewState(record);
+    if (viewState === "working" || viewState === "needs_input") {
+      runningSessionIds.push(sessionId);
+    }
+  }
+  return runningSessionIds;
+}

--- a/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
+++ b/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkMocks = vi.hoisted(() => ({
+  enrollDesktopWorker: vi.fn(),
+  revokeDesktopWorker: vi.fn(),
+}));
+const tauriMocks = vi.hoisted(() => ({
+  getDesktopInstallId: vi.fn(),
+  ensureDesktopDispatchWorker: vi.fn(),
+  stopDesktopDispatchWorker: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk", () => ({
+  enrollDesktopWorker: sdkMocks.enrollDesktopWorker,
+  revokeDesktopWorker: sdkMocks.revokeDesktopWorker,
+}));
+vi.mock("@/lib/access/tauri/desktop-install-id", () => ({
+  getDesktopInstallId: tauriMocks.getDesktopInstallId,
+}));
+vi.mock("@/lib/access/tauri/cloud-worker", () => ({
+  ensureDesktopDispatchWorker: tauriMocks.ensureDesktopDispatchWorker,
+  stopDesktopDispatchWorker: tauriMocks.stopDesktopDispatchWorker,
+}));
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  captureTelemetryException: vi.fn(),
+}));
+
+import { ensureDesktopWorker } from "./ensure-desktop-worker";
+
+describe("ensureDesktopWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tauriMocks.getDesktopInstallId.mockResolvedValue("install-1");
+    tauriMocks.ensureDesktopDispatchWorker.mockResolvedValue(undefined);
+    sdkMocks.enrollDesktopWorker.mockResolvedValue({
+      enrollmentToken: "ticket-1",
+      expiresAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("enrolls with the caller-supplied organization id", async () => {
+    await expect(ensureDesktopWorker("org-1")).resolves.toBe(true);
+
+    expect(sdkMocks.enrollDesktopWorker).toHaveBeenCalledWith("install-1", "org-1");
+    expect(tauriMocks.ensureDesktopDispatchWorker).toHaveBeenCalledWith({
+      targetId: "install-1",
+      enrollmentToken: "ticket-1",
+    });
+  });
+
+  it("enrolls org-less users with a null organization id", async () => {
+    await expect(ensureDesktopWorker(null)).resolves.toBe(true);
+
+    expect(sdkMocks.enrollDesktopWorker).toHaveBeenCalledWith("install-1", null);
+  });
+
+  it("resolves false when enrollment fails so the guard can retry", async () => {
+    sdkMocks.enrollDesktopWorker.mockRejectedValue(new Error("offline"));
+
+    await expect(ensureDesktopWorker(null)).resolves.toBe(false);
+
+    expect(tauriMocks.ensureDesktopDispatchWorker).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
+++ b/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
@@ -19,15 +19,22 @@ function enqueueWorkerLifecycleTask<T>(task: () => Promise<T>): Promise<T> {
   return run;
 }
 
-// Ensures a runtime dispatch worker is enrolled for this desktop install.
+// Ensures a runtime dispatch worker is enrolled for this desktop install
+// under the given organization (null for org-less users). The caller passes
+// the organization it decided to enroll for — the enrollment guard's effect
+// captures it — instead of this workflow re-reading the store after an await,
+// so the enrolled org provably matches the guard's identity key even when the
+// active organization changes mid-flight.
 // Runs opportunistically on login; never blocks or throws on failure.
-// Resolves true when the worker was ensured and false when it failed (the
-// enrollment guard uses this to avoid latching a silent failure forever).
-export function ensureDesktopWorker(): Promise<boolean> {
+// Resolves false when enrollment failed so the guard can retry.
+export function ensureDesktopWorker(organizationId: string | null): Promise<boolean> {
   return enqueueWorkerLifecycleTask(async () => {
     try {
       const desktopInstallId = await getDesktopInstallId();
-      const { enrollmentToken } = await enrollDesktopWorker(desktopInstallId);
+      const { enrollmentToken } = await enrollDesktopWorker(
+        desktopInstallId,
+        organizationId,
+      );
       await ensureDesktopDispatchWorker({
         targetId: desktopInstallId,
         enrollmentToken,
@@ -64,12 +71,12 @@ export async function revokeDesktopWorkerServerSide(): Promise<void> {
   }
 }
 
-// Local teardown of the desktop worker on sign-out: stops the worker process
-// and deletes the integration-gateway dotfile so local sessions cannot keep
-// using the departed user's integrations. Server-side revocation happens
+// Local teardown of the desktop worker: stops the worker process and deletes
+// the integration-gateway dotfile so local sessions cannot keep using the
+// departed identity's integrations. Server-side revocation happens
 // separately via revokeDesktopWorkerServerSide (while the auth token is still
-// valid) and via the predecessor-retiring enrollment of the next user. Never
-// blocks or throws.
+// valid) and via the predecessor-retiring enrollment of the next identity.
+// Never blocks or throws.
 export function teardownDesktopWorker(): Promise<void> {
   return enqueueWorkerLifecycleTask(async () => {
     try {

--- a/cloud/sdk/src/client/desktop-workers.ts
+++ b/cloud/sdk/src/client/desktop-workers.ts
@@ -7,12 +7,13 @@ export interface DesktopWorkerEnrollmentResponse {
 
 export async function enrollDesktopWorker(
   desktopInstallId: string,
+  organizationId: string | null = null,
   client: ProliferateCloudClient = getProliferateClient(),
 ): Promise<DesktopWorkerEnrollmentResponse> {
   return client.requestJson<DesktopWorkerEnrollmentResponse>({
     method: "POST",
     path: "/v1/cloud/workers/desktop/enrollment",
-    body: { desktopInstallId },
+    body: { desktopInstallId, organizationId },
   });
 }
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -3783,6 +3783,8 @@ export interface components {
         DesktopWorkerEnrollmentRequest: {
             /** Desktopinstallid */
             desktopInstallId: string;
+            /** Organizationid */
+            organizationId?: string | null;
         };
         /** DesktopWorkerEnrollmentResponse */
         DesktopWorkerEnrollmentResponse: {

--- a/server/proliferate/db/store/integrations/accounts.py
+++ b/server/proliferate/db/store/integrations/accounts.py
@@ -10,12 +10,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import Row, and_, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
 
 from proliferate.db.models.cloud.integrations import (
     CloudIntegrationAccount,
     CloudIntegrationDefinition,
+    CloudIntegrationPolicy,
 )
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.utils.time import utcnow
@@ -106,56 +108,91 @@ async def list_accounts_for_user(
     return tuple(_record(account) for account in accounts)
 
 
+@dataclass(frozen=True)
+class ReadyAccountRow:
+    """A ready account joined with its definition and (optionally) org policy.
+
+    ``org_policy_enabled`` is the org's policy verdict for the definition, or
+    ``None`` when the org has no policy row (or no org scope was requested).
+    """
+
+    account: IntegrationAccountRecord
+    definition: definitions_store.IntegrationDefinitionRecord
+    org_policy_enabled: bool | None
+
+
+def _ready_accounts_stmt(user_id: UUID, organization_id: UUID | None) -> Select:
+    """Ready accounts + non-archived definitions, LEFT JOINed to the org policy.
+
+    The policy overlay joins in the same query (one round-trip, no
+    per-definition lookups); without an org there is no policy join at all.
+    """
+    stmt = select(CloudIntegrationAccount, CloudIntegrationDefinition).join(
+        CloudIntegrationDefinition,
+        CloudIntegrationDefinition.id == CloudIntegrationAccount.definition_id,
+    )
+    if organization_id is not None:
+        stmt = stmt.add_columns(CloudIntegrationPolicy.enabled).outerjoin(
+            CloudIntegrationPolicy,
+            and_(
+                CloudIntegrationPolicy.definition_id == CloudIntegrationAccount.definition_id,
+                CloudIntegrationPolicy.organization_id == organization_id,
+            ),
+        )
+    return stmt.where(
+        CloudIntegrationAccount.owner_user_id == user_id,
+        CloudIntegrationAccount.enabled.is_(True),
+        CloudIntegrationAccount.status == "ready",
+        CloudIntegrationDefinition.archived_at.is_(None),
+        # Definition visibility mirrors the admin API: seeds are global,
+        # org_custom definitions are served only under their owning org's
+        # scope (for org-less requests this collapses to seeds only). Without
+        # this, an org-B-scoped grant would expose the user's accounts on org
+        # A's custom definitions — which org B's admins can neither see nor
+        # policy-control — and provider-name resolution could land on another
+        # org's custom definition that shares a seed namespace.
+        or_(
+            CloudIntegrationDefinition.organization_id.is_(None),
+            CloudIntegrationDefinition.organization_id == organization_id,
+        ),
+    ).order_by(CloudIntegrationAccount.created_at.asc())
+
+
+def _ready_account_row(row: Row, organization_id: UUID | None) -> ReadyAccountRow:
+    return ReadyAccountRow(
+        account=_record(row[0]),
+        definition=definitions_store.record_from_row(row[1]),
+        org_policy_enabled=row[2] if organization_id is not None else None,
+    )
+
+
 async def list_ready_accounts_for_user(
     db: AsyncSession,
     user_id: UUID,
-) -> tuple[IntegrationAccountRecord, ...]:
-    accounts = (
-        (
-            await db.execute(
-                select(CloudIntegrationAccount)
-                .where(
-                    CloudIntegrationAccount.owner_user_id == user_id,
-                    CloudIntegrationAccount.enabled.is_(True),
-                    CloudIntegrationAccount.status == "ready",
-                )
-                .order_by(CloudIntegrationAccount.created_at.asc())
-            )
-        )
-        .scalars()
-        .all()
-    )
-    return tuple(_record(account) for account in accounts)
+    *,
+    organization_id: UUID | None = None,
+) -> tuple[ReadyAccountRow, ...]:
+    """The user's enabled, ready accounts with non-archived definitions."""
+    rows = (await db.execute(_ready_accounts_stmt(user_id, organization_id))).all()
+    return tuple(_ready_account_row(row, organization_id) for row in rows)
 
 
 async def get_ready_account_for_provider(
     db: AsyncSession,
     user_id: UUID,
     namespace: str,
-) -> tuple[IntegrationAccountRecord, definitions_store.IntegrationDefinitionRecord] | None:
+    *,
+    organization_id: UUID | None = None,
+) -> ReadyAccountRow | None:
     """The user's enabled, ready account whose non-archived definition matches ``namespace``."""
     row = (
         await db.execute(
-            select(CloudIntegrationAccount, CloudIntegrationDefinition)
-            .join(
-                CloudIntegrationDefinition,
-                CloudIntegrationDefinition.id == CloudIntegrationAccount.definition_id,
-            )
-            .where(
-                CloudIntegrationAccount.owner_user_id == user_id,
-                CloudIntegrationAccount.enabled.is_(True),
-                CloudIntegrationAccount.status == "ready",
-                CloudIntegrationDefinition.namespace == namespace,
-                CloudIntegrationDefinition.archived_at.is_(None),
-            )
-            .order_by(CloudIntegrationAccount.created_at.asc())
+            _ready_accounts_stmt(user_id, organization_id)
+            .where(CloudIntegrationDefinition.namespace == namespace)
             .limit(1)
         )
     ).first()
-    if row is None:
-        return None
-    account, definition = row
-    return _record(account), definitions_store._record(definition)
+    return _ready_account_row(row, organization_id) if row is not None else None
 
 
 async def upsert_account(

--- a/server/proliferate/db/store/integrations/definitions.py
+++ b/server/proliferate/db/store/integrations/definitions.py
@@ -8,7 +8,6 @@ touch org-custom rows and vice versa.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
@@ -37,7 +36,12 @@ class IntegrationDefinitionRecord:
     updated_at: datetime
 
 
-def _record(row: CloudIntegrationDefinition) -> IntegrationDefinitionRecord:
+def record_from_row(row: CloudIntegrationDefinition) -> IntegrationDefinitionRecord:
+    """Map a definition ORM row to its record.
+
+    Public so sibling stores (e.g. the accounts store, which joins definitions)
+    can reuse the mapping instead of reaching into a private helper.
+    """
     return IntegrationDefinitionRecord(
         id=row.id,
         source=row.source,
@@ -53,6 +57,11 @@ def _record(row: CloudIntegrationDefinition) -> IntegrationDefinitionRecord:
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+# Module-internal shorthand for the many in-module call sites below; the public
+# name is record_from_row.
+_record = record_from_row
 
 
 async def list_seed_definitions(db: AsyncSession) -> tuple[IntegrationDefinitionRecord, ...]:
@@ -91,18 +100,6 @@ async def get_definition(
 ) -> IntegrationDefinitionRecord | None:
     row = await db.get(CloudIntegrationDefinition, definition_id)
     return _record(row) if row is not None else None
-
-
-async def get_definitions_by_ids(
-    db: AsyncSession, definition_ids: Iterable[UUID]
-) -> dict[UUID, IntegrationDefinitionRecord]:
-    ids = list(definition_ids)
-    if not ids:
-        return {}
-    result = await db.scalars(
-        select(CloudIntegrationDefinition).where(CloudIntegrationDefinition.id.in_(ids))
-    )
-    return {row.id: _record(row) for row in result.all()}
 
 
 async def get_seed_by_namespace(

--- a/server/proliferate/server/cloud/integration_gateway/dependencies.py
+++ b/server/proliferate/server/cloud/integration_gateway/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.engine import get_async_session
+from proliferate.db.store import organizations as organization_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.runtime_workers import IntegrationGatewayGrant
 from proliferate.server.cloud.errors import CloudApiError
@@ -44,6 +45,22 @@ async def require_integration_gateway_grant(
             "Gateway token is invalid or revoked.",
             status_code=401,
         )
+    # The org scope was membership-validated at enrollment, but workers are
+    # long-lived: re-validate on every request so a worker enrolled under an
+    # org stops serving the moment its owner is removed from that org, rather
+    # than keeping the org-scoped grant alive until the next re-enrollment.
+    if grant.organization_id is not None:
+        membership = await organization_store.get_active_membership(
+            db,
+            organization_id=grant.organization_id,
+            user_id=grant.owner_user_id,
+        )
+        if membership is None:
+            raise CloudApiError(
+                "integration_gateway_unauthorized",
+                "Gateway token is invalid or revoked.",
+                status_code=401,
+            )
     return grant
 
 

--- a/server/proliferate/server/cloud/integration_gateway/service.py
+++ b/server/proliferate/server/cloud/integration_gateway/service.py
@@ -13,7 +13,7 @@ import json
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store.integrations import accounts as accounts_store
-from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.db.store.integrations.accounts import ReadyAccountRow
 from proliferate.db.store.runtime_workers import IntegrationGatewayGrant
 from proliferate.integrations import mcp_remote
 from proliferate.integrations.mcp_remote import McpRemoteError
@@ -30,23 +30,42 @@ from proliferate.server.cloud.integrations.tools import get_or_refresh_tool_cach
 _PROTOCOL_VERSION = "2025-06-18"
 
 
+def _org_allows(grant: IntegrationGatewayGrant, row: ReadyAccountRow) -> bool:
+    """Whether the grant's org policy overlay leaves this definition enabled.
+
+    Org-scoped grants get the org overlay: an explicit policy row wins,
+    otherwise the definition's default. Org-less grants (``organization_id``
+    NULL) see seeds-with-defaults behavior — no overlay at all. That org-less
+    escape hatch is a documented v1 tradeoff (see
+    ``create_desktop_enrollment``): enrollment never forces an org, so the
+    overlay governs org-scoped workers rather than hard-blocking members who
+    enroll org-less.
+    """
+    if grant.organization_id is None:
+        return True
+    if row.org_policy_enabled is not None:
+        return row.org_policy_enabled
+    return row.definition.enabled_by_default
+
+
 async def ready_accounts_for_grant(
     db: AsyncSession,
     *,
     grant: IntegrationGatewayGrant,
 ) -> list[GatewayProviderAccount]:
-    """The owner's enabled, ready accounts whose definition is not archived."""
-    accounts = await accounts_store.list_ready_accounts_for_user(db, grant.owner_user_id)
-    definitions = await definitions_store.get_definitions_by_ids(
-        db, {account.definition_id for account in accounts}
+    """The owner's enabled, ready accounts whose definition is not archived.
+
+    For org-scoped grants, definitions disabled by the org policy overlay are
+    excluded.
+    """
+    rows = await accounts_store.list_ready_accounts_for_user(
+        db, grant.owner_user_id, organization_id=grant.organization_id
     )
-    resolved: list[GatewayProviderAccount] = []
-    for account in accounts:
-        definition = definitions.get(account.definition_id)
-        if definition is None or definition.archived_at is not None:
-            continue
-        resolved.append(GatewayProviderAccount(account=account, definition=definition))
-    return resolved
+    return [
+        GatewayProviderAccount(account=row.account, definition=row.definition)
+        for row in rows
+        if _org_allows(grant, row)
+    ]
 
 
 async def account_for_provider(
@@ -55,15 +74,22 @@ async def account_for_provider(
     grant: IntegrationGatewayGrant,
     provider: str,
 ) -> GatewayProviderAccount:
-    pair = await accounts_store.get_ready_account_for_provider(db, grant.owner_user_id, provider)
-    if pair is None:
+    row = await accounts_store.get_ready_account_for_provider(
+        db, grant.owner_user_id, provider, organization_id=grant.organization_id
+    )
+    if row is None:
         raise CloudApiError(
             "integration_provider_not_found",
             f"No connected integration provider '{provider}'.",
             status_code=404,
         )
-    account, definition = pair
-    return GatewayProviderAccount(account=account, definition=definition)
+    if not _org_allows(grant, row):
+        raise CloudApiError(
+            "integration_provider_disabled",
+            f"Integration provider '{provider}' is disabled by your organization's policy.",
+            status_code=404,
+        )
+    return GatewayProviderAccount(account=row.account, definition=row.definition)
 
 
 async def list_providers(

--- a/server/proliferate/server/cloud/runtime_workers/api.py
+++ b/server/proliferate/server/cloud/runtime_workers/api.py
@@ -71,6 +71,7 @@ async def create_desktop_worker_enrollment_endpoint(
         db,
         owner_user_id=user.id,
         desktop_install_id=body.desktop_install_id,
+        organization_id=body.organization_id,
     )
 
 

--- a/server/proliferate/server/cloud/runtime_workers/models.py
+++ b/server/proliferate/server/cloud/runtime_workers/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
@@ -46,6 +47,7 @@ class WorkerHeartbeatResponse(_CamelModel):
 
 class DesktopWorkerEnrollmentRequest(_CamelModel):
     desktop_install_id: str = Field(min_length=1, max_length=255)
+    organization_id: UUID | None = None
 
 
 class DesktopWorkerEnrollmentResponse(_CamelModel):

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -20,6 +20,7 @@ from proliferate.constants.cloud import (
     CLOUD_RUNTIME_WORKER_DESKTOP_ENROLLMENT_TTL_SECONDS,
     CLOUD_RUNTIME_WORKER_HEARTBEAT_INTERVAL_SECONDS,
 )
+from proliferate.db.store import organizations as organization_store
 from proliferate.db.store import runtime_workers as store
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime_workers.models import (
@@ -85,14 +86,39 @@ async def create_desktop_enrollment(
     *,
     owner_user_id: UUID,
     desktop_install_id: str,
+    organization_id: UUID | None = None,
 ) -> DesktopWorkerEnrollmentResponse:
-    """Mint a short-lived enrollment token for the user's desktop install."""
+    """Mint a short-lived enrollment token for the user's desktop install.
+
+    The worker identity is an immutable (user, org, install) triple: an org id
+    supplied here is membership-validated and stamped on the enrollment, so the
+    worker (and its gateway grant) is scoped to that org for its whole life.
+    Org-less users enroll with ``organization_id=None``.
+
+    Accepted v1 tradeoff: the org scope is client-declared. Personal, org-less
+    desktop use must keep working (the desktop also enrolls org-less on cold
+    start before the active org resolves), so the server does not derive or
+    require an org here — which means an org member can obtain an org-less
+    grant (no policy overlay, seeds-only definitions) by omitting the org id.
+    Org policy on the gateway is therefore governance for org-scoped workers,
+    not a hard security boundary against the org's own members.
+    """
+    if organization_id is not None:
+        # A worker must not be scoped to an org the caller does not belong to;
+        # a non-member must not learn the org exists by supplying its id.
+        membership = await organization_store.get_active_membership(
+            db, organization_id=organization_id, user_id=owner_user_id
+        )
+        if membership is None:
+            raise CloudApiError(
+                "organization_not_found", "Organization not found.", status_code=404
+            )
     token = secrets.token_urlsafe(_TOKEN_BYTES)
     expires_at = utcnow() + timedelta(seconds=CLOUD_RUNTIME_WORKER_DESKTOP_ENROLLMENT_TTL_SECONDS)
     await store.create_enrollment(
         db,
         owner_user_id=owner_user_id,
-        organization_id=None,
+        organization_id=organization_id,
         runtime_kind="desktop",
         cloud_sandbox_id=None,
         desktop_install_id=desktop_install_id,

--- a/server/tests/integration/test_cloud_integration_gateway_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_api.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_MEMBERSHIP_STATUS_REMOVED,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
@@ -24,18 +32,37 @@ def _worker_cloud_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "cloud_worker_base_url", "http://cloud.test")
 
 
-async def _gateway_bearer(client: AsyncClient, db_session: AsyncSession, *, prefix: str) -> str:
+async def _authed_user(client: AsyncClient, db_session: AsyncSession, *, prefix: str):
     auth = await create_user_and_login(client, db_session, email_prefix=prefix)
     await seed_linked_github_account(db_session, user_id=auth.user_id, access_token=f"gh-{prefix}")
+    return auth
+
+
+async def _enroll_gateway_bearer(
+    client: AsyncClient,
+    auth,
+    *,
+    prefix: str,
+    organization_id: str | None = None,
+) -> str:
+    body: dict[str, str] = {"desktopInstallId": f"install-{prefix}"}
+    if organization_id is not None:
+        body["organizationId"] = organization_id
     enrollment = await client.post(
         "/v1/cloud/workers/desktop/enrollment",
         headers=auth.headers,
-        json={"desktopInstallId": f"install-{prefix}"},
+        json=body,
     )
+    assert enrollment.status_code == 200, enrollment.text
     token = enrollment.json()["enrollmentToken"]
     enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
     authorization = enroll.json()["integrationGateway"]["authorization"]
     return authorization.removeprefix("Bearer ")
+
+
+async def _gateway_bearer(client: AsyncClient, db_session: AsyncSession, *, prefix: str) -> str:
+    auth = await _authed_user(client, db_session, prefix=prefix)
+    return await _enroll_gateway_bearer(client, auth, prefix=prefix)
 
 
 async def _seed_ready_account(db_session: AsyncSession, *, user_id: str, namespace: str) -> None:
@@ -59,6 +86,32 @@ async def _seed_ready_account(db_session: AsyncSession, *, user_id: str, namespa
         token_expires_at=None,
     )
     await db_session.commit()
+
+
+async def _create_org_with_member(db_session: AsyncSession, *, user_id: str) -> str:
+    now = datetime.now(UTC)
+    organization = Organization(
+        name="Acme",
+        logo_domain="acme.dev",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(organization)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=uuid.UUID(user_id),
+            role=ORGANIZATION_ROLE_MEMBER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()
+    return str(organization.id)
 
 
 @pytest.mark.asyncio
@@ -275,6 +328,55 @@ async def test_call_tool_upstream_failure_returns_mcp_error_not_500(
     by_id = {r["id"]: r for r in response.json()}
     assert by_id[1]["result"]["isError"] is True
     assert by_id[2]["result"]["tools"]  # sibling still returned
+
+
+async def _tool_call(client: AsyncClient, headers: dict[str, str], *, name: str, arguments: dict):
+    response = await client.post(
+        GATEWAY_URL,
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["result"]
+
+
+@pytest.mark.asyncio
+async def test_org_scoped_grant_stops_serving_after_membership_removal(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed_user(client, db_session, prefix="gw-membership")
+    org_id = await _create_org_with_member(db_session, user_id=auth.user_id)
+    bearer = await _enroll_gateway_bearer(
+        client, auth, prefix="gw-membership", organization_id=org_id
+    )
+    headers = {"Authorization": f"Bearer {bearer}"}
+    request_body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+
+    ok = await client.post(GATEWAY_URL, headers=headers, json=request_body)
+    assert ok.status_code == 200, ok.text
+
+    # Remove the owner from the org: the long-lived org-scoped grant must stop
+    # serving immediately, not at the next re-enrollment.
+    from sqlalchemy import select
+
+    membership = (
+        await db_session.execute(
+            select(OrganizationMembership).where(
+                OrganizationMembership.organization_id == uuid.UUID(org_id),
+                OrganizationMembership.user_id == uuid.UUID(auth.user_id),
+            )
+        )
+    ).scalar_one()
+    membership.status = ORGANIZATION_MEMBERSHIP_STATUS_REMOVED
+    await db_session.commit()
+
+    revoked = await client.post(GATEWAY_URL, headers=headers, json=request_body)
+    assert revoked.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_integration_gateway_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_policy_api.py
@@ -1,0 +1,179 @@
+"""Org-policy enforcement at the integration gateway (split from the main gateway suite)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.db.store.integrations import policies as policies_store
+from proliferate.utils.crypto import encrypt_json
+from tests.integration.test_cloud_integration_gateway_api import (
+    _authed_user,
+    _create_org_with_member,
+    _enroll_gateway_bearer,
+    _seed_ready_account,
+    _tool_call,
+)
+
+
+@pytest.fixture(autouse=True)
+def _worker_cloud_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cloud_worker_base_url", "http://cloud.test")
+
+
+async def _set_org_policy(
+    db_session: AsyncSession,
+    *,
+    organization_id: str,
+    namespace: str,
+    enabled: bool,
+    updated_by_user_id: str,
+) -> None:
+    definition = await definitions_store.get_seed_by_namespace(db_session, namespace)
+    assert definition is not None
+    await policies_store.upsert_policy(
+        db_session,
+        organization_id=uuid.UUID(organization_id),
+        definition_id=definition.id,
+        enabled=enabled,
+        updated_by_user_id=uuid.UUID(updated_by_user_id),
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_cross_org_custom_definition_hidden_from_other_org_grant(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed_user(client, db_session, prefix="gw-cross-custom")
+    org_a_id = await _create_org_with_member(db_session, user_id=auth.user_id)
+    org_b_id = await _create_org_with_member(db_session, user_id=auth.user_id)
+
+    definition = await definitions_store.create_org_custom_definition(
+        db_session,
+        organization_id=uuid.UUID(org_a_id),
+        namespace="acme-internal",
+        display_name="Acme Internal",
+        description=None,
+        auth_kind="api_key",
+        oauth_client_mode=None,
+        config_json="{}",
+    )
+    account = await accounts_store.upsert_account(
+        db_session,
+        user_id=uuid.UUID(auth.user_id),
+        definition_id=definition.id,
+        auth_kind="api_key",
+        status="ready",
+    )
+    await accounts_store.set_account_credentials(
+        db_session,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json({"secretFields": {"api_key": "secret"}}),
+        credential_format="secret-fields-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+    await db_session.commit()
+
+    # Under org A's scope the custom definition is served...
+    bearer_a = await _enroll_gateway_bearer(
+        client, auth, prefix="gw-cross-custom-a", organization_id=org_a_id
+    )
+    listed = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer_a}"},
+        name="integrations.list_providers",
+        arguments={},
+    )
+    providers = [p["provider"] for p in listed["structuredContent"]["providers"]]
+    assert providers == ["acme-internal"]
+
+    # ...but a grant scoped to org B (whose admins can neither see nor
+    # policy-control org A's custom definition) must not expose it.
+    bearer_b = await _enroll_gateway_bearer(
+        client, auth, prefix="gw-cross-custom-b", organization_id=org_b_id
+    )
+    hidden = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer_b}"},
+        name="integrations.list_providers",
+        arguments={},
+    )
+    assert hidden["structuredContent"]["providers"] == []
+
+
+@pytest.mark.asyncio
+async def test_orgless_grant_ignores_other_orgs_policies(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    other = await _authed_user(client, db_session, prefix="gw-org-other")
+    other_org_id = await _create_org_with_member(db_session, user_id=other.user_id)
+
+    auth = await _authed_user(client, db_session, prefix="gw-orgless")
+    bearer = await _enroll_gateway_bearer(client, auth, prefix="gw-orgless")
+    headers = {"Authorization": f"Bearer {bearer}"}
+    await _seed_ready_account(db_session, user_id=auth.user_id, namespace="context7")
+
+    # Another org disabling the definition must not leak into an org-less grant.
+    await _set_org_policy(
+        db_session,
+        organization_id=other_org_id,
+        namespace="context7",
+        enabled=False,
+        updated_by_user_id=other.user_id,
+    )
+
+    listed = await _tool_call(client, headers, name="integrations.list_providers", arguments={})
+    assert [p["provider"] for p in listed["structuredContent"]["providers"]] == ["context7"]
+
+
+@pytest.mark.asyncio
+async def test_org_policy_disables_provider_across_gateway(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    auth = await _authed_user(client, db_session, prefix="gw-org-policy")
+    org_id = await _create_org_with_member(db_session, user_id=auth.user_id)
+    bearer = await _enroll_gateway_bearer(
+        client, auth, prefix="gw-org-policy", organization_id=org_id
+    )
+    headers = {"Authorization": f"Bearer {bearer}"}
+    await _seed_ready_account(db_session, user_id=auth.user_id, namespace="context7")
+
+    # No policy row yet: the seed default applies and the provider is listed.
+    listed = await _tool_call(client, headers, name="integrations.list_providers", arguments={})
+    assert [p["provider"] for p in listed["structuredContent"]["providers"]] == ["context7"]
+
+    await _set_org_policy(
+        db_session,
+        organization_id=org_id,
+        namespace="context7",
+        enabled=False,
+        updated_by_user_id=auth.user_id,
+    )
+
+    # list_providers: the disabled definition is excluded outright.
+    hidden = await _tool_call(client, headers, name="integrations.list_providers", arguments={})
+    assert hidden["structuredContent"]["providers"] == []
+
+    # list_tools: an in-band MCP error naming the org policy.
+    tools = await _tool_call(
+        client, headers, name="integrations.list_tools", arguments={"provider": "context7"}
+    )
+    assert tools["isError"] is True
+    assert "disabled" in tools["content"][0]["text"]
+
+    # call_tool: also an in-band MCP error, never a credentialed upstream call.
+    call = await _tool_call(
+        client,
+        headers,
+        name="integrations.call_tool",
+        arguments={"provider": "context7", "tool": "resolve-library-id", "arguments": {}},
+    )
+    assert call["isError"] is True

--- a/server/tests/integration/test_cloud_runtime_workers_api.py
+++ b/server/tests/integration/test_cloud_runtime_workers_api.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+import uuid
+from datetime import UTC, datetime
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.cloud.runtime_workers import CloudRuntimeWorker
+from proliferate.db.models.organizations import Organization, OrganizationMembership
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 
@@ -24,6 +35,32 @@ async def _authed_user(client: AsyncClient, db_session: AsyncSession, *, prefix:
         access_token=f"gh-{prefix}",
     )
     return auth
+
+
+async def _create_org_with_member(db_session: AsyncSession, *, user_id: str) -> str:
+    now = datetime.now(UTC)
+    organization = Organization(
+        name="Acme",
+        logo_domain="acme.dev",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(organization)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=uuid.UUID(user_id),
+            role=ORGANIZATION_ROLE_MEMBER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await db_session.commit()
+    return str(organization.id)
 
 
 async def _desktop_enrollment_token(
@@ -194,6 +231,79 @@ class TestRuntimeWorkerEnrollment:
             json={},
         )
         assert fresh.status_code == 200
+
+
+class TestOrgScopedEnrollment:
+    @pytest.mark.asyncio
+    async def test_member_enrollment_stamps_org_on_worker(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="worker-org-member")
+        org_id = await _create_org_with_member(db_session, user_id=auth.user_id)
+
+        response = await client.post(
+            "/v1/cloud/workers/desktop/enrollment",
+            headers=auth.headers,
+            json={"desktopInstallId": "install-org-a", "organizationId": org_id},
+        )
+        assert response.status_code == 200, response.text
+        token = response.json()["enrollmentToken"]
+
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        assert enroll.status_code == 200, enroll.text
+
+        worker = (
+            await db_session.execute(
+                select(CloudRuntimeWorker).where(
+                    CloudRuntimeWorker.owner_user_id == uuid.UUID(auth.user_id),
+                    CloudRuntimeWorker.desktop_install_id == "install-org-a",
+                    CloudRuntimeWorker.status != "revoked",
+                )
+            )
+        ).scalar_one()
+        assert worker.organization_id == uuid.UUID(org_id)
+
+    @pytest.mark.asyncio
+    async def test_non_member_enrollment_is_404(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        member = await _authed_user(client, db_session, prefix="worker-org-owner2")
+        outsider = await _authed_user(client, db_session, prefix="worker-org-outsider")
+        org_id = await _create_org_with_member(db_session, user_id=member.user_id)
+
+        response = await client.post(
+            "/v1/cloud/workers/desktop/enrollment",
+            headers=outsider.headers,
+            json={"desktopInstallId": "install-org-b", "organizationId": org_id},
+        )
+        assert response.status_code == 404, response.text
+        assert response.json()["detail"]["code"] == "organization_not_found"
+
+    @pytest.mark.asyncio
+    async def test_omitted_org_enrolls_with_null_org(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="worker-org-none")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-org-c")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        assert enroll.status_code == 200, enroll.text
+
+        worker = (
+            await db_session.execute(
+                select(CloudRuntimeWorker).where(
+                    CloudRuntimeWorker.owner_user_id == uuid.UUID(auth.user_id),
+                    CloudRuntimeWorker.desktop_install_id == "install-org-c",
+                    CloudRuntimeWorker.status != "revoked",
+                )
+            )
+        ).scalar_one()
+        assert worker.organization_id is None
 
 
 async def _enroll_worker(client: AsyncClient, auth, *, install_id: str) -> dict:


### PR DESCRIPTION
## What

Restores the already-reviewed content of **PR #894** (org-scoped worker identity + gateway org-policy enforcement) onto `main`.

#894 was accidentally squash-merged into its **stale base branch** `fix/desktop-worker-user-switch` instead of `main` — GitHub kept that base branch alive and never retargeted the PR, so the reviewed change never reached `main`. Its full content lives as one squash commit `b1f211251` on `origin/fix/desktop-worker-user-switch`. This PR cherry-picks that commit onto current `main`.

Restores #894.

## Content

- **Server — runtime workers**: desktop enrollment gains an optional `organizationId` that is membership-validated (non-member → 404 `organization_not_found`) and stamped onto the enrollment, making the worker identity an immutable `(user, org, host)` triple.
- **Server — integration gateway org-policy enforcement**: org-scoped grants apply the org policy overlay via a `LEFT JOIN` on `cloud_integration_policy` in the joined ready-account queries; disabled definitions are excluded from `integrations.list_providers`, and `list_tools`/`call_tool` surface an in-band `integration_provider_disabled` error. Org membership is re-validated on every gateway request. `record_from_row()` promoted to a public store helper.
- **Cloud SDK**: `enrollDesktopWorker(desktopInstallId, organizationId = null, …)` signature + the `organizationId` OpenAPI field.
- **Desktop**: `(user, org)`-keyed enrollment guard, semi-destructive org-switch dialog/action (closes running local sessions + tears down the worker before the store change), a `running-local-sessions` domain module, and invitation-accept activation routed through the switch flow.
- **Tests**: `test_cloud_runtime_workers_api.py`, `test_cloud_integration_gateway_api.py`, the new split `test_cloud_integration_gateway_policy_api.py`, and desktop vitest coverage for the dialog/hook/domain modules.

## Conflict resolution

The squash's parent predates a batch of PRs that already landed on `main` (#893/#895/#902/#905/#911/#912/#917), so git's 3-way merge no-op'd everything main already had and only two test files conflicted:

- `server/tests/integration/test_cloud_integrations_api.py` — the `TestIntegrationForeignKeys` class #894 adds is byte-identical to what #895 already landed on main; git offset-matched the two copies. Resolved to main's single copy (the file ends identical to `main`).
- `server/tests/integration/test_cloud_integration_gateway_api.py` — a one-line `datetime` import conflict; kept main's fuller `from datetime import UTC, datetime, timedelta` since the shared body below uses `datetime.now(UTC)`.

No duplicate defs, no leftover markers; both files parse. Rebased onto current `main` (past #923, disjoint files) for a clean single-commit diff.

## Verification

- `ruff format --check` + `ruff check` on all touched server files — pass.
- `pytest test_cloud_runtime_workers_api.py test_cloud_integration_gateway_api.py test_cloud_integration_gateway_policy_api.py` — **29 passed**.
- Rebuilt cloud SDK + product-ui dists; `tsc --noEmit` in `apps/desktop` — clean.
- Vitest on the touched desktop dialog/hook/domain tests — **18 passed**.
- `check_max_lines.py`, `check_server_boundaries.py`, `check_frontend_boundaries.py`, `check_proliferate_worker_structure.py`, `report_frontend_structure.py --strict` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
