### PR TITLE
feat(automations): archive automations end-to-end

### DIFF
--- a/apps/desktop/src/components/automations/screen/AutomationsScreen.tsx
+++ b/apps/desktop/src/components/automations/screen/AutomationsScreen.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
 import { MainSidebarPageShell } from "@/components/workspace/shell/screen/MainSidebarPageShell";
 import { AutomationEditorModal } from "@/components/automations/editor/AutomationEditorModal";
 import { useAutomationActions } from "@/hooks/automations/workflows/use-automation-actions";
@@ -32,7 +33,7 @@ import { AutomationSurface } from "@proliferate/product-ui/automations/Automatio
 
 const EMPTY_AUTOMATIONS: AutomationRecord[] = [];
 const EMPTY_AUTOMATION_RUNS: AutomationRunRecord[] = [];
-type AutomationListAction = "pause" | "resume" | "run";
+type AutomationListAction = "pause" | "resume" | "run" | "archive";
 
 interface AutomationsScreenProps {
   selectedAutomationId?: string | null;
@@ -225,7 +226,24 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
     || actions.isUpdatingAutomation
     || actions.isPausingAutomation
     || actions.isResumingAutomation
-    || actions.isRunningAutomationNow;
+    || actions.isRunningAutomationNow
+    || actions.isArchivingAutomation;
+
+  const [archiveTargetId, setArchiveTargetId] = useState<string | null>(null);
+
+  const handleArchiveRequest = useCallback((automationId: string) => {
+    setArchiveTargetId(automationId);
+  }, []);
+
+  const handleArchiveConfirm = useCallback(async () => {
+    if (!archiveTargetId) return;
+    const targetId = archiveTargetId;
+    setArchiveTargetId(null);
+    await actions.archiveAutomation(targetId);
+    if (isDetailView) {
+      navigate("/workflows");
+    }
+  }, [archiveTargetId, actions, isDetailView, navigate]);
 
   return (
     <>
@@ -255,6 +273,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
             onResume={(automationId) => {
               void actions.resumeAutomation(automationId);
             }}
+            onArchive={handleArchiveRequest}
             onRunSelect={openRun}
           />
         ) : (
@@ -301,6 +320,7 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
                 () => actions.runAutomationNow(automationId),
               );
             }}
+            onArchive={handleArchiveRequest}
           />
         )}
       </MainSidebarPageShell>
@@ -321,6 +341,17 @@ export function AutomationsScreen({ selectedAutomationId = null }: AutomationsSc
           onUpdate={handleUpdate}
         />
       )}
+
+      <ConfirmationDialog
+        open={archiveTargetId !== null}
+        title="Archive this workflow?"
+        description="It will stop running and disappear from this list."
+        confirmLabel="Archive"
+        confirmVariant="destructive"
+        loading={actions.isArchivingAutomation}
+        onClose={() => setArchiveTargetId(null)}
+        onConfirm={() => { void handleArchiveConfirm(); }}
+      />
     </>
   );
 }

--- a/apps/desktop/src/hooks/access/cloud/automations/use-automation-mutations.ts
+++ b/apps/desktop/src/hooks/access/cloud/automations/use-automation-mutations.ts
@@ -7,6 +7,7 @@ import type {
   UpdateAutomationRequest,
 } from "@/lib/access/cloud/client";
 import {
+  archiveAutomation,
   createAutomation,
   pauseAutomation,
   resumeAutomation,
@@ -61,12 +62,18 @@ export function useAutomationMutations() {
     onSuccess: (_, automationId) => invalidateAutomation(automationId),
   });
 
+  const archiveMutation = useMutation<AutomationResponse, Error, string>({
+    mutationFn: (automationId) => archiveAutomation(automationId),
+    onSuccess: (automation) => invalidateAutomation(automation.id),
+  });
+
   return {
     createMutation,
     updateMutation,
     pauseMutation,
     resumeMutation,
     runNowMutation,
+    archiveMutation,
     invalidateAutomation,
   };
 }

--- a/apps/desktop/src/hooks/automations/workflows/use-automation-actions.ts
+++ b/apps/desktop/src/hooks/automations/workflows/use-automation-actions.ts
@@ -15,6 +15,7 @@ export function useAutomationActions() {
     pauseMutation,
     resumeMutation,
     runNowMutation,
+    archiveMutation,
   } = useAutomationMutations();
   const showToast = useToastStore((state) => state.show);
 
@@ -42,6 +43,14 @@ export function useAutomationActions() {
     }
   }, [runNowMutation, showToast]);
 
+  const archive = useCallback(async (automationId: string) => {
+    try {
+      await archiveMutation.mutateAsync(automationId);
+    } catch (error) {
+      showToast(`Failed to archive workflow: ${errorMessage(error)}`);
+    }
+  }, [archiveMutation, showToast]);
+
   return {
     createAutomation: createMutation.mutateAsync,
     isCreatingAutomation: createMutation.isPending,
@@ -53,5 +62,7 @@ export function useAutomationActions() {
     isResumingAutomation: resumeMutation.isPending,
     runAutomationNow: runNow,
     isRunningAutomationNow: runNowMutation.isPending,
+    archiveAutomation: archive,
+    isArchivingAutomation: archiveMutation.isPending,
   };
 }

--- a/apps/packages/product-ui/src/automations/AutomationDetailSurface.tsx
+++ b/apps/packages/product-ui/src/automations/AutomationDetailSurface.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Pause, Pencil, Play, Zap } from "lucide-react";
+import { Archive, ArrowLeft, Pause, Pencil, Play, Zap } from "lucide-react";
 import { type ReactNode } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import type {
@@ -24,6 +24,7 @@ export interface AutomationDetailSurfaceProps {
   onEdit?: (automationId: string) => void;
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
   onRunSelect?: (runId: string) => void;
 }
 
@@ -49,6 +50,7 @@ export function AutomationDetailSurface({
   onEdit,
   onPause,
   onResume,
+  onArchive,
   onRunSelect,
 }: AutomationDetailSurfaceProps) {
   const title = automation?.title ?? "Workflow";
@@ -65,6 +67,7 @@ export function AutomationDetailSurface({
           onEdit={onEdit}
           onPause={onPause}
           onResume={onResume}
+          onArchive={onArchive}
         />
       ) : null}
       maxWidthClassName={maxWidthClassName}
@@ -198,6 +201,7 @@ function AutomationDetailActions({
   onEdit,
   onPause,
   onResume,
+  onArchive,
 }: {
   automation: AutomationInventoryItemView;
   busy: boolean;
@@ -205,6 +209,7 @@ function AutomationDetailActions({
   onEdit?: (automationId: string) => void;
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
 }) {
   const runDisabledReason = automation.runNowDisabledReason
     ?? (!automation.enabled ? "Resume before queueing a run." : null);
@@ -254,6 +259,18 @@ function AutomationDetailActions({
         >
           <Play className="size-4" aria-hidden />
           Resume
+        </Button>
+      ) : null}
+      {onArchive ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onArchive(automation.id)}
+          disabled={busy}
+          className="text-destructive hover:text-destructive"
+        >
+          <Archive className="size-4" aria-hidden />
+          Archive
         </Button>
       ) : null}
     </div>

--- a/apps/packages/product-ui/src/automations/AutomationInventoryList.tsx
+++ b/apps/packages/product-ui/src/automations/AutomationInventoryList.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizontal, Pause, Pencil, Play, Zap } from "lucide-react";
+import { Archive, MoreHorizontal, Pause, Pencil, Play, Zap } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 import { Button } from "@proliferate/ui/primitives/Button";
@@ -11,13 +11,14 @@ import { AutomationStatusGlyph } from "./AutomationStatusGlyph";
 export interface AutomationInventoryListProps {
   groups: readonly AutomationInventoryGroupView[];
   busyAutomationId?: string | null;
-  busyAction?: "pause" | "resume" | "run" | null;
+  busyAction?: "pause" | "resume" | "run" | "archive" | null;
   actionsDisabled?: boolean;
   onAutomationSelect: (automationId: string) => void;
   onEdit?: (automationId: string) => void;
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
   onRunNow?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
 }
 
 export function AutomationInventoryList({
@@ -30,6 +31,7 @@ export function AutomationInventoryList({
   onPause,
   onResume,
   onRunNow,
+  onArchive,
 }: AutomationInventoryListProps) {
   return (
     <div className="w-full min-w-0 overflow-visible pb-10" role="region" aria-label="Workflows">
@@ -51,6 +53,7 @@ export function AutomationInventoryList({
                 onPause={onPause}
                 onResume={onResume}
                 onRunNow={onRunNow}
+                onArchive={onArchive}
               />
             ))}
           </div>
@@ -69,19 +72,21 @@ function AutomationInventoryRow({
   onPause,
   onResume,
   onRunNow,
+  onArchive,
 }: {
   item: AutomationInventoryItemView;
-  busy: "pause" | "resume" | "run" | null;
+  busy: "pause" | "resume" | "run" | "archive" | null;
   actionsDisabled: boolean;
   onAutomationSelect: (automationId: string) => void;
   onEdit?: (automationId: string) => void;
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
   onRunNow?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
 }) {
   const runNowReason = runNowDisabledReason(item);
   const hasToggleAction = item.enabled ? Boolean(onPause) : Boolean(onResume);
-  const hasRowActions = Boolean(onRunNow || onEdit || hasToggleAction);
+  const hasRowActions = Boolean(onRunNow || onEdit || hasToggleAction || onArchive);
 
   return (
     <div role="listitem" className="group relative">
@@ -145,6 +150,7 @@ function AutomationInventoryRow({
             onPause={onPause}
             onResume={onResume}
             onRunNow={onRunNow}
+            onArchive={onArchive}
           />
         </span>
       ) : null}
@@ -160,20 +166,22 @@ function AutomationActionMenu({
   onPause,
   onResume,
   onRunNow,
+  onArchive,
 }: {
   item: AutomationInventoryItemView;
-  busy: "pause" | "resume" | "run" | null;
+  busy: "pause" | "resume" | "run" | "archive" | null;
   actionsDisabled: boolean;
   onEdit?: (automationId: string) => void;
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
   onRunNow?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLSpanElement | null>(null);
   const runNowReason = runNowDisabledReason(item);
   const toggleAction = item.enabled ? onPause : onResume;
-  const hasActions = Boolean(onRunNow || onEdit || toggleAction);
+  const hasActions = Boolean(onRunNow || onEdit || toggleAction || onArchive);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -241,6 +249,17 @@ function AutomationActionMenu({
               disabled={actionsDisabled || busy !== null}
               onClick={() => {
                 toggleAction(item.id);
+                close();
+              }}
+            />
+          ) : null}
+          {onArchive ? (
+            <MenuAction
+              label="Archive"
+              icon={<Archive className="size-3.5" aria-hidden />}
+              disabled={actionsDisabled || busy !== null}
+              onClick={() => {
+                onArchive(item.id);
                 close();
               }}
             />

--- a/apps/packages/product-ui/src/automations/AutomationSurface.tsx
+++ b/apps/packages/product-ui/src/automations/AutomationSurface.tsx
@@ -21,7 +21,7 @@ export interface AutomationSurfaceProps {
   error?: boolean;
   actionError?: string | null;
   busyAutomationId?: string | null;
-  busyAction?: "pause" | "resume" | "run" | null;
+  busyAction?: "pause" | "resume" | "run" | "archive" | null;
   actionsDisabled?: boolean;
   description?: ReactNode;
   maxWidthClassName?: string;
@@ -34,6 +34,7 @@ export interface AutomationSurfaceProps {
   onPause?: (automationId: string) => void;
   onResume?: (automationId: string) => void;
   onRunNow?: (automationId: string) => void;
+  onArchive?: (automationId: string) => void;
 }
 
 export function AutomationSurface({
@@ -58,6 +59,7 @@ export function AutomationSurface({
   onPause,
   onResume,
   onRunNow,
+  onArchive,
 }: AutomationSurfaceProps) {
   const itemCount = groups.reduce((sum, group) => sum + group.items.length, 0);
 
@@ -134,6 +136,7 @@ export function AutomationSurface({
           onPause={onPause}
           onResume={onResume}
           onRunNow={onRunNow}
+          onArchive={onArchive}
         />
       )}
     </ProductPageShell>

--- a/cloud/sdk/src/client/automations.ts
+++ b/cloud/sdk/src/client/automations.ts
@@ -114,6 +114,24 @@ export async function resumeAutomationWithClient(
   });
 }
 
+export async function archiveAutomation(
+  automationId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<AutomationResponse> {
+  return archiveAutomationWithClient(automationId, client);
+}
+
+export async function archiveAutomationWithClient(
+  automationId: string,
+  client: ProliferateCloudClient,
+): Promise<AutomationResponse> {
+  return client.requestJson<AutomationResponse>({
+    method: "POST",
+    path: "/v1/automations/{automation_id}/archive",
+    pathParams: { automation_id: automationId },
+  });
+}
+
 export async function runAutomationNow(
   automationId: string,
   client: ProliferateCloudClient = getProliferateClient(),

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -300,6 +300,7 @@ export interface AutomationResponse {
   cloudAgentRunConfigId: string;
   enabled: boolean;
   pausedAt: string | null;
+  archivedAt: string | null;
   lastScheduledAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/server/alembic/versions/a1b2c3d4e5f6_add_archived_at_to_automation.py
+++ b/server/alembic/versions/a1b2c3d4e5f6_add_archived_at_to_automation.py
@@ -1,0 +1,44 @@
+"""add_archived_at_to_automation
+
+Revision ID: a1b2c3d4e5f6
+Revises: ff9344886948
+Create Date: 2026-07-05 10:00:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "ff9344886948"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    }
+
+
+def upgrade() -> None:
+    if _has_table("automation") and not _has_column("automation", "archived_at"):
+        op.add_column(
+            "automation",
+            sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("automation") and _has_column("automation", "archived_at"):
+        op.drop_column("automation", "archived_at")

--- a/server/proliferate/db/models/automations.py
+++ b/server/proliferate/db/models/automations.py
@@ -91,6 +91,7 @@ class Automation(Base):
     )
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     next_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_scheduled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/server/proliferate/db/store/automations.py
+++ b/server/proliferate/db/store/automations.py
@@ -51,6 +51,7 @@ class AutomationValue:
     cloud_agent_run_config_id: UUID
     enabled: bool
     paused_at: datetime | None
+    archived_at: datetime | None
     next_run_at: datetime | None
     last_scheduled_at: datetime | None
     created_at: datetime
@@ -84,6 +85,7 @@ def _automation_value(record: Automation, repo_config: CloudRepoConfig) -> Autom
         cloud_agent_run_config_id=record.cloud_agent_run_config_id,
         enabled=record.enabled,
         paused_at=record.paused_at,
+        archived_at=record.archived_at,
         next_run_at=record.next_run_at,
         last_scheduled_at=record.last_scheduled_at,
         created_at=record.created_at,
@@ -211,19 +213,23 @@ async def list_automations_for_user(
     *,
     owner_scope: str = AUTOMATION_OWNER_SCOPE_PERSONAL,
     organization_id: UUID | None = None,
+    include_archived: bool = False,
 ) -> list[AutomationValue]:
+    predicates = list(
+        _automation_owner_predicates(
+            user_id=user_id,
+            owner_scope=owner_scope,
+            organization_id=organization_id,
+        )
+    )
+    if not include_archived:
+        predicates.append(Automation.archived_at.is_(None))
     rows = list(
         (
             await db.execute(
                 select(Automation, CloudRepoConfig)
                 .join(CloudRepoConfig, Automation.cloud_repo_config_id == CloudRepoConfig.id)
-                .where(
-                    *_automation_owner_predicates(
-                        user_id=user_id,
-                        owner_scope=owner_scope,
-                        organization_id=organization_id,
-                    )
-                )
+                .where(*predicates)
                 .order_by(Automation.created_at.desc())
             )
         ).all()
@@ -264,6 +270,7 @@ async def update_automation_for_user(
     cloud_agent_run_config_id: object = _UNSET,
     enabled: object = _UNSET,
     paused_at: object = _UNSET,
+    archived_at: object = _UNSET,
     next_run_at: object = _UNSET,
 ) -> AutomationValue | None:
     record = (
@@ -298,6 +305,8 @@ async def update_automation_for_user(
         record.enabled = enabled  # type: ignore[assignment]
     if paused_at is not _UNSET:
         record.paused_at = paused_at  # type: ignore[assignment]
+    if archived_at is not _UNSET:
+        record.archived_at = archived_at  # type: ignore[assignment]
     if next_run_at is not _UNSET:
         record.next_run_at = next_run_at  # type: ignore[assignment]
     record.updated_at = utcnow()

--- a/server/proliferate/server/automations/api.py
+++ b/server/proliferate/server/automations/api.py
@@ -45,6 +45,7 @@ from proliferate.server.automations.models import (
     automation_run_payload,
 )
 from proliferate.server.automations.service import (
+    archive_automation,
     create_automation,
     get_automation,
     list_automation_runs,
@@ -244,6 +245,15 @@ async def resume_automation_endpoint(
     user: User = Depends(current_product_user),
 ) -> AutomationResponse:
     return automation_payload(await resume_automation(db, user.id, automation_id))
+
+
+@router.post("/{automation_id}/archive", response_model=AutomationResponse)
+async def archive_automation_endpoint(
+    automation_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> AutomationResponse:
+    return automation_payload(await archive_automation(db, user.id, automation_id))
 
 
 @router.post("/{automation_id}/run-now", response_model=AutomationRunResponse)

--- a/server/proliferate/server/automations/errors.py
+++ b/server/proliferate/server/automations/errors.py
@@ -83,6 +83,16 @@ class AutomationPaused(InvalidRequest):
         )
 
 
+class AutomationArchived(InvalidRequest):
+    code = "automation_archived"
+
+    def __init__(self) -> None:
+        super().__init__(
+            message="This automation is archived and cannot be modified.",
+            code=self.code,
+        )
+
+
 class AutomationRepoLimitExceeded(Conflict):
     code = "repo_limit_exceeded"
 

--- a/server/proliferate/server/automations/models.py
+++ b/server/proliferate/server/automations/models.py
@@ -85,6 +85,7 @@ class AutomationResponse(AutomationBaseModel):
     cloud_agent_run_config_id: str = Field(alias="cloudAgentRunConfigId")
     enabled: bool
     paused_at: str | None = Field(alias="pausedAt")
+    archived_at: str | None = Field(alias="archivedAt")
     last_scheduled_at: str | None = Field(alias="lastScheduledAt")
     created_at: str = Field(alias="createdAt")
     updated_at: str = Field(alias="updatedAt")
@@ -219,6 +220,7 @@ def automation_payload(value: AutomationValue) -> AutomationResponse:
         cloud_agent_run_config_id=str(value.cloud_agent_run_config_id),
         enabled=value.enabled,
         paused_at=_to_iso(value.paused_at),
+        archived_at=_to_iso(value.archived_at),
         last_scheduled_at=_to_iso(value.last_scheduled_at),
         created_at=value.created_at.isoformat(),
         updated_at=value.updated_at.isoformat(),

--- a/server/proliferate/server/automations/service.py
+++ b/server/proliferate/server/automations/service.py
@@ -48,6 +48,7 @@ from proliferate.server.automations.domain.validation import (
     normalize_title,
 )
 from proliferate.server.automations.errors import (
+    AutomationArchived,
     AutomationInvalidField,
     AutomationNotFound,
     AutomationPaused,
@@ -456,6 +457,8 @@ async def pause_automation(
         automation_id=automation_id,
         require_admin=True,
     )
+    if existing.archived_at is not None:
+        raise AutomationArchived()
     value = await update_automation_for_user(
         db,
         user_id=user_id,
@@ -482,6 +485,8 @@ async def resume_automation(
         automation_id=automation_id,
         require_admin=True,
     )
+    if existing.archived_at is not None:
+        raise AutomationArchived()
     next_run_at = next_future_occurrence(
         rrule_text=existing.schedule_rrule,
         timezone=existing.schedule_timezone,
@@ -502,6 +507,35 @@ async def resume_automation(
     return value
 
 
+async def archive_automation(
+    db: AsyncSession,
+    user_id: UUID,
+    automation_id: UUID,
+) -> AutomationValue:
+    existing = await _load_actor_automation(
+        db,
+        actor_user_id=user_id,
+        automation_id=automation_id,
+        require_admin=True,
+    )
+    if existing.archived_at is not None:
+        raise AutomationArchived()
+    value = await update_automation_for_user(
+        db,
+        user_id=user_id,
+        automation_id=automation_id,
+        owner_scope=existing.owner_scope,
+        organization_id=existing.organization_id,
+        enabled=False,
+        paused_at=None,
+        archived_at=utcnow(),
+        next_run_at=None,
+    )
+    if value is None:
+        raise AutomationNotFound()
+    return value
+
+
 async def run_automation_now(
     db: AsyncSession,
     user_id: UUID,
@@ -513,6 +547,8 @@ async def run_automation_now(
         automation_id=automation_id,
         require_admin=True,
     )
+    if existing.archived_at is not None:
+        raise AutomationArchived()
     if not existing.enabled:
         raise AutomationPaused()
     await _ensure_repo_config_id(


### PR DESCRIPTION
## Summary

- Adds `POST /automations/{id}/archive` endpoint — soft-archives an automation by setting `archived_at` timestamp, disabling it, and clearing `next_run_at`
- Archived automations are excluded from the list response server-side (`include_archived=false` default), cannot be paused/resumed/run (returns 400 with `automation_archived` code)
- Archive action in both the inventory list row menu and detail view actions bar, styled destructive, gated by a `ConfirmationDialog` ("Archive this workflow? It will stop running and disappear from this list.")
- No unarchive UI in v1; data is preserved

## Schema change

Adds nullable `archived_at TIMESTAMPTZ` column to the `automation` table via alembic migration. Additive-only — no existing constraint changes. **This branch owns its dev profile for the migration's lifetime.**

## Spec note

`specs/tbd/goals-and-workflows-v1.md` does not exist on this branch — no spec-prescribed lifecycle semantics to follow or deviate from. The implementation uses the simplest pattern: archive = disable + timestamp + server-side list exclusion, matching the pause/resume pattern.

## Layers touched

| Layer | Files |
|-------|-------|
| Server model | `db/models/automations.py` |
| Server store | `db/store/automations.py` |
| Server service | `server/automations/service.py`, `errors.py` |
| Server API | `server/automations/api.py`, `models.py` |
| Migration | `alembic/versions/a1b2c3d4e5f6_add_archived_at_to_automation.py` |
| SDK | `cloud/sdk/src/client/automations.ts`, `types/generated.ts` |
| Desktop hooks | `use-automation-mutations.ts`, `use-automation-actions.ts` |
| Desktop UI | `AutomationsScreen.tsx` |
| Product UI (shared) | `AutomationDetailSurface.tsx`, `AutomationInventoryList.tsx`, `AutomationSurface.tsx` |

## Test plan

- [ ] `apps/desktop` typecheck passes (`pnpm exec tsc --noEmit`)
- [ ] `apps/packages/product-domain` inventory tests pass
- [ ] Server syntax valid (ast.parse on all touched files)
- [ ] Boot locally with a fresh profile, create a workflow, archive it — confirm it disappears from the list, detail shows archived state, pause/resume/run-now are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)