### PR TITLE
feat(anyharness): Bedrock models in the agent gateway + enrichment fixes

### DIFF
--- a/.github/workflows/_deploy-litellm.yml
+++ b/.github/workflows/_deploy-litellm.yml
@@ -6,12 +6,15 @@
 #   - The ECS service + an initial task definition already registered
 #     (this workflow re-renders the latest task definition; it does not
 #     create the service).
+#   - For Bedrock access: the ECS task role must have the attached policy
+#     arn:aws:iam::157466816238:policy/proliferate-gateway-bedrock-invoke.
 #
 # Required GitHub environment configuration:
 #   vars:    AWS_DEPLOY_ROLE_ARN, ECS_CLUSTER, ECS_LITELLM_SERVICE,
 #            ECS_LITELLM_CONTAINER_NAME (default: litellm),
 #            ECR_LITELLM_REPOSITORY (default: proliferate-litellm),
-#            LITELLM_DEPLOY_ENABLED (set "true" once the RDS + ECS service exist)
+#            LITELLM_DEPLOY_ENABLED (set "true" once the RDS + ECS service exist),
+#            AWS_BEDROCK_REGION (default: us-east-1)
 #   secrets: LITELLM_DATABASE_URL, LITELLM_MASTER_KEY,
 #            AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY,
 #            AGENT_GATEWAY_MANAGED_OPENAI_API_KEY,
@@ -159,7 +162,10 @@ jobs:
             --type SecureString --value "$AGENT_GATEWAY_MANAGED_XAI_API_KEY" --overwrite >/dev/null
 
           jq -n \
-            '[]' > env-updates.json
+            --arg region "${AWS_BEDROCK_REGION:-us-east-1}" \
+            '[
+              {"name":"AWS_BEDROCK_REGION","value":$region}
+            ]' > env-updates.json
 
           jq -n \
             --arg prefix "$parameter_prefix" \
@@ -183,8 +189,7 @@ jobs:
                 | ["DATABASE_URL", "LITELLM_MASTER_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"] as $secret_names
                 | ($current | map(select(
                     .name as $name
-                    | ($updated_names | index($name) | not)
-                    and ($secret_names | index($name) | not)
+                    | (($updated_names + $secret_names) | index($name) | not)
                   ))) + $updates[0];
 
               def merge_secrets($updates):

--- a/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
@@ -75,11 +75,16 @@ pub(crate) fn map_model_status(status: DomainModelCatalogStatus) -> ModelCatalog
 }
 
 /// The effort control joined from a catalog model, if it declares one.
+/// Falls back to `reasoning_effort` for codex models.
 pub(crate) fn model_effort(model: &AgentCatalogModel) -> Option<ModelEffort> {
-    model.controls.get("effort").map(|control| ModelEffort {
-        values: control.values.clone(),
-        default: control.observed_value.clone(),
-    })
+    model
+        .controls
+        .get("effort")
+        .or_else(|| model.controls.get("reasoning_effort"))
+        .map(|control| ModelEffort {
+            values: control.values.clone(),
+            default: control.observed_value.clone(),
+        })
 }
 
 /// The permission/agent modes joined from a catalog model (`controls.mode`), if
@@ -457,5 +462,56 @@ mod tests {
         assert!(resolve_catalog_match("claude-sonnet-4-5-20250929", &models).is_none());
         assert!(resolve_catalog_match("claude-haiku-4-5", &models).is_none());
         assert!(resolve_catalog_match("claude-opus-4-6-20260205", &models).is_none());
+    }
+
+    #[test]
+    fn codex_model_with_reasoning_effort_enriches_effort() {
+        // Codex models use "reasoning_effort" key — verify the fallback works.
+        let mut controls = BTreeMap::new();
+        controls.insert(
+            "reasoning_effort".to_string(),
+            AgentCatalogModelControl {
+                values: vec![
+                    "low".to_string(),
+                    "medium".to_string(),
+                    "high".to_string(),
+                    "xhigh".to_string(),
+                ],
+                default: None,
+                observed_value: Some("medium".to_string()),
+            },
+        );
+        let model = AgentCatalogModel {
+            id: "codex-model".to_string(),
+            display_name: "Codex Model".to_string(),
+            description: None,
+            aliases: vec![],
+            family: None,
+            availability: AgentCatalogAvailability {
+                any_of: vec!["codex-api".to_string()],
+            },
+            default_visible: true,
+            controls,
+            status: DomainModelCatalogStatus::Active,
+            provenance: None,
+        };
+
+        let effort = model_effort(&model).expect("effort should be present");
+        assert_eq!(effort.values, vec!["low", "medium", "high", "xhigh"]);
+        assert_eq!(effort.default.as_deref(), Some("medium"));
+
+        // Also test enrichment via enrich_model
+        let entry = enrich_model("codex-model".to_string(), Some(&model));
+        assert!(entry.effort.is_some());
+        assert_eq!(entry.effort.unwrap().values, vec!["low", "medium", "high", "xhigh"]);
+    }
+
+    #[test]
+    fn claude_model_with_effort_still_works() {
+        // Claude models use "effort" key — verify it still works.
+        let model = catalog_model("claude-sonnet-4-5");
+        let effort = model_effort(&model).expect("effort should be present");
+        assert_eq!(effort.values, vec!["low", "medium", "high"]);
+        assert_eq!(effort.default.as_deref(), Some("medium"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
@@ -40,7 +40,25 @@ pub enum GatewayModelSource {
 pub fn provider_for_model(model_id: &str) -> Option<&'static str> {
     if model_id.starts_with("claude-") {
         Some("anthropic")
-    } else if model_id.starts_with("gpt-") || model_id.starts_with('o') {
+    } else if model_id.starts_with("anthropic.")
+        || model_id.starts_with("us.anthropic.")
+        || model_id.starts_with("global.anthropic.")
+        || model_id.starts_with("eu.anthropic.")
+        || model_id.starts_with("apac.anthropic.")
+    {
+        // Bedrock-style anthropic ids: us.anthropic.claude-sonnet-4-6,
+        // global.anthropic.claude-fable-5, us.anthropic.claude-haiku-4-5-...-v1:0
+        Some("anthropic")
+    } else if model_id.starts_with("openai.") {
+        // Bedrock-style openai ids: openai.gpt-oss-*
+        Some("openai")
+    } else if model_id.starts_with("gpt-") {
+        Some("openai")
+    } else if model_id.len() >= 2
+        && model_id.as_bytes()[0] == b'o'
+        && model_id.as_bytes()[1].is_ascii_digit()
+    {
+        // OpenAI o-series: o1, o3, o4-mini, etc. (but NOT opus/opus[1m])
         Some("openai")
     } else if model_id.starts_with("grok-") {
         Some("xai")
@@ -340,8 +358,40 @@ mod tests {
         assert!(!model_matches_provider("anthropic", "gpt-5.5"));
         assert!(model_matches_provider("openai", "gpt-5.5"));
         assert!(model_matches_provider("openai", "o3"));
+        assert!(model_matches_provider("openai", "o3-mini"));
+        assert!(model_matches_provider("openai", "o4-mini"));
+        assert!(model_matches_provider("openai", "openai.gpt-oss-120b-1:0"));
         assert!(model_matches_provider("xai", "grok-4"));
         assert!(!model_matches_provider("unknown", "claude-sonnet-4-5"));
+        // CLI selectors like opus/opus[1m] should NOT match openai
+        assert!(!model_matches_provider("openai", "opus"));
+        assert!(!model_matches_provider("openai", "opus[1m]"));
+        // Also verify they return None (no provider)
+        assert_eq!(provider_for_model("opus"), None);
+        assert_eq!(provider_for_model("opus[1m]"), None);
+        assert_eq!(provider_for_model("claude-sonnet-4-6"), Some("anthropic"));
+        // Bedrock-style anthropic ids (region-prefixed and bare) map to anthropic
+        // so filter_by_providers keeps them in claude's gateway model plan.
+        assert_eq!(
+            provider_for_model("us.anthropic.claude-sonnet-4-6"),
+            Some("anthropic")
+        );
+        assert_eq!(
+            provider_for_model("global.anthropic.claude-fable-5"),
+            Some("anthropic")
+        );
+        assert_eq!(
+            provider_for_model("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+            Some("anthropic")
+        );
+        assert_eq!(
+            provider_for_model("anthropic.claude-sonnet-4-6"),
+            Some("anthropic")
+        );
+        assert!(model_matches_provider(
+            "anthropic",
+            "us.anthropic.claude-sonnet-4-6"
+        ));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
@@ -103,12 +103,14 @@ impl SessionService {
                         provider: gateway_resolver::provider_for_model(&model.id)
                             .map(str::to_string),
                         status: Some(model.status),
-                        effort: model.controls.get("effort").map(|control| {
-                            ResolvedModelEffort {
+                        effort: model
+                            .controls
+                            .get("effort")
+                            .or_else(|| model.controls.get("reasoning_effort"))
+                            .map(|control| ResolvedModelEffort {
                                 values: control.values.clone(),
                                 default: control.observed_value.clone(),
-                            }
-                        }),
+                            }),
                         fast_mode: model.controls.contains_key("fast_mode"),
                         modes: model
                             .controls

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
+      AWS_BEDROCK_REGION: ${AWS_BEDROCK_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${GATEWAY_AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${GATEWAY_AWS_SECRET_ACCESS_KEY:-}
     volumes:
       - ./litellm/config.yaml:/app/config.yaml:ro
     command: ["--config", "/app/config.yaml", "--port", "4000"]

--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -123,5 +123,57 @@ model_list:
       model: xai/grok-3-mini-latest
       api_key: os.environ/XAI_API_KEY
 
+  # AWS Bedrock. Credentials come from the AWS default credential chain:
+  # deployed (prod/staging): the ECS task role with attached policy
+  # arn:aws:iam::157466816238:policy/proliferate-gateway-bedrock-invoke;
+  # local dev: GATEWAY_AWS_ACCESS_KEY_ID + GATEWAY_AWS_SECRET_ACCESS_KEY
+  # environment variables (optional; stack boots without them). Model names
+  # are the REAL inference-profile IDs so the family-key join enriches rows
+  # and Bedrock-pinned harness IDs resolve. LiteLLM's bedrock provider
+  # accepts pass-through for cross-region inference profiles (us.*, eu.*,
+  # global.*) — these IDs are verified to exist in the LiteLLM manifest.
+  #
+  # Anthropic on Bedrock (us. cross-region profiles):
+  - model_name: us.anthropic.claude-sonnet-4-6
+    litellm_params:
+      model: bedrock/us.anthropic.claude-sonnet-4-6
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: us.anthropic.claude-sonnet-5
+    litellm_params:
+      model: bedrock/us.anthropic.claude-sonnet-5
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: us.anthropic.claude-opus-4-7
+    litellm_params:
+      model: bedrock/us.anthropic.claude-opus-4-7
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: us.anthropic.claude-opus-4-8
+    litellm_params:
+      model: bedrock/us.anthropic.claude-opus-4-8
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: us.anthropic.claude-fable-5
+    litellm_params:
+      model: bedrock/us.anthropic.claude-fable-5
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: us.anthropic.claude-haiku-4-5-20251001-v1:0
+    litellm_params:
+      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  #
+  # Anthropic on Bedrock (global. cross-region profiles):
+  - model_name: global.anthropic.claude-fable-5
+    litellm_params:
+      model: bedrock/global.anthropic.claude-fable-5
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  #
+  # OpenAI open-weight on Bedrock:
+  - model_name: openai.gpt-oss-120b-1:0
+    litellm_params:
+      model: bedrock/openai.gpt-oss-120b-1:0
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+  - model_name: openai.gpt-oss-20b-1:0
+    litellm_params:
+      model: bedrock/openai.gpt-oss-20b-1:0
+      aws_region_name: os.environ/AWS_BEDROCK_REGION
+
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
## What

Three things, one arc (approved architecture: ECS-task-role creds, real inference-profile ids):

### 1. Bedrock in the LiteLLM gateway (`server/litellm/config.yaml`)
9 new entries: the current Anthropic line as `us.` cross-region inference profiles (sonnet-4-6, sonnet-5, opus-4-7, opus-4-8, fable-5, haiku-4-5) + `global.anthropic.claude-fable-5` + OpenAI open-weight `openai.gpt-oss-120b/20b`. `model_name` = the REAL Bedrock profile id so the #926 family-key join enriches these rows and Bedrock-pinned harness ids resolve. Every id verified against LiteLLM's pricing manifest AND against the AWS account's actual inference profiles.

**Credentials:** AWS default chain — deployed: ECS task role with invoke-only policy `proliferate-gateway-bedrock-invoke` (created; attach when the litellm ECS service is created — `LITELLM_DEPLOY_ENABLED` is still unset everywhere); local: namespaced `GATEWAY_AWS_*` env vars (dedicated IAM user `proliferate-litellm-gateway-local`), empty defaults keep pdev booting without them.

**Live-verified** on an isolated compose stack: /v1/models served all 29 entries; real completions succeeded via Bedrock for `us.anthropic.claude-haiku-4-5-20251001-v1:0` ("Ok") and `openai.gpt-oss-20b-1:0`.

### 2. Provider matcher fixes (`gateway_resolver.rs`)
- `opus` / `opus[1m]` no longer misattributed to **openai** (the o-series arm was `starts_with('o')`; now `o`+digit). This was visibly wrong in the All-Models table.
- New arms: `openai.` (Bedrock gpt-oss) → openai; `{us,global,eu,apac,}anthropic.` → anthropic. Without the anthropic arms, `filter_by_providers` would silently DROP the new Bedrock ids from claude's gateway plan (`gatewayPolicy.providers = ["anthropic"]`).

### 3. Codex effort enrichment (`launch_options.rs`, `agent_gateway_catalog.rs`)
Codex stores effort under `reasoning_effort`; both enrichment sites only read `effort`, so codex rows never showed Thinking chips. Both now fall back. (Codex's missing Modes column was a stale pre-#926 snapshot, not code — refresh fixes it.)

## Gates
cargo test workspace green (one pre-existing flaky tempfile test, passes on rerun) · repo-shape 7/7 · agent-catalog validator · `docker compose config` · workflow YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)