### PR TITLE
feat(desktop): harness page restructure — method cards + single scroll

### DIFF
--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
 import {
   useAgentCatalog,
@@ -163,6 +163,42 @@ export function HarnessAllModelsSection({
 
   const isLoading = isRuntimeGateway ? gatewayModelsQuery.isLoading : catalogQuery.isLoading;
   const isRefreshing = isRuntimeGateway ? refreshGatewayModels.isPending : refreshCatalog.isPending;
+
+  // Auto-probe an empty catalog: landing on a resolved-but-empty catalog kicks
+  // off the same refresh the button uses, exactly once per (harnessKind, surface,
+  // route) scope. Guards against loops — we only fire when nothing is
+  // loading/refreshing and we haven't already probed this scope. For
+  // runtime-probed routes we skip when the runtime launch options aren't
+  // available yet (buildRuntimeCatalogModelsJson would be null); the empty
+  // message stays until the runtime is reachable.
+  const autoProbedScopeRef = useRef<string | null>(null);
+  const autoProbeScope = `${harnessKind}:${surface}:${route}`;
+  const runtimeModelsUnavailable =
+    isRuntimeProbedRoute
+    && buildRuntimeCatalogModelsJson(harnessKind, runtimeLaunchOptionsQuery.data) === null;
+  useEffect(() => {
+    if (!cloudActive || isLoading || isRefreshing || models.length > 0) {
+      return;
+    }
+    if (autoProbedScopeRef.current === autoProbeScope) {
+      return;
+    }
+    if (runtimeModelsUnavailable) {
+      return;
+    }
+    autoProbedScopeRef.current = autoProbeScope;
+    handleRefresh();
+  }, [
+    cloudActive,
+    isLoading,
+    isRefreshing,
+    models.length,
+    autoProbeScope,
+    runtimeModelsUnavailable,
+  ]);
+  // Empty catalog with a probe in flight (auto or manual) shows the probing state
+  // instead of the static empty copy.
+  const isProbingEmpty = models.length === 0 && isRefreshing;
   const freshnessLine = isRuntimeGateway
     ? gatewayModelsQuery.data
       ? gatewayModelsQuery.data.source === "probe" && gatewayModelsQuery.data.probedAt
@@ -202,6 +238,11 @@ export function HarnessAllModelsSection({
         {isLoading ? (
           <p className="text-sm text-muted-foreground">
             {HARNESS_PANE_COPY.allModelsLoading}
+          </p>
+        ) : isProbingEmpty ? (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <RefreshCw className="size-3.5 animate-spin" />
+            {HARNESS_PANE_COPY.allModelsProbing}
           </p>
         ) : models.length === 0 ? (
           <p className="text-sm text-muted-foreground">

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
+import { Plus } from "@proliferate/ui/icons";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
+import { AgentLoginTerminalPanel } from "@/components/agents/AgentLoginTerminalPanel";
+import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
+import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
+import { isReadyAgent } from "@/lib/domain/agents/status";
+import { HarnessAuthApiKeyRow } from "./HarnessAuthApiKeyRow";
+import { ProviderPickerModal } from "./ProviderPickerModal";
+import type { HarnessAuthEditorApi } from "./use-harness-auth-editor";
+
+type AuthMethod = "gateway" | "api_key" | "cli";
+
+interface HarnessAuthDetailsSectionProps {
+  displayName: string;
+  surface: AgentAuthSurface;
+  selectedMethod: AuthMethod;
+  editor: HarnessAuthEditorApi;
+}
+
+export function HarnessAuthDetailsSection({
+  displayName,
+  surface,
+  selectedMethod,
+  editor,
+}: HarnessAuthDetailsSectionProps) {
+  if (selectedMethod === "gateway") {
+    return <GatewayDetails editor={editor} />;
+  }
+
+  if (selectedMethod === "api_key") {
+    return (
+      <ApiKeyDetails
+        displayName={displayName}
+        editor={editor}
+      />
+    );
+  }
+
+  return (
+    <CliDetails
+      surface={surface}
+      editor={editor}
+    />
+  );
+}
+
+function GatewayDetails({ editor }: { editor: HarnessAuthEditorApi }) {
+  const capabilities = editor.capabilitiesQuery.data;
+  const enrollment = editor.enrollmentQuery.data;
+  return (
+    <SettingsSection title={HARNESS_PANE_COPY.detailsGateway}>
+      <p className="py-3 text-sm text-muted-foreground">
+        {gatewaySubtitle(capabilities, enrollment)}
+      </p>
+    </SettingsSection>
+  );
+}
+
+function ApiKeyDetails({
+  displayName,
+  editor,
+}: {
+  displayName: string;
+  editor: HarnessAuthEditorApi;
+}) {
+  const apiKeys = editor.apiKeysQuery.data ?? [];
+  const { providerModalOpen, setProviderModalOpen } = useProviderModal();
+
+  return (
+    <SettingsSection
+      title={HARNESS_PANE_COPY.detailsApiKey}
+      description={HARNESS_PANE_COPY.authenticationDescription(displayName)}
+    >
+      <div className="space-y-3">
+        <div className="flex flex-col">
+          {editor.editorState.rows.map((row) => (
+            <HarnessAuthApiKeyRow
+              key={row.uid}
+              row={row}
+              apiKeys={apiKeys}
+              busy={editor.busy}
+              onEnvVarChange={editor.handleRowEnvVarChange}
+              onEnvVarBlur={editor.handleRowEnvVarBlur}
+              onKeySelect={editor.handleRowKeySelect}
+              onEnabledToggle={editor.handleRowEnabledToggle}
+              onRemove={editor.handleRemoveRow}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="gap-1.5"
+            disabled={editor.busy}
+            onClick={editor.handleAddVariable}
+          >
+            <Plus className="size-3.5" />
+            {HARNESS_PANE_COPY.addVariable}
+          </Button>
+          {editor.multiSource ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="gap-1.5"
+              disabled={editor.busy}
+              onClick={() => setProviderModalOpen(true)}
+            >
+              <Plus className="size-3.5" />
+              {HARNESS_PANE_COPY.addProvider}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {editor.multiSource ? (
+        <ProviderPickerModal
+          open={providerModalOpen}
+          onClose={() => setProviderModalOpen(false)}
+          onSelect={(provider) =>
+            editor.addRow(provider.envVarNames[0] ?? "", provider.id)}
+        />
+      ) : null}
+    </SettingsSection>
+  );
+}
+
+function CliDetails({
+  surface,
+  editor,
+}: {
+  surface: AgentAuthSurface;
+  editor: HarnessAuthEditorApi;
+}) {
+  const { localAgent, loginSession, loginWorkflow } = editor;
+
+  if (surface === "cloud") {
+    return (
+      <SettingsSection title={HARNESS_PANE_COPY.detailsCli}>
+        <p className="py-3 text-sm text-muted-foreground">
+          {HARNESS_PANE_COPY.nativeStateCloud}
+        </p>
+      </SettingsSection>
+    );
+  }
+
+  const canRunLogin =
+    localAgent != null
+    && !isReadyAgent(localAgent)
+    && localAgent.readiness === "login_required"
+    && localAgent.supportsLogin;
+
+  const showLoginTerminal =
+    loginSession != null
+    && (loginSession.isStarting
+      || loginSession.terminal !== null
+      || loginSession.errorMessage !== null);
+
+  const isAuthenticated = localAgent != null && isReadyAgent(localAgent);
+
+  return (
+    <SettingsSection title={HARNESS_PANE_COPY.detailsCli}>
+      <div className="space-y-3">
+        {canRunLogin ? (
+          <p className="text-sm font-medium text-destructive">
+            {HARNESS_PANE_COPY.cliNotAuthenticated}
+          </p>
+        ) : isAuthenticated ? (
+          <p className="text-sm text-muted-foreground">
+            {HARNESS_PANE_COPY.cliAuthenticated}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {HARNESS_PANE_COPY.nativeStateLocal}
+          </p>
+        )}
+
+        {canRunLogin ? (
+          <div>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={loginSession?.isStarting ?? false}
+              onClick={() => {
+                if (localAgent) {
+                  void loginWorkflow.openAuthTerminal(localAgent, {
+                    restart: Boolean(loginSession),
+                  });
+                }
+              }}
+            >
+              {loginSession?.isStarting
+                ? HARNESS_PANE_COPY.runLoginOpening
+                : HARNESS_PANE_COPY.runLogin}
+            </Button>
+          </div>
+        ) : null}
+
+        {showLoginTerminal && loginSession ? (
+          <AgentLoginTerminalPanel
+            session={loginSession}
+            baseUrl={loginWorkflow.runtimeConnection.baseUrl}
+            authToken={loginWorkflow.runtimeConnection.authToken}
+            onClose={(kind) => {
+              void loginWorkflow.closeAuthTerminal(kind);
+            }}
+            onExit={(kind, code) => {
+              void loginWorkflow.handleTerminalExit(kind, code);
+            }}
+            onRestart={() => {
+              if (localAgent) {
+                void loginWorkflow.openAuthTerminal(localAgent, { restart: true });
+              }
+            }}
+          />
+        ) : null}
+      </div>
+    </SettingsSection>
+  );
+}
+
+function useProviderModal() {
+  const [providerModalOpen, setProviderModalOpen] = useState(false);
+  return { providerModalOpen, setProviderModalOpen };
+}

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -1,41 +1,33 @@
-import { useEffect, useRef, useState } from "react";
-import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
-import {
-  useAgentApiKeys,
-  useAgentGatewayCapabilities,
-  useAgentGatewayEnrollment,
-  useAuthSelections,
-  usePutAuthSelections,
-} from "@proliferate/cloud-sdk-react";
-import { Plus } from "@proliferate/ui/icons";
-import { Button } from "@proliferate/ui/primitives/Button";
-import { Switch } from "@proliferate/ui/primitives/Switch";
-import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import type React from "react";
+import { Check, CloudIcon, KeyRound, SquareTerminal } from "@proliferate/ui/icons";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
-import { AgentLoginTerminalPanel } from "@/components/agents/AgentLoginTerminalPanel";
-import { HarnessAuthApiKeyRow } from "./HarnessAuthApiKeyRow";
-import { ProviderPickerModal } from "./ProviderPickerModal";
-import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
 import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
-import { getHarnessEnvVarSuggestions } from "@/config/harness-env-vars";
-import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
-import { useAgentLoginTerminalWorkflow } from "@/hooks/agents/workflows/use-agent-login-terminal-workflow";
-import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
-import { isReadyAgent } from "@/lib/domain/agents/status";
-import { useToastStore } from "@/stores/toast/toast-store";
-import {
-  buildDesiredSources,
-  deriveEditorState,
-  isMultiSourceHarness,
-  isNativeState,
-  type EditableApiKeyRow,
-  type HarnessAuthEditorState,
-} from "@/lib/domain/settings/harness-auth-sources";
+import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
+import { isMultiSourceHarness } from "@/lib/domain/settings/harness-auth-sources";
+import type { HarnessAuthEditorApi } from "./use-harness-auth-editor";
+
+export type AuthMethod = "gateway" | "api_key" | "cli";
 
 interface HarnessAuthSectionProps {
   harnessKind: string;
   displayName: string;
-  surface: AgentAuthSurface;
+  editor: HarnessAuthEditorApi;
+}
+
+export function deriveSelectedMethod(editor: HarnessAuthEditorApi): AuthMethod {
+  if (editor.editorState.gatewayEnabled) return "gateway";
+  // Show api_key details when any row exists (even draft/disabled) — the user
+  // is actively configuring a key.
+  if (editor.editorState.rows.length > 0) return "api_key";
+  return "cli";
+}
+
+export function deriveSelectedMethods(editor: HarnessAuthEditorApi): Set<AuthMethod> {
+  const methods = new Set<AuthMethod>();
+  if (editor.editorState.gatewayEnabled) methods.add("gateway");
+  if (editor.editorState.rows.length > 0) methods.add("api_key");
+  if (methods.size === 0) methods.add("cli");
+  return methods;
 }
 
 const CURSOR_HARNESS = "cursor";
@@ -43,62 +35,8 @@ const CURSOR_HARNESS = "cursor";
 export function HarnessAuthSection({
   harnessKind,
   displayName,
-  surface,
+  editor,
 }: HarnessAuthSectionProps) {
-  const { cloudActive } = useCloudAvailabilityState();
-  const showToast = useToastStore((state) => state.show);
-
-  const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
-  const enrollmentQuery = useAgentGatewayEnrollment(cloudActive);
-  const selectionsQuery = useAuthSelections(null, cloudActive);
-  const apiKeysQuery = useAgentApiKeys(cloudActive);
-  const putSelections = usePutAuthSelections();
-  const { agentsByKind } = useAgentCatalog();
-  const loginWorkflow = useAgentLoginTerminalWorkflow();
-
-  // Local-authoritative editor: seeded once per (harness, surface) scope, then
-  // every edit PUTs the full desired source list (contract §5). We never reseed
-  // from a later refetch of the same scope, so a PUT never clobbers the draft.
-  const [gatewayEnabled, setGatewayEnabled] = useState(false);
-  const [rows, setRows] = useState<EditableApiKeyRow[]>([]);
-  const [providerModalOpen, setProviderModalOpen] = useState(false);
-  const seededScopeRef = useRef<string | null>(null);
-  const lastPutSigRef = useRef<string>("");
-  const draftCounterRef = useRef(0);
-
-  const scopeKey = `${harnessKind}:${surface}`;
-  const selections = selectionsQuery.data;
-
-  useEffect(() => {
-    if (selections === undefined || seededScopeRef.current === scopeKey) {
-      return;
-    }
-    seededScopeRef.current = scopeKey;
-    const derived = deriveEditorState(selections, harnessKind, surface);
-    setGatewayEnabled(derived.gatewayEnabled);
-    setRows(derived.rows);
-    lastPutSigRef.current = JSON.stringify(buildDesiredSources(derived));
-  }, [selections, scopeKey, harnessKind, surface]);
-
-  const localAgent = agentsByKind.get(harnessKind) ?? null;
-  const loginSession = loginWorkflow.sessionsByKind[harnessKind] ?? null;
-
-  // Close the auth terminal once the login round-trip made the agent ready.
-  useEffect(() => {
-    if (!loginSession?.terminal || !localAgent || !isReadyAgent(localAgent)) {
-      return;
-    }
-    showToast(HARNESS_PANE_COPY.readyToast(displayName));
-    void loginWorkflow.closeAuthTerminal(harnessKind);
-  }, [
-    displayName,
-    harnessKind,
-    localAgent,
-    loginSession,
-    loginWorkflow.closeAuthTerminal,
-    showToast,
-  ]);
-
   if (harnessKind === CURSOR_HARNESS) {
     return (
       <SettingsSection title={HARNESS_PANE_COPY.authenticationTitle}>
@@ -109,7 +47,7 @@ export function HarnessAuthSection({
     );
   }
 
-  if (!cloudActive) {
+  if (!editor.cloudActive) {
     return (
       <SettingsSection title={HARNESS_PANE_COPY.signInTitle}>
         <p className="py-3 text-sm text-muted-foreground">
@@ -119,243 +57,169 @@ export function HarnessAuthSection({
     );
   }
 
-  const capabilities = capabilitiesQuery.data;
-  const enrollment = enrollmentQuery.data;
-  // Undefined capabilities means "not yet known" (still loading or errored), not
-  // "gateway enabled" — treat it as disabled so a user can never persist a
-  // gateway source on a gateway-disabled account before capabilities resolve. A
-  // known-unsynced enrollment locks the gateway the same way.
-  const gatewayLocked =
-    !capabilities?.gatewayEnabled
-    || (enrollment !== undefined && enrollment.syncStatus !== "synced");
-  const apiKeys = apiKeysQuery.data ?? [];
+  if (editor.selectionsQuery.isLoading) {
+    return (
+      <SettingsSection title={HARNESS_PANE_COPY.authenticationTitle}>
+        <p className="py-3 text-sm text-muted-foreground">Loading authentication...</p>
+      </SettingsSection>
+    );
+  }
+
   const multiSource = isMultiSourceHarness(harnessKind);
-  const busy = putSelections.isPending;
-  const editorState: HarnessAuthEditorState = { gatewayEnabled, rows };
-  const native = isNativeState(editorState);
+  const selectedMethods = deriveSelectedMethods(editor);
+  const capabilities = editor.capabilitiesQuery.data;
+  const enrollment = editor.enrollmentQuery.data;
 
-  function commit(next: HarnessAuthEditorState) {
-    setGatewayEnabled(next.gatewayEnabled);
-    setRows(next.rows);
-    const sources = buildDesiredSources(next);
-    const signature = JSON.stringify(sources);
-    // De-dupe redundant PUTs (e.g. blur with no effective change).
-    if (signature === lastPutSigRef.current) {
-      return;
+  function selectMethod(method: AuthMethod) {
+    if (multiSource) {
+      handleMultiSourceSelect(method, editor);
+    } else {
+      handleSingleSourceSelect(method, editor);
     }
-    lastPutSigRef.current = signature;
-    putSelections.mutate(
-      { harnessKind, surface, body: { sources } },
-      {
-        onError: (error) => {
-          showToast(
-            error.message || HARNESS_PANE_COPY.selectionUpdateError(displayName),
-          );
-        },
-      },
-    );
   }
-
-  function handleGatewayToggle(next: boolean) {
-    // Single-source harnesses hold at most one enabled source: turning the
-    // gateway on turns every api-key row off (radio semantics via switches).
-    const nextRows =
-      next && !multiSource ? rows.map((row) => ({ ...row, enabled: false })) : rows;
-    commit({ gatewayEnabled: next, rows: nextRows });
-  }
-
-  function handleRowEnabledToggle(uid: string, next: boolean) {
-    const nextRows = rows.map((row) => {
-      if (row.uid === uid) {
-        return { ...row, enabled: next };
-      }
-      return next && !multiSource ? { ...row, enabled: false } : row;
-    });
-    const nextGateway = next && !multiSource ? false : gatewayEnabled;
-    commit({ gatewayEnabled: nextGateway, rows: nextRows });
-  }
-
-  function handleRowKeySelect(uid: string, keyId: string) {
-    commit({
-      gatewayEnabled,
-      rows: rows.map((row) => (row.uid === uid ? { ...row, apiKeyId: keyId } : row)),
-    });
-  }
-
-  function handleRowEnvVarChange(uid: string, envVarName: string) {
-    // Free-form editing stays local; the PUT lands on blur (or another action).
-    setRows((current) =>
-      current.map((row) => (row.uid === uid ? { ...row, envVarName } : row)),
-    );
-  }
-
-  function handleRowEnvVarBlur() {
-    commit(editorState);
-  }
-
-  function handleRemoveRow(uid: string) {
-    commit({ gatewayEnabled, rows: rows.filter((row) => row.uid !== uid) });
-  }
-
-  function addRow(envVarName: string, providerHint: string | null) {
-    draftCounterRef.current += 1;
-    const newRow: EditableApiKeyRow = {
-      uid: `draft-${draftCounterRef.current}`,
-      envVarName,
-      apiKeyId: null,
-      providerHint,
-      enabled: false,
-    };
-    // New rows are incomplete (no key yet) so nothing is PUT until wired.
-    setRows((current) => [...current, newRow]);
-  }
-
-  function handleAddVariable() {
-    const used = new Set(rows.map((row) => row.envVarName));
-    const suggestion = getHarnessEnvVarSuggestions(harnessKind).find(
-      (candidate) => !used.has(candidate.envVarName),
-    );
-    addRow(suggestion?.envVarName ?? "", suggestion?.providerHint ?? null);
-  }
-
-  const canRunLogin =
-    surface === "local"
-    && native
-    && localAgent !== null
-    && !isReadyAgent(localAgent)
-    && localAgent.readiness === "login_required"
-    && localAgent.supportsLogin;
-  const showLoginTerminal =
-    surface === "local"
-    && native
-    && loginSession !== null
-    && (loginSession.isStarting
-      || loginSession.terminal !== null
-      || loginSession.errorMessage !== null);
 
   return (
     <SettingsSection
       title={HARNESS_PANE_COPY.authenticationTitle}
       description={HARNESS_PANE_COPY.authenticationDescription(displayName)}
     >
-      {selectionsQuery.isLoading ? (
-        <p className="py-3 text-sm text-muted-foreground">Loading authentication...</p>
-      ) : (
-        <div className="space-y-3">
-          <SettingsRow
-            label={HARNESS_PANE_COPY.gatewayLabel}
-            description={gatewaySubtitle(capabilities, enrollment)}
-          >
-            <Switch
-              aria-label={HARNESS_PANE_COPY.gatewayLabel}
-              checked={gatewayEnabled}
-              disabled={gatewayLocked || busy}
-              onChange={handleGatewayToggle}
-            />
-          </SettingsRow>
-
-          <div>
-            <div className="flex flex-col">
-              {rows.map((row) => (
-                <HarnessAuthApiKeyRow
-                  key={row.uid}
-                  row={row}
-                  apiKeys={apiKeys}
-                  busy={busy}
-                  onEnvVarChange={handleRowEnvVarChange}
-                  onEnvVarBlur={handleRowEnvVarBlur}
-                  onKeySelect={handleRowKeySelect}
-                  onEnabledToggle={handleRowEnabledToggle}
-                  onRemove={handleRemoveRow}
-                />
-              ))}
-            </div>
-
-            <div className="flex flex-wrap gap-2 pt-2">
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="gap-1.5"
-                disabled={busy}
-                onClick={handleAddVariable}
-              >
-                <Plus className="size-3.5" />
-                {HARNESS_PANE_COPY.addVariable}
-              </Button>
-              {multiSource ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5"
-                  disabled={busy}
-                  onClick={() => setProviderModalOpen(true)}
-                >
-                  <Plus className="size-3.5" />
-                  {HARNESS_PANE_COPY.addProvider}
-                </Button>
-              ) : null}
-            </div>
-          </div>
-
-          {native ? (
-            <p className="text-sm text-muted-foreground">
-              {surface === "local"
-                ? HARNESS_PANE_COPY.nativeStateLocal
-                : HARNESS_PANE_COPY.nativeStateCloud}
-            </p>
-          ) : null}
-
-          {canRunLogin ? (
-            <div>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                disabled={loginSession?.isStarting ?? false}
-                onClick={() => {
-                  void loginWorkflow.openAuthTerminal(localAgent, {
-                    restart: Boolean(loginSession),
-                  });
-                }}
-              >
-                {loginSession?.isStarting
-                  ? HARNESS_PANE_COPY.runLoginOpening
-                  : HARNESS_PANE_COPY.runLogin}
-              </Button>
-            </div>
-          ) : null}
-
-          {showLoginTerminal && loginSession ? (
-            <AgentLoginTerminalPanel
-              session={loginSession}
-              baseUrl={loginWorkflow.runtimeConnection.baseUrl}
-              authToken={loginWorkflow.runtimeConnection.authToken}
-              onClose={(kind) => {
-                void loginWorkflow.closeAuthTerminal(kind);
-              }}
-              onExit={(kind, code) => {
-                void loginWorkflow.handleTerminalExit(kind, code);
-              }}
-              onRestart={() => {
-                if (localAgent) {
-                  void loginWorkflow.openAuthTerminal(localAgent, { restart: true });
-                }
-              }}
-            />
-          ) : null}
-        </div>
-      )}
-
-      {multiSource ? (
-        <ProviderPickerModal
-          open={providerModalOpen}
-          onClose={() => setProviderModalOpen(false)}
-          onSelect={(provider) =>
-            addRow(provider.envVarNames[0] ?? "", provider.id)}
+      <div className="grid grid-cols-3 gap-3">
+        <MethodCard
+          label={HARNESS_PANE_COPY.methodGateway}
+          icon={<CloudIcon className="size-5" />}
+          selected={selectedMethods.has("gateway")}
+          disabled={editor.gatewayLocked || editor.busy}
+          disabledReason={editor.gatewayLocked ? gatewaySubtitle(capabilities, enrollment) : undefined}
+          onClick={() => selectMethod("gateway")}
         />
-      ) : null}
+        <MethodCard
+          label={HARNESS_PANE_COPY.methodApiKey}
+          icon={<KeyRound className="size-5" />}
+          selected={selectedMethods.has("api_key")}
+          disabled={editor.busy}
+          onClick={() => selectMethod("api_key")}
+        />
+        <MethodCard
+          label={HARNESS_PANE_COPY.methodCli}
+          icon={<SquareTerminal className="size-5" />}
+          selected={selectedMethods.has("cli")}
+          disabled={editor.busy}
+          onClick={() => selectMethod("cli")}
+        />
+      </div>
     </SettingsSection>
+  );
+}
+
+function handleSingleSourceSelect(method: AuthMethod, editor: HarnessAuthEditorApi) {
+  switch (method) {
+    case "gateway":
+      editor.handleGatewayToggle(true);
+      break;
+    case "api_key": {
+      // Disable gateway; enable first complete row if one exists, otherwise seed
+      // a draft row via the existing env-var suggestion logic.
+      if (editor.editorState.gatewayEnabled) {
+        editor.handleGatewayToggle(false);
+      }
+      const firstComplete = editor.editorState.rows.find(
+        (row) => row.apiKeyId !== null,
+      );
+      if (firstComplete && !firstComplete.enabled) {
+        editor.handleRowEnabledToggle(firstComplete.uid, true);
+      } else if (editor.editorState.rows.length === 0) {
+        editor.handleAddVariable();
+      }
+      break;
+    }
+    case "cli":
+      // Disable everything → native state.
+      editor.commit({
+        gatewayEnabled: false,
+        rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
+      });
+      break;
+  }
+}
+
+function handleMultiSourceSelect(method: AuthMethod, editor: HarnessAuthEditorApi) {
+  switch (method) {
+    case "gateway":
+      editor.handleGatewayToggle(!editor.editorState.gatewayEnabled);
+      break;
+    case "api_key": {
+      const hasEnabled = editor.editorState.rows.some((row) => row.enabled);
+      if (hasEnabled) {
+        // Toggle off all api key rows.
+        editor.commit({
+          gatewayEnabled: editor.editorState.gatewayEnabled,
+          rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
+        });
+      } else {
+        const firstComplete = editor.editorState.rows.find(
+          (row) => row.apiKeyId !== null,
+        );
+        if (firstComplete) {
+          editor.handleRowEnabledToggle(firstComplete.uid, true);
+        } else if (editor.editorState.rows.length === 0) {
+          editor.handleAddVariable();
+        }
+      }
+      break;
+    }
+    case "cli":
+      // Clicking CLI in multi-source disables everything.
+      editor.commit({
+        gatewayEnabled: false,
+        rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
+      });
+      break;
+  }
+}
+
+interface MethodCardProps {
+  label: string;
+  icon: React.ReactNode;
+  selected: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+  onClick: () => void;
+}
+
+function MethodCard({
+  label,
+  icon,
+  selected,
+  disabled,
+  disabledReason,
+  onClick,
+}: MethodCardProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        aria-pressed={selected}
+        disabled={disabled}
+        className={[
+          "relative flex flex-col items-center gap-2 rounded-lg border px-4 py-5 transition-colors",
+          selected
+            ? "border-foreground/20 bg-foreground/5 text-foreground"
+            : "border-border bg-background text-muted-foreground hover:border-foreground/10 hover:bg-foreground/[0.02]",
+          disabled ? "pointer-events-none opacity-50" : "",
+        ].join(" ")}
+        onClick={onClick}
+      >
+        {selected ? (
+          <Check className="absolute right-2.5 top-2.5 size-4 text-foreground" />
+        ) : null}
+        {icon}
+        <span className="text-xs font-medium">{label}</span>
+      </button>
+      {disabled && disabledReason ? (
+        <p className="px-1 text-[11px] leading-tight text-muted-foreground">
+          {disabledReason}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -3,10 +3,13 @@ import { Check, CloudIcon, KeyRound, SquareTerminal } from "@proliferate/ui/icon
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
 import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
-import { isMultiSourceHarness } from "@/lib/domain/settings/harness-auth-sources";
+import {
+  isMultiSourceHarness,
+  type AuthMethod,
+} from "@/lib/domain/settings/harness-auth-sources";
 import type { HarnessAuthEditorApi } from "./use-harness-auth-editor";
 
-export type AuthMethod = "gateway" | "api_key" | "cli";
+export type { AuthMethod };
 
 interface HarnessAuthSectionProps {
   harnessKind: string;
@@ -14,18 +17,29 @@ interface HarnessAuthSectionProps {
   editor: HarnessAuthEditorApi;
 }
 
+/**
+ * Single-source radio selection (claude/codex/grok/…): exactly one method is
+ * active. An enabled source wins; otherwise the user's last click (pendingMethod)
+ * highlights the card even before a key is wired; the implicit fallback is CLI.
+ * Never infers from a draft/disabled row's mere presence (that lit up api_key
+ * while gateway was on).
+ */
 export function deriveSelectedMethod(editor: HarnessAuthEditorApi): AuthMethod {
   if (editor.editorState.gatewayEnabled) return "gateway";
-  // Show api_key details when any row exists (even draft/disabled) — the user
-  // is actively configuring a key.
-  if (editor.editorState.rows.length > 0) return "api_key";
+  if (editor.editorState.rows.some((row) => row.enabled)) return "api_key";
+  if (editor.pendingMethod) return editor.pendingMethod;
   return "cli";
 }
 
+/**
+ * Multi-source selection (opencode only): gateway and api_key are independent
+ * toggles and may both be selected on purpose. CLI is shown only when neither is
+ * on.
+ */
 export function deriveSelectedMethods(editor: HarnessAuthEditorApi): Set<AuthMethod> {
   const methods = new Set<AuthMethod>();
   if (editor.editorState.gatewayEnabled) methods.add("gateway");
-  if (editor.editorState.rows.length > 0) methods.add("api_key");
+  if (editor.editorState.rows.some((row) => row.enabled)) methods.add("api_key");
   if (methods.size === 0) methods.add("cli");
   return methods;
 }
@@ -66,7 +80,11 @@ export function HarnessAuthSection({
   }
 
   const multiSource = isMultiSourceHarness(harnessKind);
-  const selectedMethods = deriveSelectedMethods(editor);
+  // Single-source harnesses are a radio (exactly one active method); only
+  // opencode keeps the independent multi-select set.
+  const selectedMethods = multiSource
+    ? deriveSelectedMethods(editor)
+    : new Set<AuthMethod>([deriveSelectedMethod(editor)]);
   const capabilities = editor.capabilitiesQuery.data;
   const enrollment = editor.enrollmentQuery.data;
 
@@ -114,11 +132,16 @@ export function HarnessAuthSection({
 function handleSingleSourceSelect(method: AuthMethod, editor: HarnessAuthEditorApi) {
   switch (method) {
     case "gateway":
+      // handleGatewayToggle already turns every api-key row off (radio
+      // semantics); an enabled gateway makes deriveSelectedMethod return
+      // "gateway" so no pending marker is needed.
       editor.handleGatewayToggle(true);
+      editor.setPendingMethod("gateway");
       break;
     case "api_key": {
       // Disable gateway; enable first complete row if one exists, otherwise seed
-      // a draft row via the existing env-var suggestion logic.
+      // a draft row via the existing env-var suggestion logic. Mark api_key
+      // pending so the card highlights immediately even before a key is wired.
       if (editor.editorState.gatewayEnabled) {
         editor.handleGatewayToggle(false);
       }
@@ -130,14 +153,20 @@ function handleSingleSourceSelect(method: AuthMethod, editor: HarnessAuthEditorA
       } else if (editor.editorState.rows.length === 0) {
         editor.handleAddVariable();
       }
+      editor.setPendingMethod("api_key");
       break;
     }
     case "cli":
-      // Disable everything → native state.
+      // Native state: drop gateway and any incomplete draft rows (so nothing
+      // keeps api_key "active"), and disable the rest. Marking cli pending makes
+      // the card stick even though complete rows may linger disabled.
       editor.commit({
         gatewayEnabled: false,
-        rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
+        rows: editor.editorState.rows
+          .filter((row) => row.apiKeyId !== null)
+          .map((row) => ({ ...row, enabled: false })),
       });
+      editor.setPendingMethod("cli");
       break;
   }
 }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -186,8 +186,8 @@ function renderPane(harnessKind = "claude") {
   return render(<HarnessPane harnessKind={harnessKind} />);
 }
 
-function gatewaySwitch() {
-  return screen.getByRole("switch", { name: "Proliferate gateway" }) as HTMLButtonElement;
+function gatewayCard() {
+  return screen.getByRole("button", { name: "Proliferate gateway" }) as HTMLButtonElement;
 }
 
 afterEach(() => {
@@ -217,8 +217,8 @@ describe("HarnessPane authentication", () => {
   it("persists an enabled gateway source when the toggle is switched on", () => {
     renderPane("claude");
 
-    const gateway = gatewaySwitch();
-    expect(gateway.getAttribute("aria-checked")).toBe("false");
+    const gateway = gatewayCard();
+    expect(gateway.getAttribute("aria-pressed")).toBe("false");
 
     fireEvent.click(gateway);
 
@@ -236,7 +236,7 @@ describe("HarnessPane authentication", () => {
     renderPane("claude");
 
     fireEvent.click(screen.getByRole("radio", { name: "Cloud" }));
-    fireEvent.click(gatewaySwitch());
+    fireEvent.click(gatewayCard());
 
     expect(putMutate).toHaveBeenCalledWith(
       expect.objectContaining({ surface: "cloud" }),
@@ -254,7 +254,8 @@ describe("HarnessPane authentication", () => {
     }];
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("button", { name: /Add variable/ }));
+    // Clicking the API key card seeds a draft row via env-var suggestions.
+    fireEvent.click(screen.getByRole("button", { name: "API key" }));
     expect(screen.getByDisplayValue("ANTHROPIC_API_KEY")).toBeTruthy();
     // No PUT until the row names a key.
     expect(putMutate).not.toHaveBeenCalled();
@@ -299,7 +300,7 @@ describe("HarnessPane authentication", () => {
     );
   });
 
-  it("turns the gateway off when an api-key row is enabled on a single-source harness", () => {
+  it("turns the gateway off when the API key card is selected on a single-source harness", () => {
     state.apiKeys.data = [{
       id: "key-1",
       title: "Work key",
@@ -322,12 +323,11 @@ describe("HarnessPane authentication", () => {
     }];
     renderPane("claude");
 
-    expect(gatewaySwitch().getAttribute("aria-checked")).toBe("true");
+    expect(gatewayCard().getAttribute("aria-pressed")).toBe("true");
 
-    fireEvent.click(screen.getByRole("button", { name: /Add variable/ }));
-    fireEvent.click(screen.getByRole("button", { name: /Select an API key/ }));
-    fireEvent.click(screen.getByText("Work key"));
-    fireEvent.click(screen.getByRole("switch", { name: "Enable ANTHROPIC_API_KEY" }));
+    // Clicking "API key" card disables gateway (radio semantics) and seeds a
+    // draft row via env-var suggestions.
+    fireEvent.click(screen.getByRole("button", { name: "API key" }));
 
     // The gateway is dropped from the desired set (radio semantics).
     expect(putMutate).toHaveBeenLastCalledWith(
@@ -335,13 +335,7 @@ describe("HarnessPane authentication", () => {
         harnessKind: "claude",
         surface: "local",
         body: {
-          sources: [{
-            sourceKind: "api_key",
-            apiKeyId: "key-1",
-            envVarName: "ANTHROPIC_API_KEY",
-            providerHint: "anthropic",
-            enabled: true,
-          }],
+          sources: [],
         },
       },
       expect.anything(),
@@ -361,21 +355,63 @@ describe("HarnessPane authentication", () => {
     expect(
       screen.queryByText(/authenticates with its own sign-in/),
     ).not.toBeNull();
-    expect(screen.queryByRole("switch", { name: "Proliferate gateway" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Proliferate gateway" })).toBeNull();
     expect(screen.queryByRole("button", { name: /Add variable/ })).toBeNull();
   });
 
-  it("offers Add provider only for opencode", () => {
+  it("offers Add provider only for opencode when API key method is active", () => {
+    // Seed an api_key selection so the API key detail section is visible.
+    state.selections.data = [{
+      id: "sel-key",
+      harnessKind: "opencode",
+      surface: "local",
+      sourceKind: "api_key",
+      apiKeyId: "key-1",
+      keyTitle: null,
+      envVarName: "OPENROUTER_API_KEY",
+      providerHint: "openrouter",
+      enabled: true,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }];
     renderPane("opencode");
     expect(screen.queryByRole("button", { name: /Add provider/ })).not.toBeNull();
   });
 
   it("does not offer Add provider for single-source harnesses", () => {
+    // Seed an api_key selection so the API key detail section is visible.
+    state.selections.data = [{
+      id: "sel-key",
+      harnessKind: "claude",
+      surface: "local",
+      sourceKind: "api_key",
+      apiKeyId: "key-1",
+      keyTitle: null,
+      envVarName: "ANTHROPIC_API_KEY",
+      providerHint: "anthropic",
+      enabled: true,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }];
     renderPane("claude");
     expect(screen.queryByRole("button", { name: /Add provider/ })).toBeNull();
   });
 
   it("prefills a new row from the opencode provider picker", () => {
+    // Seed an api_key selection so the API key detail section is visible.
+    state.selections.data = [{
+      id: "sel-key",
+      harnessKind: "opencode",
+      surface: "local",
+      sourceKind: "api_key",
+      apiKeyId: "key-1",
+      keyTitle: null,
+      envVarName: "OPENAI_API_KEY",
+      providerHint: "openai",
+      enabled: true,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }];
     renderPane("opencode");
 
     fireEvent.click(screen.getByRole("button", { name: /Add provider/ }));
@@ -392,10 +428,10 @@ describe("HarnessPane authentication", () => {
     };
     renderPane("claude");
 
-    expect(gatewaySwitch().disabled).toBe(true);
+    expect(gatewayCard().disabled).toBe(true);
     expect(screen.queryByText("Unavailable for your account")).not.toBeNull();
 
-    fireEvent.click(gatewaySwitch());
+    fireEvent.click(gatewayCard());
     expect(putMutate).not.toHaveBeenCalled();
   });
 
@@ -403,7 +439,7 @@ describe("HarnessPane authentication", () => {
     state.enrollment.data = { syncStatus: "pending", lastErrorCode: null };
     renderPane("claude");
 
-    expect(gatewaySwitch().disabled).toBe(true);
+    expect(gatewayCard().disabled).toBe(true);
     expect(screen.queryByText("Enrollment pending")).not.toBeNull();
   });
 
@@ -431,13 +467,13 @@ describe("HarnessPane authentication", () => {
     state.cloudActive = false;
     renderPane("claude");
 
-    expect(screen.queryByText(/Sign in to Proliferate Cloud/)).not.toBeNull();
-    expect(screen.queryByRole("switch", { name: "Proliferate gateway" })).toBeNull();
+    expect(screen.queryAllByText(/Sign in to Proliferate Cloud/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Proliferate gateway" })).toBeNull();
   });
 });
 
 describe("HarnessPane all models", () => {
-  it("renders the layered catalog grid on the All Models subtab", () => {
+  it("renders the layered catalog grid in the All Models section", () => {
     state.catalog.data = {
       harnessKind: "claude",
       surface: "local",
@@ -453,7 +489,7 @@ describe("HarnessPane all models", () => {
     };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
 
     expect(screen.queryByText("Sonnet 4.6")).not.toBeNull();
     expect(screen.getAllByRole("switch")).toHaveLength(2);
@@ -482,7 +518,7 @@ describe("HarnessPane all models", () => {
     };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
     fireEvent.click(screen.getByRole("button", { name: /Refresh/ }));
 
     expect(refreshMutate).toHaveBeenCalledWith(
@@ -514,7 +550,7 @@ describe("HarnessPane all models", () => {
     // unreachable, or one with no ready models for this harness yet.
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
     fireEvent.click(screen.getByRole("button", { name: /Refresh/ }));
 
     expect(refreshMutate).not.toHaveBeenCalled();
@@ -539,7 +575,7 @@ describe("HarnessPane all models", () => {
     };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
     const [sonnetSwitch] = screen.getAllByRole("switch");
     fireEvent.click(sonnetSwitch);
 
@@ -584,7 +620,7 @@ describe("HarnessPane all models (local + gateway runtime)", () => {
     };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
 
     expect(screen.queryByText("Sonnet 4.6")).not.toBeNull();
     expect(screen.queryByText("seed")).not.toBeNull();
@@ -604,7 +640,7 @@ describe("HarnessPane all models (local + gateway runtime)", () => {
     };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
 
     expect(
       screen.queryByText(`probed ${new Date("2026-07-02T20:00:00Z").toLocaleString()}`),
@@ -616,7 +652,7 @@ describe("HarnessPane all models (local + gateway runtime)", () => {
     state.gatewayModels.data = { models: [], source: "seed" };
     renderPane("claude");
 
-    fireEvent.click(screen.getByRole("tab", { name: "All Models" }));
+
     fireEvent.click(screen.getByRole("button", { name: /Refresh/ }));
 
     expect(refreshGatewayModelsMutate).toHaveBeenCalledWith("claude", expect.anything());

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -342,6 +342,28 @@ describe("HarnessPane authentication", () => {
     );
   });
 
+  it("selects exactly one method for a single-source harness: API key then CLI ends on CLI", () => {
+    renderPane("claude");
+
+    const gateway = () =>
+      screen.getByRole("button", { name: "Proliferate gateway" });
+    const apiKey = () => screen.getByRole("button", { name: "API key" });
+    const cli = () => screen.getByRole("button", { name: "CLI login" });
+
+    // Clicking API key seeds a draft row and highlights ONLY the API key card —
+    // gateway and api_key are never selected together on a single-source harness.
+    fireEvent.click(apiKey());
+    expect(apiKey().getAttribute("aria-pressed")).toBe("true");
+    expect(gateway().getAttribute("aria-pressed")).toBe("false");
+    expect(cli().getAttribute("aria-pressed")).toBe("false");
+
+    // Clicking CLI drops the incomplete draft and sticks on CLI.
+    fireEvent.click(cli());
+    expect(cli().getAttribute("aria-pressed")).toBe("true");
+    expect(apiKey().getAttribute("aria-pressed")).toBe("false");
+    expect(gateway().getAttribute("aria-pressed")).toBe("false");
+  });
+
   it("shows the native empty-state copy when nothing is enabled", () => {
     renderPane("claude");
     expect(

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
@@ -5,42 +5,37 @@ import {
   SegmentedControl,
   type SegmentedControlItem,
 } from "@proliferate/ui/primitives/SegmentedControl";
-import { Tabs, type TabItem } from "@proliferate/ui/primitives/Tabs";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { getProviderDisplayName } from "@/lib/domain/agents/provider-display";
 import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
-import { HarnessAuthSection } from "./HarnessAuthSection";
+import { HarnessAuthDetailsSection } from "./HarnessAuthDetailsSection";
+import { HarnessAuthSection, deriveSelectedMethod } from "./HarnessAuthSection";
 import { HarnessSettingsSection } from "./HarnessSettingsSection";
+import { useHarnessAuthEditor } from "./use-harness-auth-editor";
 
 const SURFACE_ITEMS: readonly SegmentedControlItem<AgentAuthSurface>[] = [
   { id: "cloud", label: HARNESS_PANE_COPY.surfaceCloud, icon: <CloudIcon /> },
   { id: "local", label: HARNESS_PANE_COPY.surfaceLocal, icon: <Monitor /> },
 ];
 
-const SUBTABS = [
-  { id: "authentication", label: HARNESS_PANE_COPY.tabAuthentication },
-  { id: "models", label: HARNESS_PANE_COPY.tabAllModels },
-] as const satisfies readonly TabItem[];
-
-type HarnessSubtab = (typeof SUBTABS)[number]["id"];
-
 interface HarnessPaneProps {
   harnessKind: string;
 }
 
 export function HarnessPane({ harnessKind }: HarnessPaneProps) {
-  // The surface axis: every section below reads/writes the selected surface.
   const [surface, setSurface] = useState<AgentAuthSurface>("local");
-  const [subtab, setSubtab] = useState<HarnessSubtab>("authentication");
   const { agentsByKind } = useAgentCatalog();
 
   const displayName =
     agentsByKind.get(harnessKind)?.displayName ?? getProviderDisplayName(harnessKind);
 
+  const editor = useHarnessAuthEditor(harnessKind, displayName, surface);
+  const selectedMethod = deriveSelectedMethod(editor);
+
   return (
-    <section className="space-y-5">
+    <section className="max-w-4xl space-y-6">
       <SettingsPageHeader
         title={displayName}
         action={
@@ -52,28 +47,26 @@ export function HarnessPane({ harnessKind }: HarnessPaneProps) {
         }
       />
 
-      <Tabs
-        items={SUBTABS}
-        activeId={subtab}
-        onChange={(id) => setSubtab(id === "models" ? "models" : "authentication")}
+      <HarnessAuthSection
+        harnessKind={harnessKind}
+        displayName={displayName}
+        editor={editor}
       />
 
-      {subtab === "authentication" ? (
-        <>
-          <HarnessAuthSection
-            harnessKind={harnessKind}
-            displayName={displayName}
-            surface={surface}
-          />
-          <HarnessSettingsSection harnessKind={harnessKind} />
-        </>
-      ) : (
-        <HarnessAllModelsSection
-          harnessKind={harnessKind}
-          displayName={displayName}
-          surface={surface}
-        />
-      )}
+      <HarnessAuthDetailsSection
+        displayName={displayName}
+        surface={surface}
+        selectedMethod={selectedMethod}
+        editor={editor}
+      />
+
+      <HarnessSettingsSection harnessKind={harnessKind} />
+
+      <HarnessAllModelsSection
+        harnessKind={harnessKind}
+        displayName={displayName}
+        surface={surface}
+      />
     </section>
   );
 }

--- a/apps/desktop/src/components/settings/panes/agents/harness/use-harness-auth-editor.ts
+++ b/apps/desktop/src/components/settings/panes/agents/harness/use-harness-auth-editor.ts
@@ -17,6 +17,7 @@ import {
   deriveEditorState,
   isMultiSourceHarness,
   isNativeState,
+  type AuthMethod,
   type EditableApiKeyRow,
   type HarnessAuthEditorState,
 } from "@/lib/domain/settings/harness-auth-sources";
@@ -37,6 +38,11 @@ export interface HarnessAuthEditorApi {
   busy: boolean;
   editorState: HarnessAuthEditorState;
   native: boolean;
+  // Single-source radio: the method the user last clicked that has no wired
+  // source yet (e.g. "api_key" before a key is chosen, or "cli"). Cleared once a
+  // real source becomes enabled and reset per (harness, surface) scope.
+  pendingMethod: AuthMethod | null;
+  setPendingMethod: (method: AuthMethod | null) => void;
   localAgent: ReturnType<ReturnType<typeof useAgentCatalog>["agentsByKind"]["get"]>;
   loginSession: ReturnType<
     typeof useAgentLoginTerminalWorkflow
@@ -76,6 +82,7 @@ export function useHarnessAuthEditor(
   // from a later refetch of the same scope, so a PUT never clobbers the draft.
   const [gatewayEnabled, setGatewayEnabled] = useState(false);
   const [rows, setRows] = useState<EditableApiKeyRow[]>([]);
+  const [pendingMethod, setPendingMethod] = useState<AuthMethod | null>(null);
   const seededScopeRef = useRef<string | null>(null);
   const lastPutSigRef = useRef<string>("");
   const draftCounterRef = useRef(0);
@@ -91,6 +98,9 @@ export function useHarnessAuthEditor(
     const derived = deriveEditorState(selections, harnessKind, surface);
     setGatewayEnabled(derived.gatewayEnabled);
     setRows(derived.rows);
+    // A fresh scope starts with no pending selection — the derived state alone
+    // drives the radio until the user clicks a method.
+    setPendingMethod(null);
     lastPutSigRef.current = JSON.stringify(buildDesiredSources(derived));
   }, [selections, scopeKey, harnessKind, surface]);
 
@@ -222,6 +232,8 @@ export function useHarnessAuthEditor(
     busy,
     editorState,
     native,
+    pendingMethod,
+    setPendingMethod,
     localAgent,
     loginSession,
     loginWorkflow,

--- a/apps/desktop/src/components/settings/panes/agents/harness/use-harness-auth-editor.ts
+++ b/apps/desktop/src/components/settings/panes/agents/harness/use-harness-auth-editor.ts
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState } from "react";
+import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
+import {
+  useAgentApiKeys,
+  useAgentGatewayCapabilities,
+  useAgentGatewayEnrollment,
+  useAuthSelections,
+  usePutAuthSelections,
+} from "@proliferate/cloud-sdk-react";
+import { getHarnessEnvVarSuggestions } from "@/config/harness-env-vars";
+import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
+import { useAgentLoginTerminalWorkflow } from "@/hooks/agents/workflows/use-agent-login-terminal-workflow";
+import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
+import { isReadyAgent } from "@/lib/domain/agents/status";
+import {
+  buildDesiredSources,
+  deriveEditorState,
+  isMultiSourceHarness,
+  isNativeState,
+  type EditableApiKeyRow,
+  type HarnessAuthEditorState,
+} from "@/lib/domain/settings/harness-auth-sources";
+import { useToastStore } from "@/stores/toast/toast-store";
+import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
+
+export interface HarnessAuthEditorApi {
+  // Queries
+  cloudActive: boolean;
+  capabilitiesQuery: ReturnType<typeof useAgentGatewayCapabilities>;
+  enrollmentQuery: ReturnType<typeof useAgentGatewayEnrollment>;
+  selectionsQuery: ReturnType<typeof useAuthSelections>;
+  apiKeysQuery: ReturnType<typeof useAgentApiKeys>;
+
+  // Derived
+  gatewayLocked: boolean;
+  multiSource: boolean;
+  busy: boolean;
+  editorState: HarnessAuthEditorState;
+  native: boolean;
+  localAgent: ReturnType<ReturnType<typeof useAgentCatalog>["agentsByKind"]["get"]>;
+  loginSession: ReturnType<
+    typeof useAgentLoginTerminalWorkflow
+  >["sessionsByKind"][string] | undefined;
+  loginWorkflow: ReturnType<typeof useAgentLoginTerminalWorkflow>;
+
+  // Handlers
+  commit: (next: HarnessAuthEditorState) => void;
+  handleGatewayToggle: (next: boolean) => void;
+  handleRowEnabledToggle: (uid: string, next: boolean) => void;
+  handleRowKeySelect: (uid: string, keyId: string) => void;
+  handleRowEnvVarChange: (uid: string, envVarName: string) => void;
+  handleRowEnvVarBlur: () => void;
+  handleRemoveRow: (uid: string) => void;
+  addRow: (envVarName: string, providerHint: string | null) => void;
+  handleAddVariable: () => void;
+}
+
+export function useHarnessAuthEditor(
+  harnessKind: string,
+  displayName: string,
+  surface: AgentAuthSurface,
+): HarnessAuthEditorApi {
+  const { cloudActive } = useCloudAvailabilityState();
+  const showToast = useToastStore((state) => state.show);
+
+  const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
+  const enrollmentQuery = useAgentGatewayEnrollment(cloudActive);
+  const selectionsQuery = useAuthSelections(null, cloudActive);
+  const apiKeysQuery = useAgentApiKeys(cloudActive);
+  const putSelections = usePutAuthSelections();
+  const { agentsByKind } = useAgentCatalog();
+  const loginWorkflow = useAgentLoginTerminalWorkflow();
+
+  // Local-authoritative editor: seeded once per (harness, surface) scope, then
+  // every edit PUTs the full desired source list (contract §5). We never reseed
+  // from a later refetch of the same scope, so a PUT never clobbers the draft.
+  const [gatewayEnabled, setGatewayEnabled] = useState(false);
+  const [rows, setRows] = useState<EditableApiKeyRow[]>([]);
+  const seededScopeRef = useRef<string | null>(null);
+  const lastPutSigRef = useRef<string>("");
+  const draftCounterRef = useRef(0);
+
+  const scopeKey = `${harnessKind}:${surface}`;
+  const selections = selectionsQuery.data;
+
+  useEffect(() => {
+    if (selections === undefined || seededScopeRef.current === scopeKey) {
+      return;
+    }
+    seededScopeRef.current = scopeKey;
+    const derived = deriveEditorState(selections, harnessKind, surface);
+    setGatewayEnabled(derived.gatewayEnabled);
+    setRows(derived.rows);
+    lastPutSigRef.current = JSON.stringify(buildDesiredSources(derived));
+  }, [selections, scopeKey, harnessKind, surface]);
+
+  const localAgent = agentsByKind.get(harnessKind);
+  const loginSession = loginWorkflow.sessionsByKind[harnessKind];
+
+  // Close the auth terminal once the login round-trip made the agent ready.
+  useEffect(() => {
+    if (!loginSession?.terminal || !localAgent || !isReadyAgent(localAgent)) {
+      return;
+    }
+    showToast(HARNESS_PANE_COPY.readyToast(displayName));
+    void loginWorkflow.closeAuthTerminal(harnessKind);
+  }, [
+    displayName,
+    harnessKind,
+    localAgent,
+    loginSession,
+    loginWorkflow.closeAuthTerminal,
+    showToast,
+  ]);
+
+  // Undefined capabilities means "not yet known" (still loading or errored), not
+  // "gateway enabled" — treat it as disabled so a user can never persist a
+  // gateway source on a gateway-disabled account before capabilities resolve. A
+  // known-unsynced enrollment locks the gateway the same way.
+  const capabilities = capabilitiesQuery.data;
+  const enrollment = enrollmentQuery.data;
+  const gatewayLocked =
+    !capabilities?.gatewayEnabled
+    || (enrollment !== undefined && enrollment.syncStatus !== "synced");
+  const multiSource = isMultiSourceHarness(harnessKind);
+  const busy = putSelections.isPending;
+  const editorState: HarnessAuthEditorState = { gatewayEnabled, rows };
+  const native = isNativeState(editorState);
+
+  function commit(next: HarnessAuthEditorState) {
+    setGatewayEnabled(next.gatewayEnabled);
+    setRows(next.rows);
+    const sources = buildDesiredSources(next);
+    const signature = JSON.stringify(sources);
+    // De-dupe redundant PUTs (e.g. blur with no effective change).
+    if (signature === lastPutSigRef.current) {
+      return;
+    }
+    lastPutSigRef.current = signature;
+    putSelections.mutate(
+      { harnessKind, surface, body: { sources } },
+      {
+        onError: (error: { message?: string }) => {
+          showToast(
+            error.message || HARNESS_PANE_COPY.selectionUpdateError(displayName),
+          );
+        },
+      },
+    );
+  }
+
+  function handleGatewayToggle(next: boolean) {
+    // Single-source harnesses hold at most one enabled source: turning the
+    // gateway on turns every api-key row off (radio semantics via switches).
+    const nextRows =
+      next && !multiSource ? rows.map((row) => ({ ...row, enabled: false })) : rows;
+    commit({ gatewayEnabled: next, rows: nextRows });
+  }
+
+  function handleRowEnabledToggle(uid: string, next: boolean) {
+    const nextRows = rows.map((row) => {
+      if (row.uid === uid) {
+        return { ...row, enabled: next };
+      }
+      return next && !multiSource ? { ...row, enabled: false } : row;
+    });
+    const nextGateway = next && !multiSource ? false : gatewayEnabled;
+    commit({ gatewayEnabled: nextGateway, rows: nextRows });
+  }
+
+  function handleRowKeySelect(uid: string, keyId: string) {
+    commit({
+      gatewayEnabled,
+      rows: rows.map((row) => (row.uid === uid ? { ...row, apiKeyId: keyId } : row)),
+    });
+  }
+
+  function handleRowEnvVarChange(uid: string, envVarName: string) {
+    // Free-form editing stays local; the PUT lands on blur (or another action).
+    setRows((current) =>
+      current.map((row) => (row.uid === uid ? { ...row, envVarName } : row)),
+    );
+  }
+
+  function handleRowEnvVarBlur() {
+    commit(editorState);
+  }
+
+  function handleRemoveRow(uid: string) {
+    commit({ gatewayEnabled, rows: rows.filter((row) => row.uid !== uid) });
+  }
+
+  function addRow(envVarName: string, providerHint: string | null) {
+    draftCounterRef.current += 1;
+    const newRow: EditableApiKeyRow = {
+      uid: `draft-${draftCounterRef.current}`,
+      envVarName,
+      apiKeyId: null,
+      providerHint,
+      enabled: false,
+    };
+    // New rows are incomplete (no key yet) so nothing is PUT until wired.
+    setRows((current) => [...current, newRow]);
+  }
+
+  function handleAddVariable() {
+    const used = new Set(rows.map((row) => row.envVarName));
+    const suggestion = getHarnessEnvVarSuggestions(harnessKind).find(
+      (candidate) => !used.has(candidate.envVarName),
+    );
+    addRow(suggestion?.envVarName ?? "", suggestion?.providerHint ?? null);
+  }
+
+  return {
+    cloudActive,
+    capabilitiesQuery,
+    enrollmentQuery,
+    selectionsQuery,
+    apiKeysQuery,
+    gatewayLocked,
+    multiSource,
+    busy,
+    editorState,
+    native,
+    localAgent,
+    loginSession,
+    loginWorkflow,
+    commit,
+    handleGatewayToggle,
+    handleRowEnabledToggle,
+    handleRowKeySelect,
+    handleRowEnvVarChange,
+    handleRowEnvVarBlur,
+    handleRemoveRow,
+    addRow,
+    handleAddVariable,
+  };
+}

--- a/apps/desktop/src/copy/settings/harness-pane.ts
+++ b/apps/desktop/src/copy/settings/harness-pane.ts
@@ -21,6 +21,8 @@ export const HARNESS_PANE_COPY = {
   allModelsRefreshing: "Refreshing...",
   allModelsEmpty: "No models in the catalog for this surface yet.",
   allModelsLoading: "Loading model catalog...",
+  // Shown while an empty catalog auto-probes the runtime for models.
+  allModelsProbing: "Probing…",
   // Runtime-resolved gateway models (contract §5): freshness reads "seed" (the
   // catalog's fallback list, no probe yet) or "probed <time>" (a live probe).
   allModelsFreshnessSeed: "seed",

--- a/apps/desktop/src/copy/settings/harness-pane.ts
+++ b/apps/desktop/src/copy/settings/harness-pane.ts
@@ -1,8 +1,6 @@
 export const HARNESS_PANE_COPY = {
   surfaceCloud: "Cloud",
   surfaceLocal: "Local",
-  tabAuthentication: "Authentication",
-  tabAllModels: "All Models",
   authenticationTitle: "Authentication",
   signInTitle: "Authentication",
   gatewayLabel: "Proliferate gateway",
@@ -17,6 +15,8 @@ export const HARNESS_PANE_COPY = {
   harnessSettingsPlaceholderLabel: "Harness-specific settings",
   harnessSettingsPlaceholderDescription:
     "Options unique to this harness will appear here.",
+  // Section title for the inline all-models panel.
+  tabAllModels: "All Models",
   allModelsRefresh: "Refresh",
   allModelsRefreshing: "Refreshing...",
   allModelsEmpty: "No models in the catalog for this surface yet.",
@@ -27,6 +27,17 @@ export const HARNESS_PANE_COPY = {
   allModelsFreshnessProbed: (time: string) => `probed ${time}`,
   getApiKey: "Get an API key",
   recommendedBadge: "Recommended",
+  // Method card labels.
+  methodGateway: "Proliferate gateway",
+  methodApiKey: "API key",
+  methodCli: "CLI login",
+  // Detail section titles.
+  detailsGateway: "Gateway",
+  detailsApiKey: "API keys",
+  detailsCli: "CLI login",
+  // CLI detail status.
+  cliNotAuthenticated: "CLI not authenticated",
+  cliAuthenticated: "Authenticated",
   // Native == the implicit empty state (contract §7): zero enabled sources.
   nativeStateLocal: "No auth configured — the CLI's own login is used.",
   nativeStateCloud: "No auth configured — cloud runs stay disabled for this harness.",

--- a/apps/desktop/src/lib/domain/settings/harness-auth-sources.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-auth-sources.ts
@@ -4,6 +4,11 @@ import type {
   AgentAuthSurface,
 } from "@proliferate/cloud-sdk";
 
+// The three auth methods a harness surface can use. Single-source harnesses
+// hold exactly one (radio); multi-source (opencode) may combine gateway +
+// api_key.
+export type AuthMethod = "gateway" | "api_key" | "cli";
+
 // Mirror of the server env-var shape (selection_rules.py ENV_VAR_NAME_RE) so the
 // UI can gate the enabled switch and reject a bad name before the PUT round-trip.
 const ENV_VAR_NAME_RE = /^[A-Z][A-Z0-9_]{0,127}$/;

--- a/apps/packages/product-ui/src/settings/ModelTable.tsx
+++ b/apps/packages/product-ui/src/settings/ModelTable.tsx
@@ -36,16 +36,16 @@ export interface ModelTableProps {
 }
 
 // Header/body cell classes mirror the design-system `.ds-mct` treatment
-// (Design System Preview.html) translated onto product-ui tokens: 11px faint
-// header on `accent`, 12px hairline-divided body rows (matching the 12px page
-// body), first row un-bordered.
+// (Design System Preview.html) translated onto product-ui tokens: 10px faint
+// header on `accent`, 11px hairline-divided body rows (dense reference table),
+// first row un-bordered.
 const TH_CLASS =
-  "border-b border-border bg-accent px-3 py-2 text-left text-[11px] font-medium whitespace-nowrap text-faint";
+  "border-b border-border bg-accent px-3 py-1.5 text-left text-[10px] font-medium whitespace-nowrap text-faint";
 const TD_CLASS =
-  "border-t border-border px-3 py-2 align-top text-[12px] whitespace-nowrap";
+  "border-t border-border px-3 py-1.5 align-top text-[11px] whitespace-nowrap";
 
 function Dash() {
-  return <span className="text-[12px] text-faint">—</span>;
+  return <span className="text-[11px] text-faint">—</span>;
 }
 
 function EffortChips({ effort }: { effort?: ModelTableEffort | null }) {
@@ -61,7 +61,7 @@ function EffortChips({ effort }: { effort?: ModelTableEffort | null }) {
             key={value}
             data-default={isDefault ? "true" : undefined}
             className={twMerge(
-              "whitespace-nowrap rounded-[5px] border px-1.5 py-px text-[11px]",
+              "whitespace-nowrap rounded-[5px] border px-1 py-px text-[10px]",
               isDefault
                 ? "border-border bg-accent font-medium text-foreground"
                 : "border-border text-muted-foreground",
@@ -106,13 +106,13 @@ function ModesPills({ modes }: { modes?: readonly string[] | null }) {
       {visible.map((mode) => (
         <span
           key={mode}
-          className="whitespace-nowrap rounded-[5px] border border-border px-1.5 py-px text-[11px] text-muted-foreground"
+          className="whitespace-nowrap rounded-[5px] border border-border px-1 py-px text-[10px] text-muted-foreground"
         >
           {mode}
         </span>
       ))}
       {overflowCount > 0 ? (
-        <span className="whitespace-nowrap rounded-[5px] border border-border px-1.5 py-px text-[11px] text-muted-foreground">
+        <span className="whitespace-nowrap rounded-[5px] border border-border px-1 py-px text-[10px] text-muted-foreground">
           +{overflowCount}
         </span>
       ) : null}
@@ -164,17 +164,17 @@ export function ModelTable({ models, onToggle, className }: ModelTableProps) {
               >
                 <td className={twMerge(TD_CLASS, "max-w-[260px]")}>
                   <div
-                    className="truncate font-medium text-foreground"
+                    className="truncate text-[12px] font-medium text-foreground"
                     title={hasDescription ? model.id : undefined}
                   >
                     {model.displayName}
                   </div>
                   {hasDescription ? (
-                    <div className="mt-[3px] truncate text-[11px] leading-[1.4] text-muted-foreground">
+                    <div className="mt-[3px] truncate text-[10px] leading-[1.4] text-muted-foreground">
                       {model.description}
                     </div>
                   ) : showId ? (
-                    <div className="mt-[3px] truncate font-mono text-[11px] text-faint">
+                    <div className="mt-[3px] truncate font-mono text-[10px] text-faint">
                       {model.id}
                     </div>
                   ) : null}

--- a/apps/packages/product-ui/src/settings/ModelTable.tsx
+++ b/apps/packages/product-ui/src/settings/ModelTable.tsx
@@ -37,11 +37,12 @@ export interface ModelTableProps {
 
 // Header/body cell classes mirror the design-system `.ds-mct` treatment
 // (Design System Preview.html) translated onto product-ui tokens: 11px faint
-// header on `accent`, 13px hairline-divided body rows, first row un-bordered.
+// header on `accent`, 12px hairline-divided body rows (matching the 12px page
+// body), first row un-bordered.
 const TH_CLASS =
   "border-b border-border bg-accent px-3 py-2 text-left text-[11px] font-medium whitespace-nowrap text-faint";
 const TD_CLASS =
-  "border-t border-border px-3 py-[11px] align-top text-[13px] whitespace-nowrap";
+  "border-t border-border px-3 py-2 align-top text-[12px] whitespace-nowrap";
 
 function Dash() {
   return <span className="text-[12px] text-faint">—</span>;
@@ -169,11 +170,11 @@ export function ModelTable({ models, onToggle, className }: ModelTableProps) {
                     {model.displayName}
                   </div>
                   {hasDescription ? (
-                    <div className="mt-[3px] truncate text-[12px] leading-[1.4] text-muted-foreground">
+                    <div className="mt-[3px] truncate text-[11px] leading-[1.4] text-muted-foreground">
                       {model.description}
                     </div>
                   ) : showId ? (
-                    <div className="mt-[3px] truncate font-mono text-[12px] text-faint">
+                    <div className="mt-[3px] truncate font-mono text-[11px] text-faint">
                       {model.id}
                     </div>
                   ) : null}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/sdk/src/reducer/transcript.ts 1591 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 622 existing desktop diff viewer component
 apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
-apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 661 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3) + method-card UX fixtures
+apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 683 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3) + method-card UX fixtures
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/sdk/src/reducer/transcript.ts 1591 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 622 existing desktop diff viewer component
 apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
-apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 625 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3)
+apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 661 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3) + method-card UX fixtures
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file


### PR DESCRIPTION
## Summary
- Extract harness auth editor state into a shared hook (`use-harness-auth-editor.ts`)
- Replace Authentication/All Models tabs with a single-scroll layout
- Rewrite `HarnessAuthSection` as a 3-card method picker (Proliferate gateway, API key, CLI login)
- Add `HarnessAuthDetailsSection` rendering contextual details per selected method
- All Models section now renders inline without tab navigation

## Test plan
- [x] Desktop typecheck passes (no new errors in changed files)
- [x] All 20 existing HarnessPane tests pass after updating for new card-based UI
- [ ] Manual: verify card selection triggers correct PUT payloads
- [ ] Manual: verify opencode multi-select card behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)