### PR TITLE
fix(server): sync analytics ingest task def with deployed reality

### DIFF
--- a/server/infra/analytics/README.md
+++ b/server/infra/analytics/README.md
@@ -57,9 +57,14 @@ e.g. local dev).
   read (`ce:GetCostAndUsage`, `ce:GetCostForecast`) + Secrets Manager read
   scoped to the three secret prefixes below (see
   `iam-task-role-policy.json`).
-- **Command**: `python /app/scripts/analytics_ingest.py` (the image pins
-  `proliferate-server:latest`; re-provisioning always picks up the current
-  image with the script present).
+- **Command**: `python /app/scripts/analytics_ingest.py`. The task def pins
+  `proliferate-server:Production-latest` — the stable tag the server deploy
+  moves to the current prod image (there is no `:latest` tag in this repo's
+  ECR; images are tagged by commit short-SHA + the `Production-latest` /
+  `staging-latest` moving tags). The live schedule instead pins the exact
+  deployed SHA (re-registered on each deploy) so a mid-deploy tag move can't
+  swap the image out from under a scheduled run; this file uses the moving
+  tag so re-provisioning from scratch always lands on current prod.
 
 ### Secrets (AWS Secrets Manager)
 
@@ -67,7 +72,7 @@ e.g. local dev).
 | --- | --- | --- |
 | `proliferate/prod/analytics-ingest` | `E2B_SESSION_COOKIE`, `E2B_TEAM_SLUG` | analytics-specific; `E2B_TEAM_SLUG` is required (the job skips E2B if unset — no hardcoded default); cookie needs periodic manual refresh, see below. |
 | `proliferate/prod/database` | `DATABASE_URL` | shared with the app. |
-| `proliferate/prod/server-app` | `JWT_SECRET`, `STRIPE_SECRET_KEY` | shared with the app; `JWT_SECRET` is pulled in only because `proliferate.config.Settings` requires it to construct, not because the job uses it. |
+| `proliferate/prod/server-app` | `JWT_SECRET`, `CLOUD_SECRET_KEY`, `STRIPE_SECRET_KEY` | shared with the app; `JWT_SECRET` and `CLOUD_SECRET_KEY` are pulled in only because `proliferate.config.Settings` requires them to construct in production mode (`debug=False`), not because the job uses them. `STRIPE_SECRET_KEY` is used by the Stripe provider. |
 
 ## Schedule
 

--- a/server/infra/analytics/ecs-taskdef.json
+++ b/server/infra/analytics/ecs-taskdef.json
@@ -9,12 +9,13 @@
   "containerDefinitions": [
     {
       "name": "ingest",
-      "image": "157466816238.dkr.ecr.us-east-1.amazonaws.com/proliferate-server:latest",
+      "image": "157466816238.dkr.ecr.us-east-1.amazonaws.com/proliferate-server:Production-latest",
       "essential": true,
       "command": ["python", "/app/scripts/analytics_ingest.py"],
       "secrets": [
         {"name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/database-5plrjD:DATABASE_URL::"},
         {"name": "JWT_SECRET", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Qv4HKH:JWT_SECRET::"},
+        {"name": "CLOUD_SECRET_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Qv4HKH:CLOUD_SECRET_KEY::"},
         {"name": "STRIPE_SECRET_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Qv4HKH:STRIPE_SECRET_KEY::"},
         {"name": "E2B_SESSION_COOKIE", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/analytics-ingest-lTDQSk:E2B_SESSION_COOKIE::"},
         {"name": "E2B_TEAM_SLUG", "valueFrom": "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/analytics-ingest-lTDQSk:E2B_TEAM_SLUG::"}


### PR DESCRIPTION
Follow-up to #973. The first real post-merge run of the analytics ingest task revealed two gaps in the checked-in `ecs-taskdef.json`:

1. **Missing `CLOUD_SECRET_KEY`** — `proliferate.config.Settings` requires both `jwt_secret` and `cloud_secret_key` in production mode (`debug=False`). The job uses neither, but `Settings()` won't construct without them, so the task exited non-zero until added. (Both live in the existing `proliferate/prod/server-app` secret.)
2. **`:latest` → `Production-latest`** — there is no `:latest` tag in this repo's ECR; images are tagged by commit short-SHA plus the moving `Production-latest`/`staging-latest` tags. `:latest` would fail to pull on re-provision.

The **live EventBridge schedule** was already updated out-of-band to a task-def revision pinned to the exact deployed SHA (`9d83a48b8071`) with `CLOUD_SECRET_KEY`, and a one-off run of it against prod **exits 0** (Stripe + AWS populate; E2B/Sentry skip gracefully). This PR just brings the committed reference artifact in line so from-scratch re-provisioning works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)