### PR TITLE
feat(support): capture urgent/notify-me + outreach_email override

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -18,7 +18,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Users:Update Current User */
+        patch: operations["users_update_current_user_users_me_patch"];
         trace?: never;
     };
     "/auth/desktop/methods": {
@@ -1931,6 +1932,91 @@ export interface paths {
         put?: never;
         /** Generate Workspace Name Endpoint */
         post: operations["generate_workspace_name_endpoint_v1_ai_magic_workspace_names_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Support Message Endpoint */
+        post: operations["send_support_message_endpoint_v1_support_messages_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/report-uploads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Upload Endpoint */
+        post: operations["create_support_report_upload_endpoint_v1_support_report_uploads_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Endpoint */
+        post: operations["create_support_report_endpoint_v1_support_reports_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports/{report_id}/upload-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Support Report Upload Targets Endpoint */
+        post: operations["create_support_report_upload_targets_endpoint_v1_support_reports__report_id__upload_targets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/support/reports/{report_id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete Support Report Upload Endpoint */
+        post: operations["complete_support_report_upload_endpoint_v1_support_reports__report_id__complete_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4697,6 +4783,18 @@ export interface components {
             /** Probillingenabled */
             proBillingEnabled: boolean;
         };
+        /**
+         * ProfileUpdateRequest
+         * @description Editable fields on the authenticated user's own profile.
+         *
+         *     ``outreach_email`` is an optional override address for support/outreach
+         *     follow-up. Sending ``null`` or an empty/whitespace string clears it (falls
+         *     back to the account email); any other value must look like an email.
+         */
+        ProfileUpdateRequest: {
+            /** Outreach Email */
+            outreach_email?: string | null;
+        };
         /** PutCloudSecretEnvVarRequest */
         PutCloudSecretEnvVarRequest: {
             /** Value */
@@ -4962,6 +5060,323 @@ export interface components {
             /** Livemode */
             livemode?: boolean | null;
         };
+        /** SupportMessageContext */
+        SupportMessageContext: {
+            /**
+             * Source
+             * @default sidebar
+             * @enum {string}
+             */
+            source: "sidebar" | "home" | "settings" | "cloud_gated";
+            /**
+             * Intent
+             * @default general
+             * @enum {string}
+             */
+            intent: "general" | "unlimited_cloud" | "team_features";
+            /** Pathname */
+            pathname?: string | null;
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Workspacename */
+            workspaceName?: string | null;
+            /** Workspacelocation */
+            workspaceLocation?: ("local" | "cloud") | null;
+        };
+        /** SupportMessageRequest */
+        SupportMessageRequest: {
+            /** Message */
+            message: string;
+            context?: components["schemas"]["SupportMessageContext"] | null;
+        };
+        /** SupportMessageResponse */
+        SupportMessageResponse: {
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
+        };
+        /** SupportReportAttachmentUploadTarget */
+        SupportReportAttachmentUploadTarget: {
+            /** Objectkey */
+            objectKey: string;
+            /** Puturl */
+            putUrl: string;
+            /** Contenttype */
+            contentType: string;
+            /** Maxsizebytes */
+            maxSizeBytes: number;
+            /** Expiresinseconds */
+            expiresInSeconds: number;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+            /** Clientfileid */
+            clientFileId: string;
+        };
+        /** SupportReportCompleteRequest */
+        SupportReportCompleteRequest: {
+            diagnostics?: components["schemas"]["SupportReportCompletedObject"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportCompletedObject"][];
+            /** Packagemanifest */
+            packageManifest?: {
+                [key: string]: unknown;
+            };
+        };
+        /** SupportReportCompleteResponse */
+        SupportReportCompleteResponse: {
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
+            /** Reportid */
+            reportId: string;
+        };
+        /** SupportReportCompletedObject */
+        SupportReportCompletedObject: {
+            /** Objectkey */
+            objectKey: string;
+            /** Sha256 */
+            sha256: string;
+            /** Sizebytes */
+            sizeBytes: number;
+        };
+        /** SupportReportCreateRequest */
+        SupportReportCreateRequest: {
+            /** Clientjobid */
+            clientJobId: string;
+            /**
+             * Message
+             * @default
+             */
+            message: string;
+            /**
+             * Sourcesurface
+             * @default desktop
+             * @enum {string}
+             */
+            sourceSurface: "desktop" | "web" | "mobile" | "cloud_api";
+            context?: components["schemas"]["SupportMessageContext"] | null;
+            scope: components["schemas"]["SupportReportWorkspaceScope"];
+            /** Workspacerefs */
+            workspaceRefs?: components["schemas"]["SupportReportWorkspaceReference"][];
+            telemetryRefs?: components["schemas"]["SupportReportTelemetryReferences"] | null;
+            expectedClientUploads?: components["schemas"]["SupportReportExpectedClientUploads"];
+            /** Publiccontentconsent */
+            publicContentConsent?: boolean | null;
+            /**
+             * Kind
+             * @default bug
+             * @enum {string}
+             */
+            kind: "bug" | "feature";
+            /**
+             * Creditconsent
+             * @default false
+             */
+            creditConsent: boolean;
+            /** Creditname */
+            creditName?: string | null;
+            /**
+             * Urgent
+             * @default false
+             */
+            urgent: boolean;
+            /**
+             * Notifyme
+             * @default false
+             */
+            notifyMe: boolean;
+        };
+        /** SupportReportCreateResponse */
+        SupportReportCreateResponse: {
+            /** Reportid */
+            reportId: string;
+            /** Clientjobid */
+            clientJobId: string;
+            /** Status */
+            status: string;
+            serverCorrelation: components["schemas"]["SupportReportServerCorrelation"];
+            /** Clouddiagnosticsstatus */
+            cloudDiagnosticsStatus: string;
+        };
+        /** SupportReportDiagnosticsUpload */
+        SupportReportDiagnosticsUpload: {
+            /**
+             * Contenttype
+             * @default application/json
+             */
+            contentType: string;
+            /** Sizebytes */
+            sizeBytes: number;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** SupportReportExpectedClientUploads */
+        SupportReportExpectedClientUploads: {
+            /**
+             * Diagnostics
+             * @default true
+             */
+            diagnostics: boolean;
+            /**
+             * Attachmentcount
+             * @default 0
+             */
+            attachmentCount: number;
+        };
+        /** SupportReportServerCorrelation */
+        SupportReportServerCorrelation: {
+            /** Reportid */
+            reportId: string;
+            /** Requestid */
+            requestId?: string | null;
+            /** Owneruserid */
+            ownerUserId: string;
+            /** Primaryorganizationid */
+            primaryOrganizationId?: string | null;
+            /** Primarytenantid */
+            primaryTenantId: string;
+            /** Tenantids */
+            tenantIds?: string[];
+            /** Cloudworkspaceids */
+            cloudWorkspaceIds?: string[];
+            /** Cloudtargetids */
+            cloudTargetIds?: string[];
+            /** Anyharnessworkspaceids */
+            anyharnessWorkspaceIds?: string[];
+            /** Sessionids */
+            sessionIds?: string[];
+        };
+        /** SupportReportTelemetryReferences */
+        SupportReportTelemetryReferences: {
+            /** Posthogdistinctid */
+            posthogDistinctId?: string | null;
+            /** Posthogsessionid */
+            posthogSessionId?: string | null;
+            /** Sentryeventids */
+            sentryEventIds?: string[];
+        };
+        /** SupportReportUploadFile */
+        SupportReportUploadFile: {
+            /** Clientfileid */
+            clientFileId: string;
+            /** Filename */
+            fileName: string;
+            /**
+             * Contenttype
+             * @default application/octet-stream
+             */
+            contentType: string;
+            /** Sizebytes */
+            sizeBytes: number;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** SupportReportUploadRequest */
+        SupportReportUploadRequest: {
+            /**
+             * Message
+             * @default
+             */
+            message: string;
+            context?: components["schemas"]["SupportMessageContext"] | null;
+            scope: components["schemas"]["SupportReportWorkspaceScope"];
+            diagnostics?: components["schemas"]["SupportReportDiagnosticsUpload"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportUploadFile"][];
+            /** Publiccontentconsent */
+            publicContentConsent?: boolean | null;
+            /**
+             * Kind
+             * @default bug
+             * @enum {string}
+             */
+            kind: "bug" | "feature";
+            /**
+             * Creditconsent
+             * @default false
+             */
+            creditConsent: boolean;
+            /** Creditname */
+            creditName?: string | null;
+        };
+        /** SupportReportUploadResponse */
+        SupportReportUploadResponse: {
+            /** Reportid */
+            reportId: string;
+            diagnostics?: components["schemas"]["SupportReportUploadTarget"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportAttachmentUploadTarget"][];
+        };
+        /** SupportReportUploadTarget */
+        SupportReportUploadTarget: {
+            /** Objectkey */
+            objectKey: string;
+            /** Puturl */
+            putUrl: string;
+            /** Contenttype */
+            contentType: string;
+            /** Maxsizebytes */
+            maxSizeBytes: number;
+            /** Expiresinseconds */
+            expiresInSeconds: number;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+        };
+        /** SupportReportUploadTargetsRequest */
+        SupportReportUploadTargetsRequest: {
+            diagnostics?: components["schemas"]["SupportReportDiagnosticsUpload"] | null;
+            /** Attachments */
+            attachments?: components["schemas"]["SupportReportUploadFile"][];
+        };
+        /** SupportReportWorkspaceReference */
+        SupportReportWorkspaceReference: {
+            /** Id */
+            id: string;
+            /**
+             * Location
+             * @enum {string}
+             */
+            location: "local" | "cloud";
+            /** Cloudworkspaceid */
+            cloudWorkspaceId?: string | null;
+            /** Cloudtargetid */
+            cloudTargetId?: string | null;
+            /** Sandboxprofileid */
+            sandboxProfileId?: string | null;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId?: string | null;
+            /** Exposureid */
+            exposureId?: string | null;
+            /** Materializationid */
+            materializationId?: string | null;
+            /** Sessionids */
+            sessionIds?: string[];
+            /** Status */
+            status?: string | null;
+            /** Visibility */
+            visibility?: string | null;
+            /** Sandboxtype */
+            sandboxType?: string | null;
+        };
+        /** SupportReportWorkspaceScope */
+        SupportReportWorkspaceScope: {
+            /**
+             * Kind
+             * @default most_recent_workspace
+             * @enum {string}
+             */
+            kind: "most_recent_workspace" | "choose_workspace" | "app_only";
+            /** Workspaceids */
+            workspaceIds?: string[];
+        };
         /** TeamCheckoutIntentResponse */
         TeamCheckoutIntentResponse: {
             /** Id */
@@ -5084,6 +5499,8 @@ export interface components {
             github_login?: string | null;
             /** Avatar Url */
             avatar_url?: string | null;
+            /** Outreach Email */
+            outreach_email?: string | null;
             /** @default user */
             role: components["schemas"]["UserRole"];
         };
@@ -5464,6 +5881,44 @@ export interface operations {
             };
             /** @description Missing token or inactive user. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    users_update_current_user_users_me_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserRead"];
+                };
+            };
+            /** @description Missing token or inactive user. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description outreach_email is not a valid email address. */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -9415,6 +9870,175 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenerateWorkspaceNameResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_support_message_endpoint_v1_support_messages_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportMessageRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_upload_endpoint_v1_support_report_uploads_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_endpoint_v1_support_reports_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportCreateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_support_report_upload_targets_endpoint_v1_support_reports__report_id__upload_targets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                report_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportUploadTargetsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    complete_support_report_upload_endpoint_v1_support_reports__report_id__complete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                report_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SupportReportCompleteRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportReportCompleteResponse"];
                 };
             };
             /** @description Validation Error */

--- a/server/alembic/versions/c7f2a9b41d38_support_urgent_notify_and_user_outreach_email.py
+++ b/server/alembic/versions/c7f2a9b41d38_support_urgent_notify_and_user_outreach_email.py
@@ -1,0 +1,76 @@
+"""support urgent/notify_me flags and user outreach_email
+
+Revision ID: c7f2a9b41d38
+Revises: ff9344886948
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c7f2a9b41d38"
+down_revision: str | Sequence[str] | None = "ff9344886948"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    }
+
+
+def upgrade() -> None:
+    if _has_table("support_report"):
+        if not _has_column("support_report", "urgent"):
+            op.add_column(
+                "support_report",
+                sa.Column(
+                    "urgent",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                ),
+            )
+        if not _has_column("support_report", "notify_me"):
+            op.add_column(
+                "support_report",
+                sa.Column(
+                    "notify_me",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                ),
+            )
+
+    if _has_table("user") and not _has_column("user", "outreach_email"):
+        op.add_column(
+            "user",
+            sa.Column(
+                "outreach_email",
+                sa.String(length=320),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _has_column("user", "outreach_email"):
+        op.drop_column("user", "outreach_email")
+
+    if _has_table("support_report"):
+        if _has_column("support_report", "notify_me"):
+            op.drop_column("support_report", "notify_me")
+        if _has_column("support_report", "urgent"):
+            op.drop_column("support_report", "urgent")

--- a/server/proliferate/auth/models.py
+++ b/server/proliferate/auth/models.py
@@ -17,6 +17,7 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
     display_name: str | None = None
     github_login: str | None = None
     avatar_url: str | None = None
+    outreach_email: str | None = None
     role: UserRole = UserRole.USER
 
 

--- a/server/proliferate/auth/profile_api.py
+++ b/server/proliferate/auth/profile_api.py
@@ -1,14 +1,44 @@
-"""Read-only authenticated user profile routes."""
+"""Authenticated user profile routes."""
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, EmailStr, TypeAdapter, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_active_user
 from proliferate.auth.models import UserRead
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+_email_adapter = TypeAdapter(EmailStr)
+
+
+class ProfileUpdateRequest(BaseModel):
+    """Editable fields on the authenticated user's own profile.
+
+    ``outreach_email`` is an optional override address for support/outreach
+    follow-up. Sending ``null`` or an empty/whitespace string clears it (falls
+    back to the account email); any other value must look like an email.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    outreach_email: str | None = None
+
+    @field_validator("outreach_email")
+    @classmethod
+    def _validate_outreach_email(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        # Raises pydantic ValidationError (-> 422) when it does not look like an
+        # email. Normalize to the validated address.
+        return str(_email_adapter.validate_python(cleaned))
 
 
 @router.get(
@@ -24,4 +54,30 @@ router = APIRouter(prefix="/users", tags=["users"])
 async def current_user_profile(
     user: User = Depends(current_active_user),
 ) -> UserRead:
+    return UserRead.model_validate(user)
+
+
+@router.patch(
+    "/me",
+    response_model=UserRead,
+    name="users:update_current_user",
+    responses={
+        401: {
+            "description": "Missing token or inactive user.",
+        },
+        422: {
+            "description": "outreach_email is not a valid email address.",
+        },
+    },
+)
+async def update_current_user_profile(
+    body: ProfileUpdateRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> UserRead:
+    if "outreach_email" in body.model_fields_set:
+        user.outreach_email = body.outreach_email
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
     return UserRead.model_validate(user)

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -281,6 +281,7 @@ class Settings(BaseSettings):
     support_report_diagnostics_max_bytes: int = 25 * 1024 * 1024
     support_report_attachment_max_bytes: int = 25 * 1024 * 1024
     support_report_total_attachment_max_bytes: int = 100 * 1024 * 1024
+    support_report_internal_base_url: str = ""
     signups_slack_webhook_url: str = ""
     billing_positive_slack_webhook_url: str = ""
     billing_negative_slack_webhook_url: str = ""

--- a/server/proliferate/db/models/auth.py
+++ b/server/proliferate/db/models/auth.py
@@ -31,6 +31,9 @@ class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
 class User(SQLAlchemyBaseUserTableUUID, Base):
     display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     github_login: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Optional address the user wants support/outreach follow-up sent to,
+    # overriding their account email. Null/empty means "use the account email".
+    outreach_email: Mapped[str | None] = mapped_column(String(320), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     password_set_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/server/proliferate/db/models/support.py
+++ b/server/proliferate/db/models/support.py
@@ -98,6 +98,8 @@ class SupportReport(Base):
     kind: Mapped[str] = mapped_column(String(32), server_default="bug", default="bug")
     credit_consent: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     credit_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    urgent: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
+    notify_me: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     complete_request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     request_object_written_at: Mapped[datetime | None] = mapped_column(

--- a/server/proliferate/db/store/support_reports.py
+++ b/server/proliferate/db/store/support_reports.py
@@ -35,6 +35,8 @@ class SupportReportSnapshot:
     kind: str
     credit_consent: bool
     credit_name: str | None
+    urgent: bool
+    notify_me: bool
     request_id: str | None
     complete_request_id: str | None
     request_object_written_at: datetime | None
@@ -115,6 +117,8 @@ async def create_report(
     kind: str,
     credit_consent: bool,
     credit_name: str | None = None,
+    urgent: bool = False,
+    notify_me: bool = False,
     request_id: str | None = None,
     cloud_diagnostics_status: str = "not_applicable",
 ) -> SupportReportSnapshot:
@@ -139,6 +143,8 @@ async def create_report(
         kind=kind,
         credit_consent=credit_consent,
         credit_name=credit_name,
+        urgent=urgent,
+        notify_me=notify_me,
         request_id=request_id,
         cloud_diagnostics_status=cloud_diagnostics_status,
         created_at=now,
@@ -409,6 +415,8 @@ def _snapshot(row: SupportReport) -> SupportReportSnapshot:
         kind=row.kind,
         credit_consent=row.credit_consent,
         credit_name=row.credit_name,
+        urgent=row.urgent,
+        notify_me=row.notify_me,
         request_id=row.request_id,
         complete_request_id=row.complete_request_id,
         request_object_written_at=row.request_object_written_at,

--- a/server/proliferate/server/support/domain/message.py
+++ b/server/proliferate/server/support/domain/message.py
@@ -15,6 +15,7 @@ class SupportMessagePlan:
     message: str
     fallback_text: str
     fields: tuple[SupportMessageField, ...]
+    title: str = "*New support message*"
 
 
 def normalize_support_message(message: str) -> str | None:
@@ -66,6 +67,8 @@ def build_support_report_plan(
     kind: str = "bug",
     credit_consent: bool = False,
     credit_name: str | None = None,
+    urgent: bool = False,
+    notify_me: bool = False,
     context: Mapping[str, object] | None = None,
     correlation: Mapping[str, object] | None = None,
     request_id: str | None = None,
@@ -75,6 +78,8 @@ def build_support_report_plan(
     fields = [
         SupportMessageField("Report ID", report_id),
         SupportMessageField("Type", "Bug" if kind == "bug" else "Feature request"),
+        SupportMessageField("Urgent", "Yes" if urgent else "No"),
+        SupportMessageField("Notify requested", "Yes" if notify_me else "No"),
         SupportMessageField("From", sender_name),
         SupportMessageField("Email", sender_email),
         SupportMessageField("Diagnostics", "included" if diagnostics_included else "not included"),
@@ -100,10 +105,13 @@ def build_support_report_plan(
     _append_list_field(fields, "Cloud targets", payload_correlation.get("cloudTargetIds"))
     _append_context_field(fields, "Request ID", request_id)
 
+    title = "*:rotating_light: URGENT support report*" if urgent else "*New support report*"
+    fallback_prefix = "URGENT support report" if urgent else "Support report"
     return SupportMessagePlan(
         message=message,
-        fallback_text=f"Support report {report_id} from {sender_name}: {message[:140]}",
+        fallback_text=f"{fallback_prefix} {report_id} from {sender_name}: {message[:140]}",
         fields=tuple(fields),
+        title=title,
     )
 
 

--- a/server/proliferate/server/support/domain/report_records.py
+++ b/server/proliferate/server/support/domain/report_records.py
@@ -30,6 +30,8 @@ class SupportReportLike(Protocol):
     object_manifest: dict[str, object]
     expected_uploads: dict[str, object]
     public_content_consent: bool
+    urgent: bool
+    notify_me: bool
 
 
 class AuthorizedCloudRefLike(Protocol):
@@ -239,6 +241,8 @@ def support_request_record(
         },
         "message": message.strip(),
         "publicContentConsent": report.public_content_consent,
+        "urgent": report.urgent,
+        "notifyMe": report.notify_me,
         "context": report.source_context,
         "scope": scope,
         "workspaceRefs": list(report.workspace_refs),

--- a/server/proliferate/server/support/models.py
+++ b/server/proliferate/server/support/models.py
@@ -115,6 +115,8 @@ class SupportReportCreateRequest(BaseModel):
     kind: Literal["bug", "feature"] = Field(default="bug")
     credit_consent: bool = Field(default=False, alias="creditConsent")
     credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
+    urgent: bool = Field(default=False, alias="urgent")
+    notify_me: bool = Field(default=False, alias="notifyMe")
 
 
 class SupportReportServerCorrelation(BaseModel):

--- a/server/proliferate/server/support/notifications.py
+++ b/server/proliferate/server/support/notifications.py
@@ -49,7 +49,7 @@ async def send_support_message_notification(
         request_id=get_request_id(),
     )
     blocks = build_mrkdwn_message_blocks(
-        title="*New support message*",
+        title=plan.title,
         body=plan.message,
         fields=tuple(SlackMessageField(field.label, field.value) for field in plan.fields),
     )
@@ -76,6 +76,8 @@ async def notify_support_report(
     kind: str = "bug",
     credit_consent: bool = False,
     credit_name: str | None = None,
+    urgent: bool = False,
+    notify_me: bool = False,
     correlation: dict[str, object] | None,
 ) -> None:
     webhook_url = settings.support_slack_webhook_url.strip()
@@ -93,12 +95,14 @@ async def notify_support_report(
         kind=kind,
         credit_consent=credit_consent,
         credit_name=credit_name,
+        urgent=urgent,
+        notify_me=notify_me,
         context=context,
         correlation=correlation,
         request_id=get_request_id(),
     )
     blocks = build_mrkdwn_message_blocks(
-        title="*New support report*",
+        title=plan.title,
         body=plan.message,
         fields=tuple(SlackMessageField(field.label, field.value) for field in plan.fields),
     )

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -180,6 +180,8 @@ async def create_support_report(
             credit_name=(
                 body.credit_name if body.kind == "feature" and body.credit_consent else None
             ),
+            urgent=body.urgent,
+            notify_me=body.notify_me,
             request_id=get_request_id(),
             cloud_diagnostics_status="pending" if authorized_cloud_refs else "not_applicable",
         )
@@ -464,6 +466,8 @@ async def _complete_db_backed_report(
             kind=completed_report.kind,
             credit_consent=completed_report.credit_consent,
             credit_name=completed_report.credit_name,
+            urgent=completed_report.urgent,
+            notify_me=completed_report.notify_me,
             correlation=support_report_correlation_record(completed_report),
         )
         await support_reports.mark_report_slack_notified(db, report_id=completed_report.id)
@@ -556,6 +560,8 @@ async def _complete_legacy_report(
         attachment_count=len(body.attachments),
         kind="bug",
         credit_consent=False,
+        urgent=bool(request_record.get("urgent")),
+        notify_me=bool(request_record.get("notifyMe")),
         correlation=None,
     )
 

--- a/server/tests/unit/test_support_message_domain.py
+++ b/server/tests/unit/test_support_message_domain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from proliferate.server.support.domain.message import (
     build_support_message_plan,
+    build_support_report_plan,
     normalize_support_message,
 )
 
@@ -42,6 +43,44 @@ def test_build_support_message_plan_includes_sender_context_and_request_id() -> 
         ("Workspace ID", "cloud:123"),
         ("Request ID", "req_123"),
     ]
+
+
+def test_build_support_report_plan_marks_urgent_title_and_fields() -> None:
+    plan = build_support_report_plan(
+        sender_name="Support Tester",
+        sender_email="support@example.com",
+        message="Prod is down.",
+        report_id="report_123",
+        internal_url=None,
+        diagnostics_included=True,
+        attachment_count=0,
+        urgent=True,
+        notify_me=True,
+    )
+
+    assert plan.title == "*:rotating_light: URGENT support report*"
+    assert plan.fallback_text.startswith("URGENT support report report_123")
+    field_map = {field.label: field.value for field in plan.fields}
+    assert field_map["Urgent"] == "Yes"
+    assert field_map["Notify requested"] == "Yes"
+
+
+def test_build_support_report_plan_non_urgent_defaults() -> None:
+    plan = build_support_report_plan(
+        sender_name="Support Tester",
+        sender_email="support@example.com",
+        message="Minor question.",
+        report_id="report_456",
+        internal_url=None,
+        diagnostics_included=False,
+        attachment_count=0,
+    )
+
+    assert plan.title == "*New support report*"
+    assert plan.fallback_text.startswith("Support report report_456")
+    field_map = {field.label: field.value for field in plan.fields}
+    assert field_map["Urgent"] == "No"
+    assert field_map["Notify requested"] == "No"
 
 
 def test_build_support_message_plan_uses_location_without_workspace_name() -> None:

--- a/server/tests/unit/test_support_report_records.py
+++ b/server/tests/unit/test_support_report_records.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from proliferate.server.support.domain.report_records import support_request_record
+
+
+def _fake_report(*, urgent: bool, notify_me: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="report_abc",
+        client_job_id="job_abc",
+        request_id="req_abc",
+        created_at=datetime(2026, 7, 5, tzinfo=UTC),
+        source_context={"source": "sidebar"},
+        workspace_refs=(),
+        telemetry_refs={},
+        object_manifest={},
+        expected_uploads={"diagnostics": True, "attachmentCount": 0},
+        public_content_consent=False,
+        urgent=urgent,
+        notify_me=notify_me,
+    )
+
+
+def test_support_request_record_includes_urgent_and_notify_me() -> None:
+    record = support_request_record(
+        report=_fake_report(urgent=True, notify_me=True),
+        sender_email="support@example.com",
+        sender_display_name="Support Tester",
+        message="  Prod is down.  ",
+        scope={"kind": "app_only", "workspaceIds": []},
+        correlation={"reportId": "report_abc"},
+    )
+
+    assert record["urgent"] is True
+    assert record["notifyMe"] is True
+    assert record["message"] == "Prod is down."
+
+
+def test_support_request_record_defaults_capture_flags_false() -> None:
+    record = support_request_record(
+        report=_fake_report(urgent=False, notify_me=False),
+        sender_email="support@example.com",
+        sender_display_name=None,
+        message="Question.",
+        scope={"kind": "app_only", "workspaceIds": []},
+        correlation={},
+    )
+
+    assert record["urgent"] is False
+    assert record["notifyMe"] is False

--- a/specs/codebase/features/support-reporting.md
+++ b/specs/codebase/features/support-reporting.md
@@ -123,6 +123,15 @@ Report creation writes `request.json` to the private support S3 prefix. This
 object contains the user message, source context, workspace refs, telemetry
 refs, and server-derived correlation IDs. It must not contain presigned URLs.
 
+Reports also carry two capture-only intent flags, `urgent` and `notifyMe`,
+persisted on the `support_report` row (`urgent`, `notify_me`) and mirrored into
+`request.json` (`urgent`, `notifyMe`). `urgent` marks a report the submitter
+flagged as time-sensitive; `notifyMe` records that the submitter asked to be
+contacted about the outcome. Both default to false and are capture signals
+only — they carry no resolution/triage state, which lives in a separate ops
+service. Follow-up, when requested, goes to the submitter's `outreach_email`
+override (see below) when set, otherwise their account email.
+
 `POST /v1/support/reports/{reportId}/upload-targets` validates diagnostics and
 attachment metadata for the report owner, persists the expected object manifest,
 and returns short-lived presigned `PUT` targets. Clients may call it again while
@@ -185,6 +194,20 @@ Slack receives two best-effort notifications: the report completion receipt and,
 once available, a tracker-links update. Slack messages contain the `reportId`,
 an internal report URL when configured, and tracker URLs. They never include S3
 keys, S3 prefixes, presigned URLs, diagnostics bodies, or uploaded file content.
+
+The completion receipt surfaces the capture flags: `urgent` reports get a clear
+leading urgent marker in the Slack title, and every report renders `Urgent:
+Yes/No` and `Notify requested: Yes/No` fields so a responder can triage without
+opening the case file.
+
+## User Outreach Email
+
+Each user may set an optional `outreach_email` override on their profile
+(`PATCH /v1/users/me`, exposed on `GET /v1/users/me`). It is the address the
+user prefers for support/outreach follow-up; sending an empty string or `null`
+clears it and falls back to the account email. A non-empty value must validate
+as an email. This is account-level profile state, independent of any single
+report.
 
 ## Debug Correlation
 


### PR DESCRIPTION
## What

Lane A of the support-flow upgrade. Adds three capture-only fields and wires them end to end. The product stays capture-only — no resolution/triage state is introduced (that lives in a separate ops service).

- **`urgent` / `notify_me` on support reports** — new booleans on `support_report` (not null, default false). Threaded through `SupportReportCreateRequest` (aliases `urgent` / `notifyMe`, matching the `creditConsent`/`creditName` convention), the store, and the request-record builder so they land on the DB row **and** in the S3 `request.json` (`urgent` / `notifyMe`).
- **Slack completion receipt** — urgent reports get a clear leading urgent marker in the title (`:rotating_light: URGENT support report`), and every report now renders `Urgent: Yes/No` and `Notify requested: Yes/No` fields.
- **User `outreach_email` override** — nullable `varchar(320)` on `user`, exposed on `GET /v1/users/me` and settable/clearable via a new `PATCH /v1/users/me` (empty string or `null` clears; non-empty must validate as an email → 422 otherwise).
- **Config fix** — declared `support_report_internal_base_url` (env `SUPPORT_REPORT_INTERNAL_BASE_URL`, default `""`), which `notifications.py` already referenced but was never in `config.py`. The env var already exists in `.env.example`.
- **Migration** — `c7f2a9b41d38` adds the two support flags and `user.outreach_email` (idempotent, guarded).
- **Spec** — `specs/codebase/features/support-reporting.md` updated in the same PR (new capture flags + Slack surfacing + outreach-email section).
- **SDK** — regenerated `cloud/sdk/src/generated/openapi.ts` (`cloud-client-generate`).

## Why

Support responders need to know a report is time-sensitive and whether the submitter wants follow-up, and where to reach them, without opening the private case file. These are capture signals only.

## Verification

- `cd server && uv run pytest -q tests/unit` → **504 passed**. Extended coverage: `test_support_message_domain.py` (urgent title + fields) and new `test_support_report_records.py` (request.json carries `urgent`/`notifyMe`).
- Migration applied to a fresh profile DB (`alembic upgrade head`); verified columns: `support_report.urgent`/`notify_me` (bool, not null, default false), `user.outreach_email` (varchar(320), nullable).
- Booted the server against the profile DB + real dev S3 and submitted `POST /v1/support/reports` with `urgent:true, notifyMe:true`:
  - DB row: `urgent=t, notify_me=t`.
  - `s3://proliferate-support-reports-dev/support/reports/<date>/<id>/request.json` → `urgent=True, notifyMe=True`.
- `PATCH /v1/users/me` outreach_email: set → GET reflects; invalid email → 422; empty string clears; `null` clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
