### PR TITLE
fix(overnight): desktop-first-run — wait for agentSeed hydration before auth adoption

### DIFF
--- a/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -4,6 +4,7 @@ import {
   useAuthSelections,
   usePutAuthSelections,
 } from "@proliferate/cloud-sdk-react";
+import { useRuntimeHealthQuery } from "@anyharness/sdk-react";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { planFirstRunAuthAdoption } from "@/lib/domain/agents/auth-onboarding";
@@ -27,20 +28,29 @@ export function useFirstRunAuthAdoption() {
     reconcileSnapshot,
     reconcileStatus,
   } = useAgentCatalog();
+  const runtimeHealth = useRuntimeHealthQuery({
+    pollWhileAgentSeedHydrating: true,
+  });
   const putSelections = usePutAuthSelections();
   const attemptedRef = useRef(false);
 
   const selections = selectionsQuery.data;
   const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
   const putMutate = putSelections.mutate;
+  const agentSeedStatus = runtimeHealth.data?.agentSeed?.status;
 
   // The runtime hydrates the bundled seed then runs an installed-only reconcile
   // at startup; agent credential/install states are only trustworthy once that
   // pass has SETTLED. Deciding from a mid-hydration snapshot permanently misses
   // native creds for harnesses that hydrate after the (one-shot) decision.
+  // We must wait for BOTH agentSeed hydration AND reconcile to settle before
+  // making the one-shot adoption decision.
   const reconcileActive =
     reconcileStatus === "queued" || reconcileStatus === "running";
-  const readinessSettled = reconcileSnapshot !== null && !reconcileActive;
+  const agentSeedSettled =
+    agentSeedStatus !== "hydrating" && agentSeedStatus !== undefined;
+  const readinessSettled =
+    reconcileSnapshot !== null && !reconcileActive && agentSeedSettled;
 
   useEffect(() => {
     if (attemptedRef.current || !cloudActive) {


### PR DESCRIPTION
## Problem

Finding F5 from overnight v1 fix wave: The first-run auth adoption hook (`useFirstRunAuthAdoption`) makes a one-shot decision to adopt gateway auth for harnesses lacking native credentials. However, it only waited for reconcile readiness (`reconcileSnapshot !== null && !reconcileActive`), not agentSeed hydration completion.

**The race condition:** The runtime startup sequence (per `AgentRuntime::spawn_startup_pass`) is:
1. Hydrate agentSeed if pending
2. THEN start reconcile

The reconcile service returns an idle snapshot (non-null, status=idle, empty results) before any reconcile job runs. This means `reconcileSnapshot !== null` is satisfied prematurely while `agentSeed.status` may still be `'hydrating'`, and native credentials haven't been detected yet.

Result: The hook could adopt gateway auth for harnesses seconds before their native credentials hydrate, permanently misinterpreting them as lacking native auth.

## What changed

- Added `useRuntimeHealthQuery` to query agentSeed status (with `pollWhileAgentSeedHydrating: true`)
- Extracted `agentSeedStatus` from runtime health data
- Extended `readinessSettled` condition to require BOTH:
  - Reconcile settled: `reconcileSnapshot !== null && !reconcileActive`
  - AgentSeed settled: `agentSeedStatus !== 'hydrating' && agentSeedStatus !== undefined`

This ensures the one-shot adoption decision waits for the full startup sequence (seed hydration → reconcile) to complete before checking agent credential states.

## How to verify

1. Fresh profile test: Delete local profile, launch desktop, verify harnesses with native creds (e.g., claude harness) are NOT incorrectly adopted to gateway auth
2. No credentials test: Fresh profile with no native creds should still fall back to gateway auth after both agentSeed and reconcile settle
3. Regression check: Existing profiles should be unaffected (the hook only runs once per app launch when `selectionCount === 0`)

## Follow-ups

None. This is the minimal fix to close the race window.

---

**Findings fixed:**
- **F5**: Added agentSeed.status guard to readinessSettled check in use-first-run-auth-adoption.ts

**Findings not fixed:**
- F2 was refuted during verification — desktop uses the capabilities API with no hardcoded flag

Part of overnight v1 fix wave 2026-07-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)