### PR TITLE
fix(catalog): show bare current-gen Claude models on native/api (regression from #955)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -162,14 +162,15 @@ fn baseline_counts_as_a_context_when_active() {
 fn visible_models_are_the_default_visible_subset_of_available() {
     let catalog = draft_catalog();
 
-    // claude-opus-4-8 is available under oauth (trial-proven) but not
-    // defaultVisible: in models(), out of visible_models(). Fable 5 is the
-    // counter-case — trial-proven AND curation-advertised.
+    // claude-fable-5 and claude-opus-4-8 are oauth/api-only (the us.anthropic.*
+    // Bedrock variants are unavailable here), so they are NOT gateway duplicates
+    // and stay visible on native/api — an OAuth login serves them and this is
+    // the only form it can use.
     let available = model_ids(catalog.models("claude", &contexts(&["anthropic-oauth"])));
     assert!(available.contains(&"claude-opus-4-8"));
     assert_eq!(
         model_ids(catalog.visible_models("claude", &contexts(&["anthropic-oauth"]))),
-        vec!["default", "sonnet", "haiku", "opus", "claude-fable-5"]
+        vec!["default", "sonnet", "haiku", "opus", "claude-fable-5", "claude-opus-4-8"]
     );
 }
 

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -429,7 +429,7 @@
                 "anthropic-oauth"
               ]
             },
-            "defaultVisible": false,
+            "defaultVisible": true,
             "controls": {
               "mode": {
                 "values": [
@@ -480,7 +480,7 @@
                 "anthropic-oauth"
               ]
             },
-            "defaultVisible": false,
+            "defaultVisible": true,
             "controls": {
               "mode": {
                 "values": [

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -139,10 +139,13 @@ const CONTROL_MAPPINGS = {
 // the probe can prove a model launches.
 const MODEL_VISIBILITY_OPT_OUTS = {
   claude: [
-    // bare-direct current-gen duplicates of us.anthropic.* Bedrock entries
-    "claude-fable-5",
-    "claude-opus-4-8",
-    // global-region duplicate of us.anthropic.claude-fable-5 (bedrock)
+    // Only opt out GENUINE same-context duplicates. The bare current-gen ids
+    // (claude-fable-5, claude-opus-4-8) are oauth/api-only — never gateway-
+    // reachable — so they are NOT duplicates of the us.anthropic.* Bedrock
+    // entries and must stay visible on the native/api surfaces (that's the
+    // only form of those models an OAuth/API login can use). Only the
+    // global-region id duplicates its us.anthropic.* sibling WITHIN the
+    // bedrock context, so it alone stays opted out.
     "global.anthropic.claude-fable-5",
   ],
   grok: [

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -479,7 +479,7 @@
                 "anthropic-oauth"
               ]
             },
-            "defaultVisible": false,
+            "defaultVisible": true,
             "controls": {
               "mode": {
                 "values": [


### PR DESCRIPTION
## Problem
A user logged in via \`claude login\` (OAuth) saw only 4 Claude models and could NOT see **Fable 5** or **Opus 4.8**, despite their subscription serving them.

## Cause
PR #955's Bedrock dedup opted \`claude-fable-5\` and \`claude-opus-4-8\` out of the visible menu (\`defaultVisible:false\`) to avoid duplicate rows on the gateway model table. But those bare ids are **oauth/api-only** — the \`us.anthropic.*\` Bedrock variants are filtered out by availability on native/api surfaces, so the bare ids are the *only* form an OAuth/API login can use. The context-blind opt-out hid them everywhere.

## Fix (minimal, 4 files)
- Un-hide \`claude-fable-5\` + \`claude-opus-4-8\` (\`defaultVisible: true\`) in \`catalog.json\` + \`catalog.draft.json\`.
- Remove them from \`MODEL_VISIBILITY_OPT_OUTS.claude\` in \`build-catalog.mjs\`; **keep** \`global.anthropic.claude-fable-5\` opted out (a genuine same-context bedrock duplicate of \`us.anthropic.claude-fable-5\`).
- Update the cargo test asserting the OAuth visible set.

## Why the gateway table stays deduped
The gateway model table is fed by the runtime gateway probe of \`config.yaml\` + the availability filter — **independent** of this \`defaultVisible\` flag — so un-hiding the bare ids cannot reintroduce a gateway duplicate.

## Before → after (native / anthropic-oauth visible set)
\`default, sonnet, haiku, opus, claude-fable-5\` → \`+ claude-opus-4-8\`

## Verification
- JS validator: green
- \`cargo test -p anyharness-lib -- domains::agents::catalog\`: 57 passed
- Note: \`catalog.json\` is \`include_str!\`'d → runtime rebuild required to take effect.

Supersedes the scope-crept #974 (which regenerated the whole catalog + removed codex's gateway default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)