### PR TITLE
chore(repo-shape): unbreak main max-lines after goals stack

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -7,9 +7,9 @@
 # grows, the check fails. If it shrinks, update the count or remove the entry
 # when the file is under its threshold.
 
-anyharness/crates/anyharness-contract/src/v1/events.rs 979 existing AnyHarness contract oversized file
-anyharness/crates/anyharness-contract/src/v1/sessions.rs 772 existing AnyHarness contract oversized file
-anyharness/crates/anyharness-lib/src/api/openapi.rs 855 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1)
+anyharness/crates/anyharness-contract/src/v1/events.rs 1129 existing AnyHarness contract oversized file
+anyharness/crates/anyharness-contract/src/v1/sessions.rs 787 existing AnyHarness contract oversized file
+anyharness/crates/anyharness-lib/src/api/openapi.rs 874 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1)
 anyharness/crates/anyharness-lib/src/api/router_tests.rs 1277 existing AnyHarness oversized test file (+hosting PR-status route tests)
 anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1895 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1520 existing AnyHarness oversized file
@@ -21,10 +21,10 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 654 catalog probe with per-harness model-source fallbacks and tests
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
-anyharness/sdk-react/src/hooks/sessions.ts 707 existing SDK React oversized file
+anyharness/sdk-react/src/hooks/sessions.ts 774 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 761 existing generated cloud SDK type surface
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1919 existing SDK oversized test file
-anyharness/sdk/src/reducer/transcript.ts 1582 existing SDK oversized file
+anyharness/sdk/src/reducer/transcript.ts 1591 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 622 existing desktop diff viewer component
 apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
@@ -43,3 +43,7 @@ server/tests/integration/test_billing_api.py 1918 existing server oversized inte
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
 apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx 492 existing markdown transcript renderer pending split
 apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pending split
+anyharness/crates/anyharness-lib/src/api/router.rs 606 AnyHarness router (+goals/loops/activity/feed routes)
+anyharness/crates/anyharness-lib/src/app/mod.rs 608 AnyHarness app wiring (+goal/loop/activity/feed services)
+anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 861 loops runtime — native write path + emulated Codex scheduler
+anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 739 session startup (+goal/loop capability parsing, roster reconcile-on-attach)


### PR DESCRIPTION
The goals/loops/activity/feed stack (#909 #918 #919 #920) grew several oversized files past their allowlisted counts and pushed four new files over 600, turning the max-lines repo-shape check red on main.

This bumps the exceeded allowlist entries to their real post-merge counts and adds the four new files:

**Bumped:** events.rs 979→1129, sessions.rs 772→787, openapi.rs 855→874, transcript.ts 1582→1591, sessions.ts(react) 707→774
**Added:** router.rs (606), app/mod.rs (608), loops/runtime.rs (861), actor/startup.rs (739)

Verified locally: `python3 scripts/check_max_lines.py` passes.

Note: the frontend-structure `--strict` step of the Repo shape checks job is red independently — that is the pre-existing repo-shape blocker (red on pre-merge main too), not introduced or changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)