### PR TITLE
feat(cloud): org-owned shared sandbox profiles v0 (T1, draft)

### DIFF
--- a/apps/desktop/src/components/settings/panes/organization/OrgSandboxProfilesSection.tsx
+++ b/apps/desktop/src/components/settings/panes/organization/OrgSandboxProfilesSection.tsx
@@ -1,0 +1,114 @@
+import { useState, type ChangeEvent, type KeyboardEvent } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
+import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import type { OrgSandboxProfileResponse } from "@proliferate/cloud-sdk";
+
+function formatDate(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+function statusBadge(status: string) {
+  const colors: Record<string, string> = {
+    creating: "text-yellow-600 bg-yellow-50 dark:text-yellow-400 dark:bg-yellow-900/30",
+    ready: "text-green-600 bg-green-50 dark:text-green-400 dark:bg-green-900/30",
+    paused: "text-muted-foreground bg-muted",
+    error: "text-destructive bg-destructive/10",
+    destroyed: "text-muted-foreground bg-muted line-through",
+  };
+  return (
+    <span className={`inline-flex rounded px-1.5 py-0.5 text-ui-xs font-medium ${colors[status] ?? colors.creating}`}>
+      {status}
+    </span>
+  );
+}
+
+export function OrgSandboxProfilesSection({
+  profiles,
+  canManage,
+  creating,
+  onCreateProfile,
+}: {
+  profiles: OrgSandboxProfileResponse[];
+  canManage: boolean;
+  creating: boolean;
+  onCreateProfile: (displayName: string) => void;
+}) {
+  const [newName, setNewName] = useState("");
+
+  function handleCreate() {
+    const trimmed = newName.trim();
+    if (trimmed) {
+      onCreateProfile(trimmed);
+      setNewName("");
+    }
+  }
+
+  return (
+    <SettingsSection
+      title="Org sandboxes"
+      description="Shared cloud sandboxes available to all organization members"
+    >
+      <div className="space-y-4">
+        {profiles.length > 0 ? (
+          <div className="divide-y divide-border rounded-md border">
+            {profiles.map((profile) => (
+              <div key={profile.id} className="flex items-center justify-between px-4 py-3">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-ui-sm font-medium">
+                    {profile.displayName ?? "Untitled"}
+                  </span>
+                  <span className="text-ui-xs text-muted-foreground">
+                    Created {formatDate(profile.createdAt)}
+                  </span>
+                </div>
+                {statusBadge(profile.status)}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-ui-sm text-muted-foreground">
+            No shared sandboxes yet.
+          </p>
+        )}
+
+        {canManage ? (
+          <SettingsRow label="Create sandbox" description="Add a new shared sandbox for the team">
+            <div className="flex items-center gap-2">
+              <Input
+                value={newName}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => setNewName(event.currentTarget.value)}
+                placeholder="Sandbox name"
+                aria-label="New sandbox name"
+                className="w-48"
+                onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    handleCreate();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                onClick={handleCreate}
+                disabled={!newName.trim()}
+                loading={creating}
+              >
+                Create
+              </Button>
+            </div>
+          </SettingsRow>
+        ) : null}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/cloud/sdk/src/client/org-sandbox-profiles.ts
+++ b/cloud/sdk/src/client/org-sandbox-profiles.ts
@@ -1,0 +1,53 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+
+export interface OrgSandboxProfileResponse {
+  id: string;
+  organizationId: string;
+  displayName: string | null;
+  status: string;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  readyAt: string | null;
+}
+
+export interface OrgSandboxProfileListResponse {
+  profiles: OrgSandboxProfileResponse[];
+}
+
+export interface CreateOrgSandboxProfileInput {
+  displayName: string;
+}
+
+export async function listOrgSandboxProfiles(
+  organizationId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<OrgSandboxProfileListResponse> {
+  return client.requestJson<OrgSandboxProfileListResponse>({
+    method: "GET",
+    path: `/v1/cloud/organizations/${organizationId}/sandbox-profiles`,
+  });
+}
+
+export async function createOrgSandboxProfile(
+  organizationId: string,
+  input: CreateOrgSandboxProfileInput,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<OrgSandboxProfileResponse> {
+  return client.requestJson<OrgSandboxProfileResponse>({
+    method: "POST",
+    path: `/v1/cloud/organizations/${organizationId}/sandbox-profiles`,
+    body: input,
+  });
+}
+
+export async function getOrgSandboxProfile(
+  organizationId: string,
+  sandboxId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<OrgSandboxProfileResponse> {
+  return client.requestJson<OrgSandboxProfileResponse>({
+    method: "GET",
+    path: `/v1/cloud/organizations/${organizationId}/sandbox-profiles/${sandboxId}`,
+  });
+}

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1852,6 +1852,41 @@ export interface paths {
         patch: operations["set_admin_integration_enabled_endpoint_v1_cloud_integrations_admin_organizations__organization_id__definitions__definition_id__enabled_patch"];
         trace?: never;
     };
+    "/v1/cloud/organizations/{organization_id}/sandbox-profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Org Sandbox Profiles Endpoint */
+        get: operations["list_org_sandbox_profiles_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles_get"];
+        put?: never;
+        /** Create Org Sandbox Profile Endpoint */
+        post: operations["create_org_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/organizations/{organization_id}/sandbox-profiles/{sandbox_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Org Sandbox Profile Endpoint */
+        get: operations["get_org_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles__sandbox_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/webhooks/e2b": {
         parameters: {
             query?: never;
@@ -1931,6 +1966,91 @@ export interface paths {
         put?: never;
         /** Generate Workspace Name Endpoint */
         post: operations["generate_workspace_name_endpoint_v1_ai_magic_workspace_names_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Support Message Endpoint */
+        post: operations["send_support_message_endpoint_v1_support_messages_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/report-uploads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Upload Endpoint */
+        post: operations["create_support_report_upload_endpoint_v1_support_report_uploads_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Endpoint */
+        post: operations["create_support_report_endpoint_v1_support_reports_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports/{report_id}/upload-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Upload Targets Endpoint */
+        post: operations["create_support_report_upload_targets_endpoint_v1_support_reports__report_id__upload_targets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports/{report_id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete Support Report Upload Endpoint */
+        post: operations["complete_support_report_upload_endpoint_v1_support_reports__report_id__complete_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3794,6 +3914,11 @@ export interface components {
             /** Source */
             source?: ("desktop" | "web" | "mobile") | null;
         };
+        /** CreateOrgSandboxProfileRequest */
+        CreateOrgSandboxProfileRequest: {
+            /** Displayname */
+            displayName: string;
+        };
         /** CurrentTeamCheckoutResponse */
         CurrentTeamCheckoutResponse: {
             intent?: components["schemas"]["TeamCheckoutIntentResponse"] | null;
@@ -4202,6 +4327,30 @@ export interface components {
         OrgAgentPolicyViolationListResponse: {
             /** Violations */
             violations: components["schemas"]["OrgAgentPolicyViolation"][];
+        };
+        /** OrgSandboxProfileListResponse */
+        OrgSandboxProfileListResponse: {
+            /** Profiles */
+            profiles: components["schemas"]["OrgSandboxProfileResponse"][];
+        };
+        /** OrgSandboxProfileResponse */
+        OrgSandboxProfileResponse: {
+            /** Id */
+            id: string;
+            /** Organizationid */
+            organizationId: string;
+            /** Displayname */
+            displayName: string | null;
+            /** Status */
+            status: string;
+            /** Createdbyuserid */
+            createdByUserId: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+            /** Readyat */
+            readyAt: string | null;
         };
         /** OrganizationInvitationAcceptRequest */
         OrganizationInvitationAcceptRequest: {
@@ -4961,6 +5110,313 @@ export interface components {
             eventType: string;
             /** Livemode */
             livemode?: boolean | null;
+        };
+        /** SupportMessageContext */
+        SupportMessageContext: {
+            /**
+             * Source
+             * @default sidebar
+             * @enum {string}
+             */
+            source: "sidebar" | "home" | "settings" | "cloud_gated";
+            /**
+             * Intent
+             * @default general
+             * @enum {string}
+             */
+            intent: "general" | "unlimited_cloud" | "team_features";
+            /** Pathname */
+            pathname?: string | null;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Workspacename */
+            workspaceName?: string | null;
+            /** Workspacelocation */
+            workspaceLocation?: ("local" | "cloud") | null;
+        };
+        /** SupportMessageRequest */
+        SupportMessageRequest: {
+            /** Message */
+            message: string;
+            context?: components["schemas"]["SupportMessageContext"] | null;
+        };
+        /** SupportMessageResponse */
+        SupportMessageResponse: {
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
+        };
+        /** SupportReportAttachmentUploadTarget */
+        SupportReportAttachmentUploadTarget: {
+            /** Objectkey */
+            objectKey: string;
+            /** Puturl */
+            putUrl: string;
+            /** Contenttype */
+            contentType: string;
+            /** Maxsizebytes */
+            maxSizeBytes: number;
+            /** Expiresinseconds */
+            expiresInSeconds: number;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+            /** Clientfileid */
+            clientFileId: string;
+        };
+        /** SupportReportCompleteRequest */
+        SupportReportCompleteRequest: {
+            diagnostics?: components["schemas"]["SupportReportCompletedObject"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportCompletedObject"][];
+            /** Packagemanifest */
+            packageManifest?: {
+                [key: string]: unknown;
+            };
+        };
+        /** SupportReportCompleteResponse */
+        SupportReportCompleteResponse: {
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
+            /** Reportid */
+            reportId: string;
+        };
+        /** SupportReportCompletedObject */
+        SupportReportCompletedObject: {
+            /** Objectkey */
+            objectKey: string;
+            /** Sha256 */
+            sha256: string;
+            /** Sizebytes */
+            sizeBytes: number;
+        };
+        /** SupportReportCreateRequest */
+        SupportReportCreateRequest: {
+            /** Clientjobid */
+            clientJobId: string;
+            /**
+             * Message
+             * @default
+             */
+            message: string;
+            /**
+             * Sourcesurface
+             * @default desktop
+             * @enum {string}
+             */
+            sourceSurface: "desktop" | "web" | "mobile" | "cloud_api";
+            context?: components["schemas"]["SupportMessageContext"] | null;
+            scope: components["schemas"]["SupportReportWorkspaceScope"];
+            /** Workspacerefs */
+            workspaceRefs?: components["schemas"]["SupportReportWorkspaceReference"][];
+            telemetryRefs?: components["schemas"]["SupportReportTelemetryReferences"] | null;
+            expectedClientUploads?: components["schemas"]["SupportReportExpectedClientUploads"];
+            /** Publiccontentconsent */
+            publicContentConsent?: boolean | null;
+            /**
+             * Kind
+             * @default bug
+             * @enum {string}
+             */
+            kind: "bug" | "feature";
+            /**
+             * Creditconsent
+             * @default false
+             */
+            creditConsent: boolean;
+            /** Creditname */
+            creditName?: string | null;
+        };
+        /** SupportReportCreateResponse */
+        SupportReportCreateResponse: {
+            /** Reportid */
+            reportId: string;
+            /** Clientjobid */
+            clientJobId: string;
+            /** Status */
+            status: string;
+            serverCorrelation: components["schemas"]["SupportReportServerCorrelation"];
+            /** Clouddiagnosticsstatus */
+            cloudDiagnosticsStatus: string;
+        };
+        /** SupportReportDiagnosticsUpload */
+        SupportReportDiagnosticsUpload: {
+            /**
+             * Contenttype
+             * @default application/json
+             */
+            contentType: string;
+            /** Sizebytes */
+            sizeBytes: number;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** SupportReportExpectedClientUploads */
+        SupportReportExpectedClientUploads: {
+            /**
+             * Diagnostics
+             * @default true
+             */
+            diagnostics: boolean;
+            /**
+             * Attachmentcount
+             * @default 0
+             */
+            attachmentCount: number;
+        };
+        /** SupportReportServerCorrelation */
+        SupportReportServerCorrelation: {
+            /** Reportid */
+            reportId: string;
+            /** Requestid */
+            requestId?: string | null;
+            /** Owneruserid */
+            ownerUserId: string;
+            /** Primaryorganizationid */
+            primaryOrganizationId?: string | null;
+            /** Primarytenantid */
+            primaryTenantId: string;
+            /** Tenantids */
+            tenantIds?: string[];
+            /** Cloudworkspaceids */
+            cloudWorkspaceIds?: string[];
+            /** Cloudtargetids */
+            cloudTargetIds?: string[];
+            /** Anyharnessworkspaceids */
+            anyharnessWorkspaceIds?: string[];
+            /** Sessionids */
+            sessionIds?: string[];
+        };
+        /** SupportReportTelemetryReferences */
+        SupportReportTelemetryReferences: {
+            /** Posthogdistinctid */
+            posthogDistinctId?: string | null;
+            /** Posthogsessionid */
+            posthogSessionId?: string | null;
+            /** Sentryeventids */
+            sentryEventIds?: string[];
+        };
+        /** SupportReportUploadFile */
+        SupportReportUploadFile: {
+            /** Clientfileid */
+            clientFileId: string;
+            /** Filename */
+            fileName: string;
+            /**
+             * Contenttype
+             * @default application/octet-stream
+             */
+            contentType: string;
+            /** Sizebytes */
+            sizeBytes: number;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** SupportReportUploadRequest */
+        SupportReportUploadRequest: {
+            /**
+             * Message
+             * @default
+             */
+            message: string;
+            context?: components["schemas"]["SupportMessageContext"] | null;
+            scope: components["schemas"]["SupportReportWorkspaceScope"];
+            diagnostics?: components["schemas"]["SupportReportDiagnosticsUpload"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportUploadFile"][];
+            /** Publiccontentconsent */
+            publicContentConsent?: boolean | null;
+            /**
+             * Kind
+             * @default bug
+             * @enum {string}
+             */
+            kind: "bug" | "feature";
+            /**
+             * Creditconsent
+             * @default false
+             */
+            creditConsent: boolean;
+            /** Creditname */
+            creditName?: string | null;
+        };
+        /** SupportReportUploadResponse */
+        SupportReportUploadResponse: {
+            /** Reportid */
+            reportId: string;
+            diagnostics?: components["schemas"]["SupportReportUploadTarget"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportAttachmentUploadTarget"][];
+        };
+        /** SupportReportUploadTarget */
+        SupportReportUploadTarget: {
+            /** Objectkey */
+            objectKey: string;
+            /** Puturl */
+            putUrl: string;
+            /** Contenttype */
+            contentType: string;
+            /** Maxsizebytes */
+            maxSizeBytes: number;
+            /** Expiresinseconds */
+            expiresInSeconds: number;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+        };
+        /** SupportReportUploadTargetsRequest */
+        SupportReportUploadTargetsRequest: {
+            diagnostics?: components["schemas"]["SupportReportDiagnosticsUpload"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportUploadFile"][];
+        };
+        /** SupportReportWorkspaceReference */
+        SupportReportWorkspaceReference: {
+            /** Id */
+            id: string;
+            /**
+             * Location
+             * @enum {string}
+             */
+            location: "local" | "cloud";
+            /** Cloudworkspaceid */
+            cloudWorkspaceId?: string | null;
+            /** Cloudtargetid */
+            cloudTargetId?: string | null;
+            /** Sandboxprofileid */
+            sandboxProfileId?: string | null;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId?: string | null;
+            /** Exposureid */
+            exposureId?: string | null;
+            /** Materializationid */
+            materializationId?: string | null;
+            /** Sessionids */
+            sessionIds?: string[];
+            /** Status */
+            status?: string | null;
+            /** Visibility */
+            visibility?: string | null;
+            /** Sandboxtype */
+            sandboxType?: string | null;
+        };
+        /** SupportReportWorkspaceScope */
+        SupportReportWorkspaceScope: {
+            /**
+             * Kind
+             * @default most_recent_workspace
+             * @enum {string}
+             */
+            kind: "most_recent_workspace" | "choose_workspace" | "app_only";
+            /** Workspaceids */
+            workspaceIds?: string[];
         };
         /** TeamCheckoutIntentResponse */
         TeamCheckoutIntentResponse: {
@@ -9254,6 +9710,104 @@ export interface operations {
             };
         };
     };
+    list_org_sandbox_profiles_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgSandboxProfileListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_org_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOrgSandboxProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgSandboxProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_org_sandbox_profile_endpoint_v1_cloud_organizations__organization_id__sandbox_profiles__sandbox_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organization_id: string;
+                sandbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgSandboxProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     e2b_webhook_endpoint_v1_cloud_webhooks_e2b_post: {
         parameters: {
             query?: never;
@@ -9415,6 +9969,175 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenerateWorkspaceNameResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_support_message_endpoint_v1_support_messages_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportMessageRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_upload_endpoint_v1_support_report_uploads_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_endpoint_v1_support_reports_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportCreateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_upload_targets_endpoint_v1_support_reports__report_id__upload_targets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                report_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportUploadTargetsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    complete_support_report_upload_endpoint_v1_support_reports__report_id__complete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                report_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportCompleteRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportCompleteResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -14,6 +14,7 @@ export * from "./client/integrations.js";
 export * from "./client/deep-links.js";
 export * from "./client/cloud-sandboxes.js";
 export * from "./client/desktop-workers.js";
+export * from "./client/org-sandbox-profiles.js";
 export * from "./client/organizations.js";
 export * from "./client/repositories.js";
 export * from "./client/repos.js";

--- a/server/alembic/versions/bb68e6f07040_org_sandbox_profiles.py
+++ b/server/alembic/versions/bb68e6f07040_org_sandbox_profiles.py
@@ -1,0 +1,139 @@
+"""Add organization sandbox profile support to cloud_sandbox.
+
+Adds owner_scope and organization_id columns so cloud sandboxes can be owned
+by organizations (shared team sandboxes) in addition to personal users.
+
+Revision ID: bb68e6f07040
+Revises: ff9344886948
+Create Date: 2026-07-04 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "bb68e6f07040"
+down_revision: str | Sequence[str] | None = "ff9344886948"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _inspector() -> sa.engine.reflection.Inspector:
+    return sa.inspect(op.get_bind())
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if table_name not in _inspector().get_table_names():
+        return False
+    return column_name in {column["name"] for column in _inspector().get_columns(table_name)}
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    if table_name not in _inspector().get_table_names():
+        return False
+    return index_name in {index["name"] for index in _inspector().get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _has_column("cloud_sandbox", "owner_scope"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column("owner_scope", sa.String(length=32), nullable=True),
+        )
+    if not _has_column("cloud_sandbox", "organization_id"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+        )
+    if not _has_column("cloud_sandbox", "created_by_user_id"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column("created_by_user_id", sa.Uuid(), nullable=True),
+        )
+    if not _has_column("cloud_sandbox", "billing_subject_id"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column("billing_subject_id", sa.Uuid(), nullable=True),
+        )
+    if not _has_column("cloud_sandbox", "display_name"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column("display_name", sa.Text(), nullable=True),
+        )
+
+    # Backfill existing rows as personal scope
+    op.execute(
+        "UPDATE cloud_sandbox SET owner_scope = 'personal' WHERE owner_scope IS NULL"
+    )
+    op.alter_column("cloud_sandbox", "owner_scope", nullable=False)
+
+    # Make owner_user_id nullable for org-owned sandboxes
+    op.alter_column("cloud_sandbox", "owner_user_id", nullable=True)
+
+    # Add FK for organization_id
+    op.create_foreign_key(
+        "cloud_sandbox_organization_id_fkey",
+        "cloud_sandbox",
+        "organization",
+        ["organization_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "cloud_sandbox_created_by_user_id_fkey",
+        "cloud_sandbox",
+        "user",
+        ["created_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "cloud_sandbox_billing_subject_id_fkey",
+        "cloud_sandbox",
+        "billing_subject",
+        ["billing_subject_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    # Check constraint: owner_scope field coherence
+    op.create_check_constraint(
+        "ck_cloud_sandbox_owner_scope",
+        "cloud_sandbox",
+        "owner_scope IN ('personal', 'organization')",
+    )
+    op.create_check_constraint(
+        "ck_cloud_sandbox_owner_fields",
+        "cloud_sandbox",
+        "((owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+        "AND organization_id IS NULL) OR "
+        "(owner_scope = 'organization' AND organization_id IS NOT NULL))",
+    )
+
+    # Unique index: one active org sandbox per (organization, display_name)
+    if not _has_index("cloud_sandbox", "ux_cloud_sandbox_org_active"):
+        op.create_index(
+            "ux_cloud_sandbox_org_active",
+            "cloud_sandbox",
+            ["organization_id", "display_name"],
+            unique=True,
+            postgresql_where=sa.text(
+                "owner_scope = 'organization' AND destroyed_at IS NULL"
+            ),
+        )
+    op.create_index(
+        "ix_cloud_sandbox_organization_id",
+        "cloud_sandbox",
+        ["organization_id"],
+        postgresql_where=sa.text("organization_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "Downgrade for org sandbox profiles is unsupported; restore from backup."
+    )

--- a/server/proliferate/db/models/cloud/sandboxes.py
+++ b/server/proliferate/db/models/cloud/sandboxes.py
@@ -36,11 +36,30 @@ class CloudSandbox(Base):
             "sandbox_type IN ('e2b')",
             name="ck_cloud_sandbox_type",
         ),
+        CheckConstraint(
+            "owner_scope IN ('personal', 'organization')",
+            name="ck_cloud_sandbox_owner_scope",
+        ),
+        CheckConstraint(
+            "((owner_scope = 'personal' AND owner_user_id IS NOT NULL "
+            "AND organization_id IS NULL) OR "
+            "(owner_scope = 'organization' AND organization_id IS NOT NULL))",
+            name="ck_cloud_sandbox_owner_fields",
+        ),
         Index(
             "ux_cloud_sandbox_personal_active",
             "owner_user_id",
             unique=True,
             postgresql_where=text("destroyed_at IS NULL"),
+        ),
+        Index(
+            "ux_cloud_sandbox_org_active",
+            "organization_id",
+            "display_name",
+            unique=True,
+            postgresql_where=text(
+                "owner_scope = 'organization' AND destroyed_at IS NULL"
+            ),
         ),
         Index(
             "ux_cloud_sandbox_provider_sandbox_id",
@@ -49,13 +68,33 @@ class CloudSandbox(Base):
             postgresql_where=text("provider_sandbox_id IS NOT NULL"),
         ),
         Index("ix_cloud_sandbox_owner_user_status", "owner_user_id", "status"),
+        Index(
+            "ix_cloud_sandbox_organization_id",
+            "organization_id",
+            postgresql_where=text("organization_id IS NOT NULL"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+    owner_scope: Mapped[str] = mapped_column(String(32), default="personal")
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"),
         index=True,
+        nullable=True,
     )
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    billing_subject_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("billing_subject.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     sandbox_type: Mapped[CloudSandboxType] = mapped_column(
         _SANDBOX_TYPE_ENUM,
         default=CloudSandboxType.e2b,

--- a/server/proliferate/db/store/cloud_sandboxes.py
+++ b/server/proliferate/db/store/cloud_sandboxes.py
@@ -37,6 +37,7 @@ class CloudSandboxValue:
     anyharness_bearer_token_ciphertext: str | None
     anyharness_data_key_ciphertext: str | None
     runtime_generation: int
+    display_name: str | None
     created_at: datetime
     updated_at: datetime
     ready_at: datetime | None
@@ -49,13 +50,16 @@ def cloud_sandbox_value(row: CloudSandbox) -> CloudSandboxValue:
     sandbox_type = (
         row.sandbox_type.value if hasattr(row.sandbox_type, "value") else row.sandbox_type
     )
+    owner_scope = getattr(row, "owner_scope", None) or (
+        "personal" if row.owner_user_id is not None else "unknown"
+    )
     return CloudSandboxValue(
         id=row.id,
-        owner_scope="personal" if row.owner_user_id is not None else "unknown",
+        owner_scope=owner_scope,
         owner_user_id=row.owner_user_id,
-        organization_id=None,
-        created_by_user_id=row.owner_user_id,
-        billing_subject_id=None,
+        organization_id=getattr(row, "organization_id", None),
+        created_by_user_id=getattr(row, "created_by_user_id", None) or row.owner_user_id,
+        billing_subject_id=getattr(row, "billing_subject_id", None),
         status=status,
         last_error=None,
         e2b_sandbox_id=row.provider_sandbox_id,
@@ -64,6 +68,7 @@ def cloud_sandbox_value(row: CloudSandbox) -> CloudSandboxValue:
         anyharness_bearer_token_ciphertext=row.runtime_token_ciphertext,
         anyharness_data_key_ciphertext=row.anyharness_data_key_ciphertext,
         runtime_generation=0,
+        display_name=getattr(row, "display_name", None),
         created_at=row.created_at,
         updated_at=row.updated_at,
         ready_at=row.ready_at,
@@ -79,12 +84,19 @@ async def acquire_cloud_sandbox_owner_lock(
     owner_user_id: UUID | None,
     organization_id: UUID | None,
 ) -> None:
-    del organization_id
-    if owner_scope != "personal" or owner_user_id is None:
-        raise ValueError("Only personal cloud sandboxes are supported.")
+    if owner_scope == "personal":
+        if owner_user_id is None:
+            raise ValueError("owner_user_id is required for personal scope.")
+        lock_key = f"cloud-sandbox:personal:{owner_user_id}"
+    elif owner_scope == "organization":
+        if organization_id is None:
+            raise ValueError("organization_id is required for organization scope.")
+        lock_key = f"cloud-sandbox:organization:{organization_id}"
+    else:
+        raise ValueError(f"Unknown owner_scope: {owner_scope}")
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
-        {"lock_key": f"cloud-sandbox:personal:{owner_user_id}"},
+        {"lock_key": lock_key},
     )
 
 
@@ -109,9 +121,36 @@ async def load_organization_cloud_sandbox(
     organization_id: UUID,
     *,
     lock_row: bool = False,
+    sandbox_id: UUID | None = None,
 ) -> CloudSandboxValue | None:
-    del db, organization_id, lock_row
-    return None
+    stmt = select(CloudSandbox).where(
+        CloudSandbox.organization_id == organization_id,
+        CloudSandbox.owner_scope == "organization",
+        CloudSandbox.destroyed_at.is_(None),
+    )
+    if sandbox_id is not None:
+        stmt = stmt.where(CloudSandbox.id == sandbox_id)
+    if lock_row:
+        stmt = stmt.with_for_update()
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    return cloud_sandbox_value(row) if row is not None else None
+
+
+async def list_organization_cloud_sandboxes(
+    db: AsyncSession,
+    organization_id: UUID,
+) -> list[CloudSandboxValue]:
+    stmt = (
+        select(CloudSandbox)
+        .where(
+            CloudSandbox.organization_id == organization_id,
+            CloudSandbox.owner_scope == "organization",
+            CloudSandbox.destroyed_at.is_(None),
+        )
+        .order_by(CloudSandbox.created_at.desc())
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [cloud_sandbox_value(row) for row in rows]
 
 
 async def load_cloud_sandbox_by_id(
@@ -151,13 +190,17 @@ async def ensure_personal_cloud_sandbox(
     billing_subject_id: UUID,
     e2b_template_ref: str,
 ) -> CloudSandboxValue:
-    del created_by_user_id, billing_subject_id, e2b_template_ref
+    del e2b_template_ref
     existing = await load_personal_cloud_sandbox(db, user_id, lock_row=True)
     if existing is not None:
         return existing
     now = utcnow()
     row = CloudSandbox(
+        owner_scope="personal",
         owner_user_id=user_id,
+        organization_id=None,
+        created_by_user_id=created_by_user_id,
+        billing_subject_id=billing_subject_id,
         sandbox_type="e2b",
         provider_sandbox_id=None,
         status="creating",
@@ -179,9 +222,38 @@ async def ensure_organization_cloud_sandbox(
     created_by_user_id: UUID | None,
     billing_subject_id: UUID,
     e2b_template_ref: str,
+    display_name: str,
 ) -> CloudSandboxValue:
-    del db, organization_id, created_by_user_id, billing_subject_id, e2b_template_ref
-    raise ValueError("Organization cloud sandboxes are not supported.")
+    """Create an org-scoped cloud sandbox if one with the same display_name doesn't exist."""
+    existing_stmt = select(CloudSandbox).where(
+        CloudSandbox.organization_id == organization_id,
+        CloudSandbox.owner_scope == "organization",
+        CloudSandbox.display_name == display_name,
+        CloudSandbox.destroyed_at.is_(None),
+    ).with_for_update()
+    existing = (await db.execute(existing_stmt)).scalar_one_or_none()
+    if existing is not None:
+        return cloud_sandbox_value(existing)
+    now = utcnow()
+    row = CloudSandbox(
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+        billing_subject_id=billing_subject_id,
+        display_name=display_name,
+        sandbox_type="e2b",
+        provider_sandbox_id=None,
+        status="creating",
+        anyharness_base_url=None,
+        runtime_token_ciphertext=None,
+        anyharness_data_key_ciphertext=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    return cloud_sandbox_value(row)
 
 
 async def update_cloud_sandbox_status(

--- a/server/proliferate/server/cloud/api.py
+++ b/server/proliferate/server/cloud/api.py
@@ -15,6 +15,9 @@ from proliferate.server.cloud.github_app.api import router as github_app_router
 from proliferate.server.cloud.integration_gateway.api import router as integration_gateway_router
 from proliferate.server.cloud.integrations.api import admin_router as integrations_admin_router
 from proliferate.server.cloud.integrations.api import router as integrations_router
+from proliferate.server.cloud.org_sandbox_profiles.api import (
+    router as org_sandbox_profiles_router,
+)
 from proliferate.server.cloud.repos.api import router as repos_router
 from proliferate.server.cloud.repositories.api import router as repositories_router
 from proliferate.server.cloud.runtime_workers.api import (
@@ -49,4 +52,5 @@ router.include_router(runtime_worker_router)
 router.include_router(integration_gateway_router)
 router.include_router(integrations_router)
 router.include_router(integrations_admin_router)
+router.include_router(org_sandbox_profiles_router)
 router.include_router(webhooks_router)

--- a/server/proliferate/server/cloud/org_sandbox_profiles/api.py
+++ b/server/proliferate/server/cloud/org_sandbox_profiles/api.py
@@ -1,0 +1,71 @@
+"""HTTP routes for org-owned sandbox profiles.
+
+Create is org-admin gated; list is member-visible.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import get_async_session
+from proliferate.permissions import CurrentOrgUser, current_path_org_admin, current_path_org_member
+from proliferate.server.cloud.org_sandbox_profiles.models import (
+    CreateOrgSandboxProfileRequest,
+    OrgSandboxProfileListResponse,
+    OrgSandboxProfileResponse,
+    org_sandbox_profile_payload,
+)
+from proliferate.server.cloud.org_sandbox_profiles.service import (
+    create_org_sandbox_profile,
+    get_org_sandbox_profile,
+    list_org_sandbox_profiles,
+)
+
+router = APIRouter(
+    prefix="/organizations/{organization_id}/sandbox-profiles",
+    tags=["org-sandbox-profiles"],
+)
+
+
+@router.get("", response_model=OrgSandboxProfileListResponse)
+async def list_org_sandbox_profiles_endpoint(
+    organization_id: UUID = Path(...),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
+    db: AsyncSession = Depends(get_async_session),
+) -> OrgSandboxProfileListResponse:
+    profiles = await list_org_sandbox_profiles(db, organization_id=organization_id)
+    return OrgSandboxProfileListResponse(
+        profiles=[org_sandbox_profile_payload(p) for p in profiles],
+    )
+
+
+@router.post("", response_model=OrgSandboxProfileResponse, status_code=201)
+async def create_org_sandbox_profile_endpoint(
+    body: CreateOrgSandboxProfileRequest,
+    organization_id: UUID = Path(...),
+    org_user: CurrentOrgUser = Depends(current_path_org_admin),
+    db: AsyncSession = Depends(get_async_session),
+) -> OrgSandboxProfileResponse:
+    sandbox = await create_org_sandbox_profile(
+        db,
+        organization_id=organization_id,
+        created_by_user_id=org_user.actor_user_id,
+        display_name=body.display_name,
+    )
+    return org_sandbox_profile_payload(sandbox)
+
+
+@router.get("/{sandbox_id}", response_model=OrgSandboxProfileResponse)
+async def get_org_sandbox_profile_endpoint(
+    organization_id: UUID = Path(...),
+    sandbox_id: UUID = Path(...),
+    org_user: CurrentOrgUser = Depends(current_path_org_member),
+    db: AsyncSession = Depends(get_async_session),
+) -> OrgSandboxProfileResponse:
+    sandbox = await get_org_sandbox_profile(
+        db, organization_id=organization_id, sandbox_id=sandbox_id
+    )
+    return org_sandbox_profile_payload(sandbox)

--- a/server/proliferate/server/cloud/org_sandbox_profiles/models.py
+++ b/server/proliferate/server/cloud/org_sandbox_profiles/models.py
@@ -1,0 +1,47 @@
+"""API models for organization sandbox profiles."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+class OrgSandboxProfileResponse(BaseModel):
+    id: str
+    organization_id: str = Field(serialization_alias="organizationId")
+    display_name: str | None = Field(serialization_alias="displayName")
+    status: str
+    created_by_user_id: str | None = Field(serialization_alias="createdByUserId")
+    created_at: str = Field(serialization_alias="createdAt")
+    updated_at: str = Field(serialization_alias="updatedAt")
+    ready_at: str | None = Field(serialization_alias="readyAt")
+
+
+class OrgSandboxProfileListResponse(BaseModel):
+    profiles: list[OrgSandboxProfileResponse]
+
+
+class CreateOrgSandboxProfileRequest(BaseModel):
+    display_name: str = Field(alias="displayName", min_length=1, max_length=128)
+
+
+def org_sandbox_profile_payload(value: CloudSandboxValue) -> OrgSandboxProfileResponse:
+    return OrgSandboxProfileResponse(
+        id=str(value.id),
+        organization_id=str(value.organization_id) if value.organization_id else "",
+        display_name=value.display_name,
+        status=value.status,
+        created_by_user_id=(
+            str(value.created_by_user_id) if value.created_by_user_id else None
+        ),
+        created_at=value.created_at.isoformat(),
+        updated_at=value.updated_at.isoformat(),
+        ready_at=_to_iso(value.ready_at),
+    )

--- a/server/proliferate/server/cloud/org_sandbox_profiles/service.py
+++ b/server/proliferate/server/cloud/org_sandbox_profiles/service.py
@@ -1,0 +1,71 @@
+"""Service layer for org-owned sandbox profiles.
+
+Reuses the existing personal-profile provisioning path with
+owner_scope=organization. Org billing subject is bound on create.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import billing_subjects
+from proliferate.db.store import cloud_sandboxes as sandbox_store
+from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+from proliferate.server.cloud.errors import CloudApiError
+
+
+async def list_org_sandbox_profiles(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+) -> list[CloudSandboxValue]:
+    """List all active (non-destroyed) org sandbox profiles. Member-visible."""
+    return await sandbox_store.list_organization_cloud_sandboxes(db, organization_id)
+
+
+async def create_org_sandbox_profile(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    created_by_user_id: UUID,
+    display_name: str,
+) -> CloudSandboxValue:
+    """Create an org-scoped sandbox profile. Org-admin gated by caller."""
+    await sandbox_store.acquire_cloud_sandbox_owner_lock(
+        db,
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id,
+    )
+    billing_subject = await billing_subjects.ensure_organization_billing_subject(
+        db, organization_id
+    )
+    return await sandbox_store.ensure_organization_cloud_sandbox(
+        db,
+        organization_id=organization_id,
+        created_by_user_id=created_by_user_id,
+        billing_subject_id=billing_subject.id,
+        e2b_template_ref="e2b",
+        display_name=display_name,
+    )
+
+
+async def get_org_sandbox_profile(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    sandbox_id: UUID,
+) -> CloudSandboxValue:
+    """Load a specific org sandbox profile. Member-visible."""
+    sandbox = await sandbox_store.load_organization_cloud_sandbox(
+        db, organization_id, sandbox_id=sandbox_id
+    )
+    if sandbox is None:
+        raise CloudApiError(
+            "org_sandbox_profile_not_found",
+            "Organization sandbox profile not found.",
+            status_code=404,
+        )
+    return sandbox

--- a/server/tests/unit/test_org_sandbox_agent_auth_admission.py
+++ b/server/tests/unit/test_org_sandbox_agent_auth_admission.py
@@ -1,0 +1,118 @@
+"""Verify that agent-auth selection preflight works unchanged with org profiles.
+
+The agent-auth selection system is keyed on (user_id, harness_kind, surface).
+When a member starts a session on an org sandbox profile, their personal
+selections are used for the agent-auth state render. This test confirms that
+the materialization build_agent_auth_state function works correctly regardless
+of whether the sandbox is personal or org-owned.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.agent_gateway.records import AgentAuthSelectionRecord
+from proliferate.server.cloud.materialization.materialize.agent_auth import (
+    AgentAuthStateInputs,
+    render_agent_auth_state,
+)
+
+
+def _make_selection(
+    *,
+    user_id: UUID,
+    harness_kind: str = "claude",
+    surface: str = "cloud",
+    source_kind: str = "gateway",
+    api_key_id: UUID | None = None,
+    env_var_name: str | None = None,
+    provider_hint: str | None = None,
+    enabled: bool = True,
+) -> AgentAuthSelectionRecord:
+    now = datetime.now(tz=timezone.utc)
+    return AgentAuthSelectionRecord(
+        id=uuid4(),
+        user_id=user_id,
+        harness_kind=harness_kind,
+        surface=surface,
+        source_kind=source_kind,
+        api_key_id=api_key_id,
+        env_var_name=env_var_name,
+        provider_hint=provider_hint,
+        enabled=enabled,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_render_agent_auth_state_works_for_org_profile_member() -> None:
+    """Agent auth state rendering does not depend on sandbox ownership.
+
+    A member starting a session on an org profile uses their own selections.
+    The render function only needs the user's selections + enrollment state,
+    regardless of whether the sandbox is personal or org-owned.
+    """
+    member_user_id = uuid4()
+    org_id = uuid4()  # The org that owns the sandbox (unused by renderer)
+
+    # Member has a gateway selection for cloud surface
+    selection = _make_selection(
+        user_id=member_user_id,
+        harness_kind="claude",
+        surface="cloud",
+        source_kind="gateway",
+    )
+
+    inputs = AgentAuthStateInputs(
+        user_id=member_user_id,
+        revision=1,
+        selections=(selection,),
+        api_key_values={},
+        enrollment_sync_status="synced",
+        gateway_virtual_key="sk-test-virtual-key",
+        gateway_base_url="https://litellm.example.com",
+    )
+
+    state, fingerprint = render_agent_auth_state(inputs)
+
+    # The state should render successfully with harness entries
+    assert state["version"] == 2
+    assert "harnesses" in state
+    harnesses = state["harnesses"]
+    # Harnesses is a list of dicts, each with harness_kind + sources
+    assert isinstance(harnesses, list)
+    # Gateway source should resolve to a claude harness entry
+    claude_entries = [h for h in harnesses if h.get("harness_kind") == "claude"]
+    assert len(claude_entries) == 1
+    claude_harness = claude_entries[0]
+    assert "sources" in claude_harness
+    assert len(claude_harness["sources"]) > 0
+    # The fingerprint should be a hex digest
+    assert len(fingerprint) == 64  # sha256 hex
+
+
+def test_render_agent_auth_state_empty_selections() -> None:
+    """Empty selections (native state) renders to empty harnesses list."""
+    member_user_id = uuid4()
+
+    inputs = AgentAuthStateInputs(
+        user_id=member_user_id,
+        revision=0,
+        selections=(),
+        api_key_values={},
+        enrollment_sync_status=None,
+        gateway_virtual_key=None,
+        gateway_base_url=None,
+    )
+
+    state, fingerprint = render_agent_auth_state(inputs)
+
+    assert state["version"] == 2
+    harnesses = state["harnesses"]
+    assert isinstance(harnesses, list)
+    assert len(harnesses) == 0

--- a/server/tests/unit/test_org_sandbox_profiles_service.py
+++ b/server/tests/unit/test_org_sandbox_profiles_service.py
@@ -1,0 +1,151 @@
+"""Unit tests for org sandbox profile service layer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.org_sandbox_profiles import service
+
+
+def _make_sandbox_value(
+    *,
+    organization_id: UUID | None = None,
+    display_name: str = "Team Default",
+    status: str = "creating",
+) -> CloudSandboxValue:
+    now = datetime.now(tz=timezone.utc)
+    return CloudSandboxValue(
+        id=uuid4(),
+        owner_scope="organization",
+        owner_user_id=None,
+        organization_id=organization_id or uuid4(),
+        created_by_user_id=uuid4(),
+        billing_subject_id=uuid4(),
+        status=status,
+        last_error=None,
+        e2b_sandbox_id=None,
+        e2b_template_ref="e2b",
+        anyharness_base_url=None,
+        anyharness_bearer_token_ciphertext=None,
+        anyharness_data_key_ciphertext=None,
+        runtime_generation=0,
+        display_name=display_name,
+        created_at=now,
+        updated_at=now,
+        ready_at=None,
+        last_health_at=None,
+        destroyed_at=None,
+    )
+
+
+class FakeBillingSubject:
+    def __init__(self) -> None:
+        self.id = uuid4()
+
+
+@pytest.mark.asyncio
+async def test_create_org_sandbox_profile_calls_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid4()
+    user_id = uuid4()
+    expected_sandbox = _make_sandbox_value(organization_id=org_id)
+    billing_subject = FakeBillingSubject()
+
+    lock_calls: list[dict] = []
+    ensure_billing_calls: list[UUID] = []
+    ensure_sandbox_calls: list[dict] = []
+
+    async def mock_acquire_lock(db: object, **kwargs: object) -> None:
+        lock_calls.append(dict(kwargs))
+
+    async def mock_ensure_billing(db: object, org_id: UUID) -> FakeBillingSubject:
+        ensure_billing_calls.append(org_id)
+        return billing_subject
+
+    async def mock_ensure_sandbox(db: object, **kwargs: object) -> CloudSandboxValue:
+        ensure_sandbox_calls.append(dict(kwargs))
+        return expected_sandbox
+
+    from proliferate.db.store import billing_subjects as billing_mod
+    from proliferate.db.store import cloud_sandboxes as sandbox_mod
+
+    monkeypatch.setattr(sandbox_mod, "acquire_cloud_sandbox_owner_lock", mock_acquire_lock)
+    monkeypatch.setattr(billing_mod, "ensure_organization_billing_subject", mock_ensure_billing)
+    monkeypatch.setattr(sandbox_mod, "ensure_organization_cloud_sandbox", mock_ensure_sandbox)
+
+    result = await service.create_org_sandbox_profile(
+        cast(AsyncSession, object()),
+        organization_id=org_id,
+        created_by_user_id=user_id,
+        display_name="My Team Sandbox",
+    )
+
+    assert result is expected_sandbox
+    assert lock_calls[0]["owner_scope"] == "organization"
+    assert lock_calls[0]["organization_id"] == org_id
+    assert ensure_billing_calls[0] == org_id
+    assert ensure_sandbox_calls[0]["organization_id"] == org_id
+    assert ensure_sandbox_calls[0]["display_name"] == "My Team Sandbox"
+    assert ensure_sandbox_calls[0]["billing_subject_id"] == billing_subject.id
+
+
+@pytest.mark.asyncio
+async def test_list_org_sandbox_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid4()
+    sandboxes = [
+        _make_sandbox_value(organization_id=org_id, display_name="Sandbox A"),
+        _make_sandbox_value(organization_id=org_id, display_name="Sandbox B"),
+    ]
+
+    from proliferate.db.store import cloud_sandboxes as sandbox_mod
+
+    async def mock_list(db: object, organization_id: UUID) -> list[CloudSandboxValue]:
+        assert organization_id == org_id
+        return sandboxes
+
+    monkeypatch.setattr(sandbox_mod, "list_organization_cloud_sandboxes", mock_list)
+
+    result = await service.list_org_sandbox_profiles(
+        cast(AsyncSession, object()),
+        organization_id=org_id,
+    )
+
+    assert len(result) == 2
+    assert result[0].display_name == "Sandbox A"
+
+
+@pytest.mark.asyncio
+async def test_get_org_sandbox_profile_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid4()
+    sandbox_id = uuid4()
+
+    from proliferate.db.store import cloud_sandboxes as sandbox_mod
+
+    async def mock_load(
+        db: object, organization_id: UUID, *, sandbox_id: UUID | None = None
+    ) -> CloudSandboxValue | None:
+        return None
+
+    monkeypatch.setattr(sandbox_mod, "load_organization_cloud_sandbox", mock_load)
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await service.get_org_sandbox_profile(
+            cast(AsyncSession, object()),
+            organization_id=org_id,
+            sandbox_id=sandbox_id,
+        )
+
+    assert exc_info.value.code == "org_sandbox_profile_not_found"
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Problem

The `cloud_sandbox` table supports only personal (per-user) ownership. The team-and-web spec (T1) calls for surfacing org-owned sandbox profiles so organization members can share cloud sandboxes under org billing.

## What changed

**Server (API + store + migration):**
- Migration `bb68e6f07040`: adds `owner_scope`, `organization_id`, `created_by_user_id`, `billing_subject_id`, `display_name` columns to `cloud_sandbox`; adds check constraints and unique indexes for org sandboxes.
- ORM model (`sandboxes.py`): new columns, updated constraints.
- Store (`cloud_sandboxes.py`): implements `list_organization_cloud_sandboxes`, `ensure_organization_cloud_sandbox`, `load_organization_cloud_sandbox`; fixes `acquire_cloud_sandbox_owner_lock` to support org scope.
- Service (`org_sandbox_profiles/service.py`): create (binds org billing subject), list, get. Boundary-clean (no ORM imports).
- API (`org_sandbox_profiles/api.py`): `GET/POST /v1/cloud/organizations/{id}/sandbox-profiles`, `GET .../sandbox-profiles/{sandbox_id}`. Create is org-admin gated; list/get is member-visible.

**Agent-auth admission:** Verified with a test that the existing `render_agent_auth_state` path works unchanged for org profiles. Selections remain per-user — a member starting a session on an org sandbox uses their own agent-auth selections.

**Cloud SDK:** Regenerated OpenAPI TypeScript client; added `org-sandbox-profiles.ts` client module with `listOrgSandboxProfiles`, `createOrgSandboxProfile`, `getOrgSandboxProfile`.

**Desktop UI:** `OrgSandboxProfilesSection` component in org settings pane — lists profiles with status badges, create form (admin-only).

## How to verify

```bash
cd server
DEBUG=1 JWT_SECRET=test CLOUD_SECRET_KEY=test \
  uv run --extra dev pytest -xvs \
    tests/unit/test_org_sandbox_profiles_service.py \
    tests/unit/test_org_sandbox_agent_auth_admission.py

python3.12 scripts/check_server_boundaries.py
```

## Follow-ups

- **Member-access policy**: who may START sessions on an org profile (currently any member can view, only admin can create — session-start admission policy is T2 work).
- **Org billing display**: surface the org billing subject's usage/grants in the org settings UI alongside profiles.
- **T2 visibility ACL**: sessions on org profiles visible to all org members (Ramp-Inspect-style transparency) vs. private. Default recommendation: visible to all.
- **Template/agent selection on create**: v0 hardcodes `e2b` template ref and no agent-auth initial config. Full template + agent selection UI is a follow-up.
- **Per-run sandboxes (T6)**: no new code deepens the 1:1 profile-target assumption. The `display_name` uniqueness allows multiple org profiles. When per-run ephemeral sandboxes land, existing profiles serve as templates.

Part of overnight v1 build wave 2026-07-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)