### PR TITLE
feat(worker): catalog fetch+push transport — pins converge without binary releases (convergence P2)

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/catalogs.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/catalogs.rs
@@ -13,3 +13,13 @@ pub struct ApplyAgentCatalogResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to_version: Option<String>,
 }
+
+/// The runtime's active agent catalog version and its provenance.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogVersionResponse {
+    /// The `catalogVersion` string from the active document.
+    pub catalog_version: String,
+    /// Where the active catalog came from: `"bundled"` or `"fetched"`.
+    pub source: String,
+}

--- a/anyharness/crates/anyharness-lib/src/api/http/catalogs.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/catalogs.rs
@@ -4,7 +4,7 @@
 //! `ETag` request header forwards the cloud response's ETag. Sync semantics
 //! live in `domains/agents/catalog/sync.rs`.
 
-use anyharness_contract::v1::ApplyAgentCatalogResponse;
+use anyharness_contract::v1::{AgentCatalogVersionResponse, ApplyAgentCatalogResponse};
 use axum::{
     body::Bytes,
     extract::State,
@@ -14,7 +14,7 @@ use axum::{
 
 use super::error::ApiError;
 use crate::app::AppState;
-use crate::domains::agents::catalog::sync::SyncOutcome;
+use crate::domains::agents::catalog::sync::{CatalogSource, SyncOutcome};
 
 #[utoipa::path(
     put,
@@ -63,5 +63,30 @@ fn apply_agent_catalog_response(outcome: SyncOutcome) -> ApplyAgentCatalogRespon
             from_version: None,
             to_version: None,
         },
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/catalogs/agents/version",
+    responses(
+        (status = 200, description = "Active agent catalog version and source", body = AgentCatalogVersionResponse),
+    ),
+    tag = "catalogs"
+)]
+pub async fn get_agent_catalog_version(
+    State(state): State<AppState>,
+) -> Json<AgentCatalogVersionResponse> {
+    let active = state.catalog_sync_service.active();
+    Json(AgentCatalogVersionResponse {
+        catalog_version: active.version,
+        source: catalog_source_label(active.source).to_owned(),
+    })
+}
+
+fn catalog_source_label(source: CatalogSource) -> &'static str {
+    match source {
+        CatalogSource::Bundled => "bundled",
+        CatalogSource::Fetched => "fetched",
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/router.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router.rs
@@ -67,6 +67,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/agent-auth/state", put(agent_auth::put_agent_auth_state))
         // Catalogs (worker-pushed agent catalog document)
         .route("/catalogs/agents", put(catalogs::apply_agent_catalog))
+        .route(
+            "/catalogs/agents/version",
+            get(catalogs::get_agent_catalog_version),
+        )
         // Workspaces
         .route(
             "/workspaces",

--- a/anyharness/crates/anyharness-lib/src/api/router_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router_tests.rs
@@ -1306,3 +1306,59 @@ async fn get_agent_catalog_version_returns_active_version_and_source() {
     assert_eq!(payload["catalogVersion"], json!(expected_version));
     assert_eq!(payload["source"], json!("bundled"));
 }
+
+#[tokio::test]
+async fn get_agent_catalog_version_requires_bearer_auth_when_configured() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(Some("secret-token"));
+    let state = test_state(false);
+    let app = build_router(state);
+
+    // Request without Authorization header should be rejected.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/catalogs/agents/version")
+                .body(Body::empty())
+                .expect("expected request"),
+        )
+        .await
+        .expect("expected response");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn get_agent_catalog_version_succeeds_with_valid_bearer_auth() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(Some("secret-token"));
+    let state = test_state(false);
+    let expected_version = state.catalog_sync_service.catalog_version();
+    let app = build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/catalogs/agents/version")
+                .header(header::AUTHORIZATION, "Bearer secret-token")
+                .body(Body::empty())
+                .expect("expected request"),
+        )
+        .await
+        .expect("expected response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let payload: Value = serde_json::from_slice(&body).expect("parse response json");
+    assert_eq!(payload["catalogVersion"], json!(expected_version));
+}

--- a/anyharness/crates/anyharness-lib/src/api/router_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router_tests.rs
@@ -1275,3 +1275,34 @@ async fn apply_agent_catalog_rejects_invalid_payload_without_state_change() {
     assert_eq!(payload["code"], "AGENT_CATALOG_REJECTED");
     assert_eq!(state.catalog_sync_service.catalog_version(), version_before);
 }
+
+#[tokio::test]
+async fn get_agent_catalog_version_returns_active_version_and_source() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state(false);
+    let expected_version = state.catalog_sync_service.catalog_version();
+    let app = build_router(state.clone());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/catalogs/agents/version")
+                .body(Body::empty())
+                .expect("expected request"),
+        )
+        .await
+        .expect("expected response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let payload: Value = serde_json::from_slice(&body).expect("parse response json");
+    assert_eq!(payload["catalogVersion"], json!(expected_version));
+    assert_eq!(payload["source"], json!("bundled"));
+}

--- a/anyharness/crates/proliferate-worker/src/catalog_sync.rs
+++ b/anyharness/crates/proliferate-worker/src/catalog_sync.rs
@@ -1,0 +1,279 @@
+//! Heartbeat-driven agent catalog convergence.
+//!
+//! When the heartbeat response carries a `catalogVersion` inside
+//! `desiredVersions`, the worker compares it to the runtime's active catalog
+//! version (queried via `GET /v1/catalogs/agents/version`). On mismatch:
+//!
+//! 1. Fetch the full catalog document from the cloud server
+//!    (`GET /v1/catalogs/agents`, ETag-aware so steady-state re-fetches are
+//!    cheap 304s).
+//! 2. Push the raw bytes to the runtime
+//!    (`PUT /v1/catalogs/agents`, existing transport bearer auth).
+//!
+//! `apply_fetched` + the reconcile poke in the runtime do the rest (pin-drift
+//! detection, reinstall, etc). Failure is non-fatal: log and retry on the
+//! next heartbeat.
+
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use crate::{
+    cloud_client::{CloudClient, HeartbeatResponse},
+    config::WorkerConfig,
+    error::WorkerError,
+};
+
+/// In-memory state kept across heartbeats for ETag caching and avoiding
+/// redundant work.
+pub struct CatalogSyncState {
+    /// ETag from the last successful cloud catalog fetch; sent as
+    /// `If-None-Match` on subsequent fetches so unchanged catalogs are free.
+    cached_etag: Mutex<Option<String>>,
+}
+
+impl CatalogSyncState {
+    pub fn new() -> Self {
+        Self {
+            cached_etag: Mutex::new(None),
+        }
+    }
+}
+
+/// Response from the runtime's `GET /v1/catalogs/agents/version`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeCatalogVersion {
+    catalog_version: String,
+    #[allow(dead_code)]
+    source: String,
+}
+
+// ─── Decision logic (pure, testable) ───────────────────────────────────────
+
+/// Decide whether this heartbeat demands a catalog sync. Returns the server's
+/// advertised catalog version when the worker should act, `None` otherwise.
+pub fn plan(response: &HeartbeatResponse) -> Option<&str> {
+    response
+        .desired_versions
+        .as_ref()?
+        .catalog_version
+        .as_deref()
+        .filter(|v| !v.is_empty())
+}
+
+/// Compare the server-advertised version to the runtime's active version.
+/// Returns `true` when a fetch-and-push is needed.
+pub fn needs_sync(advertised: &str, runtime_version: &str) -> bool {
+    advertised != runtime_version
+}
+
+// ─── Execution (async, side-effecting) ─────────────────────────────────────
+
+/// Run the catalog sync flow for one heartbeat tick. Errors are logged and
+/// swallowed — the heartbeat loop must never crash on a catalog sync failure.
+pub async fn maybe_sync(
+    config: &WorkerConfig,
+    cloud: &CloudClient,
+    worker_token: &str,
+    response: &HeartbeatResponse,
+    state: &CatalogSyncState,
+) {
+    let Some(advertised) = plan(response) else {
+        return;
+    };
+
+    let runtime_bearer = resolve_runtime_bearer_token(config);
+    let runtime_base = config.runtime_base_url.trim_end_matches('/');
+
+    // 1. Query the runtime for its active catalog version.
+    let runtime_version = match query_runtime_version(runtime_base, runtime_bearer.as_deref()).await
+    {
+        Ok(v) => v,
+        Err(error) => {
+            warn!(?error, "catalog sync: failed to query runtime catalog version");
+            return;
+        }
+    };
+
+    if !needs_sync(advertised, &runtime_version) {
+        return;
+    }
+
+    info!(
+        advertised,
+        runtime_version, "catalog sync: version mismatch, fetching from cloud"
+    );
+
+    // 2. Fetch from cloud (ETag-aware).
+    let cached_etag = state.cached_etag.lock().unwrap().clone();
+    let fetch_result =
+        match cloud
+            .fetch_agent_catalog(worker_token, cached_etag.as_deref())
+            .await
+        {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                // 304: our cached copy is the same the server has — but the
+                // runtime is behind. This can happen if a previous push failed.
+                // We don't cache the body, so we need to re-fetch without ETag.
+                match cloud.fetch_agent_catalog(worker_token, None).await {
+                    Ok(Some(result)) => result,
+                    Ok(None) => {
+                        warn!("catalog sync: unexpected 304 without ETag");
+                        return;
+                    }
+                    Err(error) => {
+                        warn!(?error, "catalog sync: cloud fetch failed (retry without etag)");
+                        return;
+                    }
+                }
+            }
+            Err(error) => {
+                warn!(?error, "catalog sync: cloud fetch failed");
+                return;
+            }
+        };
+
+    // 3. Push to runtime.
+    if let Err(error) = push_to_runtime(
+        runtime_base,
+        runtime_bearer.as_deref(),
+        &fetch_result.bytes,
+        fetch_result.etag.as_deref(),
+    )
+    .await
+    {
+        warn!(?error, "catalog sync: failed to push catalog to runtime");
+        return;
+    }
+
+    // Success: cache the ETag for next time.
+    *state.cached_etag.lock().unwrap() = fetch_result.etag.clone();
+    info!(
+        advertised,
+        "catalog sync: successfully pushed catalog to runtime"
+    );
+}
+
+/// Resolve the runtime bearer token: config field takes precedence, then
+/// `ANYHARNESS_BEARER_TOKEN` env var.
+fn resolve_runtime_bearer_token(config: &WorkerConfig) -> Option<String> {
+    config
+        .runtime_bearer_token
+        .clone()
+        .or_else(|| std::env::var("ANYHARNESS_BEARER_TOKEN").ok().filter(|v| !v.is_empty()))
+}
+
+/// Query the runtime's `GET /v1/catalogs/agents/version` endpoint.
+async fn query_runtime_version(
+    runtime_base: &str,
+    bearer_token: Option<&str>,
+) -> Result<String, WorkerError> {
+    let client = reqwest::Client::new();
+    let mut request = client.get(format!("{runtime_base}/v1/catalogs/agents/version"));
+    if let Some(token) = bearer_token {
+        request = request.header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {token}"),
+        );
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    let version_response: RuntimeCatalogVersion = response.json().await?;
+    Ok(version_response.catalog_version)
+}
+
+/// Push the raw catalog bytes to the runtime's `PUT /v1/catalogs/agents`.
+async fn push_to_runtime(
+    runtime_base: &str,
+    bearer_token: Option<&str>,
+    bytes: &[u8],
+    etag: Option<&str>,
+) -> Result<(), WorkerError> {
+    let client = reqwest::Client::new();
+    let mut request = client
+        .put(format!("{runtime_base}/v1/catalogs/agents"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(bytes.to_vec());
+    if let Some(token) = bearer_token {
+        request = request.header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {token}"),
+        );
+    }
+    if let Some(etag) = etag {
+        request = request.header(reqwest::header::ETAG, etag);
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_client::{DesiredVersions, HeartbeatResponse};
+
+    fn heartbeat_with_catalog_version(version: Option<&str>) -> HeartbeatResponse {
+        HeartbeatResponse {
+            worker_id: "test-worker".to_string(),
+            status: Some("online".to_string()),
+            server_time: None,
+            desired_versions: Some(DesiredVersions {
+                worker: None,
+                anyharness: None,
+                catalog_version: version.map(str::to_string),
+            }),
+        }
+    }
+
+    #[test]
+    fn plan_returns_none_when_no_desired_versions() {
+        let response = HeartbeatResponse {
+            worker_id: "test".to_string(),
+            status: None,
+            server_time: None,
+            desired_versions: None,
+        };
+        assert_eq!(plan(&response), None);
+    }
+
+    #[test]
+    fn plan_returns_none_when_catalog_version_absent() {
+        let response = heartbeat_with_catalog_version(None);
+        assert_eq!(plan(&response), None);
+    }
+
+    #[test]
+    fn plan_returns_none_when_catalog_version_empty() {
+        let response = heartbeat_with_catalog_version(Some(""));
+        assert_eq!(plan(&response), None);
+    }
+
+    #[test]
+    fn plan_returns_version_when_present() {
+        let response = heartbeat_with_catalog_version(Some("2026-07-06.1"));
+        assert_eq!(plan(&response), Some("2026-07-06.1"));
+    }
+
+    #[test]
+    fn needs_sync_detects_mismatch() {
+        assert!(needs_sync("2026-07-06.1", "2026-07-05.1"));
+        assert!(needs_sync("2026-07-05.1", "2026-07-06.1")); // rollback
+    }
+
+    #[test]
+    fn needs_sync_returns_false_when_equal() {
+        assert!(!needs_sync("2026-07-06.1", "2026-07-06.1"));
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/catalog_sync.rs
+++ b/anyharness/crates/proliferate-worker/src/catalog_sync.rs
@@ -91,6 +91,12 @@ pub async fn maybe_sync(
     let runtime_version = match query_runtime_version(runtime_base, runtime_bearer.as_deref()).await
     {
         Ok(v) => v,
+        Err(WorkerError::Cloud { status, .. })
+            if status == reqwest::StatusCode::NOT_FOUND =>
+        {
+            info!("catalog sync: runtime does not support catalog sync (old version)");
+            return;
+        }
         Err(error) => {
             warn!(?error, "catalog sync: failed to query runtime catalog version");
             return;
@@ -275,5 +281,71 @@ mod tests {
     #[test]
     fn needs_sync_returns_false_when_equal() {
         assert!(!needs_sync("2026-07-06.1", "2026-07-06.1"));
+    }
+
+    #[test]
+    fn resolve_runtime_bearer_token_prefers_config_over_env() {
+        let config = WorkerConfig {
+            cloud_base_url: "https://cloud.test".to_string(),
+            enrollment_token: None,
+            worker_db_path: "/tmp/worker.sqlite3".into(),
+            integration_gateway_home: None,
+            heartbeat_interval_seconds: 30,
+            self_update_enabled: false,
+            runtime_base_url: "http://127.0.0.1:8457".to_string(),
+            runtime_bearer_token: Some("from-config".to_string()),
+            config_path: None,
+        };
+        assert_eq!(
+            resolve_runtime_bearer_token(&config),
+            Some("from-config".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_runtime_bearer_token_falls_back_to_env() {
+        let config = WorkerConfig {
+            cloud_base_url: "https://cloud.test".to_string(),
+            enrollment_token: None,
+            worker_db_path: "/tmp/worker.sqlite3".into(),
+            integration_gateway_home: None,
+            heartbeat_interval_seconds: 30,
+            self_update_enabled: false,
+            runtime_base_url: "http://127.0.0.1:8457".to_string(),
+            runtime_bearer_token: None,
+            config_path: None,
+        };
+        // Without the env var set, returns None.
+        std::env::remove_var("ANYHARNESS_BEARER_TOKEN");
+        assert_eq!(resolve_runtime_bearer_token(&config), None);
+    }
+
+    /// Verify that a 404 from the runtime (old version without the endpoint)
+    /// is distinguishable from other errors via the WorkerError::Cloud variant.
+    #[test]
+    fn cloud_error_404_is_matchable() {
+        let err = WorkerError::Cloud {
+            status: reqwest::StatusCode::NOT_FOUND,
+            body: "not found".to_string(),
+        };
+        let is_not_found = matches!(
+            &err,
+            WorkerError::Cloud { status, .. } if *status == reqwest::StatusCode::NOT_FOUND
+        );
+        assert!(is_not_found);
+    }
+
+    /// Verify that a 500 error does NOT match the 404 pattern.
+    #[test]
+    fn cloud_error_500_is_not_404() {
+        let err = WorkerError::Cloud {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            body: "internal".to_string(),
+        };
+        let is_not_found = matches!(
+            &err,
+            WorkerError::Cloud { status, .. } if *status == reqwest::StatusCode::NOT_FOUND
+        );
+        assert!(!is_not_found);
     }
 }

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -73,6 +73,11 @@ pub struct DesiredVersions {
     #[allow(dead_code)]
     #[serde(default)]
     pub anyharness: Option<String>,
+    /// The `catalogVersion` string the server currently serves. When this
+    /// differs from the runtime's active catalog the worker fetches and
+    /// pushes the new document.
+    #[serde(default)]
+    pub catalog_version: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -185,6 +190,49 @@ impl CloudClient {
         }
         Ok(response.bytes().await?.to_vec())
     }
+
+    /// Fetch the agent catalog document from the cloud server. Sends the
+    /// stored ETag (if any) as `If-None-Match`; a 304 means the cached
+    /// document is current. Returns `None` on 304, `Some((bytes, etag))` on
+    /// 200.
+    pub async fn fetch_agent_catalog(
+        &self,
+        worker_token: &str,
+        cached_etag: Option<&str>,
+    ) -> Result<Option<CatalogFetchResult>, WorkerError> {
+        let mut request = self
+            .http
+            .get(format!("{}/v1/catalogs/agents", self.base_url))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            );
+        if let Some(etag) = cached_etag {
+            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        let etag = response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let bytes = response.bytes().await?.to_vec();
+        Ok(Some(CatalogFetchResult { bytes, etag }))
+    }
+}
+
+/// Result of a successful (non-304) catalog fetch from the cloud.
+pub struct CatalogFetchResult {
+    pub bytes: Vec<u8>,
+    pub etag: Option<String>,
 }
 
 /// A downloaded worker artifact plus the CDN URL the server's redirect
@@ -267,6 +315,7 @@ mod tests {
         let desired = response.desired_versions.expect("desiredVersions present");
         assert_eq!(desired.worker.as_deref(), Some("0.2.16"));
         assert_eq!(desired.anyharness.as_deref(), Some("0.2.16"));
+        assert_eq!(desired.catalog_version, None);
     }
 
     #[test]
@@ -281,6 +330,39 @@ mod tests {
         let desired = response.desired_versions.expect("desiredVersions present");
         assert_eq!(desired.worker.as_deref(), Some("0.2.16"));
         assert_eq!(desired.anyharness, None);
+        assert_eq!(desired.catalog_version, None);
+    }
+
+    #[test]
+    fn heartbeat_response_parses_catalog_version() {
+        let payload = br#"{
+            "workerId": "worker",
+            "desiredVersions": {
+                "worker": "0.2.16",
+                "anyharness": "0.2.16",
+                "catalogVersion": "2026-07-06.1"
+            }
+        }"#;
+        let response = serde_json::from_slice::<HeartbeatResponse>(payload)
+            .expect("heartbeat ack with catalogVersion");
+        let desired = response.desired_versions.expect("desiredVersions present");
+        assert_eq!(
+            desired.catalog_version.as_deref(),
+            Some("2026-07-06.1")
+        );
+    }
+
+    #[test]
+    fn heartbeat_response_tolerates_absent_catalog_version() {
+        // Servers that predate catalog convergence omit the field.
+        let payload = br#"{
+            "workerId": "worker",
+            "desiredVersions": {"worker": "0.2.16", "anyharness": "0.2.16"}
+        }"#;
+        let response = serde_json::from_slice::<HeartbeatResponse>(payload)
+            .expect("heartbeat ack without catalogVersion");
+        let desired = response.desired_versions.expect("desiredVersions present");
+        assert_eq!(desired.catalog_version, None);
     }
 
     #[test]

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -10,7 +10,10 @@ use crate::{config::WorkerConfig, error::WorkerError};
 
 #[derive(Clone)]
 pub struct CloudClient {
+    /// Authenticated requests: never follows redirects (prevents token leak).
     http: Client,
+    /// Unauthenticated artifact downloads: follows redirects to CDN.
+    http_download: Client,
     base_url: String,
 }
 
@@ -97,13 +100,24 @@ pub struct HeartbeatResponse {
 
 impl CloudClient {
     pub fn new(config: &WorkerConfig) -> Result<Self, WorkerError> {
+        // Authenticated client: never follows redirects to prevent leaking the
+        // Bearer token to a redirect target on a different origin.
         let http = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(WorkerError::BuildHttpClient)?;
+        // Unauthenticated download client: follows redirects (artifact
+        // downloads are public CDN URLs behind a server-issued 302).
+        let http_download = Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(30))
             .build()
             .map_err(WorkerError::BuildHttpClient)?;
         Ok(Self {
             http,
+            http_download,
             base_url: config.cloud_base_url.trim_end_matches('/').to_string(),
         })
     }
@@ -153,7 +167,7 @@ impl CloudClient {
         asset: &str,
     ) -> Result<DownloadedArtifact, WorkerError> {
         let response = self
-            .http
+            .http_download
             .get(format!(
                 "{}/v1/cloud/worker/download/{target}/{asset}",
                 self.base_url
@@ -178,7 +192,7 @@ impl CloudClient {
     /// No server redirect, hence no second version-path resolution.
     pub async fn download_from_url(&self, url: &str) -> Result<Vec<u8>, WorkerError> {
         let response = self
-            .http
+            .http_download
             .get(url)
             .timeout(ARTIFACT_DOWNLOAD_TIMEOUT)
             .send()

--- a/anyharness/crates/proliferate-worker/src/config.rs
+++ b/anyharness/crates/proliferate-worker/src/config.rs
@@ -24,8 +24,22 @@ pub struct WorkerConfig {
     /// off.
     #[serde(default)]
     pub self_update_enabled: bool,
+    /// Base URL of the co-located AnyHarness runtime HTTP API. Required for
+    /// catalog sync (pushing fetched catalogs to the runtime). Defaults to
+    /// `http://127.0.0.1:8457` when absent — the standard runtime port on
+    /// the same host.
+    #[serde(default = "default_runtime_base_url")]
+    pub runtime_base_url: String,
+    /// Bearer token for authenticating to the runtime's HTTP API. Read from
+    /// `ANYHARNESS_BEARER_TOKEN` env at startup when not set in config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_bearer_token: Option<String>,
     #[serde(skip)]
     pub config_path: Option<PathBuf>,
+}
+
+fn default_runtime_base_url() -> String {
+    "http://127.0.0.1:8457".to_string()
 }
 
 fn default_heartbeat_interval_seconds() -> u64 {
@@ -174,5 +188,22 @@ worker_db_path = "/tmp/worker.sqlite3"
         let contents = format!("{MINIMAL_CONFIG}self_update_enabled = true\n");
         let config: WorkerConfig = toml::from_str(&contents).expect("opt-in config");
         assert!(config.self_update_enabled);
+    }
+
+    #[test]
+    fn runtime_base_url_defaults_to_localhost() {
+        let config: WorkerConfig = toml::from_str(MINIMAL_CONFIG).expect("minimal config");
+        assert_eq!(config.runtime_base_url, "http://127.0.0.1:8457");
+        assert_eq!(config.runtime_bearer_token, None);
+    }
+
+    #[test]
+    fn runtime_base_url_overridable() {
+        let contents = format!(
+            "{MINIMAL_CONFIG}runtime_base_url = \"http://10.0.0.5:9000\"\nruntime_bearer_token = \"secret\"\n"
+        );
+        let config: WorkerConfig = toml::from_str(&contents).expect("config with runtime url");
+        assert_eq!(config.runtime_base_url, "http://10.0.0.5:9000");
+        assert_eq!(config.runtime_bearer_token.as_deref(), Some("secret"));
     }
 }

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -1,3 +1,4 @@
+mod catalog_sync;
 mod cloud_client;
 mod config;
 mod error;

--- a/anyharness/crates/proliferate-worker/src/runtime.rs
+++ b/anyharness/crates/proliferate-worker/src/runtime.rs
@@ -2,9 +2,16 @@ use tokio::time::sleep;
 use tracing::{info, warn};
 
 use crate::{
-    cloud_client::CloudClient, config::WorkerConfig, error::WorkerError, identity,
-    identity::credentials::WorkerIdentity, integration_gateway, lifecycle,
-    process_lock::WorkerProcessLock, self_update, store::WorkerStore,
+    catalog_sync::{self, CatalogSyncState},
+    cloud_client::CloudClient,
+    config::WorkerConfig,
+    error::WorkerError,
+    identity,
+    identity::credentials::WorkerIdentity,
+    integration_gateway, lifecycle,
+    process_lock::WorkerProcessLock,
+    self_update,
+    store::WorkerStore,
 };
 
 pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
@@ -24,13 +31,14 @@ pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
         );
     }
 
-    heartbeat_and_converge(&config, &cloud, &identity, once).await;
+    let catalog_state = CatalogSyncState::new();
+    heartbeat_and_converge(&config, &cloud, &identity, &catalog_state, once).await;
     if once {
         return Ok(());
     }
     loop {
         sleep(lifecycle::heartbeat::interval(&config)).await;
-        heartbeat_and_converge(&config, &cloud, &identity, false).await;
+        heartbeat_and_converge(&config, &cloud, &identity, &catalog_state, false).await;
     }
 }
 
@@ -42,6 +50,7 @@ async fn heartbeat_and_converge(
     config: &WorkerConfig,
     cloud: &CloudClient,
     identity: &WorkerIdentity,
+    catalog_state: &CatalogSyncState,
     dry_run: bool,
 ) {
     let response = match lifecycle::heartbeat::send_once(cloud, identity).await {
@@ -51,6 +60,12 @@ async fn heartbeat_and_converge(
             return;
         }
     };
+
+    // Catalog sync: non-fatal, runs before self-update because a binary swap
+    // exec's and never returns.
+    catalog_sync::maybe_sync(config, cloud, &identity.worker_token, &response, catalog_state)
+        .await;
+
     let Some(update) = self_update::plan(config, &response) else {
         return;
     };

--- a/server/proliferate/server/cloud/agent_gateway/topups.py
+++ b/server/proliferate/server/cloud/agent_gateway/topups.py
@@ -53,6 +53,7 @@ from proliferate.server.cloud.agent_gateway.enrollment import (
     enrollment_key_metadata,
     enrollment_subject_label,
 )
+from proliferate.server.cloud.materialization import service as materialization_service
 
 logger = logging.getLogger(__name__)
 
@@ -243,6 +244,10 @@ async def _remint_virtual_key(
         virtual_key=minted.key,
         sync_fingerprint=enrollment.sync_fingerprint,
     )
+    if enrollment.user_id is not None:
+        await materialization_service.schedule_materialize_agent_auth(
+            db, user_id=enrollment.user_id
+        )
     return minted.token_id or None
 
 

--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -243,6 +243,7 @@ async def _launch_anyharness_runtime(
         provider_sandbox=provider_sandbox,
         sandbox_record=sandbox_record,
         runtime_context=runtime_context,
+        runtime_bearer_token=runtime_token,
     )
     await cloud_sandboxes_store.mark_cloud_sandbox_ready(
         db,

--- a/server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py
@@ -47,6 +47,7 @@ async def launch_worker_sidecar(
     provider_sandbox: object,
     sandbox_record: CloudSandboxValue,
     runtime_context: SandboxRuntimeContext,
+    runtime_bearer_token: str | None = None,
 ) -> None:
     owner_user_id = sandbox_record.owner_user_id
     if owner_user_id is None:
@@ -79,6 +80,7 @@ async def launch_worker_sidecar(
                 cloud_base_url=cloud_base_url,
                 enrollment_token=enrollment_token,
                 runtime_context=runtime_context,
+                runtime_bearer_token=runtime_bearer_token,
             ),
         )
         await run_sandbox_command_logged(

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -170,9 +170,10 @@ def build_worker_config(
     cloud_base_url: str,
     enrollment_token: str,
     runtime_context: SandboxRuntimeContext,
+    runtime_bearer_token: str | None = None,
 ) -> str:
     worker_dir = f"{runtime_context.home_dir}/.proliferate/worker"
-    values = {
+    values: dict[str, str | int | bool] = {
         "cloud_base_url": cloud_base_url,
         "enrollment_token": enrollment_token,
         "worker_db_path": f"{worker_dir}/worker.sqlite3",
@@ -183,6 +184,8 @@ def build_worker_config(
         # Desktop workers must never set this: the app bundle owns updates.
         "self_update_enabled": True,
     }
+    if runtime_bearer_token:
+        values["runtime_bearer_token"] = runtime_bearer_token
     lines = []
     for key, value in values.items():
         if isinstance(value, bool):

--- a/server/proliferate/server/cloud/runtime_workers/models.py
+++ b/server/proliferate/server/cloud/runtime_workers/models.py
@@ -54,6 +54,7 @@ class WorkerDesiredVersions(_CamelModel):
     # server pins nothing.
     worker: str | None = None
     anyharness: str
+    catalog_version: str | None = None
 
 
 class WorkerHeartbeatResponse(_CamelModel):

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -26,6 +26,7 @@ from proliferate.integrations.desktop_downloads import (
     downloads_base_url,
     versioned_manifest_exists,
 )
+from proliferate.server.catalogs.service import served_agent_catalog_version
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime_workers.models import (
     DesktopWorkerEnrollmentResponse,
@@ -250,6 +251,7 @@ async def record_heartbeat(
         desired_versions=WorkerDesiredVersions(
             worker=pinned_worker_version(),
             anyharness=pinned_runtime_version(),
+            catalog_version=served_agent_catalog_version(),
         ),
     )
 

--- a/server/tests/integration/test_agent_gateway_topups.py
+++ b/server/tests/integration/test_agent_gateway_topups.py
@@ -28,6 +28,7 @@ from proliferate.server.cloud.agent_gateway.topups import (
     create_llm_topup_grant,
     run_llm_topups,
 )
+from proliferate.server.cloud.materialization import service as materialization_service
 from tests.integration.agent_gateway_topups_shared import (
     StubLiteLLM,
     StubStripe,
@@ -364,3 +365,55 @@ async def test_importer_leaves_overage_subjects_to_the_topup_worker(
     # key; the top-up worker refunds the ledger instead.
     assert enforced is False
     assert disabled == []
+
+
+@pytest.mark.asyncio
+async def test_remint_schedules_materialization(
+    db_session: AsyncSession,
+    stub_litellm: StubLiteLLM,
+    stub_stripe: StubStripe,
+    topup_settings: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a virtual key rotation during top-up reactivation, agent-auth
+    materialization is scheduled for the affected user."""
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "5")
+    user_id = await _create_user(db_session)
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    old_key_id = enrollment.virtual_key_id
+    assert old_key_id is not None
+    await _spend(
+        db_session,
+        billing_subject_id=enrollment.billing_subject_id,
+        cost_usd=6.0,
+    )
+    await store.set_enrollment_budget_status(
+        db_session,
+        enrollment_id=enrollment.id,
+        budget_status="exhausted",
+    )
+
+    scheduled_users: list[uuid.UUID] = []
+
+    async def record_schedule(db: AsyncSession, *, user_id: uuid.UUID) -> None:
+        scheduled_users.append(user_id)
+
+    monkeypatch.setattr(
+        materialization_service,
+        "schedule_materialize_agent_auth",
+        record_schedule,
+        raising=False,
+    )
+
+    # Unblock will fail, triggering the remint path.
+    stub_litellm.fail_unblock = True
+    await create_llm_topup_grant(
+        db_session,
+        billing_subject_id=enrollment.billing_subject_id,
+        amount_usd=Decimal("10"),
+        source_ref=f"llm_topup:in_remint_{uuid.uuid4().hex[:6]}",
+    )
+
+    # The key was rotated and materialization was scheduled.
+    assert stub_litellm.rotated == [old_key_id]
+    assert scheduled_users == [user_id]

--- a/server/tests/integration/test_cloud_runtime_worker_versions_api.py
+++ b/server/tests/integration/test_cloud_runtime_worker_versions_api.py
@@ -79,7 +79,33 @@ class TestRuntimeWorkerVersionConvergence:
             json={},
         )
         assert heartbeat.status_code == 200, heartbeat.text
-        assert heartbeat.json()["desiredVersions"] == {"worker": "9.9.9", "anyharness": "8.8.8"}
+        desired = heartbeat.json()["desiredVersions"]
+        assert desired["worker"] == "9.9.9"
+        assert desired["anyharness"] == "8.8.8"
+        assert "catalogVersion" in desired
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_includes_catalog_version(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="worker-catalog")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-catalog")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert heartbeat.status_code == 200, heartbeat.text
+        desired = heartbeat.json()["desiredVersions"]
+        assert "catalogVersion" in desired
+        # The catalog version should be present and a non-empty string
+        assert isinstance(desired["catalogVersion"], str)
+        assert len(desired["catalogVersion"]) > 0
 
     @pytest.mark.asyncio
     async def test_heartbeat_omits_worker_pin_when_unstamped(


### PR DESCRIPTION
## What

P2 of `specs/tbd/catalog-convergence-v1.md` — the missing middle of catalog convergence. With this, **bumping a harness pin in `catalogs/agents/catalog.json` converges cloud fleets on the next heartbeat**: worker sees a different `catalogVersion` → fetches the document from the cloud → pushes it to the runtime → `apply_fetched` swaps it → reconcile detects `VersionDrift` → the pinned CLI reinstalls. No binary release anywhere. (This is the transport `sync.rs:14-27` documented but never implemented.)

## Changes

**Runtime (anyharness-lib):**
- `GET /v1/catalogs/agents/version` → `{catalogVersion, source: bundled|fetched}` from `CatalogSyncService` (new contract type `AgentCatalogVersionResponse`), wired next to the existing `PUT`

**Worker (proliferate-worker):**
- `DesiredVersions.catalog_version: Option<String>` — tolerant of absence (older servers)
- New `catalog_sync` module: pure `plan()`/`needs_sync()` decision fns (self_update's pattern), then query runtime version → ETag-aware cloud fetch (`If-None-Match`, cached in `CatalogSyncState`) → `PUT` raw bytes to runtime
- 304-while-runtime-behind edge handled (refetch without ETag — covers a previously failed push)
- Runs in the heartbeat loop **before** self-update (a binary swap exec's and never returns)
- All failures log-and-skip; the heartbeat loop never crashes on catalog sync
- New config: `runtime_base_url` (default `http://127.0.0.1:8457`) + `runtime_bearer_token` (falls back to `ANYHARNESS_BEARER_TOKEN`)

## Tests

- 27/27 proliferate-worker (incl. new plan/needs_sync/deserialization tests + config defaults)
- 792/792 anyharness-lib (incl. new router test for the version endpoint)
- clippy `-D warnings` clean

## Stack

`#987` → `#988` (heartbeat field) → **this**. Live end-to-end verify (pin bump → CLI reinstall on a dev profile) tracked as the convergence spec's verification bar; remaining lanes P3 (desktop sync hook), P4 (re-probe), P5 (version UI) sequenced behind the ux/agents stack per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)