### PR TITLE
fix(specs): remove stray character breaking the contract.md H1

### DIFF
--- a/specs/codebase/structures/anyharness/contract.md
+++ b/specs/codebase/structures/anyharness/contract.md
@@ -1,4 +1,4 @@
-s# Contract Crate
+# Contract Crate
 
 `anyharness-contract` is the transport schema crate for AnyHarness.
 


### PR DESCRIPTION
## Summary

- Remove a stray leading `s` in `specs/codebase/structures/anyharness/contract.md` line 1 (`s# Contract Crate`) that breaks the H1 rendering of the spec.

## PR Metadata

- Title format: `fix(specs): remove stray character breaking the contract.md H1`
- Intended labels (maintainer-applied; fork PRs cannot set labels): `release:docs`, `area:docs`

## Verification

- Rendered the markdown; the page now has a proper `# Contract Crate` heading. One-character docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Draft until a maintainer applies the release/area labels (fork PRs cannot set labels).
