### PR TITLE
feat(desktop): offline connectivity detection, network error classification, reconnect backoff

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/events.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/events.rs
@@ -759,6 +759,11 @@ pub enum ErrorEventDetails {
         unit: String,
         fallback_model_id: String,
     },
+    #[serde(rename_all = "camelCase")]
+    NetworkConnection {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-lib/src/acp/provider_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/provider_errors.rs
@@ -2,8 +2,30 @@ use anyharness_contract::v1::ErrorEventDetails;
 
 const ANTHROPIC_PROVIDER: &str = "anthropic";
 pub const PROVIDER_RATE_LIMIT_CODE: &str = "provider_rate_limit";
+pub const NETWORK_CONNECTION_CODE: &str = "network_connection";
 pub const OPUS_4_7_MODEL_ID: &str = "claude-opus-4-7";
 pub const OPUS_4_6_FALLBACK_MODEL_ID: &str = "claude-opus-4-6";
+
+/// Substrings (matched case-insensitively) that indicate a network/connectivity
+/// failure between the harness and the model provider, rather than an
+/// application-level error such as a rate limit or invalid request.
+const NETWORK_CONNECTION_MARKERS: &[&str] = &[
+    "connection closed before",
+    "connection reset",
+    "connection refused",
+    "network is unreachable",
+    "fetch failed",
+    "failed to fetch",
+    "getaddrinfo",
+    "enotfound",
+    "econnreset",
+    "econnrefused",
+    "etimedout",
+    "dns lookup",
+    "dns resolution",
+    "socket hang up",
+    "no internet",
+];
 
 pub fn classify_provider_rate_limit_error(message: &str) -> Option<ErrorEventDetails> {
     let lower = message.to_ascii_lowercase();
@@ -23,6 +45,25 @@ pub fn classify_provider_rate_limit_error(message: &str) -> Option<ErrorEventDet
         limit,
         unit: "input_tokens_per_minute".to_string(),
         fallback_model_id: OPUS_4_6_FALLBACK_MODEL_ID.to_string(),
+    })
+}
+
+/// Classifies an error message as a network/connectivity failure.
+///
+/// This must only be consulted after [`classify_provider_rate_limit_error`]
+/// returns `None`, so that provider rate-limit errors keep their richer
+/// classification even if their message happens to contain a network marker.
+pub fn classify_network_connection_error(message: &str) -> Option<ErrorEventDetails> {
+    let lower = message.to_ascii_lowercase();
+    if !NETWORK_CONNECTION_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+    {
+        return None;
+    }
+
+    Some(ErrorEventDetails::NetworkConnection {
+        provider: extract_claude_model_id(message).map(|_| ANTHROPIC_PROVIDER.to_string()),
     })
 }
 
@@ -86,5 +127,64 @@ mod tests {
             "This request would exceed your organization's rate limit of 30,000 input tokens per minute for claude-sonnet-4-6."
         )
         .is_none());
+    }
+
+    #[test]
+    fn classifies_network_connection_failures() {
+        for message in [
+            "Connection closed before message completed",
+            "read ECONNRESET",
+            "connect ECONNREFUSED 127.0.0.1:443",
+            "connection reset by peer",
+            "connection refused",
+            "network is unreachable",
+            "TypeError: fetch failed",
+            "TypeError: Failed to fetch",
+            "getaddrinfo ENOTFOUND api.anthropic.com",
+            "request to https://api.anthropic.com failed, reason: ENOTFOUND",
+            "connect ETIMEDOUT",
+            "getaddrinfo EAI_AGAIN api.anthropic.com (DNS lookup failed)",
+            "socket hang up",
+            "No internet connection",
+        ] {
+            assert!(
+                matches!(
+                    classify_network_connection_error(message),
+                    Some(ErrorEventDetails::NetworkConnection { .. })
+                ),
+                "expected network connection details for {message:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn network_classifier_populates_provider_when_model_present() {
+        let Some(ErrorEventDetails::NetworkConnection { provider }) =
+            classify_network_connection_error(
+                "fetch failed while streaming from claude-opus-4-7",
+            )
+        else {
+            panic!("expected network connection details");
+        };
+        assert_eq!(provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn network_classifier_ignores_non_network_errors() {
+        assert!(classify_network_connection_error("invalid request").is_none());
+        assert!(classify_network_connection_error(
+            "This request would exceed your organization's rate limit of 30,000 input tokens per minute for claude-opus-4-7."
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn network_classifier_rejects_false_positives() {
+        // "dns" as a bare substring should NOT match (e.g. CDN URLs, library names)
+        assert!(classify_network_connection_error("failed to load from cdns.cloudflare.com").is_none());
+        assert!(classify_network_connection_error("adns library error").is_none());
+        // Server-initiated stream close is NOT a client-side network failure
+        assert!(classify_network_connection_error("connection closed by server after max_duration").is_none());
+        assert!(classify_network_connection_error("SSE connection closed due to load shedding").is_none());
     }
 }

--- a/anyharness/crates/anyharness-lib/src/acp/provider_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/acp/provider_errors.rs
@@ -9,6 +9,11 @@ pub const OPUS_4_6_FALLBACK_MODEL_ID: &str = "claude-opus-4-6";
 /// Substrings (matched case-insensitively) that indicate a network/connectivity
 /// failure between the harness and the model provider, rather than an
 /// application-level error such as a rate limit or invalid request.
+///
+/// NOTE: "connection closed before" and "connection reset" cannot reliably
+/// distinguish a client-side network loss from a server-side stream termination.
+/// Presentation copy consuming this classification must therefore stay
+/// direction-neutral (see session-error-presentation.ts).
 const NETWORK_CONNECTION_MARKERS: &[&str] = &[
     "connection closed before",
     "connection reset",

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
@@ -2,7 +2,10 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::{SessionExecutionPhase, StopReason};
 use tokio::sync::mpsc;
 
-use crate::acp::provider_errors::{classify_provider_rate_limit_error, PROVIDER_RATE_LIMIT_CODE};
+use crate::acp::provider_errors::{
+    classify_network_connection_error, classify_provider_rate_limit_error,
+    NETWORK_CONNECTION_CODE, PROVIDER_RATE_LIMIT_CODE,
+};
 use crate::domains::sessions::extensions::SessionTurnOutcome;
 use crate::live::sessions::actor::config::queue::apply_pending_config_changes_if_idle;
 use crate::live::sessions::actor::state::SessionActor;
@@ -203,10 +206,16 @@ impl SessionActor {
                     "session.actor.prompt.conn_failed"
                 );
                 let error_message = e.to_string();
-                let error_details = classify_provider_rate_limit_error(&error_message);
-                let error_code = error_details
-                    .as_ref()
-                    .map(|_| PROVIDER_RATE_LIMIT_CODE.to_string());
+                let (error_details, error_code) =
+                    match classify_provider_rate_limit_error(&error_message) {
+                        Some(details) => (Some(details), Some(PROVIDER_RATE_LIMIT_CODE.to_string())),
+                        None => match classify_network_connection_error(&error_message) {
+                            Some(details) => {
+                                (Some(details), Some(NETWORK_CONNECTION_CODE.to_string()))
+                            }
+                            None => (None, None),
+                        },
+                    };
                 let mut sink = self.event_sink.lock().await;
                 sink.error_with_details(error_message, error_code, error_details.clone());
                 let last_event_seq = sink.debug_snapshot().next_seq - 1;

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -8360,6 +8360,26 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "network_connection"
+                ]
+              },
+              "provider": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         ]
       },

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -2345,6 +2345,10 @@ export interface components {
             provider: string;
             providerModel: string;
             unit: string;
+        } | {
+            /** @enum {string} */
+            kind: "network_connection";
+            provider?: string | null;
         };
         ExportReplayRecordingRequest: {
             name?: string | null;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { UpdateRestartDialog } from "@/components/feedback/UpdateRestartDialog"
 import { UpdateToastPresenter } from "@/components/feedback/UpdateToastPresenter"
 import { Toaster } from "@proliferate/ui/kit/Sonner"
 import { MacWindowControlsSafeArea } from "@/components/app/chrome/MacWindowControlsSafeArea"
+import { useConnectivityListeners } from "@/hooks/app/lifecycle/use-connectivity-listeners"
 import { useDebugSessionActivity } from "@/hooks/app/lifecycle/use-debug-session-activity"
 import { useDesktopWorkerEnrollment } from "@/hooks/cloud/lifecycle/use-desktop-worker-enrollment"
 import { useDevDesktopHandoff } from "@/hooks/app/lifecycle/use-dev-desktop-handoff"
@@ -191,6 +192,7 @@ function AppRuntime() {
   recordBootDiagnosticOnce("app_runtime.render.before.use_export_running_agent_count")
   useExportRunningAgentCount()
   recordBootDiagnosticOnce("app_runtime.render.after.use_export_running_agent_count")
+  useConnectivityListeners()
   useUpdateRestartWatcher()
   useDebugSessionActivity()
   // Mounted here (not in AuthenticatedAppHost, which unmounts on sign-out) so

--- a/apps/desktop/src/components/app/OfflineIndicator.tsx
+++ b/apps/desktop/src/components/app/OfflineIndicator.tsx
@@ -1,0 +1,24 @@
+import { WifiOff } from "lucide-react";
+import { useConnectivityStore } from "@/stores/infra/connectivity-store";
+
+/**
+ * Persistent banner when the app is offline. Auto-hides on reconnect.
+ * Placed at the top of the workspace shell so it is always visible.
+ */
+export function OfflineIndicator() {
+  const isOnline = useConnectivityStore((state) => state.isOnline);
+
+  if (isOnline) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-center gap-2 border-b border-warning/40 bg-warning px-3 py-1.5 text-sm font-medium text-warning-foreground"
+    >
+      <WifiOff className="size-3.5 shrink-0" aria-hidden="true" />
+      No internet connection — local work is safe; agents need a connection.
+    </div>
+  );
+}

--- a/apps/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
@@ -7,6 +7,7 @@ import { presentSessionError } from "@proliferate/product-domain/chats/transcrip
 import { useToastStore } from "@/stores/toast/toast-store";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
 import { getSessionRecord } from "@/stores/sessions/session-records";
+import { useConnectivityStore } from "@/stores/infra/connectivity-store";
 
 export function SessionErrorItem({
   item,
@@ -22,6 +23,7 @@ export function SessionErrorItem({
   const [isApplyingFallback, setIsApplyingFallback] = useState(false);
   const [detailsExpanded, setDetailsExpanded] = useState(false);
 
+  const isOnline = useConnectivityStore((state) => state.isOnline);
   const isNetworkError = (item.details as { kind?: string } | null)?.kind === "network_connection";
 
   const handleRetryNetworkError = () => {
@@ -102,6 +104,8 @@ export function SessionErrorItem({
               type="button"
               variant="secondary"
               size="sm"
+              disabled={!isOnline}
+              title={!isOnline ? "You are offline" : undefined}
               onClick={handleRetryNetworkError}
               className="px-2.5 text-sm"
             >

--- a/apps/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx
@@ -5,6 +5,8 @@ import { CircleAlert, CircleQuestion, RefreshCw } from "@proliferate/ui/icons";
 import { useSessionModelFallbackAction } from "@/hooks/sessions/workflows/use-session-model-fallback-action";
 import { presentSessionError } from "@proliferate/product-domain/chats/transcript/session-error-presentation";
 import { useToastStore } from "@/stores/toast/toast-store";
+import { useChatInputStore } from "@/stores/chat/chat-input-store";
+import { getSessionRecord } from "@/stores/sessions/session-records";
 
 export function SessionErrorItem({
   item,
@@ -19,6 +21,50 @@ export function SessionErrorItem({
   const showToast = useToastStore((state) => state.show);
   const [isApplyingFallback, setIsApplyingFallback] = useState(false);
   const [detailsExpanded, setDetailsExpanded] = useState(false);
+
+  const isNetworkError = (item.details as { kind?: string } | null)?.kind === "network_connection";
+
+  const handleRetryNetworkError = () => {
+    if (!sessionId) {
+      return;
+    }
+    const record = getSessionRecord(sessionId);
+    if (!record) {
+      return;
+    }
+    // Find the last user message in the transcript for this turn.
+    const turnId = item.turnId;
+    const turn = turnId ? record.transcript.turnsById[turnId] : null;
+    let lastUserText: string | null = null;
+    if (turn) {
+      for (const itemId of turn.itemOrder) {
+        const transcriptItem = record.transcript.itemsById[itemId];
+        if (transcriptItem?.kind === "user_message") {
+          lastUserText = transcriptItem.text;
+        }
+      }
+    }
+    // If we couldn't find it in the turn, scan all items for the last user message.
+    if (!lastUserText) {
+      const allItems = Object.values(record.transcript.itemsById);
+      for (const ti of allItems) {
+        if (ti.kind === "user_message" && ti.text) {
+          lastUserText = ti.text;
+        }
+      }
+    }
+    if (!lastUserText) {
+      showToast("Could not find the original prompt to retry.", "info");
+      return;
+    }
+    const workspaceId = record.workspaceId;
+    if (!workspaceId) {
+      return;
+    }
+    // Pre-fill the composer and focus it so the user can re-send with one click.
+    useChatInputStore.getState().setDraftText(workspaceId, lastUserText);
+    useChatInputStore.getState().requestFocus();
+  };
 
   const handleFallback = () => {
     if (!fallback || !sessionId || isApplyingFallback) {
@@ -49,8 +95,20 @@ export function SessionErrorItem({
           <div className="mt-0.5 text-muted-foreground">{presentation.description}</div>
         </div>
       </div>
-      {(fallback && sessionId) || presentation.technicalDetail ? (
+      {(fallback && sessionId) || isNetworkError || presentation.technicalDetail ? (
         <div className="mt-2 flex flex-wrap items-center gap-2 pl-6">
+          {isNetworkError && sessionId && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleRetryNetworkError}
+              className="px-2.5 text-sm"
+            >
+              <RefreshCw className="size-3.5" />
+              Retry
+            </Button>
+          )}
           {fallback && sessionId && (
             <Button
               type="button"

--- a/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -21,6 +21,7 @@ import {
   WorkspaceSidebarHeaderControls,
 } from "@/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls";
 import { DebugProfiler } from "@/components/diagnostics/DebugProfiler";
+import { OfflineIndicator } from "@/components/app/OfflineIndicator";
 import { useMainScreenState } from "@/hooks/main/facade/use-main-screen-state";
 import { useMainScreenShortcuts } from "@/hooks/main/lifecycle/use-main-screen-shortcuts";
 import { useMainScreenActions } from "@/hooks/main/workflows/use-main-screen-actions";
@@ -290,6 +291,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                     </DebugProfiler>
                   </div>
 
+                  <OfflineIndicator />
                   <div className="flex min-h-0 flex-1 overflow-hidden bg-sidebar-background">
                     {hasLaunchIntentOnlyShell ? (
                       <DebugProfiler id="workspace-content-frame">

--- a/apps/desktop/src/hooks/app/lifecycle/use-connectivity-listeners.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-connectivity-listeners.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useConnectivityStore } from "@/stores/infra/connectivity-store";
+import { flushOfflineSessionReconnects } from "@/lib/workflows/sessions/session-reconnect-state";
+
+/**
+ * Wires up window online/offline listeners to the connectivity store.
+ * Also triggers pending session reconnects when the app comes back online.
+ * Must be mounted once at the app root.
+ */
+export function useConnectivityListeners(): void {
+  useEffect(() => {
+    const setOnline = useConnectivityStore.getState().setOnline;
+
+    const handleOnline = () => {
+      setOnline(true);
+      // Immediately fire any parked reconnect runners.
+      flushOfflineSessionReconnects();
+    };
+    const handleOffline = () => {
+      setOnline(false);
+    };
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+}

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
@@ -4,6 +4,7 @@ import {
   clearSessionStreamHandle,
   setSessionStreamHandle,
 } from "@/lib/access/anyharness/session-stream-handles";
+import { resetSessionReconnectBackoff } from "@/lib/workflows/sessions/session-reconnect-state";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
   finishOrCancelMeasurementOperation,
@@ -187,6 +188,7 @@ export async function openSessionStreamConnection({
       useSessionDirectoryStore.getState().patchEntry(sessionId, {
         streamConnectionState: "open",
       });
+      resetSessionReconnectBackoff(sessionId);
       useSessionIngestStore.getState().markCurrentIfContiguous(
         sessionId,
         getSessionRecord(sessionId)?.transcript.lastSeq ?? 0,

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-reconnect.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-reconnect.ts
@@ -1,7 +1,10 @@
 import {
   clearSessionReconnectTimer,
+  nextSessionReconnectDelayMs,
+  registerOfflineSessionReconnect,
   scheduleSessionReconnectTimer,
 } from "@/lib/workflows/sessions/session-reconnect-state";
+import { isConnectivityOnline } from "@/stores/infra/connectivity-store";
 import { shouldReconnectStream } from "@/hooks/sessions/lifecycle/session-runtime-helpers";
 import type {
   RefreshSessionSlotMeta,
@@ -37,7 +40,7 @@ export function scheduleSessionStreamReconnect({
     return;
   }
 
-  scheduleSessionReconnectTimer(sessionId, () => {
+  const runner = () => {
     if (!isStillCurrent() || !shouldReconnectStream(sessionId)) {
       return;
     }
@@ -53,5 +56,15 @@ export function scheduleSessionStreamReconnect({
           });
         }
       });
-  }, delayMs);
+  };
+
+  // If offline, park the runner instead of spinning a timer — it will fire
+  // once the online transition triggers flushOfflineSessionReconnects.
+  if (!isConnectivityOnline()) {
+    registerOfflineSessionReconnect(sessionId, runner);
+    return;
+  }
+
+  const backoffDelay = nextSessionReconnectDelayMs(sessionId, delayMs);
+  scheduleSessionReconnectTimer(sessionId, runner, backoffDelay);
 }

--- a/apps/desktop/src/lib/workflows/sessions/session-reconnect-state.ts
+++ b/apps/desktop/src/lib/workflows/sessions/session-reconnect-state.ts
@@ -1,5 +1,17 @@
 const sessionReconnectTimers = new Map<string, number>();
 
+// Per-session count of consecutive reconnect attempts since the last successful
+// open. Drives exponential backoff so a persistently-failing session does not
+// hammer the runtime every 350ms forever.
+const sessionReconnectAttempts = new Map<string, number>();
+
+// Reconnect runners parked while the app is offline. We do not spin timers when
+// navigator reports offline; instead we stash the runner and fire it the moment
+// connectivity is restored (see flushOfflineSessionReconnects).
+const offlineSessionReconnects = new Map<string, () => void>();
+
+const RECONNECT_BACKOFF_CAP_MS = 15_000;
+
 export function clearSessionReconnectTimer(sessionId: string): void {
   const timerId = sessionReconnectTimers.get(sessionId);
   if (timerId !== undefined) {
@@ -22,4 +34,49 @@ export function scheduleSessionReconnectTimer(
 
   sessionReconnectTimers.set(sessionId, timerId);
   return timerId;
+}
+
+/**
+ * Returns the delay for the next reconnect attempt using exponential backoff
+ * (baseDelayMs, doubling per attempt, capped at 15s) and records that an
+ * attempt was scheduled. Reset with resetSessionReconnectBackoff on a
+ * successful open.
+ */
+export function nextSessionReconnectDelayMs(
+  sessionId: string,
+  baseDelayMs: number,
+): number {
+  const attempt = sessionReconnectAttempts.get(sessionId) ?? 0;
+  const delay = Math.min(baseDelayMs * 2 ** attempt, RECONNECT_BACKOFF_CAP_MS);
+  sessionReconnectAttempts.set(sessionId, attempt + 1);
+  return delay;
+}
+
+export function resetSessionReconnectBackoff(sessionId: string): void {
+  sessionReconnectAttempts.delete(sessionId);
+  offlineSessionReconnects.delete(sessionId);
+}
+
+/**
+ * Park a reconnect runner while offline. Registering a runner does not schedule
+ * a timer; flushOfflineSessionReconnects runs it once connectivity returns.
+ */
+export function registerOfflineSessionReconnect(
+  sessionId: string,
+  runner: () => void,
+): void {
+  clearSessionReconnectTimer(sessionId);
+  offlineSessionReconnects.set(sessionId, runner);
+}
+
+/** Fire every parked reconnect runner (called on the offline -> online edge). */
+export function flushOfflineSessionReconnects(): void {
+  if (offlineSessionReconnects.size === 0) {
+    return;
+  }
+  const runners = Array.from(offlineSessionReconnects.values());
+  offlineSessionReconnects.clear();
+  for (const runner of runners) {
+    runner();
+  }
 }

--- a/apps/desktop/src/lib/workflows/sessions/session-reconnect-state.ts
+++ b/apps/desktop/src/lib/workflows/sessions/session-reconnect-state.ts
@@ -18,6 +18,9 @@ export function clearSessionReconnectTimer(sessionId: string): void {
     window.clearTimeout(timerId);
     sessionReconnectTimers.delete(sessionId);
   }
+  // Also remove any parked offline runner so it cannot fire on the next
+  // online flush after the session has been torn down.
+  offlineSessionReconnects.delete(sessionId);
 }
 
 export function scheduleSessionReconnectTimer(

--- a/apps/desktop/src/stores/infra/connectivity-store.ts
+++ b/apps/desktop/src/stores/infra/connectivity-store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+interface ConnectivityState {
+  /** Whether the renderer currently believes it has network connectivity. */
+  isOnline: boolean;
+  setOnline: (isOnline: boolean) => void;
+}
+
+function initialOnline(): boolean {
+  if (typeof navigator === "undefined") {
+    return true;
+  }
+  // navigator.onLine is best-effort (it only reflects link-layer connectivity),
+  // but it is the only synchronous signal available and is a good-enough gate
+  // for the offline indicator + reconnect pausing.
+  return navigator.onLine;
+}
+
+export const useConnectivityStore = create<ConnectivityState>((set) => ({
+  isOnline: initialOnline(),
+  setOnline: (isOnline) =>
+    set((state) => (state.isOnline === isOnline ? state : { isOnline })),
+}));
+
+/** Vanilla accessor for non-React modules (reconnect scheduler). */
+export function isConnectivityOnline(): boolean {
+  return useConnectivityStore.getState().isOnline;
+}

--- a/apps/packages/product-domain/src/chats/transcript/session-error-presentation.ts
+++ b/apps/packages/product-domain/src/chats/transcript/session-error-presentation.ts
@@ -12,6 +12,18 @@ const GENERIC_ERROR_DESCRIPTION = "The session stopped before it could continue.
 const MAX_DESCRIPTION_LENGTH = 180;
 
 export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
+  // Defensively feature-detect the "network_connection" kind string — the Rust
+  // contract variant may ship after this code, so we check by string value.
+  if ((item.details as { kind?: string } | null)?.kind === "network_connection") {
+    return {
+      title: "Connection lost",
+      description:
+        "Your message couldn't reach the model. Your work is saved — retry when you're back online.",
+      technicalDetail: normalizeTechnicalDetail(item.message),
+      fallbackModelLabel: null,
+    };
+  }
+
   if (item.details?.kind === "provider_rate_limit") {
     const provider = formatProviderLabel(item.details.provider);
     const model = formatModelLabel(item.details.providerModel);

--- a/apps/packages/product-domain/src/chats/transcript/session-error-presentation.ts
+++ b/apps/packages/product-domain/src/chats/transcript/session-error-presentation.ts
@@ -16,9 +16,9 @@ export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
   // contract variant may ship after this code, so we check by string value.
   if ((item.details as { kind?: string } | null)?.kind === "network_connection") {
     return {
-      title: "Connection lost",
+      title: "Connection interrupted",
       description:
-        "Your message couldn't reach the model. Your work is saved — retry when you're back online.",
+        "The connection to the model was lost. Your work is saved — retry to continue.",
       technicalDetail: normalizeTechnicalDetail(item.message),
       fallbackModelLabel: null,
     };


### PR DESCRIPTION
## What

Wifi loss on desktop currently produces an ambiguous mix of a generic "Chat stopped" transcript error and an infinite loading spinner. This PR gives the app an explicit connectivity concept at both layers.

**Runtime (Rust):**
- New `ErrorEventDetails::NetworkConnection { provider }` variant (serde kind `network_connection`)
- `classify_network_connection_error` matcher at the single turn-failure catch point (`finish.rs`); rate-limit classification keeps priority. Narrow markers (`dns lookup`/`dns resolution`, not bare `dns`) with negative tests against CDN-URL false positives
- SDK OpenAPI types regenerated

**Desktop:**
- Connectivity store from `navigator.onLine` + `online`/`offline` window events, mounted in `AppRuntime`
- Warning banner at top of workspace shell when offline ("local work is safe; agents need a connection"), auto-clears on reconnect
- Network errors render as "Connection lost" with a **Retry** button (pre-fills composer with the last prompt) instead of generic "Chat stopped"
- Session stream reconnect: fixed 350ms infinite loop → exponential backoff (350ms → 15s cap), fully parked while offline, immediate attempt on `online`

## Notes

- Resume needed no changes: turn events are durably persisted mid-stream, and `repair_unclosed_turns` + ACP `session/load` on `native_session_id` already recover cleanly. This PR only makes that safety visible.
- `navigator.onLine` won't catch captive portals / DNS-only failures — accepted v1 limitation.
- Network-failure marker list is best-effort (no real harness failure fixtures exist in-repo); unmatched messages fall back to today's generic error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)