### PR TITLE
feat(cloud): heartbeat version convergence + sandbox worker self-swap (restore #897)

### DIFF
--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -116,8 +116,8 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
       # Version pins stamped into the image and reported by /health and /meta.
-      # serverVersion comes from the root VERSION file; desktop/runtime pins from
-      # their tracked package manifests at this commit.
+      # serverVersion comes from the root VERSION file; desktop/runtime/worker
+      # pins from their tracked package manifests at this commit.
       - name: Resolve version pins
         id: pins
         run: |
@@ -125,10 +125,13 @@ jobs:
           server_version="$(cat VERSION)"
           desktop_version="$(jq -r '.version' apps/desktop/package.json)"
           runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
+          worker_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' anyharness/crates/proliferate-worker/Cargo.toml | head -n 1)"
+          : "${worker_version:?Failed to read the proliferate-worker crate version.}"
           {
             echo "server_version=${server_version}"
             echo "desktop_version=${desktop_version}"
             echo "runtime_version=${runtime_version}"
+            echo "worker_version=${worker_version}"
             echo "min_desktop_version=${desktop_version}"
           } >> "$GITHUB_OUTPUT"
 
@@ -145,6 +148,7 @@ jobs:
             SERVER_VERSION=${{ steps.pins.outputs.server_version }}
             DESKTOP_VERSION=${{ steps.pins.outputs.desktop_version }}
             RUNTIME_VERSION=${{ steps.pins.outputs.runtime_version }}
+            WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
             MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
 
       - name: Render ECS task definition

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -181,18 +181,21 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Version pins stamped into the image and reported by /health and /meta.
-      # serverVersion is the release version (server-v tag / input). The desktop
-      # and runtime pins are read from their tracked package manifests at this
-      # commit; minDesktopVersion defaults to the pinned desktop version.
+      # serverVersion is the release version (server-v tag / input). The desktop,
+      # runtime, and worker pins are read from their tracked package manifests
+      # at this commit; minDesktopVersion defaults to the pinned desktop version.
       - name: Resolve version pins
         id: pins
         run: |
           set -euo pipefail
           desktop_version="$(jq -r '.version' apps/desktop/package.json)"
           runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
+          worker_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' anyharness/crates/proliferate-worker/Cargo.toml | head -n 1)"
+          : "${worker_version:?Failed to read the proliferate-worker crate version.}"
           {
             echo "desktop_version=${desktop_version}"
             echo "runtime_version=${runtime_version}"
+            echo "worker_version=${worker_version}"
             echo "min_desktop_version=${desktop_version}"
           } >> "$GITHUB_OUTPUT"
         working-directory: .
@@ -208,6 +211,7 @@ jobs:
             SERVER_VERSION=${{ steps.tags.outputs.version }}
             DESKTOP_VERSION=${{ steps.pins.outputs.desktop_version }}
             RUNTIME_VERSION=${{ steps.pins.outputs.runtime_version }}
+            WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
             MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
 
   self-hosted-release-assets:

--- a/anyharness/crates/proliferate-worker/src/cloud_client/heartbeat.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/heartbeat.rs
@@ -1,7 +1,10 @@
 use super::HeartbeatRequest;
+use crate::versions;
 
 pub fn report(status: impl Into<String>) -> HeartbeatRequest {
     HeartbeatRequest {
         status: Some(status.into()),
+        worker_version: versions::worker_version(),
+        anyharness_version: versions::anyharness_version(),
     }
 }

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -52,6 +52,27 @@ pub struct IntegrationGatewayConfig {
 pub struct HeartbeatRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    // Self-reported so the server row tracks what actually runs, including
+    // right after a self-swap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anyharness_version: Option<String>,
+}
+
+/// Component versions the server pins; self-managed workers converge onto
+/// these. Every field is optional so acks from older servers (or future shape
+/// changes) never break heartbeating.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DesiredVersions {
+    #[serde(default)]
+    pub worker: Option<String>,
+    // Parsed for completeness; the worker only swaps its own binary today.
+    // AnyHarness convergence is owned by whoever launches the runtime.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub anyharness: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -64,6 +85,9 @@ pub struct HeartbeatResponse {
     pub status: Option<String>,
     #[serde(default)]
     pub server_time: Option<String>,
+    // Absent on servers that predate version convergence.
+    #[serde(default)]
+    pub desired_versions: Option<DesiredVersions>,
 }
 
 impl CloudClient {
@@ -106,7 +130,71 @@ impl CloudClient {
             .await?;
         parse_json_response(response).await
     }
+
+    /// Fetch a pinned worker artifact via the server's redirect endpoint,
+    /// capturing the CDN URL the 302 resolved to. Unauthenticated by design
+    /// (the CDN artifacts are public); reqwest follows the 302 to the downloads
+    /// CDN. Uses a per-request timeout because a binary download can
+    /// legitimately outlive the client's default 30s cap on slow links.
+    ///
+    /// The resolved URL lets a caller fetch a sibling artifact (the binary's
+    /// `.sha256`) from the *same* published directory without re-hitting the
+    /// redirect: the server resolves pinned-vs-fallback independently per
+    /// request, so a second redirect could straddle a publish and pair the
+    /// binary with a checksum from a different version.
+    pub async fn download_worker_artifact(
+        &self,
+        target: &str,
+        asset: &str,
+    ) -> Result<DownloadedArtifact, WorkerError> {
+        let response = self
+            .http
+            .get(format!(
+                "{}/v1/cloud/worker/download/{target}/{asset}",
+                self.base_url
+            ))
+            .timeout(ARTIFACT_DOWNLOAD_TIMEOUT)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        // Capture the post-redirect URL before the body consumes the response.
+        let resolved_url = response.url().to_string();
+        let bytes = response.bytes().await?.to_vec();
+        Ok(DownloadedArtifact { bytes, resolved_url })
+    }
+
+    /// Fetch an artifact directly from an already-resolved CDN URL (used for
+    /// the checksum, whose URL is derived from the binary's resolved location
+    /// so the pair is guaranteed to share a directory — and thus a version).
+    /// No server redirect, hence no second version-path resolution.
+    pub async fn download_from_url(&self, url: &str) -> Result<Vec<u8>, WorkerError> {
+        let response = self
+            .http
+            .get(url)
+            .timeout(ARTIFACT_DOWNLOAD_TIMEOUT)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        Ok(response.bytes().await?.to_vec())
+    }
 }
+
+/// A downloaded worker artifact plus the CDN URL the server's redirect
+/// resolved to, so a sibling artifact can be fetched from the same directory.
+pub struct DownloadedArtifact {
+    pub bytes: Vec<u8>,
+    pub resolved_url: String,
+}
+
+const ARTIFACT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 
 async fn parse_json_response<T: DeserializeOwned>(
     response: reqwest::Response,
@@ -140,21 +228,72 @@ mod tests {
         assert_eq!(response.worker_token, "token");
         assert_eq!(response.heartbeat_interval_seconds, 30);
         assert_eq!(response.integration_gateway.url, "http://127.0.0.1:8300");
-        assert_eq!(response.integration_gateway.authorization, "Bearer gw-secret");
+        assert_eq!(
+            response.integration_gateway.authorization,
+            "Bearer gw-secret"
+        );
     }
 
     #[test]
     fn heartbeat_response_parses_minimal_ack() {
-        // Mirrors the real server body: workerId + serverTime + interval, no status.
+        // Mirrors an older server's body: workerId + serverTime + interval,
+        // no status and no desiredVersions.
         let payload = br#"{
             "workerId": "worker",
             "serverTime": "2026-07-01T00:00:00Z",
             "heartbeatIntervalSeconds": 30
         }"#;
-        let response = serde_json::from_slice::<HeartbeatResponse>(payload)
-            .expect("minimal heartbeat ack");
+        let response =
+            serde_json::from_slice::<HeartbeatResponse>(payload).expect("minimal heartbeat ack");
         assert_eq!(response.worker_id, "worker");
         assert_eq!(response.status, None);
-        assert_eq!(response.server_time.as_deref(), Some("2026-07-01T00:00:00Z"));
+        assert_eq!(
+            response.server_time.as_deref(),
+            Some("2026-07-01T00:00:00Z")
+        );
+        assert!(response.desired_versions.is_none());
+    }
+
+    #[test]
+    fn heartbeat_response_parses_desired_versions() {
+        let payload = br#"{
+            "workerId": "worker",
+            "serverTime": "2026-07-01T00:00:00Z",
+            "heartbeatIntervalSeconds": 30,
+            "desiredVersions": {"worker": "0.2.16", "anyharness": "0.2.16"}
+        }"#;
+        let response = serde_json::from_slice::<HeartbeatResponse>(payload)
+            .expect("heartbeat ack with desiredVersions");
+        let desired = response.desired_versions.expect("desiredVersions present");
+        assert_eq!(desired.worker.as_deref(), Some("0.2.16"));
+        assert_eq!(desired.anyharness.as_deref(), Some("0.2.16"));
+    }
+
+    #[test]
+    fn heartbeat_response_tolerates_partial_desired_versions() {
+        // Future shape changes must never break heartbeating.
+        let payload = br#"{
+            "workerId": "worker",
+            "desiredVersions": {"worker": "0.2.16"}
+        }"#;
+        let response = serde_json::from_slice::<HeartbeatResponse>(payload)
+            .expect("heartbeat ack with partial desiredVersions");
+        let desired = response.desired_versions.expect("desiredVersions present");
+        assert_eq!(desired.worker.as_deref(), Some("0.2.16"));
+        assert_eq!(desired.anyharness, None);
+    }
+
+    #[test]
+    fn heartbeat_request_serializes_versions_camel_case() {
+        let request = super::HeartbeatRequest {
+            status: Some("online".to_string()),
+            worker_version: Some("0.1.0".to_string()),
+            anyharness_version: None,
+        };
+        let value = serde_json::to_value(&request).expect("serialize heartbeat request");
+        assert_eq!(value["status"], "online");
+        assert_eq!(value["workerVersion"], "0.1.0");
+        // Absent versions are omitted entirely, not sent as null.
+        assert!(value.get("anyharnessVersion").is_none());
     }
 }

--- a/anyharness/crates/proliferate-worker/src/config.rs
+++ b/anyharness/crates/proliferate-worker/src/config.rs
@@ -17,6 +17,13 @@ pub struct WorkerConfig {
     pub integration_gateway_home: Option<PathBuf>,
     #[serde(default = "default_heartbeat_interval_seconds")]
     pub heartbeat_interval_seconds: u64,
+    /// Whether this worker converges its own binary onto the server's pinned
+    /// version (heartbeat `desiredVersions`). Default false: only launchers
+    /// that own no update mechanism of their own (the sandbox sidecar) opt
+    /// in. The desktop app bundle owns its worker binary and must leave this
+    /// off.
+    #[serde(default)]
+    pub self_update_enabled: bool,
     #[serde(skip)]
     pub config_path: Option<PathBuf>,
 }
@@ -144,4 +151,28 @@ fn default_config_path() -> PathBuf {
         .join(".proliferate")
         .join("worker")
         .join("config.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkerConfig;
+
+    const MINIMAL_CONFIG: &str = r#"
+cloud_base_url = "https://cloud.test"
+worker_db_path = "/tmp/worker.sqlite3"
+"#;
+
+    #[test]
+    fn self_update_defaults_off() {
+        // Desktop configs predate (and must never enable) self-update.
+        let config: WorkerConfig = toml::from_str(MINIMAL_CONFIG).expect("minimal config");
+        assert!(!config.self_update_enabled);
+    }
+
+    #[test]
+    fn self_update_opt_in_parses() {
+        let contents = format!("{MINIMAL_CONFIG}self_update_enabled = true\n");
+        let config: WorkerConfig = toml::from_str(&contents).expect("opt-in config");
+        assert!(config.self_update_enabled);
+    }
 }

--- a/anyharness/crates/proliferate-worker/src/error.rs
+++ b/anyharness/crates/proliferate-worker/src/error.rs
@@ -43,4 +43,23 @@ pub enum WorkerError {
     SetPrivatePermissions { path: PathBuf, source: io::Error },
     #[error("failed to write integration-gateway dotfile at {path}")]
     WriteIntegrationGateway { path: PathBuf, source: io::Error },
+    #[error("worker self-update is unsupported on {os}/{arch}")]
+    SelfUpdateUnsupported {
+        os: &'static str,
+        arch: &'static str,
+    },
+    #[error("worker artifact checksum file was empty or malformed")]
+    SelfUpdateChecksumMalformed,
+    #[error("worker artifact checksum mismatch (expected {expected}, got {actual})")]
+    SelfUpdateChecksumMismatch { expected: String, actual: String },
+    #[error("failed to locate the running worker binary")]
+    SelfUpdateCurrentExe(#[source] io::Error),
+    #[error("failed to stage the new worker binary at {path}")]
+    SelfUpdateStage { path: PathBuf, source: io::Error },
+    #[error("staged worker binary failed its preflight check: {detail}")]
+    SelfUpdatePreflight { detail: String },
+    #[error("failed to swap the worker binary at {path}")]
+    SelfUpdateSwap { path: PathBuf, source: io::Error },
+    #[error("failed to re-exec the swapped worker binary at {path}")]
+    SelfUpdateExec { path: PathBuf, source: io::Error },
 }

--- a/anyharness/crates/proliferate-worker/src/identity/enrollment.rs
+++ b/anyharness/crates/proliferate-worker/src/identity/enrollment.rs
@@ -16,7 +16,8 @@ pub fn build_enroll_request(config: &WorkerConfig) -> Result<EnrollRequest, Work
         machine_fingerprint: Some(fingerprint::machine_fingerprint()),
         hostname: fingerprint::hostname(),
         worker_version: versions::worker_version(),
-        anyharness_version: None,
+        // None until a launcher exports the env; see versions::anyharness_version.
+        anyharness_version: versions::anyharness_version(),
     })
 }
 

--- a/anyharness/crates/proliferate-worker/src/integration_gateway.rs
+++ b/anyharness/crates/proliferate-worker/src/integration_gateway.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::{
-    cloud_client::IntegrationGatewayConfig, config::WorkerConfig, error::WorkerError,
-};
+use crate::{cloud_client::IntegrationGatewayConfig, config::WorkerConfig, error::WorkerError};
 
 const DOTFILE_NAME: &str = "integration-gateway.json";
 const DOTFILE_VERSION: u32 = 1;
@@ -28,10 +26,7 @@ pub fn dotfile_path(config: &WorkerConfig) -> PathBuf {
 
 /// Atomically (re)write the integration-gateway dotfile from the enroll
 /// response. Directory is created at 0700, file at 0600.
-pub fn write(
-    config: &WorkerConfig,
-    gateway: &IntegrationGatewayConfig,
-) -> Result<(), WorkerError> {
+pub fn write(config: &WorkerConfig, gateway: &IntegrationGatewayConfig) -> Result<(), WorkerError> {
     let path = dotfile_path(config);
     let dotfile = IntegrationGatewayDotfile {
         version: DOTFILE_VERSION,

--- a/anyharness/crates/proliferate-worker/src/lifecycle/heartbeat.rs
+++ b/anyharness/crates/proliferate-worker/src/lifecycle/heartbeat.rs
@@ -1,7 +1,7 @@
 use tokio::time::Duration;
 
 use crate::{
-    cloud_client::{heartbeat, CloudClient},
+    cloud_client::{heartbeat, CloudClient, HeartbeatResponse},
     config::WorkerConfig,
     error::WorkerError,
     identity::credentials::WorkerIdentity,
@@ -15,15 +15,17 @@ pub fn interval(config: &WorkerConfig) -> Duration {
     Duration::from_secs(config.heartbeat_interval_seconds.max(10))
 }
 
+/// Send one heartbeat and hand the ack back to the caller: the runtime loop
+/// acts on `desiredVersions` (self-update convergence).
 pub async fn send_once(
     cloud: &CloudClient,
     identity: &WorkerIdentity,
-) -> Result<(), WorkerError> {
+) -> Result<HeartbeatResponse, WorkerError> {
     let health = runtime_health();
     let request = heartbeat::report(health.status);
     let response = cloud.heartbeat(&identity.worker_token, &request).await?;
     crate::observability::heartbeat_ack(&response);
-    Ok(())
+    Ok(response)
 }
 
 pub fn runtime_health() -> RuntimeHealth {

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -8,6 +8,7 @@ mod logging;
 mod observability;
 mod process_lock;
 mod runtime;
+mod self_update;
 mod store;
 mod versions;
 

--- a/anyharness/crates/proliferate-worker/src/runtime.rs
+++ b/anyharness/crates/proliferate-worker/src/runtime.rs
@@ -2,19 +2,17 @@ use tokio::time::sleep;
 use tracing::{info, warn};
 
 use crate::{
-    cloud_client::CloudClient,
-    config::WorkerConfig,
-    error::WorkerError,
-    identity, integration_gateway, lifecycle,
-    process_lock::WorkerProcessLock,
-    store::WorkerStore,
+    cloud_client::CloudClient, config::WorkerConfig, error::WorkerError, identity,
+    identity::credentials::WorkerIdentity, integration_gateway, lifecycle,
+    process_lock::WorkerProcessLock, self_update, store::WorkerStore,
 };
 
 pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
     let _process_lock = WorkerProcessLock::acquire(&config.worker_db_path)?;
     let store = WorkerStore::open(config.worker_db_path.clone())?;
     let cloud = CloudClient::new(&config)?;
-    let (identity, integration_gateway) = identity::ensure_enrolled(&config, &store, &cloud).await?;
+    let (identity, integration_gateway) =
+        identity::ensure_enrolled(&config, &store, &cloud).await?;
     info!(worker_id = %identity.worker_id, "proliferate worker started");
 
     // Write the integration-gateway dotfile on every (re)enroll.
@@ -26,16 +24,50 @@ pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
         );
     }
 
-    if let Err(error) = lifecycle::heartbeat::send_once(&cloud, &identity).await {
-        warn!(?error, "worker heartbeat failed");
-    }
+    heartbeat_and_converge(&config, &cloud, &identity, once).await;
     if once {
         return Ok(());
     }
     loop {
         sleep(lifecycle::heartbeat::interval(&config)).await;
-        if let Err(error) = lifecycle::heartbeat::send_once(&cloud, &identity).await {
+        heartbeat_and_converge(&config, &cloud, &identity, false).await;
+    }
+}
+
+/// One heartbeat plus whatever the ack demands. Never fails the worker loop:
+/// a missed heartbeat or a failed self-update leaves the current binary
+/// serving, and the next tick retries. In `--once` mode a pending update is
+/// only reported (dry run), never executed.
+async fn heartbeat_and_converge(
+    config: &WorkerConfig,
+    cloud: &CloudClient,
+    identity: &WorkerIdentity,
+    dry_run: bool,
+) {
+    let response = match lifecycle::heartbeat::send_once(cloud, identity).await {
+        Ok(response) => response,
+        Err(error) => {
             warn!(?error, "worker heartbeat failed");
+            return;
         }
+    };
+    let Some(update) = self_update::plan(config, &response) else {
+        return;
+    };
+    if dry_run {
+        info!(
+            desired = %update.desired_version,
+            "self-update pending; skipped in --once mode"
+        );
+        return;
+    }
+    // On success this never returns: converge ends by exec'ing the swapped
+    // binary in place of this process.
+    if let Err(error) = self_update::converge(cloud, &update).await {
+        warn!(
+            ?error,
+            desired = %update.desired_version,
+            "worker self-update failed; staying on the current version"
+        );
     }
 }

--- a/anyharness/crates/proliferate-worker/src/self_update.rs
+++ b/anyharness/crates/proliferate-worker/src/self_update.rs
@@ -1,0 +1,428 @@
+//! Heartbeat-driven binary self-convergence.
+//!
+//! Sandbox / self-managed workers converge onto the server's pinned worker
+//! version reported in each heartbeat ack (`desiredVersions`). The desktop
+//! worker must never self-swap — the app bundle owns that binary — so the
+//! whole path is gated on `self_update_enabled` in the worker config, which
+//! only the sandbox bootstrap turns on.
+//!
+//! Safety model:
+//! - the binary comes from the server's pinned artifact redirect and its
+//!   `.sha256` is fetched from the *same resolved directory* (the checksum URL
+//!   is derived from the binary's post-redirect URL, not resolved a second
+//!   time) so the pair always shares a version; the download is rejected
+//!   unless the digest matches;
+//! - the new binary is staged next to the current one, preflighted with
+//!   `--version` — which must both succeed and report the pinned version, so
+//!   the unpinned `stable` fallback artifact serving an older build aborts
+//!   the swap instead of silently downgrading the worker — then atomically
+//!   renamed over the current path; a crash at any point leaves a runnable
+//!   binary on disk (stale staged files are swept on the next attempt);
+//! - the swap finishes with an `exec` of the (replaced) binary path rather
+//!   than an exit: the sandbox sidecar is launched with plain `nohup`, so an
+//!   exiting worker would never come back. `exec` replaces the process image
+//!   in place — the pid, and therefore any supervising parent, never sees an
+//!   exit. `Drop` never runs across `exec`, but the process lock needs no
+//!   explicit release: it is an `flock` on a file descriptor Rust opened with
+//!   `O_CLOEXEC`, so the kernel closes the fd (releasing the lock) exactly at
+//!   the exec boundary and the new image re-acquires it during startup;
+//! - an env marker carried across the re-exec remains as a backstop against
+//!   a hot swap loop if an exec'd binary somehow still reports a diverged
+//!   version (the preflight version check catches the ordinary case — a
+//!   fallback artifact lagging the pin — before any swap happens).
+//!
+//! A lagging artifact does mean one download + aborted preflight per
+//! heartbeat until the pinned artifact publishes; that matches the existing
+//! behavior when the artifact 404s outright, and self-heals on publish.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+
+use crate::{
+    cloud_client::{CloudClient, HeartbeatResponse},
+    config::WorkerConfig,
+    error::WorkerError,
+    versions,
+};
+
+/// Carried across the re-exec so a swap that failed to change the running
+/// version is not retried on every heartbeat.
+const ATTEMPTED_VERSION_ENV: &str = "PROLIFERATE_WORKER_SELF_UPDATE_ATTEMPTED";
+
+const BINARY_ASSET: &str = "proliferate-worker";
+/// The checksum is published next to the binary as `<binary>.sha256`, so its
+/// URL is the binary's resolved URL with this suffix appended.
+const CHECKSUM_SUFFIX: &str = ".sha256";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct UpdatePlan {
+    pub desired_version: String,
+}
+
+/// Decide whether this heartbeat ack requires a binary swap. `None` means
+/// stay on the current binary (gate off, no/equal pin, or already attempted).
+pub fn plan(config: &WorkerConfig, response: &HeartbeatResponse) -> Option<UpdatePlan> {
+    if !config.self_update_enabled {
+        return None;
+    }
+    let desired = response
+        .desired_versions
+        .as_ref()?
+        .worker
+        .as_deref()?
+        .trim()
+        .to_string();
+    let running = versions::worker_version()?;
+    plan_for_versions(&running, &desired, attempted_version().as_deref())
+}
+
+fn plan_for_versions(running: &str, desired: &str, attempted: Option<&str>) -> Option<UpdatePlan> {
+    if desired.is_empty() || running == desired {
+        return None;
+    }
+    if attempted == Some(desired) {
+        warn!(
+            running,
+            desired,
+            "already swapped for this pinned version but still running another; \
+             the published artifact likely lags the pin — not retrying"
+        );
+        return None;
+    }
+    Some(UpdatePlan {
+        desired_version: desired.to_string(),
+    })
+}
+
+fn attempted_version() -> Option<String> {
+    std::env::var(ATTEMPTED_VERSION_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+/// Download, verify, swap, and re-exec. On success this never returns: the
+/// final step replaces the process image with the new binary. Every error
+/// path leaves the currently-running binary intact on disk.
+pub async fn converge(cloud: &CloudClient, update: &UpdatePlan) -> Result<(), WorkerError> {
+    let target = artifact_target()?;
+    info!(
+        desired = %update.desired_version,
+        target,
+        "worker version diverged from server pin; starting self-update"
+    );
+    let binary = cloud
+        .download_worker_artifact(&target, BINARY_ASSET)
+        .await?;
+    // Derive the checksum URL from the binary's *resolved* CDN location so the
+    // two always come from the same published directory (hence the same
+    // version). Re-hitting the redirect for the checksum resolves the
+    // pinned-vs-fallback version path a second time, which can straddle a CDN
+    // publish and pair this binary with a checksum from a different version —
+    // a spurious mismatch at best, a consistent-but-unpinned pair at worst.
+    let checksum_url = checksum_url_for(&binary.resolved_url);
+    let checksum = cloud.download_from_url(&checksum_url).await?;
+    verify_sha256(&binary.bytes, &String::from_utf8_lossy(&checksum))?;
+
+    // Resolve the exe path before touching the filesystem: on Linux,
+    // /proc/self/exe stops resolving cleanly once the original inode is
+    // replaced underneath the running process.
+    let exe_path = std::env::current_exe().map_err(WorkerError::SelfUpdateCurrentExe)?;
+    sweep_stale_staged(&exe_path);
+    let staged = stage_binary(&binary.bytes, &exe_path)?;
+    if let Err(error) = preflight(&staged, &update.desired_version).and_then(|()| {
+        std::fs::rename(&staged, &exe_path).map_err(|source| WorkerError::SelfUpdateSwap {
+            path: exe_path.clone(),
+            source,
+        })
+    }) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error);
+    }
+    info!(
+        desired = %update.desired_version,
+        "worker binary swapped; re-exec'ing into the new version"
+    );
+    // Give queued telemetry a bounded chance to leave: exec never runs Drop,
+    // so the sentry guard's usual flush-on-drop will not happen.
+    if let Some(client) = sentry::Hub::current().client() {
+        client.flush(Some(std::time::Duration::from_secs(2)));
+    }
+    Err(reexec(&exe_path, &update.desired_version))
+}
+
+/// The published `.sha256` sits next to the binary, so its URL is the binary's
+/// resolved URL with the checksum suffix appended. Deriving it (rather than
+/// re-resolving the pinned-vs-fallback path via a second redirect) guarantees
+/// the checksum and binary come from the same directory — and thus version.
+fn checksum_url_for(binary_url: &str) -> String {
+    format!("{binary_url}{CHECKSUM_SUFFIX}")
+}
+
+fn artifact_target() -> Result<String, WorkerError> {
+    let unsupported = || WorkerError::SelfUpdateUnsupported {
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+    };
+    let os = match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "macos",
+        _ => return Err(unsupported()),
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        _ => return Err(unsupported()),
+    };
+    Ok(format!("{os}-{arch}"))
+}
+
+/// Verify `bytes` against the published `.sha256` file contents (either a
+/// bare hex digest or the `sha256sum` "digest  filename" form).
+pub(crate) fn verify_sha256(bytes: &[u8], checksum_file: &str) -> Result<(), WorkerError> {
+    let expected = checksum_file
+        .split_whitespace()
+        .next()
+        .ok_or(WorkerError::SelfUpdateChecksumMalformed)?
+        .to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(WorkerError::SelfUpdateChecksumMalformed);
+    }
+    let actual: String = Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    if actual != expected {
+        return Err(WorkerError::SelfUpdateChecksumMismatch { expected, actual });
+    }
+    Ok(())
+}
+
+/// Remove leftover staged binaries from earlier update attempts. Staged
+/// files are pid-suffixed, so a worker that died between stage and rename
+/// (or errored before the in-call cleanup) leaks a full binary copy under a
+/// name no later process reuses — a crash loop would accumulate one per
+/// attempt forever. Best-effort: a sweep failure never blocks the update.
+fn sweep_stale_staged(exe_path: &Path) {
+    let Some(file_name) = exe_path.file_name().and_then(|value| value.to_str()) else {
+        return;
+    };
+    let Some(dir) = exe_path.parent() else {
+        return;
+    };
+    let prefix = format!(".{file_name}.next.");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name.starts_with(&prefix) {
+            warn!(staged = %entry.path().display(), "removing stale staged worker binary");
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// Write the verified bytes to a temp path in the same directory as the
+/// running binary (same filesystem, so the final rename is atomic) and mark
+/// it executable.
+fn stage_binary(bytes: &[u8], exe_path: &Path) -> Result<PathBuf, WorkerError> {
+    let file_name = exe_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(BINARY_ASSET);
+    let staged = exe_path.with_file_name(format!(".{file_name}.next.{}", std::process::id()));
+    let stage_err = |source: std::io::Error| WorkerError::SelfUpdateStage {
+        path: staged.clone(),
+        source,
+    };
+    std::fs::write(&staged, bytes).map_err(stage_err)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+            .map_err(stage_err)?;
+    }
+    Ok(staged)
+}
+
+/// Sanity check that the staged file is a runnable worker *carrying the
+/// pinned version* before it replaces the binary we know works: a checksum
+/// only proves we downloaded what was published, not that what was published
+/// runs here — and the server's unpinned `stable` fallback can serve an
+/// artifact that lags the pin, which would otherwise silently downgrade the
+/// worker and then (via the attempt marker) block convergence until the next
+/// pin bump or restart. Aborting instead lets a later heartbeat retry once
+/// the real artifact publishes.
+fn preflight(staged: &Path, desired_version: &str) -> Result<(), WorkerError> {
+    let output = std::process::Command::new(staged)
+        .arg("--version")
+        .output()
+        .map_err(|error| WorkerError::SelfUpdatePreflight {
+            detail: format!("failed to spawn staged binary: {error}"),
+        })?;
+    if !output.status.success() {
+        return Err(WorkerError::SelfUpdatePreflight {
+            detail: format!("--version exited with {}", output.status),
+        });
+    }
+    let reported = String::from_utf8_lossy(&output.stdout);
+    if !version_output_matches(&reported, desired_version) {
+        return Err(WorkerError::SelfUpdatePreflight {
+            detail: format!(
+                "staged binary reports {:?}, expected version {desired_version}; \
+                 the published artifact likely lags the pin — not swapping",
+                reported.trim()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// `--version` prints e.g. `proliferate-worker 0.3.0`; match on whitespace
+/// tokens (tolerating a leading `v`) rather than the exact line so the check
+/// survives formatting changes.
+fn version_output_matches(output: &str, desired: &str) -> bool {
+    output
+        .split_whitespace()
+        .any(|token| token == desired || token.strip_prefix('v') == Some(desired))
+}
+
+/// Replace this process image with the swapped binary, preserving argv. Only
+/// returns (with the underlying error) if `exec` itself fails, in which case
+/// the old image keeps running and the swap is retried on a later heartbeat.
+#[cfg(unix)]
+fn reexec(exe_path: &Path, desired_version: &str) -> WorkerError {
+    use std::os::unix::process::CommandExt;
+
+    let source = std::process::Command::new(exe_path)
+        .args(std::env::args_os().skip(1))
+        .env(ATTEMPTED_VERSION_ENV, desired_version)
+        .exec();
+    WorkerError::SelfUpdateExec {
+        path: exe_path.to_path_buf(),
+        source,
+    }
+}
+
+#[cfg(not(unix))]
+fn reexec(_exe_path: &Path, _desired_version: &str) -> WorkerError {
+    WorkerError::SelfUpdateUnsupported {
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+
+    use super::{checksum_url_for, plan_for_versions, verify_sha256, version_output_matches};
+    use crate::error::WorkerError;
+
+    fn digest_hex(bytes: &[u8]) -> String {
+        Sha256::digest(bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    #[test]
+    fn plan_is_noop_when_versions_match() {
+        assert_eq!(plan_for_versions("0.2.16", "0.2.16", None), None);
+    }
+
+    #[test]
+    fn plan_swaps_on_any_divergence_including_downgrades() {
+        let upgrade = plan_for_versions("0.2.16", "0.3.0", None).expect("upgrade plan");
+        assert_eq!(upgrade.desired_version, "0.3.0");
+        let downgrade = plan_for_versions("0.3.0", "0.2.16", None).expect("downgrade plan");
+        assert_eq!(downgrade.desired_version, "0.2.16");
+    }
+
+    #[test]
+    fn plan_skips_empty_pin_and_already_attempted_version() {
+        assert_eq!(plan_for_versions("0.2.16", "", None), None);
+        // Already swapped for this pin once and still diverged: published
+        // artifact lags the pin. Never hot-loop.
+        assert_eq!(plan_for_versions("0.2.16", "0.3.0", Some("0.3.0")), None);
+        // A newer pin supersedes the stale attempt marker.
+        assert!(plan_for_versions("0.2.16", "0.4.0", Some("0.3.0")).is_some());
+    }
+
+    #[test]
+    fn version_output_matches_clap_style_output() {
+        assert!(version_output_matches(
+            "proliferate-worker 0.3.0\n",
+            "0.3.0"
+        ));
+        assert!(version_output_matches("proliferate-worker v0.3.0", "0.3.0"));
+        assert!(version_output_matches("0.3.0", "0.3.0"));
+    }
+
+    #[test]
+    fn version_output_matches_rejects_diverged_and_junk_output() {
+        // The unpinned `stable` fallback serving an older build must abort.
+        assert!(!version_output_matches(
+            "proliferate-worker 0.2.15",
+            "0.3.0"
+        ));
+        // Substrings must not match: 0.3.0 vs 0.3.0-rc1 are different pins.
+        assert!(!version_output_matches(
+            "proliferate-worker 0.3.0-rc1",
+            "0.3.0"
+        ));
+        assert!(!version_output_matches("", "0.3.0"));
+        assert!(!version_output_matches("<html>404</html>", "0.3.0"));
+    }
+
+    #[test]
+    fn checksum_url_is_derived_from_the_binary_resolved_url() {
+        // Same directory as the binary, whichever path (pinned or fallback)
+        // the server's single redirect resolved to — never a second resolve.
+        assert_eq!(
+            checksum_url_for(
+                "https://downloads.proliferate.com/worker/stable/1.2.3/linux-x86_64/proliferate-worker"
+            ),
+            "https://downloads.proliferate.com/worker/stable/1.2.3/linux-x86_64/proliferate-worker.sha256"
+        );
+        assert_eq!(
+            checksum_url_for(
+                "https://downloads.proliferate.com/worker/stable/macos-aarch64/proliferate-worker"
+            ),
+            "https://downloads.proliferate.com/worker/stable/macos-aarch64/proliferate-worker.sha256"
+        );
+    }
+
+    #[test]
+    fn verify_sha256_accepts_bare_and_sha256sum_formats() {
+        let payload = b"worker binary bytes";
+        let hex = digest_hex(payload);
+        verify_sha256(payload, &hex).expect("bare digest");
+        verify_sha256(payload, &format!("{hex}  proliferate-worker\n")).expect("sha256sum format");
+        verify_sha256(payload, &format!("{}  x", hex.to_ascii_uppercase()))
+            .expect("uppercase digest");
+    }
+
+    #[test]
+    fn verify_sha256_rejects_mismatch() {
+        let expected = digest_hex(b"published bytes");
+        let error = verify_sha256(b"tampered bytes", &expected).expect_err("mismatch");
+        assert!(matches!(
+            error,
+            WorkerError::SelfUpdateChecksumMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn verify_sha256_rejects_malformed_checksum_files() {
+        for malformed in ["", "   \n", "not-hex", "abc123", "<html>404</html>"] {
+            let error = verify_sha256(b"payload", malformed).expect_err("malformed");
+            assert!(matches!(error, WorkerError::SelfUpdateChecksumMalformed));
+        }
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/versions.rs
+++ b/anyharness/crates/proliferate-worker/src/versions.rs
@@ -1,3 +1,20 @@
 pub fn worker_version() -> Option<String> {
     Some(env!("CARGO_PKG_VERSION").to_string())
 }
+
+/// The AnyHarness runtime version co-deployed with this worker, when the
+/// launcher advertises it via env. The worker never introspects the runtime
+/// binary itself; absence is fine — the server tolerates a missing report.
+///
+/// FOLLOW-UP: no launcher exports `PROLIFERATE_ANYHARNESS_VERSION` yet (the
+/// server only knows its *pinned* runtime version, not what actually runs in
+/// a sandbox, so the export has to come from whatever stages/launches the
+/// runtime — the sandbox supervisor or the desktop app). Until that lands,
+/// this reports `None` and `cloud_runtime_worker.anyharness_version` stays
+/// NULL for real workers.
+pub fn anyharness_version() -> Option<String> {
+    std::env::var("PROLIFERATE_ANYHARNESS_VERSION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/apps/desktop/src-tauri/src/commands/cloud_worker.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker.rs
@@ -397,6 +397,10 @@ fn write_worker_config(
         "integration_gateway_home = {}",
         toml_string(&integration_gateway_home.to_string_lossy())
     ));
+    // The desktop app bundle owns the worker binary; the worker must never
+    // self-swap here. Explicit (the worker also defaults to false) so the
+    // on-disk config documents the gate.
+    lines.push("self_update_enabled = false".to_string());
     app_config::write_string_file_atomic(path, &format!("{}\n", lines.join("\n")))?;
     set_private_file_permissions(path)
 }

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1656,6 +1656,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/worker/download/{target}/{asset}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Worker Artifact Download Endpoint
+         * @description 302 to the pinned worker binary (or its ``.sha256``) on the downloads CDN.
+         *
+         *     Unauthenticated by design, like the desktop updater redirect: install
+         *     scripts fetch the binary before any worker identity exists, and the CDN
+         *     artifacts are public.
+         */
+        get: operations["worker_artifact_download_endpoint_v1_cloud_worker_download__target___asset__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/integration-gateway/mcp": {
         parameters: {
             query?: never;
@@ -4114,6 +4138,8 @@ export interface components {
             desktopVersion: string;
             /** Runtimeversion */
             runtimeVersion: string;
+            /** Workerversion */
+            workerVersion: string;
             /** Mindesktopversion */
             minDesktopVersion: string;
         };
@@ -5077,6 +5103,16 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /**
+         * WorkerDesiredVersions
+         * @description The component versions this server pins; workers converge onto these.
+         */
+        WorkerDesiredVersions: {
+            /** Worker */
+            worker?: string | null;
+            /** Anyharness */
+            anyharness: string;
+        };
         /** WorkerEnrollRequest */
         WorkerEnrollRequest: {
             /** Enrollmenttoken */
@@ -5104,6 +5140,10 @@ export interface components {
         WorkerHeartbeatRequest: {
             /** Status */
             status?: string | null;
+            /** Workerversion */
+            workerVersion?: string | null;
+            /** Anyharnessversion */
+            anyharnessVersion?: string | null;
         };
         /** WorkerHeartbeatResponse */
         WorkerHeartbeatResponse: {
@@ -5116,6 +5156,7 @@ export interface components {
             serverTime: string;
             /** Heartbeatintervalseconds */
             heartbeatIntervalSeconds: number;
+            desiredVersions: components["schemas"]["WorkerDesiredVersions"];
         };
         /** WorkspaceCloudAccessSummary */
         WorkspaceCloudAccessSummary: {
@@ -8798,6 +8839,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkerHeartbeatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_artifact_download_endpoint_v1_cloud_worker_download__target___asset__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target: string;
+                asset: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/scripts/check_proliferate_worker_structure.py
+++ b/scripts/check_proliferate_worker_structure.py
@@ -36,6 +36,7 @@ REQUIRED_FILES = (
     WORKER_SRC / "config.rs",
     WORKER_SRC / "process_lock.rs",
     WORKER_SRC / "runtime.rs",
+    WORKER_SRC / "self_update.rs",
 )
 
 BLOCKED_IMPORT_RE = re.compile(r"\bcrate::(?:commands|sync|updates|control|tail|inventory)\b")

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,15 +16,18 @@ COPY VERSION ./VERSION
 RUN uv pip install --system --no-cache .
 
 # Version pins the API reports via /health and /meta. Release CI stamps these
-# from the root VERSION file and the desktop/runtime package manifests; a plain
-# `docker build` with no args falls back to the copied VERSION file above.
+# from the root VERSION file and the desktop/runtime/worker package manifests;
+# a plain `docker build` with no args falls back to the copied VERSION file
+# above.
 ARG SERVER_VERSION=""
 ARG DESKTOP_VERSION=""
 ARG RUNTIME_VERSION=""
+ARG WORKER_VERSION=""
 ARG MIN_DESKTOP_VERSION=""
 ENV SERVER_VERSION=${SERVER_VERSION} \
     DESKTOP_VERSION=${DESKTOP_VERSION} \
     RUNTIME_VERSION=${RUNTIME_VERSION} \
+    WORKER_VERSION=${WORKER_VERSION} \
     MIN_DESKTOP_VERSION=${MIN_DESKTOP_VERSION}
 
 EXPOSE 8000

--- a/server/proliferate/db/store/runtime_workers.py
+++ b/server/proliferate/db/store/runtime_workers.py
@@ -79,6 +79,10 @@ class RuntimeWorkerValue:
     cloud_sandbox_id: UUID | None
     desktop_install_id: str | None
     status: str
+    worker_version: str | None
+    anyharness_version: str | None
+    hostname: str | None
+    machine_fingerprint: str | None
     enrolled_at: datetime
     last_seen_at: datetime | None
 
@@ -121,6 +125,10 @@ def _worker_value(row: CloudRuntimeWorker) -> RuntimeWorkerValue:
         cloud_sandbox_id=row.cloud_sandbox_id,
         desktop_install_id=row.desktop_install_id,
         status=row.status,
+        worker_version=row.worker_version,
+        anyharness_version=row.anyharness_version,
+        hostname=row.hostname,
+        machine_fingerprint=row.machine_fingerprint,
         enrolled_at=row.enrolled_at,
         last_seen_at=row.last_seen_at,
     )
@@ -272,6 +280,10 @@ async def create_worker(
     *,
     enrollment: RuntimeWorkerEnrollmentValue,
     token_hash: str,
+    worker_version: str | None = None,
+    anyharness_version: str | None = None,
+    hostname: str | None = None,
+    machine_fingerprint: str | None = None,
 ) -> RuntimeWorkerValue:
     now = utcnow()
     row = CloudRuntimeWorker(
@@ -282,6 +294,10 @@ async def create_worker(
         desktop_install_id=enrollment.desktop_install_id,
         token_hash=token_hash,
         status="online",
+        worker_version=worker_version,
+        anyharness_version=anyharness_version,
+        hostname=hostname,
+        machine_fingerprint=machine_fingerprint,
         enrolled_at=now,
         last_seen_at=now,
     )
@@ -328,13 +344,24 @@ async def touch_worker_heartbeat(
     db: AsyncSession,
     *,
     worker_id: UUID,
+    worker_version: str | None = None,
+    anyharness_version: str | None = None,
 ) -> None:
+    """Stamp liveness and, when self-reported, the running component versions.
+
+    Versions only move forward on report (post-swap); an omitted field never
+    clears what enrollment or a prior heartbeat recorded.
+    """
     row = await db.get(CloudRuntimeWorker, worker_id)
     if row is None or row.status == "revoked":
         return
     now = utcnow()
     row.status = "online"
     row.last_seen_at = now
+    if worker_version is not None and worker_version != row.worker_version:
+        row.worker_version = worker_version
+    if anyharness_version is not None and anyharness_version != row.anyharness_version:
+        row.anyharness_version = anyharness_version
     row.updated_at = now
     await db.flush()
 

--- a/server/proliferate/integrations/desktop_downloads.py
+++ b/server/proliferate/integrations/desktop_downloads.py
@@ -6,9 +6,22 @@ Owns the raw HTTP probe for updater manifests so product domains
 
 from __future__ import annotations
 
+import os
 import time
 
 import httpx
+
+# Official CDN root that serves signed desktop updater manifests and pinned
+# runtime/worker binaries. Overridable via env for parity with the release
+# pipeline's DESKTOP_DOWNLOADS_BASE_URL.
+_DEFAULT_DOWNLOADS_BASE_URL = "https://downloads.proliferate.com"
+
+
+def downloads_base_url() -> str:
+    value = os.getenv("DESKTOP_DOWNLOADS_BASE_URL")
+    base = value.strip() if value and value.strip() else _DEFAULT_DOWNLOADS_BASE_URL
+    return base.rstrip("/")
+
 
 # A pinned desktop version can outpace the published manifests (a server built
 # from a commit whose desktop version has not been released yet, or a release

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -155,10 +155,18 @@ def build_worker_config(
         "worker_db_path": f"{worker_dir}/worker.sqlite3",
         "integration_gateway_home": anyharness_runtime_home(runtime_context),
         "heartbeat_interval_seconds": 30,
+        # The sandbox sidecar has no launcher that updates it (plain nohup),
+        # so it converges its own binary onto the heartbeat's desiredVersions.
+        # Desktop workers must never set this: the app bundle owns updates.
+        "self_update_enabled": True,
     }
     lines = []
     for key, value in values.items():
-        if isinstance(value, int):
+        if isinstance(value, bool):
+            # bool must precede int: Python bools are ints, but TOML needs
+            # lowercase true/false rather than repr()'s True/False.
+            lines.append(f"{key} = {'true' if value else 'false'}")
+        elif isinstance(value, int):
             lines.append(f"{key} = {value}")
         else:
             lines.append(f"{key} = {json.dumps(value)}")

--- a/server/proliferate/server/cloud/runtime_workers/api.py
+++ b/server/proliferate/server/cloud/runtime_workers/api.py
@@ -9,7 +9,8 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
@@ -34,6 +35,7 @@ from proliferate.server.cloud.runtime_workers.service import (
     enroll_worker,
     record_heartbeat,
     revoke_desktop_worker,
+    worker_artifact_redirect_url,
 )
 
 worker_router = APIRouter(tags=["cloud-runtime-worker"])
@@ -54,8 +56,24 @@ async def worker_heartbeat_endpoint(
     auth: WorkerAuthContext = Depends(authenticate_worker),
     db: AsyncSession = Depends(get_async_session),
 ) -> WorkerHeartbeatResponse:
-    del body
-    return await record_heartbeat(db, worker_id=auth.worker_id)
+    return await record_heartbeat(
+        db,
+        worker_id=auth.worker_id,
+        worker_version=body.worker_version,
+        anyharness_version=body.anyharness_version,
+    )
+
+
+@worker_router.get("/worker/download/{target}/{asset}")
+async def worker_artifact_download_endpoint(target: str, asset: str) -> RedirectResponse:
+    """302 to the pinned worker binary (or its ``.sha256``) on the downloads CDN.
+
+    Unauthenticated by design, like the desktop updater redirect: install
+    scripts fetch the binary before any worker identity exists, and the CDN
+    artifacts are public.
+    """
+    url = await worker_artifact_redirect_url(target=target, asset=asset)
+    return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
 
 
 @router.post(

--- a/server/proliferate/server/cloud/runtime_workers/models.py
+++ b/server/proliferate/server/cloud/runtime_workers/models.py
@@ -21,10 +21,12 @@ class IntegrationGatewayConfig(_CamelModel):
 
 class WorkerEnrollRequest(_CamelModel):
     enrollment_token: str
-    machine_fingerprint: str | None = None
-    hostname: str | None = None
-    worker_version: str | None = None
-    anyharness_version: str | None = None
+    # max_length mirrors the cloud_runtime_worker column widths so an overlong
+    # value is a 422 at the edge, not a StringDataRightTruncation 500.
+    machine_fingerprint: str | None = Field(default=None, max_length=128)
+    hostname: str | None = Field(default=None, max_length=255)
+    worker_version: str | None = Field(default=None, max_length=64)
+    anyharness_version: str | None = Field(default=None, max_length=64)
 
 
 class WorkerEnrollResponse(_CamelModel):
@@ -36,12 +38,28 @@ class WorkerEnrollResponse(_CamelModel):
 
 class WorkerHeartbeatRequest(_CamelModel):
     status: str | None = None
+    # Self-reported after a binary swap so the row tracks what actually runs.
+    # Column-width bounds, as on WorkerEnrollRequest.
+    worker_version: str | None = Field(default=None, max_length=64)
+    anyharness_version: str | None = Field(default=None, max_length=64)
+
+
+class WorkerDesiredVersions(_CamelModel):
+    """The component versions this server pins; workers converge onto these."""
+
+    # None when the server image was not stamped with WORKER_VERSION: a
+    # fallback pin could never match a worker artifact and would drive
+    # self-updating workers into perpetual swap attempts, so an unstamped
+    # server pins nothing.
+    worker: str | None = None
+    anyharness: str
 
 
 class WorkerHeartbeatResponse(_CamelModel):
     worker_id: str
     server_time: datetime
     heartbeat_interval_seconds: int
+    desired_versions: WorkerDesiredVersions
 
 
 class DesktopWorkerEnrollmentRequest(_CamelModel):

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -21,18 +21,37 @@ from proliferate.constants.cloud import (
     CLOUD_RUNTIME_WORKER_HEARTBEAT_INTERVAL_SECONDS,
 )
 from proliferate.db.store import runtime_workers as store
+from proliferate.integrations.desktop_downloads import (
+    downloads_base_url,
+    versioned_manifest_exists,
+)
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime_workers.models import (
     DesktopWorkerEnrollmentResponse,
     DesktopWorkerRevokeResponse,
     IntegrationGatewayConfig,
+    WorkerDesiredVersions,
     WorkerEnrollRequest,
     WorkerEnrollResponse,
     WorkerHeartbeatResponse,
 )
+from proliferate.server.version import runtime_version as pinned_runtime_version
+from proliferate.server.version import worker_version_pin as pinned_worker_version
 from proliferate.utils.time import utcnow
 
 _TOKEN_BYTES = 48
+
+# Platform tokens the target install script uses when fetching binaries.
+_WORKER_ARTIFACT_TARGETS = frozenset(
+    {
+        "linux-x86_64",
+        "linux-aarch64",
+        "macos-x86_64",
+        "macos-aarch64",
+    }
+)
+# The binary plus its checksum, published alongside on the downloads CDN.
+_WORKER_ARTIFACT_ASSETS = frozenset({"proliferate-worker", "proliferate-worker.sha256"})
 
 
 def worker_cloud_base_url() -> str:
@@ -164,6 +183,10 @@ async def enroll_worker(
         db,
         enrollment=enrollment,
         token_hash=store.hash_worker_token(worker_token),
+        worker_version=request.worker_version,
+        anyharness_version=request.anyharness_version,
+        hostname=request.hostname,
+        machine_fingerprint=request.machine_fingerprint,
     )
 
     gateway_token = secrets.token_urlsafe(_TOKEN_BYTES)
@@ -185,10 +208,52 @@ async def record_heartbeat(
     db: AsyncSession,
     *,
     worker_id: UUID,
+    worker_version: str | None = None,
+    anyharness_version: str | None = None,
 ) -> WorkerHeartbeatResponse:
-    await store.touch_worker_heartbeat(db, worker_id=worker_id)
+    await store.touch_worker_heartbeat(
+        db,
+        worker_id=worker_id,
+        worker_version=worker_version,
+        anyharness_version=anyharness_version,
+    )
     return WorkerHeartbeatResponse(
         worker_id=str(worker_id),
         server_time=utcnow(),
         heartbeat_interval_seconds=CLOUD_RUNTIME_WORKER_HEARTBEAT_INTERVAL_SECONDS,
+        desired_versions=WorkerDesiredVersions(
+            worker=pinned_worker_version(),
+            anyharness=pinned_runtime_version(),
+        ),
     )
+
+
+async def worker_artifact_redirect_url(*, target: str, asset: str) -> str:
+    """Resolve the downloads-CDN URL for a pinned worker binary (or checksum).
+
+    Mirrors the desktop updater redirect: the server carries only the version
+    pin, never the artifact itself, and falls back to the unpinned ``stable``
+    path when the pinned artifact has not been published yet.
+
+    Each call resolves the pinned-vs-fallback path independently, so two calls
+    (binary then checksum) can straddle a CDN publish and disagree. A worker
+    converging its binary must therefore resolve the version path *once* — it
+    fetches the binary here, then derives its ``.sha256`` URL from that
+    redirect's resolved location (same directory, same version) instead of
+    resolving the checksum through a second redirect (see
+    ``proliferate-worker``'s ``self_update`` module). The per-asset resolution
+    below remains for the install script, which fetches a fresh pair.
+    """
+    if target not in _WORKER_ARTIFACT_TARGETS or asset not in _WORKER_ARTIFACT_ASSETS:
+        raise CloudApiError(
+            "cloud_worker_artifact_unknown",
+            "Unknown worker artifact target or asset.",
+            status_code=404,
+        )
+    base = downloads_base_url()
+    pin = pinned_worker_version()
+    if pin is not None:
+        pinned = f"{base}/worker/stable/{pin}/{target}/{asset}"
+        if await versioned_manifest_exists(pinned):
+            return pinned
+    return f"{base}/worker/stable/{target}/{asset}"

--- a/server/proliferate/server/meta.py
+++ b/server/proliferate/server/meta.py
@@ -14,12 +14,13 @@ the desktop version but can never ship an unofficial build.
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
+from proliferate.integrations.desktop_downloads import (
+    downloads_base_url as _downloads_base_url,
+)
 from proliferate.integrations.desktop_downloads import (
     versioned_manifest_exists as _versioned_manifest_exists,
 )
@@ -28,26 +29,18 @@ from proliferate.server.version import (
     min_desktop_version,
     runtime_version,
     server_version,
+    worker_version,
 )
 
 router = APIRouter()
-
-# Official CDN root that serves signed desktop updater manifests. Overridable
-# via env for parity with the release pipeline's DESKTOP_DOWNLOADS_BASE_URL.
-_DEFAULT_DESKTOP_DOWNLOADS_BASE_URL = "https://downloads.proliferate.com"
 
 
 class MetaResponse(BaseModel):
     serverVersion: str
     desktopVersion: str
     runtimeVersion: str
+    workerVersion: str
     minDesktopVersion: str
-
-
-def _desktop_downloads_base_url() -> str:
-    value = os.getenv("DESKTOP_DOWNLOADS_BASE_URL")
-    base = value.strip() if value and value.strip() else _DEFAULT_DESKTOP_DOWNLOADS_BASE_URL
-    return base.rstrip("/")
 
 
 @router.get("/meta", response_model=MetaResponse)
@@ -56,13 +49,14 @@ async def meta() -> MetaResponse:
         serverVersion=server_version(),
         desktopVersion=desktop_version(),
         runtimeVersion=runtime_version(),
+        workerVersion=worker_version(),
         minDesktopVersion=min_desktop_version(),
     )
 
 
 @router.get("/desktop/updater/latest.json")
 async def desktop_updater_latest() -> RedirectResponse:
-    base = _desktop_downloads_base_url()
+    base = _downloads_base_url()
     target = f"{base}/desktop/stable/{desktop_version()}/latest.json"
     if not await _versioned_manifest_exists(target):
         target = f"{base}/desktop/stable/latest.json"

--- a/server/proliferate/server/version.py
+++ b/server/proliferate/server/version.py
@@ -3,8 +3,9 @@
 Every version the API reports is downstream of what the operator's server image
 was stamped with at build time. Release CI injects the concrete pins via env
 (``SERVER_VERSION``, ``DESKTOP_VERSION``, ``RUNTIME_VERSION``,
-``MIN_DESKTOP_VERSION``), wired from the root ``VERSION`` file and the desktop /
-runtime package manifests through Docker build args.
+``WORKER_VERSION``, ``MIN_DESKTOP_VERSION``), wired from the root ``VERSION``
+file and the desktop / runtime / worker package manifests through Docker build
+args.
 
 For local development (running from a source checkout, not the released image)
 the server version falls back to reading the repo ``VERSION`` file, then to a
@@ -59,6 +60,29 @@ def desktop_version() -> str:
 def runtime_version() -> str:
     """The runtime version this server pins; falls back to the server version."""
     return _env("RUNTIME_VERSION") or server_version()
+
+
+def worker_version() -> str:
+    """The worker version this server *displays*; falls back to the server version.
+
+    Release CI stamps ``WORKER_VERSION`` from the ``proliferate-worker`` crate
+    manifest the same way the desktop / runtime pins are stamped from theirs.
+    Display only — the heartbeat pin uses :func:`worker_version_pin`.
+    """
+    return _env("WORKER_VERSION") or server_version()
+
+
+def worker_version_pin() -> str | None:
+    """The worker version this server pins for self-updates, or ``None``.
+
+    Unlike the display fallbacks above, this pin actively drives binary
+    swaps: sandbox workers download and exec whatever it names on every
+    heartbeat. When ``WORKER_VERSION`` was not stamped (local dev, a plain
+    ``docker build``, self-hosted images) the server-version fallback could
+    never match any worker artifact, so it would drive perpetual update
+    attempts — an unstamped deployment therefore pins nothing.
+    """
+    return _env("WORKER_VERSION")
 
 
 def min_desktop_version() -> str:

--- a/server/tests/integration/test_cloud_runtime_workers_api.py
+++ b/server/tests/integration/test_cloud_runtime_workers_api.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
+from proliferate.db.models.cloud.runtime_workers import CloudRuntimeWorker
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 
@@ -194,6 +198,236 @@ class TestRuntimeWorkerEnrollment:
             json={},
         )
         assert fresh.status_code == 200
+
+
+async def _worker_row(db_session: AsyncSession, worker_id: str) -> CloudRuntimeWorker:
+    db_session.expire_all()
+    return (
+        await db_session.execute(
+            select(CloudRuntimeWorker).where(CloudRuntimeWorker.id == UUID(worker_id))
+        )
+    ).scalar_one()
+
+
+class TestRuntimeWorkerVersionConvergence:
+    @pytest.mark.asyncio
+    async def test_enroll_persists_reported_metadata(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="worker-meta")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-meta")
+
+        enroll = await client.post(
+            "/v1/cloud/worker/enroll",
+            json={
+                "enrollmentToken": token,
+                "machineFingerprint": "fp-abc123",
+                "hostname": "build-box",
+                "workerVersion": "0.1.0",
+                "anyharnessVersion": "0.4.2",
+            },
+        )
+        assert enroll.status_code == 200, enroll.text
+
+        row = await _worker_row(db_session, enroll.json()["workerId"])
+        assert row.machine_fingerprint == "fp-abc123"
+        assert row.hostname == "build-box"
+        assert row.worker_version == "0.1.0"
+        assert row.anyharness_version == "0.4.2"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_returns_desired_versions_from_pins(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("WORKER_VERSION", "9.9.9")
+        monkeypatch.setenv("RUNTIME_VERSION", "8.8.8")
+        auth = await _authed_user(client, db_session, prefix="worker-pins")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-pins")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert heartbeat.status_code == 200, heartbeat.text
+        assert heartbeat.json()["desiredVersions"] == {"worker": "9.9.9", "anyharness": "8.8.8"}
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_omits_worker_pin_when_unstamped(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No WORKER_VERSION stamp (local dev / plain docker build): pinning
+        # the server-version fallback would drive self-updating workers into
+        # perpetual swap attempts, so the pin must be absent instead.
+        monkeypatch.delenv("WORKER_VERSION", raising=False)
+        auth = await _authed_user(client, db_session, prefix="worker-nopin")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-nopin")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert heartbeat.status_code == 200, heartbeat.text
+        assert heartbeat.json()["desiredVersions"]["worker"] is None
+
+    @pytest.mark.asyncio
+    async def test_enroll_and_heartbeat_reject_overlong_metadata(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        # Values wider than the DB columns must 422 at the edge instead of
+        # blowing up as a StringDataRightTruncation 500 mid-transaction.
+        auth = await _authed_user(client, db_session, prefix="worker-long")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-long")
+
+        enroll = await client.post(
+            "/v1/cloud/worker/enroll",
+            json={"enrollmentToken": token, "workerVersion": "v" * 65},
+        )
+        assert enroll.status_code == 422, enroll.text
+
+        # The token survives the rejected request and still enrolls.
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        assert enroll.status_code == 200, enroll.text
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={"anyharnessVersion": "v" * 65},
+        )
+        assert heartbeat.status_code == 422, heartbeat.text
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_reports_update_worker_versions(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="worker-swap")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-swap")
+        enroll = await client.post(
+            "/v1/cloud/worker/enroll",
+            json={"enrollmentToken": token, "workerVersion": "0.1.0"},
+        )
+        worker_id = enroll.json()["workerId"]
+        worker_token = enroll.json()["workerToken"]
+
+        # Post-swap the worker reports what it now runs.
+        swap = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={"workerVersion": "0.2.0", "anyharnessVersion": "0.5.0"},
+        )
+        assert swap.status_code == 200, swap.text
+        row = await _worker_row(db_session, worker_id)
+        assert row.worker_version == "0.2.0"
+        assert row.anyharness_version == "0.5.0"
+
+        # A version-less heartbeat never clears what was recorded.
+        plain = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert plain.status_code == 200
+        row = await _worker_row(db_session, worker_id)
+        assert row.worker_version == "0.2.0"
+        assert row.anyharness_version == "0.5.0"
+
+
+class TestWorkerArtifactDownload:
+    @pytest.fixture(autouse=True)
+    def _pinned_cdn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DESKTOP_DOWNLOADS_BASE_URL", raising=False)
+        monkeypatch.setenv("WORKER_VERSION", "1.2.3")
+
+    def _stub_probe(self, monkeypatch: pytest.MonkeyPatch, *, exists: bool) -> list[str]:
+        from proliferate.server.cloud.runtime_workers import service as service_module
+
+        probed: list[str] = []
+
+        async def probe(url: str) -> bool:
+            probed.append(url)
+            return exists
+
+        monkeypatch.setattr(service_module, "versioned_manifest_exists", probe)
+        return probed
+
+    @pytest.mark.asyncio
+    async def test_download_redirects_to_pinned_artifact(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_probe(monkeypatch, exists=True)
+        for asset in ("proliferate-worker", "proliferate-worker.sha256"):
+            response = await client.get(f"/v1/cloud/worker/download/linux-x86_64/{asset}")
+            assert response.status_code == 302, response.text
+            assert response.headers["location"] == (
+                f"https://downloads.proliferate.com/worker/stable/1.2.3/linux-x86_64/{asset}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_falls_back_when_pin_unpublished(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        probed = self._stub_probe(monkeypatch, exists=False)
+        response = await client.get("/v1/cloud/worker/download/macos-aarch64/proliferate-worker")
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://downloads.proliferate.com/worker/stable/macos-aarch64/proliferate-worker"
+        )
+        assert probed == [
+            "https://downloads.proliferate.com/worker/stable/1.2.3/macos-aarch64/proliferate-worker"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_download_skips_probe_when_pin_unstamped(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("WORKER_VERSION", raising=False)
+        probed = self._stub_probe(monkeypatch, exists=True)
+        response = await client.get("/v1/cloud/worker/download/linux-aarch64/proliferate-worker")
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://downloads.proliferate.com/worker/stable/linux-aarch64/proliferate-worker"
+        )
+        # No pin, nothing to probe: never build a ".../None/..." URL.
+        assert probed == []
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_unknown_target_or_asset(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_probe(monkeypatch, exists=True)
+        for path in (
+            "/v1/cloud/worker/download/windows-x86_64/proliferate-worker",
+            "/v1/cloud/worker/download/linux-x86_64/anyharness",
+        ):
+            response = await client.get(path)
+            assert response.status_code == 404
+            assert response.json()["detail"]["code"] == "cloud_worker_artifact_unknown"
 
 
 async def _enroll_worker(client: AsyncClient, auth, *, install_id: str) -> dict:

--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -19,6 +19,7 @@ _PIN_ENV_VARS = (
     "SERVER_VERSION",
     "DESKTOP_VERSION",
     "RUNTIME_VERSION",
+    "WORKER_VERSION",
     "MIN_DESKTOP_VERSION",
     "DESKTOP_DOWNLOADS_BASE_URL",
 )
@@ -41,6 +42,7 @@ def test_meta_reports_stamped_pins(monkeypatch) -> None:  # type: ignore[no-unty
     monkeypatch.setenv("SERVER_VERSION", "0.3.0")
     monkeypatch.setenv("DESKTOP_VERSION", "0.3.2")
     monkeypatch.setenv("RUNTIME_VERSION", "0.3.1")
+    monkeypatch.setenv("WORKER_VERSION", "0.3.4")
     monkeypatch.setenv("MIN_DESKTOP_VERSION", "0.3.0")
 
     body = _client().get("/meta").json()
@@ -49,6 +51,7 @@ def test_meta_reports_stamped_pins(monkeypatch) -> None:  # type: ignore[no-unty
         "serverVersion": "0.3.0",
         "desktopVersion": "0.3.2",
         "runtimeVersion": "0.3.1",
+        "workerVersion": "0.3.4",
         "minDesktopVersion": "0.3.0",
     }
 
@@ -62,6 +65,7 @@ def test_meta_shape_and_types_without_env(monkeypatch) -> None:  # type: ignore[
         "serverVersion",
         "desktopVersion",
         "runtimeVersion",
+        "workerVersion",
         "minDesktopVersion",
     }
     for value in body.values():
@@ -76,6 +80,7 @@ def test_meta_pins_fall_back_to_server_version(monkeypatch) -> None:  # type: ig
 
     assert body["desktopVersion"] == "1.2.3"
     assert body["runtimeVersion"] == "1.2.3"
+    assert body["workerVersion"] == "1.2.3"
     assert body["minDesktopVersion"] == "1.2.3"
 
 


### PR DESCRIPTION
## What

Restores the already-reviewed content of **#897** (heartbeat version convergence + sandbox worker self-swap) onto `main`.

#897 was accidentally **squash-merged into its stale base branch** `infra/integrations-hygiene` instead of `main` — GitHub kept the base alive and never retargeted the PR when its parent (#895) landed on `main`. The reviewed content therefore lives only as one squash commit (`9bae7460e`) on `origin/infra/integrations-hygiene` and never reached `main`. `main` already has #895's content and #897's desktop-side changes (they arrived via #893/#895), so this PR restores only what is genuinely missing.

This branch is `git cherry-pick 9bae7460e` onto the latest `main`, resolving conflicts against current `main`.

## Scope (27 files)

- **Server** (`runtime_workers`): persist enroll metadata (`workerVersion` / `anyharnessVersion` / `hostname`); heartbeat returns `desiredVersions` from the version pins; unstamped `WORKER_VERSION` omits the worker pin; 422 (not 500) on overlong worker metadata.
- **Worker binary download**: unauthenticated `GET /worker/download/{target}/{asset}` 302 redirect to the pinned CDN artifact (with pinned-path probe + fallback).
- **Version pin + CI stamping**: `.github/workflows/_deploy-server.yml`, `server-ci.yml`, `server/proliferate/server/version.py`, `meta.py`, `Dockerfile`.
- **Rust `proliferate-worker` self-swap** (`src/self_update.rs` + cloud_client/config/runtime/versions): checksum-verified download, `--version` preflight, atomic rename, re-exec, env-marker loop backstop, config-gated `self_update_enabled` (default off; desktop stays off, sandbox opts in).
- **Manifest**: `scripts/check_proliferate_worker_structure.py`.
- **SDK regen**: `cloud/sdk/src/generated/openapi.ts` (WorkerDesiredVersions schema, worker download path, version fields).

## Conflict resolution

Two files conflicted against current `main`; both resolved preserving both #897 semantics and current `main` (reference end-state: `git show origin/infra/integrations-hygiene:<path>`):

- `server/proliferate/server/cloud/runtime_workers/api.py` — import-list conflict; kept the new `worker_artifact_redirect_url` import used by the download endpoint.
- `server/tests/integration/test_cloud_runtime_workers_api.py` — main's `test_cross_user_enrollment_revokes_prior_users_worker` (from #893) and #897's `_worker_row` helper + `TestRuntimeWorkerVersionConvergence`/`TestWorkerArtifactDownload` classes were both added after the same anchor. Kept both.

## Verification

- `ruff format --check` + `ruff check` on touched server files — clean.
- `API_BASE_URL="" CLOUD_WORKER_BASE_URL="" pytest tests/integration/test_cloud_runtime_workers_api.py -q` — **21 passed**.
- `alembic heads` — single head (`ab12cd34ef56`); no new migration (columns already exist on `main` via #895).
- `cargo check -p proliferate-worker` — clean; `cargo test -p proliferate-worker` — **17 passed**.
- Rebuilt cloud SDK dist (tsc clean) + `npx tsc --noEmit` in `apps/desktop` — **clean**.
- `check_max_lines.py`, `check_server_boundaries.py`, `check_frontend_boundaries.py`, `check_proliferate_worker_structure.py` — all passed; `report_frontend_structure.py --strict --summary-only` — 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
