### PR TITLE
fix(agent-gateway): schedule materialization after vkey rotation (P0)

### DIFF
--- a/server/proliferate/server/cloud/agent_gateway/topups.py
+++ b/server/proliferate/server/cloud/agent_gateway/topups.py
@@ -53,6 +53,7 @@ from proliferate.server.cloud.agent_gateway.enrollment import (
     enrollment_key_metadata,
     enrollment_subject_label,
 )
+from proliferate.server.cloud.materialization import service as materialization_service
 
 logger = logging.getLogger(__name__)
 
@@ -243,6 +244,10 @@ async def _remint_virtual_key(
         virtual_key=minted.key,
         sync_fingerprint=enrollment.sync_fingerprint,
     )
+    if enrollment.user_id is not None:
+        await materialization_service.schedule_materialize_agent_auth(
+            db, user_id=enrollment.user_id
+        )
     return minted.token_id or None
 
 

--- a/server/tests/integration/test_agent_gateway_topups.py
+++ b/server/tests/integration/test_agent_gateway_topups.py
@@ -28,6 +28,7 @@ from proliferate.server.cloud.agent_gateway.topups import (
     create_llm_topup_grant,
     run_llm_topups,
 )
+from proliferate.server.cloud.materialization import service as materialization_service
 from tests.integration.agent_gateway_topups_shared import (
     StubLiteLLM,
     StubStripe,
@@ -364,3 +365,55 @@ async def test_importer_leaves_overage_subjects_to_the_topup_worker(
     # key; the top-up worker refunds the ledger instead.
     assert enforced is False
     assert disabled == []
+
+
+@pytest.mark.asyncio
+async def test_remint_schedules_materialization(
+    db_session: AsyncSession,
+    stub_litellm: StubLiteLLM,
+    stub_stripe: StubStripe,
+    topup_settings: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a virtual key rotation during top-up reactivation, agent-auth
+    materialization is scheduled for the affected user."""
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "5")
+    user_id = await _create_user(db_session)
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    old_key_id = enrollment.virtual_key_id
+    assert old_key_id is not None
+    await _spend(
+        db_session,
+        billing_subject_id=enrollment.billing_subject_id,
+        cost_usd=6.0,
+    )
+    await store.set_enrollment_budget_status(
+        db_session,
+        enrollment_id=enrollment.id,
+        budget_status="exhausted",
+    )
+
+    scheduled_users: list[uuid.UUID] = []
+
+    async def record_schedule(db: AsyncSession, *, user_id: uuid.UUID) -> None:
+        scheduled_users.append(user_id)
+
+    monkeypatch.setattr(
+        materialization_service,
+        "schedule_materialize_agent_auth",
+        record_schedule,
+        raising=False,
+    )
+
+    # Unblock will fail, triggering the remint path.
+    stub_litellm.fail_unblock = True
+    await create_llm_topup_grant(
+        db_session,
+        billing_subject_id=enrollment.billing_subject_id,
+        amount_usd=Decimal("10"),
+        source_ref=f"llm_topup:in_remint_{uuid.uuid4().hex[:6]}",
+    )
+
+    # The key was rotated and materialization was scheduled.
+    assert stub_litellm.rotated == [old_key_id]
+    assert scheduled_users == [user_id]


### PR DESCRIPTION
## What

Top-up vkey rotation (`_remint_virtual_key` in `topups.py`) persisted the new virtual key but never scheduled agent-auth materialization — so **cloud sandboxes kept the old, disabled vkey in `state.json` until an unrelated selection edit**. A user who just paid to reactivate stayed broken on the cloud surface. (Local self-heals: `GET /state` renders fresh on every desktop sync — which is why the billing-stack verification passed.)

Found by the adversarial auth-chain validation pass (2026-07-06); design context in `specs/tbd/agent-auth-fixes-2026-07-06.md` (F1).

## Fix

After the enrollment persist, schedule materialization for the affected user — the exact pattern the new-enrollment path already uses (`enrollment.py:289-295`).

**Rotation-site audit** (the invariant: any mutation of `virtual_key_ciphertext` schedules materialization):
- `topups.py _remint_virtual_key` — **fixed here**
- `enrollment.py _sync_enrollment` — already correct
- `usage_import.py disable_virtual_key` — no trigger needed (disable doesn't change file content)
- `worker.py` / `free_credits.py` — no key mutations

## Tests

- New regression test `test_remint_schedules_materialization`
- 21/21 topup tests green (`cd server && uv run pytest -q tests/{integration,unit}/test_agent_gateway_topups.py`)

## Stack

Base of a 3-PR stack: this → heartbeat catalogVersion → worker catalog sync. Independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)