### PR TITLE
feat(desktop): Codex-style review layout — sticky headers, jump-to-file, virtualization

### DIFF
--- a/apps/desktop/src/components/content/ui/FileDiffCard.test.tsx
+++ b/apps/desktop/src/components/content/ui/FileDiffCard.test.tsx
@@ -38,7 +38,8 @@ describe("FileChangesCard and FileDiffCard", () => {
     expect(html).toContain("codex-review-diff-card");
     expect(html).toContain("--codex-diffs-header-surface:var(--color-diff-sidebar-file-header-surface)");
     expect(html).toContain("--codex-diffs-separator-surface:var(--color-diff-sidebar-file-header-hover-surface)");
-    expect(html).toContain("bg-[var(--codex-diffs-header-surface)]");
+    expect(html).toContain("sticky top-0 bg-[color-mix(in_srgb,var(--codex-diffs-header-surface)_97%,transparent)]");
+    expect(html).not.toContain("backdrop-blur");
     expect(html).not.toContain("#1c1c1c");
     expect(html).toContain("data-app-action-review-file-expanded=\"true\"");
     expect(html).toContain("data-app-action-review-file-toggle=\"\"");

--- a/apps/desktop/src/components/content/ui/FileDiffCard.tsx
+++ b/apps/desktop/src/components/content/ui/FileDiffCard.tsx
@@ -85,9 +85,10 @@ export function FileDiffCard({
       : {}),
     backgroundColor: "var(--codex-diffs-surface)",
   } as CSSProperties;
-  // Sidebar review cards use a frosted sticky header: the sticky wrapper paints
-  // a translucent color-mix of the header surface + backdrop-blur, so the
-  // inner shell must stay transparent for the blur to read through.
+  // Sidebar review cards use a near-opaque sticky header: the sticky wrapper
+  // paints a 97% color-mix of the header surface (no backdrop-filter — blur
+  // resampling across many sticky headers starves the WKWebView compositor),
+  // so the inner shell must stay transparent for that paint to show.
   const headerShellClass = isSidebar
     ? "bg-transparent"
     : "bg-[var(--codex-diffs-header-surface)]";
@@ -132,7 +133,7 @@ export function FileDiffCard({
           : undefined
       }
       data-chat-diff-wrap-context-trigger={isSidebar ? undefined : "file-header"}
-      className={`z-10 select-none ${isSidebar ? "sticky top-0 backdrop-blur-sm bg-[color-mix(in_srgb,var(--codex-diffs-header-surface)_88%,transparent)]" : "bg-[var(--codex-diffs-header-surface)]"} ${canExpand ? "cursor-pointer" : ""}`}
+      className={`z-10 select-none ${isSidebar ? "sticky top-0 bg-[color-mix(in_srgb,var(--codex-diffs-header-surface)_97%,transparent)]" : "bg-[var(--codex-diffs-header-surface)]"} ${canExpand ? "cursor-pointer" : ""}`}
     >
       <div className={headerShellClass}>
         <div className={headerInnerClass}>

--- a/apps/desktop/src/components/content/ui/FileDiffCard.tsx
+++ b/apps/desktop/src/components/content/ui/FileDiffCard.tsx
@@ -85,8 +85,11 @@ export function FileDiffCard({
       : {}),
     backgroundColor: "var(--codex-diffs-surface)",
   } as CSSProperties;
+  // Sidebar review cards use a frosted sticky header: the sticky wrapper paints
+  // a translucent color-mix of the header surface + backdrop-blur, so the
+  // inner shell must stay transparent for the blur to read through.
   const headerShellClass = isSidebar
-    ? "bg-[var(--codex-diffs-header-surface)]"
+    ? "bg-transparent"
     : "bg-[var(--codex-diffs-header-surface)]";
   const chatHeaderHoverClass = headerTone === "inlineTool"
     ? "hover:bg-[var(--color-diff-chat-inline-tool-header-hover-surface)]"
@@ -129,7 +132,7 @@ export function FileDiffCard({
           : undefined
       }
       data-chat-diff-wrap-context-trigger={isSidebar ? undefined : "file-header"}
-      className={`z-10 select-none bg-[var(--codex-diffs-header-surface)] ${isSidebar ? "sticky top-0" : ""} ${canExpand ? "cursor-pointer" : ""}`}
+      className={`z-10 select-none ${isSidebar ? "sticky top-0 backdrop-blur-sm bg-[color-mix(in_srgb,var(--codex-diffs-header-surface)_88%,transparent)]" : "bg-[var(--codex-diffs-header-surface)]"} ${canExpand ? "cursor-pointer" : ""}`}
     >
       <div className={headerShellClass}>
         <div className={headerInnerClass}>

--- a/apps/desktop/src/components/workspace/git/GitPanel.test.tsx
+++ b/apps/desktop/src/components/workspace/git/GitPanel.test.tsx
@@ -156,12 +156,14 @@ describe("GitPanel", () => {
       wrapLongLines: true,
       fileTreeOpen: false,
       allFilesCollapsed: false,
+      reviewEntries: [],
       onFilterChange: vi.fn(),
       onBaseRefChange: vi.fn(),
       onToggleLayout: vi.fn(),
       onToggleWrap: vi.fn(),
       onToggleFileTree: vi.fn(),
       onToggleAllFiles: vi.fn(),
+      onFocusFile: vi.fn(),
       onRefresh: vi.fn(),
     };
 
@@ -199,6 +201,7 @@ describe("GitPanel", () => {
         wrapLongLines: false,
         fileTreeOpen: false,
         allFilesCollapsed: false,
+        reviewEntries: [],
         changesFilter: "unstaged",
         onFilterChange: vi.fn(),
         onBaseRefChange: vi.fn(),
@@ -206,6 +209,7 @@ describe("GitPanel", () => {
         onToggleWrap: vi.fn(),
         onToggleFileTree: vi.fn(),
         onToggleAllFiles: vi.fn(),
+        onFocusFile: vi.fn(),
         onRefresh: vi.fn(),
       }),
     );

--- a/apps/desktop/src/components/workspace/git/GitPanel.tsx
+++ b/apps/desktop/src/components/workspace/git/GitPanel.tsx
@@ -5,6 +5,7 @@ import {
   useUnstageGitPathsMutation,
 } from "@anyharness/sdk-react";
 import { GitPanelHeader } from "./GitPanelHeader";
+import { SkeletonBlock, shimmerDelay } from "@/components/feedback/Skeleton";
 import { GitReviewFileTree } from "./GitReviewFileTree";
 import { GitPanelReviewBody } from "./GitPanelReviewBody";
 import { formatGitPanelUndoError } from "./GitPanelReviewChrome";
@@ -47,14 +48,50 @@ export function GitPanel() {
   if (diffReviewMeasurement.deferQueryMount) {
     return (
       <div className="flex h-full min-w-0 flex-col overflow-hidden bg-sidebar text-sidebar-foreground">
-        <p className="px-4 py-8 text-center text-xs text-sidebar-muted-foreground">
-          Loading changes
-        </p>
+        <GitPanelLoadingSkeleton />
       </div>
     );
   }
 
   return <GitPanelContent diffReviewMeasurement={diffReviewMeasurement} />;
+}
+
+function GitPanelLoadingSkeleton() {
+  return (
+    <div
+      className="flex flex-col gap-1.5 px-2 pt-2"
+      role="status"
+      aria-label="Loading changes"
+    >
+      {[0, 1, 2].map((index) => (
+        <div
+          key={index}
+          className="overflow-clip rounded-lg bg-[var(--color-diff-panel-surface)]"
+        >
+          <div className="flex min-h-9 items-center gap-2.5 bg-[var(--color-diff-sidebar-file-header-surface)] px-5 py-1.5">
+            <SkeletonBlock
+              className="h-3 w-40 bg-sidebar-accent"
+              style={shimmerDelay(index)}
+            />
+            <SkeletonBlock
+              className="ms-auto h-3 w-12 bg-sidebar-accent"
+              style={shimmerDelay(index + 1)}
+            />
+          </div>
+          <div className="space-y-2 px-5 py-3">
+            <SkeletonBlock
+              className="h-2.5 w-3/4 bg-sidebar-accent"
+              style={shimmerDelay(index + 1)}
+            />
+            <SkeletonBlock
+              className="h-2.5 w-1/2 bg-sidebar-accent"
+              style={shimmerDelay(index + 2)}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 type DiffReviewMeasurementState = ReturnType<typeof useDiffReviewMeasurement>;
@@ -330,12 +367,14 @@ function GitPanelContent({
         wrapLongLines={wrapLongLines}
         fileTreeOpen={fileTreeOpen}
         allFilesCollapsed={allFilesCollapsed}
+        reviewEntries={reviewEntries}
         onFilterChange={setChangesFilter}
         onBaseRefChange={setSelectedBaseRef}
         onToggleLayout={handleToggleLayout}
         onToggleWrap={handleToggleWrap}
         onToggleFileTree={() => setFileTreeOpen((value) => !value)}
         onToggleAllFiles={handleToggleAllFiles}
+        onFocusFile={focusReviewFile}
         onRefresh={() => void refetch()}
       />
 

--- a/apps/desktop/src/components/workspace/git/GitPanelHeader.tsx
+++ b/apps/desktop/src/components/workspace/git/GitPanelHeader.tsx
@@ -1,10 +1,15 @@
+import { useState } from "react";
 import type { GitBranchRef } from "@anyharness/sdk";
 import { GitReviewOptionsMenu } from "./GitReviewOptionsMenu";
 import { GitReviewBaseSelector } from "./GitReviewBaseSelector";
 import { GitReviewTargetSelector } from "./GitReviewTargetSelector";
-import { Columns2, FolderTree } from "@proliferate/ui/icons";
+import { CollapseAll, Columns2, ExpandAll, FolderTree, Search } from "@proliferate/ui/icons";
 import { PaneIconButton } from "@proliferate/ui/layout/PaneIconButton";
+import { PopoverButton, POPOVER_SURFACE_CLASS } from "@proliferate/ui/primitives/PopoverButton";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
+import { PopoverSearchField } from "@proliferate/ui/primitives/PopoverSearchField";
 import type { GitPanelMode } from "@/lib/domain/workspaces/changes/git-panel-diff";
+import type { GitReviewFileEntry } from "@/lib/domain/workspaces/changes/git-review-entries";
 
 interface GitPanelHeaderProps {
   changesFilter: GitPanelMode;
@@ -18,12 +23,14 @@ interface GitPanelHeaderProps {
   wrapLongLines: boolean;
   fileTreeOpen: boolean;
   allFilesCollapsed: boolean;
+  reviewEntries: readonly GitReviewFileEntry[];
   onFilterChange: (mode: GitPanelMode) => void;
   onBaseRefChange: (baseRef: string | null) => void;
   onToggleLayout: () => void;
   onToggleWrap: () => void;
   onToggleFileTree: () => void;
   onToggleAllFiles: () => void;
+  onFocusFile: (entry: GitReviewFileEntry) => void;
   onRefresh: () => void;
 }
 
@@ -39,12 +46,14 @@ export function GitPanelHeader({
   wrapLongLines,
   fileTreeOpen,
   allFilesCollapsed,
+  reviewEntries,
   onFilterChange,
   onBaseRefChange,
   onToggleLayout,
   onToggleWrap,
   onToggleFileTree,
   onToggleAllFiles,
+  onFocusFile,
   onRefresh,
 }: GitPanelHeaderProps) {
   const showTargetSelector = changesFilter === "branch";
@@ -73,6 +82,19 @@ export function GitPanelHeader({
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-px">
+        <PaneIconButton
+          label={allFilesCollapsed ? "Expand all diffs" : "Collapse all diffs"}
+          aria-pressed={allFilesCollapsed}
+          onClick={onToggleAllFiles}
+        >
+          {allFilesCollapsed
+            ? <ExpandAll className="size-3.5" />
+            : <CollapseAll className="size-3.5" />}
+        </PaneIconButton>
+        <GitReviewJumpToFileMenu
+          reviewEntries={reviewEntries}
+          onFocusFile={onFocusFile}
+        />
         <GitReviewOptionsMenu
           allFilesCollapsed={allFilesCollapsed}
           wrapLongLines={wrapLongLines}
@@ -97,6 +119,95 @@ export function GitPanelHeader({
         </PaneIconButton>
       </div>
     </div>
+  );
+}
+
+function GitReviewJumpToFileMenu({
+  reviewEntries,
+  onFocusFile,
+}: {
+  reviewEntries: readonly GitReviewFileEntry[];
+  onFocusFile: (entry: GitReviewFileEntry) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const query = search.trim().toLowerCase();
+  const filteredEntries = query
+    ? reviewEntries.filter((entry) =>
+        entry.file.displayPath.toLowerCase().includes(query)
+        || entry.file.path.toLowerCase().includes(query))
+    : reviewEntries;
+
+  return (
+    <PopoverButton
+      trigger={(
+        <PaneIconButton label="Jump to file" disabled={reviewEntries.length === 0}>
+          <Search className="size-3.5" />
+        </PaneIconButton>
+      )}
+      align="end"
+      className={`w-72 ${POPOVER_SURFACE_CLASS}`}
+      onOpenChange={(open: boolean) => {
+        if (!open) {
+          setSearch("");
+        }
+      }}
+    >
+      {(close: () => void) => (
+        <div className="flex max-h-80 flex-col">
+          <PopoverSearchField
+            value={search}
+            onChange={setSearch}
+            placeholder="Jump to file"
+            ariaLabel="Filter changed files"
+            autoFocus
+          />
+          <div className="h-px shrink-0 bg-border" />
+          <div className="min-h-0 flex-1 overflow-y-auto p-1">
+            {filteredEntries.length === 0 ? (
+              <p className="px-2.5 py-2 text-ui-sm text-muted-foreground">No files</p>
+            ) : (
+              filteredEntries.map((entry) => {
+                const baseName = entry.file.displayPath.split("/").pop()
+                  ?? entry.file.displayPath;
+                const dirPath = entry.file.displayPath.slice(
+                  0,
+                  entry.file.displayPath.length - baseName.length,
+                ).replace(/\/$/, "");
+                const additions = entry.file.currentDiff?.additions ?? 0;
+                const deletions = entry.file.currentDiff?.deletions ?? 0;
+                return (
+                  <PopoverMenuItem
+                    key={entry.key}
+                    title={entry.file.displayPath}
+                    label={(
+                      <span className="flex min-w-0 items-baseline gap-1.5">
+                        <span className="truncate">{baseName}</span>
+                        {dirPath && (
+                          <span className="min-w-0 truncate text-base text-muted-foreground">
+                            {dirPath}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    trailing={(additions > 0 || deletions > 0) ? (
+                      <span className="inline-flex items-center gap-1 tabular-nums tracking-tight">
+                        {additions > 0 && <span className="text-git-green">+{additions}</span>}
+                        {deletions > 0 && <span className="text-git-red">-{deletions}</span>}
+                      </span>
+                    ) : undefined}
+                    density="compact"
+                    onClick={() => {
+                      onFocusFile(entry);
+                      close();
+                    }}
+                  />
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </PopoverButton>
   );
 }
 

--- a/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -161,6 +161,7 @@ export function GitReviewFileRow({
     <div
       id={id}
       data-review-path={file.path}
+      className="scroll-mt-2"
       style={SIDEBAR_DIFF_SURFACE_STYLE}
     >
       <FileDiffCard

--- a/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -32,6 +32,38 @@ const SIDEBAR_DIFF_SURFACE_STYLE = {
   "--codex-diffs-surface-override": "var(--color-diff-surface)",
 } as CSSProperties;
 
+// Header row (min-h-9 + py) plus the diff viewer's 24-line viewport cap
+// (GitReviewFileRow passes max-h of --diffs-line-height * 24 to DiffViewer).
+const REVIEW_CARD_HEADER_ESTIMATE_PX = 38;
+const REVIEW_CARD_MAX_VISIBLE_LINES = 24;
+
+/**
+ * Off-screen review cards skip layout/paint via content-visibility:auto —
+ * without it every diff row of every file stays painted and long change
+ * lists starve the WKWebView compositor (black flashes while scrolling).
+ * The intrinsic-size estimate keeps the scrollbar stable: header height
+ * plus the expected visible diff lines (changed lines ~+50% context,
+ * capped by the viewer's 24-line viewport) in --diffs-line-height units.
+ */
+function reviewCardVirtualizationStyle({
+  collapsed,
+  changedLines,
+}: {
+  collapsed: boolean;
+  changedLines: number;
+}): CSSProperties {
+  const estimatedLines = collapsed
+    ? 0
+    : Math.min(
+        Math.ceil(Math.max(changedLines, 1) * 1.5),
+        REVIEW_CARD_MAX_VISIBLE_LINES,
+      );
+  return {
+    contentVisibility: "auto",
+    containIntrinsicSize: `auto calc(${REVIEW_CARD_HEADER_ESTIMATE_PX}px + var(--diffs-line-height) * ${estimatedLines})`,
+  } as CSSProperties;
+}
+
 export function GitReviewFileRow({
   id,
   workspaceId,
@@ -162,7 +194,13 @@ export function GitReviewFileRow({
       id={id}
       data-review-path={file.path}
       className="scroll-mt-2"
-      style={SIDEBAR_DIFF_SURFACE_STYLE}
+      style={{
+        ...SIDEBAR_DIFF_SURFACE_STYLE,
+        ...reviewCardVirtualizationStyle({
+          collapsed,
+          changedLines: additions + deletions,
+        }),
+      }}
     >
       <FileDiffCard
         filePath={file.displayPath}

--- a/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -19,7 +19,10 @@ import { GitReviewStageAction } from "@/components/workspace/git/GitReviewStageA
 import { GitReviewStatusBadge } from "@/components/workspace/git/GitReviewStatusBadge";
 import { useLazyDiffFileLines } from "@/hooks/ui/diff/use-lazy-diff-file-lines";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
-import { resolveDiffDisplayPolicy } from "@/lib/domain/workspaces/changes/diff-display-policy";
+import {
+  DIFF_ROW_VIRTUALIZATION_LINE_THRESHOLD,
+  resolveDiffDisplayPolicy,
+} from "@/lib/domain/workspaces/changes/diff-display-policy";
 import type {
   GitPanelReviewFile,
   GitPanelReviewScope,
@@ -164,6 +167,14 @@ export function GitReviewFileRow({
     && !diffQuery.data
     && !diffQuery.isError,
   );
+  // Opt large diffs into per-row content-visibility virtualization (the
+  // [data-diff-row-virtualization] rule in design desktop.css): the diff
+  // scrolls inside this card's 24-line max-h viewport, so without it every
+  // row of a multi-thousand-line patch stays painted while scrolling.
+  const virtualizeDiffRows = Boolean(
+    patchPolicy
+    && patchPolicy.patchLineCount > DIFF_ROW_VIRTUALIZATION_LINE_THRESHOLD,
+  );
   const emptyDiffState = formatEmptyDiffState({
     binary: Boolean(diffQuery.data?.binary || currentDiff?.binary),
     truncated: Boolean(diffQuery.data?.truncated && !patch),
@@ -193,6 +204,7 @@ export function GitReviewFileRow({
     <div
       id={id}
       data-review-path={file.path}
+      data-diff-row-virtualization={virtualizeDiffRows ? "" : undefined}
       className="scroll-mt-2"
       style={{
         ...SIDEBAR_DIFF_SURFACE_STYLE,

--- a/apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
+++ b/apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
@@ -2,7 +2,7 @@ export const DIFF_AUTO_COLLAPSE_LINE_LIMIT = 1_000;
 export const DIFF_HARD_INLINE_LINE_LIMIT = 5_000;
 export const DIFF_HARD_INLINE_BYTE_LIMIT = 250_000;
 export const CHAT_VISIBLE_FILE_CHANGE_LIMIT = 3;
-export const GIT_DIFF_FETCH_CONCURRENCY_LIMIT = 2;
+export const GIT_DIFF_FETCH_CONCURRENCY_LIMIT = 5;
 
 export type DiffDisplayPolicyKind =
   | "safe"

--- a/apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
+++ b/apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts
@@ -3,6 +3,14 @@ export const DIFF_HARD_INLINE_LINE_LIMIT = 5_000;
 export const DIFF_HARD_INLINE_BYTE_LIMIT = 250_000;
 export const CHAT_VISIBLE_FILE_CHANGE_LIMIT = 3;
 export const GIT_DIFF_FETCH_CONCURRENCY_LIMIT = 5;
+/**
+ * Above this many diff lines, sidebar review cards opt their diff rows into
+ * content-visibility row virtualization (the [data-diff-row-virtualization]
+ * rule in design/src/css/desktop.css) so off-screen rows of one large file
+ * skip layout/paint. Small diffs stay un-contained: full paint is already
+ * cheap and per-row containment has its own overhead.
+ */
+export const DIFF_ROW_VIRTUALIZATION_LINE_THRESHOLD = 300;
 
 export type DiffDisplayPolicyKind =
   | "safe"

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -848,6 +848,24 @@ mark.codex-thread-find-active {
   contain-intrinsic-size: auto 36px;
 }
 
+/*
+ * Row-level virtualization for LARGE sidebar review diffs (opted in per card
+ * via data-diff-row-virtualization when the patch exceeds
+ * DIFF_ROW_VIRTUALIZATION_LINE_THRESHOLD). Every diff row cell — gutter and
+ * content are separate grid children in all three viewers — skips layout and
+ * paint while outside its scrollport, so scrolling one multi-thousand-row
+ * diff no longer keeps every row painted. `auto` in contain-intrinsic-size
+ * remembers each cell's real rendered height, so wrapped lines and per-gap
+ * context expanders don't make the scrollbar jump after first paint; the
+ * one-line-height fallback matches the min-height every unwrapped row has,
+ * keeping subgrid track sizing stable for cells that were never rendered.
+ */
+[data-diff-row-virtualization] .diff-gutter-cell,
+[data-diff-row-virtualization] .diff-content-cell {
+  content-visibility: auto;
+  contain-intrinsic-size: auto var(--diffs-line-height);
+}
+
 .composer-diff-simple-line {
   --codex-diffs-surface: var(--color-diff-main-surface);
   --codex-diffs-header-surface: var(--codex-diffs-surface);


### PR DESCRIPTION
Part 3/5 of the Changes-sidebar overhaul. Stacked on the expanders PR.

- Sticky per-file headers (97% color-mix surface, no backdrop-blur — blur starved the WKWebView compositor)
- Collapse-all/Expand-all promoted to toolbar; searchable Jump-to-file popover
- Skeleton loading state replacing bare "Loading changes" text
- Perf: card-level + row-level content-visibility virtualization (row-level activates >300 patch lines) — fixes black flashes when scrolling large diffs
- Diff-fetch concurrency 2 → 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)