### PR TITLE
fix(automations): stop showing session/model configuration twice in the editor

### DIFF
--- a/apps/desktop/src/components/automations/editor/AutomationAgentHarnessControls.tsx
+++ b/apps/desktop/src/components/automations/editor/AutomationAgentHarnessControls.tsx
@@ -22,7 +22,7 @@ export function AutomationAgentHarnessControls({
   onSelectModel: (agent: DesktopAgentLaunchAgent, model: DesktopAgentLaunchModel) => void;
 }) {
   const label = selectedAgent && selectedModel
-    ? `${selectedAgent.displayName} · ${selectedModel.displayName}`
+    ? selectedModel.displayName
     : loading
       ? "Loading agents"
       : "Agent harness";


### PR DESCRIPTION
## Summary

Fixes duplication in the automation editor where agent/model information was displayed redundantly.

### Before
The agent/model selector pill displayed:
- Agent icon (e.g., Claude icon)
- Agent name + model name (e.g., "Claude · Haiku 4.5")

This created visual redundancy since the icon already indicates which agent is selected.

### After
The agent/model selector pill now displays:
- Agent icon (e.g., Claude icon) 
- Model name only (e.g., "Haiku 4.5")

The display is now more concise while preserving all necessary information. Each piece of information appears exactly once.

## Test plan

- [ ] Open automation editor in desktop app
- [ ] Verify agent/model selector pill shows icon + model name (not "Agent · Model")
- [ ] Verify the pill is still clickable and opens the model picker
- [ ] Verify session config pills (mode, reasoning, etc.) still display correctly
- [ ] Verify creating/editing an automation works as expected

## Changes

- Modified `AutomationAgentHarnessControls.tsx` to show only model name in label (agent is shown via icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)