### PR TITLE
feat(desktop): support modal urgent/notify/credit/logs + outreach email footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
+        "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "transparent": true,

--- a/apps/desktop/src-tauri/tauri.dev.json
+++ b/apps/desktop/src-tauri/tauri.dev.json
@@ -9,6 +9,7 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
+        "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "transparent": true,

--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -36,7 +36,6 @@ import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-o
 import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
-import { useSupportModalStore } from "@/stores/support/support-modal-store";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
@@ -65,8 +64,11 @@ export function SidebarAccountFooter() {
   const { openExternal } = useTauriShellActions();
   const handleSignOut = useAppSidebarSignOutAction();
   const openShortcutsDialog = useKeyboardShortcutsDialogStore((state) => state.setOpen);
-  const openSupport = useOpenSupportReportWindow({ source: "sidebar" });
-  const openPrompt = useSupportModalStore((state) => state.openPrompt);
+  const {
+    openBug: openSupport,
+    openFeature: openPrompt,
+    disabledReason: supportDisabledReason,
+  } = useOpenSupportReportWindow({ source: "sidebar" });
   const showToast = useToastStore((state) => state.show);
   const { data: billingPlan } = useCloudBilling();
   const {
@@ -298,6 +300,8 @@ export function SidebarAccountFooter() {
                   label="Send feedback"
                   icon={<MessageSquare className="size-4" />}
                   trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openSupport)}</span>}
+                  disabled={Boolean(supportDisabledReason)}
+                  title={supportDisabledReason ?? undefined}
                   onClick={() => {
                     openSupport();
                     close();
@@ -307,6 +311,8 @@ export function SidebarAccountFooter() {
                   variant="sidebar"
                   label="Submit a prompt"
                   icon={<Lightbulb className="size-4" />}
+                  disabled={Boolean(supportDisabledReason)}
+                  title={supportDisabledReason ?? undefined}
                   onClick={() => {
                     openPrompt();
                     close();

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -188,7 +188,7 @@ export function SettingsSidebar({
   updateActionState,
 }: SettingsSidebarProps) {
   const appVersion = useAppVersion().data?.trim();
-  const handleOpenSupport = useOpenSupportReportWindow({ source: "settings" });
+  const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "settings" });
   const shortcutRevealVisible = useShortcutRevealVisible();
   const visibleNavGroups = useMemo(() =>
     getSettingsScopeNav(activeScope).groups.map((group) => ({

--- a/apps/desktop/src/components/support/SendFeedbackModal.tsx
+++ b/apps/desktop/src/components/support/SendFeedbackModal.tsx
@@ -5,6 +5,10 @@ import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { CloudUpload, FileText, X } from "@proliferate/ui/icons";
 import { useSupportModalState, type StagedAttachment } from "@/hooks/support/facade/use-support-modal-state";
+import { useSupportOutreachEmail } from "@/hooks/support/facade/use-support-outreach-email";
+import { SupportCheckboxRow } from "./SupportCheckboxRow";
+import { SupportCreditField } from "./SupportCreditField";
+import { SupportModalFooter } from "./SupportModalFooter";
 
 interface SendFeedbackModalProps {
   onClose: () => void;
@@ -15,18 +19,29 @@ export function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
   const {
     attachments,
     canSend,
+    creditConsent,
+    creditName,
     handleAttachmentDragOver,
     handleAttachmentDrop,
     handleAttachmentInputChange,
     handleAttachmentPaste,
     handleCancel,
     handleSend,
+    includeLogs,
     isSubmitting,
     message,
+    notifyMe,
     removeAttachment,
+    setCreditConsent,
+    setCreditName,
+    setIncludeLogs,
     setMessage,
+    setNotifyMe,
+    setUrgent,
     stagingError,
+    urgent,
   } = useSupportModalState({ kind: "bug", onClose });
+  const outreach = useSupportOutreachEmail();
 
   return (
     <ModalShell
@@ -66,23 +81,47 @@ export function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
           onInputChange={handleAttachmentInputChange}
         />
 
-        <div className="flex items-center justify-between gap-3 pt-1">
-          <p className="text-ui text-muted-foreground">
-            We'll get back to you on this by tomorrow.
-          </p>
-          <div className="flex items-center gap-2">
-            <Button type="button" variant="ghost" onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={!canSend}
-              loading={isSubmitting}
-              onClick={() => { void handleSend(); }}
-            >
-              Send
-            </Button>
-          </div>
+        <div className="space-y-0.5">
+          <SupportCheckboxRow
+            checked={urgent}
+            onCheckedChange={setUrgent}
+            label="This is urgent"
+            helper="We'll send you an email by tomorrow."
+          />
+          <SupportCheckboxRow
+            checked={notifyMe}
+            onCheckedChange={setNotifyMe}
+            label="Let me know when you fix this"
+            helper="We'll send you an update within a day."
+          />
+          <SupportCreditField
+            label="Credit me"
+            creditConsent={creditConsent}
+            setCreditConsent={setCreditConsent}
+            creditName={creditName}
+            setCreditName={setCreditName}
+          />
+          <SupportCheckboxRow
+            checked={includeLogs}
+            onCheckedChange={setIncludeLogs}
+            label="Include app logs"
+          />
+        </div>
+
+        <SupportModalFooter outreach={outreach} />
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button type="button" variant="ghost" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSend}
+            loading={isSubmitting}
+            onClick={() => { void handleSend(); }}
+          >
+            Send
+          </Button>
         </div>
       </div>
     </ModalShell>

--- a/apps/desktop/src/components/support/SendFeedbackModal.tsx
+++ b/apps/desktop/src/components/support/SendFeedbackModal.tsx
@@ -92,7 +92,6 @@ export function SendFeedbackModal({ onClose }: SendFeedbackModalProps) {
             checked={notifyMe}
             onCheckedChange={setNotifyMe}
             label="Let me know when you fix this"
-            helper="We'll send you an update within a day."
           />
           <SupportCreditField
             label="Credit me"

--- a/apps/desktop/src/components/support/SubmitPromptModal.tsx
+++ b/apps/desktop/src/components/support/SubmitPromptModal.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
-import { Input } from "@proliferate/ui/primitives/Input";
-import { Label } from "@proliferate/ui/primitives/Label";
 import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { useSupportModalState } from "@/hooks/support/facade/use-support-modal-state";
+import { useSupportOutreachEmail } from "@/hooks/support/facade/use-support-outreach-email";
+import { SupportCheckboxRow } from "./SupportCheckboxRow";
+import { SupportCreditField } from "./SupportCreditField";
+import { SupportModalFooter } from "./SupportModalFooter";
 
 interface SubmitPromptModalProps {
   onClose: () => void;
@@ -19,11 +20,14 @@ export function SubmitPromptModal({ onClose }: SubmitPromptModalProps) {
     handleSend,
     isSubmitting,
     message,
+    notifyMe,
     setCreditConsent,
     setCreditName,
     setMessage,
+    setNotifyMe,
     stagingError,
   } = useSupportModalState({ kind: "feature", onClose });
+  const outreach = useSupportOutreachEmail();
 
   return (
     <ModalShell
@@ -49,34 +53,26 @@ export function SubmitPromptModal({ onClose }: SubmitPromptModalProps) {
           />
         </section>
 
-        <div className="space-y-2">
-          <Label className="mb-0 flex cursor-pointer items-center gap-3 rounded-lg border border-border/70 bg-surface-control/60 px-3 py-2.5 text-ui text-foreground">
-            <Checkbox
-              checked={creditConsent}
-              onCheckedChange={(checked) => setCreditConsent(checked === true)}
-            />
-            <span className="font-medium text-ui">Credit me if this merges</span>
-          </Label>
-
-          <div
-            className="grid transition-[grid-template-rows] duration-200 ease-out"
-            style={{ gridTemplateRows: creditConsent ? "1fr" : "0fr" }}
-          >
-            <div className="overflow-hidden p-px">
-              <Input
-                value={creditName}
-                onChange={(event) => setCreditName(event.target.value)}
-                placeholder="Your name or @handle"
-                aria-label="Name to credit"
-                className="mt-1"
-              />
-            </div>
-          </div>
+        <div className="space-y-0.5">
+          <SupportCreditField
+            label="Credit me if this merges"
+            creditConsent={creditConsent}
+            setCreditConsent={setCreditConsent}
+            creditName={creditName}
+            setCreditName={setCreditName}
+          />
+          <SupportCheckboxRow
+            checked={notifyMe}
+            onCheckedChange={setNotifyMe}
+            label="Let me know when you merge this"
+          />
         </div>
 
         {stagingError ? (
           <p className="text-ui-sm text-destructive">{stagingError}</p>
         ) : null}
+
+        <SupportModalFooter outreach={outreach} />
 
         <div className="flex items-center justify-end gap-2 pt-1">
           <Button type="button" variant="ghost" onClick={handleCancel}>

--- a/apps/desktop/src/components/support/SubmitPromptModal.tsx
+++ b/apps/desktop/src/components/support/SubmitPromptModal.tsx
@@ -3,7 +3,6 @@ import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
 import { Textarea } from "@proliferate/ui/primitives/Textarea";
 import { useSupportModalState } from "@/hooks/support/facade/use-support-modal-state";
 import { useSupportOutreachEmail } from "@/hooks/support/facade/use-support-outreach-email";
-import { SupportCheckboxRow } from "./SupportCheckboxRow";
 import { SupportCreditField } from "./SupportCreditField";
 import { SupportModalFooter } from "./SupportModalFooter";
 
@@ -20,11 +19,9 @@ export function SubmitPromptModal({ onClose }: SubmitPromptModalProps) {
     handleSend,
     isSubmitting,
     message,
-    notifyMe,
     setCreditConsent,
     setCreditName,
     setMessage,
-    setNotifyMe,
     stagingError,
   } = useSupportModalState({ kind: "feature", onClose });
   const outreach = useSupportOutreachEmail();
@@ -60,11 +57,6 @@ export function SubmitPromptModal({ onClose }: SubmitPromptModalProps) {
             setCreditConsent={setCreditConsent}
             creditName={creditName}
             setCreditName={setCreditName}
-          />
-          <SupportCheckboxRow
-            checked={notifyMe}
-            onCheckedChange={setNotifyMe}
-            label="Let me know when you merge this"
           />
         </div>
 

--- a/apps/desktop/src/components/support/SupportCheckboxRow.tsx
+++ b/apps/desktop/src/components/support/SupportCheckboxRow.tsx
@@ -1,0 +1,37 @@
+import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
+import { Label } from "@proliferate/ui/primitives/Label";
+
+interface SupportCheckboxRowProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  label: string;
+  /** Helper line revealed under the row while the box is checked. */
+  helper?: string;
+}
+
+/**
+ * A support-modal checkbox row: a plain, low-profile clickable label wrapping
+ * a Radix checkbox, with an optional helper line that appears only while
+ * checked. Kept unbordered so several can stack without feeling heavy.
+ */
+export function SupportCheckboxRow({
+  checked,
+  onCheckedChange,
+  label,
+  helper,
+}: SupportCheckboxRowProps) {
+  return (
+    <div>
+      <Label className="mb-0 flex cursor-pointer items-center gap-2.5 py-1 text-ui-sm text-foreground">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={(next) => onCheckedChange(next === true)}
+        />
+        <span className="text-ui-sm">{label}</span>
+      </Label>
+      {helper && checked ? (
+        <p className="mt-0.5 pl-6 text-ui-sm text-muted-foreground">{helper}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/support/SupportCreditField.tsx
+++ b/apps/desktop/src/components/support/SupportCreditField.tsx
@@ -1,0 +1,51 @@
+import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
+
+interface SupportCreditFieldProps {
+  label: string;
+  creditConsent: boolean;
+  setCreditConsent: (checked: boolean) => void;
+  creditName: string;
+  setCreditName: (value: string) => void;
+}
+
+/**
+ * "Credit me" consent checkbox with an animated name input that reveals while
+ * checked. Shared by the bug and prompt support modals so both surfaces get the
+ * identical interaction.
+ */
+export function SupportCreditField({
+  label,
+  creditConsent,
+  setCreditConsent,
+  creditName,
+  setCreditName,
+}: SupportCreditFieldProps) {
+  return (
+    <div>
+      <Label className="mb-0 flex cursor-pointer items-center gap-2.5 py-1 text-ui-sm text-foreground">
+        <Checkbox
+          checked={creditConsent}
+          onCheckedChange={(checked) => setCreditConsent(checked === true)}
+        />
+        <span className="text-ui-sm">{label}</span>
+      </Label>
+
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out"
+        style={{ gridTemplateRows: creditConsent ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden pl-6">
+          <Input
+            value={creditName}
+            onChange={(event) => setCreditName(event.target.value)}
+            placeholder="Your name or @handle"
+            aria-label="Name to credit"
+            className="mb-1 mt-0.5"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/support/SupportModalFooter.tsx
+++ b/apps/desktop/src/components/support/SupportModalFooter.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import type { SupportOutreachEmailState } from "@/hooks/support/facade/use-support-outreach-email";
+
+interface SupportModalFooterProps {
+  outreach: SupportOutreachEmailState;
+}
+
+/**
+ * Muted "Updates go to {email} · change" line shown above the action buttons in
+ * both support modals. "change" swaps to an inline editor that persists the
+ * account-wide `outreach_email` override.
+ */
+export function SupportModalFooter({ outreach }: SupportModalFooterProps) {
+  if (outreach.isEditing) {
+    return (
+      <div className="space-y-2 pt-1">
+        <div className="flex items-center gap-2">
+          <Input
+            type="email"
+            autoFocus
+            value={outreach.draft}
+            onChange={(event) => outreach.setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void outreach.save();
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                outreach.cancelEdit();
+              }
+            }}
+            placeholder="you@example.com"
+            aria-label="Email for support updates"
+            aria-invalid={outreach.error ? true : undefined}
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            size="sm"
+            loading={outreach.isSaving}
+            onClick={() => { void outreach.save(); }}
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={outreach.isSaving}
+            onClick={outreach.cancelEdit}
+          >
+            Cancel
+          </Button>
+        </div>
+        {outreach.error ? (
+          <p className="text-ui-sm text-destructive">{outreach.error}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-ui-sm text-muted-foreground">
+      Updates go to {outreach.effectiveEmail ?? "your account email"}
+      {" · "}
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        className="underline underline-offset-2 hover:text-foreground"
+        onClick={outreach.beginEdit}
+      >
+        change
+      </Button>
+    </p>
+  );
+}

--- a/apps/desktop/src/components/support/SupportModalHost.tsx
+++ b/apps/desktop/src/components/support/SupportModalHost.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { useSupportModalStore } from "@/stores/support/support-modal-store";
+import { useSupportAvailability } from "@/hooks/support/facade/use-support-availability";
 import { SendFeedbackModal } from "./SendFeedbackModal";
 import { SubmitPromptModal } from "./SubmitPromptModal";
 
@@ -6,8 +8,18 @@ export function SupportModalHost() {
   const open = useSupportModalStore((state) => state.open);
   const kind = useSupportModalStore((state) => state.kind);
   const close = useSupportModalStore((state) => state.close);
+  const { canSubmit } = useSupportAvailability();
 
-  if (!open) {
+  // Backstop for the store-level gate: if the session drops while the modal is
+  // open (e.g. sign-out mid-report), close it rather than leave a report being
+  // composed that can't be sent.
+  useEffect(() => {
+    if (open && !canSubmit) {
+      close();
+    }
+  }, [open, canSubmit, close]);
+
+  if (!open || !canSubmit) {
     return null;
   }
 

--- a/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -59,7 +59,7 @@ export const MainSidebar = memo(function MainSidebar() {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
   const actions = useWorkspaceSidebarActions();
-  const handleOpenSupport = useOpenSupportReportWindow({ source: "sidebar" });
+  const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
   const shortcutRevealVisible = useShortcutRevealVisible();
   const sidebarShortcutTargetIds = useSidebarShortcutTargets();
   const {

--- a/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
+++ b/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
@@ -4,7 +4,7 @@ import { APP_ROUTES } from "@/config/app-routes";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
-import { useSupportModalStore } from "@/stores/support/support-modal-store";
+import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
 import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import type { AppCommandActions } from "./app-command-action-types";
@@ -45,10 +45,10 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
       showToast("Failed to open the web app.");
     });
   }, [openExternal, showToast]);
-  const openFeedback = useSupportModalStore((state) => state.openFeedback);
-  const openSupport = useCallback(() => {
-    openFeedback();
-  }, [openFeedback]);
+  const {
+    openBug: openSupport,
+    disabledReason: supportDisabledReason,
+  } = useOpenSupportReportWindow({ source: "sidebar" });
 
   return useMemo<AppNavigationCommandActions>(() => ({
     openSettings: {
@@ -73,13 +73,14 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
     },
     openSupport: {
       execute: openSupport,
-      disabledReason: null,
+      disabledReason: supportDisabledReason,
     },
   }), [
     goHome,
     goWorkflows,
     openSettings,
     openSupport,
+    supportDisabledReason,
     openWebApp,
     showKeyboardShortcuts,
   ]);

--- a/apps/desktop/src/hooks/support/facade/use-support-availability.test.ts
+++ b/apps/desktop/src/hooks/support/facade/use-support-availability.test.ts
@@ -1,0 +1,34 @@
+/* @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useSupportAvailability } from "./use-support-availability";
+
+const initial = useAuthStore.getState();
+
+afterEach(() => {
+  useAuthStore.setState(initial, true);
+});
+
+describe("useSupportAvailability", () => {
+  it("allows submit only when authenticated", () => {
+    useAuthStore.setState({ status: "authenticated" });
+    const { result } = renderHook(() => useSupportAvailability());
+    expect(result.current.canSubmit).toBe(true);
+    expect(result.current.disabledReason).toBeNull();
+  });
+
+  it("blocks (with a reason) when anonymous", () => {
+    useAuthStore.setState({ status: "anonymous" });
+    const { result } = renderHook(() => useSupportAvailability());
+    expect(result.current.canSubmit).toBe(false);
+    expect(result.current.disabledReason).toMatch(/sign in/i);
+  });
+
+  it("blocks WITHOUT a reason while bootstrapping (no premature flash)", () => {
+    useAuthStore.setState({ status: "bootstrapping" });
+    const { result } = renderHook(() => useSupportAvailability());
+    expect(result.current.canSubmit).toBe(false);
+    expect(result.current.disabledReason).toBeNull();
+  });
+});

--- a/apps/desktop/src/hooks/support/facade/use-support-availability.ts
+++ b/apps/desktop/src/hooks/support/facade/use-support-availability.ts
@@ -1,0 +1,34 @@
+import { useAuthStore } from "@/stores/auth/auth-store";
+
+export interface SupportAvailability {
+  /** True only when a real Cloud session exists (uploads will succeed). */
+  canSubmit: boolean;
+  /**
+   * Why support is unavailable, for menu/command `disabledReason`. Null when
+   * available. Also null while auth is still bootstrapping — we don't want to
+   * flash a "sign in" reason before the session has resolved.
+   */
+  disabledReason: string | null;
+}
+
+/**
+ * Support reports always require a real Proliferate Cloud session to upload,
+ * regardless of whether the app itself requires auth (dev builds run
+ * `anonymous`). Gating the modal open on this makes the confusing
+ * submit-then-"sign in, report queued" path unreachable: we never open the
+ * modal unless the report can actually be sent.
+ */
+export function useSupportAvailability(): SupportAvailability {
+  const status = useAuthStore((state) => state.status);
+
+  if (status === "authenticated") {
+    return { canSubmit: true, disabledReason: null };
+  }
+  if (status === "bootstrapping") {
+    return { canSubmit: false, disabledReason: null };
+  }
+  return {
+    canSubmit: false,
+    disabledReason: "Sign in to Proliferate Cloud to send feedback.",
+  };
+}

--- a/apps/desktop/src/hooks/support/facade/use-support-modal-state.test.tsx
+++ b/apps/desktop/src/hooks/support/facade/use-support-modal-state.test.tsx
@@ -1,0 +1,127 @@
+/* @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SUPPORT_REPORT_JOB_EVENT } from "@/lib/access/tauri/support";
+import type { SupportReportJob } from "@/lib/domain/support/report-types";
+import { useSupportModalState } from "@/hooks/support/facade/use-support-modal-state";
+
+vi.mock("@/lib/access/tauri/support", () => ({
+  SUPPORT_REPORT_JOB_EVENT: "support-report-job",
+  deleteStagedSupportReportAttachment: vi.fn(async () => {}),
+  stageSupportReportAttachment: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/access/tauri/diagnostics", () => ({
+  logRendererEvent: vi.fn(async () => {}),
+}));
+
+vi.mock("@/hooks/support/derived/use-support-report-snapshot", () => ({
+  useSupportReportSnapshot: () => ({
+    openedAt: "2026-07-05T00:00:00.000Z",
+    source: "sidebar",
+    context: { source: "sidebar", intent: "general" },
+    defaultScope: "app_only",
+    defaultWorkspaceId: null,
+    workspaceOptions: [],
+  }),
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: { activeSessionId: string | null }) => unknown) =>
+    selector({ activeSessionId: null }),
+}));
+
+function captureDispatchedJob(): { current: SupportReportJob | null } {
+  const captured: { current: SupportReportJob | null } = { current: null };
+  window.addEventListener(SUPPORT_REPORT_JOB_EVENT, ((event: CustomEvent<SupportReportJob>) => {
+    captured.current = event.detail;
+  }) as EventListener);
+  return captured;
+}
+
+describe("useSupportModalState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("carries urgent, notifyMe, includeLogs, and credit fields on the bug job", async () => {
+    const captured = captureDispatchedJob();
+    const rendered = renderHook(() =>
+      useSupportModalState({ kind: "bug", onClose: vi.fn() })
+    );
+
+    act(() => {
+      rendered.result.current.setMessage("It broke");
+      rendered.result.current.setUrgent(true);
+      rendered.result.current.setNotifyMe(true);
+      rendered.result.current.setCreditConsent(true);
+    });
+    act(() => {
+      rendered.result.current.setCreditName("Ada Lovelace");
+      rendered.result.current.setIncludeLogs(false);
+    });
+    await act(async () => {
+      await rendered.result.current.handleSend();
+    });
+
+    expect(captured.current).not.toBeNull();
+    expect(captured.current).toMatchObject({
+      kind: "bug",
+      urgent: true,
+      notifyMe: true,
+      includeLogs: false,
+      creditConsent: true,
+      creditName: "Ada Lovelace",
+    });
+  });
+
+  it("defaults the bug job to logs-on, not urgent, no notify", async () => {
+    const captured = captureDispatchedJob();
+    const rendered = renderHook(() =>
+      useSupportModalState({ kind: "bug", onClose: vi.fn() })
+    );
+
+    act(() => {
+      rendered.result.current.setMessage("It broke");
+    });
+    await act(async () => {
+      await rendered.result.current.handleSend();
+    });
+
+    expect(captured.current).toMatchObject({
+      urgent: false,
+      notifyMe: false,
+      includeLogs: true,
+      creditConsent: false,
+      creditName: null,
+    });
+  });
+
+  it("keeps prompt jobs non-urgent with logs included while carrying notifyMe", async () => {
+    const captured = captureDispatchedJob();
+    const rendered = renderHook(() =>
+      useSupportModalState({ kind: "feature", onClose: vi.fn() })
+    );
+
+    act(() => {
+      rendered.result.current.setMessage("Build me a thing");
+      rendered.result.current.setUrgent(true); // Should be ignored for prompts.
+      rendered.result.current.setNotifyMe(true);
+    });
+    await act(async () => {
+      await rendered.result.current.handleSend();
+    });
+
+    expect(captured.current).toMatchObject({
+      kind: "feature",
+      urgent: false,
+      notifyMe: true,
+      includeLogs: true,
+    });
+  });
+});

--- a/apps/desktop/src/hooks/support/facade/use-support-modal-state.ts
+++ b/apps/desktop/src/hooks/support/facade/use-support-modal-state.ts
@@ -38,6 +38,9 @@ export function useSupportModalState({ kind, onClose }: UseSupportModalStateOpti
   const [message, setMessage] = useState("");
   const [creditConsent, setCreditConsentRaw] = useState(false);
   const [creditName, setCreditName] = useState("");
+  const [urgent, setUrgent] = useState(false);
+  const [notifyMe, setNotifyMe] = useState(false);
+  const [includeLogs, setIncludeLogs] = useState(true);
   const [attachments, setAttachments] = useState<StagedAttachment[]>([]);
 
   function setCreditConsent(next: boolean) {
@@ -148,8 +151,14 @@ export function useSupportModalState({ kind, onClose }: UseSupportModalStateOpti
       },
       publicContentConsent: false,
       kind,
-      creditConsent: kind === "feature" ? creditConsent : false,
-      creditName: kind === "feature" && creditConsent ? creditName.trim() || null : null,
+      creditConsent,
+      creditName: creditConsent ? creditName.trim() || null : null,
+      // `urgent` is a bug-only signal; prompt submissions never mark urgent.
+      urgent: kind === "bug" ? urgent : false,
+      notifyMe,
+      // App-log inclusion is a bug-modal toggle; prompt submissions always
+      // include diagnostics (there is no toggle on that surface).
+      includeLogs: kind === "bug" ? includeLogs : true,
       snapshot: {
         ...snapshot,
         openedAt: openedAtRef.current,
@@ -205,7 +214,13 @@ export function useSupportModalState({ kind, onClose }: UseSupportModalStateOpti
     removeAttachment,
     setCreditConsent,
     setCreditName,
+    setIncludeLogs,
     setMessage,
+    setNotifyMe,
+    setUrgent,
+    includeLogs,
+    notifyMe,
+    urgent,
     stagingError,
   };
 }

--- a/apps/desktop/src/hooks/support/facade/use-support-outreach-email.ts
+++ b/apps/desktop/src/hooks/support/facade/use-support-outreach-email.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import { getCurrentUser, updateCurrentUser } from "@proliferate/cloud-sdk/client/users";
+import { useAuthStore } from "@/stores/auth/auth-store";
+
+/**
+ * Footer state for the support modals: which address support follow-up goes to,
+ * and an inline editor that PATCHes the account-wide `outreach_email` override.
+ *
+ * The effective address is `outreach_email ?? account email` from
+ * `GET /v1/users/me`. Saving an empty value clears the override (falls back to
+ * the account email). Invalid emails surface the server's 422 as an inline
+ * error rather than throwing.
+ */
+export interface SupportOutreachEmailState {
+  /** The address updates are sent to: outreach override, else account email. */
+  effectiveEmail: string | null;
+  isEditing: boolean;
+  draft: string;
+  setDraft: (value: string) => void;
+  isSaving: boolean;
+  error: string | null;
+  beginEdit: () => void;
+  cancelEdit: () => void;
+  save: () => Promise<void>;
+}
+
+export function useSupportOutreachEmail(): SupportOutreachEmailState {
+  const sessionEmail = useAuthStore((state) => state.session?.email ?? null);
+  const [accountEmail, setAccountEmail] = useState<string | null>(sessionEmail);
+  const [outreachEmail, setOutreachEmail] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Load the persisted account-wide profile so the footer reflects the real
+  // outreach override. Cloud may be unconfigured (dev bypass) — fall back to
+  // the session email silently.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const user = await getCurrentUser();
+        if (cancelled) {
+          return;
+        }
+        setAccountEmail(user.email ?? sessionEmail);
+        setOutreachEmail(user.outreach_email ?? null);
+      } catch {
+        // Keep the session email fallback.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionEmail]);
+
+  const effectiveEmail = outreachEmail ?? accountEmail;
+
+  const beginEdit = useCallback(() => {
+    setDraft(outreachEmail ?? "");
+    setError(null);
+    setIsEditing(true);
+  }, [outreachEmail]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setError(null);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    const trimmed = draft.trim();
+    try {
+      const user = await updateCurrentUser({ outreach_email: trimmed.length > 0 ? trimmed : null });
+      if (!mountedRef.current) {
+        return;
+      }
+      setAccountEmail(user.email ?? accountEmail);
+      setOutreachEmail(user.outreach_email ?? null);
+      setIsEditing(false);
+    } catch (caught) {
+      if (!mountedRef.current) {
+        return;
+      }
+      if (caught instanceof ProliferateClientError && caught.status === 422) {
+        setError("Enter a valid email address.");
+      } else {
+        setError("Couldn't save. Please try again.");
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsSaving(false);
+      }
+    }
+  }, [accountEmail, draft, isSaving]);
+
+  return {
+    effectiveEmail,
+    isEditing,
+    draft,
+    setDraft,
+    isSaving,
+    error,
+    beginEdit,
+    cancelEdit,
+    save,
+  };
+}

--- a/apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.test.ts
+++ b/apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SupportReportJob } from "@/lib/domain/support/report-types";
+
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  getSupportReportTelemetryRefs: () => ({}),
+  trackProductEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/access/tauri/support", () => ({
+  readStagedSupportReportAttachment: vi.fn(async () => ""),
+}));
+
+import {
+  buildCreateReportRequest,
+  completeRequestForUpload,
+} from "./support-report-upload-payload";
+
+function makeJob(overrides: Partial<SupportReportJob> = {}): SupportReportJob {
+  return {
+    jobId: "job-1",
+    createdAt: "2026-07-05T00:00:00.000Z",
+    message: "Something broke",
+    scope: { kind: "app_only", workspaceIds: [] },
+    publicContentConsent: false,
+    kind: "bug",
+    creditConsent: false,
+    snapshot: {
+      openedAt: "2026-07-05T00:00:00.000Z",
+      source: "sidebar",
+      context: { source: "sidebar", intent: "general" },
+      defaultScope: "app_only",
+      defaultWorkspaceId: null,
+      workspaceOptions: [],
+    },
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe("buildCreateReportRequest", () => {
+  it("carries urgent / notifyMe and diagnostics=true by default", () => {
+    const request = buildCreateReportRequest(makeJob({ urgent: true, notifyMe: true }), 0);
+    expect(request.urgent).toBe(true);
+    expect(request.notifyMe).toBe(true);
+    expect(request.expectedClientUploads?.diagnostics).toBe(true);
+  });
+
+  it("sets diagnostics=false when includeLogs is off", () => {
+    const request = buildCreateReportRequest(makeJob({ includeLogs: false }), 0);
+    expect(request.expectedClientUploads?.diagnostics).toBe(false);
+  });
+
+  it("defaults urgent/notifyMe to false for legacy persisted jobs", () => {
+    const request = buildCreateReportRequest(makeJob(), 2);
+    expect(request.urgent).toBe(false);
+    expect(request.notifyMe).toBe(false);
+    // Missing includeLogs defaults to logs-included.
+    expect(request.expectedClientUploads?.diagnostics).toBe(true);
+    expect(request.expectedClientUploads?.attachmentCount).toBe(2);
+  });
+
+  it("passes credit name only when consented", () => {
+    expect(buildCreateReportRequest(makeJob({ creditConsent: true, creditName: "Ada" }), 0).creditName)
+      .toBe("Ada");
+    expect(buildCreateReportRequest(makeJob(), 0).creditName).toBeNull();
+  });
+});
+
+describe("completeRequestForUpload", () => {
+  it("omits the diagnostics object when logs are excluded", () => {
+    const request = completeRequestForUpload({
+      job: makeJob({ includeLogs: false }),
+      reportId: "report-1",
+      diagnostics: undefined,
+      generatedAt: "2026-07-05T00:00:00.000Z",
+      cloudDiagnosticsStatus: "not_applicable",
+      attachments: [],
+    });
+    expect(request.diagnostics).toBeNull();
+    expect(request.packageManifest?.diagnosticsIncluded).toBe(false);
+    expect(request.packageManifest?.diagnosticsBytes).toBe(0);
+  });
+
+  it("includes the diagnostics object when logs are present", () => {
+    const request = completeRequestForUpload({
+      job: makeJob(),
+      reportId: "report-1",
+      diagnostics: { objectKey: "k", sha256: "abc", sizeBytes: 123 },
+      generatedAt: "2026-07-05T00:00:00.000Z",
+      cloudDiagnosticsStatus: "not_applicable",
+      attachments: [],
+    });
+    expect(request.diagnostics).toEqual({ objectKey: "k", sha256: "abc", sizeBytes: 123 });
+    expect(request.packageManifest?.diagnosticsIncluded).toBe(true);
+  });
+});

--- a/apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.ts
+++ b/apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.ts
@@ -35,13 +35,15 @@ export function buildCreateReportRequest(
     workspaceRefs: workspaceRefsForJob(job),
     telemetryRefs: getSupportReportTelemetryRefs(),
     expectedClientUploads: {
-      diagnostics: true,
+      diagnostics: job.includeLogs !== false,
       attachmentCount,
     },
     publicContentConsent: false,
     kind: job.kind ?? "bug",
     creditConsent: job.creditConsent ?? false,
     creditName: job.creditName ?? null,
+    urgent: job.urgent ?? false,
+    notifyMe: job.notifyMe ?? false,
   };
 }
 
@@ -88,7 +90,7 @@ export function trackSupportReportSubmitted(
     source_surface: "desktop",
     scope_kind: job.scope.kind,
     public_content_consent: job.publicContentConsent !== false,
-    diagnostics_included: true,
+    diagnostics_included: job.includeLogs !== false,
     attachment_count: attachmentCount,
     workspace_count: workspaceIds.length,
     cloud_workspace_count: correlation.cloudWorkspaceIds.length,
@@ -157,26 +159,35 @@ export async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
 export function completeRequestForUpload(input: {
   job: SupportReportJob;
   reportId: string;
-  diagnosticsObjectKey: string;
-  diagnosticsSha256: string;
-  diagnosticsBytes: number;
+  /**
+   * Diagnostics object metadata. Omitted (undefined) when the submitter turned
+   * off "Include app logs" so no diagnostics.json was uploaded for this report.
+   */
+  diagnostics?: {
+    objectKey: string;
+    sha256: string;
+    sizeBytes: number;
+  };
   generatedAt: string;
   cloudDiagnosticsStatus: unknown;
   attachments: NonNullable<SupportReportCompleteRequest["attachments"]>;
 }): SupportReportCompleteRequest {
   return {
-    diagnostics: {
-      objectKey: input.diagnosticsObjectKey,
-      sha256: input.diagnosticsSha256,
-      sizeBytes: input.diagnosticsBytes,
-    },
+    diagnostics: input.diagnostics
+      ? {
+          objectKey: input.diagnostics.objectKey,
+          sha256: input.diagnostics.sha256,
+          sizeBytes: input.diagnostics.sizeBytes,
+        }
+      : null,
     attachments: input.attachments,
     packageManifest: {
       schemaVersion: 2,
       jobId: input.job.jobId,
       reportId: input.reportId,
       generatedAt: input.generatedAt,
-      diagnosticsBytes: input.diagnosticsBytes,
+      diagnosticsBytes: input.diagnostics?.sizeBytes ?? 0,
+      diagnosticsIncluded: input.diagnostics != null,
       attachmentCount: input.attachments.length,
       cloudDiagnosticsStatus: input.cloudDiagnosticsStatus,
     },

--- a/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.test.tsx
+++ b/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.test.tsx
@@ -2,6 +2,10 @@
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  SupportReportCompleteRequest,
+  SupportReportCreateRequest,
+} from "@proliferate/cloud-sdk/types";
 import { useSupportReportUploadQueue } from "@/hooks/support/lifecycle/use-support-report-upload-queue";
 import type { SupportReportJob } from "@/lib/domain/support/report-types";
 
@@ -321,6 +325,34 @@ describe("useSupportReportUploadQueue", () => {
       "Report already sent. Support has the details.",
       "info",
     );
+  });
+
+  it("skips diagnostics and completes directly when logs are excluded and there are no attachments", async () => {
+    renderHook(() => useSupportReportUploadQueue());
+
+    await waitFor(() => {
+      expect(activeListeners()).toHaveLength(1);
+    });
+
+    const job = makeSupportReportJob("job-no-logs", recentIso());
+    job.includeLogs = false;
+    activeListeners()[0]?.handler(job);
+
+    await waitFor(() => {
+      expect(cloudSupportMocks.completeSupportReportUpload).toHaveBeenCalledTimes(1);
+    });
+    // No diagnostics collected, no upload targets requested, complete carries no
+    // diagnostics object.
+    expect(uploadWorkflowMocks.buildSupportReportPackage).not.toHaveBeenCalled();
+    expect(cloudSupportMocks.createSupportReportUploadTargets).not.toHaveBeenCalled();
+    const completeArgs = cloudSupportMocks.completeSupportReportUpload.mock.calls[0] as
+      unknown as [string, SupportReportCompleteRequest];
+    expect(completeArgs[1].diagnostics ?? null).toBeNull();
+
+    // Create request declared diagnostics=false.
+    const createArgs = cloudSupportMocks.createSupportReport.mock.calls[0] as
+      unknown as [SupportReportCreateRequest];
+    expect(createArgs[0].expectedClientUploads?.diagnostics).toBe(false);
   });
 
   it("cleans up a queued job when create returns an already completed report", async () => {

--- a/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
+++ b/apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts
@@ -225,6 +225,11 @@ async function uploadSupportReport(
     };
   }
 
+  // "Include app logs" toggle (bug modal): when OFF, we neither collect nor
+  // upload diagnostics.json for this job. Defaults to ON for jobs persisted
+  // before the toggle existed.
+  const includeLogs = job.includeLogs !== false;
+
   const attachmentBlobs = await Promise.all(job.attachments.map(async (attachment) => ({
     attachment,
     blob: await loadAttachmentBlob(attachment),
@@ -233,27 +238,61 @@ async function uploadSupportReport(
     sha256Hex(await blob.arrayBuffer())
   ));
 
-  const reportPackage = await buildSupportReportPackage(job, dependencies, serverCorrelation);
-  const diagnosticsBlob = jsonBlob(reportPackage);
-  if (diagnosticsBlob.size > DIAGNOSTICS_MAX_BYTES) {
-    throw new Error("Diagnostics are too large to upload.");
+  // Only collect/build the diagnostics package when logs are included.
+  let diagnosticsUpload:
+    | { blob: Blob; sha256: string; generatedAt: string }
+    | null = null;
+  if (includeLogs) {
+    const reportPackage = await buildSupportReportPackage(job, dependencies, serverCorrelation);
+    const diagnosticsBlob = jsonBlob(reportPackage);
+    if (diagnosticsBlob.size > DIAGNOSTICS_MAX_BYTES) {
+      throw new Error("Diagnostics are too large to upload.");
+    }
+    diagnosticsUpload = {
+      blob: diagnosticsBlob,
+      sha256: await sha256Hex(await diagnosticsBlob.arrayBuffer()),
+      generatedAt: reportPackage.generatedAt,
+    };
   }
-  const diagnosticsSha256 = await sha256Hex(await diagnosticsBlob.arrayBuffer());
+
+  // Logs off + no attachments: nothing to upload. Complete directly — the
+  // server allows completion without an upload-target manifest when the
+  // expected upload intent is diagnostics=false and attachmentCount=0.
+  if (!diagnosticsUpload && attachmentBlobs.length === 0) {
+    const completeRequest = completeRequestForUpload({
+      job,
+      reportId: report.reportId,
+      diagnostics: undefined,
+      generatedAt: dependencies.now().toISOString(),
+      cloudDiagnosticsStatus: report.cloudDiagnosticsStatus,
+      attachments: [],
+    });
+    await completeSupportReportUpload(report.reportId, completeRequest);
+    trackSupportReportSubmitted(job, serverCorrelation, 0);
+    await deleteSupportReportJobAttachments(job);
+    return {
+      reportId: report.reportId,
+    };
+  }
 
   const uploadRequest: SupportReportUploadTargetsRequest = {
-    diagnostics: {
-      contentType: "application/json",
-      sizeBytes: diagnosticsBlob.size,
-      sha256: diagnosticsSha256,
-    },
+    diagnostics: diagnosticsUpload
+      ? {
+          contentType: "application/json",
+          sizeBytes: diagnosticsUpload.blob.size,
+          sha256: diagnosticsUpload.sha256,
+        }
+      : undefined,
     attachments: attachmentUploadFiles(attachmentBlobs, attachmentHashes),
   };
 
   const upload = await createSupportReportUploadTargets(report.reportId, uploadRequest);
-  if (!upload.diagnostics) {
-    throw new Error("Cloud did not return a diagnostics upload URL.");
+  if (diagnosticsUpload) {
+    if (!upload.diagnostics) {
+      throw new Error("Cloud did not return a diagnostics upload URL.");
+    }
+    await putPresignedObject(upload.diagnostics, diagnosticsUpload.blob);
   }
-  await putPresignedObject(upload.diagnostics, diagnosticsBlob);
 
   const completedAttachments: NonNullable<SupportReportCompleteRequest["attachments"]> = [];
   for (const [index, item] of attachmentBlobs.entries()) {
@@ -274,10 +313,14 @@ async function uploadSupportReport(
   const completeRequest = completeRequestForUpload({
     job,
     reportId: report.reportId,
-    diagnosticsObjectKey: upload.diagnostics.objectKey,
-    diagnosticsSha256,
-    diagnosticsBytes: diagnosticsBlob.size,
-    generatedAt: reportPackage.generatedAt,
+    diagnostics: diagnosticsUpload && upload.diagnostics
+      ? {
+          objectKey: upload.diagnostics.objectKey,
+          sha256: diagnosticsUpload.sha256,
+          sizeBytes: diagnosticsUpload.blob.size,
+        }
+      : undefined,
+    generatedAt: diagnosticsUpload?.generatedAt ?? dependencies.now().toISOString(),
     cloudDiagnosticsStatus: report.cloudDiagnosticsStatus,
     attachments: completedAttachments,
   });

--- a/apps/desktop/src/hooks/support/workflows/use-open-support-report-window.ts
+++ b/apps/desktop/src/hooks/support/workflows/use-open-support-report-window.ts
@@ -1,17 +1,47 @@
 import { useCallback } from "react";
 import { useSupportModalStore } from "@/stores/support/support-modal-store";
+import { useSupportAvailability } from "@/hooks/support/facade/use-support-availability";
+import { useToastStore } from "@/stores/toast/toast-store";
 import type { SupportMessageContext } from "@/lib/domain/support/types";
 
 interface UseOpenSupportReportWindowOptions {
   source: SupportMessageContext["source"];
 }
 
+/**
+ * Gated openers for the support modals. Opening is only allowed with a real
+ * Cloud session — otherwise we surface the reason instead of opening a modal
+ * whose report could never upload. Entry points should also disable their
+ * trigger via `useSupportAvailability().disabledReason`; this guard is the
+ * defensive floor for any path that can't (e.g. keyboard shortcuts).
+ */
 export function useOpenSupportReportWindow({
   source: _source,
 }: UseOpenSupportReportWindowOptions) {
   const openFeedback = useSupportModalStore((state) => state.openFeedback);
+  const openPrompt = useSupportModalStore((state) => state.openPrompt);
+  const { canSubmit, disabledReason } = useSupportAvailability();
+  const showToast = useToastStore((state) => state.show);
 
-  return useCallback(() => {
+  const openBug = useCallback(() => {
+    if (!canSubmit) {
+      if (disabledReason) {
+        showToast(disabledReason);
+      }
+      return;
+    }
     openFeedback();
-  }, [openFeedback]);
+  }, [canSubmit, disabledReason, openFeedback, showToast]);
+
+  const openFeature = useCallback(() => {
+    if (!canSubmit) {
+      if (disabledReason) {
+        showToast(disabledReason);
+      }
+      return;
+    }
+    openPrompt();
+  }, [canSubmit, disabledReason, openPrompt, showToast]);
+
+  return { openBug, openFeature, canSubmit, disabledReason };
 }

--- a/apps/desktop/src/lib/domain/support/report-types.ts
+++ b/apps/desktop/src/lib/domain/support/report-types.ts
@@ -67,6 +67,23 @@ export interface SupportReportJob {
   kind: "bug" | "feature";
   creditConsent: boolean;
   creditName?: string | null;
+  /**
+   * Capture-only intent flag: the submitter marked the report as time-sensitive.
+   * Optional so persisted jobs created before this field still load; defaults
+   * to `false` downstream.
+   */
+  urgent?: boolean;
+  /**
+   * Capture-only intent flag: the submitter asked to be contacted about the
+   * outcome. Optional for backwards-compatible persistence; defaults to `false`.
+   */
+  notifyMe?: boolean;
+  /**
+   * When `false`, diagnostics (app logs) are not collected or uploaded for this
+   * report. Optional for backwards-compatible persistence; defaults to `true`
+   * (logs included) so pre-existing queued jobs keep their original behavior.
+   */
+  includeLogs?: boolean;
   snapshot: SupportReportWindowSnapshot;
   attachments: SupportReportAttachmentPayload[];
   activeWorkspaceId?: string;

--- a/cloud/sdk-react/src/hooks/support.ts
+++ b/cloud/sdk-react/src/hooks/support.ts
@@ -43,6 +43,10 @@ export function useCloudSupportReportActions(): CloudSupportReportActions {
             attachmentCount: 0,
           },
           publicContentConsent: input.publicContentConsent,
+          kind: "bug",
+          creditConsent: false,
+          urgent: false,
+          notifyMe: false,
         },
         client,
       );

--- a/cloud/sdk/src/client/users.ts
+++ b/cloud/sdk/src/client/users.ts
@@ -1,0 +1,24 @@
+import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
+import type { ProfileUpdateRequest, UserRead } from "../types/index.js";
+
+export type { ProfileUpdateRequest, UserRead };
+
+/** Fetch the authenticated user's own profile (`GET /users/me`). */
+export async function getCurrentUser(
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<UserRead> {
+  return (await client.GET("/users/me")).data!;
+}
+
+/**
+ * Update editable fields on the authenticated user's own profile
+ * (`PATCH /users/me`). Sending `outreach_email: null` or an empty/whitespace
+ * string clears the override; a non-empty value must validate as an email
+ * (the server returns 422 otherwise).
+ */
+export async function updateCurrentUser(
+  input: ProfileUpdateRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<UserRead> {
+  return (await client.PATCH("/users/me", { body: input })).data!;
+}

--- a/cloud/sdk/src/index.ts
+++ b/cloud/sdk/src/index.ts
@@ -18,6 +18,7 @@ export * from "./client/organizations.js";
 export * from "./client/repositories.js";
 export * from "./client/repos.js";
 export * from "./client/support.js";
+export * from "./client/users.js";
 export * from "./client/timing.js";
 export * from "./client/workspaces.js";
 export * from "./client/worktree-policy.js";

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -615,6 +615,8 @@ export type GenerateSessionTitleRequest = Schema<"GenerateSessionTitleRequest">;
 export type GenerateSessionTitleResponse = Schema<"GenerateSessionTitleResponse">;
 export type GenerateWorkspaceNameRequest = Schema<"GenerateWorkspaceNameRequest">;
 export type GenerateWorkspaceNameResponse = Schema<"GenerateWorkspaceNameResponse">;
+export type UserRead              = Schema<"UserRead">;
+export type ProfileUpdateRequest  = Schema<"ProfileUpdateRequest">;
 export type SupportMessageContext     = Schema<"SupportMessageContext">;
 export type SendSupportMessageRequest = Schema<"SupportMessageRequest">;
 export type SupportReportCompleteRequest =
@@ -651,11 +653,11 @@ export interface SupportReportUploadResponse {
   attachments?: SupportReportUploadTarget[];
 }
 export interface SupportReportUploadTargetsRequest {
-  diagnostics: {
+  diagnostics?: {
     contentType: string;
     sizeBytes: number;
     sha256: string;
-  };
+  } | null;
   attachments?: Array<{
     clientFileId: string;
     fileName: string;

--- a/server/proliferate/server/support/notifications.py
+++ b/server/proliferate/server/support/notifications.py
@@ -82,6 +82,16 @@ async def notify_support_report(
 ) -> None:
     webhook_url = settings.support_slack_webhook_url.strip()
     if not webhook_url:
+        # Fail loudly: a completed report that no one gets pinged about is a
+        # silent hole in the support loop. This is a misconfiguration, not a
+        # normal state — surface it (ERROR → Sentry via LoggingIntegration)
+        # rather than returning quietly.
+        logger.error(
+            "Support report %s completed but SUPPORT_SLACK_WEBHOOK_URL is unset — "
+            "no Slack notification sent. Set the webhook secret in this environment.",
+            report_id,
+            extra={"support_report_id": report_id, "urgent": urgent},
+        )
         return
 
     plan = build_support_report_plan(
@@ -114,7 +124,18 @@ async def notify_support_report(
             blocks=blocks,
         )
     except SlackWebhookError as exc:
-        logger.warning("Support report Slack notification failed: %s", exc)
+        # Fail loudly to US, not to the reporter: their report is already
+        # persisted + uploaded and this runs before the request's commit, so
+        # re-raising would roll back a successful submission and 500 the user.
+        # Log at ERROR with exc_info so it reaches Sentry (LoggingIntegration)
+        # — never downgrade to warning — but let the request succeed.
+        logger.error(
+            "Support report %s Slack notification failed to deliver: %s",
+            report_id,
+            exc,
+            exc_info=True,
+            extra={"support_report_id": report_id, "urgent": urgent},
+        )
 
 
 def _support_report_internal_url(report_id: str) -> str | None:

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -177,9 +177,9 @@ async def create_support_report(
             public_content_consent=False,
             kind=body.kind,
             credit_consent=body.credit_consent,
-            credit_name=(
-                body.credit_name if body.kind == "feature" and body.credit_consent else None
-            ),
+            # Credit consent is available on both the bug and prompt modals
+            # (previously prompt-only); gate on consent alone.
+            credit_name=(body.credit_name if body.credit_consent else None),
             urgent=body.urgent,
             notify_me=body.notify_me,
             request_id=get_request_id(),

--- a/specs/codebase/features/support-reporting.md
+++ b/specs/codebase/features/support-reporting.md
@@ -51,6 +51,50 @@ Development builds may keep the old manual debug exports available behind the
 legacy support dialog. Production UI must not expose raw export names such as
 active session JSON, workspace JSON, debug bundle, or investigation JSON.
 
+### In-app feedback and prompt modals
+
+Desktop also exposes two lightweight in-app modals that submit through the same
+report lifecycle: a bug modal ("Send feedback") and a prompt modal ("Submit a
+prompt"). Both share one modal-state hook, build the same `SupportReportJob`,
+and reuse the upload queue.
+
+The bug modal, below the message textarea and attachment zone, shows in order:
+
+- `This is urgent` — sets the report's `urgent` capture flag. When checked it
+  reveals the helper line "We'll send you an email by tomorrow."
+- `Let me know when you fix this` — sets `notifyMe`. When checked it reveals
+  "We'll send you an update within a day."
+- `Credit me` — reveals a name input; when consented the name is sent as
+  `creditName` (same interaction as the prompt modal's credit field).
+- `Include app logs` — defaults ON. When turned OFF, the report's
+  `expectedClientUploads.diagnostics` is `false` and the upload pipeline skips
+  collecting and uploading `diagnostics.json` for that job. If logs are off and
+  there are no attachments, the client completes the report directly with no
+  upload-target manifest (the diagnostics=false / attachmentCount=0 path).
+
+The prompt modal keeps its `Credit me if this merges` field and adds
+`Let me know when you merge this`, which sets `notifyMe`. Prompt submissions
+never set `urgent` and always include diagnostics (there is no logs toggle on
+that surface).
+
+Both modals render a muted footer above the action buttons reading
+"Updates go to {email} · change", where `{email}` is the user's
+`outreach_email` override when set, otherwise their account email (from
+`GET /v1/users/me`). "change" swaps to an inline email editor whose save
+PATCHes `/v1/users/me` `outreach_email` (account-wide, not per-report); an empty
+value clears the override and an invalid address surfaces the server's 422 as an
+inline error.
+
+`urgent`, `notifyMe`, and the logs choice flow from the modal state through the
+`SupportReportJob` into `buildCreateReportRequest`. They are optional on the
+persisted job with defaults (`urgent`/`notifyMe` false, logs included) so jobs
+queued before this change still upload unchanged.
+
+Server-side, `credit_name` is persisted whenever `credit_consent` is true,
+regardless of report `kind` — the bug modal's `Credit me` field needed the
+same persistence the prompt modal already had (previously gated to
+`kind == "feature"` only).
+
 ## Diagnostics
 
 Desktop diagnostics are collected outside the support webview so closing the

--- a/specs/tbd/support-capture-v1.md
+++ b/specs/tbd/support-capture-v1.md
@@ -1,0 +1,415 @@
+# Support capture v1 — implementation record & architecture
+
+*2026-07-06. The complete record of the support-flow upgrade built across PRs
+#972 (server capture fields), #976 (desktop modals), and the parked
+`support-ops` prototype. Written after the 2026-07-06 split decision: capture
+(this doc's subject) is permanent and merging; resolution/triage/notify is
+superseded by `specs/tbd/issue-autofix-system-v1.md` (the issues service).
+Read that spec for everything after a report is captured.*
+
+---
+
+## 0. One paragraph
+
+Users submit bug reports and feature prompts from two desktop modals. Reports
+carry four new signals — `urgent`, `notify_me`, `credit_consent`/`credit_name`
+(now on bugs too), and an account-wide `outreach_email` override — plus an
+"Include app logs" toggle that, for the first time, lets a reporter exclude
+diagnostics. Everything lands in the `support_report` Postgres row AND in
+`request.json` in S3, which is the read boundary for the downstream issues
+service. Slack gets a 🚨-titled message for urgent reports. The product layer
+stops there by design: it captures and never resolves, triages, or emails
+reporters.
+
+## 1. Architecture and the deliberate boundary
+
+```
+Desktop app (Tauri)                     Product server                      S3 bucket
+───────────────────                     ──────────────                      ─────────
+SendFeedbackModal ─┐                                                   proliferate-support-
+SubmitPromptModal ─┤ SupportReportJob                                  reports-{dev,prod}
+                   ▼                                                   support/reports/
+persisted upload queue ──POST──▶ /v1/support/reports ────────────────▶  {date}/{id}/
+(retry/backoff, survives          (creates support_report row)            request.json  ◀── carries urgent/
+ app restarts)         ──POST──▶ .../upload-targets                       diagnostics.json    notifyMe/credit
+                                  (presigned S3 PUTs) ──client PUT──▶     attachment-*
+                       ──POST──▶ .../complete                             complete.json
+                                    │
+                                    ▼
+                              Slack webhook (🚨 title if urgent)
+
+────────────────────────────── CAPTURE / RESOLUTION BOUNDARY ──────────────────────────────
+
+Everything below is the issues service (specs/tbd/issue-autofix-system-v1.md):
+ingestion via a pollable /v1/support/reports endpoint (scoped, not built),
+triage/fix workflows, state machine, and ALL reporter-facing email (Customer.io
+transactional, approval-gated).
+```
+
+Why the boundary is where it is (decided at align, reaffirmed by the split):
+mixing notification into the product is how transactional email systems
+bifurcate — the old CIO welcome path died from exactly that. The product's
+support tables are **capture-only**: no resolution columns exist or will be
+added here. The `support-ops` repo prototyped the other side of the boundary
+and validated the separations (service-owns-truth, duplicate grouping, gated
+email) before the issues service was spec'd; it is now parked.
+
+## 2. PR map and merge order
+
+| PR | Branch | Base | Status |
+|---|---|---|---|
+| proliferate#972 | `support/capture-fields` | `main` | draft — **merge first** |
+| proliferate#976 | `support/modal-fields` | `support/capture-fields` | draft, stacked — merge second |
+| support-ops#1 | `init/core` | `main` (separate repo) | **parked, do not merge** (superseded) |
+
+\#976 is stacked: its GitHub diff shows only desktop work on top of #972. The
+regenerated SDK in #972 (`cloud/sdk/src/generated/openapi.ts`) is the contract
+\#976 compiles against.
+
+---
+
+## 3. PR #972 — server capture fields
+
+### 3.1 File tree
+
+```
+server/
+├─ alembic/versions/
+│  └─ c7f2a9b41d38_support_urgent_notify_and_user_outreach_email.py   [NEW]
+├─ proliferate/
+│  ├─ config.py                          [+support_report_internal_base_url]
+│  ├─ auth/
+│  │  ├─ models.py                       [UserRead +outreach_email]
+│  │  └─ profile_api.py                  [+PATCH /v1/users/me]
+│  ├─ db/
+│  │  ├─ models/auth.py                  [User.outreach_email]
+│  │  ├─ models/support.py               [SupportReport.urgent, .notify_me]
+│  │  └─ store/support_reports.py        [persist both columns]
+│  └─ server/support/
+│     ├─ models.py                       [SupportReportCreateRequest +urgent/notifyMe]
+│     ├─ service.py                      [thread fields through create flow]
+│     ├─ notifications.py                [urgent/notify_me → Slack plan]
+│     └─ domain/
+│        ├─ message.py                   [urgent title + 2 new Slack fields]
+│        └─ report_records.py            [urgent/notifyMe → request.json]
+├─ tests/unit/
+│  ├─ test_support_message_domain.py     [urgent-title assertions]
+│  └─ test_support_report_records.py     [NEW]
+cloud/sdk/src/generated/openapi.ts        [regenerated]
+specs/codebase/features/support-reporting.md
+```
+
+### 3.2 Migration `c7f2a9b41d38` (chains off `ff9344886948`)
+
+```python
+def upgrade() -> None:
+    if _has_table("support_report"):
+        if not _has_column("support_report", "urgent"):
+            op.add_column("support_report", sa.Column(
+                "urgent", sa.Boolean(), nullable=False, server_default=sa.false()))
+        if not _has_column("support_report", "notify_me"):
+            op.add_column("support_report", sa.Column(
+                "notify_me", sa.Boolean(), nullable=False, server_default=sa.false()))
+    if _has_table("user") and not _has_column("user", "outreach_email"):
+        op.add_column("user", sa.Column(
+            "outreach_email", sa.String(length=320), nullable=True))
+```
+
+Idempotent via `_has_table`/`_has_column` guards — the dev profile
+(`support-capture`, DB `proliferate_dev_support_capture`) was rebuilt more
+than once during verification and this survived it. Single alembic head
+preserved by chaining off #932's `kind`/`credit_consent` migration.
+
+### 3.3 Wire contract
+
+`server/proliferate/server/support/models.py` — same alias convention as the
+existing credit pair, so clients learn nothing new:
+
+```python
+kind: Literal["bug", "feature"] = Field(default="bug")
+credit_consent: bool = Field(default=False, alias="creditConsent")
+credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
+urgent: bool = Field(default=False, alias="urgent")
+notify_me: bool = Field(default=False, alias="notifyMe")
+```
+
+Both fields flow to **two** sinks via `service.py`: the `support_report` row
+(`db/store/support_reports.py`) and, via `domain/report_records.py`, the
+`request.json` object in S3. The S3 copy is what makes downstream consumers
+(issues service) independent of product-DB reads for report content.
+
+### 3.4 `PATCH /v1/users/me` — outreach_email
+
+`server/proliferate/auth/profile_api.py` went from read-only to read/write:
+
+```python
+class ProfileUpdateRequest(BaseModel):
+    outreach_email: str | None = None
+
+    @field_validator("outreach_email")
+    @classmethod
+    def _validate_outreach_email(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        return str(_email_adapter.validate_python(cleaned))  # ValidationError → 422
+
+@router.patch("/me", response_model=UserRead, ...)
+async def update_current_user_profile(body, user, db) -> UserRead:
+    if "outreach_email" in body.model_fields_set:
+        user.outreach_email = body.outreach_email
+    ...
+```
+
+Semantics worth remembering:
+- key absent from PATCH body → value untouched (`model_fields_set` check)
+- `null` or `""`/whitespace → cleared (falls back to account email)
+- anything else must validate as an email → else 422
+
+All support outreach should address `outreach_email ?? email`. **Caveat for
+the issues service:** the autofix spec sends via Customer.io keyed on the
+user profile — it must resolve this override or the setting is dead weight
+(flagged to Pablo 2026-07-06; unresolved).
+
+### 3.5 Slack urgency
+
+`domain/message.py` — `SupportMessagePlan` gained a `title`:
+
+```python
+title = "*:rotating_light: URGENT support report*" if urgent else "*New support report*"
+fields += [
+    SupportMessageField("Urgent", "Yes" if urgent else "No"),
+    SupportMessageField("Notify requested", "Yes" if notify_me else "No"),
+]
+```
+
+Verified by unit test only — local dev has no `SUPPORT_SLACK_WEBHOOK_URL`.
+Eyeball the real channel after the first urgent prod report.
+
+### 3.6 Rode-along config fix
+
+`notifications.py` referenced `settings.support_report_internal_base_url`
+(the "view in admin" Slack link) but `config.py` never declared it, even
+though `SUPPORT_REPORT_INTERNAL_BASE_URL` sits in `server/.env`. Fixed:
+
+```python
+support_report_internal_base_url: str = ""
+```
+
+### 3.7 Verification (all real, not mocked)
+
+- `uv run pytest -q tests/unit` → 504 passed.
+- Migration applied to fresh Postgres; `information_schema` confirms types.
+- Real server boot on profile `support-capture` → `/setup` claim → bearer →
+  `POST /v1/support/reports {"urgent":true,"notifyMe":true}` →
+  DB row `urgent=t, notify_me=t` AND
+  `s3://proliferate-support-reports-dev/.../request.json` contains both.
+- outreach_email: set → GET reflects; `not-an-email` → 422; `""`/`null` → cleared.
+
+---
+
+## 4. PR #976 — desktop modals
+
+### 4.1 File tree
+
+```
+apps/desktop/src/
+├─ components/support/
+│  ├─ SendFeedbackModal.tsx          [urgent/notify/credit/logs checks + footer]
+│  ├─ SubmitPromptModal.tsx          [+notify-me check + footer]
+│  ├─ SupportCheckboxRow.tsx         [NEW shared row]
+│  ├─ SupportCreditField.tsx         [NEW shared credit check + name input]
+│  └─ SupportModalFooter.tsx         [NEW "Updates go to {email} · change"]
+├─ hooks/support/
+│  ├─ facade/
+│  │  ├─ use-support-modal-state.ts        [+urgent/notifyMe/includeLogs state]
+│  │  └─ use-support-outreach-email.ts     [NEW GET/PATCH edit-state hook]
+│  └─ lifecycle/
+│     ├─ support-report-upload-payload.ts  [diagnostics now conditional]
+│     └─ use-support-report-upload-queue.ts [skip diagnostics when logs off]
+├─ lib/domain/support/report-types.ts [SupportReportJob +3 fields]
+cloud/sdk/src/client/users.ts         [NEW getCurrentUser/updateCurrentUser]
+cloud/sdk-react/src/hooks/support.ts  [fields threaded, web UI unchanged]
+server/proliferate/server/support/service.py  [credit_name bugfix — §4.5]
+specs/codebase/features/support-reporting.md
+```
+
+### 4.2 The modals (copy is Pablo's, verbatim from the workspace doc)
+
+```tsx
+// SendFeedbackModal.tsx (bug)
+<SupportCheckboxRow checked={urgent} onCheckedChange={setUrgent}
+  label="This is urgent" helper="We'll send you an email by tomorrow." />
+<SupportCheckboxRow checked={notifyMe} onCheckedChange={setNotifyMe}
+  label="Let me know when you fix this" helper="We'll send you an update within a day." />
+<SupportCreditField label="Credit me" ... />
+<SupportCheckboxRow checked={includeLogs} onCheckedChange={setIncludeLogs}
+  label="Include app logs" />   {/* default ON */}
+```
+
+Prompt modal: `"Credit me if this merges"` (pre-existing) +
+`"Let me know when you merge this"` (notifyMe; urgent is bug-only —
+`urgent: kind === "bug" ? urgent : false`). The static
+"We'll get back to you on this by tomorrow." line was removed — superseded by
+the conditional helpers.
+
+The shared rows are deliberately low-profile — plain `text-ui-sm` labels,
+`space-y-0.5` group spacing, no borders — reworked mid-build from #932's
+bordered-box idiom because 4 stacked boxes read as heavy (Pablo's call):
+
+```tsx
+// SupportCheckboxRow.tsx
+<Label className="mb-0 flex cursor-pointer items-center gap-2.5 py-1 text-ui-sm text-foreground">
+  <Checkbox checked={checked} onCheckedChange={(next) => onCheckedChange(next === true)} />
+  <span className="text-ui-sm">{label}</span>
+</Label>
+{helper && checked ? (
+  <p className="mt-0.5 pl-6 text-ui-sm text-muted-foreground">{helper}</p>
+) : null}
+```
+
+### 4.3 Logs toggle — pipeline surgery, not just a checkbox
+
+Diagnostics upload used to be unconditional. Now:
+
+```ts
+// support-report-upload-payload.ts
+expectedClientUploads: {
+  diagnostics: job.includeLogs !== false,   // was hardcoded true
+  attachmentCount,
+},
+```
+
+`completeRequestForUpload` accepts `diagnostics?: {...}` and emits
+`diagnostics: null` + `packageManifest.diagnosticsIncluded: false` when
+absent. The queue (`use-support-report-upload-queue.ts`) skips collection
+entirely when logs are off; with no attachments either it completes directly
+without ever requesting upload targets. Old persisted queue jobs (pre-field)
+still upload — every new field is optional with a safe default. Covered by a
+dedicated test:
+
+```ts
+it("skips diagnostics and completes directly when logs are excluded and there are no attachments", ...)
+// asserts: buildSupportReportPackage never called, no upload-targets call,
+// complete.diagnostics === null, create.expectedClientUploads.diagnostics === false
+```
+
+### 4.4 Outreach-email footer
+
+`use-support-outreach-email.ts` wraps GET/PATCH `/v1/users/me` (via the new
+`cloud/sdk/src/client/users.ts`) into begin/save/cancel edit state;
+`SupportModalFooter.tsx` renders:
+
+```tsx
+<p className="text-ui-sm text-muted-foreground">
+  Updates go to {outreach.effectiveEmail ?? "your account email"}
+  {" · "}
+  <Button variant="unstyled" onClick={outreach.beginEdit}>change</Button>
+</p>
+```
+
+`effectiveEmail = outreach_email ?? email`, computed client-side. Save is
+account-wide (a PATCH), not per-report. Server 422 surfaces inline.
+
+### 4.5 The bug this lane caught
+
+`server/proliferate/server/support/service.py` gated credit-name persistence
+on `kind == "feature"` — a #932 leftover. With credit-me now on the bug
+modal, every bug report's name would have been silently dropped:
+
+```diff
+-  credit_name=(body.credit_name if body.kind == "feature" and body.credit_consent else None),
++  credit_name=(body.credit_name if body.credit_consent else None),
+```
+
+### 4.6 Verification
+
+- `pnpm vitest run src/components/support src/hooks/support` → 20/20.
+- `tsc --noEmit` clean; touched server tests 9/9.
+- Behavioral, on real infra (profile `support-modals`, real bucket): the
+  all-checked submit → DB `urgent=t, notify_me=t, credit_consent=t,
+  credit_name='Ada Lovelace'` + `request.json` carries urgent/notifyMe;
+  logs-off submit → no `diagnostics.json` object exists; outreach round-trip
+  + 422 both exercised. **Deviation:** the Tauri UI itself was never
+  visually driven (headless build sandbox) — the identical code path was
+  exercised via the built cloud-sdk dist. Worth 10 min in pdev before merge.
+
+---
+
+## 5. support-ops — parked prototype (do not build on)
+
+Repo: `github.com/proliferate-ai/support-ops` (private), local `~/support-ops`,
+PR #1 open and permanently unmerged. Superseded 2026-07-06 by the issues
+service (`specs/tbd/issue-autofix-system-v1.md` §9/§10): S3-polling → pollable
+server endpoint; sqlite resolution state → issues-service Postgres; Resend
+sender → Customer.io transactional behind an approval queue. Rationale: two
+parallel "we fixed it" email systems is the failure mode that killed the old
+transactional welcome path.
+
+What it proved on real data (5 dev reports) before parking, and what's worth
+lifting when building the issues service:
+
+- **Defensive `request.json` parsing** (`src/support_ops/parse.py`) — real
+  reports are schemaVersion 2 without the new fields; every field optional
+  with defaults. The issues service's `sync_support` needs the same posture.
+- **Duplicate-group fan-out** (`canonical_report_id` self-FK; resolve on the
+  canonical, duplicates inherit `resolution_message`/`resolved_at`; notify
+  fans out over the group, filtering `notify_me=true AND notified_at IS NULL`).
+  Direct ancestor of the spec's `root_issue_id` + reporter-append model.
+- **Dry-run-first sends** (render to `./outbox/`, `--execute` to fire,
+  idempotent via `notified_at`) — the manual precursor of the spec's
+  `drafted → approved → sent` queue.
+- **Graceful schema probing** — `product_db.py` checks `information_schema`
+  for `outreach_email` and falls back to `email`, so it works on DBs from
+  before #972.
+
+## 6. Data reference
+
+`support_report` row (capture-relevant columns after #972):
+
+| column | type | source |
+|---|---|---|
+| `kind` | bug \| feature | #932 |
+| `credit_consent` / `credit_name` | bool / varchar(200) | #932 (bugfix in #976) |
+| `urgent` | bool NOT NULL default false | #972 |
+| `notify_me` | bool NOT NULL default false | #972 |
+| `owner_user_id` | FK user | #932 — the issues service's reporter identity |
+| `telemetry_refs_json` | TEXT (JSON: posthogDistinctId, posthogSessionId, sentryEventIds[≤20]) | #932 — ticket↔Sentry dedup evidence |
+| `status` / `completed_at` | lifecycle | #932 — poll-endpoint cursor material |
+
+`user.outreach_email` — varchar(320) NULL, #972. Resolution rule everywhere:
+`outreach_email ?? email`.
+
+S3 layout per report: `support/reports/{date}/{id}/{request.json,
+diagnostics.json?, attachment-*, complete.json}` — `complete.json` last;
+its presence = fully uploaded.
+
+## 7. What remains (as of 2026-07-06)
+
+**Work:**
+1. Merge #972 → then #976 (stacked). Optionally 10 min of eyes-on pdev for
+   the modal spacing first (never visually driven).
+2. Pollable `/v1/support/reports` endpoint — scoped in the Support Workspace
+   doc (keyset cursor over `(completed_at, id)` + new index, items only for
+   completed reports, structured telemetry_refs, static bearer token, S3
+   pointers not content). **Awaiting Pablo's scoping approval.** ~1 lane.
+3. Post-merge: watch one real urgent report hit Slack (webhook leg unverified
+   locally).
+
+**Human decisions (Pablo):**
+1. **Modal copy vs pipeline reality** — "email by tomorrow" (urgent) and
+   "update within a day" (notify) ship in #976, but the issues service emails
+   at *ship time* (hours-to-days) and nothing automates an urgent same-day
+   email. Soften copy pre-merge, or own it as a manual commitment.
+2. **outreach_email must survive the CIO path** — the autofix spec sends via
+   Customer.io keyed on profile email and never mentions the override. Needs
+   a line in that spec (resolve `outreach_email ?? email` when drafting, or
+   sync the override into the CIO profile), else the footer setting is inert.
+3. Poll-endpoint scoping questions: (a) first-poll backfill: all history or
+   from-now (recommend: full backfill — the service dedups); (b) emit
+   resolved reporter email in `data`, or `owner_user_id` only per spec §4.1
+   (recommend: emit resolved email, kills two birds with decision 2);
+   (c) auth token: new `SUPPORT_POLL_API_TOKEN` setting vs waiting for a
+   shared service-auth mechanism (recommend: new setting, trivial to swap).


### PR DESCRIPTION
## Summary

- Bug modal (SendFeedbackModal) gains, below the attachment zone: "This is urgent" (helper: "We'll send you an email by tomorrow."), "Let me know when you fix this" (helper: "We'll send you an update within a day."), "Credit me" (+ name input, same interaction as the prompt modal), and "Include app logs" (default ON — when OFF, `expectedClientUploads.diagnostics=false` and the upload pipeline skips collecting/uploading `diagnostics.json`). Removes the now-superseded static "We'll get back to you on this by tomorrow." line.
- Prompt modal (SubmitPromptModal) gains "Let me know when you merge this" (wire: `notifyMe`); `urgent` stays false for prompts.
- Both modals get a muted footer above the action buttons: "Updates go to {email} · change", where `{email}` is `outreach_email ?? account email` from `GET /v1/users/me`. "change" swaps to an inline email input; saving PATCHes `/v1/users/me` `outreach_email` (account-wide, not per-report). Invalid email surfaces the server's 422 inline.
- `urgent`/`notifyMe`/`includeLogs` flow from modal state → `SupportReportJob` → `buildCreateReportRequest` → wire, all optional with backwards-compatible defaults so jobs persisted before this change still upload.
- New `@proliferate/cloud-sdk` `client/users.ts` (`getCurrentUser`/`updateCurrentUser`) plus `ProfileUpdateRequest`/`UserRead` SDK types, and a diagnostics-optional fix to `SupportReportUploadTargetsRequest`.
- Server fix: `credit_name` is now persisted whenever `credit_consent` is true, not just for `kind == "feature"` — the bug modal's new "Credit me" field needed the same persistence the prompt modal already had.
- Spec: `specs/codebase/features/support-reporting.md` documents the modal behavior and the credit-name fix.

Stacked on `support/capture-fields` (Lane A: server fields + regenerated SDK for `urgent`/`notifyMe`/`outreach_email`).

## Test plan

- [x] `pnpm vitest run src/components/support src/hooks/support` — 20/20 pass (unit tests for the modal-state hook, upload payload builder, and upload queue, including new `includeLogs=false` and urgent/notify/credit cases)
- [x] `pnpm exec tsc --noEmit` (apps/desktop) — clean
- [x] `cd server && uv run pytest -q tests/unit/test_support_message_domain.py tests/unit/test_support_report_records.py tests/unit/test_support_redaction.py` — 9/9 pass
- [x] Behavioral verification against a live `support-modals` dev profile (server + real S3 bucket `proliferate-support-reports-dev`, real JWT session — driving the Tauri desktop UI directly isn't feasible in this headless sandbox, so I drove the same code path the upload queue calls: `createSupportReport` → `createSupportReportUploadTargets` → S3 PUT → `completeSupportReportUpload`, and `getCurrentUser`/`updateCurrentUser`):
  - Bug report with urgent/notify/credit+name/logs all on → DB row `urgent=t, notify_me=t, credit_consent=t, credit_name='Ada Lovelace'`; S3 `request.json` carries `urgent: true, notifyMe: true`; `diagnostics.json` present.
  - Bug report with logs off, no attachments → DB row all false/empty; S3 `request.json` has `expectedClientUploads.diagnostics: false`; no `diagnostics.json` object written; report completes via the diagnostics=false/attachmentCount=0 path.
  - Outreach email: `GET /v1/users/me` reflected the account email initially, `PATCH` set an override and `GET` reflected it, an invalid address returned 422, and clearing (`null`) fell back to the account email.

## Deviations

- Found and fixed a pre-existing server gap (not introduced by this PR, but blocking its behavior): `credit_name` was only persisted when `kind == "feature"`, silently dropping the name for bug reports. Fixed in `server/proliferate/server/support/service.py` to gate on `credit_consent` alone.
- Verification used a headless harness calling the same cloud-sdk client functions the upload queue calls, against the live dev stack, rather than clicking through the Tauri desktop UI — no display is available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)