### PR TITLE
fix(desktop): sidebar dates/icons, neutral update pill, stable workspace sort

### DIFF
--- a/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -136,6 +136,24 @@ vi.mock("@/hooks/support/derived/use-support-report-snapshot", () => ({
   }),
 }));
 
+vi.mock("@/hooks/support/workflows/use-open-support-report-window", () => ({
+  useOpenSupportReportWindow: () => ({
+    openBug: vi.fn(() => {
+      useSupportModalStore.getState().openFeedback();
+    }),
+    openFeature: vi.fn(),
+    canSubmit: true,
+    disabledReason: null,
+  }),
+}));
+
+vi.mock("@/hooks/support/facade/use-support-availability", () => ({
+  useSupportAvailability: () => ({
+    canSubmit: true,
+    disabledReason: null,
+  }),
+}));
+
 vi.mock("@/stores/sessions/session-selection-store", () => ({
   useSessionSelectionStore: (selector: (state: { pendingWorkspaceEntry: null }) => unknown) =>
     selector({ pendingWorkspaceEntry: null }),

--- a/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@proliferate/ui/icons", () => ({
   FolderClosedFilled: () => <span data-icon="folder-closed" />,
   FolderFilled: () => <span data-icon="folder-filled" />,
   Globe: () => <span data-icon="globe" />,
-  SquarePlus: () => <span data-icon="plus" />,
+  Plus: () => <span data-icon="plus" />,
   Settings: () => <span data-icon="settings" />,
   Trash: () => <span data-icon="trash" />,
 }));

--- a/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { ChevronRight, CloudIcon, FolderClosedFilled, FolderFilled, Globe, Settings, SquarePlus, Trash } from "@proliferate/ui/icons";
+import { ChevronRight, CloudIcon, FolderClosedFilled, FolderFilled, Globe, Plus, Settings, Trash } from "@proliferate/ui/icons";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
@@ -119,7 +119,7 @@ export function RepoGroup({
               alwaysVisible
               className="absolute inset-0 rounded-md opacity-0 group-hover/folder-row:opacity-100 focus-visible:opacity-100"
             >
-              <SquarePlus className="size-3" />
+              <Plus className="size-3" />
             </SidebarActionButton>
           }
           side="right"

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx
@@ -2,8 +2,8 @@ import {
   Check,
   ChevronDownUp,
   ChevronUpDown,
-  Filter,
   FolderPlus,
+  ListFilter,
 } from "@proliferate/ui/icons";
 import { PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
@@ -66,7 +66,7 @@ export function SidebarRepositoriesHeader({
                 active={filtersActive}
                 variant="section"
               >
-                <Filter className="size-3" />
+                <ListFilter className="size-3" />
               </SidebarActionButton>
             }
           >

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
@@ -117,13 +117,13 @@ export function SidebarUpdatePill({
     }
   }
 
-  // UX spec §12: 12px, --special text, pill on --accent. Downloading keeps the
-  // active tone (non-disabled-looking) but isn't clickable; armed is subdued.
+  // Neutral pill: foreground/5 card surface, foreground text. Downloading keeps
+  // the active tone (non-disabled-looking) but isn't clickable; armed is subdued.
   const toneClass = isDownloading
-    ? "cursor-default bg-accent text-special"
+    ? "cursor-default bg-foreground/5 text-muted-foreground"
     : variant === "armed"
-      ? "bg-accent text-muted-foreground hover:bg-foreground/10"
-      : "bg-accent text-special hover:bg-foreground/10";
+      ? "bg-foreground/5 text-muted-foreground hover:bg-foreground/10"
+      : "bg-foreground/5 text-foreground hover:bg-foreground/10";
 
   return (
     <Button

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -208,6 +208,7 @@ export function SidebarWorkspaceContent({
                 detailIndicators={item.detailIndicators}
                 cloudStatus={item.cloudStatus}
                 branchName={item.branchName}
+                lastInteracted={item.lastInteracted}
                 gitStatus={item.gitStatus}
                 needsReview={item.needsReview}
                 shortcutLabel={shortcutLabelByWorkspaceId.get(item.id) ?? null}

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -28,6 +28,7 @@ import {
   sidebarGitGlyphForStatus,
 } from "@/lib/domain/workspaces/git-status/pr-status-presentation";
 import type { WorkspaceGitStatus } from "@/lib/domain/workspaces/git-status/workspace-git-status-model";
+import { formatSidebarRelativeTime } from "@/lib/domain/workspaces/display/workspace-display";
 import {
   SidebarDetailIndicatorsView,
   SidebarStatusIndicatorView,
@@ -64,6 +65,12 @@ interface WorkspaceItemProps {
   shortcutRevealVisible?: boolean;
   /** Current git branch, shown read-only in the three-dot menu git section. */
   branchName?: string | null;
+  /**
+   * Last interaction timestamp for this workspace. Rendered as a relative
+   * timestamp in the trailing label cell; trumped by trailingStatus
+   * (spinner/error) and unreadDot per ProductSidebarWorkspaceRow's precedence.
+   */
+  lastInteracted?: string | null;
   /**
    * Composed git/PR status (§3.2/§3.3). Drives the leading PR glyph, the PR
    * status dot, tooltips, and the "Open pull request" menu item. The well is
@@ -106,6 +113,7 @@ export function WorkspaceItem({
   shortcutLabel = null,
   shortcutRevealVisible = false,
   branchName = null,
+  lastInteracted = null,
   gitStatus = null,
   needsReview = false,
   onSelect,
@@ -200,11 +208,14 @@ export function WorkspaceItem({
 
   // Leading well (§3.2): PR glyph + dot for real PR states only — rows with
   // no PR (null/unknown or authoritative "none") leave the well empty.
-  // Activity indicators live in the row's RIGHT slot (trailingStatus), where
-  // the relative timestamp used to sit.
+  // Activity indicators live in the row's RIGHT slot (trailingStatus).
+  // Relative timestamp (trailingLabel) is also in the RIGHT slot, with lower
+  // precedence than trailingStatus and unreadDot.
   const gitGlyph = sidebarGitGlyphForStatus(gitStatus);
   const prStatusView = gitGlyph ? prStatusViewFromGitStatus(gitStatus) : null;
   const leadingGlyph = gitGlyph ? <SidebarWorkspaceGitGlyph glyph={gitGlyph} /> : null;
+
+  const timestampLabel = lastInteracted ? formatSidebarRelativeTime(lastInteracted) : null;
 
   const row = (
     <ProductSidebarWorkspaceRow
@@ -216,6 +227,7 @@ export function WorkspaceItem({
           onAction={onIndicatorAction}
         />
       ) : null}
+      trailingLabel={timestampLabel}
       leadingGlyph={leadingGlyph}
       label={name}
       detail={detail}

--- a/apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
+++ b/apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
@@ -152,7 +152,8 @@ describe("planBatchedStreamSideEffects", () => {
     });
 
     expect(plan.reviewParentSessionIds).toEqual(["parent-1", "parent-2"]);
-    expect(plan.lastActivityTimestamp).toBe("2026-04-04T00:00:04Z");
+    // review_run_updated is a mid-turn tick and does not bump activity
+    expect(plan.lastActivityTimestamp).toBe(null);
   });
 
   it("plans subagent effects from completed MCP tool calls", () => {
@@ -245,6 +246,56 @@ describe("planBatchedStreamSideEffects", () => {
     expect(plan.invalidateWorkspaceCollections).toBe(true);
   });
 
+  it("bumps activity on turn boundary events only", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        turnStarted(2),
+        interactionRequested(3),
+        turnEnded(4),
+        errorEvent(5),
+        sessionEnded(6),
+      ],
+    });
+
+    expect(plan.lastActivityTimestamp).toBe("2026-04-04T00:00:06Z");
+  });
+
+  it("does not bump activity on mid-turn item ticks", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        itemStarted(2),
+        itemCompleted(3, "tool-1"),
+      ],
+    });
+
+    expect(plan.lastActivityTimestamp).toBe(null);
+  });
+
+  it("does not bump activity on subagent or session_link mid-turn events", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        subagentTurnCompleted(2),
+        sessionLinkTurnCompleted(3, "cowork_coding_session"),
+      ],
+    });
+
+    expect(plan.lastActivityTimestamp).toBe(null);
+  });
+
+  it("does not bump activity on interaction_resolved (subsequent turn events handle it)", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [
+        interactionResolved(2),
+      ],
+    });
+
+    expect(plan.lastActivityTimestamp).toBe(null);
+  });
+
   it("carries reconciled mode preference intents into the plan", () => {
     const liveConfig = liveConfigSnapshot();
     const reconciledChange = {
@@ -314,6 +365,49 @@ function turnEnded(seq: number): SessionEventEnvelope {
     type: "turn_ended",
     stopReason: "end_turn",
   });
+}
+
+function itemStarted(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "item_started",
+    item: {
+      kind: "tool_call",
+      status: "in_progress",
+      sourceAgentKind: "codex",
+      contentParts: [],
+    },
+  } as unknown as SessionEventEnvelope["event"]);
+}
+
+function interactionRequested(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "interaction_requested",
+    requestId: `interaction-${seq}`,
+    kind: "permission",
+    source: { tool_call_id: null },
+  } as unknown as SessionEventEnvelope["event"]);
+}
+
+function interactionResolved(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "interaction_resolved",
+    requestId: `interaction-${seq}`,
+    kind: "permission",
+    outcome: "allowed",
+  } as unknown as SessionEventEnvelope["event"]);
+}
+
+function errorEvent(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "error",
+    message: "test error",
+  } as unknown as SessionEventEnvelope["event"]);
+}
+
+function sessionEnded(seq: number): SessionEventEnvelope {
+  return envelope(seq, {
+    type: "session_ended",
+  } as unknown as SessionEventEnvelope["event"]);
 }
 
 function subagentTurnCompleted(seq: number): SessionEventEnvelope {

--- a/apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
+++ b/apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
@@ -314,19 +314,18 @@ function shouldScheduleActiveSummaryRefresh(eventType: string): boolean {
   }
 }
 
+/**
+ * Gates the sidebar recency sort and displayed relative date. Only turn
+ * boundaries count — never mid-turn item ticks — so concurrent runs don't
+ * leapfrog each other in the sidebar while agents are working.
+ */
 function shouldTrackWorkspaceWorkActivity(eventType: string): boolean {
   switch (eventType) {
     case "turn_started":
-    case "item_started":
-    case "item_completed":
-    case "interaction_requested":
-    case "interaction_resolved":
     case "turn_ended":
     case "error":
     case "session_ended":
-    case "subagent_turn_completed":
-    case "session_link_turn_completed":
-    case "review_run_updated":
+    case "interaction_requested":
       return true;
     default:
       return false;

--- a/apps/packages/ui/src/kit/Sonner.tsx
+++ b/apps/packages/ui/src/kit/Sonner.tsx
@@ -17,6 +17,9 @@ export function Toaster({ toastOptions, ...props }: ComponentProps<typeof Sonner
       theme="dark"
       position="bottom-right"
       richColors={false}
+      // Always expanded: prevents the hover-enter resize animation that sonner
+      // applies when transitioning stacked toasts from collapsed to expanded.
+      expand
       {...props}
       toastOptions={{
         ...toastOptions,


### PR DESCRIPTION
## What

Four sidebar/update-UI fixes from UX review:

1. **Relative dates restored on workspace rows** — the git/PR-status change (ddb1f9260) dropped the trailing timestamp entirely; it's back as `trailingLabel`, and the row's existing trailing-cell precedence hides it exactly when an activity spinner or unread dot is showing.
2. **Icon swaps** — filter popover: funnel `Filter` → `ListFilter`; repo-group "New workspace" hover action: `SquarePlus` → borderless `Plus`.
3. **Update pill neutralized** — `bg-accent text-special` (blue) → the restart dialog's neutral card language (`bg-foreground/5`, foreground/muted text). Morph/progress-ring/sweep behavior unchanged.
4. **Toast hover-resize killed** — sonner's collapsed-stack default animates a 0.4s height transition on pointer enter (and the scaled rear toast reads as a stray border behind the card). `expand` on the kit Toaster renders toasts at natural height from mount; swipe-dismiss and enter/exit animations unaffected.

Plus a behavior fix surfaced during review:

5. **Stable sidebar ordering under concurrent runs** — sidebar recency previously bumped on every `item_started`/`item_completed` (each tool call), so workspaces running in parallel constantly leapfrogged. `shouldTrackWorkspaceWorkActivity` now gates on turn boundaries only (`turn_started`, `turn_ended`, `error`, `session_ended`, `interaction_requested`). `interaction_resolved` verified redundant (resuming always emits its own turn event); unread-dot behavior verified unaffected (`turn_ended` still bumps `lastInteracted`).

## Testing

- 34 tests across the five touched sidebar/update test files, plus retargeted stream-plan tests (item ticks assert **no** bump; boundaries assert a bump)
- `tsc --noEmit` clean
- Exercised live in a dev profile: dates + precedence on rows, both icons, pill in all phases via the updater mock, toast stack hover (no resize), multi-workspace concurrent runs hold position

🤖 Generated with [Claude Code](https://claude.com/claude-code)