### PR TITLE
fix(workflows): stop showing session/model config twice in the workflow editor

### DIFF
--- a/apps/desktop/src/components/workflows/editor/WorkflowSetupCard.tsx
+++ b/apps/desktop/src/components/workflows/editor/WorkflowSetupCard.tsx
@@ -27,19 +27,11 @@ export interface WorkflowSetupCardProps {
 
 const ARG_TYPES: WorkflowArgType[] = ["string", "number", "boolean", "enum"];
 
-function summaryText(setup: WorkflowSetup, agents: readonly EditorAgent[], argCount: number): string {
-  const agent = agents.find((a) => a.kind === setup.harness);
-  const harness = agent?.displayName ?? (setup.harness || "No agent");
-  const model = agent?.models.find((m) => m.id === setup.model)?.label ?? setup.model;
-  const parts = [harness];
-  if (model) {
-    parts.push(model);
+function summaryText(argCount: number): string {
+  if (argCount === 0) {
+    return "No arguments";
   }
-  parts.push(setup.sessionBinding === "headless" ? "headless" : "fresh");
-  if (argCount > 0) {
-    parts.push(`${argCount} ${argCount === 1 ? "arg" : "args"}`);
-  }
-  return parts.join(" · ");
+  return `${argCount} ${argCount === 1 ? "arg" : "args"}`;
 }
 
 function ArgRow({
@@ -154,7 +146,7 @@ export function WorkflowSetupCard({ setup, args, agents, onSetupChange, onArgsCh
       >
         <span className="flex min-w-0 flex-col">
           <span className="text-ui-sm font-medium text-foreground">Setup</span>
-          <span className="truncate text-xs text-muted-foreground">{summaryText(setup, agents, args.length)}</span>
+          <span className="truncate text-xs text-muted-foreground">{summaryText(args.length)}</span>
         </span>
         {expanded ? <ChevronDown className="size-4 shrink-0 text-faint" /> : <ChevronRight className="size-4 shrink-0 text-faint" />}
       </button>


### PR DESCRIPTION
## Summary

The workflow editor Setup card was displaying configuration values redundantly in both the collapsed summary line and the expanded edit controls.

## Changes

**BEFORE:**
- **Summary (collapsed):** "Claude · Haiku 4.5 · fresh · 1 arg"
- **Expanded Agent section:** AgentHarnessModelSelector showing "Claude · Haiku 4.5"
- **Expanded Session section:** Select dropdown showing "Fresh (visible)"

**AFTER:**
- **Summary (collapsed):** "1 arg" (or "No arguments")
- **Expanded Agent section:** AgentHarnessModelSelector showing agent + model (unchanged)
- **Expanded Session section:** Select dropdown showing session binding (unchanged)

## Implementation

Modified `WorkflowSetupCard.tsx`:
- Simplified `summaryText()` function to only show argument count
- Removed agent harness, model, and session binding from the collapsed summary
- The editable control for each value now owns the exclusive right to display it
- Helper text explaining bypass mode and run location behavior remains unchanged

## Verification

- TypeScript compilation passes with no errors
- No component tests exist for WorkflowSetupCard
- File size reduced from 230 to 221 lines

## Files Changed

- `apps/desktop/src/components/workflows/editor/WorkflowSetupCard.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)