### PR TITLE
fix(desktop): file-viewer scroll + open-in fixes

### DIFF
--- a/apps/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -42,6 +42,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
     rawPath: filePath,
     workspacePath: filePath,
   });
+  const canOpenExternal = fileActions.canOpenExternal;
   const [wordWrap, setWordWrap] = useState(false);
   const [browserOpen, setBrowserOpen] = useState(false);
   const changedPaths = useGitChangedPaths(materializedWorkspaceId);
@@ -126,6 +127,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         richPreviewEnabled={normalizedEffectiveMode === "rendered"}
         canCopyContent={false}
         canFindInFile={false}
+        canOpenExternal={canOpenExternal}
         onToggleWordWrap={() => setWordWrap((value) => !value)}
         onToggleRichPreview={toggleRichPreview}
         onCopyContent={copyContent}
@@ -152,6 +154,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
         richPreviewEnabled={normalizedEffectiveMode === "rendered"}
         canCopyContent={false}
         canFindInFile={false}
+        canOpenExternal={canOpenExternal}
         onToggleWordWrap={() => setWordWrap((value) => !value)}
         onToggleRichPreview={toggleRichPreview}
         onCopyContent={copyContent}
@@ -179,6 +182,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       richPreviewEnabled={normalizedEffectiveMode === "rendered"}
       canCopyContent={Boolean(read?.isText && !read.tooLarge)}
       canFindInFile={canFindInFile}
+      canOpenExternal={canOpenExternal}
       onToggleWordWrap={() => setWordWrap((value) => !value)}
       onToggleRichPreview={toggleRichPreview}
       onCopyContent={copyContent}

--- a/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
+++ b/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
@@ -27,6 +27,13 @@ const FILE_SOURCE_VERTICAL_PADDING_PX = 8;
 // briefly exposing the (dark) code element background as "blank rows" until
 // the next render catches up. A larger buffer absorbs typical fling deltas.
 const FILE_SOURCE_VIRTUAL_OVERSCAN = 60;
+// Below this line count we render every row in normal document flow (no
+// windowing). Virtualization's absolute-positioned rows get repositioned via
+// transform on scroll, and a fast fling can outrun that reposition for a frame
+// — showing the dark background as "blank blocks". Small files don't need
+// windowing at all, so rendering them statically removes that failure mode
+// entirely and native scroll of static content can never blank.
+const FILE_SOURCE_VIRTUALIZE_THRESHOLD = 2000;
 const FILE_SOURCE_INITIAL_VIEWPORT_HEIGHT = 600;
 const FILE_SOURCE_INITIAL_ROW_COUNT =
   Math.ceil(FILE_SOURCE_INITIAL_VIEWPORT_HEIGHT / FILE_SOURCE_ESTIMATED_LINE_HEIGHT)
@@ -118,6 +125,7 @@ export function FileSourceView({
     measureElement: (element) =>
       element.getBoundingClientRect().height || FILE_SOURCE_ESTIMATED_LINE_HEIGHT,
   });
+  const shouldVirtualize = lines.length > FILE_SOURCE_VIRTUALIZE_THRESHOLD;
   const virtualRows = virtualizer.getVirtualItems();
   const initialVirtualRows = useMemo(
     () => buildInitialVirtualRows(lines.length),
@@ -182,33 +190,51 @@ export function FileSourceView({
           <code
             ref={codeElementRef}
             data-code
-            className={`relative block min-h-full ${
+            className={`relative block min-h-full bg-background ${
               wordWrap ? "w-full min-w-0" : "w-max min-w-full"
             }`}
-            style={{
-              height: `${virtualizer.getTotalSize()}px`,
-            }}
+            style={
+              shouldVirtualize
+                ? { height: `${virtualizer.getTotalSize()}px` }
+                : undefined
+            }
           >
-            {renderedRows.map((virtualRow) => (
-              <SourceLine
-                ref={virtualizer.measureElement}
-                key={virtualRow.key}
-                virtualIndex={virtualRow.index}
-                lineNumber={virtualRow.index + 1}
-                tokens={lines[virtualRow.index] ?? []}
-                wordWrap={wordWrap}
-                contentSearchQuery={contentSearchQuery}
-                activeMatchId={activeMatchId}
-                contentSearchUnitId={contentSearchUnitId}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: wordWrap ? "100%" : "max-content",
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-              />
-            ))}
+            {shouldVirtualize
+              ? renderedRows.map((virtualRow) => (
+                  <SourceLine
+                    ref={virtualizer.measureElement}
+                    key={virtualRow.key}
+                    virtualIndex={virtualRow.index}
+                    lineNumber={virtualRow.index + 1}
+                    tokens={lines[virtualRow.index] ?? []}
+                    wordWrap={wordWrap}
+                    contentSearchQuery={contentSearchQuery}
+                    activeMatchId={activeMatchId}
+                    contentSearchUnitId={contentSearchUnitId}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: wordWrap ? "100%" : "max-content",
+                      transform: `translateY(${virtualRow.start}px)`,
+                    }}
+                  />
+                ))
+              : lines.map((tokens, index) => (
+                  <SourceLine
+                    key={index}
+                    virtualIndex={index}
+                    lineNumber={index + 1}
+                    tokens={tokens}
+                    wordWrap={wordWrap}
+                    contentSearchQuery={contentSearchQuery}
+                    activeMatchId={activeMatchId}
+                    contentSearchUnitId={contentSearchUnitId}
+                    style={{
+                      width: wordWrap ? "100%" : "max-content",
+                    }}
+                  />
+                ))}
           </code>
         </pre>
       </div>
@@ -270,7 +296,7 @@ const SourceLine = forwardRef<HTMLSpanElement, SourceLineProps>(function SourceL
       style={style}
     >
       <span
-        className="file-source-line-number sticky left-0 z-10 select-none px-2 text-right tabular-nums"
+        className="file-source-line-number select-none bg-background px-2 text-right tabular-nums"
         data-column-number={lineNumber}
         data-gutter=""
         data-line-index={virtualIndex}

--- a/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
+++ b/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
@@ -22,7 +22,11 @@ import { useContentSearchStore } from "@/stores/search/content-search-store";
 
 const FILE_SOURCE_ESTIMATED_LINE_HEIGHT = 20;
 const FILE_SOURCE_VERTICAL_PADDING_PX = 8;
-const FILE_SOURCE_VIRTUAL_OVERSCAN = 24;
+// Overscan is the buffer of off-screen rows kept mounted above/below the
+// viewport. A fast fling can jump well past a small buffer in a single frame,
+// briefly exposing the (dark) code element background as "blank rows" until
+// the next render catches up. A larger buffer absorbs typical fling deltas.
+const FILE_SOURCE_VIRTUAL_OVERSCAN = 60;
 const FILE_SOURCE_INITIAL_VIEWPORT_HEIGHT = 600;
 const FILE_SOURCE_INITIAL_ROW_COUNT =
   Math.ceil(FILE_SOURCE_INITIAL_VIEWPORT_HEIGHT / FILE_SOURCE_ESTIMATED_LINE_HEIGHT)
@@ -113,7 +117,6 @@ export function FileSourceView({
     },
     measureElement: (element) =>
       element.getBoundingClientRect().height || FILE_SOURCE_ESTIMATED_LINE_HEIGHT,
-    useAnimationFrameWithResizeObserver: true,
   });
   const virtualRows = virtualizer.getVirtualItems();
   const initialVirtualRows = useMemo(

--- a/apps/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/apps/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -32,6 +32,7 @@ export function FileViewerFrame({
   onCopyContent,
   onCopyPath,
   onOpenExternal,
+  canOpenExternal,
   onOpenContentSearch,
   browserOpen,
   onToggleBrowser,
@@ -45,6 +46,7 @@ export function FileViewerFrame({
   richPreviewEnabled: boolean;
   canCopyContent: boolean;
   canFindInFile: boolean;
+  canOpenExternal: boolean;
   onToggleWordWrap: () => void;
   onToggleRichPreview: () => void;
   onCopyContent: () => void;
@@ -81,6 +83,7 @@ export function FileViewerFrame({
           />
           <FileViewerToolbarButton
             label="Open in default editor"
+            disabled={!canOpenExternal}
             onClick={onOpenExternal}
           >
             <ExternalLink className="size-4" />
@@ -170,11 +173,13 @@ function FileBreadcrumbs({
 function FileViewerToolbarButton({
   label,
   active = false,
+  disabled = false,
   onClick,
   children,
 }: {
   label: string;
   active?: boolean;
+  disabled?: boolean;
   onClick: () => void;
   children: ReactNode;
 }) {
@@ -184,6 +189,7 @@ function FileViewerToolbarButton({
       variant="ghost"
       size="icon-sm"
       aria-label={label}
+      disabled={disabled}
       className={`${FILE_VIEWER_TOOLBAR_BUTTON_CLASS} ${
         active ? "bg-list-hover text-foreground" : ""
       }`}


### PR DESCRIPTION
Three file-viewer fixes Pablo hit in the desktop app. None are regressions from the files-experience overhaul (#927/#930/#931) — all pre-existing, surfaced now that the files experience is prominent. The scroll ones are **WKWebView-specific** (the Tauri shell); a Chromium/CDP dev harness renders them fine, so they were only observable in the real app.

## 1. Line-number gutter lags the code during scroll (primary)
Each row's line-number gutter used `position: sticky; left-0`. WKWebView repositions/repaints 200+ individually-pinned sticky elements per frame, so numbers visibly trail the code (which moves as one layer). Chromium composites this away.
**Fix:** remove the per-row sticky — line numbers scroll with the code. A Codex-style split gutter outside the horizontal scroller is the follow-up if pinned numbers are wanted back.

## 2. Blank/black rows during fast scroll
Fast-flinging showed blank blocks where virtualized rows hadn't mounted yet, exposing the code element's dark background.
**Fix:** render files under 2000 lines in normal document flow (no windowing — small files can't blank on scroll); paint the code element background so the horizontal-overflow area right of short lines isn't bare.

## 3. "Open in default editor" silent no-op
The toolbar button called `openDefault()`, which early-returns when the file reference has no absolute path (resolution fails / no active workspace root) — so it looked live but did nothing.
**Fix:** thread `canOpenExternal` through and disable the button when the path can't resolve, making the state visible instead of silent.

## Verification
Scroll fixes confirmed by Pablo in the running desktop app (WKWebView) — line numbers track the code, no blank rows on fling. Open-in change: typecheck + file test suites pass (9/9); the disabled-state affordance can only be exercised in the real Tauri shell (no `window.__TAURI__` in the dev browser). Chromium automation cannot reproduce the WebKit paint bugs — that's why this relied on in-app confirmation.