### PR TITLE
feat: opencode native auth coexists with gateway/api-key sources

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/materialize.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/materialize.rs
@@ -43,8 +43,10 @@ const CLAUDE_CONFIG_DIR_NAME: &str = "claude-config";
 const CODEX_CONFIG_FILE_NAME: &str = "config.toml";
 pub(super) const OPENCODE_CONFIG_FILE_NAME: &str = "opencode.json";
 
-/// Isolated XDG subdir names materialized beside the opencode config; the
-/// render layer points XDG_CONFIG_HOME/XDG_DATA_HOME at these.
+/// Isolated XDG subdir names materialized beside the opencode config.
+/// XDG_CONFIG_HOME is pointed here (isolated provider config); XDG_DATA_HOME is
+/// left ambient (native auth coexistence). The xdg-data dir is still created
+/// for forward-compat but no env var points at it.
 pub(super) const OPENCODE_XDG_CONFIG_SUBDIR: &str = "xdg-config";
 pub(super) const OPENCODE_XDG_DATA_SUBDIR: &str = "xdg-data";
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render.rs
@@ -280,15 +280,17 @@ fn render_opencode_gateway(
         materialize::OPENCODE_CONFIG_PREFIX,
         revision,
     );
-    // Isolate XDG so opencode cannot reach the user's global config/auth
-    // (HARNESS-MATRIX opencode recipe: XDG_CONFIG_HOME/XDG_DATA_HOME isolated).
+    // Isolate XDG_CONFIG_HOME so opencode reads OUR injected provider config
+    // (revision-keyed, deterministic) rather than the user's global
+    // ~/.config/opencode. XDG_DATA_HOME is intentionally LEFT AMBIENT so that
+    // opencode resolves auth at the real ~/.local/share/opencode/auth.json —
+    // this lets natively-logged-in providers (via `opencode auth login`)
+    // coexist with the injected proliferate provider and any api_key env
+    // sources. The config-layer merge design ("ADDS it to the user's own
+    // providers") only works when the auth file is reachable.
     rendered.set(
         "XDG_CONFIG_HOME",
         path_string(&config_dir.join(materialize::OPENCODE_XDG_CONFIG_SUBDIR)),
-    );
-    rendered.set(
-        "XDG_DATA_HOME",
-        path_string(&config_dir.join(materialize::OPENCODE_XDG_DATA_SUBDIR)),
     );
     rendered.set(
         "OPENCODE_CONFIG",

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -247,16 +247,20 @@ fn opencode_gateway_writes_config_with_static_models() {
     let providers: Vec<&String> = config["provider"].as_object().unwrap().keys().collect();
     assert_eq!(providers, vec!["proliferate"]);
 
-    // XDG isolation: opencode must not reach the user's global config/auth.
+    // XDG_CONFIG_HOME is isolated (our injected provider config stays
+    // revision-keyed and deterministic). XDG_DATA_HOME is NOT overridden —
+    // opencode resolves auth at the real ~/.local/share/opencode/auth.json so
+    // natively-logged-in providers coexist with the gateway provider.
     let xdg_config = rendered
         .set
         .get("XDG_CONFIG_HOME")
         .expect("XDG_CONFIG_HOME");
-    let xdg_data = rendered.set.get("XDG_DATA_HOME").expect("XDG_DATA_HOME");
     assert!(std::path::Path::new(xdg_config).is_dir());
-    assert!(std::path::Path::new(xdg_data).is_dir());
     assert!(xdg_config.contains("opencode-config"));
-    assert!(xdg_data.contains("opencode-config"));
+    assert!(
+        !rendered.set.contains_key("XDG_DATA_HOME"),
+        "XDG_DATA_HOME must NOT be overridden — native auth coexistence"
+    );
 }
 
 #[test]

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx
@@ -6,28 +6,58 @@ import { AgentLoginTerminalPanel } from "@/components/agents/AgentLoginTerminalP
 import { gatewaySubtitle } from "@/copy/settings/agent-auth-copy";
 import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
 import { isReadyAgent } from "@/lib/domain/agents/status";
+import {
+  isMultiSourceHarness,
+  type AuthMethod,
+} from "@/lib/domain/settings/harness-auth-sources";
 import { HarnessPanelBlock, type HarnessBlockVariant } from "./HarnessPanelBlock";
 import { HarnessAuthApiKeyRow } from "./HarnessAuthApiKeyRow";
+import { isMultiSourceApiKeyConfigVisible } from "./HarnessAuthSection";
 import { ProviderPickerModal } from "./ProviderPickerModal";
 import type { HarnessAuthEditorApi } from "./use-harness-auth-editor";
 
-type AuthMethod = "gateway" | "api_key" | "cli";
-
 interface HarnessAuthDetailsSectionProps {
+  harnessKind: string;
   displayName: string;
   surface: AgentAuthSurface;
+  // Single-source harnesses pass the resolved radio method; multi-source
+  // harnesses ignore it and render the union of active/config blocks.
   selectedMethod: AuthMethod;
   editor: HarnessAuthEditorApi;
   variant?: HarnessBlockVariant;
 }
 
 export function HarnessAuthDetailsSection({
+  harnessKind,
   displayName,
   surface,
   selectedMethod,
   editor,
   variant = "section",
 }: HarnessAuthDetailsSectionProps) {
+  // Multi-source (opencode): gateway, api_key, and native CLI can all be active
+  // at once, so the details area is not a single-method switch. Render the
+  // gateway block when gateway is on, the api_key block whenever there are rows
+  // present or a key is being configured, and always the CLI/native block
+  // (opencode's own providers always coexist).
+  if (isMultiSourceHarness(harnessKind)) {
+    return (
+      <>
+        {editor.editorState.gatewayEnabled ? (
+          <GatewayDetails editor={editor} variant={variant} />
+        ) : null}
+        {isMultiSourceApiKeyConfigVisible(editor) ? (
+          <ApiKeyDetails
+            displayName={displayName}
+            editor={editor}
+            variant={variant}
+          />
+        ) : null}
+        <CliDetails surface={surface} editor={editor} variant={variant} />
+      </>
+    );
+  }
+
   if (selectedMethod === "gateway") {
     return <GatewayDetails editor={editor} variant={variant} />;
   }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -41,12 +41,36 @@ export function deriveSelectedMethod(editor: HarnessAuthEditorApi): AuthMethod {
  * opencode's native providers coexist with injected sources — the render plane
  * no longer isolates XDG_DATA_HOME, so `opencode auth login` providers are
  * always reachable alongside gateway/api_key sources.
+ *
+ * api_key lights when a row is enabled (a wired key is truly active) OR while
+ * the user is mid-configuration (pendingMethod === "api_key"): clicking the
+ * card seeds a draft row that is not yet enabled, so a plain rows.some(enabled)
+ * check would leave the card dark and the deadlock in place. Turning api_key
+ * off clears pendingMethod, so "off" darkens the card even though disabled rows
+ * linger for re-enabling.
  */
 export function deriveSelectedMethods(editor: HarnessAuthEditorApi): Set<AuthMethod> {
   const methods = new Set<AuthMethod>(["cli"]);
   if (editor.editorState.gatewayEnabled) methods.add("gateway");
-  if (editor.editorState.rows.some((row) => row.enabled)) methods.add("api_key");
+  if (isMultiSourceApiKeyActive(editor)) methods.add("api_key");
   return methods;
+}
+
+/** api_key is "on or being configured" for a multi-source harness. */
+export function isMultiSourceApiKeyActive(editor: HarnessAuthEditorApi): boolean {
+  return (
+    editor.editorState.rows.some((row) => row.enabled)
+    || editor.pendingMethod === "api_key"
+  );
+}
+
+/**
+ * Whether the api_key row editor should be surfaced for a multi-source harness.
+ * Broader than the highlight: any row present (draft OR persisted-but-disabled)
+ * or a pending click keeps the editor open so the user can wire/re-enable keys.
+ */
+export function isMultiSourceApiKeyConfigVisible(editor: HarnessAuthEditorApi): boolean {
+  return editor.editorState.rows.length > 0 || editor.pendingMethod === "api_key";
 }
 
 const CURSOR_HARNESS = "cursor";
@@ -212,14 +236,23 @@ function handleMultiSourceSelect(method: AuthMethod, editor: HarnessAuthEditorAp
       editor.handleGatewayToggle(!editor.editorState.gatewayEnabled);
       break;
     case "api_key": {
-      const hasEnabled = editor.editorState.rows.some((row) => row.enabled);
-      if (hasEnabled) {
-        // Toggle off all api key rows.
+      if (isMultiSourceApiKeyActive(editor)) {
+        // Toggle OFF: disable every row, but keep the ones that carry a wired
+        // key (apiKeyId != null) so the user can re-enable them; drop bare draft
+        // rows so nothing lingers. Clearing pendingMethod darkens the card, so
+        // "off" reads as off even though wired-but-disabled rows remain.
         editor.commit({
           gatewayEnabled: editor.editorState.gatewayEnabled,
-          rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
+          rows: editor.editorState.rows
+            .filter((row) => row.apiKeyId !== null)
+            .map((row) => ({ ...row, enabled: false })),
         });
+        editor.setPendingMethod(null);
       } else {
+        // Toggle ON: enable the first wired row if one exists, otherwise seed a
+        // draft row so the row editor appears. Mark api_key pending so the card
+        // lights immediately even before a key is wired (presence of a draft row
+        // is the deadlock-free signal, but pending keeps the highlight honest).
         const firstComplete = editor.editorState.rows.find(
           (row) => row.apiKeyId !== null,
         );
@@ -228,6 +261,7 @@ function handleMultiSourceSelect(method: AuthMethod, editor: HarnessAuthEditorAp
         } else if (editor.editorState.rows.length === 0) {
           editor.handleAddVariable();
         }
+        editor.setPendingMethod("api_key");
       }
       break;
     }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -37,14 +37,15 @@ export function deriveSelectedMethod(editor: HarnessAuthEditorApi): AuthMethod {
 
 /**
  * Multi-source selection (opencode only): gateway and api_key are independent
- * toggles and may both be selected on purpose. CLI is shown only when neither is
- * on.
+ * toggles that may both be active. CLI (native auth) is ALWAYS selected because
+ * opencode's native providers coexist with injected sources — the render plane
+ * no longer isolates XDG_DATA_HOME, so `opencode auth login` providers are
+ * always reachable alongside gateway/api_key sources.
  */
 export function deriveSelectedMethods(editor: HarnessAuthEditorApi): Set<AuthMethod> {
-  const methods = new Set<AuthMethod>();
+  const methods = new Set<AuthMethod>(["cli"]);
   if (editor.editorState.gatewayEnabled) methods.add("gateway");
   if (editor.editorState.rows.some((row) => row.enabled)) methods.add("api_key");
-  if (methods.size === 0) methods.add("cli");
   return methods;
 }
 
@@ -154,7 +155,8 @@ function HarnessAuthMethods({
           label={HARNESS_PANE_COPY.methodCli}
           icon={<SquareTerminal className="size-5" />}
           selected={selectedMethods.has("cli")}
-          disabled={editor.busy}
+          disabled={multiSource || editor.busy}
+          disabledReason={multiSource ? HARNESS_PANE_COPY.cliAlwaysActive : undefined}
           onClick={() => selectMethod("cli")}
         />
       </div>
@@ -230,11 +232,9 @@ function handleMultiSourceSelect(method: AuthMethod, editor: HarnessAuthEditorAp
       break;
     }
     case "cli":
-      // Clicking CLI in multi-source disables everything.
-      editor.commit({
-        gatewayEnabled: false,
-        rows: editor.editorState.rows.map((row) => ({ ...row, enabled: false })),
-      });
+      // No-op: native auth always participates for multi-source harnesses
+      // (opencode's own providers coexist with gateway/api_key sources).
+      // The CLI card is permanently selected and not a toggle.
       break;
   }
 }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -426,6 +426,34 @@ describe("HarnessPane authentication", () => {
     expect(screen.queryByRole("button", { name: /Add provider/ })).toBeNull();
   });
 
+  it("always shows CLI as selected for multi-source (opencode) even with gateway on", () => {
+    state.selections.data = [{
+      id: "sel-gw",
+      harnessKind: "opencode",
+      surface: "local",
+      sourceKind: "gateway",
+      apiKeyId: null,
+      keyTitle: null,
+      envVarName: null,
+      providerHint: null,
+      enabled: true,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }];
+    renderPane("opencode");
+
+    const cli = screen.getByRole("button", { name: "CLI login" });
+    const gateway = screen.getByRole("button", { name: "Proliferate gateway" });
+
+    // CLI is always selected for multi-source harnesses (native coexistence).
+    expect(cli.getAttribute("aria-pressed")).toBe("true");
+    expect(gateway.getAttribute("aria-pressed")).toBe("true");
+
+    // CLI card is disabled (not a toggle) and shows the coexistence hint.
+    expect((cli as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByText("Native logins always apply alongside other sources.")).not.toBeNull();
+  });
+
   it("prefills a new row from the opencode provider picker", () => {
     // Seed an api_key selection so the API key detail section is visible.
     state.selections.data = [{

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -454,6 +454,124 @@ describe("HarnessPane authentication", () => {
     expect(screen.queryByText("Native logins always apply alongside other sources.")).not.toBeNull();
   });
 
+  it("opencode: clicking API key surfaces the row editor and reflects the in-progress state", () => {
+    renderPane("opencode");
+
+    const apiKey = () => screen.getByRole("button", { name: "API key" });
+    // Before the click there is no api_key detail block: no row editor and no
+    // multi-source-only "Add provider" affordance.
+    expect(apiKey().getAttribute("aria-pressed")).toBe("false");
+    expect(screen.queryByRole("button", { name: /Add provider/ })).toBeNull();
+    expect(screen.queryByLabelText("Environment variable name")).toBeNull();
+
+    fireEvent.click(apiKey());
+
+    // The card lights immediately (pending), even before a key is wired, and the
+    // api_key details block is now visible — this is the deadlock the fix closes.
+    expect(apiKey().getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByLabelText("Environment variable name")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Add provider/ })).toBeTruthy();
+    // Seeding a draft row wires nothing, so nothing is PUT yet.
+    expect(putMutate).not.toHaveBeenCalled();
+
+    // CLI stays always-selected and disabled (native coexistence) throughout.
+    const cli = screen.getByRole("button", { name: "CLI login" }) as HTMLButtonElement;
+    expect(cli.getAttribute("aria-pressed")).toBe("true");
+    expect(cli.disabled).toBe(true);
+  });
+
+  it("opencode: toggling API key off darkens the card and collapses the bare draft", () => {
+    renderPane("opencode");
+
+    const apiKey = () => screen.getByRole("button", { name: "API key" });
+
+    fireEvent.click(apiKey());
+    expect(apiKey().getAttribute("aria-pressed")).toBe("true");
+    expect(screen.queryByRole("button", { name: /Add provider/ })).not.toBeNull();
+
+    // Clicking again turns api_key off: the bare draft (no wired key) is dropped
+    // and the highlight clears, so "off" visibly means off.
+    fireEvent.click(apiKey());
+    expect(apiKey().getAttribute("aria-pressed")).toBe("false");
+    expect(screen.queryByRole("button", { name: /Add provider/ })).toBeNull();
+    expect(screen.queryByLabelText("Environment variable name")).toBeNull();
+  });
+
+  it("opencode: enabling a wired api key lights it alongside the gateway", () => {
+    state.apiKeys.data = [{
+      id: "key-1",
+      title: "Work key",
+      redactedHint: "sk-...abcd",
+      status: "active",
+      createdAt: "2026-07-01T00:00:00Z",
+    }];
+    // Gateway on + a wired-but-disabled api_key row: the api_key editor is
+    // visible (rows present) but the card stays dark until a row is enabled.
+    state.selections.data = [
+      {
+        id: "sel-gw",
+        harnessKind: "opencode",
+        surface: "local",
+        sourceKind: "gateway",
+        apiKeyId: null,
+        keyTitle: null,
+        envVarName: null,
+        providerHint: null,
+        enabled: true,
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-01T00:00:00Z",
+      },
+      {
+        id: "sel-key",
+        harnessKind: "opencode",
+        surface: "local",
+        sourceKind: "api_key",
+        apiKeyId: "key-1",
+        keyTitle: "Work key",
+        envVarName: "OPENROUTER_API_KEY",
+        providerHint: "openrouter",
+        enabled: false,
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-01T00:00:00Z",
+      },
+    ];
+    renderPane("opencode");
+
+    const apiKey = () => screen.getByRole("button", { name: "API key" });
+    expect(screen.getByDisplayValue("OPENROUTER_API_KEY")).toBeTruthy();
+    expect(apiKey().getAttribute("aria-pressed")).toBe("false");
+    expect(gatewayCard().getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("switch", { name: "Enable OPENROUTER_API_KEY" }));
+
+    // The api_key card lights and the gateway stays on — both coexist.
+    expect(apiKey().getAttribute("aria-pressed")).toBe("true");
+    expect(gatewayCard().getAttribute("aria-pressed")).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "CLI login" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    expect(putMutate).toHaveBeenLastCalledWith(
+      {
+        harnessKind: "opencode",
+        surface: "local",
+        body: {
+          sources: [
+            { sourceKind: "gateway", enabled: true },
+            {
+              sourceKind: "api_key",
+              apiKeyId: "key-1",
+              envVarName: "OPENROUTER_API_KEY",
+              providerHint: "openrouter",
+              enabled: true,
+            },
+          ],
+        },
+      },
+      expect.anything(),
+    );
+  });
+
   it("prefills a new row from the opencode provider picker", () => {
     // Seed an api_key selection so the API key detail section is visible.
     state.selections.data = [{

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
@@ -76,6 +76,7 @@ function HarnessSurfaceCloud({
         />
 
         <HarnessAuthDetailsSection
+          harnessKind={harnessKind}
           displayName={displayName}
           surface="cloud"
           selectedMethod={selectedMethod}
@@ -117,6 +118,7 @@ function HarnessSurfaceLocal({
         />
 
         <HarnessAuthDetailsSection
+          harnessKind={harnessKind}
           displayName={displayName}
           surface="local"
           selectedMethod={selectedMethod}

--- a/apps/desktop/src/copy/settings/harness-pane.ts
+++ b/apps/desktop/src/copy/settings/harness-pane.ts
@@ -54,6 +54,7 @@ export const HARNESS_PANE_COPY = {
   // Native == the implicit empty state (contract §7): zero enabled sources.
   nativeStateLocal: "No auth configured — the CLI's own login is used.",
   nativeStateCloud: "No auth configured — cloud runs stay disabled for this harness.",
+  cliAlwaysActive: "Native logins always apply alongside other sources.",
   cursorNativeDescription: (displayName: string) =>
     `${displayName} authenticates with its own sign-in. There is nothing to configure here.`,
   signInDescription: (displayName: string) =>

--- a/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
+++ b/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
@@ -93,7 +93,7 @@ Recipe:
 - **UPDATED (2026-07-03 re-verification):** with a valid OPENAI_API_KEY, gpt-5-mini/gpt-5.2 now fail with a *different*, external error — `404 ... organization must be verified` — not a key problem. The cross-provider path (claude-haiku-4-5-20251001, tested here for both plain completion and a shell tool call) remains the verified, supported route; native gpt-5-family stays blocked-external pending OpenAI org verification (out of scope to fix).
 
 ## opencode — WORKS
-Recipe (opencode.json in workdir; XDG_CONFIG_HOME/XDG_DATA_HOME isolated):
+Recipe (opencode.json in workdir; XDG_CONFIG_HOME isolated, XDG_DATA_HOME ambient for native auth coexistence):
   {"provider":{"proliferate":{"npm":"@ai-sdk/openai-compatible","options":{"baseURL":"http://<proxy>/v1","apiKey":"{env:PROLIFERATE_GATEWAY_KEY}"},"models":{"claude-haiku-4-5-20251001":{}}}}}
   opencode run -m proliferate/claude-haiku-4-5-20251001 "..."
 - Endpoint: POST /v1/chat/completions 200. Explicit models map REQUIRED (confirms spec).

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/sdk/src/reducer/transcript.ts 1591 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 622 existing desktop diff viewer component
 apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
-apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 690 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3) + method-card UX fixtures + CloudGuard availability mock for the cloud-surface auth gate
+apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 836 P3 runtime catalog extends All-Models coverage for the local+gateway runtime-resolved model plan (contract §5) + enriched gateway model row fixtures (model-table §3) + method-card UX fixtures + CloudGuard availability mock + opencode native/gateway/api-key coexistence fixtures
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file


### PR DESCRIPTION
## Summary

- **Rust**: Stop overriding `XDG_DATA_HOME` in `render_opencode_gateway` so spawned opencode resolves auth at the real `~/.local/share/opencode/auth.json`. Natively-logged-in providers now coexist with the injected proliferate gateway provider and any `api_key` env sources. `XDG_CONFIG_HOME` remains isolated (revision-keyed deterministic config).
- **UI**: For multi-source harnesses (opencode), the CLI card is always selected (native always participates) and disabled as a toggle, with a "Native logins always apply alongside other sources" hint. `deriveSelectedMethods` always includes `"cli"`. Clicking CLI in multi-source is a no-op rather than a kill-switch.
- **Docs**: Updated HARNESS-MATRIX.md opencode recipe.

## Sanitize analysis

No ambient env leaks: `OPENCODE_CONFIG` is explicitly set by the render plane (overrides any ambient value). The only thing now ambient is `XDG_DATA_HOME` which opencode uses solely for its auth.json — this is the desired coexistence behavior. No credentials leak from the auth file into the gateway path; opencode's own provider-resolution logic handles the merge.

## Test plan

- [x] `cargo test -p anyharness-lib route_auth` — 50 tests pass (XDG_DATA_HOME absence asserted)
- [x] `pnpm exec tsc --noEmit` — no new errors (only pre-existing unrelated `any` noise)
- [x] `vitest run HarnessPane.test.tsx` — 22 tests pass (new test: CLI always selected for opencode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)