### PR TITLE
fix(ci): split oversized diff viewers under repo-shape caps

### DIFF
--- a/apps/desktop/src/components/content/ui/diff/ChatDiffCells.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffCells.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from "react";
+import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
+import {
+  DiffCollapsedContentLabel,
+  DiffCollapsedGutterIcon,
+  DiffGapContentLabel,
+  DiffGapGutterControls,
+  DiffGapInfoRow,
+  type ExpandDirection,
+} from "@/components/content/ui/diff/DiffContextExpander";
+import { Button } from "@proliferate/ui/primitives/Button";
+import type { CollapsedContext, DiffLine, InterHunkGap } from "@/lib/domain/files/diff-parser";
+import {
+  getChatLineNumber,
+  getChatLineType,
+  getDiffLineIndex,
+} from "@/lib/domain/files/diff-view-rows";
+import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
+
+export function ChatGutterLine({ line }: { line: DiffLine }) {
+  const lineType = getChatLineType(line);
+  const lineNumber = getChatLineNumber(line);
+
+  return (
+    <div
+      data-line-type={lineType}
+      data-column-number={lineNumber ?? undefined}
+      data-line-index={getDiffLineIndex(line)}
+      className="diff-gutter-cell box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
+    >
+      <span data-line-number-content="">{lineNumber ?? ""}</span>
+    </div>
+  );
+}
+
+export function ChatGutterSeparatorLine({ children }: { children?: React.ReactNode }) {
+  return (
+    <div
+      data-separator="simple"
+      className="diff-gutter-cell flex min-h-[var(--diffs-line-height)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ChatContentLine({
+  line,
+  tokens,
+  wrapLongLines,
+  contentSearchQuery,
+  activeMatchId,
+  contentSearchUnitId,
+  hunkIndex,
+  onHunkHover,
+  pill,
+}: {
+  line: DiffLine;
+  tokens: HighlightedToken[][] | null;
+  wrapLongLines: boolean;
+  contentSearchQuery: string;
+  activeMatchId: string | null;
+  contentSearchUnitId: string;
+  hunkIndex?: number;
+  onHunkHover?: (hunkIndex: number) => void;
+  pill?: ReactNode;
+}) {
+  const lineType = getChatLineType(line);
+  const lineNumber = getChatLineNumber(line);
+  const altLineNumber = line.type === "context" ? line.oldLineNum : undefined;
+
+  return (
+    <div
+      data-line={lineNumber ?? undefined}
+      data-alt-line={altLineNumber}
+      data-line-type={lineType}
+      data-line-index={getDiffLineIndex(line)}
+      onMouseEnter={
+        onHunkHover != null && hunkIndex != null
+          ? () => onHunkHover(hunkIndex)
+          : undefined
+      }
+      className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
+        wrapLongLines
+          ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
+          : "flex min-w-max items-center whitespace-pre"
+      }`}
+    >
+      <DiffLineContent
+        line={line}
+        tokens={tokens}
+        contentSearchQuery={contentSearchQuery}
+        activeMatchId={activeMatchId}
+        contentSearchLineId={`${contentSearchUnitId}:line:${line.tokenIndex}`}
+      />
+      {pill}
+    </div>
+  );
+}
+
+export function ChatCollapsedRow({
+  section,
+  onExpand,
+}: {
+  section: CollapsedContext;
+  onExpand: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      data-separator="simple"
+      onClick={onExpand}
+      aria-label={`Expand ${section.lineCount} unmodified lines`}
+      title={`${section.lineCount} unmodified lines`}
+      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
+    >
+      <DiffCollapsedContentLabel
+        lineCount={section.lineCount}
+        stickyLeft="var(--diffs-column-number-width)"
+      />
+    </Button>
+  );
+}
+
+export function ChatGutterColumn({
+  rows,
+  rowCount,
+  onExpandGap,
+  canExpandGaps,
+}: {
+  rows: Array<{ kind: string; key: string; line?: DiffLine; gap?: InterHunkGap; gapIndex?: number; section?: CollapsedContext }>;
+  rowCount: number;
+  onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
+  canExpandGaps: boolean;
+}) {
+  return (
+    <div
+      data-gutter=""
+      style={{ gridColumn: "1", gridRow: `1 / span ${rowCount}` }}
+      className="sticky left-0 z-10 grid bg-[var(--diffs-bg)] [grid-template-rows:subgrid]"
+    >
+      {rows.map((row) => {
+        if (row.kind === "line" || row.kind === "expanded-gap-line") {
+          return <ChatGutterLine key={row.key} line={row.line!} />;
+        }
+        if (row.kind === "gap" && canExpandGaps) {
+          return (
+            <ChatGutterSeparatorLine key={row.key}>
+              <DiffGapGutterControls
+                gap={row.gap!}
+                onExpand={(direction) => onExpandGap(row.gapIndex!, row.gap!, direction)}
+              />
+            </ChatGutterSeparatorLine>
+          );
+        }
+        if (row.kind === "collapsed") {
+          return (
+            <ChatGutterSeparatorLine key={row.key}>
+              <DiffCollapsedGutterIcon />
+            </ChatGutterSeparatorLine>
+          );
+        }
+        // gap without expand capability
+        return <ChatGutterSeparatorLine key={row.key} />;
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -4,42 +4,37 @@ import {
   useMemo,
   useState,
   type CSSProperties,
-  type ReactNode,
   type WheelEvent as ReactWheelEvent,
 } from "react";
-import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
-  DiffCollapsedContentLabel,
-  DiffCollapsedGutterIcon,
-  DiffGapContentLabel,
-  DiffGapGutterControls,
   DiffGapInfoRow,
   type ExpandDirection,
 } from "@/components/content/ui/diff/DiffContextExpander";
 import { ChatDiffLineWrapContextMenu } from "@/components/content/ui/diff/ChatDiffLineWrapContextMenu";
 import { HunkActionPill } from "@/components/content/ui/diff/HunkActionPill";
 import type { UnifiedDiffHunkActions } from "@/components/content/ui/diff/UnifiedDiffViewer";
+import {
+  ChatCollapsedRow,
+  ChatContentLine,
+  ChatGutterColumn,
+} from "@/components/content/ui/diff/ChatDiffCells";
+import {
+  flattenWithGapExpansion,
+  type ChatRenderRow,
+} from "@/lib/domain/files/chat-diff-rows";
 import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
 import {
   buildContentSearchLineMatchIds,
   normalizeContentSearchQuery,
 } from "@/lib/domain/content-search/content-search";
-import { Button } from "@proliferate/ui/primitives/Button";
 import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
-import type { CollapsedContext, DiffLine, InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
+import type { InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
 import {
   getChatDiffRows,
-  getChatLineNumber,
-  getChatLineType,
-  getDiffLineIndex,
   getDiffLineNumberColumnWidth,
-  type ChatDiffRow,
 } from "@/lib/domain/files/diff-view-rows";
 import {
-  clampGapReveal,
-  resolveGapLineCount,
   useGapExpansion,
-  type GapExpansionState,
 } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 import { useContentSearchStore } from "@/stores/search/content-search-store";
@@ -58,158 +53,6 @@ const CHAT_DIFF_CODE_BASE_STYLE = {
   "--diffs-column-content-width": "700px",
   "--diffs-column-width": "736px",
 } as CSSProperties;
-
-function ChatGutterLine({ line }: { line: DiffLine }) {
-  const lineType = getChatLineType(line);
-  const lineNumber = getChatLineNumber(line);
-
-  return (
-    <div
-      data-line-type={lineType}
-      data-column-number={lineNumber ?? undefined}
-      data-line-index={getDiffLineIndex(line)}
-      className="diff-gutter-cell box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
-    >
-      <span data-line-number-content="">{lineNumber ?? ""}</span>
-    </div>
-  );
-}
-
-function ChatGutterSeparatorLine({ children }: { children?: React.ReactNode }) {
-  return (
-    <div
-      data-separator="simple"
-      className="diff-gutter-cell flex min-h-[var(--diffs-line-height)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
-    >
-      {children}
-    </div>
-  );
-}
-
-function ChatContentLine({
-  line,
-  tokens,
-  wrapLongLines,
-  contentSearchQuery,
-  activeMatchId,
-  contentSearchUnitId,
-  hunkIndex,
-  onHunkHover,
-  pill,
-}: {
-  line: DiffLine;
-  tokens: HighlightedToken[][] | null;
-  wrapLongLines: boolean;
-  contentSearchQuery: string;
-  activeMatchId: string | null;
-  contentSearchUnitId: string;
-  hunkIndex?: number;
-  onHunkHover?: (hunkIndex: number) => void;
-  pill?: ReactNode;
-}) {
-  const lineType = getChatLineType(line);
-  const lineNumber = getChatLineNumber(line);
-  const altLineNumber = line.type === "context" ? line.oldLineNum : undefined;
-
-  return (
-    <div
-      data-line={lineNumber ?? undefined}
-      data-alt-line={altLineNumber}
-      data-line-type={lineType}
-      data-line-index={getDiffLineIndex(line)}
-      onMouseEnter={
-        onHunkHover != null && hunkIndex != null
-          ? () => onHunkHover(hunkIndex)
-          : undefined
-      }
-      className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
-        wrapLongLines
-          ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
-          : "flex min-w-max items-center whitespace-pre"
-      }`}
-    >
-      <DiffLineContent
-        line={line}
-        tokens={tokens}
-        contentSearchQuery={contentSearchQuery}
-        activeMatchId={activeMatchId}
-        contentSearchLineId={`${contentSearchUnitId}:line:${line.tokenIndex}`}
-      />
-      {pill}
-    </div>
-  );
-}
-
-function ChatCollapsedRow({
-  section,
-  onExpand,
-}: {
-  section: CollapsedContext;
-  onExpand: () => void;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="unstyled"
-      size="unstyled"
-      data-separator="simple"
-      onClick={onExpand}
-      aria-label={`Expand ${section.lineCount} unmodified lines`}
-      title={`${section.lineCount} unmodified lines`}
-      className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
-    >
-      <DiffCollapsedContentLabel
-        lineCount={section.lineCount}
-        stickyLeft="var(--diffs-column-number-width)"
-      />
-    </Button>
-  );
-}
-
-function ChatGutterColumn({
-  rows,
-  rowCount,
-  onExpandGap,
-  canExpandGaps,
-}: {
-  rows: ChatRenderRow[];
-  rowCount: number;
-  onExpandGap: (gapIndex: number, gap: InterHunkGap, direction: ExpandDirection) => void;
-  canExpandGaps: boolean;
-}) {
-  return (
-    <div
-      data-gutter=""
-      style={{ gridColumn: "1", gridRow: `1 / span ${rowCount}` }}
-      className="sticky left-0 z-10 grid bg-[var(--diffs-bg)] [grid-template-rows:subgrid]"
-    >
-      {rows.map((row) => {
-        if (row.kind === "line" || row.kind === "expanded-gap-line") {
-          return <ChatGutterLine key={row.key} line={row.line} />;
-        }
-        if (row.kind === "gap" && canExpandGaps) {
-          return (
-            <ChatGutterSeparatorLine key={row.key}>
-              <DiffGapGutterControls
-                gap={row.gap}
-                onExpand={(direction) => onExpandGap(row.gapIndex, row.gap, direction)}
-              />
-            </ChatGutterSeparatorLine>
-          );
-        }
-        if (row.kind === "collapsed") {
-          return (
-            <ChatGutterSeparatorLine key={row.key}>
-              <DiffCollapsedGutterIcon />
-            </ChatGutterSeparatorLine>
-          );
-        }
-        // gap without expand capability
-        return <ChatGutterSeparatorLine key={row.key} />;
-      })}
-    </div>
-  );
-}
 
 function ChatContentColumn({
   rows,
@@ -327,87 +170,6 @@ function ChatContentColumn({
   );
 }
 
-/** Flattened render row: either a data row from the diff or an expanded gap line */
-type ChatRenderRow =
-  | ChatDiffRow
-  | { kind: "expanded-gap-line"; key: string; line: DiffLine };
-
-function makeGapContextLine(
-  fileLines: string[],
-  gap: InterHunkGap,
-  offset: number,
-): DiffLine {
-  const newLine = gap.newStartLine + offset;
-  return {
-    type: "context",
-    marker: " ",
-    content: fileLines[newLine - 1] ?? "",
-    oldLineNum: gap.oldStartLine + offset,
-    newLineNum: newLine,
-    lineNum: newLine,
-    tokenIndex: -1,
-  };
-}
-
-function flattenWithGapExpansion(
-  rows: ChatDiffRow[],
-  gapStates: Map<number, GapExpansionState>,
-  fileLines: string[] | undefined,
-): ChatRenderRow[] {
-  const result: ChatRenderRow[] = [];
-  for (const row of rows) {
-    if (row.kind !== "gap") {
-      result.push(row);
-      continue;
-    }
-
-    // Resolve unknown trailing gap count against fetched file length
-    const gap = resolveGapLineCount(row.gap, fileLines);
-    if (!gap) continue;
-    const resolvedRow: ChatDiffRow = gap === row.gap ? row : { ...row, gap };
-
-    const state = gapStates.get(row.gapIndex);
-    if (!fileLines || !state || gap.lineCount <= 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    const totalGapLines = gap.lineCount;
-    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
-    if (top === 0 && bottom === 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    for (let i = 0; i < top; i++) {
-      result.push({
-        kind: "expanded-gap-line",
-        key: `${row.key}-top-${i}`,
-        line: makeGapContextLine(fileLines, gap, i),
-      });
-    }
-
-    if (!fullyExpanded) {
-      const residualGap: InterHunkGap = {
-        kind: "gap",
-        oldStartLine: gap.oldStartLine + top,
-        newStartLine: gap.newStartLine + top,
-        lineCount: totalGapLines - top - bottom,
-      };
-      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-    }
-
-    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
-      result.push({
-        kind: "expanded-gap-line",
-        key: `${row.key}-bottom-${i}`,
-        line: makeGapContextLine(fileLines, gap, i),
-      });
-    }
-  }
-  return result;
-}
-
 export function ChatDiffViewer({
   parsed,
   tokens,
@@ -497,10 +259,9 @@ export function ChatDiffViewer({
   const lineNumberDigits = useMemo(() => {
     let maxLineNumber = 0;
     for (const row of rows) {
-      if (row.kind === "line") {
-        maxLineNumber = Math.max(maxLineNumber, getChatLineNumber(row.line) ?? 0);
-      } else if (row.kind === "expanded-gap-line") {
-        maxLineNumber = Math.max(maxLineNumber, getChatLineNumber(row.line) ?? 0);
+      if (row.kind === "line" || row.kind === "expanded-gap-line") {
+        const lineNum = row.line.newLineNum ?? row.line.oldLineNum ?? 0;
+        maxLineNumber = Math.max(maxLineNumber, lineNum);
       }
     }
     return Math.max(String(maxLineNumber).length, 1);

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffCells.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffCells.tsx
@@ -1,0 +1,180 @@
+import { Fragment } from "react";
+import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
+import {
+  DiffCollapsedContentLabel,
+  DiffCollapsedGutterIcon,
+  DiffGapContentLabel,
+  DiffGapGutterControls,
+  type ExpandDirection,
+  formatUnmodifiedLinesLabel,
+} from "@/components/content/ui/diff/DiffContextExpander";
+import { Button } from "@proliferate/ui/primitives/Button";
+import type { CollapsedContext, DiffLine, InterHunkGap } from "@/lib/domain/files/diff-parser";
+import {
+  getDiffLineIndex,
+  getSplitAltLineNumber,
+  getSplitEmptyLineType,
+  getSplitLineNumber,
+  getSplitLineType,
+  type SplitSide,
+} from "@/lib/domain/files/diff-view-rows";
+import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
+
+export function SplitEmptyCell({
+  emptyLineType,
+}: {
+  emptyLineType: "change-addition" | "change-deletion" | undefined;
+}) {
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-empty-side={emptyLineType}
+        data-gutter-buffer="buffer"
+        data-buffer-size="1"
+        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--diffs-bg)]"
+      />
+      <div
+        data-content=""
+        data-empty-side={emptyLineType}
+        className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
+      />
+    </>
+  );
+}
+
+export function SplitLineCells({
+  line,
+  peerLine,
+  tokens,
+  side,
+  wrapLongLines,
+}: {
+  line: DiffLine | null;
+  peerLine: DiffLine | null;
+  tokens: HighlightedToken[][] | null;
+  side: SplitSide;
+  wrapLongLines: boolean;
+}) {
+  if (!line) {
+    return <SplitEmptyCell emptyLineType={getSplitEmptyLineType(peerLine)} />;
+  }
+
+  const lineType = getSplitLineType(line);
+  const lineNumber = getSplitLineNumber(line, side);
+  const altLineNumber = getSplitAltLineNumber(line, side);
+
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-line-type={lineType}
+        data-column-number={lineNumber ?? undefined}
+        data-line-index={getDiffLineIndex(line)}
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
+      >
+        <span data-line-number-content="">{lineNumber ?? ""}</span>
+      </div>
+      <div
+        data-content=""
+        data-line={lineNumber ?? undefined}
+        data-alt-line={altLineNumber}
+        data-line-type={lineType}
+        data-line-index={getDiffLineIndex(line)}
+        className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
+          wrapLongLines
+            ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
+            : "flex min-w-max items-center whitespace-pre"
+        }`}
+      >
+        <DiffLineContent line={line} tokens={tokens} />
+      </div>
+    </>
+  );
+}
+
+export function SplitCollapsedCells({
+  section,
+  onExpand,
+}: {
+  section: CollapsedContext;
+  onExpand: () => void;
+}) {
+  return (
+    <>
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        data-gutter=""
+        data-separator="line-info"
+        onClick={onExpand}
+        aria-label={`Expand ${section.lineCount} unmodified lines`}
+        title={`${section.lineCount} unmodified lines`}
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] cursor-pointer items-center justify-center bg-[var(--codex-diffs-separator-surface)] border-0 p-0 text-muted-foreground/60 transition-colors hover:text-foreground"
+      >
+        <DiffCollapsedGutterIcon />
+      </Button>
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        data-content=""
+        data-separator="line-info"
+        onClick={onExpand}
+        aria-label={`Expand ${section.lineCount} unmodified lines`}
+        title={`${section.lineCount} unmodified lines`}
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
+      >
+        <DiffCollapsedContentLabel
+          lineCount={section.lineCount}
+          stickyLeft="var(--diffs-column-number-width)"
+        />
+      </Button>
+    </>
+  );
+}
+
+export function SplitGapCells({
+  gap,
+  onExpand,
+  canExpand,
+}: {
+  gap: InterHunkGap;
+  onExpand: (direction: ExpandDirection) => void;
+  canExpand: boolean;
+}) {
+  return (
+    <>
+      <div
+        data-gutter=""
+        data-separator="gap-expander"
+        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
+      >
+        {canExpand && (
+          <DiffGapGutterControls gap={gap} onExpand={onExpand} />
+        )}
+      </div>
+      <div
+        data-content=""
+        data-separator="gap-expander"
+        className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
+      >
+        {canExpand ? (
+          <DiffGapContentLabel
+            gap={gap}
+            onExpand={onExpand}
+            stickyLeft="var(--diffs-column-number-width)"
+          />
+        ) : (
+          <span
+            style={{ position: "sticky", left: "var(--diffs-column-number-width)" }}
+            className="w-max px-2 text-[10px] leading-none text-muted-foreground/50"
+          >
+            {formatUnmodifiedLinesLabel(gap.lineCount)}
+          </span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -5,112 +5,30 @@ import {
   type CSSProperties,
   type WheelEvent as ReactWheelEvent,
 } from "react";
-import { DiffLineContent } from "@/components/content/ui/diff/DiffLineContent";
 import {
-  DiffCollapsedContentLabel,
-  DiffCollapsedGutterIcon,
-  DiffGapContentLabel,
-  DiffGapGutterControls,
   type ExpandDirection,
-  formatUnmodifiedLinesLabel,
 } from "@/components/content/ui/diff/DiffContextExpander";
-import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
-import { Button } from "@proliferate/ui/primitives/Button";
-import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
-import type { CollapsedContext, DiffLine, InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
 import {
-  getDiffLineIndex,
+  SplitCollapsedCells,
+  SplitGapCells,
+  SplitLineCells,
+} from "@/components/content/ui/diff/SplitDiffCells";
+import {
+  flattenSplitWithGapExpansion,
+  type SplitRenderRow,
+} from "@/lib/domain/files/split-diff-rows";
+import { useResolvedMode } from "@/hooks/theme/derived/use-resolved-mode";
+import { chainVerticalWheelScroll } from "@proliferate/ui/utils/scroll-chain";
+import type { InterHunkGap, ParsedPatch } from "@/lib/domain/files/diff-parser";
+import {
   getDiffLineNumberColumnWidth,
-  getSplitAltLineNumber,
   getSplitDiffRows,
-  getSplitEmptyLineType,
-  getSplitLineNumber,
-  getSplitLineType,
-  type SplitDiffRow,
   type SplitSide,
 } from "@/lib/domain/files/diff-view-rows";
 import {
-  clampGapReveal,
-  resolveGapLineCount,
   useGapExpansion,
-  type GapExpansionState,
 } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
-
-/** Flattened render row for split view */
-type SplitRenderRow =
-  | SplitDiffRow
-  | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
-
-function makeSplitGapContextLine(
-  fileLines: string[],
-  gap: InterHunkGap,
-  offset: number,
-): DiffLine {
-  const newLine = gap.newStartLine + offset;
-  return {
-    type: "context",
-    marker: " ",
-    content: fileLines[newLine - 1] ?? "",
-    oldLineNum: gap.oldStartLine + offset,
-    newLineNum: newLine,
-    lineNum: newLine,
-    tokenIndex: -1,
-  };
-}
-
-function flattenSplitWithGapExpansion(
-  rows: SplitDiffRow[],
-  gapStates: Map<number, GapExpansionState>,
-  fileLines: string[] | undefined,
-): SplitRenderRow[] {
-  const result: SplitRenderRow[] = [];
-  for (const row of rows) {
-    if (row.kind !== "gap") {
-      result.push(row);
-      continue;
-    }
-
-    // Resolve unknown trailing gap count against fetched file length
-    const gap = resolveGapLineCount(row.gap, fileLines);
-    if (!gap) continue;
-    const resolvedRow: SplitDiffRow = gap === row.gap ? row : { ...row, gap };
-
-    const state = gapStates.get(row.gapIndex);
-    if (!fileLines || !state || gap.lineCount <= 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    const totalGapLines = gap.lineCount;
-    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
-    if (top === 0 && bottom === 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    for (let i = 0; i < top; i++) {
-      const line = makeSplitGapContextLine(fileLines, gap, i);
-      result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
-    }
-
-    if (!fullyExpanded) {
-      const residualGap: InterHunkGap = {
-        kind: "gap",
-        oldStartLine: gap.oldStartLine + top,
-        newStartLine: gap.newStartLine + top,
-        lineCount: totalGapLines - top - bottom,
-      };
-      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-    }
-
-    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
-      const line = makeSplitGapContextLine(fileLines, gap, i);
-      result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
-    }
-  }
-  return result;
-}
 
 const SPLIT_DIFF_PRE_STYLE = {
   color: "var(--diffs-fg)",
@@ -126,165 +44,6 @@ const SPLIT_DIFF_CODE_BASE_STYLE = {
   "--diffs-column-content-width": "360px",
   "--diffs-column-width": "360px",
 } as CSSProperties;
-
-function SplitEmptyCell({
-  emptyLineType,
-}: {
-  emptyLineType: "change-addition" | "change-deletion" | undefined;
-}) {
-  return (
-    <>
-      <div
-        data-gutter=""
-        data-empty-side={emptyLineType}
-        data-gutter-buffer="buffer"
-        data-buffer-size="1"
-        className="diff-gutter-cell sticky left-0 z-10 box-border min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] bg-[var(--diffs-bg)]"
-      />
-      <div
-        data-content=""
-        data-empty-side={emptyLineType}
-        className="diff-content-cell min-h-[var(--diffs-line-height)] bg-[var(--diffs-bg)]"
-      />
-    </>
-  );
-}
-
-function SplitLineCells({
-  line,
-  peerLine,
-  tokens,
-  side,
-  wrapLongLines,
-}: {
-  line: DiffLine | null;
-  peerLine: DiffLine | null;
-  tokens: HighlightedToken[][] | null;
-  side: SplitSide;
-  wrapLongLines: boolean;
-}) {
-  if (!line) {
-    return <SplitEmptyCell emptyLineType={getSplitEmptyLineType(peerLine)} />;
-  }
-
-  const lineType = getSplitLineType(line);
-  const lineNumber = getSplitLineNumber(line, side);
-  const altLineNumber = getSplitAltLineNumber(line, side);
-
-  return (
-    <>
-      <div
-        data-gutter=""
-        data-line-type={lineType}
-        data-column-number={lineNumber ?? undefined}
-        data-line-index={getDiffLineIndex(line)}
-        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-start justify-end bg-[var(--diffs-bg)] pr-2 pl-3 pt-[calc((var(--diffs-line-height)-1em)/2)] text-right tabular-nums"
-      >
-        <span data-line-number-content="">{lineNumber ?? ""}</span>
-      </div>
-      <div
-        data-content=""
-        data-line={lineNumber ?? undefined}
-        data-alt-line={altLineNumber}
-        data-line-type={lineType}
-        data-line-index={getDiffLineIndex(line)}
-        className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
-          wrapLongLines
-            ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
-            : "flex min-w-max items-center whitespace-pre"
-        }`}
-      >
-        <DiffLineContent line={line} tokens={tokens} />
-      </div>
-    </>
-  );
-}
-
-function SplitCollapsedCells({
-  section,
-  onExpand,
-}: {
-  section: CollapsedContext;
-  onExpand: () => void;
-}) {
-  return (
-    <>
-      <Button
-        type="button"
-        variant="unstyled"
-        size="unstyled"
-        data-gutter=""
-        data-separator="line-info"
-        onClick={onExpand}
-        aria-label={`Expand ${section.lineCount} unmodified lines`}
-        title={`${section.lineCount} unmodified lines`}
-        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] cursor-pointer items-center justify-center bg-[var(--codex-diffs-separator-surface)] border-0 p-0 text-muted-foreground/60 transition-colors hover:text-foreground"
-      >
-        <DiffCollapsedGutterIcon />
-      </Button>
-      <Button
-        type="button"
-        variant="unstyled"
-        size="unstyled"
-        data-content=""
-        data-separator="line-info"
-        onClick={onExpand}
-        aria-label={`Expand ${section.lineCount} unmodified lines`}
-        title={`${section.lineCount} unmodified lines`}
-        className="diff-content-cell flex min-h-[var(--diffs-line-height)] cursor-pointer items-center justify-start border-0 bg-[var(--codex-diffs-separator-surface)] p-0 text-left font-[inherit] text-[inherit] leading-[inherit] text-muted-foreground/60 transition-colors hover:text-foreground"
-      >
-        <DiffCollapsedContentLabel
-          lineCount={section.lineCount}
-          stickyLeft="var(--diffs-column-number-width)"
-        />
-      </Button>
-    </>
-  );
-}
-
-function SplitGapCells({
-  gap,
-  onExpand,
-  canExpand,
-}: {
-  gap: InterHunkGap;
-  onExpand: (direction: ExpandDirection) => void;
-  canExpand: boolean;
-}) {
-  return (
-    <>
-      <div
-        data-gutter=""
-        data-separator="gap-expander"
-        className="diff-gutter-cell sticky left-0 z-10 box-border flex min-h-[var(--diffs-line-height)] w-[var(--diffs-column-number-width)] min-w-[var(--diffs-column-number-width)] items-center justify-center bg-[var(--codex-diffs-separator-surface)]"
-      >
-        {canExpand && (
-          <DiffGapGutterControls gap={gap} onExpand={onExpand} />
-        )}
-      </div>
-      <div
-        data-content=""
-        data-separator="gap-expander"
-        className="diff-content-cell flex min-h-[var(--diffs-line-height)] items-center bg-[var(--codex-diffs-separator-surface)]"
-      >
-        {canExpand ? (
-          <DiffGapContentLabel
-            gap={gap}
-            onExpand={onExpand}
-            stickyLeft="var(--diffs-column-number-width)"
-          />
-        ) : (
-          <span
-            style={{ position: "sticky", left: "var(--diffs-column-number-width)" }}
-            className="w-max px-2 text-[10px] leading-none text-muted-foreground/50"
-          >
-            {formatUnmodifiedLinesLabel(gap.lineCount)}
-          </span>
-        )}
-      </div>
-    </>
-  );
-}
 
 function SplitCodeColumn({
   side,

--- a/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
+++ b/apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts
@@ -1,20 +1,14 @@
 import { useCallback, useState } from "react";
 import type { InterHunkGap } from "@/lib/domain/files/diff-parser";
 import type { ExpandDirection } from "@/components/content/ui/diff/DiffContextExpander";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  type GapExpansionState,
+} from "@/lib/domain/files/gap-expansion";
 
 /** Number of lines to reveal per directional expand click */
 const EXPAND_STEP = 20;
-
-export interface GapExpansionState {
-  /**
-   * Lines requested from the top of the gap (adjacent to hunk above).
-   * Unclamped — viewers clamp against the gap's actual line count at
-   * render time (counts may be unknown until file content is fetched).
-   */
-  revealedTop: number;
-  /** Lines requested from the bottom of the gap (adjacent to hunk below) */
-  revealedBottom: number;
-}
 
 /**
  * Manages per-gap expansion state, keyed by gap index. Reveal amounts are
@@ -56,48 +50,5 @@ export function useGapExpansion() {
   return { gapStates, expandGap, getGapState };
 }
 
-/**
- * Clamp raw reveal amounts against the gap's actual line count.
- * Returns effective top/bottom line counts plus whether the gap is
- * fully consumed.
- */
-export function clampGapReveal(
-  state: GapExpansionState,
-  totalLines: number,
-): { top: number; bottom: number; fullyExpanded: boolean } {
-  if (totalLines <= 0) {
-    return { top: 0, bottom: 0, fullyExpanded: false };
-  }
-  const top = Math.min(state.revealedTop, totalLines);
-  const bottom = Math.min(state.revealedBottom, totalLines - top);
-  return { top, bottom, fullyExpanded: top + bottom >= totalLines };
-}
-
-/**
- * Resolve a gap with unknown line count (-1, trailing gap) against the
- * fetched file's total line count. Returns null when the gap turns out
- * to be empty, or when the count is unknown and file content has not
- * been fetched yet — a separator must never render without a number.
- */
-export function resolveGapLineCount(
-  gap: InterHunkGap,
-  fileLines: string[] | undefined,
-): InterHunkGap | null {
-  if (gap.lineCount >= 0) {
-    return gap.lineCount === 0 ? null : gap;
-  }
-  if (!fileLines) {
-    return null;
-  }
-  // Trailing file content often ends with a newline, producing one empty
-  // trailing element from split("\n") that is not a real line.
-  const totalNewLines =
-    fileLines.length > 0 && fileLines[fileLines.length - 1] === ""
-      ? fileLines.length - 1
-      : fileLines.length;
-  const lineCount = totalNewLines - gap.newStartLine + 1;
-  if (lineCount <= 0) {
-    return null;
-  }
-  return { ...gap, lineCount };
-}
+// Re-export pure domain functions for convenience
+export { clampGapReveal, resolveGapLineCount, type GapExpansionState };

--- a/apps/desktop/src/lib/domain/files/chat-diff-rows.ts
+++ b/apps/desktop/src/lib/domain/files/chat-diff-rows.ts
@@ -1,0 +1,88 @@
+import type { DiffLine, InterHunkGap } from "@/lib/domain/files/diff-parser";
+import type { ChatDiffRow } from "@/lib/domain/files/diff-view-rows";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  type GapExpansionState,
+} from "@/lib/domain/files/gap-expansion";
+
+/** Flattened render row: either a data row from the diff or an expanded gap line */
+export type ChatRenderRow =
+  | ChatDiffRow
+  | { kind: "expanded-gap-line"; key: string; line: DiffLine };
+
+function makeGapContextLine(
+  fileLines: string[],
+  gap: InterHunkGap,
+  offset: number,
+): DiffLine {
+  const newLine = gap.newStartLine + offset;
+  return {
+    type: "context",
+    marker: " ",
+    content: fileLines[newLine - 1] ?? "",
+    oldLineNum: gap.oldStartLine + offset,
+    newLineNum: newLine,
+    lineNum: newLine,
+    tokenIndex: -1,
+  };
+}
+
+export function flattenWithGapExpansion(
+  rows: ChatDiffRow[],
+  gapStates: Map<number, GapExpansionState>,
+  fileLines: string[] | undefined,
+): ChatRenderRow[] {
+  const result: ChatRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: ChatDiffRow = gap === row.gap ? row : { ...row, gap };
+
+    const state = gapStates.get(row.gapIndex);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    const totalGapLines = gap.lineCount;
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    for (let i = 0; i < top; i++) {
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-top-${i}`,
+        line: makeGapContextLine(fileLines, gap, i),
+      });
+    }
+
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+    }
+
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-bottom-${i}`,
+        line: makeGapContextLine(fileLines, gap, i),
+      });
+    }
+  }
+  return result;
+}

--- a/apps/desktop/src/lib/domain/files/gap-expansion.ts
+++ b/apps/desktop/src/lib/domain/files/gap-expansion.ts
@@ -1,0 +1,58 @@
+import type { InterHunkGap } from "@/lib/domain/files/diff-parser";
+
+export interface GapExpansionState {
+  /**
+   * Lines requested from the top of the gap (adjacent to hunk above).
+   * Unclamped — viewers clamp against the gap's actual line count at
+   * render time (counts may be unknown until file content is fetched).
+   */
+  revealedTop: number;
+  /** Lines requested from the bottom of the gap (adjacent to hunk below) */
+  revealedBottom: number;
+}
+
+/**
+ * Clamp raw reveal amounts against the gap's actual line count.
+ * Returns effective top/bottom line counts plus whether the gap is
+ * fully consumed.
+ */
+export function clampGapReveal(
+  state: GapExpansionState,
+  totalLines: number,
+): { top: number; bottom: number; fullyExpanded: boolean } {
+  if (totalLines <= 0) {
+    return { top: 0, bottom: 0, fullyExpanded: false };
+  }
+  const top = Math.min(state.revealedTop, totalLines);
+  const bottom = Math.min(state.revealedBottom, totalLines - top);
+  return { top, bottom, fullyExpanded: top + bottom >= totalLines };
+}
+
+/**
+ * Resolve a gap with unknown line count (-1, trailing gap) against the
+ * fetched file's total line count. Returns null when the gap turns out
+ * to be empty, or when the count is unknown and file content has not
+ * been fetched yet — a separator must never render without a number.
+ */
+export function resolveGapLineCount(
+  gap: InterHunkGap,
+  fileLines: string[] | undefined,
+): InterHunkGap | null {
+  if (gap.lineCount >= 0) {
+    return gap.lineCount === 0 ? null : gap;
+  }
+  if (!fileLines) {
+    return null;
+  }
+  // Trailing file content often ends with a newline, producing one empty
+  // trailing element from split("\n") that is not a real line.
+  const totalNewLines =
+    fileLines.length > 0 && fileLines[fileLines.length - 1] === ""
+      ? fileLines.length - 1
+      : fileLines.length;
+  const lineCount = totalNewLines - gap.newStartLine + 1;
+  if (lineCount <= 0) {
+    return null;
+  }
+  return { ...gap, lineCount };
+}

--- a/apps/desktop/src/lib/domain/files/split-diff-rows.ts
+++ b/apps/desktop/src/lib/domain/files/split-diff-rows.ts
@@ -1,0 +1,82 @@
+import type { DiffLine, InterHunkGap } from "@/lib/domain/files/diff-parser";
+import type { SplitDiffRow } from "@/lib/domain/files/diff-view-rows";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  type GapExpansionState,
+} from "@/lib/domain/files/gap-expansion";
+
+/** Flattened render row for split view */
+export type SplitRenderRow =
+  | SplitDiffRow
+  | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
+
+function makeSplitGapContextLine(
+  fileLines: string[],
+  gap: InterHunkGap,
+  offset: number,
+): DiffLine {
+  const newLine = gap.newStartLine + offset;
+  return {
+    type: "context",
+    marker: " ",
+    content: fileLines[newLine - 1] ?? "",
+    oldLineNum: gap.oldStartLine + offset,
+    newLineNum: newLine,
+    lineNum: newLine,
+    tokenIndex: -1,
+  };
+}
+
+export function flattenSplitWithGapExpansion(
+  rows: SplitDiffRow[],
+  gapStates: Map<number, GapExpansionState>,
+  fileLines: string[] | undefined,
+): SplitRenderRow[] {
+  const result: SplitRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: SplitDiffRow = gap === row.gap ? row : { ...row, gap };
+
+    const state = gapStates.get(row.gapIndex);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    const totalGapLines = gap.lineCount;
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    for (let i = 0; i < top; i++) {
+      const line = makeSplitGapContextLine(fileLines, gap, i);
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
+    }
+
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+    }
+
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+      const line = makeSplitGapContextLine(fileLines, gap, i);
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Problem
Main CI failing repo-shape check — `ChatDiffViewer` (578→500) and `SplitDiffViewer` (540→500) exceed max-lines cap. #941 addresses `render_tests.rs`; this PR fixes the two new violations from morning's diff-viewer merges.

## What changed
- Extracted cell/row components → `ChatDiffCells.tsx` + `SplitDiffCells.tsx`
- Extracted gap-expansion helpers → `chat-diff-rows.ts` + `split-diff-rows.ts`
- Moved pure gap logic to `lib/domain/files/gap-expansion.ts` (frontend boundary compliance)
- `ChatDiffViewer`: 578 → 383 lines
- `SplitDiffViewer`: 540 → 299 lines

Split pattern matches #853/#854 (extract cohesive units to siblings, wire back). No behavior changes — launch-critical UI.

## How to verify
- `python3 scripts/check_max_lines.py` — both files clean
- `python3 scripts/check_frontend_boundaries.py` — passes
- `python3 scripts/report_frontend_structure.py --strict` — no new violations
- `pnpm --filter @proliferate/desktop exec tsc --noEmit` — typechecks

Complements #941; together they turn main green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)