### PR TITLE
obs: version+context on server logs, report_critical severity helper

### DIFF
--- a/server/proliferate/background/correlation.py
+++ b/server/proliferate/background/correlation.py
@@ -1,0 +1,40 @@
+"""Correlation context binding for Celery background tasks.
+
+Provides a Celery base task class that extracts correlation IDs from task
+headers and binds them into the request-context context vars, so log lines
+and Sentry events emitted by background tasks carry the same correlation
+fields as API requests.
+
+Usage:
+    @celery_app.task(base=CorrelatedTask, name="...")
+    def my_task(payload, **kwargs):
+        ...
+
+Producers should pass correlation fields via task headers:
+    task.apply_async(args=[...], headers=capture_correlation_context())
+"""
+
+from __future__ import annotations
+
+from celery import Task
+
+from proliferate.middleware.request_context import (
+    _CORRELATION_VARS,
+    with_correlation_context,
+)
+
+_HEADER_KEYS = frozenset(_CORRELATION_VARS.keys())
+
+
+class CorrelatedTask(Task):
+    """Celery base task that binds correlation context from task headers."""
+
+    abstract = True
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        headers = getattr(self.request, "headers", None) or {}
+        context_fields = {
+            key: value for key, value in headers.items() if key in _HEADER_KEYS and value
+        }
+        with with_correlation_context(**context_fields):
+            return super().__call__(*args, **kwargs)

--- a/server/proliferate/background/tasks/notifications.py
+++ b/server/proliferate/background/tasks/notifications.py
@@ -6,9 +6,10 @@ import asyncio
 
 from proliferate.background.celery_app import celery_app
 from proliferate.background.config import NOTIFICATIONS_SEND_SLACK_TASK
+from proliferate.background.correlation import CorrelatedTask
 from proliferate.server.notifications import deliver_slack_notification_task_payload
 
 
-@celery_app.task(name=NOTIFICATIONS_SEND_SLACK_TASK)
+@celery_app.task(base=CorrelatedTask, name=NOTIFICATIONS_SEND_SLACK_TASK)
 def send_slack(payload: dict[str, object]) -> bool:
     return asyncio.run(deliver_slack_notification_task_payload(payload))

--- a/server/proliferate/integrations/sentry.py
+++ b/server/proliferate/integrations/sentry.py
@@ -193,6 +193,46 @@ def capture_server_sentry_exception(
         sentry_sdk.capture_exception(normalized)
 
 
+_report_critical_logger = logging.getLogger("proliferate.critical")
+
+
+def report_critical(
+    error: Any,
+    *,
+    tags: dict[str, str] | None = None,
+    extras: dict[str, Any] | None = None,
+    **context: Any,
+) -> None:
+    """Report a page-worthy failure to Sentry (level=fatal) and structured logs.
+
+    Contract fields (stable for Grafana/Sentry alert rules):
+    - Sentry tag: critical_failure=true, level=fatal
+    - Log extra: critical_failure=True
+    - Log message contains "CRITICAL_FAILURE" marker for CloudWatch filtering
+    """
+    merged_tags = dict(tags or {})
+    merged_tags["critical_failure"] = "true"
+
+    capture_server_sentry_exception(
+        error,
+        level="fatal",
+        tags=merged_tags,
+        extras=extras,
+    )
+
+    log_extra: dict[str, Any] = {"critical_failure": True}
+    if context:
+        log_extra.update(context)
+    if extras:
+        log_extra.update(extras)
+
+    _report_critical_logger.exception(
+        "CRITICAL_FAILURE: %s",
+        str(error),
+        extra=log_extra,
+    )
+
+
 def flush_server_sentry(timeout: float = 2.0) -> None:
     if not settings.sentry_dsn or sentry_sdk is None or not is_vendor_telemetry_enabled():
         return

--- a/server/proliferate/middleware/request_context.py
+++ b/server/proliferate/middleware/request_context.py
@@ -99,6 +99,21 @@ def with_correlation_context(**fields: object) -> Iterator[None]:
             context_var.reset(token)
 
 
+def bind_background_correlation_context(**fields: str | None) -> list[Token[str | None]]:
+    """Bind correlation context vars for background work (workers, Celery tasks).
+
+    Returns tokens for resetting. Caller should reset in reverse order when done,
+    or use ``with_correlation_context`` for scoped binding.
+    """
+    tokens: list[Token[str | None]] = []
+    for key, value in fields.items():
+        context_var = _CORRELATION_VARS.get(key)
+        if context_var is None:
+            continue
+        tokens.append(context_var.set(str(value) if value is not None else None))
+    return tokens
+
+
 class RequestContextMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self,

--- a/server/proliferate/server/automations/worker/cloud_executor.py
+++ b/server/proliferate/server/automations/worker/cloud_executor.py
@@ -35,10 +35,24 @@ from proliferate.server.automations.worker.cloud_executor_config import (
     CloudExecutorConfig,
     build_cloud_executor_config,
 )
+from proliferate.middleware.request_context import with_correlation_context
 from proliferate.server.cloud.agent_run_config.domain.resolve import (
     validate_config_execution_scope,
 )
 from proliferate.utils.time import utcnow
+
+
+def _claim_correlation_fields(claim: AutomationRunClaimValue) -> dict[str, object | None]:
+    """Correlation identity for a single automation run's unit of work."""
+    return {
+        "organization_id": claim.organization_id,
+        "user_id": claim.user_id,
+        "session_id": claim.anyharness_session_id,
+        "sandbox_profile_id": claim.sandbox_profile_id,
+        "cloud_workspace_id": claim.cloud_workspace_id,
+        "cloud_target_id": claim.cloud_target_id_snapshot,
+        "anyharness_workspace_id": claim.anyharness_workspace_id,
+    }
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +95,8 @@ async def execute_cloud_automation_run(
             )
         logger.info("automation cloud executor run not claimable run_id=%s", run_id)
         return False
-    await process_cloud_automation_run(claim, config=resolved)
+    with with_correlation_context(**_claim_correlation_fields(claim)):
+        await process_cloud_automation_run(claim, config=resolved)
     return True
 
 

--- a/server/proliferate/server/automations/worker/main.py
+++ b/server/proliferate/server/automations/worker/main.py
@@ -13,6 +13,7 @@ from proliferate.integrations.sentry import (
     flush_server_sentry,
     init_server_sentry,
 )
+from proliferate.middleware.request_context import with_correlation_context
 from proliferate.server.automations.worker.scheduler import run_scheduler_loop
 from proliferate.utils.logging import configure_server_logging
 
@@ -41,15 +42,16 @@ async def _amain(args: argparse.Namespace) -> None:
     init_server_sentry()
     stop_event = asyncio.Event()
     _install_signal_handlers(stop_event)
-    try:
-        await run_scheduler_loop(
-            interval_seconds=args.interval_seconds,
-            batch_size=args.batch_size,
-            stop_event=stop_event,
-            validate_schema=_validate_schema,
-        )
-    finally:
-        flush_server_sentry()
+    with with_correlation_context(worker_id=f"automation-{args.role}"):
+        try:
+            await run_scheduler_loop(
+                interval_seconds=args.interval_seconds,
+                batch_size=args.batch_size,
+                stop_event=stop_event,
+                validate_schema=_validate_schema,
+            )
+        finally:
+            flush_server_sentry()
 
 
 def _positive_float(value: str) -> float:

--- a/server/proliferate/server/automations/worker/scheduler.py
+++ b/server/proliferate/server/automations/worker/scheduler.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 
 from proliferate.db import engine as db_engine
-from proliferate.integrations.sentry import capture_server_sentry_exception
+from proliferate.integrations.sentry import report_critical
 from proliferate.server.automations.worker.service import run_scheduler_tick
 
 logger = logging.getLogger(__name__)
@@ -59,12 +59,10 @@ async def run_scheduler_loop(
                 next_delay,
             )
             if consecutive_failures >= FAILURE_ESCALATION_THRESHOLD:
-                capture_server_sentry_exception(
+                report_critical(
                     exc,
-                    level="error",
                     tags={"worker": "automation_scheduler"},
                     extras={"consecutive_failures": consecutive_failures},
-                    fingerprint=["automation-scheduler", "tick-failed"],
                 )
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=next_delay)

--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -56,7 +56,7 @@ from proliferate.integrations.sandbox import (
     SandboxProvider,
     get_configured_sandbox_provider,
 )
-from proliferate.integrations.sentry import capture_server_sentry_exception
+from proliferate.integrations.sentry import report_critical
 from proliferate.server.billing.accounting_pass import run_billing_accounting_pass
 from proliferate.server.billing.models import BillingSnapshot
 from proliferate.server.billing.snapshots import get_billing_snapshot_for_subject
@@ -430,14 +430,13 @@ async def _billing_reconciler_loop() -> None:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            capture_server_sentry_exception(
+            report_critical(
                 exc,
                 tags={
                     "domain": "billing",
                     "action": "reconcile_loop",
                 },
             )
-            logger.exception("billing reconciler pass failed")
         await asyncio.sleep(max(BILLING_RECONCILE_INTERVAL_SECONDS, 30))
 
 

--- a/server/proliferate/server/cloud/agent_gateway/worker.py
+++ b/server/proliferate/server/cloud/agent_gateway/worker.py
@@ -19,6 +19,7 @@ from contextlib import suppress
 
 from proliferate.config import settings
 from proliferate.db import session_ops as db_session
+from proliferate.integrations.sentry import report_critical
 from proliferate.server.cloud.agent_gateway.enrollment import backfill_enrollments
 from proliferate.server.cloud.agent_gateway.topups import (
     LlmTopupRunResult,
@@ -49,8 +50,11 @@ async def _backfill_loop() -> None:
                     "Agent gateway enrollment backfill processed subjects",
                     extra={"processed": processed},
                 )
-        except Exception:
-            logger.exception("Agent gateway enrollment backfill tick failed")
+        except Exception as exc:
+            report_critical(
+                exc,
+                tags={"domain": "agent_gateway", "action": "enrollment_backfill"},
+            )
         await asyncio.sleep(settings.agent_gateway_backfill_interval_seconds)
 
 
@@ -90,8 +94,11 @@ async def _usage_import_loop() -> None:
                         "exhausted_subjects": result.exhausted_subjects,
                     },
                 )
-        except Exception:
-            logger.exception("Agent gateway usage import tick failed")
+        except Exception as exc:
+            report_critical(
+                exc,
+                tags={"domain": "agent_gateway", "action": "usage_import"},
+            )
         await asyncio.sleep(settings.agent_gateway_usage_import_interval_seconds)
 
 
@@ -132,8 +139,11 @@ async def _topup_loop() -> None:
                         "skipped": result.skipped,
                     },
                 )
-        except Exception:
-            logger.exception("Agent gateway LLM top-up tick failed")
+        except Exception as exc:
+            report_critical(
+                exc,
+                tags={"domain": "agent_gateway", "action": "llm_topup"},
+            )
         await asyncio.sleep(settings.agent_gateway_topup_interval_seconds)
 
 

--- a/server/proliferate/server/cloud/materialization/runner.py
+++ b/server/proliferate/server/cloud/materialization/runner.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.engine import async_session_factory
 from proliferate.db.engine import run_after_commit as db_run_after_commit
+from proliferate.integrations.sentry import report_critical
 
 logger = logging.getLogger("proliferate.cloud.materialization")
 
@@ -24,8 +25,11 @@ async def run_after_commit(
     async def _run() -> None:
         try:
             await task()
-        except Exception:
-            logger.exception("cloud materialization task failed label=%s", label)
+        except Exception as exc:
+            report_critical(
+                exc,
+                tags={"domain": "cloud_materialization", "label": label},
+            )
 
     async def _callback() -> None:
         asyncio.create_task(_run())
@@ -48,9 +52,12 @@ async def _run_with_fresh_session(
         try:
             await fn(db, **kwargs)
             await db.commit()
-        except Exception:
+        except Exception as exc:
             await db.rollback()
-            logger.exception(
-                "cloud materialization fresh-session task failed fn=%s",
-                getattr(fn, "__name__", repr(fn)),
+            report_critical(
+                exc,
+                tags={
+                    "domain": "cloud_materialization",
+                    "fn": getattr(fn, "__name__", repr(fn)),
+                },
             )

--- a/server/proliferate/server/notifications.py
+++ b/server/proliferate/server/notifications.py
@@ -340,12 +340,14 @@ def _send_slack_task_to_celery(
     task_id: str | None,
 ) -> None:
     from proliferate.background.celery_app import celery_app
+    from proliferate.middleware.request_context import capture_correlation_context
 
     celery_app.send_task(
         NOTIFICATIONS_SEND_SLACK_TASK,
         args=(payload,),
         queue=NOTIFICATIONS_QUEUE,
         task_id=task_id,
+        headers=capture_correlation_context() or None,
     )
 
 

--- a/server/proliferate/utils/logging.py
+++ b/server/proliferate/utils/logging.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime
 
 from proliferate.config import settings
 from proliferate.middleware.request_context import get_correlation_context
+from proliferate.server.version import server_version
 
 _APP_LOGGER_NAME = "proliferate"
 _UVICORN_ERROR_LOGGER_NAME = "uvicorn.error"
 _FALLBACK_FORMAT = "%(levelname)s:%(name)s:%(message)s"
 _STANDARD_RECORD_KEYS = frozenset(logging.makeLogRecord({}).__dict__)
+
+# Computed once at import/configure time — not per-record.
+_SERVER_VERSION: str | None = None
+_SERVER_GIT_SHA: str | None = None
 
 
 class CorrelationLogFilter(logging.Filter):
@@ -31,6 +37,10 @@ class JsonLogFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
+        if _SERVER_VERSION:
+            payload["version"] = _SERVER_VERSION
+        if _SERVER_GIT_SHA:
+            payload["git_sha"] = _SERVER_GIT_SHA
         for key, value in get_correlation_context().items():
             payload[key] = value
         for key, value in record.__dict__.items():
@@ -44,6 +54,10 @@ class JsonLogFormatter(logging.Formatter):
 
 def configure_server_logging() -> None:
     """Ensure application logs are visible in dev and under Uvicorn."""
+    global _SERVER_VERSION, _SERVER_GIT_SHA
+    _SERVER_VERSION = server_version()
+    _SERVER_GIT_SHA = os.getenv("SERVER_GIT_SHA") or None
+
     app_logger = logging.getLogger(_APP_LOGGER_NAME)
     if getattr(app_logger, "_proliferate_configured", False):
         return

--- a/server/tests/unit/test_logging_observability.py
+++ b/server/tests/unit/test_logging_observability.py
@@ -1,0 +1,239 @@
+"""Tests for observability enhancements: version fields on JSON logs and report_critical."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from proliferate.config import settings
+from proliferate.integrations import sentry as sentry_integration
+from proliferate.middleware.request_context import (
+    bind_background_correlation_context,
+    get_correlation_context,
+    with_correlation_context,
+)
+from proliferate.utils import logging as logging_module
+from proliferate.utils.logging import JsonLogFormatter, configure_server_logging
+
+
+class TestJsonLogFormatterVersionFields:
+    """JsonLogFormatter emits version and git_sha fields."""
+
+    def test_version_field_present_when_set(self) -> None:
+        with patch.object(logging_module, "_SERVER_VERSION", "1.2.3"):
+            with patch.object(logging_module, "_SERVER_GIT_SHA", None):
+                formatter = JsonLogFormatter()
+                record = logging.LogRecord(
+                    name="test",
+                    level=logging.INFO,
+                    pathname="",
+                    lineno=0,
+                    msg="hello",
+                    args=None,
+                    exc_info=None,
+                )
+                output = formatter.format(record)
+                parsed = json.loads(output)
+                assert parsed["version"] == "1.2.3"
+                assert "git_sha" not in parsed
+
+    def test_git_sha_field_present_when_set(self) -> None:
+        with patch.object(logging_module, "_SERVER_VERSION", "2.0.0"):
+            with patch.object(logging_module, "_SERVER_GIT_SHA", "abc1234"):
+                formatter = JsonLogFormatter()
+                record = logging.LogRecord(
+                    name="test",
+                    level=logging.INFO,
+                    pathname="",
+                    lineno=0,
+                    msg="world",
+                    args=None,
+                    exc_info=None,
+                )
+                output = formatter.format(record)
+                parsed = json.loads(output)
+                assert parsed["version"] == "2.0.0"
+                assert parsed["git_sha"] == "abc1234"
+
+    def test_version_fields_absent_when_none(self) -> None:
+        with patch.object(logging_module, "_SERVER_VERSION", None):
+            with patch.object(logging_module, "_SERVER_GIT_SHA", None):
+                formatter = JsonLogFormatter()
+                record = logging.LogRecord(
+                    name="test",
+                    level=logging.INFO,
+                    pathname="",
+                    lineno=0,
+                    msg="no version",
+                    args=None,
+                    exc_info=None,
+                )
+                output = formatter.format(record)
+                parsed = json.loads(output)
+                assert "version" not in parsed
+                assert "git_sha" not in parsed
+
+    def test_configure_server_logging_sets_version_globals(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(logging_module, "_SERVER_VERSION", None)
+        monkeypatch.setattr(logging_module, "_SERVER_GIT_SHA", None)
+        monkeypatch.setenv("SERVER_GIT_SHA", "deadbeef")
+        # Reset configured flag so configure_server_logging runs fully
+        app_logger = logging.getLogger("proliferate")
+        app_logger._proliferate_configured = False  # type: ignore[attr-defined]
+
+        configure_server_logging()
+
+        assert logging_module._SERVER_VERSION is not None
+        assert logging_module._SERVER_VERSION != ""
+        assert logging_module._SERVER_GIT_SHA == "deadbeef"
+
+
+class _FakeScope:
+    def __init__(self) -> None:
+        self.level: str | None = None
+        self.fingerprint: list[str] | None = None
+        self.tags: dict[str, str] = {}
+        self.extras: dict[str, object] = {}
+
+    def set_tag(self, key: str, value: str) -> None:
+        self.tags[key] = value
+
+    def set_extra(self, key: str, value: object) -> None:
+        self.extras[key] = value
+
+
+class _TrackingSentrySdk:
+    """Fake SDK that tracks the scope passed to capture_exception."""
+
+    def __init__(self) -> None:
+        self.captured: list[tuple[Exception, _FakeScope]] = []
+        self._current_scope: _FakeScope | None = None
+
+    def push_scope(self):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _ctx():
+            scope = _FakeScope()
+            self._current_scope = scope
+            try:
+                yield scope
+            finally:
+                self._current_scope = None
+
+        return _ctx()
+
+    def capture_exception(self, error: Exception) -> None:
+        self.captured.append((error, self._current_scope or _FakeScope()))
+
+
+class TestReportCritical:
+    """report_critical emits to Sentry with fatal level and logs with marker."""
+
+    def test_captures_to_sentry_with_fatal_and_critical_tag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_sdk = _TrackingSentrySdk()
+        monkeypatch.setattr(settings, "sentry_dsn", "https://sentry.example/123")
+        monkeypatch.setattr(settings, "telemetry_mode", "hosted_product")
+        monkeypatch.setattr(sentry_integration, "sentry_sdk", fake_sdk)
+
+        error = RuntimeError("disk full")
+        sentry_integration.report_critical(
+            error,
+            tags={"domain": "billing"},
+            extras={"detail": "safe value"},
+        )
+
+        assert len(fake_sdk.captured) == 1
+        _captured_error, scope = fake_sdk.captured[0]
+        assert scope.level == "fatal"
+        assert scope.tags["critical_failure"] == "true"
+        assert scope.tags["domain"] == "billing"
+
+    def test_emits_logger_exception_with_marker_and_extra(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Disable Sentry to isolate log testing
+        monkeypatch.setattr(settings, "sentry_dsn", "")
+
+        calls: list[tuple[str, dict[str, Any]]] = []
+        original_logger = sentry_integration._report_critical_logger
+
+        class _FakeLogger:
+            def exception(self, msg: str, *args: object, **kwargs: object) -> None:
+                calls.append((msg % args, dict(kwargs)))
+
+        monkeypatch.setattr(sentry_integration, "_report_critical_logger", _FakeLogger())
+
+        error = RuntimeError("bad state")
+        sentry_integration.report_critical(
+            error,
+            tags={"worker": "scheduler"},
+            extras={"count": 5},
+            worker_name="test-worker",
+        )
+
+        assert len(calls) == 1
+        message, kwargs = calls[0]
+        assert "CRITICAL_FAILURE" in message
+        assert "bad state" in message
+        extra = kwargs["extra"]
+        assert extra["critical_failure"] is True
+        assert extra["count"] == 5
+        assert extra["worker_name"] == "test-worker"
+
+    def test_report_critical_noops_sentry_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even when sentry is disabled, the log is still emitted."""
+        monkeypatch.setattr(settings, "sentry_dsn", "")
+
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        class _FakeLogger:
+            def exception(self, msg: str, *args: object, **kwargs: object) -> None:
+                calls.append((msg % args, dict(kwargs)))
+
+        monkeypatch.setattr(sentry_integration, "_report_critical_logger", _FakeLogger())
+
+        error = RuntimeError("oops")
+        sentry_integration.report_critical(error)
+
+        assert len(calls) == 1
+        assert "CRITICAL_FAILURE" in calls[0][0]
+
+
+class TestCorrelationContextBackground:
+    """bind_background_correlation_context sets context vars for background work."""
+
+    def test_bind_sets_vars_and_returns_tokens(self) -> None:
+        tokens = bind_background_correlation_context(
+            organization_id="org-123",
+            tenant_id="ten-456",
+        )
+        try:
+            ctx = get_correlation_context()
+            assert ctx["organization_id"] == "org-123"
+            assert ctx["tenant_id"] == "ten-456"
+        finally:
+            from proliferate.middleware.request_context import _CORRELATION_VARS
+
+            # Reset using with_correlation_context to clean up
+            for var in _CORRELATION_VARS.values():
+                var.set(None)
+
+    def test_with_correlation_context_scoped(self) -> None:
+        with with_correlation_context(worker_id="test-worker", organization_id="org-1"):
+            ctx = get_correlation_context()
+            assert ctx["worker_id"] == "test-worker"
+            assert ctx["organization_id"] == "org-1"
+        # After context manager, values should be reset
+        ctx = get_correlation_context()
+        assert "worker_id" not in ctx

--- a/specs/developing/analytics/sentry.md
+++ b/specs/developing/analytics/sentry.md
@@ -57,6 +57,20 @@ as `id` only. Do not send email, display name, prompt text, transcript content,
 terminal output, repo names, raw file paths, request bodies, cookies, auth
 headers, or environment values.
 
+## Structured server logs
+
+`JsonLogFormatter` (`server/proliferate/utils/logging.py`) stamps two build
+identity fields on every JSON log record, computed once at
+`configure_server_logging()` time (never per-record):
+
+- `version` — from `server_version()`
+  (`server/proliferate/server/version.py`): stamped `SERVER_VERSION`, else the
+  repo `VERSION` file, else a dev sentinel.
+- `git_sha` — from the `SERVER_GIT_SHA` env when set; omitted otherwise.
+
+These are stable contract fields referenced by the Grafana dashboard and Sentry
+alert rules — do not rename. The debug/plain log format is unchanged.
+
 ## Support Correlation
 
 Server requests install a scrubbed correlation context for Sentry. The context
@@ -65,11 +79,43 @@ support report ID, cloud workspace ID, cloud target ID, sandbox IDs,
 AnyHarness workspace ID, session ID, interaction ID, command ID, worker ID, and
 slot generation when those values are known.
 
+Background work binds the same correlation context so its logs and Sentry
+events carry identity like API requests do:
+
+- Automation cloud executor binds organization / user / session / sandbox /
+  workspace / target IDs from the run claim at the start of each run
+  (`process` boundary in
+  `server/proliferate/server/automations/worker/cloud_executor.py`); the
+  scheduler loop binds `worker_id`.
+- Celery tasks use the `CorrelatedTask` base
+  (`server/proliferate/background/correlation.py`), which restores correlation
+  fields from task headers. Producers propagate them via
+  `headers=capture_correlation_context()`.
+
 `tenant_id`, `support_report_id`, and normalized cloud/runtime IDs are allowed
 as diagnostic tags for support flows even though they can be high-cardinality.
 Do not add free-form messages, raw URLs, prompts, transcript bodies, command
 payloads, provider responses, auth headers, cookies, tokens, or file contents
 to tags or context.
+
+## Critical-failure severity
+
+`report_critical(error, *, tags=None, extras=None, **context)`
+(`server/proliferate/integrations/sentry.py`) marks a clearly page-worthy
+failure. It captures to Sentry at `level="fatal"` with tag
+`critical_failure=true`, and emits `logger.exception` carrying
+`extra={"critical_failure": True, ...}` plus a `CRITICAL_FAILURE` marker in the
+message for log-based alerting. `critical_failure` is a stable contract field.
+
+Adopt it only at page-worthy sites (not ambient errors, which stay a plain
+`logger.exception`). Current call sites:
+
+- automation scheduler loop failure escalation (`automations/worker/scheduler.py`)
+- billing reconciler loop (`server/billing/reconciler.py`)
+- agent-gateway worker loops: enrollment backfill, usage import, LLM top-up
+  (`server/cloud/agent_gateway/worker.py`)
+- cloud materialization after-commit / fresh-session task failures
+  (`server/cloud/materialization/runner.py`)
 
 ## Alerts
 


### PR DESCRIPTION
## What changed

### 1. Version on every log line
`JsonLogFormatter` (`server/proliferate/utils/logging.py`) now stamps two build-identity fields on every JSON record, computed **once** at `configure_server_logging()` time (never per-record):
- `version` — from `server_version()` (`server/proliferate/server/version.py`)
- `git_sha` — from the `SERVER_GIT_SHA` env when set (omitted otherwise)

Debug/plain format is unchanged.

### 2. Correlation context in background work
Background units of work now bind correlation context vars so their logs and Sentry events carry identity like API requests do:
- **Automation cloud executor** binds org/user/session/sandbox/workspace/target IDs from the run claim at the start of each run; the scheduler loop binds `worker_id`.
- **Celery tasks** use a new `CorrelatedTask` base (`server/proliferate/background/correlation.py`) that restores correlation fields from task headers; producers propagate them via `headers=capture_correlation_context()` (wired for the Slack notification task).
- Added `bind_background_correlation_context` helper to `middleware/request_context.py`.

### 3. Severity convention
New `report_critical(error, *, tags=None, extras=None, **context)` in `server/proliferate/integrations/sentry.py`:
- Sentry capture at `level="fatal"` with tag `critical_failure=true`
- `logger.exception` with `extra={"critical_failure": True, ...}` and a `CRITICAL_FAILURE` marker in the message

Adopted only at clearly page-worthy sites (ambient errors stay plain `logger.exception`).

## Contract fields (referenced by Grafana dashboard + Sentry alert rules — do not rename)
- `version`
- `git_sha`
- `critical_failure`

## report_critical call sites
- `server/proliferate/server/automations/worker/scheduler.py` — scheduler-loop failure escalation
- `server/proliferate/server/billing/reconciler.py` — reconciler loop
- `server/proliferate/server/cloud/agent_gateway/worker.py` — enrollment backfill, usage import, LLM top-up loops (3)
- `server/proliferate/server/cloud/materialization/runner.py` — after-commit + fresh-session task failures (2)

## Verification
- `cd server && uv run pytest -q tests/unit` → **509 passed**
- New tests: `server/tests/unit/test_logging_observability.py` (formatter version/git_sha fields; `report_critical` with Sentry mocked; correlation-context binding)
- Spec updated: `specs/developing/analytics/sentry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)