### PR TITLE
fix(cloud): repair GitHub-connect pre-clone TypeError (silent since #823 era)

### DIFF
--- a/server/proliferate/server/cloud/materialization/materialize/sandbox.py
+++ b/server/proliferate/server/cloud/materialization/materialize/sandbox.py
@@ -7,6 +7,9 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
+from proliferate.db.store import (
+    cloud_repo_environment_materializations as repo_mat_store,
+)
 from proliferate.db.store import repositories as repositories_store
 from proliferate.server.cloud.materialization import operation
 from proliferate.server.cloud.materialization.materialize import (
@@ -53,10 +56,18 @@ async def _materialize_sandbox(
         user_id=user_id,
     )
     for repo_environment in repo_environments:
+        materialization = await repo_mat_store.begin_repo_environment_materialization(
+            db,
+            cloud_sandbox_id=ctx.sandbox.id,
+            repo_environment_id=repo_environment.id,
+        )
+        attempt_updated_at = materialization.updated_at
         await repo_environment_materializer.materialize_repo_environment_in_context(
             db,
             ctx=ctx,
-            repo_environment=repo_environment,
+            repo_environment_id=repo_environment.id,
+            materialization_id=materialization.id,
+            attempt_updated_at=attempt_updated_at,
         )
     # Last, defensively: agent-auth materialization writes a fail-closed state
     # even when a selection can't yet be satisfied (e.g. enrollment still

--- a/server/tests/unit/test_sandbox_materialization.py
+++ b/server/tests/unit/test_sandbox_materialization.py
@@ -26,11 +26,17 @@ def _repo_environment(
 ) -> RepoEnvironmentValue:
     return RepoEnvironmentValue(
         id=id or uuid.uuid4(),
+        repo_config_id=uuid.uuid4(),
         user_id=user_id,
-        environment_kind="cloud",
+        git_provider="github",
         git_owner=git_owner,
         git_repo_name=git_repo_name,
+        environment_kind="cloud",
+        desktop_install_id=None,
+        local_path=None,
         default_branch=None,
+        setup_script="",
+        run_command="",
         created_at=NOW,
         updated_at=NOW,
     )

--- a/server/tests/unit/test_sandbox_materialization.py
+++ b/server/tests/unit/test_sandbox_materialization.py
@@ -1,0 +1,209 @@
+"""Unit tests for cloud sandbox materialization."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from proliferate.db.store.repositories import RepoEnvironmentValue
+from proliferate.server.cloud.materialization.materialize import sandbox
+
+USER_ID = uuid.uuid4()
+NOW = datetime(2026, 7, 4, tzinfo=UTC)
+
+
+def _repo_environment(
+    *,
+    id: uuid.UUID | None = None,
+    user_id: uuid.UUID = USER_ID,
+    git_owner: str = "test-org",
+    git_repo_name: str = "test-repo",
+) -> RepoEnvironmentValue:
+    return RepoEnvironmentValue(
+        id=id or uuid.uuid4(),
+        user_id=user_id,
+        environment_kind="cloud",
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        default_branch=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _ctx() -> Any:
+    return SimpleNamespace(
+        sandbox=SimpleNamespace(id=uuid.uuid4()),
+        target=object(),
+    )
+
+
+class TestMaterializeSandboxWithRepoEnvironments:
+    @pytest.mark.asyncio
+    async def test_calls_repo_environment_materializer_with_correct_signature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for TypeError when calling materialize_repo_environment_in_context.
+
+        The bug was that sandbox.py called materialize_repo_environment_in_context with
+        (db, ctx=ctx, repo_environment=repo_environment) but the real signature requires
+        (db, ctx=ctx, repo_environment_id=..., materialization_id=..., attempt_updated_at=...).
+        """
+        repo_env = _repo_environment()
+        materialization_id = uuid.uuid4()
+
+        # Track what arguments were passed to the function
+        materialization_calls: list[dict[str, Any]] = []
+
+        async def mock_materialize_in_context(
+            db: Any,
+            *,
+            ctx: Any,
+            repo_environment_id: uuid.UUID,
+            materialization_id: uuid.UUID,
+            attempt_updated_at: datetime,
+        ) -> None:
+            materialization_calls.append({
+                "db": db,
+                "ctx": ctx,
+                "repo_environment_id": repo_environment_id,
+                "materialization_id": materialization_id,
+                "attempt_updated_at": attempt_updated_at,
+            })
+
+        # Mock dependencies
+        async def mock_materialize_github_creds(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_materialize_secrets(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_materialize_agent_auth(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_list_repo_environments(db: Any, *, user_id: uuid.UUID) -> list[RepoEnvironmentValue]:
+            return [repo_env]
+
+        async def mock_begin_materialization(
+            db: Any,
+            *,
+            cloud_sandbox_id: uuid.UUID,
+            repo_environment_id: uuid.UUID,
+        ) -> Any:
+            return SimpleNamespace(
+                id=materialization_id,
+                updated_at=NOW,
+            )
+
+        from proliferate.db.store import cloud_repo_environment_materializations as repo_mat_store
+        from proliferate.db.store import repositories as repositories_store
+        from proliferate.server.cloud.materialization.materialize import (
+            agent_auth,
+            github_credentials,
+            repo_environment as repo_environment_materializer,
+            secret_set,
+        )
+
+        monkeypatch.setattr(github_credentials, "materialize_github_credentials", mock_materialize_github_creds)
+        monkeypatch.setattr(secret_set, "materialize_global_secrets_for_user", mock_materialize_secrets)
+        monkeypatch.setattr(agent_auth, "materialize_agent_auth", mock_materialize_agent_auth)
+        monkeypatch.setattr(repositories_store, "list_cloud_repo_environments", mock_list_repo_environments)
+        monkeypatch.setattr(repo_mat_store, "begin_repo_environment_materialization", mock_begin_materialization)
+        monkeypatch.setattr(
+            repo_environment_materializer,
+            "materialize_repo_environment_in_context",
+            mock_materialize_in_context,
+        )
+
+        # Execute
+        ctx = _ctx()
+        await sandbox._materialize_sandbox(ctx, db=object(), user_id=USER_ID)
+
+        # Verify that materialize_repo_environment_in_context was called with correct signature
+        assert len(materialization_calls) == 1
+        call = materialization_calls[0]
+        assert call["repo_environment_id"] == repo_env.id
+        assert call["materialization_id"] == materialization_id
+        assert call["attempt_updated_at"] == NOW
+        assert call["ctx"] == ctx
+
+    @pytest.mark.asyncio
+    async def test_handles_multiple_repo_environments(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that all repo environments are materialized in order."""
+        repo_env1 = _repo_environment(git_repo_name="repo1")
+        repo_env2 = _repo_environment(git_repo_name="repo2")
+        mat1_id = uuid.uuid4()
+        mat2_id = uuid.uuid4()
+
+        materialization_calls: list[uuid.UUID] = []
+
+        async def mock_materialize_in_context(
+            db: Any,
+            *,
+            ctx: Any,
+            repo_environment_id: uuid.UUID,
+            materialization_id: uuid.UUID,
+            attempt_updated_at: datetime,
+        ) -> None:
+            materialization_calls.append(repo_environment_id)
+
+        async def mock_materialize_github_creds(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_materialize_secrets(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_materialize_agent_auth(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def mock_list_repo_environments(db: Any, *, user_id: uuid.UUID) -> list[RepoEnvironmentValue]:
+            return [repo_env1, repo_env2]
+
+        call_count = 0
+        async def mock_begin_materialization(
+            db: Any,
+            *,
+            cloud_sandbox_id: uuid.UUID,
+            repo_environment_id: uuid.UUID,
+        ) -> Any:
+            nonlocal call_count
+            call_count += 1
+            mat_id = mat1_id if call_count == 1 else mat2_id
+            return SimpleNamespace(
+                id=mat_id,
+                updated_at=NOW,
+            )
+
+        from proliferate.db.store import cloud_repo_environment_materializations as repo_mat_store
+        from proliferate.db.store import repositories as repositories_store
+        from proliferate.server.cloud.materialization.materialize import (
+            agent_auth,
+            github_credentials,
+            repo_environment as repo_environment_materializer,
+            secret_set,
+        )
+
+        monkeypatch.setattr(github_credentials, "materialize_github_credentials", mock_materialize_github_creds)
+        monkeypatch.setattr(secret_set, "materialize_global_secrets_for_user", mock_materialize_secrets)
+        monkeypatch.setattr(agent_auth, "materialize_agent_auth", mock_materialize_agent_auth)
+        monkeypatch.setattr(repositories_store, "list_cloud_repo_environments", mock_list_repo_environments)
+        monkeypatch.setattr(repo_mat_store, "begin_repo_environment_materialization", mock_begin_materialization)
+        monkeypatch.setattr(
+            repo_environment_materializer,
+            "materialize_repo_environment_in_context",
+            mock_materialize_in_context,
+        )
+
+        # Execute
+        ctx = _ctx()
+        await sandbox._materialize_sandbox(ctx, db=object(), user_id=USER_ID)
+
+        # Verify both repo environments were materialized
+        assert materialization_calls == [repo_env1.id, repo_env2.id]


### PR DESCRIPTION
## Problem

When a user connects a GitHub repo via the GitHub App integration, the server triggers sandbox materialization to pre-clone the repository. However, the `_materialize_sandbox` function in `server/proliferate/server/cloud/materialization/materialize/sandbox.py` was calling `materialize_repo_environment_in_context` with the wrong signature:

**Old call (lines 55-60):**
```python
await repo_environment_materializer.materialize_repo_environment_in_context(
    db,
    ctx=ctx,
    repo_environment=repo_environment,
)
```

**Expected signature (repo_environment.py:67-74):**
```python
async def materialize_repo_environment_in_context(
    db: AsyncSession,
    *,
    ctx: operation.MaterializationContext,
    repo_environment_id: UUID,
    materialization_id: UUID,
    attempt_updated_at: datetime,
) -> None:
```

This caused a `TypeError` on every GitHub connect attempt for users with >=1 cloud repo environment. The exception was logged by `materialization/runner.py` but not surfaced to the user.

**Net effect:** GitHub connect appeared successful, but repos were never pre-cloned, so the first workspace create ate the full git clone inline (slow first-run experience).

## What changed

1. Fixed `sandbox.py` to call `begin_repo_environment_materialization` before the `materialize_repo_environment_in_context` call, matching the correct pattern from `repo_environment.py:materialize_repo_environment` (lines 36-54)
2. Added import for `cloud_repo_environment_materializations` store
3. Added regression test (`test_sandbox_materialization.py`) that verifies:
   - The correct function signature is used
   - Multiple repo environments are all materialized
   - All required parameters are passed correctly

## How to verify

### Unit test
```bash
cd server && .venv/bin/python -m pytest tests/unit/test_sandbox_materialization.py -xvs
```

### Integration test
1. Connect a GitHub repo via the GitHub App
2. Check server logs for no TypeError in materialization tasks
3. SSH into sandbox and verify repo is pre-cloned at the expected path

## Follow-ups

None. The `runner.py` exception logging already logs at ERROR level with full traceback (`logger.exception`), which is appropriate for ops visibility.

---

Part of overnight v1 fix wave 2026-07-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)