### PR TITLE
fix(alembic): merge divergent support-capture + dashboards migration heads

### DIFF
--- a/server/alembic/versions/bcc0459a6f11_merge_support_capture_dashboards_heads.py
+++ b/server/alembic/versions/bcc0459a6f11_merge_support_capture_dashboards_heads.py
@@ -1,0 +1,28 @@
+"""merge support capture + dashboards heads
+
+Revision ID: bcc0459a6f11
+Revises: c7f2a9b41d38, 15649bf2cf24
+Create Date: 2026-07-06 14:59:44.975527
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bcc0459a6f11'
+down_revision: Union[str, Sequence[str], None] = ('c7f2a9b41d38', '15649bf2cf24')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## What

`main` currently has **two alembic heads**, so `alembic upgrade head` fails with *"Multiple head revisions are present"* — migrations don't run cleanly on a fresh DB.

- #972 added `c7f2a9b41d38` (support urgent/notify_me + outreach_email)
- #973 added `15649bf2cf24` (dashboards provider ingestion)

Both declared `down_revision = ff9344886948` and merged without either rebasing onto the other, forking the migration graph.

## Fix

A standard no-op alembic merge revision `bcc0459a6f11` whose `down_revision = (c7f2a9b41d38, 15649bf2cf24)`, rejoining the graph to a single head. No schema change.

## Verification

`uv run alembic upgrade head` runs clean end-to-end; `alembic heads` reports a single head (`bcc0459a6f11`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)