### PR TITLE
feat: catalog-driven per-harness settings — Claude Chrome toggle (--chrome)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
@@ -4,6 +4,7 @@ pub mod gateway_resolver;
 pub mod loader;
 pub mod schema;
 pub mod service;
+pub mod settings;
 pub mod sync;
 pub mod validation;
 pub mod validation_pairing;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -51,6 +51,10 @@ pub struct AgentCatalogAgent {
     #[serde(default)]
     pub auth_contexts: Vec<AgentCatalogAuthContext>,
     pub session: AgentCatalogSession,
+    /// Per-harness advanced settings (v1: boolean toggles mapped to CLI flags or
+    /// env vars). Absent when a harness declares no settings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<AgentCatalogSetting>,
     pub provenance: AgentCatalogAgentProvenance,
 }
 
@@ -364,6 +368,41 @@ pub struct AgentCatalogProbeRun {
     pub snapshot_path: Option<String>,
 }
 
+/// A declared per-harness setting (v1: boolean toggles). Applied at spawn
+/// according to the mapping kind: `cli_flag` appends the flag to argv when
+/// the value is `true`; `env` sets an env var to the string form of the value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogSetting {
+    pub key: String,
+    /// v1: only `"boolean"` is supported.
+    #[serde(rename = "type")]
+    pub setting_type: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// The default value for this setting (JSON-typed: bool for boolean settings).
+    #[serde(default)]
+    pub default: serde_json::Value,
+    /// Which delivery surfaces this setting is relevant to (subset of `{local, cloud}`).
+    #[serde(default)]
+    pub surfaces: Vec<String>,
+    pub mapping: AgentCatalogSettingMapping,
+}
+
+/// How a setting value maps to the harness spawn. Externally tagged by `kind`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogSettingMapping {
+    pub kind: String,
+    /// For `cli_flag`: the flag to append (e.g. `"--chrome"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flag: Option<String>,
+    /// For `env`: the env var name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+}
+
 #[cfg(test)]
 pub(crate) fn draft_catalog_json() -> &'static str {
     include_str!(concat!(
@@ -373,214 +412,5 @@ pub(crate) fn draft_catalog_json() -> &'static str {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse_draft() -> AgentCatalogDocument {
-        serde_json::from_str(draft_catalog_json()).expect("draft catalog must parse")
-    }
-
-    #[test]
-    fn draft_catalog_parses_with_expected_shape() {
-        let catalog = parse_draft();
-
-        assert_eq!(catalog.schema_version, 2);
-        assert_eq!(catalog.catalog_version, draft_catalog_version().as_str());
-        let probed_against = catalog.probed_against.as_ref().expect("probedAgainst");
-        assert_eq!(
-            probed_against.registry_version.as_deref(),
-            Some(bundled_registry_version().as_str())
-        );
-        assert_eq!(catalog.agents.len(), 5);
-
-        let claude = &catalog.agents[0];
-        assert_eq!(claude.kind, "claude");
-        assert_eq!(claude.harness.agent_process.version, "0.44.0");
-        assert_eq!(
-            claude
-                .harness
-                .native
-                .as_ref()
-                .map(|pin| pin.version.as_str()),
-            Some("2.1.181")
-        );
-        assert_eq!(
-            claude
-                .auth_contexts
-                .iter()
-                .map(|context| context.id.as_str())
-                .collect::<Vec<_>>(),
-            vec!["bedrock", "anthropic-api", "anthropic-oauth", "gateway"]
-        );
-        // The gateway context is route-engaged: it references the registry
-        // gateway slot but carries no detection signals (never classifier-active).
-        let gateway_context = claude
-            .auth_contexts
-            .iter()
-            .find(|context| context.id == "gateway")
-            .expect("claude gateway auth context");
-        assert_eq!(gateway_context.auth_slot_id.as_deref(), Some("gateway"));
-        assert!(gateway_context.signals.is_none());
-        // gatewayPolicy carries the small-fast role pin that used to be a Rust const.
-        let policy = claude
-            .session
-            .gateway_policy
-            .as_ref()
-            .expect("claude gatewayPolicy");
-        assert_eq!(policy.providers, vec!["anthropic"]);
-        assert_eq!(
-            policy.roles.get("small_fast").map(String::as_str),
-            Some("claude-haiku-4-5-20251001")
-        );
-        let first = &claude.session.models[0];
-        assert_eq!(first.id, "default");
-        assert_eq!(
-            first.availability.any_of,
-            vec!["anthropic-api", "anthropic-oauth", "bedrock"]
-        );
-        assert!(first.default_visible);
-        let effort = first.controls.get("effort").expect("effort control");
-        assert_eq!(
-            effort.values,
-            vec!["default", "low", "medium", "high", "xhigh", "max"]
-        );
-        assert_eq!(effort.observed_value.as_deref(), Some("default"));
-        assert_eq!(effort.default, None);
-
-        let codex = &catalog.agents[1];
-        let model_control = codex
-            .session
-            .controls
-            .iter()
-            .find(|control| control.key == "model")
-            .expect("model control");
-        let mapping = model_control.mapping.as_ref().expect("model mapping");
-        assert_eq!(mapping.switch_via.as_deref(), Some("configOption"));
-        assert_eq!(mapping.variant_syntax.as_deref(), None);
-
-        let cursor = &catalog.agents[2];
-        assert!(cursor.provenance.attestation.is_none());
-        assert!(cursor.harness.native.is_none());
-        // Cursor is the variant-carrying agent: its model control declares the
-        // bracket-params syntax and its models carry probe-observed variant ids.
-        let cursor_model_control = cursor
-            .session
-            .controls
-            .iter()
-            .find(|control| control.key == "model")
-            .expect("cursor model control");
-        let cursor_mapping = cursor_model_control
-            .mapping
-            .as_ref()
-            .expect("cursor model mapping");
-        assert_eq!(
-            cursor_mapping.variant_syntax.as_deref(),
-            Some("bracket-params")
-        );
-        // Variant families are draft data — anchor on the stable shape, not a
-        // fixed model id (the probed model list moves between catalog runs).
-        let with_variants = cursor
-            .session
-            .models
-            .iter()
-            .find(|model| {
-                model
-                    .provenance
-                    .as_ref()
-                    .is_some_and(|provenance| !provenance.variant_ids.is_empty())
-            })
-            .expect("some cursor model carries variant ids");
-        let provenance = with_variants.provenance.as_ref().expect("provenance");
-        assert!(provenance
-            .variant_ids
-            .iter()
-            .any(|variant| variant.starts_with(&format!("{}[", with_variants.id))));
-
-        let opencode = &catalog.agents[4];
-        assert!(opencode
-            .auth_contexts
-            .iter()
-            .any(|context| context.id == "baseline" && context.auth_slot_id.is_none()));
-        assert_eq!(
-            opencode
-                .session
-                .observed_defaults
-                .get("baseline")
-                .map(String::as_str),
-            Some("opencode/big-pickle")
-        );
-    }
-
-    #[test]
-    fn auth_signals_round_trip_bedrock_all_of_example() {
-        // The bedrock-style signature from the migration doc (§5.4).
-        let json = serde_json::json!({
-            "allOf": [
-                { "envFlag": "CLAUDE_CODE_USE_BEDROCK=1" },
-                { "discovery": "aws-credential-chain" }
-            ]
-        });
-
-        let signal: AgentCatalogAuthSignal =
-            serde_json::from_value(json.clone()).expect("bedrock signal must parse");
-
-        assert_eq!(
-            signal,
-            AgentCatalogAuthSignal::AllOf(vec![
-                AgentCatalogAuthSignal::EnvFlag("CLAUDE_CODE_USE_BEDROCK=1".to_string()),
-                AgentCatalogAuthSignal::Discovery("aws-credential-chain".to_string()),
-            ])
-        );
-        assert_eq!(signal.depth(), 2);
-        assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
-    }
-
-    #[test]
-    fn auth_signals_round_trip_any_of_and_leaves() {
-        let json = serde_json::json!({
-            "anyOf": [
-                { "env": "CLAUDE_CODE_OAUTH_TOKEN" },
-                { "discovery": "claude-oauth-creds" }
-            ]
-        });
-
-        let signal: AgentCatalogAuthSignal =
-            serde_json::from_value(json.clone()).expect("oauth signal must parse");
-
-        assert_eq!(signal.depth(), 2);
-        assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
-
-        let leaf: AgentCatalogAuthSignal =
-            serde_json::from_value(serde_json::json!({ "env": "ANTHROPIC_API_KEY" }))
-                .expect("leaf signal must parse");
-        assert_eq!(
-            leaf,
-            AgentCatalogAuthSignal::Env("ANTHROPIC_API_KEY".to_string())
-        );
-        assert_eq!(leaf.depth(), 1);
-    }
-
-    fn bundled_registry_version() -> String {
-        let text = std::fs::read_to_string(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../../catalogs/agents/registry.json"
-        ))
-        .expect("read bundled registry");
-        serde_json::from_str::<serde_json::Value>(&text).expect("parse registry")["registryVersion"]
-            .as_str()
-            .expect("registryVersion")
-            .to_string()
-    }
-
-    fn draft_catalog_version() -> String {
-        let text = std::fs::read_to_string(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../../scripts/agent-catalog/catalog.draft.json"
-        ))
-        .expect("read draft catalog");
-        serde_json::from_str::<serde_json::Value>(&text).expect("parse draft")["catalogVersion"]
-            .as_str()
-            .expect("catalogVersion")
-            .to_string()
-    }
-}
+#[path = "schema_tests.rs"]
+mod tests;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -1,0 +1,212 @@
+//! Unit tests for the agent catalog schema (split from schema.rs to keep
+//! the module under the repo line-count ceiling).
+
+use super::*;
+
+fn parse_draft() -> AgentCatalogDocument {
+    serde_json::from_str(draft_catalog_json()).expect("draft catalog must parse")
+}
+
+#[test]
+fn draft_catalog_parses_with_expected_shape() {
+    let catalog = parse_draft();
+
+    assert_eq!(catalog.schema_version, 2);
+    assert_eq!(catalog.catalog_version, draft_catalog_version().as_str());
+    let probed_against = catalog.probed_against.as_ref().expect("probedAgainst");
+    assert_eq!(
+        probed_against.registry_version.as_deref(),
+        Some(bundled_registry_version().as_str())
+    );
+    assert_eq!(catalog.agents.len(), 5);
+
+    let claude = &catalog.agents[0];
+    assert_eq!(claude.kind, "claude");
+    assert_eq!(claude.harness.agent_process.version, "0.44.0");
+    assert_eq!(
+        claude
+            .harness
+            .native
+            .as_ref()
+            .map(|pin| pin.version.as_str()),
+        Some("2.1.181")
+    );
+    assert_eq!(
+        claude
+            .auth_contexts
+            .iter()
+            .map(|context| context.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["bedrock", "anthropic-api", "anthropic-oauth", "gateway"]
+    );
+    // The gateway context is route-engaged: it references the registry
+    // gateway slot but carries no detection signals (never classifier-active).
+    let gateway_context = claude
+        .auth_contexts
+        .iter()
+        .find(|context| context.id == "gateway")
+        .expect("claude gateway auth context");
+    assert_eq!(gateway_context.auth_slot_id.as_deref(), Some("gateway"));
+    assert!(gateway_context.signals.is_none());
+    // gatewayPolicy carries the small-fast role pin that used to be a Rust const.
+    let policy = claude
+        .session
+        .gateway_policy
+        .as_ref()
+        .expect("claude gatewayPolicy");
+    assert_eq!(policy.providers, vec!["anthropic"]);
+    assert_eq!(
+        policy.roles.get("small_fast").map(String::as_str),
+        Some("claude-haiku-4-5-20251001")
+    );
+    let first = &claude.session.models[0];
+    assert_eq!(first.id, "default");
+    assert_eq!(
+        first.availability.any_of,
+        vec!["anthropic-api", "anthropic-oauth", "bedrock"]
+    );
+    assert!(first.default_visible);
+    let effort = first.controls.get("effort").expect("effort control");
+    assert_eq!(
+        effort.values,
+        vec!["default", "low", "medium", "high", "xhigh", "max"]
+    );
+    assert_eq!(effort.observed_value.as_deref(), Some("default"));
+    assert_eq!(effort.default, None);
+
+    let codex = &catalog.agents[1];
+    let model_control = codex
+        .session
+        .controls
+        .iter()
+        .find(|control| control.key == "model")
+        .expect("model control");
+    let mapping = model_control.mapping.as_ref().expect("model mapping");
+    assert_eq!(mapping.switch_via.as_deref(), Some("configOption"));
+    assert_eq!(mapping.variant_syntax.as_deref(), None);
+
+    let cursor = &catalog.agents[2];
+    assert!(cursor.provenance.attestation.is_none());
+    assert!(cursor.harness.native.is_none());
+    // Cursor is the variant-carrying agent: its model control declares the
+    // bracket-params syntax and its models carry probe-observed variant ids.
+    let cursor_model_control = cursor
+        .session
+        .controls
+        .iter()
+        .find(|control| control.key == "model")
+        .expect("cursor model control");
+    let cursor_mapping = cursor_model_control
+        .mapping
+        .as_ref()
+        .expect("cursor model mapping");
+    assert_eq!(
+        cursor_mapping.variant_syntax.as_deref(),
+        Some("bracket-params")
+    );
+    // Variant families are draft data — anchor on the stable shape, not a
+    // fixed model id (the probed model list moves between catalog runs).
+    let with_variants = cursor
+        .session
+        .models
+        .iter()
+        .find(|model| {
+            model
+                .provenance
+                .as_ref()
+                .is_some_and(|provenance| !provenance.variant_ids.is_empty())
+        })
+        .expect("some cursor model carries variant ids");
+    let provenance = with_variants.provenance.as_ref().expect("provenance");
+    assert!(provenance
+        .variant_ids
+        .iter()
+        .any(|variant| variant.starts_with(&format!("{}[", with_variants.id))));
+
+    let opencode = &catalog.agents[4];
+    assert!(opencode
+        .auth_contexts
+        .iter()
+        .any(|context| context.id == "baseline" && context.auth_slot_id.is_none()));
+    assert_eq!(
+        opencode
+            .session
+            .observed_defaults
+            .get("baseline")
+            .map(String::as_str),
+        Some("opencode/big-pickle")
+    );
+}
+
+#[test]
+fn auth_signals_round_trip_bedrock_all_of_example() {
+    // The bedrock-style signature from the migration doc (§5.4).
+    let json = serde_json::json!({
+        "allOf": [
+            { "envFlag": "CLAUDE_CODE_USE_BEDROCK=1" },
+            { "discovery": "aws-credential-chain" }
+        ]
+    });
+
+    let signal: AgentCatalogAuthSignal =
+        serde_json::from_value(json.clone()).expect("bedrock signal must parse");
+
+    assert_eq!(
+        signal,
+        AgentCatalogAuthSignal::AllOf(vec![
+            AgentCatalogAuthSignal::EnvFlag("CLAUDE_CODE_USE_BEDROCK=1".to_string()),
+            AgentCatalogAuthSignal::Discovery("aws-credential-chain".to_string()),
+        ])
+    );
+    assert_eq!(signal.depth(), 2);
+    assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
+}
+
+#[test]
+fn auth_signals_round_trip_any_of_and_leaves() {
+    let json = serde_json::json!({
+        "anyOf": [
+            { "env": "CLAUDE_CODE_OAUTH_TOKEN" },
+            { "discovery": "claude-oauth-creds" }
+        ]
+    });
+
+    let signal: AgentCatalogAuthSignal =
+        serde_json::from_value(json.clone()).expect("oauth signal must parse");
+
+    assert_eq!(signal.depth(), 2);
+    assert_eq!(serde_json::to_value(&signal).expect("serialize"), json);
+
+    let leaf: AgentCatalogAuthSignal =
+        serde_json::from_value(serde_json::json!({ "env": "ANTHROPIC_API_KEY" }))
+            .expect("leaf signal must parse");
+    assert_eq!(
+        leaf,
+        AgentCatalogAuthSignal::Env("ANTHROPIC_API_KEY".to_string())
+    );
+    assert_eq!(leaf.depth(), 1);
+}
+
+fn bundled_registry_version() -> String {
+    let text = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../catalogs/agents/registry.json"
+    ))
+    .expect("read bundled registry");
+    serde_json::from_str::<serde_json::Value>(&text).expect("parse registry")["registryVersion"]
+        .as_str()
+        .expect("registryVersion")
+        .to_string()
+}
+
+fn draft_catalog_version() -> String {
+    let text = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../scripts/agent-catalog/catalog.draft.json"
+    ))
+    .expect("read draft catalog");
+    serde_json::from_str::<serde_json::Value>(&text).expect("parse draft")["catalogVersion"]
+        .as_str()
+        .expect("catalogVersion")
+        .to_string()
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/settings.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/settings.rs
@@ -1,0 +1,170 @@
+//! Resolve catalog-declared per-harness settings into launch-time deltas
+//! (extra CLI args and env vars). Reads the persisted settings map from the
+//! agent-auth state file and the setting declarations from the bundled catalog.
+//!
+//! Application rule (v1):
+//! - `cli_flag` + value `true` → append the `flag` to argv
+//! - `env` + any value → set the env var to the JSON string form of the value
+//! - A setting absent from the persisted map (or with a `false`/null value for
+//!   cli_flag) produces no delta.
+
+use std::collections::BTreeMap;
+
+use super::schema::{AgentCatalogSetting, AgentCatalogSettingMapping};
+
+/// Resolved settings deltas to apply at harness spawn.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedSettingsDeltas {
+    /// Extra CLI args to append after the base spawn args.
+    pub extra_args: Vec<String>,
+    /// Extra env vars to set in the spawn environment.
+    pub extra_env: BTreeMap<String, String>,
+}
+
+/// Resolve the settings for a harness kind from the catalog declarations and
+/// persisted values. `surface` filters settings to those relevant for the
+/// delivery surface (e.g. `"local"` for desktop launches).
+pub fn resolve_settings_deltas(
+    catalog_settings: &[AgentCatalogSetting],
+    persisted: Option<&serde_json::Map<String, serde_json::Value>>,
+    surface: &str,
+) -> ResolvedSettingsDeltas {
+    let mut deltas = ResolvedSettingsDeltas::default();
+    let empty_map = serde_json::Map::new();
+    let values = persisted.unwrap_or(&empty_map);
+
+    for setting in catalog_settings {
+        // Skip settings not relevant to this surface.
+        if !setting.surfaces.iter().any(|s| s == surface) {
+            continue;
+        }
+
+        let value = values.get(&setting.key);
+        apply_setting_mapping(&setting.mapping, value, &mut deltas);
+    }
+
+    deltas
+}
+
+fn apply_setting_mapping(
+    mapping: &AgentCatalogSettingMapping,
+    value: Option<&serde_json::Value>,
+    deltas: &mut ResolvedSettingsDeltas,
+) {
+    match mapping.kind.as_str() {
+        "cli_flag" => {
+            // Append the flag only when the value is explicitly `true`.
+            if value == Some(&serde_json::Value::Bool(true)) {
+                if let Some(flag) = &mapping.flag {
+                    deltas.extra_args.push(flag.clone());
+                }
+            }
+        }
+        "env" => {
+            // Set the env var to the string representation of the value.
+            if let (Some(env_name), Some(val)) = (&mapping.env, value) {
+                let str_val = match val {
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    other => other.to_string(),
+                };
+                deltas.extra_env.insert(env_name.clone(), str_val);
+            }
+        }
+        _ => {} // Unknown mapping kinds are silently ignored (forward compat).
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::catalog::schema::{AgentCatalogSetting, AgentCatalogSettingMapping};
+
+    fn chrome_setting() -> AgentCatalogSetting {
+        AgentCatalogSetting {
+            key: "chrome".to_string(),
+            setting_type: "boolean".to_string(),
+            label: "Use Claude Code with Chrome".to_string(),
+            description: Some(
+                "Allow Claude Code to control your Chrome browser.".to_string(),
+            ),
+            default: serde_json::Value::Bool(false),
+            surfaces: vec!["local".to_string()],
+            mapping: AgentCatalogSettingMapping {
+                kind: "cli_flag".to_string(),
+                flag: Some("--chrome".to_string()),
+                env: None,
+            },
+        }
+    }
+
+    fn env_setting() -> AgentCatalogSetting {
+        AgentCatalogSetting {
+            key: "debug".to_string(),
+            setting_type: "boolean".to_string(),
+            label: "Debug mode".to_string(),
+            description: None,
+            default: serde_json::Value::Bool(false),
+            surfaces: vec!["local".to_string(), "cloud".to_string()],
+            mapping: AgentCatalogSettingMapping {
+                kind: "env".to_string(),
+                flag: None,
+                env: Some("CLAUDE_DEBUG".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn chrome_true_appends_flag() {
+        let settings = vec![chrome_setting()];
+        let mut persisted = serde_json::Map::new();
+        persisted.insert("chrome".to_string(), serde_json::Value::Bool(true));
+
+        let deltas = resolve_settings_deltas(&settings, Some(&persisted), "local");
+        assert_eq!(deltas.extra_args, vec!["--chrome"]);
+        assert!(deltas.extra_env.is_empty());
+    }
+
+    #[test]
+    fn chrome_false_does_not_append_flag() {
+        let settings = vec![chrome_setting()];
+        let mut persisted = serde_json::Map::new();
+        persisted.insert("chrome".to_string(), serde_json::Value::Bool(false));
+
+        let deltas = resolve_settings_deltas(&settings, Some(&persisted), "local");
+        assert!(deltas.extra_args.is_empty());
+    }
+
+    #[test]
+    fn chrome_absent_does_not_append_flag() {
+        let settings = vec![chrome_setting()];
+        let deltas = resolve_settings_deltas(&settings, None, "local");
+        assert!(deltas.extra_args.is_empty());
+    }
+
+    #[test]
+    fn env_setting_sets_env_var() {
+        let settings = vec![env_setting()];
+        let mut persisted = serde_json::Map::new();
+        persisted.insert("debug".to_string(), serde_json::Value::Bool(true));
+
+        let deltas = resolve_settings_deltas(&settings, Some(&persisted), "local");
+        assert!(deltas.extra_args.is_empty());
+        assert_eq!(
+            deltas.extra_env.get("CLAUDE_DEBUG").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn surface_filtering_works() {
+        let settings = vec![chrome_setting()]; // surfaces: ["local"]
+        let mut persisted = serde_json::Map::new();
+        persisted.insert("chrome".to_string(), serde_json::Value::Bool(true));
+
+        // cloud surface: chrome setting is filtered out
+        let deltas = resolve_settings_deltas(&settings, Some(&persisted), "cloud");
+        assert!(deltas.extra_args.is_empty());
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs
@@ -10,6 +10,7 @@ use chrono::DateTime;
 use super::schema::{
     AgentCatalogAgent, AgentCatalogArtifactPin, AgentCatalogArtifactSource,
     AgentCatalogAuthContext, AgentCatalogAuthSignal, AgentCatalogDocument, AgentCatalogModel,
+    AgentCatalogSetting,
 };
 use crate::domains::agents::model::AgentKind;
 
@@ -80,6 +81,8 @@ fn validate_agent(
     for model in &agent.session.models {
         validate_model(&agent.kind, model, &context_ids, &mut seen_models)?;
     }
+
+    validate_settings(&agent.kind, &agent.settings)?;
     Ok(())
 }
 
@@ -285,6 +288,81 @@ fn validate_model(
                     "agent catalog agent '{agent_kind}' model '{}' control '{control_key}' default '{default}' is not a value",
                     model.id
                 );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Valid setting types (v1: boolean only).
+const VALID_SETTING_TYPES: &[&str] = &["boolean"];
+/// Valid delivery surfaces for settings.
+const VALID_SETTING_SURFACES: &[&str] = &["local", "cloud"];
+/// Valid mapping kinds.
+const VALID_SETTING_MAPPING_KINDS: &[&str] = &["cli_flag", "env"];
+
+fn validate_settings(agent_kind: &str, settings: &[AgentCatalogSetting]) -> anyhow::Result<()> {
+    let mut seen_keys = HashSet::new();
+    for setting in settings {
+        if setting.key.trim().is_empty() {
+            anyhow::bail!("agent catalog agent '{agent_kind}' has setting with empty key");
+        }
+        if !seen_keys.insert(setting.key.clone()) {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' setting '{}' is duplicated",
+                setting.key
+            );
+        }
+        if !VALID_SETTING_TYPES.contains(&setting.setting_type.as_str()) {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' setting '{}' has unsupported type '{}'",
+                setting.key,
+                setting.setting_type
+            );
+        }
+        if setting.label.trim().is_empty() {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' setting '{}' has empty label",
+                setting.key
+            );
+        }
+        if setting.surfaces.is_empty() {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' setting '{}' has no surfaces",
+                setting.key
+            );
+        }
+        for surface in &setting.surfaces {
+            if !VALID_SETTING_SURFACES.contains(&surface.as_str()) {
+                anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' setting '{}' has invalid surface '{surface}'",
+                    setting.key
+                );
+            }
+        }
+        if !VALID_SETTING_MAPPING_KINDS.contains(&setting.mapping.kind.as_str()) {
+            anyhow::bail!(
+                "agent catalog agent '{agent_kind}' setting '{}' has unsupported mapping kind '{}'",
+                setting.key,
+                setting.mapping.kind
+            );
+        }
+        if setting.mapping.kind == "cli_flag" {
+            match setting.mapping.flag.as_deref() {
+                Some(flag) if !flag.trim().is_empty() => {}
+                _ => anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' setting '{}' cli_flag mapping is missing flag",
+                    setting.key
+                ),
+            }
+        }
+        if setting.mapping.kind == "env" {
+            match setting.mapping.env.as_deref() {
+                Some(env) if !env.trim().is_empty() => {}
+                _ => anyhow::bail!(
+                    "agent catalog agent '{agent_kind}' setting '{}' env mapping is missing env",
+                    setting.key
+                ),
             }
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
@@ -176,6 +176,7 @@ mod tests {
         HarnessAuth {
             harness_kind: kind.into(),
             sources,
+            settings: None,
         }
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
@@ -79,6 +79,11 @@ pub struct HarnessAuth {
     pub harness_kind: String,
     #[serde(default)]
     pub sources: Vec<AuthSource>,
+    /// Per-harness advanced settings (persisted toggle values). Keys are
+    /// setting keys declared in the agent catalog; values are JSON primitives
+    /// (booleans for v1). Absent/null when no settings are configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 /// The whole declarative state file (contract §3, v2).
@@ -265,6 +270,7 @@ mod tests {
                 HarnessAuth {
                     harness_kind: "claude".into(),
                     sources: vec![gateway_source("https://llm.proliferate.ai", "sk-vk")],
+                    settings: None,
                 },
                 HarnessAuth {
                     harness_kind: "opencode".into(),
@@ -272,6 +278,7 @@ mod tests {
                         gateway_source("https://llm.proliferate.ai", "sk-vk"),
                         api_key_source("ANTHROPIC_API_KEY", "sk-ant"),
                     ],
+                    settings: None,
                 },
             ],
         };
@@ -291,6 +298,7 @@ mod tests {
             harnesses: vec![HarnessAuth {
                 harness_kind: "codex".into(),
                 sources: vec![api_key_source("OPENAI_API_KEY", "sk-raw")],
+                settings: None,
             }],
         };
         assert_eq!(state.sources_for("codex").len(), 1);
@@ -314,6 +322,7 @@ mod tests {
             harnesses: vec![HarnessAuth {
                 harness_kind: "claude".into(),
                 sources: vec![api_key_source("ANTHROPIC_API_KEY", "sk-raw")],
+                settings: None,
             }],
         }
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_policy.rs
@@ -9,6 +9,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use crate::domains::agents::catalog::settings::ResolvedSettingsDeltas;
 use crate::domains::agents::model::{AgentKind, ResolvedAgent};
 use crate::domains::agents::route_auth::RenderedRouteAuth;
 use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
@@ -175,6 +176,9 @@ pub(super) struct SessionLaunchContext {
     /// Rendered agent-auth route layer for this launch (empty for
     /// native/legacy). See `domains::agents::route_auth`.
     pub route_auth: RenderedRouteAuth,
+    /// Catalog settings deltas (extra CLI args and env vars from persisted
+    /// per-harness settings). See `domains::agents::catalog::settings`.
+    pub settings_deltas: ResolvedSettingsDeltas,
     pub mcp_servers: Vec<SessionMcpServer>,
     pub startup: SessionStartupStrategy,
     pub every_prompt_append: Option<String>,
@@ -183,6 +187,12 @@ pub(super) struct SessionLaunchContext {
 
 /// Pure assembly of the launch bundle from already-resolved facts.
 pub(super) fn assemble_session_launch(ctx: SessionLaunchContext) -> SessionLaunch {
+    // Merge settings env deltas into the route_auth layer (settings env wins
+    // over nothing, but route_auth is a good home — it lands after session env).
+    let mut route_auth_set = ctx.route_auth.set;
+    for (key, value) in ctx.settings_deltas.extra_env {
+        route_auth_set.insert(key, value);
+    }
     SessionLaunch {
         session: ctx.record,
         agent: ctx.agent,
@@ -190,8 +200,9 @@ pub(super) fn assemble_session_launch(ctx: SessionLaunchContext) -> SessionLaunc
         env: LaunchEnv {
             workspace: ctx.workspace_env,
             session: ctx.session_env,
-            route_auth: ctx.route_auth.set,
+            route_auth: route_auth_set,
             route_auth_remove: ctx.route_auth.remove,
+            settings_extra_args: ctx.settings_deltas.extra_args,
         },
         mcp_servers: ctx.mcp_servers,
         startup: ctx.startup,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -2,9 +2,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::domains::agents::catalog::bundled::bundled_agent_catalog_document;
+use crate::domains::agents::catalog::settings::resolve_settings_deltas;
 use crate::domains::agents::readiness::service::resolve_agent_with_env;
 use crate::domains::agents::registry;
 use crate::domains::agents::route_auth::resolve_launch_route_auth;
+use crate::domains::agents::route_auth::state::load_state_file;
 use crate::domains::sessions::extensions::{SessionStartedContext, SessionTurnFinishedContext};
 use crate::domains::sessions::links::model::SessionLinkRelation;
 use crate::domains::sessions::mcp_bindings::assembly::{
@@ -350,6 +353,28 @@ impl SessionRuntime {
         // Never blocks this launch — it already used seed data above.
         self.gateway_model_resolver
             .schedule_launch_probe_if_stale(&record.agent_kind, &self.runtime_home);
+        // Catalog settings: resolve persisted toggle values into launch-time
+        // deltas (extra CLI args, extra env vars). The surface is always "local"
+        // for local runtime launches (cloud sandboxes use their own surface).
+        let settings_deltas = {
+            let catalog = bundled_agent_catalog_document();
+            let catalog_settings = catalog
+                .agents
+                .iter()
+                .find(|a| a.kind == record.agent_kind)
+                .map(|a| a.settings.as_slice())
+                .unwrap_or(&[]);
+            let state = load_state_file(&self.runtime_home).ok().flatten();
+            let persisted_settings = state
+                .as_ref()
+                .and_then(|s| {
+                    s.harnesses
+                        .iter()
+                        .find(|h| h.harness_kind == record.agent_kind)
+                })
+                .and_then(|h| h.settings.as_ref());
+            resolve_settings_deltas(catalog_settings, persisted_settings, "local")
+        };
         let mcp_launch = assemble_session_mcp_launch(
             self.session_data_cipher.as_ref(),
             &self.session_extensions,
@@ -373,6 +398,7 @@ impl SessionRuntime {
             workspace_env,
             session_env: session_launch_env,
             route_auth,
+            settings_deltas,
             mcp_servers: mcp_launch.mcp_servers,
             startup: startup_strategy,
             every_prompt_append: mcp_launch.system_prompt_append,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/process.rs
@@ -87,6 +87,7 @@ pub(in crate::live::sessions) fn spawn_agent_process(
     let mut command = tokio::process::Command::new(spawn_program);
     command
         .args(spawn_args)
+        .args(&launch_env.settings_extra_args)
         .envs(&spawn_env)
         .current_dir(spawn_cwd)
         .stdin(std::process::Stdio::piped())
@@ -342,6 +343,7 @@ mod tests {
                 "ANTHROPIC_API_KEY".to_string(),
                 "CLAUDE_CODE_USE_BEDROCK".to_string(),
             ],
+            ..Default::default()
         };
 
         let merged = merge_spawn_env(&launch_env, None);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -101,6 +101,9 @@ pub struct LaunchEnv {
     /// Env keys the route-auth render plane requires ABSENT in the spawned
     /// process (ambient Bedrock/Vertex reroutes, stale provider keys).
     pub route_auth_remove: Vec<String>,
+    /// Extra CLI args appended to the harness command line, derived from
+    /// catalog settings (e.g. `--chrome` when the chrome setting is true).
+    pub settings_extra_args: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
@@ -84,7 +84,7 @@ function HarnessSurfaceCloud({
           variant="panel"
         />
 
-        <HarnessSettingsSection harnessKind={harnessKind} variant="panel" />
+        <HarnessSettingsSection harnessKind={harnessKind} surface="cloud" variant="panel" />
       </div>
 
       <HarnessAllModelsSection
@@ -126,7 +126,7 @@ function HarnessSurfaceLocal({
           variant="panel"
         />
 
-        <HarnessSettingsSection harnessKind={harnessKind} variant="panel" />
+        <HarnessSettingsSection harnessKind={harnessKind} surface="local" variant="panel" />
       </div>
 
       <HarnessAllModelsSection

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
@@ -1,29 +1,139 @@
+import { useCallback, useMemo } from "react";
+import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
+import { Switch } from "@proliferate/ui/primitives/Switch";
 import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import {
+  usePutAuthSelections,
+  useAgentAuthState,
+  useAuthSelections,
+} from "@proliferate/cloud-sdk-react";
+import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
 import { HarnessPanelBlock, type HarnessBlockVariant } from "./HarnessPanelBlock";
 
-// Reserved for harness-specific settings (e.g. the Claude Chrome flag). No
-// harness ships any yet, so the section stays gated off and renders nothing.
-const HARNESS_SETTINGS_ENABLED_KINDS: ReadonlySet<string> = new Set();
+// --------------------------------------------------------------------------- #
+// Catalog-declared settings (mirrors catalogs/agents/catalog.json)
+// --------------------------------------------------------------------------- #
+
+interface CatalogSetting {
+  key: string;
+  type: "boolean";
+  label: string;
+  description?: string;
+  default: boolean;
+  surfaces: AgentAuthSurface[];
+}
+
+const CATALOG_SETTINGS: Record<string, CatalogSetting[]> = {
+  claude: [
+    {
+      key: "chrome",
+      type: "boolean",
+      label: "Use Claude Code with Chrome",
+      description:
+        "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+      default: false,
+      surfaces: ["local"],
+    },
+  ],
+};
+
+// --------------------------------------------------------------------------- #
+// Component
+// --------------------------------------------------------------------------- #
 
 interface HarnessSettingsSectionProps {
   harnessKind: string;
+  surface: AgentAuthSurface;
   variant?: HarnessBlockVariant;
 }
 
 export function HarnessSettingsSection({
   harnessKind,
+  surface,
   variant = "section",
 }: HarnessSettingsSectionProps) {
-  if (!HARNESS_SETTINGS_ENABLED_KINDS.has(harnessKind)) {
+  const allSettings = CATALOG_SETTINGS[harnessKind];
+  const settings = allSettings?.filter((s) => s.surfaces.includes(surface));
+
+  if (!settings || settings.length === 0) {
     return null;
   }
+
   return (
     <HarnessPanelBlock variant={variant} title={HARNESS_PANE_COPY.harnessSettingsTitle}>
-      <SettingsRow
-        label={HARNESS_PANE_COPY.harnessSettingsPlaceholderLabel}
-        description={HARNESS_PANE_COPY.harnessSettingsPlaceholderDescription}
-      />
+      {settings.map((setting) => (
+        <HarnessSettingRow
+          key={setting.key}
+          harnessKind={harnessKind}
+          surface={surface}
+          setting={setting}
+        />
+      ))}
     </HarnessPanelBlock>
+  );
+}
+
+// --------------------------------------------------------------------------- #
+// Individual setting row
+// --------------------------------------------------------------------------- #
+
+function HarnessSettingRow({
+  harnessKind,
+  surface,
+  setting,
+}: {
+  harnessKind: string;
+  surface: AgentAuthSurface;
+  setting: CatalogSetting;
+}) {
+  const { cloudActive } = useCloudAvailabilityState();
+  const stateQuery = useAgentAuthState(surface, cloudActive);
+  const selectionsQuery = useAuthSelections(surface, cloudActive);
+  const putSelections = usePutAuthSelections();
+
+  // Read persisted value from the auth state response.
+  const harness = stateQuery.data?.harnesses?.find(
+    (h) => h.harness_kind === harnessKind,
+  );
+  const persisted = harness?.settings as Record<string, boolean> | undefined;
+  const currentValue = persisted?.[setting.key] ?? setting.default;
+
+  // Build the current sources for this harness+surface so the PUT does not
+  // clear them when we only want to toggle a setting.
+  const currentSources = useMemo(() => {
+    if (!selectionsQuery.data) return [];
+    return selectionsQuery.data
+      .filter((s) => s.harnessKind === harnessKind && s.surface === surface)
+      .map((s) => ({
+        sourceKind: s.sourceKind,
+        apiKeyId: s.apiKeyId ?? undefined,
+        envVarName: s.envVarName ?? undefined,
+        providerHint: s.providerHint ?? undefined,
+        enabled: s.enabled,
+      }));
+  }, [selectionsQuery.data, harnessKind, surface]);
+
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      const nextSettings = { ...persisted, [setting.key]: next };
+      putSelections.mutate({
+        harnessKind,
+        surface,
+        body: { sources: currentSources, settings: nextSettings },
+      });
+    },
+    [harnessKind, surface, setting.key, persisted, currentSources, putSelections],
+  );
+
+  return (
+    <SettingsRow label={setting.label} description={setting.description}>
+      <Switch
+        checked={currentValue}
+        onChange={handleToggle}
+        aria-label={setting.label}
+        disabled={!cloudActive}
+      />
+    </SettingsRow>
   );
 }

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -198,7 +198,7 @@
           {
             "id": "opus[1m]",
             "displayName": "Opus 4.8 (1M context)",
-            "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
+            "description": "Opus 4.8 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -248,7 +248,7 @@
           {
             "id": "sonnet",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -292,7 +292,7 @@
           {
             "id": "sonnet[1m]",
             "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
+            "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -334,7 +334,7 @@
           {
             "id": "haiku",
             "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 · Fastest for quick answers",
+            "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -369,7 +369,7 @@
           {
             "id": "opus",
             "displayName": "Opus 4.6",
-            "description": "Opus 4.6 · Legacy",
+            "description": "Opus 4.6 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -525,7 +525,7 @@
           {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -607,7 +607,7 @@
           {
             "id": "us.anthropic.claude-fable-5",
             "displayName": "Fable 5",
-            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+            "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -649,7 +649,7 @@
           {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
-            "description": "Opus 4.1 · Legacy",
+            "description": "Opus 4.1 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -680,7 +680,7 @@
           {
             "id": "us.anthropic.claude-opus-4-8",
             "displayName": "Opus 4.8",
-            "description": "Opus 4.8 · Best for everyday, complex tasks",
+            "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -764,7 +764,7 @@
           {
             "id": "us.anthropic.claude-opus-4-7",
             "displayName": "Opus 4.7",
-            "description": "Opus 4.7 · Legacy",
+            "description": "Opus 4.7 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -968,7 +968,23 @@
             "snapshotPath": "generated/claude.bedrock.probe.json"
           }
         ]
-      }
+      },
+      "settings": [
+        {
+          "key": "chrome",
+          "type": "boolean",
+          "label": "Use Claude Code with Chrome",
+          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+          "default": false,
+          "surfaces": [
+            "local"
+          ],
+          "mapping": {
+            "kind": "cli_flag",
+            "flag": "--chrome"
+          }
+        }
+      ]
     },
     {
       "kind": "codex",

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -2635,6 +2635,8 @@ export interface components {
         AgentAuthSelectionsPutRequest: {
             /** Sources */
             sources: components["schemas"]["AgentAuthSourceInput"][];
+            /** Settings */
+            settings?: Record<string, unknown> | null;
         };
         /**
          * AgentAuthSourceInput
@@ -2664,6 +2666,8 @@ export interface components {
             harness_kind: string;
             /** Sources */
             sources: components["schemas"]["AgentAuthStateSource"][];
+            /** Settings */
+            settings?: Record<string, unknown> | null;
         };
         /**
          * AgentAuthStateResponse

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -157,6 +157,23 @@ const MODEL_VISIBILITY_OPT_OUTS = {
   ],
 };
 
+// Per-harness advanced settings: declared here (curation-owned), emitted onto
+// the agent entry, and applied at launch per the mapping kind. v1 supports
+// boolean-only, surfaces ⊆ {local, cloud}, mapping.kind ∈ {cli_flag, env}.
+const HARNESS_SETTINGS = {
+  claude: [
+    {
+      key: "chrome",
+      type: "boolean",
+      label: "Use Claude Code with Chrome",
+      description: "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+      default: false,
+      surfaces: ["local"],
+      mapping: { kind: "cli_flag", flag: "--chrome" },
+    },
+  ],
+};
+
 // Explicit display overrides where prettifying alone is ambiguous (two
 // "GPT-5.4" rows when the bedrock CMB models sit beside the API ones).
 const MODEL_DISPLAY_OVERRIDES = {
@@ -588,6 +605,7 @@ for (const [kind, runs] of byAgent) {
       defaults: AGENT_SESSION_DEFAULTS[kind] ?? {},
       observedDefaults,
     },
+    ...(HARNESS_SETTINGS[kind] ? { settings: HARNESS_SETTINGS[kind] } : {}),
     provenance: {
       probedAt: runs.map((r) => r.data.probedAt).sort().at(-1),
       attestation,

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -197,7 +197,7 @@
           {
             "id": "opus[1m]",
             "displayName": "Opus 4.8 (1M context)",
-            "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
+            "description": "Opus 4.8 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -247,7 +247,7 @@
           {
             "id": "sonnet",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -291,7 +291,7 @@
           {
             "id": "sonnet[1m]",
             "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
+            "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -333,7 +333,7 @@
           {
             "id": "haiku",
             "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 · Fastest for quick answers",
+            "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -368,7 +368,7 @@
           {
             "id": "opus",
             "displayName": "Opus 4.6",
-            "description": "Opus 4.6 · Legacy",
+            "description": "Opus 4.6 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -524,7 +524,7 @@
           {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -606,7 +606,7 @@
           {
             "id": "us.anthropic.claude-fable-5",
             "displayName": "Fable 5",
-            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+            "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -648,7 +648,7 @@
           {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
-            "description": "Opus 4.1 · Legacy",
+            "description": "Opus 4.1 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -679,7 +679,7 @@
           {
             "id": "us.anthropic.claude-opus-4-8",
             "displayName": "Opus 4.8",
-            "description": "Opus 4.8 · Best for everyday, complex tasks",
+            "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -763,7 +763,7 @@
           {
             "id": "us.anthropic.claude-opus-4-7",
             "displayName": "Opus 4.7",
-            "description": "Opus 4.7 · Legacy",
+            "description": "Opus 4.7 \u00b7 Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -967,7 +967,23 @@
             "snapshotPath": "generated/claude.bedrock.probe.json"
           }
         ]
-      }
+      },
+      "settings": [
+        {
+          "key": "chrome",
+          "type": "boolean",
+          "label": "Use Claude Code with Chrome",
+          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+          "default": false,
+          "surfaces": [
+            "local"
+          ],
+          "mapping": {
+            "kind": "cli_flag",
+            "flag": "--chrome"
+          }
+        }
+      ]
     },
     {
       "kind": "codex",

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -36,6 +36,8 @@ apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file
 apps/web/src/hooks/chat/workflows/use-web-cloud-prompt-actions.ts 434 managed sandbox web prompt flow awaiting chat action split
 server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read path extends existing identity store
+server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_settings model added for catalog-driven per-harness settings
+server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
 server/tests/integration/test_agent_gateway_store.py 673 P1 auth rebuild rewrote store coverage for titled-key + agent_auth_selection model

--- a/scripts/validate-agent-catalog.mjs
+++ b/scripts/validate-agent-catalog.mjs
@@ -13,6 +13,9 @@ const CATALOG_PATH = path.resolve("catalogs/agents/catalog.json");
 const REGISTRY_PATH = path.resolve("catalogs/agents/registry.json");
 const VALID_AGENT_KINDS = new Set(["claude", "codex", "cursor", "opencode", "grok"]);
 const VALID_STATUSES = new Set(["candidate", "active", "deprecated", "hidden"]);
+const VALID_SETTING_TYPES = new Set(["boolean"]);
+const VALID_SETTING_SURFACES = new Set(["local", "cloud"]);
+const VALID_SETTING_MAPPING_KINDS = new Set(["cli_flag", "env"]);
 const BASELINE_CONTEXT_ID = "baseline";
 // The gateway auth context is route-engaged (its models/default are resolved by
 // the runtime gateway probe, not authored as catalog model rows), so its default
@@ -112,6 +115,7 @@ function validateCatalog(catalog) {
     }
 
     validateGatewayPolicy(kind, agent.session?.gatewayPolicy);
+    validateAgentSettings(kind, agent.settings);
   }
 }
 
@@ -141,6 +145,57 @@ function validateGatewayPolicy(kind, gatewayPolicy) {
       for (const [role, modelId] of Object.entries(roles)) {
         if (typeof modelId !== "string" || !modelId.trim()) {
           fail(`${kind}: gatewayPolicy.roles['${role}'] must be a non-empty string`);
+        }
+      }
+    }
+  }
+}
+
+function validateAgentSettings(kind, settings) {
+  if (settings === undefined || settings === null) return;
+  if (!Array.isArray(settings)) {
+    fail(`${kind}: settings must be an array`);
+    return;
+  }
+  const seenKeys = new Set();
+  for (const setting of settings) {
+    if (typeof setting.key !== "string" || !setting.key.trim()) {
+      fail(`${kind}: setting with empty key`);
+      continue;
+    }
+    if (seenKeys.has(setting.key)) {
+      fail(`${kind}: setting key '${setting.key}' is duplicated`);
+    }
+    seenKeys.add(setting.key);
+    if (!VALID_SETTING_TYPES.has(setting.type)) {
+      fail(`${kind}.settings.${setting.key}: type '${setting.type}' is not supported (must be one of: ${[...VALID_SETTING_TYPES].join(", ")})`);
+    }
+    if (typeof setting.label !== "string" || !setting.label.trim()) {
+      fail(`${kind}.settings.${setting.key}: label must be a non-empty string`);
+    }
+    if (!Array.isArray(setting.surfaces) || setting.surfaces.length === 0) {
+      fail(`${kind}.settings.${setting.key}: surfaces must be a non-empty array`);
+    } else {
+      for (const surface of setting.surfaces) {
+        if (!VALID_SETTING_SURFACES.has(surface)) {
+          fail(`${kind}.settings.${setting.key}: surface '${surface}' is not valid (must be one of: ${[...VALID_SETTING_SURFACES].join(", ")})`);
+        }
+      }
+    }
+    if (typeof setting.mapping !== "object" || setting.mapping === null || Array.isArray(setting.mapping)) {
+      fail(`${kind}.settings.${setting.key}: mapping must be an object`);
+    } else {
+      if (!VALID_SETTING_MAPPING_KINDS.has(setting.mapping.kind)) {
+        fail(`${kind}.settings.${setting.key}: mapping.kind '${setting.mapping.kind}' is not supported (must be one of: ${[...VALID_SETTING_MAPPING_KINDS].join(", ")})`);
+      }
+      if (setting.mapping.kind === "cli_flag") {
+        if (typeof setting.mapping.flag !== "string" || !setting.mapping.flag.trim()) {
+          fail(`${kind}.settings.${setting.key}: mapping.flag must be a non-empty string for cli_flag mapping`);
+        }
+      }
+      if (setting.mapping.kind === "env") {
+        if (typeof setting.mapping.env !== "string" || !setting.mapping.env.trim()) {
+          fail(`${kind}.settings.${setting.key}: mapping.env must be a non-empty string for env mapping`);
         }
       }
     }

--- a/server/alembic/versions/d4bbfa6e0669_add_agent_auth_harness_settings.py
+++ b/server/alembic/versions/d4bbfa6e0669_add_agent_auth_harness_settings.py
@@ -1,0 +1,59 @@
+"""Add agent_auth_harness_settings table for per-harness advanced settings.
+
+Revision ID: a1b2c3d4e5f6
+Revises: bcc0459a6f11
+Create Date: 2026-07-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4bbfa6e0669"
+down_revision: str | Sequence[str] | None = "bcc0459a6f11"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_auth_harness_settings",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("harness_kind", sa.String(64), nullable=False),
+        sa.Column("surface", sa.Text(), nullable=False),
+        sa.Column("settings_json", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "harness_kind",
+            "surface",
+            name="uq_agent_auth_harness_settings_scope",
+        ),
+        sa.CheckConstraint(
+            "surface IN ('local', 'cloud')",
+            name="ck_agent_auth_harness_settings_surface",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agent_auth_harness_settings")

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -145,6 +145,45 @@ class AgentAuthSelection(Base):
     )
 
 
+class AgentAuthHarnessSettings(Base):
+    """Per-(user, harness, surface) advanced settings (catalog-declared toggles).
+
+    Settings are independent of auth source selections: a user can toggle
+    --chrome for their Claude harness regardless of which auth source is wired.
+    The ``settings_json`` column is a JSON object mapping setting keys to their
+    persisted values (booleans for v1).
+    """
+
+    __tablename__ = "agent_auth_harness_settings"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "harness_kind",
+            "surface",
+            name="uq_agent_auth_harness_settings_scope",
+        ),
+        CheckConstraint(
+            "surface IN ('local', 'cloud')",
+            name="ck_agent_auth_harness_settings_surface",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    harness_kind: Mapped[str] = mapped_column(String(64))
+    surface: Mapped[str] = mapped_column(Text)
+    settings_json: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )
+
+
 class AgentGatewayEnrollment(Base):
     """LiteLLM enrollment state per billing subject (team + user + virtual key)."""
 

--- a/server/proliferate/db/store/agent_gateway/__init__.py
+++ b/server/proliferate/db/store/agent_gateway/__init__.py
@@ -37,6 +37,11 @@ from proliferate.db.store.agent_gateway.enrollments import (
     revoke_enrollment,
     set_enrollment_budget_status,
 )
+from proliferate.db.store.agent_gateway.harness_settings import (
+    get_harness_settings,
+    list_harness_settings_for_surface,
+    put_harness_settings,
+)
 from proliferate.db.store.agent_gateway.policy import (
     OrgMemberRouteSelectionRecord,
     get_org_agent_policy,
@@ -100,6 +105,7 @@ __all__ = [
     "get_enrollment_virtual_key_decrypted",
     "get_latest_catalog_snapshot",
     "get_org_agent_policy",
+    "get_harness_settings",
     "get_remaining_credit_usd",
     "get_scope_auth_selections",
     "get_usage_import_cursor",
@@ -110,6 +116,7 @@ __all__ = [
     "list_billing_subject_ids_with_active_enrollments",
     "list_enabled_auth_selections",
     "list_enabled_selections_referencing_key",
+    "list_harness_settings_for_surface",
     "list_enrollments_needing_sync",
     "list_org_member_route_selections",
     "list_org_memberships_missing_enrollment",
@@ -117,6 +124,7 @@ __all__ = [
     "mark_enrollment_failed",
     "mark_enrollment_synced",
     "put_auth_selections",
+    "put_harness_settings",
     "revoke_agent_api_key",
     "revoke_enrollment",
     "set_enrollment_budget_status",

--- a/server/proliferate/db/store/agent_gateway/harness_settings.py
+++ b/server/proliferate/db/store/agent_gateway/harness_settings.py
@@ -1,0 +1,95 @@
+"""Agent auth harness settings persistence (per user/harness/surface toggles)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.agent_gateway import AgentAuthHarnessSettings
+from proliferate.utils.time import utcnow
+
+
+async def get_harness_settings(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+) -> dict[str, Any] | None:
+    """Get persisted settings for a scope. Returns None if no row exists."""
+    row = (
+        await db.execute(
+            select(AgentAuthHarnessSettings).where(
+                AgentAuthHarnessSettings.user_id == user_id,
+                AgentAuthHarnessSettings.harness_kind == harness_kind,
+                AgentAuthHarnessSettings.surface == surface,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return json.loads(row.settings_json)  # type: ignore[no-any-return]
+
+
+async def list_harness_settings_for_surface(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    surface: str,
+) -> dict[str, dict[str, Any]]:
+    """All settings rows for a user+surface, keyed by harness_kind."""
+    rows = (
+        (
+            await db.execute(
+                select(AgentAuthHarnessSettings).where(
+                    AgentAuthHarnessSettings.user_id == user_id,
+                    AgentAuthHarnessSettings.surface == surface,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {row.harness_kind: json.loads(row.settings_json) for row in rows}
+
+
+async def put_harness_settings(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+    settings: dict[str, Any],
+) -> dict[str, Any]:
+    """Upsert settings for a scope. Returns the persisted settings."""
+    row = (
+        await db.execute(
+            select(AgentAuthHarnessSettings).where(
+                AgentAuthHarnessSettings.user_id == user_id,
+                AgentAuthHarnessSettings.harness_kind == harness_kind,
+                AgentAuthHarnessSettings.surface == surface,
+            )
+        )
+    ).scalar_one_or_none()
+    now = utcnow()
+    settings_json = json.dumps(settings, sort_keys=True)
+    if row is None:
+        db.add(
+            AgentAuthHarnessSettings(
+                user_id=user_id,
+                harness_kind=harness_kind,
+                surface=surface,
+                settings_json=settings_json,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    else:
+        row.settings_json = settings_json
+        row.updated_at = now
+    await db.flush()
+    return settings

--- a/server/proliferate/server/cloud/agent_gateway/api.py
+++ b/server/proliferate/server/cloud/agent_gateway/api.py
@@ -146,6 +146,18 @@ async def put_agent_auth_selections_endpoint(
         )
     except CloudApiError as error:
         raise_cloud_error(error)
+    # Persist settings alongside sources when provided.
+    if body.settings is not None:
+        try:
+            await service.put_harness_settings(
+                db,
+                user_id=user.id,
+                harness_kind=harness_kind,
+                surface=surface,
+                settings_dict=body.settings,
+            )
+        except CloudApiError as error:
+            raise_cloud_error(error)
     titles = await service.key_titles(db, user_id=user.id)
     return [
         auth_selection_payload(record, key_title=titles.get(record.api_key_id))

--- a/server/proliferate/server/cloud/agent_gateway/models.py
+++ b/server/proliferate/server/cloud/agent_gateway/models.py
@@ -91,6 +91,11 @@ class AgentAuthSourceInput(AgentGatewayBaseModel):
 
 class AgentAuthSelectionsPutRequest(AgentGatewayBaseModel):
     sources: list[AgentAuthSourceInput]
+    # Per-harness advanced settings (catalog-declared toggles). Keys are setting
+    # keys from the agent catalog; values are booleans (v1). Null/absent means
+    # "no change to settings". The server validates shape (dict[str, bool]) but
+    # does NOT validate keys against the catalog (runtime-only artifact).
+    settings: dict[str, Any] | None = None
 
 
 # --------------------------------------------------------------------------- #
@@ -111,6 +116,7 @@ class AgentAuthStateSource(BaseModel):
 class AgentAuthStateHarness(BaseModel):
     harness_kind: str
     sources: list[AgentAuthStateSource]
+    settings: dict[str, Any] | None = None
 
 
 class AgentAuthStateResponse(BaseModel):

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -238,6 +238,32 @@ async def put_auth_selections(
     return rows
 
 
+async def put_harness_settings(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+    settings_dict: dict[str, object],
+) -> dict[str, object]:
+    """Validate shape (all values must be bool) and upsert harness settings."""
+    for key, value in settings_dict.items():
+        if not isinstance(key, str) or not isinstance(value, bool):
+            raise CloudApiError(
+                "invalid_harness_settings",
+                "Settings must be a dict[str, bool]. "
+                f"Key {key!r} has value of type {type(value).__name__}.",
+                status_code=400,
+            )
+    return await agent_gateway_store.put_harness_settings(
+        db,
+        user_id=user_id,
+        harness_kind=harness_kind,
+        surface=surface,
+        settings=settings_dict,
+    )
+
+
 async def get_auth_state(
     db: AsyncSession,
     *,

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -103,6 +103,7 @@ class AgentAuthStateInputs:
     enrollment_sync_status: str | None
     gateway_virtual_key: str | None
     gateway_base_url: str | None
+    harness_settings: Mapping[str, dict[str, object]]  # keyed by harness_kind
 
 
 def render_agent_auth_state(inputs: AgentAuthStateInputs) -> tuple[dict[str, object], str]:
@@ -129,9 +130,14 @@ def render_agent_auth_state(inputs: AgentAuthStateInputs) -> tuple[dict[str, obj
     harnesses: list[dict[str, object]] = []
     for harness_kind in sorted(by_harness):
         ordered = sorted(by_harness[harness_kind], key=lambda item: item[0])
-        harnesses.append(
-            {"harness_kind": harness_kind, "sources": [source for _, source in ordered]}
-        )
+        harness_entry: dict[str, object] = {
+            "harness_kind": harness_kind,
+            "sources": [source for _, source in ordered],
+        }
+        harness_settings = inputs.harness_settings.get(harness_kind)
+        if harness_settings:
+            harness_entry["settings"] = harness_settings
+        harnesses.append(harness_entry)
 
     state: dict[str, object] = {
         "version": AGENT_AUTH_STATE_VERSION,
@@ -273,6 +279,12 @@ async def _load_state_inputs(
                     )
                 )
 
+    harness_settings = await agent_gateway_store.list_harness_settings_for_surface(
+        db,
+        user_id=user_id,
+        surface=surface,
+    )
+
     return AgentAuthStateInputs(
         user_id=user_id,
         revision=revision,
@@ -281,6 +293,7 @@ async def _load_state_inputs(
         enrollment_sync_status=enrollment_sync_status,
         gateway_virtual_key=gateway_virtual_key,
         gateway_base_url=settings.agent_gateway_litellm_public_base_url or None,
+        harness_settings=harness_settings,
     )
 
 

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -60,6 +60,7 @@ def _inputs(
         enrollment_sync_status=enrollment_sync_status,
         gateway_virtual_key=gateway_virtual_key,
         gateway_base_url=gateway_base_url,
+        harness_settings={},
     )
 
 


### PR DESCRIPTION
## Summary

- Adds a generic system for per-harness advanced settings declared in the agent catalog, persisted with auth selections, and applied at harness spawn time.
- First shipped setting: Claude "Use Claude Code with Chrome" boolean mapping to the `--chrome` CLI flag (local surface only).
- 8-layer implementation spanning catalog JSON, JS validator, Rust catalog structs + validation + resolver, state.json persistence, spawn-time application, server API/DB, cloud SDK types, and desktop UI.

## Architecture decisions

- Settings are per `(user, harness_kind, surface)` — independent of auth source selections. Stored in a separate `agent_auth_harness_settings` table.
- Settings resolution reads catalog settings from the bundled catalog document and persisted values from state.json at launch time.
- The server validates shape only (`dict[str, bool]` for v1) — it does NOT validate keys against the catalog (runtime-only artifact).
- `cli_flag` mapping + `true` appends the flag to extra_args; `env` mapping sets an env var.

## DB schema change

New table `agent_auth_harness_settings` (Alembic revision `d4bbfa6e0669`).
Profile ownership rule: this branch owns its dev profile for its lifetime.

## Verification

- [x] JS validator: `node scripts/validate-agent-catalog.mjs` passes
- [x] Rust: `cargo test -p anyharness-lib` — 796 tests pass
- [x] Server: `pytest` passes (materialization + all unit tests)
- [x] Desktop: tsc errors are only pre-existing shared-package module resolution (no logic errors from this change)

## Test plan

- [ ] Boot local runtime, toggle Chrome setting in desktop UI, verify state.json gains `settings: {"chrome": true}` under the claude harness
- [ ] Start a Claude session with chrome enabled, verify `--chrome` appears in the spawned process args
- [ ] Toggle off, verify flag is absent on next session
- [ ] Cloud surface: setting does not render (filtered by `surfaces: ["local"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)