### PR TITLE
fix(cloud): stalled-materialization detection + recovery (no more infinite spinner)

### DIFF
--- a/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
+++ b/apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
@@ -27,6 +27,17 @@ import {
 
 const CLOUD_WORKSPACE_POLL_INTERVAL_MS = 3000;
 
+/**
+ * Client-side deadline for materialization polling. If a workspace has been in
+ * a pending/materializing state for longer than this duration (measured from
+ * the pending entry createdAt timestamp), the poller will treat it as stalled
+ * and surface an error regardless of what the server still reports. This is a
+ * belt-and-suspenders guard against infinite spinners — the server itself will
+ * report materialization_stalled after 15 min, but the client enforces a
+ * matching deadline in case network issues delay that signal.
+ */
+const CLIENT_MATERIALIZATION_DEADLINE_MS = 16 * 60 * 1000; // 16 minutes
+
 export function useCloudWorkspacePolling() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
@@ -117,6 +128,41 @@ export function useCloudWorkspacePolling() {
           pendingElapsedMs: pendingWorkspaceEntry ? elapsedSince(pendingWorkspaceEntry.createdAt) : null,
         });
         if (cancelled) {
+          return;
+        }
+
+        // Client-side staleness deadline: if we have been polling for longer
+        // than CLIENT_MATERIALIZATION_DEADLINE_MS and the workspace is still
+        // not ready, treat it as failed regardless of server status.
+        const pendingElapsed = pendingWorkspaceEntry
+          ? elapsedSince(pendingWorkspaceEntry.createdAt)
+          : null;
+        if (
+          refreshedStatus !== "ready"
+          && refreshedStatus !== "error"
+          && pendingElapsed != null
+          && pendingElapsed > CLIENT_MATERIALIZATION_DEADLINE_MS
+        ) {
+          shouldScheduleNextPoll = false;
+          const pending = useSessionSelectionStore.getState().pendingWorkspaceEntry;
+          if (
+            pending
+            && pending.workspaceId === selectedWorkspaceId
+            && pending.stage === "awaiting-cloud-ready"
+          ) {
+            setPendingWorkspaceEntry({
+              ...pending,
+              stage: "failed",
+              request: { kind: "select-existing", workspaceId: selectedWorkspaceId },
+              errorMessage:
+                "Workspace provisioning timed out. Delete this workspace and try again.",
+            });
+          }
+          logLatency("workspace.cloud_polling.client_deadline_exceeded", {
+            workspaceId: selectedWorkspaceId,
+            pendingAttemptId: pending?.attemptId ?? null,
+            pendingElapsedMs: pendingElapsed,
+          });
           return;
         }
 

--- a/cloud/sdk/src/client/workspaces.ts
+++ b/cloud/sdk/src/client/workspaces.ts
@@ -54,6 +54,7 @@ function normalizeCloudWorkspaceStatus(value: string | undefined): CloudWorkspac
     case "archived":
     case "stopped":
       return "archived";
+    case "materialization_stalled":
     case "error":
     default:
       return "error";

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -7,7 +7,9 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-CloudWorkspaceStatus = Literal["pending", "materializing", "ready", "archived", "error"]
+CloudWorkspaceStatus = Literal[
+    "pending", "materializing", "materialization_stalled", "ready", "archived", "error"
+]
 CloudRuntimeStatus = Literal["pending", "running", "paused", "error", "disabled"]
 
 

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -8,6 +8,7 @@ stores the returned workspace id.
 from __future__ import annotations
 
 import re
+from datetime import timedelta
 from typing import Literal, Protocol
 from uuid import UUID
 
@@ -484,6 +485,7 @@ async def _workspace_payload(
     payload_type = WorkspaceDetail if detail else WorkspaceSummary
     status = _workspace_status(workspace)
     runtime_status = _runtime_status(sandbox)
+    stalled = status == "materialization_stalled"
     return payload_type(
         id=str(workspace.id),
         target_id=None,
@@ -504,6 +506,16 @@ async def _workspace_payload(
             status=runtime_status,
             generation=sandbox.runtime_generation if sandbox is not None else 0,
         ),
+        status_detail=(
+            "Workspace provisioning timed out. Delete this workspace and try again."
+            if stalled
+            else None
+        ),
+        last_error=(
+            "Provisioning did not complete within the expected time."
+            if stalled
+            else None
+        ),
         updated_at=workspace.updated_at.isoformat() if workspace.updated_at else None,
         created_at=workspace.created_at.isoformat() if workspace.created_at else None,
         ready_at=workspace.created_at.isoformat() if workspace.created_at else None,
@@ -512,10 +524,24 @@ async def _workspace_payload(
     )
 
 
+# A workspace row without an anyharness_workspace_id is still materializing.
+# If it remains in that state longer than this deadline (measured from
+# created_at), we report it as stalled so the client can stop spinning and
+# surface a recovery action.  The deadline must exceed the repo-clone timeout
+# (600 s in materialize/repo_environment.py) plus overhead for AnyHarness
+# worktree creation.
+_MATERIALIZATION_STALL_DEADLINE = timedelta(seconds=900)
+
+
 def _workspace_status(workspace: CloudWorkspaceValue) -> CloudWorkspaceStatus:
     if workspace.archived_at is not None:
         return "archived"
     if not workspace.anyharness_workspace_id:
+        from proliferate.utils.time import utcnow
+
+        elapsed = utcnow() - workspace.created_at
+        if elapsed > _MATERIALIZATION_STALL_DEADLINE:
+            return "materialization_stalled"
         return "materializing"
     return "ready"
 

--- a/server/tests/unit/test_cloud_workspace_status.py
+++ b/server/tests/unit/test_cloud_workspace_status.py
@@ -1,0 +1,79 @@
+"""Unit tests for cloud workspace status derivation with staleness detection."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
+from proliferate.server.cloud.workspaces.service import (
+    _MATERIALIZATION_STALL_DEADLINE,
+    _workspace_status,
+)
+
+
+def _make_workspace(
+    *,
+    anyharness_workspace_id: str | None = None,
+    created_at: datetime | None = None,
+    archived_at: datetime | None = None,
+) -> CloudWorkspaceValue:
+    now = datetime.now(timezone.utc)
+    return CloudWorkspaceValue(
+        id=uuid4(),
+        owner_user_id=uuid4(),
+        repo_environment_id=uuid4(),
+        display_name="test-workspace",
+        git_branch="feat/test",
+        git_base_branch="main",
+        anyharness_workspace_id=anyharness_workspace_id,
+        created_at=created_at or now,
+        updated_at=created_at or now,
+        archived_at=archived_at,
+    )
+
+
+def test_ready_when_anyharness_workspace_id_present() -> None:
+    workspace = _make_workspace(anyharness_workspace_id="ws_123")
+    assert _workspace_status(workspace) == "ready"
+
+
+def test_archived_when_archived_at_set() -> None:
+    workspace = _make_workspace(
+        anyharness_workspace_id=None,
+        archived_at=datetime.now(timezone.utc),
+    )
+    assert _workspace_status(workspace) == "archived"
+
+
+def test_materializing_within_deadline() -> None:
+    # Created 5 minutes ago, well within the 15-minute deadline.
+    workspace = _make_workspace(
+        created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    assert _workspace_status(workspace) == "materializing"
+
+
+def test_materialization_stalled_beyond_deadline() -> None:
+    # Created well beyond the deadline.
+    workspace = _make_workspace(
+        created_at=datetime.now(timezone.utc) - _MATERIALIZATION_STALL_DEADLINE - timedelta(seconds=1),
+    )
+    assert _workspace_status(workspace) == "materialization_stalled"
+
+
+def test_materialization_not_stalled_just_under_deadline() -> None:
+    # Just under the deadline should still report materializing.
+    workspace = _make_workspace(
+        created_at=datetime.now(timezone.utc) - _MATERIALIZATION_STALL_DEADLINE + timedelta(seconds=5),
+    )
+    assert _workspace_status(workspace) == "materializing"
+
+
+def test_archived_takes_precedence_over_stalled() -> None:
+    # Even if the workspace would be stalled, archived takes priority.
+    workspace = _make_workspace(
+        created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        archived_at=datetime.now(timezone.utc),
+    )
+    assert _workspace_status(workspace) == "archived"


### PR DESCRIPTION
## Problem

When workspace provisioning dies between the row insert (service.py:187) and the anyharness_workspace_id write (service.py:219), the workspace row is stuck permanently: status is derived purely from `anyharness_workspace_id IS NULL` returning `"materializing"` forever. The desktop poller (3s interval, bare catch on errors, no deadline) spins indefinitely showing an infinite spinner with no recovery path.

## What changed

**Server (`server/proliferate/server/cloud/workspaces/`)**
- `_workspace_status` now checks `created_at` age: if the workspace has been without an `anyharness_workspace_id` for longer than 15 minutes (900s, exceeding the 600s repo-clone timeout), it reports `"materialization_stalled"` instead of `"materializing"`.
- The workspace payload includes `statusDetail` and `lastError` for stalled rows so the client shows a meaningful error message.
- Added `"materialization_stalled"` to the `CloudWorkspaceStatus` Literal type.

**Cloud SDK (`cloud/sdk/src/client/workspaces.ts`)**
- `normalizeCloudWorkspaceStatus` maps `"materialization_stalled"` to `"error"`, so existing desktop error-handling flows catch it immediately (poller stops, error screen appears with delete/retry affordance).

**Desktop poller (`apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts`)**
- Added a 16-minute client-side deadline as belt-and-suspenders: if the pending workspace entry has been waiting longer than this and the server still reports a non-terminal status, the poller forcibly transitions to "failed" with a timeout message.
- This guards against the case where network issues delay delivery of the server's stalled signal.

**Recovery path**
- The existing `DELETE /v1/cloud/workspaces/:id` endpoint already works on any workspace state (including stalled rows). Users see the error state with guidance to delete and recreate.

**Tests**
- Added `server/tests/unit/test_cloud_workspace_status.py` with 6 unit tests covering all branches of the staleness detection logic.

## How to verify

1. Create a cloud workspace row manually in the DB with `anyharness_workspace_id = NULL` and `created_at` older than 15 minutes.
2. Hit GET `/v1/cloud/workspaces` — the workspace should report `status: "materialization_stalled"` with appropriate `statusDetail`/`lastError`.
3. On the desktop, the SDK normalizes this to `"error"`, stopping the poller and showing the error/retry screen.
4. Deleting the workspace via the existing action works normally.

## Follow-ups

- Consider adding a "retry materialization" endpoint that resets and re-runs the AnyHarness worktree creation for a stalled row (currently users must delete + recreate).
- Consider server-side cleanup of very old stalled rows (auto-archive after N days).

Part of overnight v1 fix wave 2026-07-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)