### PR TITLE
obs: org/sandbox/runtime-env identity tags on all Sentry surfaces

### DIFF
--- a/anyharness/crates/anyharness-lib/src/process_env.rs
+++ b/anyharness/crates/anyharness-lib/src/process_env.rs
@@ -7,6 +7,9 @@ const RUNTIME_PRIVATE_ENV: &[&str] = &[
     "PROLIFERATE_TARGET_SENTRY_ENVIRONMENT",
     "PROLIFERATE_TARGET_SENTRY_RELEASE",
     "PROLIFERATE_TARGET_SENTRY_TRACES_SAMPLE_RATE",
+    "PROLIFERATE_ORG_ID",
+    "PROLIFERATE_SANDBOX_ID",
+    "PROLIFERATE_RUNTIME_ENV",
 ];
 
 pub(crate) fn remove_runtime_private_env(command: &mut tokio::process::Command) {

--- a/anyharness/crates/anyharness-lib/src/process_env.rs
+++ b/anyharness/crates/anyharness-lib/src/process_env.rs
@@ -10,6 +10,7 @@ const RUNTIME_PRIVATE_ENV: &[&str] = &[
     "PROLIFERATE_ORG_ID",
     "PROLIFERATE_SANDBOX_ID",
     "PROLIFERATE_RUNTIME_ENV",
+    "PROLIFERATE_USER_ID",
 ];
 
 pub(crate) fn remove_runtime_private_env(command: &mut tokio::process::Command) {

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -140,6 +140,11 @@ fn sentry_scope_tags() -> Vec<(&'static str, String)> {
             tags.push(("sandbox_id", sandbox_id));
         }
     }
+    if let Ok(user_id) = std::env::var("PROLIFERATE_USER_ID") {
+        if !user_id.trim().is_empty() {
+            tags.push(("user_id", user_id));
+        }
+    }
     if let Ok(target_id) = std::env::var("ANYHARNESS_RUNTIME_TARGET_ID") {
         if !target_id.trim().is_empty() {
             tags.push(("target_id", target_id));

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -104,7 +104,7 @@ pub fn init(command: &Commands) -> TelemetryGuards {
 
     if telemetry.is_some() {
         sentry::configure_scope(|scope| {
-            for (key, value) in sentry_scope_tags() {
+            for (key, value) in &sentry_scope_tags() {
                 scope.set_tag(key, value);
             }
         });
@@ -120,11 +120,33 @@ pub fn init(command: &Commands) -> TelemetryGuards {
     }
 }
 
-fn sentry_scope_tags() -> [(&'static str, &'static str); 2] {
-    [
-        ("surface", "anyharness_runtime"),
-        ("telemetry_mode", ANYHARNESS_TELEMETRY_MODE),
-    ]
+fn sentry_scope_tags() -> Vec<(&'static str, String)> {
+    let mut tags: Vec<(&'static str, String)> = vec![
+        ("surface", "anyharness_runtime".to_string()),
+        ("telemetry_mode", ANYHARNESS_TELEMETRY_MODE.to_string()),
+    ];
+
+    let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
+        .unwrap_or_else(|_| "local".to_string());
+    tags.push(("runtime_env", runtime_env));
+
+    if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
+        if !org_id.trim().is_empty() {
+            tags.push(("org_id", org_id));
+        }
+    }
+    if let Ok(sandbox_id) = std::env::var("PROLIFERATE_SANDBOX_ID") {
+        if !sandbox_id.trim().is_empty() {
+            tags.push(("sandbox_id", sandbox_id));
+        }
+    }
+    if let Ok(target_id) = std::env::var("ANYHARNESS_RUNTIME_TARGET_ID") {
+        if !target_id.trim().is_empty() {
+            tags.push(("target_id", target_id));
+        }
+    }
+
+    tags
 }
 
 #[cfg(test)]
@@ -139,13 +161,10 @@ mod tests {
 
     #[test]
     fn sentry_scope_tags_include_runtime_surface_and_mode() {
-        assert_eq!(
-            sentry_scope_tags(),
-            [
-                ("surface", "anyharness_runtime"),
-                ("telemetry_mode", "hosted_product"),
-            ]
-        );
+        let tags = sentry_scope_tags();
+        assert!(tags.iter().any(|(k, v)| *k == "surface" && v == "anyharness_runtime"));
+        assert!(tags.iter().any(|(k, v)| *k == "telemetry_mode" && v == "hosted_product"));
+        assert!(tags.iter().any(|(k, v)| *k == "runtime_env" && !v.is_empty()));
     }
 
     #[test]

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -323,6 +323,21 @@ pub fn init() -> TelemetryGuards {
         sentry::configure_scope(|scope| {
             scope.set_tag("surface", "proliferate_supervisor");
             scope.set_tag("telemetry_mode", "hosted_product");
+
+            let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
+                .unwrap_or_else(|_| "local".to_string());
+            scope.set_tag("runtime_env", &runtime_env);
+
+            if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
+                if !org_id.trim().is_empty() {
+                    scope.set_tag("org_id", &org_id);
+                }
+            }
+            if let Ok(sandbox_id) = std::env::var("PROLIFERATE_SANDBOX_ID") {
+                if !sandbox_id.trim().is_empty() {
+                    scope.set_tag("sandbox_id", &sandbox_id);
+                }
+            }
         });
     }
 

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -338,6 +338,11 @@ pub fn init() -> TelemetryGuards {
                     scope.set_tag("sandbox_id", &sandbox_id);
                 }
             }
+            if let Ok(user_id) = std::env::var("PROLIFERATE_USER_ID") {
+                if !user_id.trim().is_empty() {
+                    scope.set_tag("user_id", &user_id);
+                }
+            }
         });
     }
 

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -323,6 +323,21 @@ pub fn init() -> TelemetryGuards {
         sentry::configure_scope(|scope| {
             scope.set_tag("surface", "proliferate_worker");
             scope.set_tag("telemetry_mode", "hosted_product");
+
+            let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
+                .unwrap_or_else(|_| "local".to_string());
+            scope.set_tag("runtime_env", &runtime_env);
+
+            if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
+                if !org_id.trim().is_empty() {
+                    scope.set_tag("org_id", &org_id);
+                }
+            }
+            if let Ok(sandbox_id) = std::env::var("PROLIFERATE_SANDBOX_ID") {
+                if !sandbox_id.trim().is_empty() {
+                    scope.set_tag("sandbox_id", &sandbox_id);
+                }
+            }
         });
     }
 

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -338,6 +338,11 @@ pub fn init() -> TelemetryGuards {
                     scope.set_tag("sandbox_id", &sandbox_id);
                 }
             }
+            if let Ok(user_id) = std::env::var("PROLIFERATE_USER_ID") {
+                if !user_id.trim().is_empty() {
+                    scope.set_tag("user_id", &user_id);
+                }
+            }
         });
     }
 

--- a/apps/desktop/src-tauri/src/sidecar.rs
+++ b/apps/desktop/src-tauri/src/sidecar.rs
@@ -223,6 +223,8 @@ where
         }
     }
 
+    env.insert("PROLIFERATE_RUNTIME_ENV".to_string(), "local".to_string());
+
     env
 }
 

--- a/apps/desktop/src-tauri/src/telemetry.rs
+++ b/apps/desktop/src-tauri/src/telemetry.rs
@@ -131,6 +131,7 @@ pub fn init() -> TelemetryGuards {
     if telemetry.is_some() {
         sentry::configure_scope(|scope| {
             scope.set_tag("surface", "desktop_native");
+            scope.set_tag("runtime_env", "local");
             if let Some(mode_tag) = telemetry_mode_tag(telemetry_mode) {
                 scope.set_tag("telemetry_mode", mode_tag);
             }

--- a/apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
+++ b/apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts
@@ -1,5 +1,6 @@
 import { useTelemetryAuthIdentity } from "./use-telemetry-auth-identity";
 import { useTelemetryAgentSeed } from "./use-telemetry-agent-seed";
+import { useTelemetryOrganizationIdentity } from "./use-telemetry-organization-identity";
 import { useTelemetryRouteViews } from "./use-telemetry-route-views";
 import { useTelemetryRuntimeState } from "./use-telemetry-runtime-state";
 import { useTelemetryWorkspaceSelection } from "./use-telemetry-workspace-selection";
@@ -8,6 +9,7 @@ import { useTelemetryWorkspaceSelection } from "./use-telemetry-workspace-select
 export function useTelemetryBootstrap() {
   useTelemetryAuthIdentity();
   useTelemetryAgentSeed();
+  useTelemetryOrganizationIdentity();
   useTelemetryRouteViews();
   useTelemetryRuntimeState();
   useTelemetryWorkspaceSelection();

--- a/apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-organization-identity.ts
+++ b/apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-organization-identity.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { setTelemetryTag } from "@/lib/integrations/telemetry/client";
+import { useOrganizationStore } from "@/stores/organizations/organization-store";
+
+// Owns the organization_id Sentry tag. Sets it whenever the active org is known.
+export function useTelemetryOrganizationIdentity() {
+  const activeOrganizationId = useOrganizationStore(
+    (state) => state.activeOrganizationId,
+  );
+
+  useEffect(() => {
+    if (activeOrganizationId) {
+      setTelemetryTag("organization_id", activeOrganizationId);
+    } else {
+      setTelemetryTag("organization_id", "none");
+    }
+  }, [activeOrganizationId]);
+}

--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import secrets
 import shlex
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
+from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
 from proliferate.integrations.sandbox import (
     RuntimeEndpoint,
@@ -50,6 +52,29 @@ def _runtime_data_key(sandbox: CloudSandboxValue) -> str | None:
     if not sandbox.anyharness_data_key_ciphertext:
         return None
     return decrypt_text(sandbox.anyharness_data_key_ciphertext)
+
+
+async def _resolve_owner_organization_id(
+    db: AsyncSession,
+    sandbox: CloudSandboxValue,
+) -> UUID | None:
+    """Resolve the sandbox's owning organization for observability identity tags.
+
+    The cloud_sandbox row has no organization column, but the owner is one
+    membership lookup away. Uses the owner's current (first active)
+    membership; best-effort — identity tags must never block a launch.
+    """
+    if sandbox.organization_id is not None:
+        return sandbox.organization_id
+    if sandbox.owner_user_id is None:
+        return None
+    try:
+        record = await organizations_store.get_current_membership_for_user(
+            db, sandbox.owner_user_id
+        )
+    except Exception:  # noqa: BLE001 - identity tagging is best-effort.
+        return None
+    return record.organization.id if record is not None else None
 
 
 async def connect_ready_sandbox(
@@ -163,6 +188,7 @@ async def _launch_anyharness_runtime(
     anyharness_data_key: str,
 ) -> None:
     launcher_path = runtime_launcher_path(runtime_context)
+    organization_id = await _resolve_owner_organization_id(db, sandbox_record)
     await provider.write_file(
         provider_sandbox,
         launcher_path,
@@ -172,8 +198,9 @@ async def _launch_anyharness_runtime(
             build_runtime_env(
                 runtime_token,
                 anyharness_data_key=anyharness_data_key,
-                organization_id=sandbox_record.organization_id,
+                organization_id=organization_id,
                 sandbox_id=provider_sandbox_id,
+                user_id=sandbox_record.owner_user_id,
             ),
         ),
     )

--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -172,6 +172,8 @@ async def _launch_anyharness_runtime(
             build_runtime_env(
                 runtime_token,
                 anyharness_data_key=anyharness_data_key,
+                organization_id=sandbox_record.organization_id,
+                sandbox_id=provider_sandbox_id,
             ),
         ),
     )

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -47,12 +47,28 @@ def _target_sentry_env() -> dict[str, str]:
     return env
 
 
+def _identity_env(
+    *,
+    organization_id: UUID | None = None,
+    sandbox_id: str | None = None,
+) -> dict[str, str]:
+    """Identity env vars for observability (Sentry tags on all runtime surfaces)."""
+    env: dict[str, str] = {"PROLIFERATE_RUNTIME_ENV": "e2b"}
+    if organization_id is not None:
+        env["PROLIFERATE_ORG_ID"] = str(organization_id)
+    if sandbox_id:
+        env["PROLIFERATE_SANDBOX_ID"] = sandbox_id
+    return env
+
+
 def build_runtime_env(
     runtime_token: str,
     *,
     anyharness_data_key: str,
     target_id: UUID | None = None,
     repo_env_vars: Mapping[str, str] | None = None,
+    organization_id: UUID | None = None,
+    sandbox_id: str | None = None,
 ) -> dict[str, str]:
     env: dict[str, str] = {
         "ANYHARNESS_DEV_CORS": "1",
@@ -70,6 +86,7 @@ def build_runtime_env(
     env["ANYHARNESS_DATA_KEY"] = anyharness_data_key
     if target_id is not None:
         env["ANYHARNESS_RUNTIME_TARGET_ID"] = str(target_id)
+    env.update(_identity_env(organization_id=organization_id, sandbox_id=sandbox_id))
     if repo_env_vars:
         env.update(repo_env_vars)
     return env
@@ -194,9 +211,15 @@ def build_supervisor_config(
     provider: SandboxProvider,
     runtime_context: SandboxRuntimeContext,
     runtime_env: Mapping[str, str],
+    *,
+    organization_id: UUID | None = None,
+    sandbox_id: str | None = None,
 ) -> str:
     anyharness_env = {**runtime_context.base_env, **runtime_env}
-    process_env = _target_sentry_env()
+    process_env = {
+        **_target_sentry_env(),
+        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id),
+    }
     values = {
         "anyharness_binary": runtime_context.runtime_binary_path,
         "worker_binary": worker_binary_path(runtime_context),
@@ -229,7 +252,12 @@ def _pgrep_pattern_for_path(path: str) -> str:
     return path
 
 
-def build_detached_supervisor_launch_command(runtime_context: SandboxRuntimeContext) -> str:
+def build_detached_supervisor_launch_command(
+    runtime_context: SandboxRuntimeContext,
+    *,
+    organization_id: UUID | None = None,
+    sandbox_id: str | None = None,
+) -> str:
     supervisor_binary = supervisor_binary_path(runtime_context)
     config_path = supervisor_config_path(runtime_context)
     log_path = supervisor_log_path(runtime_context)
@@ -260,8 +288,12 @@ def build_detached_supervisor_launch_command(runtime_context: SandboxRuntimeCont
                 "fi",
             ]
         )
+    combined_env = {
+        **_target_sentry_env(),
+        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id),
+    }
     target_env_lines = [
-        f"export {key}={shlex.quote(value)}" for key, value in sorted(_target_sentry_env().items())
+        f"export {key}={shlex.quote(value)}" for key, value in sorted(combined_env.items())
     ]
     script = "\n".join(
         [

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -51,6 +51,7 @@ def _identity_env(
     *,
     organization_id: UUID | None = None,
     sandbox_id: str | None = None,
+    user_id: UUID | None = None,
 ) -> dict[str, str]:
     """Identity env vars for observability (Sentry tags on all runtime surfaces)."""
     env: dict[str, str] = {"PROLIFERATE_RUNTIME_ENV": "e2b"}
@@ -58,6 +59,8 @@ def _identity_env(
         env["PROLIFERATE_ORG_ID"] = str(organization_id)
     if sandbox_id:
         env["PROLIFERATE_SANDBOX_ID"] = sandbox_id
+    if user_id is not None:
+        env["PROLIFERATE_USER_ID"] = str(user_id)
     return env
 
 
@@ -69,6 +72,7 @@ def build_runtime_env(
     repo_env_vars: Mapping[str, str] | None = None,
     organization_id: UUID | None = None,
     sandbox_id: str | None = None,
+    user_id: UUID | None = None,
 ) -> dict[str, str]:
     env: dict[str, str] = {
         "ANYHARNESS_DEV_CORS": "1",
@@ -86,7 +90,9 @@ def build_runtime_env(
     env["ANYHARNESS_DATA_KEY"] = anyharness_data_key
     if target_id is not None:
         env["ANYHARNESS_RUNTIME_TARGET_ID"] = str(target_id)
-    env.update(_identity_env(organization_id=organization_id, sandbox_id=sandbox_id))
+    env.update(
+        _identity_env(organization_id=organization_id, sandbox_id=sandbox_id, user_id=user_id)
+    )
     if repo_env_vars:
         env.update(repo_env_vars)
     return env
@@ -214,11 +220,12 @@ def build_supervisor_config(
     *,
     organization_id: UUID | None = None,
     sandbox_id: str | None = None,
+    user_id: UUID | None = None,
 ) -> str:
     anyharness_env = {**runtime_context.base_env, **runtime_env}
     process_env = {
         **_target_sentry_env(),
-        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id),
+        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id, user_id=user_id),
     }
     values = {
         "anyharness_binary": runtime_context.runtime_binary_path,
@@ -257,6 +264,7 @@ def build_detached_supervisor_launch_command(
     *,
     organization_id: UUID | None = None,
     sandbox_id: str | None = None,
+    user_id: UUID | None = None,
 ) -> str:
     supervisor_binary = supervisor_binary_path(runtime_context)
     config_path = supervisor_config_path(runtime_context)
@@ -290,7 +298,7 @@ def build_detached_supervisor_launch_command(
         )
     combined_env = {
         **_target_sentry_env(),
-        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id),
+        **_identity_env(organization_id=organization_id, sandbox_id=sandbox_id, user_id=user_id),
     }
     target_env_lines = [
         f"export {key}={shlex.quote(value)}" for key, value in sorted(combined_env.items())


### PR DESCRIPTION
## Summary

- Every Sentry event from desktop (native + renderer), anyharness runtime, proliferate-worker, and proliferate-supervisor now carries `org_id`, `sandbox_id`, `user_id`, and `runtime_env` identity tags where available.
- `runtime_env` defaults to `"local"` when `PROLIFERATE_RUNTIME_ENV` is absent.
- Server bootstrap passes `PROLIFERATE_RUNTIME_ENV=e2b`, `PROLIFERATE_SANDBOX_ID` (the E2B provider sandbox id), `PROLIFERATE_ORG_ID`, and `PROLIFERATE_USER_ID` into both the runtime launch env and the supervisor `[process_env]` section.
- `PROLIFERATE_ORG_ID` is resolved at launch time in `connect.py` via the existing org-membership store (`get_current_membership_for_user`) from the sandbox's `owner_user_id` — the `cloud_sandbox` table has no organization column and this lane adds no migration. Resolution is best-effort and never blocks a launch.
- Desktop sidecar passes `PROLIFERATE_RUNTIME_ENV=local` to the local runtime.
- Renderer adds a telemetry lifecycle hook that sets `organization_id` Sentry tag from the active org store.
- `process_env.rs` strips all new identity vars so they don't leak into user shells.

**Contract env vars** (referenced by parallel lanes): `PROLIFERATE_ORG_ID`, `PROLIFERATE_SANDBOX_ID`, `PROLIFERATE_RUNTIME_ENV` (values `"local"` | `"e2b"`), plus `PROLIFERATE_USER_ID`.

### Identity availability by surface

| Surface | org_id | sandbox_id | user_id | runtime_env | target_id |
|---------|--------|------------|---------|-------------|-----------|
| anyharness runtime | yes (env, via membership lookup) | yes (env) | yes (env) | yes (default local) | yes (existing) |
| proliferate-worker | yes (env, via membership lookup) | yes (env) | yes (env) | yes (default local) | n/a |
| proliferate-supervisor | yes (env, via membership lookup) | yes (env) | yes (env) | yes (default local) | n/a |
| desktop native (Rust) | no (would need new IPC) | n/a | n/a | yes (hardcoded local) | n/a |
| desktop renderer (JS) | yes (from org store) | n/a | yes (existing user.id) | n/a (renderer is always local) | n/a |

**Ambiguity note on org resolution:** a user can belong to multiple orgs; `get_current_membership_for_user` returns the first active membership (orgs ordered by name). The sandbox row carries no billing/org context to disambiguate, so multi-org owners may get their alphabetically-first org tagged. Acceptable for observability; revisit if/when `cloud_sandbox` gains an organization column.

**Note on `PROLIFERATE_SANDBOX_ID`:** the E2B provider sandbox id (`provider_sandbox_id` / `e2b_sandbox_id`), known at launch time.

## Test plan

- [x] `cargo check` passes (touched crates + workspace)
- [x] `cargo test -p anyharness -p anyharness-lib -p proliferate-worker -p proliferate-supervisor` — 831 tests pass
- [x] Server unit tests (`test_anyharness_runtime.py`, `test_e2b_runtime.py`) — 17 pass; connect/bootstrap import sanity verified
- [x] Desktop tsc finds no errors in new/modified files (pre-existing shared-pkg errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)