### PR TITLE
feat(desktop): Codex-quality diff renderer — layered color-mix + airy typography

### DIFF
--- a/apps/desktop/src/components/content/ui/DiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/DiffViewer.tsx
@@ -24,7 +24,7 @@ interface DiffViewerProps {
 }
 
 const ROOT_CLASS =
-  "font-mono text-[length:var(--readable-code-font-size)] leading-[var(--readable-code-line-height)]";
+  "font-mono text-[length:var(--diffs-font-size)] leading-[var(--diffs-line-height)]";
 
 export function DiffViewer({
   patch,

--- a/apps/desktop/src/components/content/ui/FileChangeStats.tsx
+++ b/apps/desktop/src/components/content/ui/FileChangeStats.tsx
@@ -16,7 +16,7 @@ export function FileChangeStats({
   return (
     <span
       data-thread-find-skip="true"
-      className={`inline-flex shrink-0 items-baseline gap-1 tabular-nums tracking-tight ${className ?? ""}`}
+      className={`inline-flex shrink-0 items-baseline gap-1 tabular-nums tracking-tight [font-feature-settings:'cv01'_on,'cv02'_on] ${className ?? ""}`}
     >
       {additions > 0 && (
         <FileChangeStat sign="+" value={additions} className="text-git-green" />

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -9,17 +9,11 @@ import type {
 } from "@/lib/domain/files/diff-parser";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 
-const LINE_BG: Record<DiffLine["type"], string> = {
-  added: "bg-[var(--color-diff-added-bg)]",
-  removed: "bg-[var(--color-diff-deleted-bg)]",
-  context: "",
-};
-
-const LINE_MARKER: Record<DiffLine["type"], string> = {
-  added: "text-[color:var(--color-diff-added)]",
-  removed: "text-[color:var(--color-diff-deleted)]",
-  context: "text-muted-foreground/30",
-};
+function getLineType(type: DiffLine["type"]): string {
+  if (type === "added") return "change-addition";
+  if (type === "removed") return "change-deletion";
+  return "context";
+}
 
 function DiffLineRow({
   line,
@@ -32,18 +26,23 @@ function DiffLineRow({
   wrapLongLines: boolean;
   variant: "default" | "chat";
 }) {
+  const lineType = getLineType(line.type);
   const lineNumberClass =
     variant === "chat"
-      ? "inline-block min-w-[4ch] shrink-0 select-none pr-1.5 text-right text-[10px] text-muted-foreground/35"
-      : "inline-block w-6 shrink-0 select-none pr-1 text-right text-[10px] text-muted-foreground/30";
+      ? "diff-gutter-cell inline-block min-w-[4ch] shrink-0 select-none pr-1.5 text-right tabular-nums"
+      : "diff-gutter-cell inline-block w-6 shrink-0 select-none pr-1 text-right tabular-nums";
 
   return (
-    <div className={`flex min-w-max py-px ${LINE_BG[line.type]}`}>
-      <span className={lineNumberClass}>
+    <div
+      data-line-type={lineType}
+      className="flex min-w-max"
+    >
+      <span className={lineNumberClass} data-line-type={lineType}>
         {line.lineNum ?? ""}
       </span>
       <span
-        className={`inline-block w-4 shrink-0 select-none whitespace-pre text-center text-[11px] ${LINE_MARKER[line.type]}`}
+        className="diff-content-cell inline-block w-4 shrink-0 select-none whitespace-pre text-center"
+        data-line-type={lineType}
       >
         {line.marker}
       </span>
@@ -173,8 +172,8 @@ export function UnifiedDiffViewer({
   return (
     <AutoHideScrollArea
       className={className}
-      viewportClassName={`bg-[var(--codex-diffs-surface)] ${viewportClassName ?? ""}`}
-      contentClassName={`min-h-full bg-[var(--codex-diffs-surface)] ${
+      viewportClassName={`composer-diff-simple-line bg-[var(--codex-diffs-surface)] ${viewportClassName ?? ""}`}
+      contentClassName={`min-h-full bg-[var(--codex-diffs-surface)] font-[family:var(--diffs-font-family)] text-[length:var(--diffs-font-size)] leading-[var(--diffs-line-height)] text-[color:var(--diffs-fg)] ${
         wrapLongLines ? "" : "min-w-max"
       }`}
       allowHorizontal={!wrapLongLines}

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -314,8 +314,8 @@
   --color-diff-added: #00a240;
   --color-diff-deleted: #e02e2a;
   --diffs-font-family: var(--font-mono);
-  --diffs-font-size: 9px;
-  --diffs-line-height: calc(var(--diffs-font-size, 9px) * 1.8);
+  --diffs-font-size: 12px;
+  --diffs-line-height: calc(var(--diffs-font-size, 12px) * 1.8);
   --scratch-font-family: var(--font-sans);
   --scratch-code-font-family: var(--font-mono);
   --scratch-font-size: var(--text-chat, 10px);
@@ -340,10 +340,12 @@
   --diffs-bg-context-override: var(--codex-diffs-context-surface);
   --diffs-bg-separator-override: var(--codex-diffs-separator-surface);
   --diffs-bg-hover-override: var(--codex-diffs-hover-surface);
-  --diffs-bg-addition-override: color-mix(in srgb, var(--color-diff-main-surface) 86%, #00a240);
-  --diffs-bg-deletion-override: color-mix(in srgb, var(--color-diff-main-surface) 86%, #e02e2a);
-  --diffs-bg-addition-number-override: color-mix(in srgb, var(--color-diff-main-surface) 89%, #00a240);
-  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--color-diff-main-surface) 89%, #e02e2a);
+  --diffs-bg-addition-override: color-mix(in srgb, var(--color-diff-main-surface) 88%, #00a240);
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--color-diff-main-surface) 88%, #e02e2a);
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--color-diff-main-surface) 82%, #00a240);
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--color-diff-main-surface) 82%, #e02e2a);
+  --diffs-bg-addition-number-override: color-mix(in srgb, var(--color-diff-main-surface) 91%, #00a240);
+  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--color-diff-main-surface) 91%, #e02e2a);
   --color-diff-added-bg: var(--diffs-bg-addition-override);
   --color-diff-deleted-bg: var(--diffs-bg-deletion-override);
 
@@ -810,6 +812,8 @@ mark.codex-thread-find-active {
   --color-file-icon-red: hsl(0 0% 17%);
   --diffs-bg-addition-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-addition-color-override));
   --diffs-bg-deletion-override: color-mix(in srgb, var(--codex-diffs-surface) 84%, var(--diffs-deletion-color-override));
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--codex-diffs-surface) 78%, var(--diffs-addition-color-override));
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--codex-diffs-surface) 78%, var(--diffs-deletion-color-override));
   --color-diff-chat-turn-header-surface: var(--color-diff-surface);
   --color-diff-chat-inline-tool-header-surface: var(--color-diff-surface);
 }
@@ -879,6 +883,29 @@ mark.codex-thread-find-active {
 
 .composer-diff-simple-line [data-line-type="change-deletion"] {
   background-color: var(--diffs-bg-deletion-override);
+}
+
+.composer-diff-simple-line [data-line-type="change-addition"]:hover,
+.composer-diff-simple-line [data-line-type="change-addition"]:hover > .diff-gutter-cell {
+  background-color: var(--diffs-bg-addition-hover-override);
+}
+
+.composer-diff-simple-line [data-line-type="change-deletion"]:hover,
+.composer-diff-simple-line [data-line-type="change-deletion"]:hover > .diff-gutter-cell {
+  background-color: var(--diffs-bg-deletion-hover-override);
+}
+
+.composer-diff-simple-line .diff-gutter-cell[data-line-type="context"],
+.composer-diff-simple-line .diff-content-cell[data-line-type="context"] {
+  color: color-mix(in srgb, var(--diffs-fg) 30%, transparent);
+}
+
+.composer-diff-simple-line .diff-content-cell[data-line-type="change-addition"] {
+  color: var(--color-diff-added);
+}
+
+.composer-diff-simple-line .diff-content-cell[data-line-type="change-deletion"] {
+  color: var(--color-diff-deleted);
 }
 
 .composer-diff-simple-line [data-separator] {


### PR DESCRIPTION
Part 1/5 of the Changes-sidebar overhaul (Codex-parity review experience).

- Diff font 11px → 12px with 1.8× line-height (airy, uncramped)
- Layered color-mix backgrounds: body rows 88%, gutter 91%, hover 82% — subtle recessed gutter + hover tints instead of flat highlights, all derived from existing tokens
- UnifiedDiffViewer migrated from Tailwind color maps to the data-line-type + CSS pattern the other viewers already use
- tabular-nums + disambiguated digits on +/- stat chips

Stack: this PR → context-expanders → review-layout → hunk-actions → fullheight-layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)