### PR TITLE
feat(desktop): per-gap context expanders with gutter chevrons

### DIFF
--- a/apps/desktop/src/components/content/ui/DiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/DiffViewer.tsx
@@ -21,6 +21,12 @@ interface DiffViewerProps {
   overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
+  /**
+   * Full file content (new-side) split into lines. When provided, enables
+   * Codex-style per-gap context expansion. Without this, gap separators
+   * are still rendered but expansion is disabled.
+   */
+  fileLines?: string[];
 }
 
 const ROOT_CLASS =
@@ -40,6 +46,7 @@ export function DiffViewer({
   overscrollBehaviorX,
   overscrollBehaviorY,
   chainVerticalWheel,
+  fileLines,
 }: DiffViewerProps) {
   const { parsed, tokens } = useDiffHighlight(patch, filePath, operationId);
   const chatWrapLongLines = useChatDiffPreferencesStore((state) =>
@@ -62,6 +69,7 @@ export function DiffViewer({
           overscrollBehaviorX={overscrollBehaviorX}
           overscrollBehaviorY={overscrollBehaviorY}
           chainVerticalWheel={chainVerticalWheel}
+          fileLines={fileLines}
         />
       </DebugProfiler>
     );
@@ -82,6 +90,7 @@ export function DiffViewer({
           overscrollBehaviorX={overscrollBehaviorX}
           overscrollBehaviorY={overscrollBehaviorY}
           chainVerticalWheel={chainVerticalWheel}
+          fileLines={fileLines}
         />
       </DebugProfiler>
     );
@@ -100,6 +109,7 @@ export function DiffViewer({
         overscrollBehaviorX={overscrollBehaviorX}
         overscrollBehaviorY={overscrollBehaviorY}
         chainVerticalWheel={chainVerticalWheel}
+        fileLines={fileLines}
       />
     </DebugProfiler>
   );

--- a/apps/desktop/src/components/content/ui/DiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/DiffViewer.tsx
@@ -27,6 +27,12 @@ interface DiffViewerProps {
    * are still rendered but expansion is disabled.
    */
   fileLines?: string[];
+  /**
+   * Lazy fetch trigger for `fileLines`, invoked on the first expander
+   * interaction. When provided, expanders are interactive even before
+   * `fileLines` arrives.
+   */
+  onRequestFileLines?: () => void;
 }
 
 const ROOT_CLASS =
@@ -47,6 +53,7 @@ export function DiffViewer({
   overscrollBehaviorY,
   chainVerticalWheel,
   fileLines,
+  onRequestFileLines,
 }: DiffViewerProps) {
   const { parsed, tokens } = useDiffHighlight(patch, filePath, operationId);
   const chatWrapLongLines = useChatDiffPreferencesStore((state) =>
@@ -70,6 +77,7 @@ export function DiffViewer({
           overscrollBehaviorY={overscrollBehaviorY}
           chainVerticalWheel={chainVerticalWheel}
           fileLines={fileLines}
+          onRequestFileLines={onRequestFileLines}
         />
       </DebugProfiler>
     );
@@ -91,6 +99,7 @@ export function DiffViewer({
           overscrollBehaviorY={overscrollBehaviorY}
           chainVerticalWheel={chainVerticalWheel}
           fileLines={fileLines}
+          onRequestFileLines={onRequestFileLines}
         />
       </DebugProfiler>
     );
@@ -110,6 +119,7 @@ export function DiffViewer({
         overscrollBehaviorY={overscrollBehaviorY}
         chainVerticalWheel={chainVerticalWheel}
         fileLines={fileLines}
+        onRequestFileLines={onRequestFileLines}
       />
     </DebugProfiler>
   );

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -7,6 +7,7 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
+import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
 import { ChatDiffLineWrapContextMenu } from "@/components/content/ui/diff/ChatDiffLineWrapContextMenu";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import {
@@ -15,16 +16,16 @@ import {
 } from "@/lib/domain/content-search/content-search";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
-import type { CollapsedContext, DiffLine, ParsedPatch } from "@/lib/domain/files/diff-parser";
+import type { CollapsedContext, DiffLine, InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
 import {
   getChatDiffRows,
   getChatLineNumber,
-  getChatLineNumberDigits,
   getChatLineType,
   getDiffLineIndex,
   getDiffLineNumberColumnWidth,
   type ChatDiffRow,
 } from "@/lib/domain/files/diff-view-rows";
+import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 import { useContentSearchStore } from "@/stores/search/content-search-store";
 
@@ -141,7 +142,7 @@ function ChatGutterColumn({
   rows,
   rowCount,
 }: {
-  rows: ChatDiffRow[];
+  rows: ChatRenderRow[];
   rowCount: number;
 }) {
   return (
@@ -151,7 +152,7 @@ function ChatGutterColumn({
       className="sticky left-0 z-10 grid bg-[var(--diffs-bg)] [grid-template-rows:subgrid]"
     >
       {rows.map((row) =>
-        row.kind === "line" ? (
+        row.kind === "line" || row.kind === "expanded-gap-line" ? (
           <ChatGutterLine key={row.key} line={row.line} />
         ) : (
           <ChatGutterSeparatorLine key={row.key} />
@@ -170,8 +171,10 @@ function ChatContentColumn({
   activeMatchId,
   contentSearchUnitId,
   onExpandCollapsedRow,
+  onExpandGap,
+  fileLines,
 }: {
-  rows: ChatDiffRow[];
+  rows: ChatRenderRow[];
   rowCount: number;
   tokens: HighlightedToken[][] | null;
   wrapLongLines: boolean;
@@ -179,6 +182,8 @@ function ChatContentColumn({
   activeMatchId: string | null;
   contentSearchUnitId: string;
   onExpandCollapsedRow: (key: string) => void;
+  onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
+  fileLines?: string[];
 }) {
   return (
     <div
@@ -186,27 +191,158 @@ function ChatContentColumn({
       style={{ gridColumn: "2", gridRow: `1 / span ${rowCount}` }}
       className="grid [grid-template-rows:subgrid]"
     >
-      {rows.map((row) =>
-        row.kind === "line" ? (
-          <ChatContentLine
-            key={row.key}
-            line={row.line}
-            tokens={tokens}
-            wrapLongLines={wrapLongLines}
-            contentSearchQuery={contentSearchQuery}
-            activeMatchId={activeMatchId}
-            contentSearchUnitId={contentSearchUnitId}
-          />
-        ) : (
+      {rows.map((row) => {
+        if (row.kind === "line") {
+          return (
+            <ChatContentLine
+              key={row.key}
+              line={row.line}
+              tokens={tokens}
+              wrapLongLines={wrapLongLines}
+              contentSearchQuery={contentSearchQuery}
+              activeMatchId={activeMatchId}
+              contentSearchUnitId={contentSearchUnitId}
+            />
+          );
+        }
+        if (row.kind === "expanded-gap-line") {
+          return (
+            <ChatContentLine
+              key={row.key}
+              line={row.line}
+              tokens={null}
+              wrapLongLines={wrapLongLines}
+              contentSearchQuery={contentSearchQuery}
+              activeMatchId={activeMatchId}
+              contentSearchUnitId={contentSearchUnitId}
+            />
+          );
+        }
+        if (row.kind === "gap") {
+          // Only show expander if file lines are available
+          if (!fileLines) {
+            return (
+              <ChatCollapsedRow
+                key={row.key}
+                section={{ kind: "collapsed", lineCount: row.gap.lineCount > 0 ? row.gap.lineCount : 0, lines: [] }}
+                onExpand={() => {}}
+              />
+            );
+          }
+          return (
+            <DiffContextExpander
+              key={row.key}
+              gap={row.gap}
+              onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
+            />
+          );
+        }
+        // collapsed
+        return (
           <ChatCollapsedRow
             key={row.key}
             section={row.section}
             onExpand={() => onExpandCollapsedRow(row.key)}
           />
-        )
-      )}
+        );
+      })}
     </div>
   );
+}
+
+/** Flattened render row: either a data row from the diff or an expanded gap line */
+type ChatRenderRow =
+  | ChatDiffRow
+  | { kind: "expanded-gap-line"; key: string; line: DiffLine };
+
+function flattenWithGapExpansion(
+  rows: ChatDiffRow[],
+  gapStates: Map<number, { revealedTop: number; revealedBottom: number; fullyExpanded: boolean }>,
+  fileLines: string[] | undefined,
+): ChatRenderRow[] {
+  if (!fileLines || gapStates.size === 0) return rows;
+
+  const result: ChatRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    const state = gapStates.get(row.gapIndex);
+    if (!state || (state.revealedTop === 0 && state.revealedBottom === 0)) {
+      result.push(row);
+      continue;
+    }
+
+    const { gap } = row;
+    const totalGapLines = gap.lineCount;
+    if (totalGapLines <= 0) {
+      result.push(row);
+      continue;
+    }
+
+    const gapFileStart = gap.newStartLine - 1; // 0-indexed into fileLines
+
+    // Top expanded lines
+    for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
+      const fileIndex = gapFileStart + i;
+      const content = fileLines[fileIndex] ?? "";
+      const oldLine = gap.oldStartLine + i;
+      const newLine = gap.newStartLine + i;
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-top-${i}`,
+        line: {
+          type: "context",
+          marker: " ",
+          content,
+          oldLineNum: oldLine,
+          newLineNum: newLine,
+          lineNum: newLine,
+          tokenIndex: -1,
+        },
+      });
+    }
+
+    // Remaining gap separator (if not fully expanded)
+    if (!state.fullyExpanded) {
+      const remainingLines = totalGapLines - state.revealedTop - state.revealedBottom;
+      if (remainingLines > 0) {
+        const residualGap: InterHunkGap = {
+          kind: "gap",
+          oldStartLine: gap.oldStartLine + state.revealedTop,
+          newStartLine: gap.newStartLine + state.revealedTop,
+          lineCount: remainingLines,
+        };
+        result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+      }
+    }
+
+    // Bottom expanded lines
+    const bottomStart = totalGapLines - state.revealedBottom;
+    for (let i = bottomStart; i < totalGapLines; i++) {
+      if (i < state.revealedTop) continue; // already shown by top
+      const fileIndex = gapFileStart + i;
+      const content = fileLines[fileIndex] ?? "";
+      const oldLine = gap.oldStartLine + i;
+      const newLine = gap.newStartLine + i;
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-bottom-${i}`,
+        line: {
+          type: "context",
+          marker: " ",
+          content,
+          oldLineNum: oldLine,
+          newLineNum: newLine,
+          lineNum: newLine,
+          tokenIndex: -1,
+        },
+      });
+    }
+  }
+  return result;
 }
 
 export function ChatDiffViewer({
@@ -221,6 +357,7 @@ export function ChatDiffViewer({
   overscrollBehaviorX,
   overscrollBehaviorY,
   chainVerticalWheel = false,
+  fileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -233,14 +370,20 @@ export function ChatDiffViewer({
   overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
+  fileLines?: string[];
 }) {
   const resolvedMode = useResolvedMode();
   const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
     new Set(),
   );
-  const rows = useMemo(
+  const { gapStates, expandGap } = useGapExpansion();
+  const baseRows = useMemo(
     () => getChatDiffRows(parsed, expandedCollapsedKeys),
     [parsed, expandedCollapsedKeys],
+  );
+  const rows = useMemo(
+    () => flattenWithGapExpansion(baseRows, gapStates, fileLines),
+    [baseRows, gapStates, fileLines],
   );
   const contentSearchSurface = useContentSearchStore((state) => state.surface);
   const contentSearchOpen = useContentSearchStore((state) => state.open);
@@ -274,7 +417,17 @@ export function ChatDiffViewer({
     [contentSearchQuery, contentSearchUnitId, parsed.allCodeLines, tokens],
   );
   const rowCount = Math.max(rows.length, 1);
-  const lineNumberDigits = getChatLineNumberDigits(rows);
+  const lineNumberDigits = useMemo(() => {
+    let maxLineNumber = 0;
+    for (const row of rows) {
+      if (row.kind === "line") {
+        maxLineNumber = Math.max(maxLineNumber, getChatLineNumber(row.line) ?? 0);
+      } else if (row.kind === "expanded-gap-line") {
+        maxLineNumber = Math.max(maxLineNumber, getChatLineNumber(row.line) ?? 0);
+      }
+    }
+    return Math.max(String(maxLineNumber).length, 1);
+  }, [rows]);
   const codeStyle = useMemo(
     () => ({
       ...CHAT_DIFF_CODE_BASE_STYLE,
@@ -372,6 +525,8 @@ export function ChatDiffViewer({
             activeMatchId={activeMatchId}
             contentSearchUnitId={contentSearchUnitId}
             onExpandCollapsedRow={expandCollapsedRow}
+            onExpandGap={expandGap}
+            fileLines={fileLines}
           />
         </code>
       </pre>

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -137,7 +137,7 @@ function ChatCollapsedRow({
       onClick={onExpand}
       aria-label={`Expand ${section.lineCount} unmodified lines`}
       title={`${section.lineCount} unmodified lines`}
-      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
+      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
     >
       <DiffCollapsedContextCluster
         lineCount={section.lineCount}

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -8,8 +8,10 @@ import {
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
-  DiffCollapsedContextCluster,
-  DiffContextExpander,
+  DiffCollapsedContentLabel,
+  DiffCollapsedGutterIcon,
+  DiffGapContentLabel,
+  DiffGapGutterControls,
   DiffGapInfoRow,
   type ExpandDirection,
 } from "@/components/content/ui/diff/DiffContextExpander";
@@ -70,12 +72,14 @@ function ChatGutterLine({ line }: { line: DiffLine }) {
   );
 }
 
-function ChatGutterSeparatorLine() {
+function ChatGutterSeparatorLine({ children }: { children?: React.ReactNode }) {
   return (
     <div
       data-separator="simple"
-      className="diff-gutter-cell min-h-[var(--diffs-line-height)] bg-[var(--codex-diffs-separator-surface)]"
-    />
+      className="diff-gutter-cell flex min-h-[var(--diffs-line-height)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
+    >
+      {children}
+    </div>
   );
 }
 
@@ -139,7 +143,7 @@ function ChatCollapsedRow({
       title={`${section.lineCount} unmodified lines`}
       className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
     >
-      <DiffCollapsedContextCluster
+      <DiffCollapsedContentLabel
         lineCount={section.lineCount}
         stickyLeft="var(--diffs-column-number-width)"
       />
@@ -150,9 +154,13 @@ function ChatCollapsedRow({
 function ChatGutterColumn({
   rows,
   rowCount,
+  onExpandGap,
+  canExpandGaps,
 }: {
   rows: ChatRenderRow[];
   rowCount: number;
+  onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
+  canExpandGaps: boolean;
 }) {
   return (
     <div
@@ -160,13 +168,30 @@ function ChatGutterColumn({
       style={{ gridColumn: "1", gridRow: `1 / span ${rowCount}` }}
       className="sticky left-0 z-10 grid bg-[var(--diffs-bg)] [grid-template-rows:subgrid]"
     >
-      {rows.map((row) =>
-        row.kind === "line" || row.kind === "expanded-gap-line" ? (
-          <ChatGutterLine key={row.key} line={row.line} />
-        ) : (
-          <ChatGutterSeparatorLine key={row.key} />
-        )
-      )}
+      {rows.map((row) => {
+        if (row.kind === "line" || row.kind === "expanded-gap-line") {
+          return <ChatGutterLine key={row.key} line={row.line} />;
+        }
+        if (row.kind === "gap" && canExpandGaps) {
+          return (
+            <ChatGutterSeparatorLine key={row.key}>
+              <DiffGapGutterControls
+                gap={row.gap}
+                onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
+              />
+            </ChatGutterSeparatorLine>
+          );
+        }
+        if (row.kind === "collapsed") {
+          return (
+            <ChatGutterSeparatorLine key={row.key}>
+              <DiffCollapsedGutterIcon />
+            </ChatGutterSeparatorLine>
+          );
+        }
+        // gap without expand capability
+        return <ChatGutterSeparatorLine key={row.key} />;
+      })}
     </div>
   );
 }
@@ -228,8 +253,7 @@ function ChatContentColumn({
           );
         }
         if (row.kind === "gap") {
-          // The chat viewport owns horizontal scroll and the gutter column
-          // is sticky at left 0, so pin the cluster just past the gutter.
+          // Controls are in the gutter; content column shows just the label.
           if (!canExpandGaps) {
             return (
               <DiffGapInfoRow
@@ -240,12 +264,17 @@ function ChatContentColumn({
             );
           }
           return (
-            <DiffContextExpander
+            <div
               key={row.key}
-              gap={row.gap}
-              onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
-              stickyLeft="var(--diffs-column-number-width)"
-            />
+              data-separator="gap-expander"
+              className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
+            >
+              <DiffGapContentLabel
+                gap={row.gap}
+                onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
+                stickyLeft="var(--diffs-column-number-width)"
+              />
+            </div>
           );
         }
         // collapsed
@@ -523,7 +552,7 @@ export function ChatDiffViewer({
               : "grid-cols-[var(--diffs-column-number-width)_minmax(max-content,1fr)]"
           }`}
         >
-          <ChatGutterColumn rows={rows} rowCount={rowCount} />
+          <ChatGutterColumn rows={rows} rowCount={rowCount} onExpandGap={expandGapWithFetch} canExpandGaps={canExpandGaps} />
           <ChatContentColumn
             rows={rows}
             rowCount={rowCount}

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -7,7 +7,11 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
-import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
+import {
+  DiffContextExpander,
+  DiffGapInfoRow,
+  type ExpandDirection,
+} from "@/components/content/ui/diff/DiffContextExpander";
 import { ChatDiffLineWrapContextMenu } from "@/components/content/ui/diff/ChatDiffLineWrapContextMenu";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import {
@@ -224,22 +228,15 @@ function ChatContentColumn({
           );
         }
         if (row.kind === "gap") {
+          // The chat viewport owns horizontal scroll and the gutter column
+          // is sticky at left 0, so pin the cluster just past the gutter.
           if (!canExpandGaps) {
-            // Informational-only separator when expansion is unavailable
             return (
-              <div
+              <DiffGapInfoRow
                 key={row.key}
-                data-separator="gap-info"
-                className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center gap-2 bg-[var(--codex-diffs-separator-surface)] px-2 text-muted-foreground/60"
-              >
-                <span className="h-px min-w-4 flex-1 bg-border/40" />
-                <span className="shrink-0 text-[10px] leading-none">
-                  {row.gap.lineCount > 0
-                    ? `${row.gap.lineCount} unmodified line${row.gap.lineCount === 1 ? "" : "s"}`
-                    : "unmodified lines"}
-                </span>
-                <span className="h-px min-w-4 flex-1 bg-border/40" />
-              </div>
+                lineCount={row.gap.lineCount}
+                stickyLeft="var(--diffs-column-number-width)"
+              />
             );
           }
           return (
@@ -247,6 +244,7 @@ function ChatContentColumn({
               key={row.key}
               gap={row.gap}
               onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
+              stickyLeft="var(--diffs-column-number-width)"
             />
           );
         }

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
+  DiffCollapsedContextCluster,
   DiffContextExpander,
   DiffGapInfoRow,
   type ExpandDirection,
@@ -73,7 +74,7 @@ function ChatGutterSeparatorLine() {
   return (
     <div
       data-separator="simple"
-      className="diff-gutter-cell min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
+      className="diff-gutter-cell min-h-[var(--diffs-line-height)] bg-[var(--codex-diffs-separator-surface)]"
     />
   );
 }
@@ -134,15 +135,14 @@ function ChatCollapsedRow({
       size="unstyled"
       data-separator="simple"
       onClick={onExpand}
-      aria-label={`Show ${section.lineCount} unmodified lines`}
+      aria-label={`Expand ${section.lineCount} unmodified lines`}
       title={`${section.lineCount} unmodified lines`}
-      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center gap-2 border-0 bg-transparent px-2 py-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/70 hover:text-muted-foreground"
+      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
     >
-      <span className="h-px min-w-4 flex-1 bg-border/60" />
-      <span className="shrink-0 text-[10px] leading-none">
-        Show {section.lineCount} unchanged line{section.lineCount === 1 ? "" : "s"}
-      </span>
-      <span className="h-px min-w-4 flex-1 bg-border/60" />
+      <DiffCollapsedContextCluster
+        lineCount={section.lineCount}
+        stickyLeft="var(--diffs-column-number-width)"
+      />
     </Button>
   );
 }

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -25,7 +25,12 @@ import {
   getDiffLineNumberColumnWidth,
   type ChatDiffRow,
 } from "@/lib/domain/files/diff-view-rows";
-import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  useGapExpansion,
+  type GapExpansionState,
+} from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 import { useContentSearchStore } from "@/stores/search/content-search-store";
 
@@ -172,7 +177,7 @@ function ChatContentColumn({
   contentSearchUnitId,
   onExpandCollapsedRow,
   onExpandGap,
-  fileLines,
+  canExpandGaps,
 }: {
   rows: ChatRenderRow[];
   rowCount: number;
@@ -183,7 +188,7 @@ function ChatContentColumn({
   contentSearchUnitId: string;
   onExpandCollapsedRow: (key: string) => void;
   onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
-  fileLines?: string[];
+  canExpandGaps: boolean;
 }) {
   return (
     <div
@@ -219,14 +224,22 @@ function ChatContentColumn({
           );
         }
         if (row.kind === "gap") {
-          // Only show expander if file lines are available
-          if (!fileLines) {
+          if (!canExpandGaps) {
+            // Informational-only separator when expansion is unavailable
             return (
-              <ChatCollapsedRow
+              <div
                 key={row.key}
-                section={{ kind: "collapsed", lineCount: row.gap.lineCount > 0 ? row.gap.lineCount : 0, lines: [] }}
-                onExpand={() => {}}
-              />
+                data-separator="gap-info"
+                className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center gap-2 bg-[var(--codex-diffs-separator-surface)] px-2 text-muted-foreground/60"
+              >
+                <span className="h-px min-w-4 flex-1 bg-border/40" />
+                <span className="shrink-0 text-[10px] leading-none">
+                  {row.gap.lineCount > 0
+                    ? `${row.gap.lineCount} unmodified line${row.gap.lineCount === 1 ? "" : "s"}`
+                    : "unmodified lines"}
+                </span>
+                <span className="h-px min-w-4 flex-1 bg-border/40" />
+              </div>
             );
           }
           return (
@@ -255,13 +268,28 @@ type ChatRenderRow =
   | ChatDiffRow
   | { kind: "expanded-gap-line"; key: string; line: DiffLine };
 
+function makeGapContextLine(
+  fileLines: string[],
+  gap: InterHunkGap,
+  offset: number,
+): DiffLine {
+  const newLine = gap.newStartLine + offset;
+  return {
+    type: "context",
+    marker: " ",
+    content: fileLines[newLine - 1] ?? "",
+    oldLineNum: gap.oldStartLine + offset,
+    newLineNum: newLine,
+    lineNum: newLine,
+    tokenIndex: -1,
+  };
+}
+
 function flattenWithGapExpansion(
   rows: ChatDiffRow[],
-  gapStates: Map<number, { revealedTop: number; revealedBottom: number; fullyExpanded: boolean }>,
+  gapStates: Map<number, GapExpansionState>,
   fileLines: string[] | undefined,
 ): ChatRenderRow[] {
-  if (!fileLines || gapStates.size === 0) return rows;
-
   const result: ChatRenderRow[] = [];
   for (const row of rows) {
     if (row.kind !== "gap") {
@@ -269,76 +297,47 @@ function flattenWithGapExpansion(
       continue;
     }
 
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: ChatDiffRow = gap === row.gap ? row : { ...row, gap };
+
     const state = gapStates.get(row.gapIndex);
-    if (!state || (state.revealedTop === 0 && state.revealedBottom === 0)) {
-      result.push(row);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
       continue;
     }
 
-    const { gap } = row;
     const totalGapLines = gap.lineCount;
-    if (totalGapLines <= 0) {
-      result.push(row);
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
       continue;
     }
 
-    const gapFileStart = gap.newStartLine - 1; // 0-indexed into fileLines
-
-    // Top expanded lines
-    for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
-      const fileIndex = gapFileStart + i;
-      const content = fileLines[fileIndex] ?? "";
-      const oldLine = gap.oldStartLine + i;
-      const newLine = gap.newStartLine + i;
+    for (let i = 0; i < top; i++) {
       result.push({
         kind: "expanded-gap-line",
         key: `${row.key}-top-${i}`,
-        line: {
-          type: "context",
-          marker: " ",
-          content,
-          oldLineNum: oldLine,
-          newLineNum: newLine,
-          lineNum: newLine,
-          tokenIndex: -1,
-        },
+        line: makeGapContextLine(fileLines, gap, i),
       });
     }
 
-    // Remaining gap separator (if not fully expanded)
-    if (!state.fullyExpanded) {
-      const remainingLines = totalGapLines - state.revealedTop - state.revealedBottom;
-      if (remainingLines > 0) {
-        const residualGap: InterHunkGap = {
-          kind: "gap",
-          oldStartLine: gap.oldStartLine + state.revealedTop,
-          newStartLine: gap.newStartLine + state.revealedTop,
-          lineCount: remainingLines,
-        };
-        result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-      }
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
     }
 
-    // Bottom expanded lines
-    const bottomStart = totalGapLines - state.revealedBottom;
-    for (let i = bottomStart; i < totalGapLines; i++) {
-      if (i < state.revealedTop) continue; // already shown by top
-      const fileIndex = gapFileStart + i;
-      const content = fileLines[fileIndex] ?? "";
-      const oldLine = gap.oldStartLine + i;
-      const newLine = gap.newStartLine + i;
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
       result.push({
         kind: "expanded-gap-line",
         key: `${row.key}-bottom-${i}`,
-        line: {
-          type: "context",
-          marker: " ",
-          content,
-          oldLineNum: oldLine,
-          newLineNum: newLine,
-          lineNum: newLine,
-          tokenIndex: -1,
-        },
+        line: makeGapContextLine(fileLines, gap, i),
       });
     }
   }
@@ -358,6 +357,7 @@ export function ChatDiffViewer({
   overscrollBehaviorY,
   chainVerticalWheel = false,
   fileLines,
+  onRequestFileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -371,12 +371,22 @@ export function ChatDiffViewer({
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
   fileLines?: string[];
+  onRequestFileLines?: () => void;
 }) {
   const resolvedMode = useResolvedMode();
   const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
     new Set(),
   );
   const { gapStates, expandGap } = useGapExpansion();
+  const canExpandGaps = Boolean(fileLines || onRequestFileLines);
+  const expandGapWithFetch = (
+    gapIndex: number,
+    gap: InterHunkGap,
+    direction: ExpandDirection,
+  ) => {
+    onRequestFileLines?.();
+    expandGap(gapIndex, gap, direction);
+  };
   const baseRows = useMemo(
     () => getChatDiffRows(parsed, expandedCollapsedKeys),
     [parsed, expandedCollapsedKeys],
@@ -525,8 +535,8 @@ export function ChatDiffViewer({
             activeMatchId={activeMatchId}
             contentSearchUnitId={contentSearchUnitId}
             onExpandCollapsedRow={expandCollapsedRow}
-            onExpandGap={expandGap}
-            fileLines={fileLines}
+            onExpandGap={expandGapWithFetch}
+            canExpandGaps={canExpandGaps}
           />
         </code>
       </pre>

--- a/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
+++ b/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
@@ -106,6 +106,39 @@ export function DiffContextExpander({
 }
 
 /**
+ * Inner cluster for legacy intra-hunk CollapsedContext sections (lines
+ * present in the patch but folded away). One click on the wrapping
+ * button reveals the whole section, so this is a single expand-all
+ * affordance — same treatment as the small-gap expander: left-anchored,
+ * scroll-pinned. The chevron is decorative; the caller's button owns
+ * the interaction and accessible name.
+ */
+export function DiffCollapsedContextCluster({
+  lineCount,
+  stickyLeft = "0px",
+}: {
+  lineCount: number;
+  stickyLeft?: string;
+}) {
+  return (
+    <span
+      style={{ position: "sticky", left: stickyLeft }}
+      className="flex w-max items-center gap-0.5 px-2"
+    >
+      <span
+        aria-hidden="true"
+        className="flex shrink-0 items-center justify-center rounded p-0.5"
+      >
+        <ChevronsUpDown className="h-3 w-3" />
+      </span>
+      <span className="shrink-0 pl-1 text-[10px] leading-none">
+        {formatUnmodifiedLinesLabel(lineCount)}
+      </span>
+    </span>
+  );
+}
+
+/**
  * Non-interactive variant for surfaces where gap expansion is
  * unavailable (content fetch impossible for the diff's revision).
  * Same left-anchored, scroll-pinned layout.

--- a/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
+++ b/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
@@ -1,0 +1,88 @@
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
+import type { InterHunkGap } from "@/lib/domain/files/diff-parser";
+
+/** Threshold: gaps with this many lines or fewer show a single expand-all control */
+const SMALL_GAP_THRESHOLD = 7;
+
+export type ExpandDirection = "up" | "down" | "all";
+
+interface DiffContextExpanderProps {
+  gap: InterHunkGap;
+  onExpand: (direction: ExpandDirection) => void;
+}
+
+/**
+ * Codex-style per-gap separator row with expand affordances.
+ * For small gaps (<=7 lines), renders a single combined expand-all control.
+ * For larger gaps, renders expand-up, expand-down, and expand-all buttons.
+ */
+export function DiffContextExpander({ gap, onExpand }: DiffContextExpanderProps) {
+  const lineCount = gap.lineCount;
+  const isUnknown = lineCount < 0;
+  const isSmall = !isUnknown && lineCount <= SMALL_GAP_THRESHOLD;
+  const label = isUnknown
+    ? "unmodified lines"
+    : `${lineCount} unmodified line${lineCount === 1 ? "" : "s"}`;
+
+  if (isSmall) {
+    return (
+      <div
+        data-separator="gap-expander"
+        className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center gap-2 bg-[var(--codex-diffs-separator-surface)] px-2"
+      >
+        <span className="h-px min-w-3 flex-1 bg-border/40" />
+        <button
+          type="button"
+          onClick={() => onExpand("all")}
+          aria-label={`Expand ${label}`}
+          title={`Expand ${label}`}
+          className="flex shrink-0 cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground/70 transition-colors hover:text-muted-foreground"
+        >
+          <ChevronsUpDown className="h-3 w-3" />
+          <span>{label}</span>
+        </button>
+        <span className="h-px min-w-3 flex-1 bg-border/40" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-separator="gap-expander"
+      className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center gap-1.5 bg-[var(--codex-diffs-separator-surface)] px-2"
+    >
+      <span className="h-px min-w-3 flex-1 bg-border/40" />
+      <button
+        type="button"
+        onClick={() => onExpand("down")}
+        aria-label="Expand lines down (adjacent to hunk above)"
+        title="Expand down"
+        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+      >
+        <ChevronDown className="h-3 w-3" />
+      </button>
+      <span className="shrink-0 text-[10px] leading-none text-muted-foreground/70">
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={() => onExpand("up")}
+        aria-label="Expand lines up (adjacent to hunk below)"
+        title="Expand up"
+        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+      >
+        <ChevronUp className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onExpand("all")}
+        aria-label={`Expand all ${label}`}
+        title="Expand all"
+        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+      >
+        <ChevronsUpDown className="h-3 w-3" />
+      </button>
+      <span className="h-px min-w-3 flex-1 bg-border/40" />
+    </div>
+  );
+}

--- a/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
+++ b/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
@@ -26,6 +26,149 @@ export function formatUnmodifiedLinesLabel(lineCount: number): string {
 }
 
 /**
+ * Gutter-column expand controls for inter-hunk gap rows.
+ *
+ * Small gaps (<=7 lines): single expand-both (ChevronsUpDown) icon.
+ * Large gaps: expand-down chevron on top (extends hunk above), expand-up
+ * below (extends hunk below) — matching Codex ordering where each control
+ * is adjacent to the hunk it extends.
+ */
+export function DiffGapGutterControls({
+  gap,
+  onExpand,
+}: {
+  gap: InterHunkGap;
+  onExpand: (direction: ExpandDirection) => void;
+}) {
+  const lineCount = gap.lineCount;
+  const isSmall = lineCount >= 0 && lineCount <= SMALL_GAP_THRESHOLD;
+  const label = formatUnmodifiedLinesLabel(lineCount);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-0">
+      {isSmall ? (
+        <button
+          type="button"
+          onClick={() => onExpand("all")}
+          aria-label={`Expand ${label}`}
+          title={`Expand ${label}`}
+          className={ICON_BUTTON_CLASS}
+        >
+          <ChevronsUpDown className="h-3 w-3" />
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={() => onExpand("down")}
+            aria-label="Expand down (reveal lines adjacent to the hunk above)"
+            title="Expand down"
+            className={ICON_BUTTON_CLASS}
+          >
+            <ChevronDown className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onExpand("up")}
+            aria-label="Expand up (reveal lines adjacent to the hunk below)"
+            title="Expand up"
+            className={ICON_BUTTON_CLASS}
+          >
+            <ChevronUp className="h-3 w-3" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Content-column label for inter-hunk gap rows.
+ * Shows "N unmodified lines" and, for large gaps, an "Expand all" text button.
+ * Sticky-pinned against horizontal scroll via stickyLeft.
+ */
+export function DiffGapContentLabel({
+  gap,
+  onExpand,
+  stickyLeft = "0px",
+}: {
+  gap: InterHunkGap;
+  onExpand?: (direction: ExpandDirection) => void;
+  stickyLeft?: string;
+}) {
+  const lineCount = gap.lineCount;
+  const isSmall = lineCount >= 0 && lineCount <= SMALL_GAP_THRESHOLD;
+  const label = formatUnmodifiedLinesLabel(lineCount);
+
+  return (
+    <div
+      style={{ position: "sticky", left: stickyLeft }}
+      className="flex w-max items-center gap-0.5 px-2"
+    >
+      <span className="shrink-0 text-[10px] leading-none text-muted-foreground/70">
+        {label}
+      </span>
+      {!isSmall && onExpand && (
+        <button
+          type="button"
+          onClick={() => onExpand("all")}
+          aria-label={`Expand all ${label}`}
+          title="Expand all"
+          className="ml-1.5 shrink-0 cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[10px] leading-none text-muted-foreground/60 transition-colors hover:text-foreground"
+        >
+          Expand all
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Gutter-column expand icon for collapsed-context rows.
+ * Single expand-both icon (decorative in the sense that the parent button
+ * owns the click, but visually conveys expandability).
+ */
+export function DiffCollapsedGutterIcon() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <span
+        aria-hidden="true"
+        className="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground/60"
+      >
+        <ChevronsUpDown className="h-3 w-3" />
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Content-column label for collapsed-context rows.
+ * Shows "N unmodified lines" text, sticky-pinned.
+ */
+export function DiffCollapsedContentLabel({
+  lineCount,
+  stickyLeft = "0px",
+}: {
+  lineCount: number;
+  stickyLeft?: string;
+}) {
+  return (
+    <span
+      style={{ position: "sticky", left: stickyLeft }}
+      className="flex w-max items-center gap-0.5 px-2"
+    >
+      <span className="shrink-0 text-[10px] leading-none">
+        {formatUnmodifiedLinesLabel(lineCount)}
+      </span>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy combined components (kept for UnifiedDiffViewer simple layout)
+// ---------------------------------------------------------------------------
+
+/**
  * Codex-style per-gap separator row: a compact, left-anchored inline
  * cluster of expand affordances followed by the "N unmodified lines"
  * label. The cluster is `position: sticky` against the nearest
@@ -50,10 +193,8 @@ export function DiffContextExpander({
       data-separator="gap-expander"
       className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
     >
-      <div
-        style={{ position: "sticky", left: stickyLeft }}
-        className="flex w-max items-center gap-0.5 px-2"
-      >
+      {/* Gutter-width area for expand controls */}
+      <div className="flex w-[var(--diffs-column-number-width,1.5rem)] shrink-0 items-center justify-center">
         {isSmall ? (
           <button
             type="button"
@@ -65,16 +206,7 @@ export function DiffContextExpander({
             <ChevronsUpDown className="h-3 w-3" />
           </button>
         ) : (
-          <>
-            <button
-              type="button"
-              onClick={() => onExpand("up")}
-              aria-label="Expand up (reveal lines adjacent to the hunk below)"
-              title="Expand up"
-              className={ICON_BUTTON_CLASS}
-            >
-              <ChevronUp className="h-3 w-3" />
-            </button>
+          <div className="flex flex-col items-center gap-0">
             <button
               type="button"
               onClick={() => onExpand("down")}
@@ -84,9 +216,24 @@ export function DiffContextExpander({
             >
               <ChevronDown className="h-3 w-3" />
             </button>
-          </>
+            <button
+              type="button"
+              onClick={() => onExpand("up")}
+              aria-label="Expand up (reveal lines adjacent to the hunk below)"
+              title="Expand up"
+              className={ICON_BUTTON_CLASS}
+            >
+              <ChevronUp className="h-3 w-3" />
+            </button>
+          </div>
         )}
-        <span className="shrink-0 pl-1 text-[10px] leading-none text-muted-foreground/70">
+      </div>
+      {/* Content area: label + expand all */}
+      <div
+        style={{ position: "sticky", left: stickyLeft }}
+        className="flex w-max items-center gap-0.5 px-2"
+      >
+        <span className="shrink-0 text-[10px] leading-none text-muted-foreground/70">
           {label}
         </span>
         {!isSmall && (

--- a/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
+++ b/apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx
@@ -6,83 +6,128 @@ const SMALL_GAP_THRESHOLD = 7;
 
 export type ExpandDirection = "up" | "down" | "all";
 
+const ICON_BUTTON_CLASS =
+  "flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground";
+
 interface DiffContextExpanderProps {
   gap: InterHunkGap;
   onExpand: (direction: ExpandDirection) => void;
+  /**
+   * `left` offset for pinning the control cluster against horizontal
+   * scroll (typically the gutter width so it clears sticky line numbers).
+   */
+  stickyLeft?: string;
+}
+
+export function formatUnmodifiedLinesLabel(lineCount: number): string {
+  return lineCount >= 0
+    ? `${lineCount} unmodified line${lineCount === 1 ? "" : "s"}`
+    : "unmodified lines";
 }
 
 /**
- * Codex-style per-gap separator row with expand affordances.
- * For small gaps (<=7 lines), renders a single combined expand-all control.
- * For larger gaps, renders expand-up, expand-down, and expand-all buttons.
+ * Codex-style per-gap separator row: a compact, left-anchored inline
+ * cluster of expand affordances followed by the "N unmodified lines"
+ * label. The cluster is `position: sticky` against the nearest
+ * horizontally scrolling ancestor so it never drifts out of the visible
+ * viewport when long diff lines scroll sideways.
+ *
+ * Small gaps (<= 7 lines) get a single combined expand-both control;
+ * larger gaps get expand-up + expand-down icon buttons and an
+ * "Expand all" text button at the end.
  */
-export function DiffContextExpander({ gap, onExpand }: DiffContextExpanderProps) {
+export function DiffContextExpander({
+  gap,
+  onExpand,
+  stickyLeft = "0px",
+}: DiffContextExpanderProps) {
   const lineCount = gap.lineCount;
-  const isUnknown = lineCount < 0;
-  const isSmall = !isUnknown && lineCount <= SMALL_GAP_THRESHOLD;
-  const label = isUnknown
-    ? "unmodified lines"
-    : `${lineCount} unmodified line${lineCount === 1 ? "" : "s"}`;
-
-  if (isSmall) {
-    return (
-      <div
-        data-separator="gap-expander"
-        className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center gap-2 bg-[var(--codex-diffs-separator-surface)] px-2"
-      >
-        <span className="h-px min-w-3 flex-1 bg-border/40" />
-        <button
-          type="button"
-          onClick={() => onExpand("all")}
-          aria-label={`Expand ${label}`}
-          title={`Expand ${label}`}
-          className="flex shrink-0 cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground/70 transition-colors hover:text-muted-foreground"
-        >
-          <ChevronsUpDown className="h-3 w-3" />
-          <span>{label}</span>
-        </button>
-        <span className="h-px min-w-3 flex-1 bg-border/40" />
-      </div>
-    );
-  }
+  const isSmall = lineCount >= 0 && lineCount <= SMALL_GAP_THRESHOLD;
+  const label = formatUnmodifiedLinesLabel(lineCount);
 
   return (
     <div
       data-separator="gap-expander"
-      className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center gap-1.5 bg-[var(--codex-diffs-separator-surface)] px-2"
+      className="diff-gap-expander flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
     >
-      <span className="h-px min-w-3 flex-1 bg-border/40" />
-      <button
-        type="button"
-        onClick={() => onExpand("down")}
-        aria-label="Expand lines down (adjacent to hunk above)"
-        title="Expand down"
-        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+      <div
+        style={{ position: "sticky", left: stickyLeft }}
+        className="flex w-max items-center gap-0.5 px-2"
       >
-        <ChevronDown className="h-3 w-3" />
-      </button>
-      <span className="shrink-0 text-[10px] leading-none text-muted-foreground/70">
-        {label}
+        {isSmall ? (
+          <button
+            type="button"
+            onClick={() => onExpand("all")}
+            aria-label={`Expand ${label}`}
+            title={`Expand ${label}`}
+            className={ICON_BUTTON_CLASS}
+          >
+            <ChevronsUpDown className="h-3 w-3" />
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => onExpand("up")}
+              aria-label="Expand up (reveal lines adjacent to the hunk below)"
+              title="Expand up"
+              className={ICON_BUTTON_CLASS}
+            >
+              <ChevronUp className="h-3 w-3" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onExpand("down")}
+              aria-label="Expand down (reveal lines adjacent to the hunk above)"
+              title="Expand down"
+              className={ICON_BUTTON_CLASS}
+            >
+              <ChevronDown className="h-3 w-3" />
+            </button>
+          </>
+        )}
+        <span className="shrink-0 pl-1 text-[10px] leading-none text-muted-foreground/70">
+          {label}
+        </span>
+        {!isSmall && (
+          <button
+            type="button"
+            onClick={() => onExpand("all")}
+            aria-label={`Expand all ${label}`}
+            title="Expand all"
+            className="ml-1.5 shrink-0 cursor-pointer rounded border-0 bg-transparent px-1 py-0.5 text-[10px] leading-none text-muted-foreground/60 transition-colors hover:text-foreground"
+          >
+            Expand all
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Non-interactive variant for surfaces where gap expansion is
+ * unavailable (content fetch impossible for the diff's revision).
+ * Same left-anchored, scroll-pinned layout.
+ */
+export function DiffGapInfoRow({
+  lineCount,
+  stickyLeft = "0px",
+}: {
+  lineCount: number;
+  stickyLeft?: string;
+}) {
+  return (
+    <div
+      data-separator="gap-info"
+      className="flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
+    >
+      <span
+        style={{ position: "sticky", left: stickyLeft }}
+        className="w-max px-2 text-[10px] leading-none text-muted-foreground/50"
+      >
+        {formatUnmodifiedLinesLabel(lineCount)}
       </span>
-      <button
-        type="button"
-        onClick={() => onExpand("up")}
-        aria-label="Expand lines up (adjacent to hunk below)"
-        title="Expand up"
-        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-      >
-        <ChevronUp className="h-3 w-3" />
-      </button>
-      <button
-        type="button"
-        onClick={() => onExpand("all")}
-        aria-label={`Expand all ${label}`}
-        title="Expand all"
-        className="flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-      >
-        <ChevronsUpDown className="h-3 w-3" />
-      </button>
-      <span className="h-px min-w-3 flex-1 bg-border/40" />
     </div>
   );
 }

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -221,7 +221,7 @@ function SplitCollapsedCells({
         onClick={onExpand}
         aria-label={`Expand ${section.lineCount} unmodified lines`}
         title={`${section.lineCount} unmodified lines`}
-        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
       >
         <DiffCollapsedContextCluster
           lineCount={section.lineCount}

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -7,10 +7,12 @@ import {
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
-  DiffCollapsedContextCluster,
-  DiffContextExpander,
-  DiffGapInfoRow,
+  DiffCollapsedContentLabel,
+  DiffCollapsedGutterIcon,
+  DiffGapContentLabel,
+  DiffGapGutterControls,
   type ExpandDirection,
+  formatUnmodifiedLinesLabel,
 } from "@/components/content/ui/diff/DiffContextExpander";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -207,11 +209,19 @@ function SplitCollapsedCells({
 }) {
   return (
     <>
-      <div
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
         data-gutter=""
         data-separator="line-info"
-        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
-      />
+        onClick={onExpand}
+        aria-label={`Expand ${section.lineCount} unmodified lines`}
+        title={`${section.lineCount} unmodified lines`}
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] cursor-pointer items-center justify-center bg-[var(--codex-diffs-separator-surface)] border-0 p-0 text-muted-foreground/60 transition-colors hover:text-foreground"
+      >
+        <DiffCollapsedGutterIcon />
+      </Button>
       <Button
         type="button"
         variant="unstyled"
@@ -223,7 +233,7 @@ function SplitCollapsedCells({
         title={`${section.lineCount} unmodified lines`}
         className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
       >
-        <DiffCollapsedContextCluster
+        <DiffCollapsedContentLabel
           lineCount={section.lineCount}
           stickyLeft="var(--diffs-column-number-width)"
         />
@@ -241,31 +251,35 @@ function SplitGapCells({
   onExpand: (direction: ExpandDirection) => void;
   canExpand: boolean;
 }) {
-  // Each split code column owns its own horizontal scroll; the gutter cell
-  // is sticky at left 0, so the cluster pins just past the gutter width.
   return (
     <>
       <div
         data-gutter=""
         data-separator="gap-expander"
-        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
-      />
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
+      >
+        {canExpand && (
+          <DiffGapGutterControls gap={gap} onExpand={onExpand} />
+        )}
+      </div>
       <div
         data-content=""
         data-separator="gap-expander"
-        className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--codex-diffs-separator-surface)]"
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
       >
         {canExpand ? (
-          <DiffContextExpander
+          <DiffGapContentLabel
             gap={gap}
             onExpand={onExpand}
             stickyLeft="var(--diffs-column-number-width)"
           />
         ) : (
-          <DiffGapInfoRow
-            lineCount={gap.lineCount}
-            stickyLeft="var(--diffs-column-number-width)"
-          />
+          <span
+            style={{ position: "sticky", left: "var(--diffs-column-number-width)" }}
+            className="w-max px-2 text-[10px] leading-none text-muted-foreground/50"
+          >
+            {formatUnmodifiedLinesLabel(gap.lineCount)}
+          </span>
         )}
       </div>
     </>

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
+  DiffCollapsedContextCluster,
   DiffContextExpander,
   DiffGapInfoRow,
   type ExpandDirection,
@@ -209,7 +210,7 @@ function SplitCollapsedCells({
       <div
         data-gutter=""
         data-separator="line-info"
-        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--diffs-bg)]"
+        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
       />
       <Button
         type="button"
@@ -218,15 +219,14 @@ function SplitCollapsedCells({
         data-content=""
         data-separator="line-info"
         onClick={onExpand}
-        aria-label={`Show ${section.lineCount} unmodified lines`}
+        aria-label={`Expand ${section.lineCount} unmodified lines`}
         title={`${section.lineCount} unmodified lines`}
-        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center gap-2 border-0 bg-transparent px-2 py-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/70 hover:text-muted-foreground"
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
       >
-        <span className="h-px min-w-4 flex-1 bg-border/60" />
-        <span data-unmodified-lines="" className="shrink-0 text-[10px] leading-none">
-          Show {section.lineCount} unchanged line{section.lineCount === 1 ? "" : "s"}
-        </span>
-        <span className="h-px min-w-4 flex-1 bg-border/60" />
+        <DiffCollapsedContextCluster
+          lineCount={section.lineCount}
+          stickyLeft="var(--diffs-column-number-width)"
+        />
       </Button>
     </>
   );

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -22,7 +22,12 @@ import {
   type SplitDiffRow,
   type SplitSide,
 } from "@/lib/domain/files/diff-view-rows";
-import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  useGapExpansion,
+  type GapExpansionState,
+} from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 
 /** Flattened render row for split view */
@@ -30,13 +35,28 @@ type SplitRenderRow =
   | SplitDiffRow
   | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
 
+function makeSplitGapContextLine(
+  fileLines: string[],
+  gap: InterHunkGap,
+  offset: number,
+): DiffLine {
+  const newLine = gap.newStartLine + offset;
+  return {
+    type: "context",
+    marker: " ",
+    content: fileLines[newLine - 1] ?? "",
+    oldLineNum: gap.oldStartLine + offset,
+    newLineNum: newLine,
+    lineNum: newLine,
+    tokenIndex: -1,
+  };
+}
+
 function flattenSplitWithGapExpansion(
   rows: SplitDiffRow[],
-  gapStates: Map<number, { revealedTop: number; revealedBottom: number; fullyExpanded: boolean }>,
+  gapStates: Map<number, GapExpansionState>,
   fileLines: string[] | undefined,
 ): SplitRenderRow[] {
-  if (!fileLines || gapStates.size === 0) return rows;
-
   const result: SplitRenderRow[] = [];
   for (const row of rows) {
     if (row.kind !== "gap") {
@@ -44,70 +64,41 @@ function flattenSplitWithGapExpansion(
       continue;
     }
 
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: SplitDiffRow = gap === row.gap ? row : { ...row, gap };
+
     const state = gapStates.get(row.gapIndex);
-    if (!state || (state.revealedTop === 0 && state.revealedBottom === 0)) {
-      result.push(row);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
       continue;
     }
 
-    const { gap } = row;
     const totalGapLines = gap.lineCount;
-    if (totalGapLines <= 0) {
-      result.push(row);
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
       continue;
     }
 
-    const gapFileStart = gap.newStartLine - 1;
-
-    // Top expanded lines
-    for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
-      const fileIndex = gapFileStart + i;
-      const content = fileLines[fileIndex] ?? "";
-      const oldLine = gap.oldStartLine + i;
-      const newLine = gap.newStartLine + i;
-      const line: DiffLine = {
-        type: "context",
-        marker: " ",
-        content,
-        oldLineNum: oldLine,
-        newLineNum: newLine,
-        lineNum: newLine,
-        tokenIndex: -1,
-      };
+    for (let i = 0; i < top; i++) {
+      const line = makeSplitGapContextLine(fileLines, gap, i);
       result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
     }
 
-    // Residual gap
-    if (!state.fullyExpanded) {
-      const remainingLines = totalGapLines - state.revealedTop - state.revealedBottom;
-      if (remainingLines > 0) {
-        const residualGap: InterHunkGap = {
-          kind: "gap",
-          oldStartLine: gap.oldStartLine + state.revealedTop,
-          newStartLine: gap.newStartLine + state.revealedTop,
-          lineCount: remainingLines,
-        };
-        result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-      }
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
     }
 
-    // Bottom expanded lines
-    const bottomStart = totalGapLines - state.revealedBottom;
-    for (let i = bottomStart; i < totalGapLines; i++) {
-      if (i < state.revealedTop) continue;
-      const fileIndex = gapFileStart + i;
-      const content = fileLines[fileIndex] ?? "";
-      const oldLine = gap.oldStartLine + i;
-      const newLine = gap.newStartLine + i;
-      const line: DiffLine = {
-        type: "context",
-        marker: " ",
-        content,
-        oldLineNum: oldLine,
-        newLineNum: newLine,
-        lineNum: newLine,
-        tokenIndex: -1,
-      };
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+      const line = makeSplitGapContextLine(fileLines, gap, i);
       result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
     }
   }
@@ -240,13 +231,13 @@ function SplitCollapsedCells({
 function SplitGapCells({
   gap,
   onExpand,
-  fileLines,
+  canExpand,
 }: {
   gap: InterHunkGap;
   onExpand: (direction: ExpandDirection) => void;
-  fileLines?: string[];
+  canExpand: boolean;
 }) {
-  if (!fileLines) {
+  if (!canExpand) {
     // Show non-interactive info row when no file lines available
     return (
       <>
@@ -293,7 +284,7 @@ function SplitCodeColumn({
   lineNumberDigits,
   onExpandCollapsed,
   onExpandGap,
-  fileLines,
+  canExpandGaps,
 }: {
   side: SplitSide;
   rows: SplitRenderRow[];
@@ -303,7 +294,7 @@ function SplitCodeColumn({
   lineNumberDigits: number;
   onExpandCollapsed: (key: string) => void;
   onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
-  fileLines?: string[];
+  canExpandGaps: boolean;
 }) {
   const codeStyle = useMemo(
     () => ({
@@ -365,7 +356,7 @@ function SplitCodeColumn({
               <SplitGapCells
                 gap={row.gap}
                 onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
-                fileLines={fileLines}
+                canExpand={canExpandGaps}
               />
             </Fragment>
           );
@@ -394,6 +385,7 @@ export function SplitDiffViewer({
   overscrollBehaviorY,
   chainVerticalWheel = false,
   fileLines,
+  onRequestFileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -405,12 +397,22 @@ export function SplitDiffViewer({
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
   fileLines?: string[];
+  onRequestFileLines?: () => void;
 }) {
   const resolvedMode = useResolvedMode();
   const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
     new Set(),
   );
   const { gapStates, expandGap } = useGapExpansion();
+  const canExpandGaps = Boolean(fileLines || onRequestFileLines);
+  const expandGapWithFetch = (
+    gapIndex: number,
+    gap: InterHunkGap,
+    direction: ExpandDirection,
+  ) => {
+    onRequestFileLines?.();
+    expandGap(gapIndex, gap, direction);
+  };
   const baseRows = useMemo(
     () => getSplitDiffRows(parsed, expandedCollapsedKeys),
     [parsed, expandedCollapsedKeys],
@@ -506,8 +508,8 @@ export function SplitDiffViewer({
             wrapLongLines={wrapLongLines}
             lineNumberDigits={oldLineNumberDigits}
             onExpandCollapsed={expandCollapsedRow}
-            onExpandGap={expandGap}
-            fileLines={fileLines}
+            onExpandGap={expandGapWithFetch}
+            canExpandGaps={canExpandGaps}
           />
           <SplitCodeColumn
             side="new"
@@ -517,8 +519,8 @@ export function SplitDiffViewer({
             wrapLongLines={wrapLongLines}
             lineNumberDigits={newLineNumberDigits}
             onExpandCollapsed={expandCollapsedRow}
-            onExpandGap={expandGap}
-            fileLines={fileLines}
+            onExpandGap={expandGapWithFetch}
+            canExpandGaps={canExpandGaps}
           />
         </pre>
       </div>

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -6,10 +6,11 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
+import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
-import type { CollapsedContext, DiffLine, ParsedPatch } from "@/lib/domain/files/diff-parser";
+import type { CollapsedContext, DiffLine, InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
 import {
   getDiffLineIndex,
   getDiffLineNumberColumnWidth,
@@ -17,12 +18,101 @@ import {
   getSplitDiffRows,
   getSplitEmptyLineType,
   getSplitLineNumber,
-  getSplitLineNumberDigits,
   getSplitLineType,
   type SplitDiffRow,
   type SplitSide,
 } from "@/lib/domain/files/diff-view-rows";
+import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
+
+/** Flattened render row for split view */
+type SplitRenderRow =
+  | SplitDiffRow
+  | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
+
+function flattenSplitWithGapExpansion(
+  rows: SplitDiffRow[],
+  gapStates: Map<number, { revealedTop: number; revealedBottom: number; fullyExpanded: boolean }>,
+  fileLines: string[] | undefined,
+): SplitRenderRow[] {
+  if (!fileLines || gapStates.size === 0) return rows;
+
+  const result: SplitRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    const state = gapStates.get(row.gapIndex);
+    if (!state || (state.revealedTop === 0 && state.revealedBottom === 0)) {
+      result.push(row);
+      continue;
+    }
+
+    const { gap } = row;
+    const totalGapLines = gap.lineCount;
+    if (totalGapLines <= 0) {
+      result.push(row);
+      continue;
+    }
+
+    const gapFileStart = gap.newStartLine - 1;
+
+    // Top expanded lines
+    for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
+      const fileIndex = gapFileStart + i;
+      const content = fileLines[fileIndex] ?? "";
+      const oldLine = gap.oldStartLine + i;
+      const newLine = gap.newStartLine + i;
+      const line: DiffLine = {
+        type: "context",
+        marker: " ",
+        content,
+        oldLineNum: oldLine,
+        newLineNum: newLine,
+        lineNum: newLine,
+        tokenIndex: -1,
+      };
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
+    }
+
+    // Residual gap
+    if (!state.fullyExpanded) {
+      const remainingLines = totalGapLines - state.revealedTop - state.revealedBottom;
+      if (remainingLines > 0) {
+        const residualGap: InterHunkGap = {
+          kind: "gap",
+          oldStartLine: gap.oldStartLine + state.revealedTop,
+          newStartLine: gap.newStartLine + state.revealedTop,
+          lineCount: remainingLines,
+        };
+        result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+      }
+    }
+
+    // Bottom expanded lines
+    const bottomStart = totalGapLines - state.revealedBottom;
+    for (let i = bottomStart; i < totalGapLines; i++) {
+      if (i < state.revealedTop) continue;
+      const fileIndex = gapFileStart + i;
+      const content = fileLines[fileIndex] ?? "";
+      const oldLine = gap.oldStartLine + i;
+      const newLine = gap.newStartLine + i;
+      const line: DiffLine = {
+        type: "context",
+        marker: " ",
+        content,
+        oldLineNum: oldLine,
+        newLineNum: newLine,
+        lineNum: newLine,
+        tokenIndex: -1,
+      };
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
+    }
+  }
+  return result;
+}
 
 const SPLIT_DIFF_PRE_STYLE = {
   color: "var(--diffs-fg)",
@@ -147,6 +237,53 @@ function SplitCollapsedCells({
   );
 }
 
+function SplitGapCells({
+  gap,
+  onExpand,
+  fileLines,
+}: {
+  gap: InterHunkGap;
+  onExpand: (direction: ExpandDirection) => void;
+  fileLines?: string[];
+}) {
+  if (!fileLines) {
+    // Show non-interactive info row when no file lines available
+    return (
+      <>
+        <div
+          data-gutter=""
+          data-separator="line-info"
+          className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
+        />
+        <div
+          data-content=""
+          data-separator="line-info"
+          className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)] px-2 text-[10px] text-muted-foreground/70"
+        >
+          {gap.lineCount > 0 ? `${gap.lineCount} unmodified lines` : ""}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-separator="gap-expander"
+        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
+      />
+      <div
+        data-content=""
+        data-separator="gap-expander"
+        className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--codex-diffs-separator-surface)]"
+      >
+        <DiffContextExpander gap={gap} onExpand={onExpand} />
+      </div>
+    </>
+  );
+}
+
 function SplitCodeColumn({
   side,
   rows,
@@ -155,14 +292,18 @@ function SplitCodeColumn({
   wrapLongLines,
   lineNumberDigits,
   onExpandCollapsed,
+  onExpandGap,
+  fileLines,
 }: {
   side: SplitSide;
-  rows: SplitDiffRow[];
+  rows: SplitRenderRow[];
   rowCount: number;
   tokens: HighlightedToken[][] | null;
   wrapLongLines: boolean;
   lineNumberDigits: number;
   onExpandCollapsed: (key: string) => void;
+  onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
+  fileLines?: string[];
 }) {
   const codeStyle = useMemo(
     () => ({
@@ -191,26 +332,53 @@ function SplitCodeColumn({
           : "min-w-0 max-w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] grid-cols-[var(--diffs-column-number-width)_minmax(max-content,1fr)]"
       }`}
     >
-      {rows.map((row) =>
-        row.kind === "line" ? (
-          <Fragment key={row.key}>
-            <SplitLineCells
-              line={side === "old" ? row.oldLine : row.newLine}
-              peerLine={side === "old" ? row.newLine : row.oldLine}
-              tokens={tokens}
-              side={side}
-              wrapLongLines={wrapLongLines}
-            />
-          </Fragment>
-        ) : (
+      {rows.map((row) => {
+        if (row.kind === "line") {
+          return (
+            <Fragment key={row.key}>
+              <SplitLineCells
+                line={side === "old" ? row.oldLine : row.newLine}
+                peerLine={side === "old" ? row.newLine : row.oldLine}
+                tokens={tokens}
+                side={side}
+                wrapLongLines={wrapLongLines}
+              />
+            </Fragment>
+          );
+        }
+        if (row.kind === "expanded-gap-line") {
+          return (
+            <Fragment key={row.key}>
+              <SplitLineCells
+                line={side === "old" ? row.oldLine : row.newLine}
+                peerLine={side === "old" ? row.newLine : row.oldLine}
+                tokens={null}
+                side={side}
+                wrapLongLines={wrapLongLines}
+              />
+            </Fragment>
+          );
+        }
+        if (row.kind === "gap") {
+          return (
+            <Fragment key={row.key}>
+              <SplitGapCells
+                gap={row.gap}
+                onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
+                fileLines={fileLines}
+              />
+            </Fragment>
+          );
+        }
+        return (
           <Fragment key={row.key}>
             <SplitCollapsedCells
               section={row.section}
               onExpand={() => onExpandCollapsed(row.key)}
             />
           </Fragment>
-        )
-      )}
+        );
+      })}
     </code>
   );
 }
@@ -225,6 +393,7 @@ export function SplitDiffViewer({
   overscrollBehaviorX,
   overscrollBehaviorY,
   chainVerticalWheel = false,
+  fileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -235,18 +404,42 @@ export function SplitDiffViewer({
   overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
+  fileLines?: string[];
 }) {
   const resolvedMode = useResolvedMode();
   const [expandedCollapsedKeys, setExpandedCollapsedKeys] = useState<Set<string>>(
     new Set(),
   );
-  const rows = useMemo(
+  const { gapStates, expandGap } = useGapExpansion();
+  const baseRows = useMemo(
     () => getSplitDiffRows(parsed, expandedCollapsedKeys),
     [parsed, expandedCollapsedKeys],
   );
+  const rows = useMemo(
+    () => flattenSplitWithGapExpansion(baseRows, gapStates, fileLines),
+    [baseRows, gapStates, fileLines],
+  );
   const rowCount = Math.max(rows.length, 1);
-  const oldLineNumberDigits = getSplitLineNumberDigits(rows, "old");
-  const newLineNumberDigits = getSplitLineNumberDigits(rows, "new");
+  const oldLineNumberDigits = useMemo(() => {
+    let max = 0;
+    for (const row of rows) {
+      if (row.kind === "line" || row.kind === "expanded-gap-line") {
+        const line = row.oldLine;
+        if (line) max = Math.max(max, line.oldLineNum ?? 0);
+      }
+    }
+    return Math.max(String(max).length, 1);
+  }, [rows]);
+  const newLineNumberDigits = useMemo(() => {
+    let max = 0;
+    for (const row of rows) {
+      if (row.kind === "line" || row.kind === "expanded-gap-line") {
+        const line = row.newLine;
+        if (line) max = Math.max(max, line.newLineNum ?? 0);
+      }
+    }
+    return Math.max(String(max).length, 1);
+  }, [rows]);
   const viewportStyle = useMemo(
     () => ({
       overscrollBehavior,
@@ -313,6 +506,8 @@ export function SplitDiffViewer({
             wrapLongLines={wrapLongLines}
             lineNumberDigits={oldLineNumberDigits}
             onExpandCollapsed={expandCollapsedRow}
+            onExpandGap={expandGap}
+            fileLines={fileLines}
           />
           <SplitCodeColumn
             side="new"
@@ -322,6 +517,8 @@ export function SplitDiffViewer({
             wrapLongLines={wrapLongLines}
             lineNumberDigits={newLineNumberDigits}
             onExpandCollapsed={expandCollapsedRow}
+            onExpandGap={expandGap}
+            fileLines={fileLines}
           />
         </pre>
       </div>

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -6,7 +6,11 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
-import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
+import {
+  DiffContextExpander,
+  DiffGapInfoRow,
+  type ExpandDirection,
+} from "@/components/content/ui/diff/DiffContextExpander";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
@@ -237,26 +241,8 @@ function SplitGapCells({
   onExpand: (direction: ExpandDirection) => void;
   canExpand: boolean;
 }) {
-  if (!canExpand) {
-    // Show non-interactive info row when no file lines available
-    return (
-      <>
-        <div
-          data-gutter=""
-          data-separator="line-info"
-          className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--codex-diffs-separator-surface)]"
-        />
-        <div
-          data-content=""
-          data-separator="line-info"
-          className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)] px-2 text-[10px] text-muted-foreground/70"
-        >
-          {gap.lineCount > 0 ? `${gap.lineCount} unmodified lines` : ""}
-        </div>
-      </>
-    );
-  }
-
+  // Each split code column owns its own horizontal scroll; the gutter cell
+  // is sticky at left 0, so the cluster pins just past the gutter width.
   return (
     <>
       <div
@@ -269,7 +255,18 @@ function SplitGapCells({
         data-separator="gap-expander"
         className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--codex-diffs-separator-surface)]"
       >
-        <DiffContextExpander gap={gap} onExpand={onExpand} />
+        {canExpand ? (
+          <DiffContextExpander
+            gap={gap}
+            onExpand={onExpand}
+            stickyLeft="var(--diffs-column-number-width)"
+          />
+        ) : (
+          <DiffGapInfoRow
+            lineCount={gap.lineCount}
+            stickyLeft="var(--diffs-column-number-width)"
+          />
+        )}
       </div>
     </>
   );

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type CSSProperties } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
+  DiffCollapsedContextCluster,
   DiffContextExpander,
   DiffGapInfoRow,
   type ExpandDirection,
@@ -105,9 +106,11 @@ function CollapsedSection({
           setExpanded(true);
         }
       }}
-      className="flex cursor-pointer items-center justify-center py-0.5 text-[10px] text-muted-foreground/40 transition-colors hover:text-muted-foreground/70 hover:bg-muted/20"
+      aria-label={`Expand ${section.lineCount} unmodified lines`}
+      title={`${section.lineCount} unmodified lines`}
+      className="flex min-h-[var(--diffs-line-height)] cursor-pointer items-center bg-[var(--codex-diffs-separator-surface)] text-muted-foreground/60 transition-colors hover:text-foreground"
     >
-      ↕ {section.lineCount} unmodified lines
+      <DiffCollapsedContextCluster lineCount={section.lineCount} />
     </div>
   );
 }

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -1,12 +1,15 @@
-import { useState, type CSSProperties } from "react";
+import { useMemo, useState, type CSSProperties } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
+import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
 import type {
   CollapsedContext,
   DiffHunk,
   DiffLine,
+  InterHunkGap,
   ParsedPatch,
 } from "@/lib/domain/files/diff-parser";
+import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 
 function getLineType(type: DiffLine["type"]): string {
@@ -146,6 +149,52 @@ function HunkView({
   );
 }
 
+function GapSeparator({
+  gap,
+  onExpand,
+  fileLines,
+}: {
+  gap: InterHunkGap;
+  onExpand: (direction: ExpandDirection) => void;
+  fileLines?: string[];
+}) {
+  if (!fileLines) {
+    // Non-interactive informational row
+    if (gap.lineCount <= 0) return null;
+    return (
+      <div className="flex items-center justify-center bg-[var(--codex-diffs-separator-surface)] py-0.5 text-[10px] text-muted-foreground/40">
+        {gap.lineCount} unmodified lines
+      </div>
+    );
+  }
+
+  return <DiffContextExpander gap={gap} onExpand={onExpand} />;
+}
+
+function ExpandedGapLines({
+  lines,
+  wrapLongLines,
+  variant,
+}: {
+  lines: DiffLine[];
+  wrapLongLines: boolean;
+  variant: "default" | "chat";
+}) {
+  return (
+    <>
+      {lines.map((line, i) => (
+        <DiffLineRow
+          key={`expanded-${line.newLineNum}-${i}`}
+          line={line}
+          tokens={null}
+          wrapLongLines={wrapLongLines}
+          variant={variant}
+        />
+      ))}
+    </>
+  );
+}
+
 export function UnifiedDiffViewer({
   parsed,
   tokens,
@@ -157,6 +206,7 @@ export function UnifiedDiffViewer({
   overscrollBehaviorX,
   overscrollBehaviorY,
   chainVerticalWheel,
+  fileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -168,7 +218,67 @@ export function UnifiedDiffViewer({
   overscrollBehaviorX?: CSSProperties["overscrollBehaviorX"];
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
+  fileLines?: string[];
 }) {
+  const { gapStates, expandGap } = useGapExpansion();
+  const gaps = parsed.interHunkGaps;
+
+  // Build expanded gap line arrays
+  const expandedGapContent = useMemo(() => {
+    if (!fileLines || gapStates.size === 0) return new Map<number, { topLines: DiffLine[]; bottomLines: DiffLine[]; residualGap: InterHunkGap | null }>();
+    const result = new Map<number, { topLines: DiffLine[]; bottomLines: DiffLine[]; residualGap: InterHunkGap | null }>();
+    for (const [gapIndex, state] of gapStates) {
+      const gap = gaps[gapIndex];
+      if (!gap || gap.lineCount <= 0) continue;
+      const totalGapLines = gap.lineCount;
+      const gapFileStart = gap.newStartLine - 1;
+
+      const topLines: DiffLine[] = [];
+      for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
+        const fileIndex = gapFileStart + i;
+        const content = fileLines[fileIndex] ?? "";
+        topLines.push({
+          type: "context", marker: " ", content,
+          oldLineNum: gap.oldStartLine + i,
+          newLineNum: gap.newStartLine + i,
+          lineNum: gap.newStartLine + i,
+          tokenIndex: -1,
+        });
+      }
+
+      const bottomLines: DiffLine[] = [];
+      const bottomStart = totalGapLines - state.revealedBottom;
+      for (let i = bottomStart; i < totalGapLines; i++) {
+        if (i < state.revealedTop) continue;
+        const fileIndex = gapFileStart + i;
+        const content = fileLines[fileIndex] ?? "";
+        bottomLines.push({
+          type: "context", marker: " ", content,
+          oldLineNum: gap.oldStartLine + i,
+          newLineNum: gap.newStartLine + i,
+          lineNum: gap.newStartLine + i,
+          tokenIndex: -1,
+        });
+      }
+
+      let residualGap: InterHunkGap | null = null;
+      if (!state.fullyExpanded) {
+        const remaining = totalGapLines - state.revealedTop - state.revealedBottom;
+        if (remaining > 0) {
+          residualGap = {
+            kind: "gap",
+            oldStartLine: gap.oldStartLine + state.revealedTop,
+            newStartLine: gap.newStartLine + state.revealedTop,
+            lineCount: remaining,
+          };
+        }
+      }
+
+      result.set(gapIndex, { topLines, bottomLines, residualGap });
+    }
+    return result;
+  }, [fileLines, gapStates, gaps]);
+
   return (
     <AutoHideScrollArea
       className={className}
@@ -182,15 +292,73 @@ export function UnifiedDiffViewer({
       overscrollBehaviorY={overscrollBehaviorY}
       chainVerticalWheel={chainVerticalWheel}
     >
-      {parsed.hunks.map((hunk, index) => (
-        <HunkView
-          key={index}
-          hunk={hunk}
-          tokens={tokens}
-          wrapLongLines={wrapLongLines}
-          variant={variant}
-        />
-      ))}
+      {parsed.hunks.map((hunk, index) => {
+        const gapBefore = gaps[index];
+        const expandedBefore = expandedGapContent.get(index);
+        const showGapBefore = gapBefore && gapBefore.lineCount !== 0;
+
+        return (
+          <div key={index}>
+            {showGapBefore && expandedBefore && (
+              <>
+                <ExpandedGapLines lines={expandedBefore.topLines} wrapLongLines={wrapLongLines} variant={variant} />
+                {expandedBefore.residualGap ? (
+                  <GapSeparator
+                    gap={expandedBefore.residualGap}
+                    onExpand={(dir) => expandGap(index, expandedBefore.residualGap!, dir)}
+                    fileLines={fileLines}
+                  />
+                ) : null}
+                <ExpandedGapLines lines={expandedBefore.bottomLines} wrapLongLines={wrapLongLines} variant={variant} />
+              </>
+            )}
+            {showGapBefore && !expandedBefore && (
+              <GapSeparator
+                gap={gapBefore}
+                onExpand={(dir) => expandGap(index, gapBefore, dir)}
+                fileLines={fileLines}
+              />
+            )}
+            <HunkView
+              hunk={hunk}
+              tokens={tokens}
+              wrapLongLines={wrapLongLines}
+              variant={variant}
+            />
+          </div>
+        );
+      })}
+      {/* Gap after last hunk */}
+      {(() => {
+        const lastGapIndex = parsed.hunks.length;
+        const gapAfter = gaps[lastGapIndex];
+        const expandedAfter = expandedGapContent.get(lastGapIndex);
+        if (!gapAfter || gapAfter.lineCount === 0) return null;
+
+        if (expandedAfter) {
+          return (
+            <div>
+              <ExpandedGapLines lines={expandedAfter.topLines} wrapLongLines={wrapLongLines} variant={variant} />
+              {expandedAfter.residualGap ? (
+                <GapSeparator
+                  gap={expandedAfter.residualGap}
+                  onExpand={(dir) => expandGap(lastGapIndex, expandedAfter.residualGap!, dir)}
+                  fileLines={fileLines}
+                />
+              ) : null}
+              <ExpandedGapLines lines={expandedAfter.bottomLines} wrapLongLines={wrapLongLines} variant={variant} />
+            </div>
+          );
+        }
+
+        return (
+          <GapSeparator
+            gap={gapAfter}
+            onExpand={(dir) => expandGap(lastGapIndex, gapAfter, dir)}
+            fileLines={fileLines}
+          />
+        );
+      })()}
     </AutoHideScrollArea>
   );
 }

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -7,6 +7,8 @@ import {
   DiffGapInfoRow,
   type ExpandDirection,
 } from "@/components/content/ui/diff/DiffContextExpander";
+// UnifiedDiffViewer uses the legacy combined DiffContextExpander / DiffCollapsedContextCluster
+// which now render controls at the row-start gutter-width area internally.
 import type {
   CollapsedContext,
   DiffHunk,

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -9,7 +9,11 @@ import type {
   InterHunkGap,
   ParsedPatch,
 } from "@/lib/domain/files/diff-parser";
-import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  useGapExpansion,
+} from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 
 function getLineType(type: DiffLine["type"]): string {
@@ -152,13 +156,13 @@ function HunkView({
 function GapSeparator({
   gap,
   onExpand,
-  fileLines,
+  canExpand,
 }: {
   gap: InterHunkGap;
   onExpand: (direction: ExpandDirection) => void;
-  fileLines?: string[];
+  canExpand: boolean;
 }) {
-  if (!fileLines) {
+  if (!canExpand) {
     // Non-interactive informational row
     if (gap.lineCount <= 0) return null;
     return (
@@ -207,6 +211,7 @@ export function UnifiedDiffViewer({
   overscrollBehaviorY,
   chainVerticalWheel,
   fileLines,
+  onRequestFileLines,
 }: {
   parsed: ParsedPatch;
   tokens: HighlightedToken[][] | null;
@@ -219,59 +224,68 @@ export function UnifiedDiffViewer({
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
   fileLines?: string[];
+  onRequestFileLines?: () => void;
 }) {
   const { gapStates, expandGap } = useGapExpansion();
-  const gaps = parsed.interHunkGaps;
+  const canExpandGaps = Boolean(fileLines || onRequestFileLines);
+  const expandGapWithFetch = (
+    gapIndex: number,
+    gap: InterHunkGap,
+    direction: ExpandDirection,
+  ) => {
+    onRequestFileLines?.();
+    expandGap(gapIndex, gap, direction);
+  };
+
+  // Resolve unknown trailing gap counts against fetched file length
+  const gaps = useMemo(
+    () =>
+      parsed.interHunkGaps.map((gap) => resolveGapLineCount(gap, fileLines)),
+    [parsed.interHunkGaps, fileLines],
+  );
 
   // Build expanded gap line arrays
   const expandedGapContent = useMemo(() => {
-    if (!fileLines || gapStates.size === 0) return new Map<number, { topLines: DiffLine[]; bottomLines: DiffLine[]; residualGap: InterHunkGap | null }>();
     const result = new Map<number, { topLines: DiffLine[]; bottomLines: DiffLine[]; residualGap: InterHunkGap | null }>();
+    if (!fileLines || gapStates.size === 0) return result;
     for (const [gapIndex, state] of gapStates) {
       const gap = gaps[gapIndex];
       if (!gap || gap.lineCount <= 0) continue;
       const totalGapLines = gap.lineCount;
-      const gapFileStart = gap.newStartLine - 1;
+      const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+      if (top === 0 && bottom === 0) continue;
+
+      const makeLine = (offset: number): DiffLine => {
+        const newLine = gap.newStartLine + offset;
+        return {
+          type: "context",
+          marker: " ",
+          content: fileLines[newLine - 1] ?? "",
+          oldLineNum: gap.oldStartLine + offset,
+          newLineNum: newLine,
+          lineNum: newLine,
+          tokenIndex: -1,
+        };
+      };
 
       const topLines: DiffLine[] = [];
-      for (let i = 0; i < state.revealedTop && i < totalGapLines; i++) {
-        const fileIndex = gapFileStart + i;
-        const content = fileLines[fileIndex] ?? "";
-        topLines.push({
-          type: "context", marker: " ", content,
-          oldLineNum: gap.oldStartLine + i,
-          newLineNum: gap.newStartLine + i,
-          lineNum: gap.newStartLine + i,
-          tokenIndex: -1,
-        });
+      for (let i = 0; i < top; i++) {
+        topLines.push(makeLine(i));
       }
 
       const bottomLines: DiffLine[] = [];
-      const bottomStart = totalGapLines - state.revealedBottom;
-      for (let i = bottomStart; i < totalGapLines; i++) {
-        if (i < state.revealedTop) continue;
-        const fileIndex = gapFileStart + i;
-        const content = fileLines[fileIndex] ?? "";
-        bottomLines.push({
-          type: "context", marker: " ", content,
-          oldLineNum: gap.oldStartLine + i,
-          newLineNum: gap.newStartLine + i,
-          lineNum: gap.newStartLine + i,
-          tokenIndex: -1,
-        });
+      for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+        bottomLines.push(makeLine(i));
       }
 
       let residualGap: InterHunkGap | null = null;
-      if (!state.fullyExpanded) {
-        const remaining = totalGapLines - state.revealedTop - state.revealedBottom;
-        if (remaining > 0) {
-          residualGap = {
-            kind: "gap",
-            oldStartLine: gap.oldStartLine + state.revealedTop,
-            newStartLine: gap.newStartLine + state.revealedTop,
-            lineCount: remaining,
-          };
-        }
+      if (!fullyExpanded) {
+        residualGap = {
+          kind: "gap",
+          oldStartLine: gap.oldStartLine + top,
+          newStartLine: gap.newStartLine + top,
+          lineCount: totalGapLines - top - bottom,
+        };
       }
 
       result.set(gapIndex, { topLines, bottomLines, residualGap });
@@ -295,28 +309,28 @@ export function UnifiedDiffViewer({
       {parsed.hunks.map((hunk, index) => {
         const gapBefore = gaps[index];
         const expandedBefore = expandedGapContent.get(index);
-        const showGapBefore = gapBefore && gapBefore.lineCount !== 0;
+        const showGapBefore = Boolean(gapBefore && gapBefore.lineCount !== 0);
 
         return (
           <div key={index}>
-            {showGapBefore && expandedBefore && (
+            {gapBefore && showGapBefore && expandedBefore && (
               <>
                 <ExpandedGapLines lines={expandedBefore.topLines} wrapLongLines={wrapLongLines} variant={variant} />
                 {expandedBefore.residualGap ? (
                   <GapSeparator
                     gap={expandedBefore.residualGap}
-                    onExpand={(dir) => expandGap(index, expandedBefore.residualGap!, dir)}
-                    fileLines={fileLines}
+                    onExpand={(dir) => expandGapWithFetch(index, expandedBefore.residualGap!, dir)}
+                    canExpand={canExpandGaps}
                   />
                 ) : null}
                 <ExpandedGapLines lines={expandedBefore.bottomLines} wrapLongLines={wrapLongLines} variant={variant} />
               </>
             )}
-            {showGapBefore && !expandedBefore && (
+            {gapBefore && showGapBefore && !expandedBefore && (
               <GapSeparator
                 gap={gapBefore}
-                onExpand={(dir) => expandGap(index, gapBefore, dir)}
-                fileLines={fileLines}
+                onExpand={(dir) => expandGapWithFetch(index, gapBefore, dir)}
+                canExpand={canExpandGaps}
               />
             )}
             <HunkView
@@ -342,8 +356,8 @@ export function UnifiedDiffViewer({
               {expandedAfter.residualGap ? (
                 <GapSeparator
                   gap={expandedAfter.residualGap}
-                  onExpand={(dir) => expandGap(lastGapIndex, expandedAfter.residualGap!, dir)}
-                  fileLines={fileLines}
+                  onExpand={(dir) => expandGapWithFetch(lastGapIndex, expandedAfter.residualGap!, dir)}
+                  canExpand={canExpandGaps}
                 />
               ) : null}
               <ExpandedGapLines lines={expandedAfter.bottomLines} wrapLongLines={wrapLongLines} variant={variant} />
@@ -354,8 +368,8 @@ export function UnifiedDiffViewer({
         return (
           <GapSeparator
             gap={gapAfter}
-            onExpand={(dir) => expandGap(lastGapIndex, gapAfter, dir)}
-            fileLines={fileLines}
+            onExpand={(dir) => expandGapWithFetch(lastGapIndex, gapAfter, dir)}
+            canExpand={canExpandGaps}
           />
         );
       })()}

--- a/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState, type CSSProperties } from "react";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
 import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
-import { DiffContextExpander, type ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
+import {
+  DiffContextExpander,
+  DiffGapInfoRow,
+  type ExpandDirection,
+} from "@/components/content/ui/diff/DiffContextExpander";
 import type {
   CollapsedContext,
   DiffHunk,
@@ -162,14 +166,11 @@ function GapSeparator({
   onExpand: (direction: ExpandDirection) => void;
   canExpand: boolean;
 }) {
+  // The AutoHideScrollArea viewport owns horizontal scroll and there is
+  // no sticky gutter in this simple layout, so the cluster pins at left 0.
   if (!canExpand) {
-    // Non-interactive informational row
     if (gap.lineCount <= 0) return null;
-    return (
-      <div className="flex items-center justify-center bg-[var(--codex-diffs-separator-surface)] py-0.5 text-[10px] text-muted-foreground/40">
-        {gap.lineCount} unmodified lines
-      </div>
-    );
+    return <DiffGapInfoRow lineCount={gap.lineCount} />;
   }
 
   return <DiffContextExpander gap={gap} onExpand={onExpand} />;

--- a/apps/desktop/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { DiffViewer } from "@/components/content/ui/DiffViewer";
 import { FileDiffCard } from "@/components/content/ui/FileDiffCard";
 import { useTurnCurrentFilePatch } from "@/hooks/chat/cache/use-turn-current-file-diffs";
+import { useLazyDiffFileLines } from "@/hooks/ui/diff/use-lazy-diff-file-lines";
 import type { GitPanelReviewFile } from "@/lib/domain/workspaces/changes/git-panel-diff";
 import { CircleAlert, FileCode, FileIcon, RefreshCw } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -53,6 +54,13 @@ export function TurnDiffFileCard({
     workspaceId,
     baseRef,
     enabled: isRuntimeReady && isExpanded,
+  });
+  // Turn diffs use scope=base_worktree (worktree vs merge-base), so the
+  // diff's NEW side is the current worktree file — safe for gap expansion.
+  const { fileLines, requestFileLines } = useLazyDiffFileLines({
+    workspaceId,
+    path: file.path,
+    enabled: isRuntimeReady,
   });
   const emptyDiffState = formatEmptyDiffState({
     binary: Boolean(diffQuery.data?.binary || currentDiff?.binary),
@@ -132,6 +140,8 @@ export function TurnDiffFileCard({
               contentSearchUnitId={`diff:${turnId}:${file.path}`}
               viewportClassName={TURN_DIFF_VIEWPORT_CLASS}
               variant="chat"
+              fileLines={fileLines}
+              onRequestFileLines={requestFileLines}
             />
             {diffQuery.data?.truncated ? (
               <p className="px-3 py-2 text-center text-xs text-muted-foreground">

--- a/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/workspace/git/GitReviewInlineState";
 import { GitReviewStageAction } from "@/components/workspace/git/GitReviewStageAction";
 import { GitReviewStatusBadge } from "@/components/workspace/git/GitReviewStatusBadge";
+import { useLazyDiffFileLines } from "@/hooks/ui/diff/use-lazy-diff-file-lines";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type {
@@ -72,6 +73,17 @@ export function GitReviewFileRow({
   const isBranchMode = sectionScope === "branch";
   const isLastTurnMode = sectionScope === "last_turn";
   const shouldUnstage = sectionScope === "staged";
+  // Gap expansion reads the worktree file, which only matches the diff's
+  // NEW side for worktree-target scopes: `unstaged` (worktree vs index) and
+  // `last_turn`/`base_worktree` (worktree vs merge-base). `staged` diffs
+  // target the index and `branch` diffs target HEAD, so those degrade to
+  // informational separators.
+  const gapExpansionScopeValid = sectionScope === "unstaged" || isLastTurnMode;
+  const { fileLines, requestFileLines } = useLazyDiffFileLines({
+    workspaceId,
+    path: file.path,
+    enabled: gapExpansionScopeValid && isRuntimeReady,
+  });
   const metadataPolicy = useMemo(
     () => currentDiff
       ? resolveDiffDisplayPolicy({
@@ -225,6 +237,8 @@ export function GitReviewFileRow({
                 overscrollBehaviorX="none"
                 overscrollBehaviorY="none"
                 chainVerticalWheel
+                fileLines={fileLines}
+                onRequestFileLines={requestFileLines}
               />
               {diffQuery.data?.truncated ? (
                 <p className="px-3 py-2 text-center text-xs text-sidebar-muted-foreground">

--- a/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
+++ b/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
@@ -76,7 +76,8 @@ export function clampGapReveal(
 /**
  * Resolve a gap with unknown line count (-1, trailing gap) against the
  * fetched file's total line count. Returns null when the gap turns out
- * to be empty.
+ * to be empty, or when the count is unknown and file content has not
+ * been fetched yet — a separator must never render without a number.
  */
 export function resolveGapLineCount(
   gap: InterHunkGap,
@@ -86,7 +87,7 @@ export function resolveGapLineCount(
     return gap.lineCount === 0 ? null : gap;
   }
   if (!fileLines) {
-    return gap;
+    return null;
   }
   // Trailing file content often ends with a newline, producing one empty
   // trailing element from split("\n") that is not a real line.

--- a/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
+++ b/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
@@ -1,0 +1,57 @@
+import { useCallback, useState } from "react";
+import type { InterHunkGap } from "@/lib/domain/files/diff-parser";
+import type { ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
+
+/** Number of lines to reveal per directional expand click */
+const EXPAND_STEP = 20;
+
+export interface GapExpansionState {
+  /** Lines revealed from the top of the gap (adjacent to hunk above) */
+  revealedTop: number;
+  /** Lines revealed from the bottom of the gap (adjacent to hunk below) */
+  revealedBottom: number;
+  /** Whether fully expanded */
+  fullyExpanded: boolean;
+}
+
+/**
+ * Manages per-gap expansion state. Expansion is purely client-side using
+ * file content lines provided externally. When file content is not available,
+ * callers should hide the expander.
+ */
+export function useGapExpansion() {
+  const [gapStates, setGapStates] = useState<Map<number, GapExpansionState>>(new Map());
+
+  const expandGap = useCallback(
+    (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => {
+      setGapStates((prev) => {
+        const next = new Map(prev);
+        const current = next.get(gapIndex) ?? { revealedTop: 0, revealedBottom: 0, fullyExpanded: false };
+        const totalLines = gap.lineCount;
+
+        if (direction === "all" || totalLines <= 0) {
+          next.set(gapIndex, { revealedTop: totalLines, revealedBottom: 0, fullyExpanded: true });
+        } else if (direction === "down") {
+          // Expand from top (lines adjacent to hunk above = top of gap)
+          const newTop = Math.min(current.revealedTop + EXPAND_STEP, totalLines - current.revealedBottom);
+          const fullyExpanded = newTop + current.revealedBottom >= totalLines;
+          next.set(gapIndex, { ...current, revealedTop: newTop, fullyExpanded });
+        } else if (direction === "up") {
+          // Expand from bottom (lines adjacent to hunk below = bottom of gap)
+          const newBottom = Math.min(current.revealedBottom + EXPAND_STEP, totalLines - current.revealedTop);
+          const fullyExpanded = current.revealedTop + newBottom >= totalLines;
+          next.set(gapIndex, { ...current, revealedBottom: newBottom, fullyExpanded });
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const getGapState = useCallback(
+    (gapIndex: number): GapExpansionState | undefined => gapStates.get(gapIndex),
+    [gapStates],
+  );
+
+  return { gapStates, expandGap, getGapState };
+}

--- a/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
+++ b/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
@@ -6,41 +6,41 @@ import type { ExpandDirection } from "@/components/content/ui/diff/DiffContextEx
 const EXPAND_STEP = 20;
 
 export interface GapExpansionState {
-  /** Lines revealed from the top of the gap (adjacent to hunk above) */
+  /**
+   * Lines requested from the top of the gap (adjacent to hunk above).
+   * Unclamped — viewers clamp against the gap's actual line count at
+   * render time (counts may be unknown until file content is fetched).
+   */
   revealedTop: number;
-  /** Lines revealed from the bottom of the gap (adjacent to hunk below) */
+  /** Lines requested from the bottom of the gap (adjacent to hunk below) */
   revealedBottom: number;
-  /** Whether fully expanded */
-  fullyExpanded: boolean;
 }
 
 /**
- * Manages per-gap expansion state. Expansion is purely client-side using
- * file content lines provided externally. When file content is not available,
- * callers should hide the expander.
+ * Manages per-gap expansion state, keyed by gap index. Reveal amounts are
+ * stored unclamped so expansion requested before file content arrives
+ * (lazy fetch) applies correctly once line counts are known.
  */
 export function useGapExpansion() {
   const [gapStates, setGapStates] = useState<Map<number, GapExpansionState>>(new Map());
 
   const expandGap = useCallback(
-    (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => {
+    (gapIndex: number, _gap: InterHunkGap, direction: ExpandDirection) => {
       setGapStates((prev) => {
         const next = new Map(prev);
-        const current = next.get(gapIndex) ?? { revealedTop: 0, revealedBottom: 0, fullyExpanded: false };
-        const totalLines = gap.lineCount;
+        const current = next.get(gapIndex) ?? { revealedTop: 0, revealedBottom: 0 };
 
-        if (direction === "all" || totalLines <= 0) {
-          next.set(gapIndex, { revealedTop: totalLines, revealedBottom: 0, fullyExpanded: true });
+        if (direction === "all") {
+          next.set(gapIndex, {
+            revealedTop: Number.MAX_SAFE_INTEGER,
+            revealedBottom: 0,
+          });
         } else if (direction === "down") {
           // Expand from top (lines adjacent to hunk above = top of gap)
-          const newTop = Math.min(current.revealedTop + EXPAND_STEP, totalLines - current.revealedBottom);
-          const fullyExpanded = newTop + current.revealedBottom >= totalLines;
-          next.set(gapIndex, { ...current, revealedTop: newTop, fullyExpanded });
+          next.set(gapIndex, { ...current, revealedTop: current.revealedTop + EXPAND_STEP });
         } else if (direction === "up") {
           // Expand from bottom (lines adjacent to hunk below = bottom of gap)
-          const newBottom = Math.min(current.revealedBottom + EXPAND_STEP, totalLines - current.revealedTop);
-          const fullyExpanded = current.revealedTop + newBottom >= totalLines;
-          next.set(gapIndex, { ...current, revealedBottom: newBottom, fullyExpanded });
+          next.set(gapIndex, { ...current, revealedBottom: current.revealedBottom + EXPAND_STEP });
         }
         return next;
       });
@@ -54,4 +54,49 @@ export function useGapExpansion() {
   );
 
   return { gapStates, expandGap, getGapState };
+}
+
+/**
+ * Clamp raw reveal amounts against the gap's actual line count.
+ * Returns effective top/bottom line counts plus whether the gap is
+ * fully consumed.
+ */
+export function clampGapReveal(
+  state: GapExpansionState,
+  totalLines: number,
+): { top: number; bottom: number; fullyExpanded: boolean } {
+  if (totalLines <= 0) {
+    return { top: 0, bottom: 0, fullyExpanded: false };
+  }
+  const top = Math.min(state.revealedTop, totalLines);
+  const bottom = Math.min(state.revealedBottom, totalLines - top);
+  return { top, bottom, fullyExpanded: top + bottom >= totalLines };
+}
+
+/**
+ * Resolve a gap with unknown line count (-1, trailing gap) against the
+ * fetched file's total line count. Returns null when the gap turns out
+ * to be empty.
+ */
+export function resolveGapLineCount(
+  gap: InterHunkGap,
+  fileLines: string[] | undefined,
+): InterHunkGap | null {
+  if (gap.lineCount >= 0) {
+    return gap.lineCount === 0 ? null : gap;
+  }
+  if (!fileLines) {
+    return gap;
+  }
+  // Trailing file content often ends with a newline, producing one empty
+  // trailing element from split("\n") that is not a real line.
+  const totalNewLines =
+    fileLines.length > 0 && fileLines[fileLines.length - 1] === ""
+      ? fileLines.length - 1
+      : fileLines.length;
+  const lineCount = totalNewLines - gap.newStartLine + 1;
+  if (lineCount <= 0) {
+    return null;
+  }
+  return { ...gap, lineCount };
 }

--- a/apps/desktop/src/hooks/ui/diff/use-lazy-diff-file-lines.ts
+++ b/apps/desktop/src/hooks/ui/diff/use-lazy-diff-file-lines.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useReadWorkspaceFileMutation } from "@anyharness/sdk-react";
+
+export interface LazyDiffFileLinesResult {
+  /** New-side file content split into lines, once fetched successfully */
+  fileLines: string[] | undefined;
+  /**
+   * Trigger the lazy fetch. Undefined when expansion is not possible
+   * (disabled scope, missing workspace, or a previous fetch failed) so
+   * viewers can degrade gap separators to informational labels.
+   */
+  requestFileLines: (() => void) | undefined;
+}
+
+/**
+ * Lazily fetches the current worktree content of a file for diff gap
+ * expansion. The fetch fires on the first expander interaction (not
+ * eagerly per file), is cached for the component lifetime, and degrades
+ * silently on failure (binary/too-large/missing file).
+ *
+ * Only valid when the diff's NEW side matches the worktree state
+ * (unstaged / base_worktree scopes). Callers must gate `enabled` on that.
+ */
+export function useLazyDiffFileLines({
+  workspaceId,
+  path,
+  enabled,
+}: {
+  workspaceId: string | null;
+  path: string;
+  enabled: boolean;
+}): LazyDiffFileLinesResult {
+  const readFile = useReadWorkspaceFileMutation({ workspaceId });
+  const [fileLines, setFileLines] = useState<string[] | undefined>(undefined);
+  const [failed, setFailed] = useState(false);
+  const requestedPathRef = useRef<string | null>(null);
+  const mutateAsync = readFile.mutateAsync;
+
+  // Reset cache when the target file changes (component reuse across files)
+  useEffect(() => {
+    if (requestedPathRef.current !== null && requestedPathRef.current !== path) {
+      requestedPathRef.current = null;
+      setFileLines(undefined);
+      setFailed(false);
+    }
+  }, [path]);
+
+  const requestFileLines = useCallback(() => {
+    if (requestedPathRef.current === path) return;
+    requestedPathRef.current = path;
+    mutateAsync({ path })
+      .then((response) => {
+        if (!response.isText || response.tooLarge || typeof response.content !== "string") {
+          setFailed(true);
+          return;
+        }
+        setFileLines(response.content.split("\n"));
+      })
+      .catch(() => {
+        setFailed(true);
+      });
+  }, [mutateAsync, path]);
+
+  const canRequest = enabled && Boolean(workspaceId) && !failed;
+
+  return {
+    fileLines,
+    requestFileLines: canRequest ? requestFileLines : undefined,
+  };
+}

--- a/apps/desktop/src/lib/domain/files/diff-parser.test.ts
+++ b/apps/desktop/src/lib/domain/files/diff-parser.test.ts
@@ -116,6 +116,54 @@ index 1111111..2222222 100644
     ]);
   });
 
+  it("computes inter-hunk gaps between hunks", () => {
+    const parsed = parsePatch(`@@ -5,3 +5,3 @@
+ context
+-old
++new
+@@ -20,3 +20,3 @@
+ context
+-old2
++new2`);
+
+    expect(parsed.interHunkGaps).toHaveLength(3);
+    // Gap before first hunk: lines 1..4
+    expect(parsed.interHunkGaps[0]).toMatchObject({
+      kind: "gap",
+      oldStartLine: 1,
+      newStartLine: 1,
+      lineCount: 4,
+    });
+    // Gap between hunks: lines 8..19 (first hunk ends at new line 8, second starts at 20)
+    expect(parsed.interHunkGaps[1]).toMatchObject({
+      kind: "gap",
+      oldStartLine: 8,
+      newStartLine: 8,
+      lineCount: 12,
+    });
+    // Gap after last hunk: unknown (-1) since totalNewLines not provided
+    expect(parsed.interHunkGaps[2]).toMatchObject({
+      kind: "gap",
+      lineCount: -1,
+    });
+  });
+
+  it("computes gap after last hunk when totalNewLines provided", () => {
+    const parsed = parsePatch(`@@ -1,3 +1,3 @@
+ context
+-old
++new`, 10);
+
+    // Gap before: 0 lines (hunk starts at line 1)
+    expect(parsed.interHunkGaps[0]).toMatchObject({ lineCount: 0 });
+    // Gap after: lines 4..10 = 7 lines
+    expect(parsed.interHunkGaps[1]).toMatchObject({
+      kind: "gap",
+      newStartLine: 4,
+      lineCount: 7,
+    });
+  });
+
   it("preserves line numbers and token indexes inside collapsed context", () => {
     const parsed = parsePatch(`@@ -1,8 +1,8 @@
  one

--- a/apps/desktop/src/lib/domain/files/diff-parser.ts
+++ b/apps/desktop/src/lib/domain/files/diff-parser.ts
@@ -27,13 +27,34 @@ export interface DiffHunk {
   items: Array<DiffLine | CollapsedContext>;
 }
 
+/**
+ * Represents a gap between hunks (or before the first / after the last hunk)
+ * where lines exist in the file but are NOT included in the diff patch.
+ */
+export interface InterHunkGap {
+  kind: "gap";
+  /** 1-based old-side start line of the gap (inclusive) */
+  oldStartLine: number;
+  /** 1-based new-side start line of the gap (inclusive) */
+  newStartLine: number;
+  /** Number of unchanged lines in this gap */
+  lineCount: number;
+}
+
 export interface ParsedPatch {
   hunks: DiffHunk[];
   /** All code lines (prefix-stripped) in order, for bulk highlighting */
   allCodeLines: string[];
+  /**
+   * Inter-hunk gaps: regions of unchanged lines between hunks (and before/after).
+   * Length = hunks.length + 1 (gap[0] is before first hunk, gap[n] is after last).
+   * A gap with lineCount === 0 means hunks are adjacent (no gap).
+   * A gap with lineCount === -1 means unknown (e.g., gap after last hunk when
+   * total file length is not available).
+   */
+  interHunkGaps: InterHunkGap[];
 }
 
-const HUNK_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 const HUNK_CONTEXT_RE = /^@@ .+? @@\s*(.*)$/;
 
 function classifyLine(line: string): "added" | "removed" | "context" | "hunk" | "meta" {
@@ -101,7 +122,9 @@ function collapseContextRuns(lines: DiffLine[], keep: number): Array<DiffLine | 
   return items;
 }
 
-export function parsePatch(patch: string): ParsedPatch {
+const HUNK_RANGE_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parsePatch(patch: string, totalNewLines?: number): ParsedPatch {
   const hunks: DiffHunk[] = [];
   const allCodeLines: string[] = [];
 
@@ -111,6 +134,16 @@ export function parsePatch(patch: string): ParsedPatch {
   let newNum = 1;
   let tokenIndex = 0;
 
+  // Track hunk start/end positions for inter-hunk gap computation
+  interface HunkBounds {
+    oldStart: number;
+    oldCount: number;
+    newStart: number;
+    newCount: number;
+  }
+  const hunkBounds: HunkBounds[] = [];
+  let pendingBounds: HunkBounds | null = null;
+
   function flushHunk() {
     if (currentLines.length === 0) return;
     hunks.push({
@@ -118,6 +151,9 @@ export function parsePatch(patch: string): ParsedPatch {
       contextLabel: currentLabel,
       items: collapseContextRuns(currentLines, 1),
     });
+    if (pendingBounds) {
+      hunkBounds.push(pendingBounds);
+    }
     currentLines = [];
   }
 
@@ -128,10 +164,15 @@ export function parsePatch(patch: string): ParsedPatch {
 
     if (cls === "hunk") {
       flushHunk();
-      const match = HUNK_RE.exec(raw);
+      const match = HUNK_RANGE_RE.exec(raw);
       if (match) {
         oldNum = parseInt(match[1], 10);
-        newNum = parseInt(match[2], 10);
+        newNum = parseInt(match[3], 10);
+        const oldCount = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+        const newCount = match[4] !== undefined ? parseInt(match[4], 10) : 1;
+        pendingBounds = { oldStart: oldNum, oldCount, newStart: newNum, newCount };
+      } else {
+        pendingBounds = { oldStart: oldNum, oldCount: 0, newStart: newNum, newCount: 0 };
       }
       const ctxMatch = HUNK_CONTEXT_RE.exec(raw);
       currentLabel = ctxMatch?.[1]?.trim() ?? "";
@@ -181,5 +222,55 @@ export function parsePatch(patch: string): ParsedPatch {
 
   flushHunk();
 
-  return { hunks, allCodeLines };
+  // Compute inter-hunk gaps
+  const interHunkGaps: InterHunkGap[] = [];
+
+  if (hunkBounds.length === 0) {
+    // No hunks — single gap representing the whole file
+    interHunkGaps.push({
+      kind: "gap",
+      oldStartLine: 1,
+      newStartLine: 1,
+      lineCount: totalNewLines != null ? totalNewLines : -1,
+    });
+  } else {
+    // Gap before first hunk
+    const first = hunkBounds[0];
+    const linesBeforeFirst = first.newStart - 1;
+    interHunkGaps.push({
+      kind: "gap",
+      oldStartLine: 1,
+      newStartLine: 1,
+      lineCount: linesBeforeFirst,
+    });
+
+    // Gaps between hunks
+    for (let i = 0; i < hunkBounds.length - 1; i++) {
+      const prev = hunkBounds[i];
+      const next = hunkBounds[i + 1];
+      const prevOldEnd = prev.oldStart + prev.oldCount;
+      const prevNewEnd = prev.newStart + prev.newCount;
+      const gapLines = next.newStart - prevNewEnd;
+      interHunkGaps.push({
+        kind: "gap",
+        oldStartLine: prevOldEnd,
+        newStartLine: prevNewEnd,
+        lineCount: Math.max(0, gapLines),
+      });
+    }
+
+    // Gap after last hunk
+    const last = hunkBounds[hunkBounds.length - 1];
+    const lastNewEnd = last.newStart + last.newCount;
+    const lastOldEnd = last.oldStart + last.oldCount;
+    const linesAfterLast = totalNewLines != null ? totalNewLines - lastNewEnd + 1 : -1;
+    interHunkGaps.push({
+      kind: "gap",
+      oldStartLine: lastOldEnd,
+      newStartLine: lastNewEnd,
+      lineCount: linesAfterLast,
+    });
+  }
+
+  return { hunks, allCodeLines, interHunkGaps };
 }

--- a/apps/desktop/src/lib/domain/files/diff-view-rows.ts
+++ b/apps/desktop/src/lib/domain/files/diff-view-rows.ts
@@ -1,6 +1,7 @@
 import type {
   CollapsedContext,
   DiffLine,
+  InterHunkGap,
   ParsedPatch,
 } from "@/lib/domain/files/diff-parser";
 
@@ -11,7 +12,8 @@ export type DiffLineDisplayType =
 
 export type ChatDiffRow =
   | { kind: "line"; key: string; line: DiffLine }
-  | { kind: "collapsed"; key: string; section: CollapsedContext };
+  | { kind: "collapsed"; key: string; section: CollapsedContext }
+  | { kind: "gap"; key: string; gap: InterHunkGap; gapIndex: number };
 
 export type SplitSide = "old" | "new";
 
@@ -22,7 +24,8 @@ export type SplitDiffRow =
       oldLine: DiffLine | null;
       newLine: DiffLine | null;
     }
-  | { kind: "collapsed"; key: string; section: CollapsedContext };
+  | { kind: "collapsed"; key: string; section: CollapsedContext }
+  | { kind: "gap"; key: string; gap: InterHunkGap; gapIndex: number };
 
 export function getDiffLineNumberColumnWidth(lineNumberDigits: number): string {
   return `max(40px, calc(${lineNumberDigits}ch + 1.5rem))`;
@@ -55,8 +58,17 @@ export function getChatDiffRows(
   expandedCollapsedKeys: ReadonlySet<string>,
 ): ChatDiffRow[] {
   const rows: ChatDiffRow[] = [];
+  const gaps = parsed.interHunkGaps;
 
   parsed.hunks.forEach((hunk, hunkIndex) => {
+    // Gap before this hunk
+    if (gaps.length > 0) {
+      const gap = gaps[hunkIndex];
+      if (gap && gap.lineCount !== 0) {
+        rows.push({ kind: "gap", key: `gap-${hunkIndex}`, gap, gapIndex: hunkIndex });
+      }
+    }
+
     hunk.items.forEach((item, itemIndex) => {
       const key = `${hunkIndex}-${itemIndex}`;
       if ("kind" in item && item.kind === "collapsed") {
@@ -82,6 +94,14 @@ export function getChatDiffRows(
       });
     });
   });
+
+  // Gap after last hunk
+  if (gaps.length > parsed.hunks.length) {
+    const gap = gaps[parsed.hunks.length];
+    if (gap && gap.lineCount !== 0) {
+      rows.push({ kind: "gap", key: `gap-${parsed.hunks.length}`, gap, gapIndex: parsed.hunks.length });
+    }
+  }
 
   return rows;
 }
@@ -134,8 +154,17 @@ export function getSplitDiffRows(
   expandedCollapsedKeys: ReadonlySet<string>,
 ): SplitDiffRow[] {
   const rows: SplitDiffRow[] = [];
+  const gaps = parsed.interHunkGaps;
 
   parsed.hunks.forEach((hunk, hunkIndex) => {
+    // Gap before this hunk
+    if (gaps.length > 0) {
+      const gap = gaps[hunkIndex];
+      if (gap && gap.lineCount !== 0) {
+        rows.push({ kind: "gap", key: `gap-${hunkIndex}`, gap, gapIndex: hunkIndex });
+      }
+    }
+
     hunk.items.forEach((item, itemIndex) => {
       const key = `${hunkIndex}-${itemIndex}`;
       if ("kind" in item && item.kind === "collapsed") {
@@ -163,6 +192,14 @@ export function getSplitDiffRows(
       });
     });
   });
+
+  // Gap after last hunk
+  if (gaps.length > parsed.hunks.length) {
+    const gap = gaps[parsed.hunks.length];
+    if (gap && gap.lineCount !== 0) {
+      rows.push({ kind: "gap", key: `gap-${parsed.hunks.length}`, gap, gapIndex: parsed.hunks.length });
+    }
+  }
 
   return rows;
 }


### PR DESCRIPTION
Part 2/5 of the Changes-sidebar overhaul. Stacked on #933.

- Codex-style "N unmodified lines" separators between hunks: expand up / down / all per gap (single expand-both for gaps ≤7)
- Expand controls live in the gutter column (sticky-pinned against horizontal scroll); label left-anchored in content column
- Lazy file-content fetch on first expander click (readWorkspaceTextFile), cached per file; trailing gap resolved from fetched line count
- Correctness gating: expansion only where the diff's new side == worktree (unstaged/last-turn/turn card); staged/branch scopes degrade to informational label
- Legacy "Show N unchanged lines" collapsed-context rows in all three viewers unified to the same treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)