### PR TITLE
feat(desktop): ModelTable round 2 — modes column, family-key enrichment, description subtitles

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/agents.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/agents.rs
@@ -114,6 +114,11 @@ pub struct AgentLaunchModelOption {
     pub effort: Option<ModelEffort>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_mode: Option<bool>,
+    /// The permission/agent modes the model supports (joined from the bundled
+    /// catalog's `controls.mode.values`); absent when the model has no mode
+    /// control (contract §5).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modes: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
@@ -18,13 +18,13 @@ use axum::{
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use std::collections::HashMap;
-
 use anyharness_contract::v1::{ModelCatalogStatus, ModelEffort};
 
 use super::error::ApiError;
 use crate::app::AppState;
-use crate::domains::agents::catalog::gateway_resolver::{provider_for_model, GatewayModelSource};
+use crate::domains::agents::catalog::gateway_resolver::{
+    normalize_model_family, provider_for_model, GatewayModelSource,
+};
 use crate::domains::agents::catalog::schema::AgentCatalogModel;
 use crate::domains::agents::model::ModelCatalogStatus as DomainModelCatalogStatus;
 use crate::domains::agents::route_auth::load_state_file;
@@ -58,6 +58,10 @@ pub struct GatewayModelEntry {
     /// Whether the model carries a `fast_mode` control; absent for probe-only ids.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_mode: Option<bool>,
+    /// The permission/agent modes the model supports (`controls.mode.values`);
+    /// absent when the model has no mode control or is probe-only (contract §5).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modes: Option<Vec<String>>,
 }
 
 /// Map the runtime-owned lifecycle status to the wire enum (identical variants).
@@ -78,6 +82,41 @@ pub(crate) fn model_effort(model: &AgentCatalogModel) -> Option<ModelEffort> {
     })
 }
 
+/// The permission/agent modes joined from a catalog model (`controls.mode`), if
+/// it declares that control (contract §5).
+pub(crate) fn model_modes(model: &AgentCatalogModel) -> Option<Vec<String>> {
+    model
+        .controls
+        .get("mode")
+        .map(|control| control.values.clone())
+}
+
+/// Resolve the bundled catalog row for a resolved gateway id (contract §5).
+/// Tries an exact id match first, then falls back to a FAMILY-key match (see
+/// [`normalize_model_family`]). When several catalog entries share the family
+/// key, prefer the non-`[1m]` entry, then the longest (most-specific) id, then
+/// a lexical tiebreak — deterministic regardless of catalog ordering.
+fn resolve_catalog_match<'a>(
+    id: &str,
+    catalog_models: &'a [AgentCatalogModel],
+) -> Option<&'a AgentCatalogModel> {
+    if let Some(model) = catalog_models.iter().find(|model| model.id == id) {
+        return Some(model);
+    }
+    let key = normalize_model_family(id);
+    catalog_models
+        .iter()
+        .filter(|model| normalize_model_family(&model.id) == key)
+        .max_by(|a, b| {
+            let a_non_1m = !a.id.ends_with("[1m]");
+            let b_non_1m = !b.id.ends_with("[1m]");
+            a_non_1m
+                .cmp(&b_non_1m)
+                .then_with(|| a.id.len().cmp(&b.id.len()))
+                .then_with(|| a.id.cmp(&b.id))
+        })
+}
+
 /// Enrich a resolved gateway model id by joining the bundled catalog row.
 /// Catalog-known → full object; probe-only → `{ id, provider? }`.
 fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModelEntry {
@@ -91,6 +130,7 @@ fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModel
             status: Some(map_model_status(model.status)),
             effort: model_effort(model),
             fast_mode: Some(model.controls.contains_key("fast_mode")),
+            modes: model_modes(model),
         },
         None => GatewayModelEntry {
             id,
@@ -100,6 +140,7 @@ fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModel
             status: None,
             effort: None,
             fast_mode: None,
+            modes: None,
         },
     }
 }
@@ -159,15 +200,11 @@ pub async fn get_gateway_models(
         GatewayModelSource::Probe { probed_at } => ("probe".to_string(), Some(probed_at)),
     };
     let catalog_models = state.gateway_model_resolver.catalog_models(&kind);
-    let lookup: HashMap<&str, &AgentCatalogModel> = catalog_models
-        .iter()
-        .map(|model| (model.id.as_str(), model))
-        .collect();
     let models = plan
         .models
         .into_iter()
         .map(|id| {
-            let catalog = lookup.get(id.as_str()).copied();
+            let catalog = resolve_catalog_match(&id, &catalog_models);
             enrich_model(id, catalog)
         })
         .collect();
@@ -284,6 +321,18 @@ mod tests {
                 observed_value: None,
             },
         );
+        controls.insert(
+            "mode".to_string(),
+            AgentCatalogModelControl {
+                values: vec![
+                    "default".to_string(),
+                    "acceptEdits".to_string(),
+                    "plan".to_string(),
+                ],
+                default: None,
+                observed_value: None,
+            },
+        );
         AgentCatalogModel {
             id: id.to_string(),
             display_name: "Claude Sonnet 4.5".to_string(),
@@ -314,6 +363,14 @@ mod tests {
         assert_eq!(effort.values, vec!["low", "medium", "high"]);
         assert_eq!(effort.default.as_deref(), Some("medium"));
         assert_eq!(entry.fast_mode, Some(true));
+        assert_eq!(
+            entry.modes,
+            Some(vec![
+                "default".to_string(),
+                "acceptEdits".to_string(),
+                "plan".to_string()
+            ])
+        );
     }
 
     #[test]
@@ -324,6 +381,7 @@ mod tests {
 
         assert!(entry.effort.is_none());
         assert_eq!(entry.fast_mode, Some(false));
+        assert!(entry.modes.is_none());
         // Catalog-known rows still carry display metadata + status.
         assert_eq!(entry.display_name.as_deref(), Some("Claude Sonnet 4.5"));
         assert!(entry.status.is_some());
@@ -350,5 +408,54 @@ mod tests {
         assert_eq!(entry.id, "mystery-model");
         assert!(entry.provider.is_none());
         assert!(entry.display_name.is_none());
+    }
+
+    // --- The family-key join (contract §5, `resolve_catalog_match`), exercised
+    // with the REAL claude catalog + gateway id sets. ---
+
+    /// The catalog's real claude opus-4-8 entries (three ids sharing a family
+    /// key) plus the drifted sonnet/opus-4-6 entries that DON'T bridge today.
+    fn claude_catalog() -> Vec<AgentCatalogModel> {
+        [
+            "sonnet",
+            "opus[1m]",
+            "us.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-sonnet-4-6[1m]",
+            "us.anthropic.claude-opus-4-6-v1[1m]",
+            "claude-opus-4-8",
+            "us.anthropic.claude-opus-4-8",
+            "us.anthropic.claude-opus-4-8[1m]",
+        ]
+        .into_iter()
+        .map(catalog_model)
+        .collect()
+    }
+
+    #[test]
+    fn exact_id_wins_over_family() {
+        let models = claude_catalog();
+        let hit = resolve_catalog_match("claude-opus-4-8", &models).expect("match");
+        // Exact id match, even though bedrock opus-4-8 variants share its family.
+        assert_eq!(hit.id, "claude-opus-4-8");
+    }
+
+    #[test]
+    fn dated_gateway_id_family_joins_preferring_non_1m_most_specific() {
+        let models = claude_catalog();
+        // No exact id: the dated gateway id family-matches the three opus-4-8
+        // catalog entries; prefer non-[1m], then the longest/most-specific id.
+        let hit = resolve_catalog_match("claude-opus-4-8-20260101", &models).expect("match");
+        assert_eq!(hit.id, "us.anthropic.claude-opus-4-8");
+    }
+
+    #[test]
+    fn drifted_gateway_ids_stay_sparse_today() {
+        let models = claude_catalog();
+        // Real config.yaml gateway ids: catalog moved to 4-6/4-8, gateway serves
+        // 4-5 and a bedrock-`-v1` 4-6 — none bridge, so enrichment is sparse.
+        assert!(resolve_catalog_match("claude-sonnet-4-5", &models).is_none());
+        assert!(resolve_catalog_match("claude-sonnet-4-5-20250929", &models).is_none());
+        assert!(resolve_catalog_match("claude-haiku-4-5", &models).is_none());
+        assert!(resolve_catalog_match("claude-opus-4-6-20260205", &models).is_none());
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/agents_contract.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agents_contract.rs
@@ -309,6 +309,7 @@ pub(super) fn launch_options_response(
                             default: effort.default,
                         }),
                         fast_mode: Some(model.fast_mode),
+                        modes: model.modes,
                     })
                     .collect(),
             })

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
@@ -49,6 +49,71 @@ pub fn provider_for_model(model_id: &str) -> Option<&'static str> {
     }
 }
 
+/// Normalize a model id to a conservative FAMILY key for the enrichment join
+/// (contract §5). Catalog ids and gateway ids share almost no exact ids
+/// (catalog: `sonnet`, `us.anthropic.claude-sonnet-4-6[1m]`; gateway:
+/// `claude-sonnet-4-5`, `claude-opus-4-6-20260205`), so the enrichment falls
+/// back to matching on this key. It strips, in order:
+///   1. the `us.anthropic.` / `global.anthropic.` vendor prefix,
+///   2. a trailing `[1m]` context-window suffix,
+///   3. a trailing bedrock `-vN:M` version suffix (colon-bearing only — a bare
+///      `-vN` is deliberately NOT a version suffix),
+///   4. a trailing `-YYYYMMDD` release date,
+/// and lowercases the result. Pure CLI selectors (`default`, `sonnet`, `opus`,
+/// `haiku`) normalize to themselves, which never equals a real gateway model id
+/// family — so they stay unbridged by design (no guessy displayName matching).
+pub fn normalize_model_family(model_id: &str) -> String {
+    let mut s = model_id.trim();
+    for prefix in ["us.anthropic.", "global.anthropic."] {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            s = rest;
+            break;
+        }
+    }
+    let mut s = s.to_ascii_lowercase();
+    if let Some(rest) = s.strip_suffix("[1m]") {
+        s = rest.to_string();
+    }
+    s = strip_bedrock_version_suffix(&s);
+    s = strip_release_date_suffix(&s);
+    s
+}
+
+/// Strip a trailing bedrock `-vN:M` version suffix (e.g. `-v1:0`). A bare `-vN`
+/// (no colon) is left intact — the catalog uses `claude-opus-4-6-v1` as a
+/// distinct family from `claude-opus-4-6`.
+fn strip_bedrock_version_suffix(s: &str) -> String {
+    let Some(idx) = s.rfind("-v") else {
+        return s.to_string();
+    };
+    let tail = &s[idx + 2..];
+    let Some((n, m)) = tail.split_once(':') else {
+        return s.to_string();
+    };
+    if !n.is_empty()
+        && n.bytes().all(|b| b.is_ascii_digit())
+        && !m.is_empty()
+        && m.bytes().all(|b| b.is_ascii_digit())
+    {
+        s[..idx].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Strip a trailing `-YYYYMMDD` release date (dash + exactly 8 ASCII digits).
+fn strip_release_date_suffix(s: &str) -> String {
+    let Some(idx) = s.rfind('-') else {
+        return s.to_string();
+    };
+    let tail = &s[idx + 1..];
+    if tail.len() == 8 && tail.bytes().all(|b| b.is_ascii_digit()) {
+        s[..idx].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
 /// Does `provider` serve `model_id`? A provider not in the family table (or a
 /// model matching no family) matches nothing.
 fn model_matches_provider(provider: &str, model_id: &str) -> bool {
@@ -295,5 +360,111 @@ mod tests {
         let filtered =
             filter_by_providers(models, &["anthropic".to_string(), "openai".to_string()]);
         assert_eq!(filtered, vec!["claude-sonnet-4-5", "gpt-5.5"]);
+    }
+
+    // --- normalize_model_family (contract §5), exercised with the REAL id sets
+    // from catalogs/agents/catalog.json (catalog) and server/litellm/config.yaml
+    // (gateway). ---
+
+    #[test]
+    fn normalize_strips_vendor_prefix_bracket_version_and_date() {
+        // Vendor prefix + [1m] window suffix (catalog).
+        assert_eq!(
+            normalize_model_family("us.anthropic.claude-sonnet-4-6[1m]"),
+            "claude-sonnet-4-6"
+        );
+        assert_eq!(
+            normalize_model_family("global.anthropic.claude-fable-5"),
+            "claude-fable-5"
+        );
+        // Bedrock version + date (catalog).
+        assert_eq!(
+            normalize_model_family("us.anthropic.claude-opus-4-1-20250805-v1:0"),
+            "claude-opus-4-1"
+        );
+        // Trailing release dates (gateway / config.yaml).
+        assert_eq!(
+            normalize_model_family("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            normalize_model_family("claude-haiku-4-5-20251001"),
+            "claude-haiku-4-5"
+        );
+        assert_eq!(
+            normalize_model_family("claude-opus-4-6-20260205"),
+            "claude-opus-4-6"
+        );
+        // Pure CLI selectors normalize to themselves.
+        assert_eq!(normalize_model_family("opus[1m]"), "opus");
+        assert_eq!(normalize_model_family("sonnet"), "sonnet");
+        assert_eq!(normalize_model_family("default"), "default");
+    }
+
+    #[test]
+    fn bare_dash_v_is_not_a_version_suffix() {
+        // The catalog's bedrock opus-4-6 entry carries a bare `-v1` (no colon),
+        // which is a DISTINCT family from a plain `claude-opus-4-6`.
+        assert_eq!(
+            normalize_model_family("us.anthropic.claude-opus-4-6-v1[1m]"),
+            "claude-opus-4-6-v1"
+        );
+    }
+
+    #[test]
+    fn sonnet_4_6_catalog_does_not_match_sonnet_4_5_gateway() {
+        // The headline real-data hazard: catalog moved to 4-6 while the gateway
+        // config still serves 4-5, so these must NOT bridge.
+        assert_ne!(
+            normalize_model_family("us.anthropic.claude-sonnet-4-6[1m]"),
+            normalize_model_family("claude-sonnet-4-5")
+        );
+    }
+
+    #[test]
+    fn opus_4_6_dated_gateway_family_key() {
+        // The dated gateway id normalizes to the plain family; it would bridge
+        // to a catalog `claude-opus-4-6` entry IF one existed. Today the closest
+        // catalog entry is a bedrock `-v1[1m]` variant, which normalizes
+        // distinctly, so opus-4-6 stays unbridged.
+        assert_eq!(
+            normalize_model_family("claude-opus-4-6-20260205"),
+            "claude-opus-4-6"
+        );
+        assert_ne!(
+            normalize_model_family("claude-opus-4-6-20260205"),
+            normalize_model_family("us.anthropic.claude-opus-4-6-v1[1m]")
+        );
+    }
+
+    #[test]
+    fn pure_selectors_never_match_a_gateway_id() {
+        // Selector families never collide with a real gateway model id family.
+        assert_ne!(
+            normalize_model_family("sonnet"),
+            normalize_model_family("claude-sonnet-4-5")
+        );
+        assert_ne!(
+            normalize_model_family("opus"),
+            normalize_model_family("claude-opus-4-6-20260205")
+        );
+    }
+
+    #[test]
+    fn dated_opus_4_8_bridges_to_bedrock_family() {
+        // A genuine positive: the catalog's opus-4-8 entries and a dated gateway
+        // opus-4-8 id share a family key.
+        assert_eq!(
+            normalize_model_family("us.anthropic.claude-opus-4-8[1m]"),
+            normalize_model_family("us.anthropic.claude-opus-4-8")
+        );
+        assert_eq!(
+            normalize_model_family("claude-opus-4-8-20260101"),
+            "claude-opus-4-8"
+        );
+        assert_eq!(
+            normalize_model_family("claude-opus-4-8-20260101"),
+            normalize_model_family("us.anthropic.claude-opus-4-8[1m]")
+        );
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/launch_options.rs
@@ -26,6 +26,9 @@ pub struct ResolvedLaunchModelOption {
     pub status: Option<crate::domains::agents::model::ModelCatalogStatus>,
     pub effort: Option<ResolvedModelEffort>,
     pub fast_mode: bool,
+    /// The permission/agent modes the model supports (`controls.mode.values`);
+    /// `None` when the model declares no mode control (contract §5).
+    pub modes: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
@@ -110,6 +110,10 @@ impl SessionService {
                             }
                         }),
                         fast_mode: model.controls.contains_key("fast_mode"),
+                        modes: model
+                            .controls
+                            .get("mode")
+                            .map(|control| control.values.clone()),
                     })
                     .collect(),
             });

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -5955,6 +5955,16 @@
           "isDefault": {
             "type": "boolean"
           },
+          "modes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "The permission/agent modes the model supports (joined from the bundled\ncatalog's `controls.mode.values`); absent when the model has no mode\ncontrol (contract §5)."
+          },
           "provider": {
             "type": [
               "string",
@@ -8587,6 +8597,16 @@
           "id": {
             "type": "string",
             "description": "The gateway model id (always present — the render plane keys on this)."
+          },
+          "modes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "The permission/agent modes the model supports (`controls.mode.values`);\nabsent when the model has no mode control or is probe-only (contract §5)."
           },
           "provider": {
             "type": [

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -1800,6 +1800,12 @@ export interface components {
             fastMode?: boolean | null;
             id: string;
             isDefault: boolean;
+            /**
+             * @description The permission/agent modes the model supports (joined from the bundled
+             *     catalog's `controls.mode.values`); absent when the model has no mode
+             *     control (contract §5).
+             */
+            modes?: string[] | null;
             provider?: string | null;
             status?: null | components["schemas"]["ModelCatalogStatus"];
         };
@@ -2403,6 +2409,11 @@ export interface components {
             fastMode?: boolean | null;
             /** @description The gateway model id (always present — the render plane keys on this). */
             id: string;
+            /**
+             * @description The permission/agent modes the model supports (`controls.mode.values`);
+             *     absent when the model has no mode control or is probe-only (contract §5).
+             */
+            modes?: string[] | null;
             /**
              * @description Provider id from the id-prefix matcher (`claude-*`→anthropic, …); absent
              *     when no family matches.

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -86,9 +86,11 @@ export function HarnessAllModelsSection({
   const rows: ModelTableRow[] = models.map((model) => ({
     id: model.id,
     displayName: model.displayName,
+    description: model.description,
     provider: model.provider,
     status: model.status,
     effort: model.effort,
+    modes: model.modes,
     fastMode: model.fastMode,
     enabled: model.enabled,
     toggleDisabled: isRuntimeGateway || upsertOverride.isPending,

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
@@ -80,20 +80,24 @@ describe("normalizeGatewayModels", () => {
         gatewayModel({
           id: "claude-sonnet-4-5",
           displayName: "Sonnet 4.6",
+          description: "Balanced coding model",
           provider: "anthropic",
           status: "active",
           effort: { values: ["low", "medium", "high"], default: "medium" },
           fastMode: true,
+          modes: ["default", "acceptEdits", "plan"],
         }),
       ]),
     ).toEqual([
       {
         id: "claude-sonnet-4-5",
         displayName: "Sonnet 4.6",
+        description: "Balanced coding model",
         provider: "anthropic",
         status: "active",
         effort: { values: ["low", "medium", "high"], default: "medium" },
         fastMode: true,
+        modes: ["default", "acceptEdits", "plan"],
         enabled: true,
       },
     ]);
@@ -106,10 +110,12 @@ describe("normalizeGatewayModels", () => {
       {
         id: "gpt-5.5",
         displayName: "gpt-5.5",
+        description: null,
         provider: "openai",
         status: null,
         effort: null,
         fastMode: null,
+        modes: null,
         enabled: true,
       },
     ]);
@@ -122,10 +128,12 @@ describe("normalizeGatewayModels", () => {
       {
         id: "grok-5",
         displayName: "grok-5",
+        description: null,
         provider: null,
         status: null,
         effort: null,
         fastMode: null,
+        modes: null,
         enabled: true,
       },
     ]);
@@ -140,10 +148,12 @@ describe("normalizeCatalogModels", () => {
         {
           id: "sonnet",
           displayName: "Sonnet 4.6",
+          description: "Balanced coding model",
           provider: "anthropic",
           status: "active",
           effort: { values: ["low", "high"], default: "high" },
           fastMode: false,
+          modes: ["default", "plan"],
         },
         { id: "haiku", displayName: "Haiku 4.5", enabled: false },
       ]),
@@ -151,19 +161,23 @@ describe("normalizeCatalogModels", () => {
       {
         id: "sonnet",
         displayName: "Sonnet 4.6",
+        description: "Balanced coding model",
         provider: "anthropic",
         status: "active",
         effort: { values: ["low", "high"], default: "high" },
         fastMode: false,
+        modes: ["default", "plan"],
         enabled: true,
       },
       {
         id: "haiku",
         displayName: "Haiku 4.5",
+        description: null,
         provider: null,
         status: null,
         effort: null,
         fastMode: null,
+        modes: null,
         enabled: false,
       },
     ]);
@@ -174,10 +188,12 @@ describe("normalizeCatalogModels", () => {
       {
         id: "legacy",
         displayName: "legacy",
+        description: null,
         provider: null,
         status: null,
         effort: null,
         fastMode: null,
+        modes: null,
         enabled: true,
       },
     ]);
@@ -233,6 +249,7 @@ describe("buildRuntimeCatalogModelsJson", () => {
               status: "active",
               effort: { values: ["low", "medium", "high"], default: "medium" },
               fastMode: true,
+              modes: ["default", "acceptEdits", "plan"],
             },
           ],
         },
@@ -249,6 +266,7 @@ describe("buildRuntimeCatalogModelsJson", () => {
           status: "active",
           effort: { values: ["low", "medium", "high"], default: "medium" },
           fastMode: true,
+          modes: ["default", "acceptEdits", "plan"],
         },
       ]),
     );

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.ts
@@ -13,15 +13,34 @@ export interface HarnessCatalogModelEffort {
 export interface HarnessCatalogModel {
   id: string;
   displayName: string;
+  // Catalog description (contract §5): becomes the table's name-block subtitle
+  // when present; null for probe-only ids and old thin snapshots.
+  description: string | null;
   provider: string | null;
   status: string | null;
   effort: HarnessCatalogModelEffort | null;
   fastMode: boolean | null;
+  // The permission/agent modes the model supports (contract §5), joined from the
+  // catalog's `controls.mode.values`; null when the model has no mode control or
+  // for old thin snapshots that predate mode enrichment.
+  modes: string[] | null;
   enabled: boolean;
 }
 
 function normalizeString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+// The enriched modes list (contract §5): a non-empty array of non-empty strings.
+// Old thin snapshots (pre-enrichment) omit it → null, so the row renders sparse.
+function normalizeModes(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const modes = value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
+  return modes.length > 0 ? modes : null;
 }
 
 // The enriched effort control (contract §1): `{ values, default }`. Old thin
@@ -60,10 +79,12 @@ export function normalizeCatalogModels(
     normalized.push({
       id,
       displayName: normalizeString(entry.displayName) ?? id,
+      description: normalizeString(entry.description),
       provider: normalizeString(entry.provider),
       status: normalizeString(entry.status),
       effort: normalizeEffort(entry.effort),
       fastMode: typeof entry.fastMode === "boolean" ? entry.fastMode : null,
+      modes: normalizeModes(entry.modes),
       enabled: entry.enabled !== false,
     });
   }
@@ -84,10 +105,12 @@ export function normalizeGatewayModels(
     .map((model) => ({
       id: model.id,
       displayName: normalizeString(model.displayName) ?? model.id,
+      description: normalizeString(model.description),
       provider: normalizeString(model.provider),
       status: normalizeString(model.status),
       effort: normalizeEffort(model.effort),
       fastMode: typeof model.fastMode === "boolean" ? model.fastMode : null,
+      modes: normalizeModes(model.modes),
       enabled: true,
     }));
 }
@@ -120,6 +143,7 @@ export function buildRuntimeCatalogModelsJson(
     ...(model.status != null ? { status: model.status } : {}),
     ...(model.effort != null ? { effort: model.effort } : {}),
     ...(model.fastMode != null ? { fastMode: model.fastMode } : {}),
+    ...(model.modes != null ? { modes: model.modes } : {}),
   }));
   return JSON.stringify(entries);
 }

--- a/apps/packages/product-ui/src/settings/ModelTable.test.tsx
+++ b/apps/packages/product-ui/src/settings/ModelTable.test.tsx
@@ -10,6 +10,7 @@ function row(overrides: Partial<ModelTableRow> = {}): ModelTableRow {
     displayName: "Sonnet 4.6",
     provider: "anthropic",
     effort: { values: ["low", "medium", "high"], default: "medium" },
+    modes: ["ask", "code"],
     fastMode: true,
     status: "active",
     enabled: true,
@@ -20,7 +21,7 @@ function row(overrides: Partial<ModelTableRow> = {}): ModelTableRow {
 describe("ModelTable", () => {
   afterEach(cleanup);
 
-  it("renders the enriched columns: name, monospace id, provider, chips, fast mode, status", () => {
+  it("renders the enriched columns: name, monospace id, provider, chips, modes, fast mode", () => {
     render(<ModelTable models={[row()]} onToggle={vi.fn()} />);
 
     expect(screen.getByText("Sonnet 4.6")).toBeTruthy();
@@ -29,8 +30,46 @@ describe("ModelTable", () => {
     expect(screen.getByText("anthropic")).toBeTruthy();
     expect(screen.getByText("low")).toBeTruthy();
     expect(screen.getByText("high")).toBeTruthy();
+    // Modes render as quiet pills.
+    expect(screen.getByText("ask")).toBeTruthy();
+    expect(screen.getByText("code")).toBeTruthy();
     expect(screen.getByText("On")).toBeTruthy();
-    expect(screen.getByText("Active")).toBeTruthy();
+  });
+
+  it("renders modes plainly (no overflow pill) when there are three or fewer", () => {
+    render(<ModelTable models={[row({ modes: ["ask", "code", "architect"] })]} onToggle={vi.fn()} />);
+
+    expect(screen.getByText("ask")).toBeTruthy();
+    expect(screen.getByText("code")).toBeTruthy();
+    expect(screen.getByText("architect")).toBeTruthy();
+    expect(screen.queryByText(/^\+\d+$/)).toBeNull();
+    expect(screen.getByLabelText("Modes").getAttribute("title")).toBe("ask, code, architect");
+  });
+
+  it("collapses modes beyond three into a '+N' overflow pill with a full-list title", () => {
+    const sixModes = ["ask", "code", "architect", "debug", "orchestrator", "review"];
+    render(<ModelTable models={[row({ modes: sixModes })]} onToggle={vi.fn()} />);
+
+    // Only the first three render as individual pills.
+    expect(screen.getByText("ask")).toBeTruthy();
+    expect(screen.getByText("code")).toBeTruthy();
+    expect(screen.getByText("architect")).toBeTruthy();
+    expect(screen.queryByText("debug")).toBeNull();
+    expect(screen.queryByText("orchestrator")).toBeNull();
+    expect(screen.queryByText("review")).toBeNull();
+
+    // The overflow pill summarizes the rest.
+    expect(screen.getByText("+3")).toBeTruthy();
+
+    // The cell's title attribute lists every mode, comma-separated.
+    expect(screen.getByLabelText("Modes").getAttribute("title")).toBe(sixModes.join(", "));
+  });
+
+  it("does not render the (dropped) Status column", () => {
+    render(<ModelTable models={[row({ status: "active" })]} onToggle={vi.fn()} />);
+
+    expect(screen.queryByText("Status")).toBeNull();
+    expect(screen.queryByText("Active")).toBeNull();
   });
 
   it("highlights the default effort chip via data-default", () => {
@@ -38,6 +77,30 @@ describe("ModelTable", () => {
 
     expect(screen.getByText("medium").getAttribute("data-default")).toBe("true");
     expect(screen.getByText("low").getAttribute("data-default")).toBeNull();
+  });
+
+  it("renders the description as the subtitle and moves the id to a hover title", () => {
+    render(
+      <ModelTable
+        models={[row({ description: "Balanced everyday model" })]}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Balanced everyday model")).toBeTruthy();
+    // With a description present, the id is no longer a visible subtitle line…
+    expect(screen.queryByText("claude-sonnet-4-5")).toBeNull();
+    // …it moves to the name block's title attribute.
+    expect(screen.getByText("Sonnet 4.6").getAttribute("title")).toBe(
+      "claude-sonnet-4-5",
+    );
+  });
+
+  it("falls back to the id subtitle (no title) when no description is present", () => {
+    render(<ModelTable models={[row({ description: null })]} onToggle={vi.fn()} />);
+
+    expect(screen.getByText("claude-sonnet-4-5")).toBeTruthy();
+    expect(screen.getByText("Sonnet 4.6").getAttribute("title")).toBeNull();
   });
 
   it("renders sparse probe-only rows with dashes and no duplicate id line", () => {
@@ -49,6 +112,7 @@ describe("ModelTable", () => {
             displayName: "mystery-model",
             provider: null,
             effort: null,
+            modes: null,
             fastMode: null,
             status: null,
             enabled: true,
@@ -60,7 +124,7 @@ describe("ModelTable", () => {
 
     // displayName === id → the id renders exactly once (as the name).
     expect(screen.getAllByText("mystery-model")).toHaveLength(1);
-    // Provider, Thinking, Fast mode, Status all collapse to em-dashes.
+    // Provider, Thinking, Modes, Fast mode all collapse to em-dashes.
     expect(screen.getAllByText("—")).toHaveLength(4);
   });
 

--- a/apps/packages/product-ui/src/settings/ModelTable.tsx
+++ b/apps/packages/product-ui/src/settings/ModelTable.tsx
@@ -1,5 +1,5 @@
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
-import { Badge, type BadgeTone } from "@proliferate/ui/primitives/Badge";
+import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Switch } from "@proliferate/ui/primitives/Switch";
 
 export interface ModelTableEffort {
@@ -12,9 +12,17 @@ export interface ModelTableRow {
   id: string;
   /** Falls back to `id` (caller-normalized); the monospace id line is shown only when it differs. */
   displayName: string;
+  /** Catalog description; when present it becomes the name-block subtitle and the id moves to a hover title. */
+  description?: string | null;
   provider?: string | null;
   effort?: ModelTableEffort | null;
+  /** The permission/agent modes the model supports (contract §5); "—" when absent. */
+  modes?: readonly string[] | null;
   fastMode?: boolean | null;
+  /**
+   * Retained on the row type but no longer rendered (contract §5 dropped the Status
+   * column until non-`active` statuses actually occur).
+   */
   status?: string | null;
   enabled: boolean;
   /** Toggle is read-only (e.g. runtime-resolved gateway rows have no override endpoint). */
@@ -34,13 +42,6 @@ const TH_CLASS =
   "border-b border-border bg-accent px-3 py-2 text-left text-[11px] font-medium whitespace-nowrap text-faint";
 const TD_CLASS =
   "border-t border-border px-3 py-[11px] align-top text-[13px] whitespace-nowrap";
-
-const STATUS_TONE: Record<string, BadgeTone> = {
-  active: "success",
-  candidate: "info",
-  deprecated: "warning",
-  hidden: "neutral",
-};
 
 function Dash() {
   return <span className="text-[12px] text-faint">—</span>;
@@ -80,18 +81,47 @@ function FastModeCell({ fastMode }: { fastMode?: boolean | null }) {
   return fastMode ? <Badge tone="success">On</Badge> : <Badge tone="neutral">Off</Badge>;
 }
 
-function StatusCell({ status }: { status?: string | null }) {
-  if (!status) {
+// Quiet mode pills (contract §5 / design-system `.ds-mct-pill`): a bordered,
+// muted-foreground, un-highlighted treatment so Modes reads quieter than the
+// Thinking chips (whose default value is bg-filled + medium-weight). Only the
+// first MAX_VISIBLE_MODES render as pills; the rest collapse into a single
+// "+N" overflow pill (review finding: six full-word pills pushed Fast
+// mode/Enabled off-viewport). The cell's title attribute always lists every
+// mode, comma-separated, so hovering reveals the full set.
+const MAX_VISIBLE_MODES = 3;
+
+function ModesPills({ modes }: { modes?: readonly string[] | null }) {
+  if (!modes || modes.length === 0) {
     return <Dash />;
   }
-  const tone = STATUS_TONE[status] ?? "neutral";
-  const label = status.charAt(0).toUpperCase() + status.slice(1);
-  return <Badge tone={tone}>{label}</Badge>;
+  const visible = modes.slice(0, MAX_VISIBLE_MODES);
+  const overflowCount = modes.length - visible.length;
+  return (
+    <span
+      className="inline-flex flex-nowrap gap-1"
+      aria-label="Modes"
+      title={modes.join(", ")}
+    >
+      {visible.map((mode) => (
+        <span
+          key={mode}
+          className="whitespace-nowrap rounded-[5px] border border-border px-1.5 py-px text-[11px] text-muted-foreground"
+        >
+          {mode}
+        </span>
+      ))}
+      {overflowCount > 0 ? (
+        <span className="whitespace-nowrap rounded-[5px] border border-border px-1.5 py-px text-[11px] text-muted-foreground">
+          +{overflowCount}
+        </span>
+      ) : null}
+    </span>
+  );
 }
 
 /**
- * "All Models" catalog table (CONTRACT §2): a scroll-contained table with
- * Model · Provider · Thinking · Fast mode · Status · Enabled columns. Rows are
+ * "All Models" catalog table (CONTRACT §2/§5): a scroll-contained table with
+ * Model · Provider · Thinking · Modes · Fast mode · Enabled columns. Rows are
  * intentionally sparse — probe-only models carry only an id and render "—" for
  * every unknown cell. Styled after the design-system `.ds-mct` treatment.
  * `ModelConfigGrid` still backs the org agent-policy grid; only the All-Models
@@ -111,14 +141,18 @@ export function ModelTable({ models, onToggle, className }: ModelTableProps) {
             <th className={TH_CLASS}>Model</th>
             <th className={TH_CLASS}>Provider</th>
             <th className={TH_CLASS}>Thinking</th>
+            <th className={TH_CLASS}>Modes</th>
             <th className={TH_CLASS}>Fast mode</th>
-            <th className={TH_CLASS}>Status</th>
             <th className={twMerge(TH_CLASS, "text-right")}>Enabled</th>
           </tr>
         </thead>
         <tbody>
           {models.map((model) => {
             const showId = model.displayName !== model.id;
+            // Subtitle precedence (contract §5): description wins; the id then
+            // moves to a hover title on the name block. Absent description falls
+            // back to the id subtitle, but only when it differs from the name.
+            const hasDescription = Boolean(model.description);
             return (
               <tr
                 key={model.id}
@@ -128,10 +162,17 @@ export function ModelTable({ models, onToggle, className }: ModelTableProps) {
                 )}
               >
                 <td className={twMerge(TD_CLASS, "max-w-[260px]")}>
-                  <div className="truncate font-medium text-foreground">
+                  <div
+                    className="truncate font-medium text-foreground"
+                    title={hasDescription ? model.id : undefined}
+                  >
                     {model.displayName}
                   </div>
-                  {showId ? (
+                  {hasDescription ? (
+                    <div className="mt-[3px] truncate text-[12px] leading-[1.4] text-muted-foreground">
+                      {model.description}
+                    </div>
+                  ) : showId ? (
                     <div className="mt-[3px] truncate font-mono text-[12px] text-faint">
                       {model.id}
                     </div>
@@ -148,10 +189,10 @@ export function ModelTable({ models, onToggle, className }: ModelTableProps) {
                   <EffortChips effort={model.effort} />
                 </td>
                 <td className={TD_CLASS}>
-                  <FastModeCell fastMode={model.fastMode} />
+                  <ModesPills modes={model.modes} />
                 </td>
                 <td className={TD_CLASS}>
-                  <StatusCell status={model.status} />
+                  <FastModeCell fastMode={model.fastMode} />
                 </td>
                 <td className={twMerge(TD_CLASS, "text-right")}>
                   <Switch

--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -48,6 +48,34 @@ model_list:
     litellm_params:
       model: anthropic/claude-opus-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
+  # Current-generation entries matching the bundled agent catalog's model
+  # families (sonnet-4-6 / opus-4-7 / opus-4-8 / sonnet-5 / fable-5) so
+  # gateway ids family-join to catalog metadata. Upstream ids verified
+  # against LiteLLM's model_prices_and_context_window.json.
+  - model_name: claude-sonnet-4-6
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-sonnet-5
+    litellm_params:
+      model: anthropic/claude-sonnet-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-4-7
+    litellm_params:
+      model: anthropic/claude-opus-4-7
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-4-7-20260416
+    litellm_params:
+      model: anthropic/claude-opus-4-7
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-opus-4-8
+    litellm_params:
+      model: anthropic/claude-opus-4-8
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: claude-fable-5
+    litellm_params:
+      model: anthropic/claude-fable-5
+      api_key: os.environ/ANTHROPIC_API_KEY
 
   # OpenAI
   - model_name: gpt-5.2


### PR DESCRIPTION
## What

Round 2 of the All-Models table (contract `codex/model-table-contract.md` §5, decisions locked with real-data screenshots reviewed pre-merge):

- **Modes column** (reverses round 1's exclusion): per-model permission modes from `controls.mode.values`, rendered as quiet pills — capped at 3 + `+N` overflow, full list on hover — so the table stays inside its container.
- **Family-key enrichment join**: gateway ids now bridge to catalog metadata via `normalize_model_family` (strips `us./global.anthropic.` prefixes, `[1m]`, bedrock `-vN:M`, trailing dates; exact-id first; ambiguity prefers non-`[1m]` most-specific). Round-1 finding was zero overlap; with the join **plus** current-generation Anthropic entries added to `server/litellm/config.yaml` (sonnet-4-6, sonnet-5, opus-4-7, opus-4-8, fable-5 — every upstream id verified against LiteLLM's model table), **5 gateway rows now enrich, live-verified** including a real completion through an isolated proxy.
- **Description subtitles** (id moves to hover title) and **Status column dropped** until non-active statuses exist in real data.

## Verification

- cargo workspace green (join unit tests use the real catalog/config id sets); anyharness SDK regen no-drift
- product-ui 116 tests; desktop tsc + touched suites (35 tests); mobile typecheck; repo-shape; catalog validator
- Live proxy verify: 20 models served, 5 family-bridged, `claude-sonnet-4-6` completion → "Ok" (isolated compose project, torn down)
- Real-data screenshots re-rendered from this worktree and approved pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)