### PR TITLE
fix(overnight): wake-resume — explicit sandbox wake before gateway proxy

### DIFF
--- a/server/proliferate/server/cloud/gateway/api.py
+++ b/server/proliferate/server/cloud/gateway/api.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 from fastapi import APIRouter, Depends, Request, WebSocket, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.gateway.access import (
     GatewayWebSocketAuthError,
     accepted_gateway_websocket_subprotocol,
@@ -18,7 +21,10 @@ from proliferate.server.cloud.gateway.proxy import (
     proxy_http_to_anyharness,
     proxy_websocket_to_anyharness,
 )
-from proliferate.server.cloud.gateway.service import ensure_cloud_sandbox_gateway_access
+from proliferate.server.cloud.gateway.service import (
+    ensure_cloud_sandbox_gateway_access,
+    invalidate_gateway_access_for_user,
+)
 
 router = APIRouter(tags=["cloud-sandbox-gateway"])
 
@@ -35,12 +41,19 @@ async def proxy_cloud_sandbox_anyharness_http(
     user: User = Depends(current_product_user),
 ) -> object:
     access = await ensure_cloud_sandbox_gateway_access(db, user)
-    return await proxy_http_to_anyharness(
-        request,
-        upstream_base_url=access.upstream_base_url,
-        upstream_token=access.upstream_token,
-        path=path,
-    )
+    try:
+        return await proxy_http_to_anyharness(
+            request,
+            upstream_base_url=access.upstream_base_url,
+            upstream_token=access.upstream_token,
+            path=path,
+        )
+    except CloudApiError as exc:
+        if exc.code == "cloud_sandbox_resuming":
+            # Invalidate cached access so the next retry re-resolves and re-wakes
+            # the sandbox before attempting the proxy connection again.
+            invalidate_gateway_access_for_user(user.id)
+        raise
 
 
 @router.websocket("/cloud-sandbox/anyharness/{path:path}")
@@ -58,10 +71,17 @@ async def proxy_cloud_sandbox_anyharness_websocket(
     except GatewayWebSocketAuthError:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
-    await proxy_websocket_to_anyharness(
-        websocket,
-        upstream_base_url=access.upstream_base_url,
-        upstream_token=access.upstream_token,
-        path=path,
-        accept_subprotocol=accepted_gateway_websocket_subprotocol(websocket),
-    )
+    try:
+        await proxy_websocket_to_anyharness(
+            websocket,
+            upstream_base_url=access.upstream_base_url,
+            upstream_token=access.upstream_token,
+            path=path,
+            accept_subprotocol=accepted_gateway_websocket_subprotocol(websocket),
+        )
+    except CloudApiError as exc:
+        if exc.code == "cloud_sandbox_resuming":
+            invalidate_gateway_access_for_user(user.id)
+        with suppress(RuntimeError):
+            await websocket.close(code=1011)
+        return

--- a/server/proliferate/server/cloud/gateway/proxy.py
+++ b/server/proliferate/server/cloud/gateway/proxy.py
@@ -19,7 +19,7 @@ from websockets.exceptions import ConnectionClosed
 from proliferate.server.cloud.errors import CloudApiError
 
 _ANYHARNESS_MARKER = "/cloud-sandbox/anyharness"
-_HTTP_TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)
+_HTTP_TIMEOUT = httpx.Timeout(connect=60.0, read=None, write=30.0, pool=10.0)
 _STRIP_REQUEST_HEADERS = {
     "authorization",
     "cookie",
@@ -143,9 +143,10 @@ async def proxy_http_to_anyharness(
     except httpx.RequestError as exc:
         await client.aclose()
         raise CloudApiError(
-            "cloud_sandbox_gateway_unreachable",
-            "Cloud sandbox runtime could not be reached.",
-            status_code=502,
+            "cloud_sandbox_resuming",
+            "Cloud sandbox is waking up. Please retry shortly.",
+            status_code=503,
+            headers={"Retry-After": "5"},
         ) from exc
 
     return StreamingResponse(
@@ -251,6 +252,9 @@ async def proxy_websocket_to_anyharness(
     except Exception as exc:
         if isinstance(exc, ConnectionClosed):
             return
-        with suppress(RuntimeError):
-            await websocket.close(code=1011)
-        return
+        raise CloudApiError(
+            "cloud_sandbox_resuming",
+            "Cloud sandbox is waking up. Please retry shortly.",
+            status_code=503,
+            headers={"Retry-After": "5"},
+        ) from exc

--- a/server/proliferate/server/cloud/gateway/service.py
+++ b/server/proliferate/server/cloud/gateway/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
 from typing import Protocol
@@ -10,10 +11,13 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.integrations.sandbox import get_sandbox_provider
 from proliferate.server.cloud.cloud_sandboxes.service import (
     ensure_cloud_sandbox_ready,
     load_cloud_sandbox_runtime_access,
 )
+
+logger = logging.getLogger("proliferate.cloud.gateway")
 
 
 class _UserWithId(Protocol):
@@ -67,6 +71,11 @@ def _remember_gateway_access(
     return access
 
 
+def invalidate_gateway_access_for_user(user_id: UUID) -> None:
+    """Remove cached gateway access so the next request re-resolves (and re-wakes)."""
+    _gateway_access_cache.pop(user_id, None)
+
+
 def _reset_cloud_sandbox_gateway_access_cache_for_tests() -> None:
     _gateway_access_cache.clear()
     _gateway_access_locks.clear()
@@ -95,6 +104,25 @@ async def _resolve_cloud_sandbox_gateway_access(
 ) -> CloudSandboxGatewayAccess:
     sandbox = await ensure_cloud_sandbox_ready(db, user)
     upstream_base_url, upstream_token, _data_key = await load_cloud_sandbox_runtime_access(sandbox)
+
+    # Ensure the sandbox VM is awake before proxying traffic to it.
+    # E2B sandboxes may be paused after inactivity; resume_sandbox reconnects
+    # (and auto-resumes) the VM so the gateway proxy does not hit a cold host.
+    provider_sandbox_id = sandbox.e2b_sandbox_id
+    template_ref = sandbox.e2b_template_ref
+    if provider_sandbox_id is not None and template_ref is not None:
+        try:
+            provider = get_sandbox_provider(template_ref)
+            await provider.resume_sandbox(provider_sandbox_id)
+        except Exception:
+            logger.warning(
+                "gateway wake: resume_sandbox failed for sandbox_id=%s user=%s, "
+                "proxy will attempt connection anyway",
+                provider_sandbox_id,
+                user.id,
+                exc_info=True,
+            )
+
     return CloudSandboxGatewayAccess(
         upstream_base_url=upstream_base_url,
         upstream_token=upstream_token,

--- a/server/tests/unit/test_cloud_sandbox_gateway_proxy.py
+++ b/server/tests/unit/test_cloud_sandbox_gateway_proxy.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import Request, WebSocket
 from starlette.datastructures import QueryParams
 
+from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.gateway import proxy
 
 
@@ -163,6 +164,75 @@ async def test_http_proxy_returns_499_when_client_disconnects_before_forwarding(
     )
 
     assert response.status_code == 499
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_raises_503_cloud_sandbox_resuming_on_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingAsyncClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def build_request(self, *_args: object, **_kwargs: object) -> httpx.Request:
+            return httpx.Request("POST", "https://sandbox.example.test/v1/sessions")
+
+        async def send(self, *_args: object, **_kwargs: object) -> object:
+            raise httpx.ConnectError("Connection refused")
+
+        async def aclose(self) -> None:
+            pass
+
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", _FailingAsyncClient)
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await proxy.proxy_http_to_anyharness(
+            _request(),
+            upstream_base_url="https://sandbox.example.test",
+            upstream_token="sandbox-token",
+            path="v1/sessions/ws/encoded",
+        )
+
+    assert exc_info.value.code == "cloud_sandbox_resuming"
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.headers["Retry-After"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_websocket_proxy_raises_cloud_api_error_on_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeWebSocket:
+        scope = {
+            "raw_path": b"/v1/gateway/cloud-sandbox/anyharness/v1/terminals/ws",
+        }
+        query_params = QueryParams("access_token=product-token")
+        headers = {"x-client-header": "kept"}
+
+    async def _failing_connect(*_args: object, **_kwargs: object) -> object:
+        raise OSError("Connection refused")
+
+    # websockets.connect is a context manager; patch it at the module level
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def _mock_connect(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        raise OSError("Connection refused")
+        yield  # unreachable, but needed for async generator syntax  # noqa: RUF027
+
+    monkeypatch.setattr(proxy.websockets, "connect", _mock_connect)
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await proxy.proxy_websocket_to_anyharness(
+            cast(WebSocket, _FakeWebSocket()),
+            upstream_base_url="https://sandbox.example.test",
+            upstream_token="sandbox-token",
+            path="v1/terminals/ws",
+            accept_subprotocol=None,
+        )
+
+    assert exc_info.value.code == "cloud_sandbox_resuming"
+    assert exc_info.value.status_code == 503
 
 
 def test_websocket_upstream_url_rewrites_access_token_and_preserves_after_seq() -> None:

--- a/server/tests/unit/test_cloud_sandbox_gateway_service.py
+++ b/server/tests/unit/test_cloud_sandbox_gateway_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -23,7 +24,7 @@ async def test_gateway_access_reuses_recent_runtime_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user = SimpleNamespace(id=uuid4())
-    sandbox = SimpleNamespace(runtime_generation=7)
+    sandbox = SimpleNamespace(runtime_generation=7, e2b_sandbox_id=None, e2b_template_ref=None)
     ensure_calls = 0
     load_calls = 0
 
@@ -62,7 +63,7 @@ async def test_gateway_access_singleflights_concurrent_runtime_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user = SimpleNamespace(id=uuid4())
-    sandbox = SimpleNamespace(runtime_generation=8)
+    sandbox = SimpleNamespace(runtime_generation=8, e2b_sandbox_id=None, e2b_template_ref=None)
     ensure_calls = 0
     load_calls = 0
 
@@ -107,7 +108,9 @@ async def test_gateway_access_refreshes_after_cache_expiry(
     async def ensure_ready(*_args: object, **_kwargs: object) -> object:
         nonlocal ensure_calls
         ensure_calls += 1
-        return SimpleNamespace(runtime_generation=ensure_calls)
+        return SimpleNamespace(
+            runtime_generation=ensure_calls, e2b_sandbox_id=None, e2b_template_ref=None
+        )
 
     async def load_access(*_args: object, **_kwargs: object) -> tuple[str, str, str]:
         return ("https://sandbox.example.test", f"sandbox-token-{ensure_calls}", "data-key")
@@ -135,3 +138,146 @@ async def test_gateway_access_refreshes_after_cache_expiry(
     assert second.runtime_generation == 2
     assert second.upstream_token == "sandbox-token-2"
     assert ensure_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_calls_resume_sandbox_for_paused_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paused sandbox triggers resume_sandbox before access is returned."""
+    user = SimpleNamespace(id=uuid4())
+    sandbox = SimpleNamespace(
+        runtime_generation=3,
+        e2b_sandbox_id="sb-paused-123",
+        e2b_template_ref="e2b",
+    )
+
+    async def ensure_ready(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_access(*_args: object, **_kwargs: object) -> tuple[str, str, str]:
+        return ("https://sandbox.example.test", "sandbox-token", "data-key")
+
+    monkeypatch.setattr(service, "ensure_cloud_sandbox_ready", ensure_ready)
+    monkeypatch.setattr(service, "load_cloud_sandbox_runtime_access", load_access)
+
+    mock_provider = AsyncMock()
+    mock_provider.resume_sandbox = AsyncMock()
+
+    with patch.object(service, "get_sandbox_provider", return_value=mock_provider) as mock_get:
+        access = await service.ensure_cloud_sandbox_gateway_access(
+            cast(AsyncSession, object()),
+            cast(service._UserWithId, user),
+        )
+
+    mock_get.assert_called_once_with("e2b")
+    mock_provider.resume_sandbox.assert_awaited_once_with("sb-paused-123")
+    assert access.upstream_base_url == "https://sandbox.example.test"
+    assert access.upstream_token == "sandbox-token"
+
+
+@pytest.mark.asyncio
+async def test_resolve_resume_failure_does_not_block_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If resume_sandbox raises, access is still returned (with a warning log)."""
+    user = SimpleNamespace(id=uuid4())
+    sandbox = SimpleNamespace(
+        runtime_generation=5,
+        e2b_sandbox_id="sb-fail-456",
+        e2b_template_ref="e2b",
+    )
+
+    async def ensure_ready(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_access(*_args: object, **_kwargs: object) -> tuple[str, str, str]:
+        return ("https://sandbox.example.test", "sandbox-token", "data-key")
+
+    monkeypatch.setattr(service, "ensure_cloud_sandbox_ready", ensure_ready)
+    monkeypatch.setattr(service, "load_cloud_sandbox_runtime_access", load_access)
+
+    mock_provider = AsyncMock()
+    mock_provider.resume_sandbox = AsyncMock(side_effect=RuntimeError("E2B timeout"))
+
+    with patch.object(service, "get_sandbox_provider", return_value=mock_provider):
+        access = await service.ensure_cloud_sandbox_gateway_access(
+            cast(AsyncSession, object()),
+            cast(service._UserWithId, user),
+        )
+
+    # Access is still returned despite resume failure
+    assert access.upstream_base_url == "https://sandbox.example.test"
+    assert access.upstream_token == "sandbox-token"
+    assert access.runtime_generation == 5
+
+
+@pytest.mark.asyncio
+async def test_resolve_skips_resume_when_no_provider_sandbox_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No resume_sandbox call when e2b_sandbox_id is None (sandbox still creating)."""
+    user = SimpleNamespace(id=uuid4())
+    sandbox = SimpleNamespace(
+        runtime_generation=1,
+        e2b_sandbox_id=None,
+        e2b_template_ref="e2b",
+    )
+
+    async def ensure_ready(*_args: object, **_kwargs: object) -> object:
+        return sandbox
+
+    async def load_access(*_args: object, **_kwargs: object) -> tuple[str, str, str]:
+        return ("https://sandbox.example.test", "sandbox-token", "data-key")
+
+    monkeypatch.setattr(service, "ensure_cloud_sandbox_ready", ensure_ready)
+    monkeypatch.setattr(service, "load_cloud_sandbox_runtime_access", load_access)
+
+    with patch.object(service, "get_sandbox_provider") as mock_get:
+        access = await service.ensure_cloud_sandbox_gateway_access(
+            cast(AsyncSession, object()),
+            cast(service._UserWithId, user),
+        )
+
+    mock_get.assert_not_called()
+    assert access.upstream_base_url == "https://sandbox.example.test"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_gateway_access_forces_re_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After invalidation the next call re-resolves (re-wakes) the sandbox."""
+    user = SimpleNamespace(id=uuid4())
+    resolve_count = 0
+
+    sandbox = SimpleNamespace(
+        runtime_generation=1,
+        e2b_sandbox_id=None,
+        e2b_template_ref=None,
+    )
+
+    async def ensure_ready(*_args: object, **_kwargs: object) -> object:
+        nonlocal resolve_count
+        resolve_count += 1
+        return sandbox
+
+    async def load_access(*_args: object, **_kwargs: object) -> tuple[str, str, str]:
+        return ("https://sandbox.example.test", "sandbox-token", "data-key")
+
+    monkeypatch.setattr(service, "ensure_cloud_sandbox_ready", ensure_ready)
+    monkeypatch.setattr(service, "load_cloud_sandbox_runtime_access", load_access)
+
+    await service.ensure_cloud_sandbox_gateway_access(
+        cast(AsyncSession, object()),
+        cast(service._UserWithId, user),
+    )
+    assert resolve_count == 1
+
+    # Invalidate and verify re-resolve
+    service.invalidate_gateway_access_for_user(user.id)
+    await service.ensure_cloud_sandbox_gateway_access(
+        cast(AsyncSession, object()),
+        cast(service._UserWithId, user),
+    )
+    assert resolve_count == 2


### PR DESCRIPTION
## Problem

The gateway proxy (service.py → proxy.py) attempts to connect to E2B cloud sandboxes that may be paused after inactivity. The proxy's connect timeout was only 10s, but E2B auto-resume can take >10s. When this happened, `httpx.RequestError` raised a 502 `cloud_sandbox_gateway_unreachable` error with no retry path — the desktop had no way to recover or display a "waking" state.

## What changed

**F1 fix** — three complementary changes in `server/proliferate/server/cloud/gateway/`:

| File | Change |
|------|--------|
| `service.py` | Call `provider.resume_sandbox()` during gateway access resolution (mirrors materialization path in `connect.py:83`). Adds `invalidate_gateway_access_for_user()` export. |
| `proxy.py` | Increase HTTP connect timeout 10s → 60s. Change error from 502 `cloud_sandbox_gateway_unreachable` to 503 `cloud_sandbox_resuming` with `Retry-After: 5` header. |
| `api.py` | On `cloud_sandbox_resuming` error, invalidate gateway access cache so next retry re-resolves and re-wakes the sandbox. |

## How to verify

1. `DEBUG=true pytest tests/unit/test_cloud_sandbox_gateway_service.py tests/unit/test_cloud_sandbox_gateway_proxy.py` — passes (existing tests still green).
2. `python scripts/check_server_boundaries.py` — passes.
3. Manual: pause a cloud sandbox, hit the gateway endpoint — should resume transparently instead of 502.

## Findings

- **F1 (confirmed, fixed)**: Gateway proxy attempted connection to paused sandboxes without waking them first; 10s timeout too short for E2B resume.
- F10 (refuted): No 'resuming' status in DB — not applicable.
- F6 (refuted): Infinite read timeout is deliberate for SSE streaming — not applicable.

## Follow-ups

- Add SDK-level retry for 503 responses in `@anyharness/sdk` (AnyHarnessTransport).
- Surface "Cloud sandbox waking..." UI state in desktop when 503 `cloud_sandbox_resuming` is received.

Part of overnight v1 fix wave 2026-07-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)