### PR TITLE
fix(anyharness): dedup gateway model table to Bedrock-only current-gen + fix names

### DIFF
--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -421,14 +421,14 @@
           },
           {
             "id": "claude-fable-5",
-            "displayName": "Claude-Fable-5",
+            "displayName": "Fable 5",
             "availability": {
               "anyOf": [
                 "anthropic-api",
                 "anthropic-oauth"
               ]
             },
-            "defaultVisible": true,
+            "defaultVisible": false,
             "controls": {
               "mode": {
                 "values": [
@@ -472,7 +472,7 @@
           },
           {
             "id": "claude-opus-4-8",
-            "displayName": "Claude-Opus-4-8",
+            "displayName": "Opus 4.8",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -887,7 +887,7 @@
           },
           {
             "id": "global.anthropic.claude-fable-5",
-            "displayName": "Global.anthropic.claude-Fable-5",
+            "displayName": "Fable 5",
             "availability": {
               "anyOf": [
                 "bedrock"

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -129,7 +129,8 @@ const CONTROL_MAPPINGS = {
 // the probe can prove a model launches.
 const MODEL_VISIBILITY_OPT_OUTS = {
   claude: [
-    // trial-id duplicate of menu id "opus" (Opus 4.8)
+    // bare-direct current-gen duplicates of us.anthropic.* Bedrock entries
+    "claude-fable-5",
     "claude-opus-4-8",
     // global-region duplicate of us.anthropic.claude-fable-5 (bedrock)
     "global.anthropic.claude-fable-5",
@@ -146,6 +147,11 @@ const MODEL_VISIBILITY_OPT_OUTS = {
 // Explicit display overrides where prettifying alone is ambiguous (two
 // "GPT-5.4" rows when the bedrock CMB models sit beside the API ones).
 const MODEL_DISPLAY_OVERRIDES = {
+  claude: {
+    "claude-fable-5": "Fable 5",
+    "claude-opus-4-8": "Opus 4.8",
+    "global.anthropic.claude-fable-5": "Fable 5",
+  },
   codex: {
     "openai.gpt-5.4-cmb": "GPT-5.4 on Bedrock",
     "openai.gpt-5.4-cmb/xhigh": "GPT-5.4 (xhigh) on Bedrock",

--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -48,34 +48,6 @@ model_list:
     litellm_params:
       model: anthropic/claude-opus-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
-  # Current-generation entries matching the bundled agent catalog's model
-  # families (sonnet-4-6 / opus-4-7 / opus-4-8 / sonnet-5 / fable-5) so
-  # gateway ids family-join to catalog metadata. Upstream ids verified
-  # against LiteLLM's model_prices_and_context_window.json.
-  - model_name: claude-sonnet-4-6
-    litellm_params:
-      model: anthropic/claude-sonnet-4-6
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-sonnet-5
-    litellm_params:
-      model: anthropic/claude-sonnet-5
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-opus-4-7
-    litellm_params:
-      model: anthropic/claude-opus-4-7
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-opus-4-7-20260416
-    litellm_params:
-      model: anthropic/claude-opus-4-7
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-opus-4-8
-    litellm_params:
-      model: anthropic/claude-opus-4-8
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-fable-5
-    litellm_params:
-      model: anthropic/claude-fable-5
-      api_key: os.environ/ANTHROPIC_API_KEY
 
   # OpenAI
   - model_name: gpt-5.2


### PR DESCRIPTION
## What

Follow-up to #928. The All-Models table showed each current-gen Claude model 2–3× (direct `claude-*` + dated alias + `us.anthropic.*` Bedrock) plus three auto-titlecased garbage display names (`Claude-Fable-5`, `Global.anthropic.claude-Fable-5`, etc.). Pablo's call: **Bedrock-only for current gen.**

- **config.yaml** — drop the 6 bare-direct current-gen entries #928 added (`claude-sonnet-4-6`, `claude-sonnet-5`, `claude-opus-4-7` + dated, `claude-opus-4-8`, `claude-fable-5`). Current-gen Claude now routes through Bedrock only. **Older-gen direct entries stay** (`sonnet-4-5`/`haiku-4-5`/`opus-4-6`) — the pinned claude CLI 0.44.0 sends those bare/dated ids and would 400 without them.
- **catalog.json** — fix the 3 garbage display names to clean human names and hide the bare-direct dupes (`defaultVisible: false`), making the `us.anthropic.*` rows canonical.
- **build-catalog.mjs** — add display overrides + visibility opt-outs so a future probe re-derives clean names instead of regenerating the garbage.

## Verified
Throwaway litellm proxy from this branch's config: **23 models, all 6 duplicates gone, current-gen Bedrock + older-gen direct both intact.** Gates: cargo test workspace (791 passed) · catalog validator · YAML parse · repo-shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)