### PR TITLE
feat(settings): rework Account IA and Appearance preview

### DIFF
--- a/apps/desktop/src/components/settings/panes/AppearancePane.tsx
+++ b/apps/desktop/src/components/settings/panes/AppearancePane.tsx
@@ -4,8 +4,7 @@ import { SETTINGS_CONTROL_WIDTH_CLASS, SettingsRow } from "@proliferate/product-
 import { SettingsMenu } from "@proliferate/ui/primitives/SettingsMenu";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { DiffViewer } from "@/components/content/ui/DiffViewer";
-import { FileDiffCard } from "@/components/content/ui/FileDiffCard";
+import { HighlightedCodeBlock } from "@/components/content/ui/HighlightedCodeBlock";
 import { Minus, Monitor, Moon, Plus, Sun } from "@proliferate/ui/icons";
 import { Switch } from "@proliferate/ui/primitives/Switch";
 import {
@@ -35,12 +34,16 @@ const MODE_ICONS: Record<ColorMode, FC<{ className?: string }>> = {
   system: Monitor,
 };
 
-const PREVIEW_DIFF = `@@ -1,5 +1,5 @@
- export const environment = {
--  branch: "develop",
-+  branch: "main",
-   command: "pnpm dev",
- };`;
+const PREVIEW_CODE = `// Environment configuration
+export const environment = {
+  apiUrl: "https://api.example.com",
+  maxRetries: 3,
+  timeout: 5000,
+} as const;
+
+export function buildEndpoint(path: string): string {
+  return \`\${environment.apiUrl}/\${path}\`;
+}`;
 
 export function AppearancePane() {
   const [mode, setMode] = useColorMode();
@@ -57,8 +60,6 @@ export function AppearancePane() {
       <SettingsPageHeader title="Appearance" />
 
       <SettingsSection title="Preferences">
-          <AppearancePreview />
-
           <SettingsRow
             label="Mode"
             description="Light, dark, or follow the system setting"
@@ -170,39 +171,16 @@ export function AppearancePane() {
             />
           </SettingsRow>
       </SettingsSection>
-    </section>
-  );
-}
 
-function AppearancePreview() {
-  return (
-    <div className="space-y-2 p-2.5">
-      <div className="flex items-center justify-between gap-3 px-0.5">
-        <div className="min-w-0 text-xs font-medium text-muted-foreground">
-          Preview
-        </div>
-        <div className="shrink-0 text-xs text-muted-foreground">
-          Git diff
-        </div>
-      </div>
-      <div className="overflow-hidden rounded-lg border border-border/70">
-        <FileDiffCard
-          filePath="src/environment.ts"
-          additions={1}
-          deletions={1}
-          isExpanded
-          embedded
-          collapsible={false}
-        >
-          <DiffViewer
-            patch={PREVIEW_DIFF}
-            filePath="src/environment.ts"
-            className="w-full"
-            viewportClassName="max-h-[calc(var(--diffs-line-height)*5)]"
-            variant="chat"
-          />
-        </FileDiffCard>
-      </div>
-    </div>
+      <SettingsSection title="Preview">
+        <HighlightedCodeBlock
+          code={PREVIEW_CODE}
+          language="typescript"
+          showLanguageLabel={false}
+          showCopyButton={false}
+          showLineNumbers
+        />
+      </SettingsSection>
+    </section>
   );
 }

--- a/apps/packages/product-ui/src/account/AccountPasswordCredentialCard.tsx
+++ b/apps/packages/product-ui/src/account/AccountPasswordCredentialCard.tsx
@@ -5,7 +5,6 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { Label } from "@proliferate/ui/primitives/Label";
 
-import { SettingsSection } from "../settings/SettingsSection";
 import { ProviderBrandIcon } from "../auth/ProviderBrandIcon";
 
 export interface AccountPasswordCredentialSubmit {
@@ -21,7 +20,11 @@ export interface AccountPasswordCredentialView {
   onSubmit?: (input: AccountPasswordCredentialSubmit) => void | Promise<void>;
 }
 
-export function AccountPasswordCredentialCard({
+/**
+ * Inline row variant for use inside the sign-in methods card.
+ * Renders as a row with expand-in-place form below.
+ */
+export function AccountPasswordCredentialRow({
   credential,
 }: {
   credential: AccountPasswordCredentialView;
@@ -77,127 +80,144 @@ export function AccountPasswordCredentialCard({
     }
   }
 
-  return (
-    <SettingsSection>
-      <div className="space-y-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 space-y-1">
-            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-              <ProviderBrandIcon provider="password" className="size-4 shrink-0 text-muted-foreground" />
-              <span>Email/password</span>
-            </div>
-            <p className="max-w-xl text-sm leading-6 text-muted-foreground">
-              {credential.enabled
-                ? "Email sign-in is enabled for this account."
-                : credential.loading
-                  ? "Checking email sign-in for this account."
-                : "Add a password to sign in with email on web and mobile."}
-            </p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Badge tone={credential.enabled ? "success" : "neutral"}>
-              {credential.loading ? "Checking" : credential.enabled ? "Enabled" : "Not set"}
-            </Badge>
-            {credential.onSubmit ? (
-              <Button
-                type="button"
-                variant="secondary"
-                disabled={actionDisabled || submitting}
-                onClick={() => {
-                  setError(null);
-                  if (editing) {
-                    setCurrentPassword("");
-                    setNewPassword("");
-                    setConfirmPassword("");
-                    setEditing(false);
-                  } else {
-                    setEditing(true);
-                  }
-                }}
-              >
-                {editing ? "Cancel" : credential.enabled ? "Change password" : "Set password"}
-              </Button>
-            ) : null}
-          </div>
-        </div>
+  const statusLabel = credential.loading
+    ? "Checking"
+    : credential.enabled
+      ? "Enabled"
+      : "Not set";
 
-        {editing ? (
-          <form className="grid gap-3 sm:max-w-md" onSubmit={submit}>
-            {needsCurrentPassword ? (
-              <div className="space-y-1.5">
-                <Label htmlFor={currentPasswordId}>Current password</Label>
-                <Input
-                  id={currentPasswordId}
-                  type="password"
-                  value={currentPassword}
-                  disabled={submitting}
-                  autoComplete="current-password"
-                  data-telemetry-mask
-                  onChange={(event) => setCurrentPassword(event.currentTarget.value)}
-                />
-              </div>
-            ) : null}
-            <div className="space-y-1.5">
-              <Label htmlFor={newPasswordId}>New password</Label>
-              <Input
-                id={newPasswordId}
-                type="password"
-                value={newPassword}
-                disabled={submitting}
-                autoComplete="new-password"
-                data-telemetry-mask
-                onChange={(event) => setNewPassword(event.currentTarget.value)}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor={confirmPasswordId}>Confirm new password</Label>
-              <Input
-                id={confirmPasswordId}
-                type="password"
-                value={confirmPassword}
-                disabled={submitting}
-                autoComplete="new-password"
-                data-telemetry-mask
-                onChange={(event) => setConfirmPassword(event.currentTarget.value)}
-              />
-            </div>
-            {passwordMismatch ? (
-              <p className="text-sm text-destructive" role="alert">
-                New passwords do not match.
-              </p>
-            ) : null}
-            <div className="flex items-center gap-2">
-              <Button
-                type="submit"
-                variant="primary"
-                loading={submitting}
-                disabled={!canSubmit}
-              >
-                {submitting ? "Saving" : credential.enabled ? "Save password" : "Set password"}
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                disabled={submitting}
-                onClick={() => {
+  const detailText = credential.enabled
+    ? "Email sign-in is enabled for this account."
+    : credential.loading
+      ? "Checking email sign-in for this account."
+      : "Add a password to sign in with email";
+
+  return (
+    <div className="border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0">
+      <div className="flex min-h-[2.75rem] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 font-medium text-foreground">
+            <ProviderBrandIcon provider="password" className="size-4 shrink-0 text-muted-foreground" />
+            <span>Email &amp; password</span>
+          </div>
+          <div className="truncate text-muted-foreground">{detailText}</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Badge tone={credential.enabled ? "success" : "neutral"}>
+            {statusLabel}
+          </Badge>
+          {credential.onSubmit ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={actionDisabled || submitting}
+              onClick={() => {
+                setError(null);
+                if (editing) {
                   setCurrentPassword("");
                   setNewPassword("");
                   setConfirmPassword("");
-                  setError(null);
                   setEditing(false);
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-            {error ? (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
-              </p>
-            ) : null}
-          </form>
-        ) : null}
+                } else {
+                  setEditing(true);
+                }
+              }}
+            >
+              {editing ? "Cancel" : credential.enabled ? "Change password" : "Set password"}
+            </Button>
+          ) : null}
+        </div>
       </div>
-    </SettingsSection>
+
+      {editing ? (
+        <form className="mt-3 grid gap-3 sm:max-w-md" onSubmit={submit}>
+          {needsCurrentPassword ? (
+            <div className="space-y-1.5">
+              <Label htmlFor={currentPasswordId}>Current password</Label>
+              <Input
+                id={currentPasswordId}
+                type="password"
+                value={currentPassword}
+                disabled={submitting}
+                autoComplete="current-password"
+                data-telemetry-mask
+                onChange={(event) => setCurrentPassword(event.currentTarget.value)}
+              />
+            </div>
+          ) : null}
+          <div className="space-y-1.5">
+            <Label htmlFor={newPasswordId}>New password</Label>
+            <Input
+              id={newPasswordId}
+              type="password"
+              value={newPassword}
+              disabled={submitting}
+              autoComplete="new-password"
+              data-telemetry-mask
+              onChange={(event) => setNewPassword(event.currentTarget.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={confirmPasswordId}>Confirm new password</Label>
+            <Input
+              id={confirmPasswordId}
+              type="password"
+              value={confirmPassword}
+              disabled={submitting}
+              autoComplete="new-password"
+              data-telemetry-mask
+              onChange={(event) => setConfirmPassword(event.currentTarget.value)}
+            />
+          </div>
+          {passwordMismatch ? (
+            <p className="text-sm text-destructive" role="alert">
+              New passwords do not match.
+            </p>
+          ) : null}
+          <div className="flex items-center gap-2">
+            <Button
+              type="submit"
+              variant="primary"
+              loading={submitting}
+              disabled={!canSubmit}
+            >
+              {submitting ? "Saving" : credential.enabled ? "Save password" : "Set password"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => {
+                setCurrentPassword("");
+                setNewPassword("");
+                setConfirmPassword("");
+                setError(null);
+                setEditing(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </form>
+      ) : null}
+    </div>
   );
+}
+
+/**
+ * Legacy standalone card export — kept for API compatibility.
+ * The pane now uses AccountPasswordCredentialRow inline.
+ */
+export function AccountPasswordCredentialCard({
+  credential,
+}: {
+  credential: AccountPasswordCredentialView;
+}) {
+  return <AccountPasswordCredentialRow credential={credential} />;
 }

--- a/apps/packages/product-ui/src/account/AccountPasswordCredentialCard.tsx
+++ b/apps/packages/product-ui/src/account/AccountPasswordCredentialCard.tsx
@@ -95,15 +95,15 @@ export function AccountPasswordCredentialRow({
   return (
     <div className="border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0">
       <div className="flex min-h-[2.75rem] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 font-medium text-foreground">
-            <ProviderBrandIcon provider="password" className="size-4 shrink-0 text-muted-foreground" />
-            <span>Email &amp; password</span>
+        <div className="flex min-w-0 items-center gap-3">
+          <ProviderBrandIcon provider="password" className="size-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="font-medium text-foreground">Email &amp; password</div>
+            <div className="truncate text-muted-foreground">{detailText}</div>
           </div>
-          <div className="truncate text-muted-foreground">{detailText}</div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <Badge tone={credential.enabled ? "success" : "neutral"}>
+          <Badge tone="neutral">
             {statusLabel}
           </Badge>
           {credential.onSubmit ? (

--- a/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
+++ b/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
@@ -4,9 +4,8 @@ import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
 
 import { SettingsSection } from "../settings/SettingsSection";
-import { SettingsRow } from "../settings/SettingsRow";
 import {
-  AccountPasswordCredentialCard,
+  AccountPasswordCredentialRow,
   type AccountPasswordCredentialView,
 } from "./AccountPasswordCredentialCard";
 import { ProviderBrandIcon } from "../auth/ProviderBrandIcon";
@@ -82,66 +81,64 @@ export function AccountSettingsPane({
   githubLabel,
   providers,
   actions,
-  accessTitle = "Account access",
-  accessDescription = "Sign in and link providers so web, mobile, and desktop resolve to the same Proliferate account.",
-  providersTitle = "Connected providers",
-  providersDescription = "GitHub is required for repository access. Add Google and Apple identities to sign in across devices without creating a separate account.",
+  accessDescription,
+  providersTitle = "Sign-in methods",
+  providersDescription = "How you sign in to this account across desktop, web, and mobile.",
   connectedServicesTitle = "Connected services",
   connectedServicesDescription = "Authorize services Proliferate uses inside managed cloud sandboxes.",
   connectedServices = [],
   passwordCredential,
   error,
 }: AccountSettingsPaneProps) {
+  // Resolve the sign-in methods section description: accessDescription overrides
+  // providersDescription when present (desktop passes contextual state copy here).
+  const signInMethodsDescription = accessDescription ?? providersDescription;
+
+  // Build the effective provider rows, synthesizing apple/google if only an action exists
+  const effectiveProviders = buildEffectiveProviders(providers, actions);
+
+  // Determine sign-in section action (signIn for signed-out state)
+  const sectionAction = actions.signIn ? (
+    <AccountAction action={actions.signIn} variant="secondary" />
+  ) : null;
+
   return (
     <div className="space-y-6">
+      {/* 1. Profile header */}
       <SettingsSection>
         <AccountProfileHeader
           avatarUrl={avatarUrl ?? null}
           displayName={displayName}
           email={email}
-          githubLabel={githubLabel}
           profileSummary={profileSummary}
         />
       </SettingsSection>
 
-      <SettingsSection>
-        <SettingsRow label={accessTitle} description={accessDescription}>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {actions.signIn ? <AccountAction action={actions.signIn} /> : null}
-            {actions.connectGitHub ? <AccountAction action={actions.connectGitHub} /> : null}
-            {actions.reconnectGitHub ? <AccountAction action={actions.reconnectGitHub} /> : null}
-            {actions.manageGitHubAccess ? (
-              <AccountAction action={actions.manageGitHubAccess} variant="ghost" />
-            ) : null}
-            {actions.signOut ? <AccountAction action={actions.signOut} variant="ghost" /> : null}
-          </div>
-        </SettingsRow>
-      </SettingsSection>
-
-      <SettingsSection title={providersTitle} description={providersDescription}>
-        <div className="space-y-3">
-          {actions.connectGoogle || actions.connectApple ? (
-            <div className="flex flex-wrap items-center gap-2">
-              {actions.connectGoogle ? (
-                <AccountAction action={actions.connectGoogle} variant="secondary" />
-              ) : null}
-              {actions.connectApple ? (
-                <AccountAction action={actions.connectApple} variant="secondary" />
-              ) : null}
-            </div>
+      {/* 2. Sign-in methods */}
+      <SettingsSection
+        title={providersTitle}
+        description={signInMethodsDescription}
+        action={sectionAction}
+      >
+        <div className="overflow-clip rounded-lg bg-foreground/5">
+          {effectiveProviders.map((row) => (
+            <SignInMethodRow
+              key={`${row.provider.provider}-${row.provider.accountLabel ?? row.provider.label}`}
+              provider={row.provider}
+              actions={row.actions}
+              githubLabel={githubLabel}
+            />
+          ))}
+          {passwordCredential ? (
+            <AccountPasswordCredentialRow credential={passwordCredential} />
           ) : null}
-
-          <div className="flex flex-col">
-            {providers.map((provider) => (
-              <ProviderRow key={`${provider.provider}-${provider.accountLabel ?? provider.label}`} provider={provider} />
-            ))}
-          </div>
         </div>
       </SettingsSection>
 
+      {/* 3. Connected services */}
       {connectedServices.length > 0 ? (
         <SettingsSection title={connectedServicesTitle} description={connectedServicesDescription}>
-          <div className="flex flex-col">
+          <div className="overflow-clip rounded-lg bg-foreground/5">
             {connectedServices.map((service) => (
               <ConnectedServiceRow key={service.id} service={service} />
             ))}
@@ -149,26 +146,107 @@ export function AccountSettingsPane({
         </SettingsSection>
       ) : null}
 
-      {passwordCredential ? (
-        <AccountPasswordCredentialCard credential={passwordCredential} />
-      ) : null}
-
+      {/* 4. Footer */}
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {actions.signOut ? (
+        <div className="flex">
+          <AccountAction action={actions.signOut} variant="ghost" />
+        </div>
+      ) : null}
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Internal: build effective provider rows with their matched actions
+// ---------------------------------------------------------------------------
+
+interface ProviderRowData {
+  provider: AccountProviderView;
+  actions: AccountActionView[];
+}
+
+function buildEffectiveProviders(
+  providers: AccountProviderView[],
+  actions: AccountSettingsPaneProps["actions"],
+): ProviderRowData[] {
+  const rows: ProviderRowData[] = providers.map((provider) => ({
+    provider,
+    actions: getActionsForProvider(provider, actions),
+  }));
+
+  // Synthesize apple row if connectApple action exists but no apple provider row
+  const hasAppleRow = providers.some((p) => p.provider === "apple");
+  if (!hasAppleRow && actions.connectApple) {
+    rows.push({
+      provider: {
+        provider: "apple",
+        label: "Apple",
+        accountLabel: "Not connected",
+        connected: false,
+      },
+      actions: [actions.connectApple],
+    });
+  }
+
+  // Synthesize google row if connectGoogle action exists but no google provider row
+  const hasGoogleRow = providers.some((p) => p.provider === "google");
+  if (!hasGoogleRow && actions.connectGoogle) {
+    rows.push({
+      provider: {
+        provider: "google",
+        label: "Google",
+        accountLabel: "Not connected",
+        connected: false,
+      },
+      actions: [actions.connectGoogle],
+    });
+  }
+
+  return rows;
+}
+
+function getActionsForProvider(
+  provider: AccountProviderView,
+  actions: AccountSettingsPaneProps["actions"],
+): AccountActionView[] {
+  const result: AccountActionView[] = [];
+
+  if (provider.provider === "github") {
+    if (actions.connectGitHub) result.push(actions.connectGitHub);
+    if (actions.reconnectGitHub) result.push(actions.reconnectGitHub);
+    if (actions.manageGitHubAccess) result.push(actions.manageGitHubAccess);
+  }
+
+  if (provider.provider === "google" && actions.connectGoogle && !provider.connected) {
+    result.push(actions.connectGoogle);
+  }
+
+  if (provider.provider === "apple" && actions.connectApple && !provider.connected) {
+    result.push(actions.connectApple);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Internal components
+// ---------------------------------------------------------------------------
+
 function AccountAction({
   action,
   variant = "secondary",
+  size = "sm",
 }: {
   action: AccountActionView;
   variant?: "secondary" | "ghost";
+  size?: "sm" | "md";
 }) {
   return (
     <Button
       type="button"
       variant={action.destructive ? "ghost" : variant}
+      size={size}
       disabled={action.disabled}
       loading={action.loading}
       onClick={action.onClick}
@@ -180,13 +258,68 @@ function AccountAction({
   );
 }
 
+function SignInMethodRow({
+  provider,
+  actions: rowActions,
+  githubLabel,
+}: {
+  provider: AccountProviderView;
+  actions: AccountActionView[];
+  githubLabel: string;
+}) {
+  const statusLabel = provider.connected
+    ? provider.status === "needs_reauth"
+      ? "Reconnect"
+      : provider.status === "expired"
+        ? "Expired"
+        : "Connected"
+    : "Not connected";
+
+  // Use githubLabel as detail fallback for GitHub row when no accountLabel
+  const detail = provider.provider === "github" && !provider.accountLabel
+    ? githubLabel
+    : provider.accountLabel;
+
+  return (
+    <div className="flex min-h-[3.5rem] flex-col gap-2 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <ProviderBrandIcon
+            provider={provider.provider}
+            label={provider.brandLabel ?? provider.label}
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+          <span>{provider.label}</span>
+          {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
+        </div>
+        <div className="truncate text-muted-foreground">
+          {detail || (provider.connected ? "Connected" : "Not connected")}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge tone={providerStatusTone(provider)} className="shrink-0">
+          {statusLabel}
+        </Badge>
+        {rowActions.map((action, idx) => (
+          <AccountAction
+            key={idx}
+            action={action}
+            variant={idx === 0 ? "secondary" : "ghost"}
+            size="sm"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function ConnectedServiceRow({
   service,
 }: {
   service: AccountConnectedServiceView;
 }) {
   return (
-    <div className="flex flex-col gap-3 border-b border-border-light px-3 py-2.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex min-h-[3.5rem] flex-col gap-3 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0 space-y-1">
         <div className="flex flex-wrap items-center gap-2 font-medium text-foreground">
           <span>{service.label}</span>
@@ -212,13 +345,11 @@ function AccountProfileHeader({
   avatarUrl,
   displayName,
   email,
-  githubLabel,
   profileSummary,
 }: {
   avatarUrl: string | null;
   displayName: string;
   email: string;
-  githubLabel: string;
   profileSummary: string;
 }) {
   return (
@@ -228,15 +359,10 @@ function AccountProfileHeader({
         avatarUrl={avatarUrl}
         displayName={displayName}
       />
-      <div className="min-w-0 flex-1 space-y-3">
-        <div className="min-w-0 space-y-1">
-          <div className="truncate text-lg font-medium text-foreground">{displayName}</div>
-          <p className="text-sm leading-6 text-muted-foreground">{profileSummary}</p>
-        </div>
-        <div className="grid gap-2">
-          <AccountProfileRow label="Email" value={email} />
-          <AccountProfileRow label="GitHub" value={githubLabel} />
-        </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="truncate text-lg font-medium text-foreground">{displayName}</div>
+        <div className="truncate text-sm text-muted-foreground">{email}</div>
+        <p className="text-sm leading-6 text-muted-foreground">{profileSummary}</p>
       </div>
     </div>
   );
@@ -265,53 +391,6 @@ function AccountAvatar({
       ) : (
         <span>{initialsForName(displayName)}</span>
       )}
-    </div>
-  );
-}
-
-function AccountProfileRow({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-3 text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <span className="min-w-0 truncate text-foreground">{value}</span>
-    </div>
-  );
-}
-
-function ProviderRow({ provider }: { provider: AccountProviderView }) {
-  const statusLabel = provider.connected
-    ? provider.status === "needs_reauth"
-      ? "Reconnect"
-      : provider.status === "expired"
-        ? "Expired"
-        : "Connected"
-    : "Not connected";
-
-  return (
-    <div className="flex items-center justify-between gap-3 border-b border-border-light px-3 py-2.5 text-sm last:border-b-0">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2 font-medium text-foreground">
-          <ProviderBrandIcon
-            provider={provider.provider}
-            label={provider.brandLabel ?? provider.label}
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-          <span>{provider.label}</span>
-          {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
-        </div>
-        <div className="truncate text-muted-foreground">
-          {provider.accountLabel || (provider.connected ? "Connected" : "Not connected")}
-        </div>
-      </div>
-      <Badge tone={providerStatusTone(provider)} className="shrink-0">
-        {statusLabel}
-      </Badge>
     </div>
   );
 }

--- a/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
+++ b/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
@@ -150,7 +150,7 @@ export function AccountSettingsPane({
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
       {actions.signOut ? (
         <div className="flex">
-          <AccountAction action={actions.signOut} variant="ghost" />
+          <AccountAction action={actions.signOut} variant="secondary" />
         </div>
       ) : null}
     </div>
@@ -215,7 +215,6 @@ function getActionsForProvider(
   if (provider.provider === "github") {
     if (actions.connectGitHub) result.push(actions.connectGitHub);
     if (actions.reconnectGitHub) result.push(actions.reconnectGitHub);
-    if (actions.manageGitHubAccess) result.push(actions.manageGitHubAccess);
   }
 
   if (provider.provider === "google" && actions.connectGoogle && !provider.connected) {
@@ -245,12 +244,12 @@ function AccountAction({
   return (
     <Button
       type="button"
-      variant={action.destructive ? "ghost" : variant}
+      variant={variant}
       size={size}
       disabled={action.disabled}
       loading={action.loading}
       onClick={action.onClick}
-      className={action.destructive ? "text-destructive hover:text-destructive" : ""}
+      className={action.destructive && variant === "ghost" ? "text-destructive hover:text-destructive" : ""}
     >
       {!action.loading && action.icon ? action.icon : null}
       {action.label}
@@ -282,22 +281,24 @@ function SignInMethodRow({
 
   return (
     <div className="flex min-h-[3.5rem] flex-col gap-2 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2 font-medium text-foreground">
-          <ProviderBrandIcon
-            provider={provider.provider}
-            label={provider.brandLabel ?? provider.label}
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-          <span>{provider.label}</span>
-          {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
-        </div>
-        <div className="truncate text-muted-foreground">
-          {detail || (provider.connected ? "Connected" : "Not connected")}
+      <div className="flex min-w-0 items-center gap-3">
+        <ProviderBrandIcon
+          provider={provider.provider}
+          label={provider.brandLabel ?? provider.label}
+          className="size-5 shrink-0 text-muted-foreground"
+        />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 font-medium text-foreground">
+            <span>{provider.label}</span>
+            {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
+          </div>
+          <div className="truncate text-muted-foreground">
+            {detail || (provider.connected ? "Connected" : "Not connected")}
+          </div>
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        <Badge tone={providerStatusTone(provider)} className="shrink-0">
+        <Badge tone="neutral" className="shrink-0">
           {statusLabel}
         </Badge>
         {rowActions.map((action, idx) => (
@@ -323,7 +324,7 @@ function ConnectedServiceRow({
       <div className="min-w-0 space-y-1">
         <div className="flex flex-wrap items-center gap-2 font-medium text-foreground">
           <span>{service.label}</span>
-          <Badge tone={service.tone ?? "neutral"} className="shrink-0">
+          <Badge tone="neutral" className="shrink-0">
             {service.statusLabel}
           </Badge>
         </div>
@@ -353,7 +354,7 @@ function AccountProfileHeader({
   profileSummary: string;
 }) {
   return (
-    <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
       <AccountAvatar
         key={avatarUrl ?? "account-avatar"}
         avatarUrl={avatarUrl}
@@ -393,19 +394,6 @@ function AccountAvatar({
       )}
     </div>
   );
-}
-
-function providerStatusTone(provider: AccountProviderView): "neutral" | "success" | "warning" | "destructive" {
-  if (!provider.connected) {
-    return "neutral";
-  }
-  if (provider.status === "expired") {
-    return "destructive";
-  }
-  if (provider.status === "needs_reauth") {
-    return "warning";
-  }
-  return "success";
 }
 
 function initialsForName(name: string): string {

--- a/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
+++ b/apps/packages/product-ui/src/account/AccountSettingsPane.tsx
@@ -1,14 +1,16 @@
 import { useState, type ReactNode } from "react";
 
-import { Badge } from "@proliferate/ui/primitives/Badge";
-import { Button } from "@proliferate/ui/primitives/Button";
-
 import { SettingsSection } from "../settings/SettingsSection";
 import {
   AccountPasswordCredentialRow,
   type AccountPasswordCredentialView,
 } from "./AccountPasswordCredentialCard";
-import { ProviderBrandIcon } from "../auth/ProviderBrandIcon";
+import {
+  AccountAction,
+  buildEffectiveProviders,
+  ConnectedServiceRow,
+  SignInMethodRow,
+} from "./AccountSignInMethods";
 
 export type {
   AccountPasswordCredentialSubmit,
@@ -151,191 +153,6 @@ export function AccountSettingsPane({
       {actions.signOut ? (
         <div className="flex">
           <AccountAction action={actions.signOut} variant="secondary" />
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Internal: build effective provider rows with their matched actions
-// ---------------------------------------------------------------------------
-
-interface ProviderRowData {
-  provider: AccountProviderView;
-  actions: AccountActionView[];
-}
-
-function buildEffectiveProviders(
-  providers: AccountProviderView[],
-  actions: AccountSettingsPaneProps["actions"],
-): ProviderRowData[] {
-  const rows: ProviderRowData[] = providers.map((provider) => ({
-    provider,
-    actions: getActionsForProvider(provider, actions),
-  }));
-
-  // Synthesize apple row if connectApple action exists but no apple provider row
-  const hasAppleRow = providers.some((p) => p.provider === "apple");
-  if (!hasAppleRow && actions.connectApple) {
-    rows.push({
-      provider: {
-        provider: "apple",
-        label: "Apple",
-        accountLabel: "Not connected",
-        connected: false,
-      },
-      actions: [actions.connectApple],
-    });
-  }
-
-  // Synthesize google row if connectGoogle action exists but no google provider row
-  const hasGoogleRow = providers.some((p) => p.provider === "google");
-  if (!hasGoogleRow && actions.connectGoogle) {
-    rows.push({
-      provider: {
-        provider: "google",
-        label: "Google",
-        accountLabel: "Not connected",
-        connected: false,
-      },
-      actions: [actions.connectGoogle],
-    });
-  }
-
-  return rows;
-}
-
-function getActionsForProvider(
-  provider: AccountProviderView,
-  actions: AccountSettingsPaneProps["actions"],
-): AccountActionView[] {
-  const result: AccountActionView[] = [];
-
-  if (provider.provider === "github") {
-    if (actions.connectGitHub) result.push(actions.connectGitHub);
-    if (actions.reconnectGitHub) result.push(actions.reconnectGitHub);
-  }
-
-  if (provider.provider === "google" && actions.connectGoogle && !provider.connected) {
-    result.push(actions.connectGoogle);
-  }
-
-  if (provider.provider === "apple" && actions.connectApple && !provider.connected) {
-    result.push(actions.connectApple);
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Internal components
-// ---------------------------------------------------------------------------
-
-function AccountAction({
-  action,
-  variant = "secondary",
-  size = "sm",
-}: {
-  action: AccountActionView;
-  variant?: "secondary" | "ghost";
-  size?: "sm" | "md";
-}) {
-  return (
-    <Button
-      type="button"
-      variant={variant}
-      size={size}
-      disabled={action.disabled}
-      loading={action.loading}
-      onClick={action.onClick}
-      className={action.destructive && variant === "ghost" ? "text-destructive hover:text-destructive" : ""}
-    >
-      {!action.loading && action.icon ? action.icon : null}
-      {action.label}
-    </Button>
-  );
-}
-
-function SignInMethodRow({
-  provider,
-  actions: rowActions,
-  githubLabel,
-}: {
-  provider: AccountProviderView;
-  actions: AccountActionView[];
-  githubLabel: string;
-}) {
-  const statusLabel = provider.connected
-    ? provider.status === "needs_reauth"
-      ? "Reconnect"
-      : provider.status === "expired"
-        ? "Expired"
-        : "Connected"
-    : "Not connected";
-
-  // Use githubLabel as detail fallback for GitHub row when no accountLabel
-  const detail = provider.provider === "github" && !provider.accountLabel
-    ? githubLabel
-    : provider.accountLabel;
-
-  return (
-    <div className="flex min-h-[3.5rem] flex-col gap-2 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 items-center gap-3">
-        <ProviderBrandIcon
-          provider={provider.provider}
-          label={provider.brandLabel ?? provider.label}
-          className="size-5 shrink-0 text-muted-foreground"
-        />
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 font-medium text-foreground">
-            <span>{provider.label}</span>
-            {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
-          </div>
-          <div className="truncate text-muted-foreground">
-            {detail || (provider.connected ? "Connected" : "Not connected")}
-          </div>
-        </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <Badge tone="neutral" className="shrink-0">
-          {statusLabel}
-        </Badge>
-        {rowActions.map((action, idx) => (
-          <AccountAction
-            key={idx}
-            action={action}
-            variant={idx === 0 ? "secondary" : "ghost"}
-            size="sm"
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ConnectedServiceRow({
-  service,
-}: {
-  service: AccountConnectedServiceView;
-}) {
-  return (
-    <div className="flex min-h-[3.5rem] flex-col gap-3 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0 space-y-1">
-        <div className="flex flex-wrap items-center gap-2 font-medium text-foreground">
-          <span>{service.label}</span>
-          <Badge tone="neutral" className="shrink-0">
-            {service.statusLabel}
-          </Badge>
-        </div>
-        <div className="text-muted-foreground">{service.description}</div>
-        {service.accountLabel ? (
-          <div className="truncate text-muted-foreground">{service.accountLabel}</div>
-        ) : null}
-      </div>
-      {service.action ? (
-        <div className="shrink-0">
-          <AccountAction action={service.action} variant="secondary" />
         </div>
       ) : null}
     </div>

--- a/apps/packages/product-ui/src/account/AccountSignInMethods.tsx
+++ b/apps/packages/product-ui/src/account/AccountSignInMethods.tsx
@@ -1,0 +1,195 @@
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+
+import { ProviderBrandIcon } from "../auth/ProviderBrandIcon";
+import type {
+  AccountActionView,
+  AccountConnectedServiceView,
+  AccountProviderView,
+  AccountSettingsPaneProps,
+} from "./AccountSettingsPane";
+
+// ---------------------------------------------------------------------------
+// Build effective provider rows with their matched actions
+// ---------------------------------------------------------------------------
+
+export interface ProviderRowData {
+  provider: AccountProviderView;
+  actions: AccountActionView[];
+}
+
+export function buildEffectiveProviders(
+  providers: AccountProviderView[],
+  actions: AccountSettingsPaneProps["actions"],
+): ProviderRowData[] {
+  const rows: ProviderRowData[] = providers.map((provider) => ({
+    provider,
+    actions: getActionsForProvider(provider, actions),
+  }));
+
+  // Synthesize apple row if connectApple action exists but no apple provider row
+  const hasAppleRow = providers.some((p) => p.provider === "apple");
+  if (!hasAppleRow && actions.connectApple) {
+    rows.push({
+      provider: {
+        provider: "apple",
+        label: "Apple",
+        accountLabel: "Not connected",
+        connected: false,
+      },
+      actions: [actions.connectApple],
+    });
+  }
+
+  // Synthesize google row if connectGoogle action exists but no google provider row
+  const hasGoogleRow = providers.some((p) => p.provider === "google");
+  if (!hasGoogleRow && actions.connectGoogle) {
+    rows.push({
+      provider: {
+        provider: "google",
+        label: "Google",
+        accountLabel: "Not connected",
+        connected: false,
+      },
+      actions: [actions.connectGoogle],
+    });
+  }
+
+  return rows;
+}
+
+function getActionsForProvider(
+  provider: AccountProviderView,
+  actions: AccountSettingsPaneProps["actions"],
+): AccountActionView[] {
+  const result: AccountActionView[] = [];
+
+  if (provider.provider === "github") {
+    if (actions.connectGitHub) result.push(actions.connectGitHub);
+    if (actions.reconnectGitHub) result.push(actions.reconnectGitHub);
+  }
+
+  if (provider.provider === "google" && actions.connectGoogle && !provider.connected) {
+    result.push(actions.connectGoogle);
+  }
+
+  if (provider.provider === "apple" && actions.connectApple && !provider.connected) {
+    result.push(actions.connectApple);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+export function AccountAction({
+  action,
+  variant = "secondary",
+  size = "sm",
+}: {
+  action: AccountActionView;
+  variant?: "secondary" | "ghost";
+  size?: "sm" | "md";
+}) {
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      disabled={action.disabled}
+      loading={action.loading}
+      onClick={action.onClick}
+      className={action.destructive && variant === "ghost" ? "text-destructive hover:text-destructive" : ""}
+    >
+      {!action.loading && action.icon ? action.icon : null}
+      {action.label}
+    </Button>
+  );
+}
+
+export function SignInMethodRow({
+  provider,
+  actions: rowActions,
+  githubLabel,
+}: {
+  provider: AccountProviderView;
+  actions: AccountActionView[];
+  githubLabel: string;
+}) {
+  const statusLabel = provider.connected
+    ? provider.status === "needs_reauth"
+      ? "Reconnect"
+      : provider.status === "expired"
+        ? "Expired"
+        : "Connected"
+    : "Not connected";
+
+  // Use githubLabel as detail fallback for GitHub row when no accountLabel
+  const detail = provider.provider === "github" && !provider.accountLabel
+    ? githubLabel
+    : provider.accountLabel;
+
+  return (
+    <div className="flex min-h-[3.5rem] flex-col gap-2 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 items-center gap-3">
+        <ProviderBrandIcon
+          provider={provider.provider}
+          label={provider.brandLabel ?? provider.label}
+          className="size-5 shrink-0 text-muted-foreground"
+        />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 font-medium text-foreground">
+            <span>{provider.label}</span>
+            {provider.primary && provider.connected ? <Badge tone="neutral">Primary</Badge> : null}
+          </div>
+          <div className="truncate text-muted-foreground">
+            {detail || (provider.connected ? "Connected" : "Not connected")}
+          </div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge tone="neutral" className="shrink-0">
+          {statusLabel}
+        </Badge>
+        {rowActions.map((action, idx) => (
+          <AccountAction
+            key={idx}
+            action={action}
+            variant={idx === 0 ? "secondary" : "ghost"}
+            size="sm"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ConnectedServiceRow({
+  service,
+}: {
+  service: AccountConnectedServiceView;
+}) {
+  return (
+    <div className="flex min-h-[3.5rem] flex-col gap-3 border-b border-border-light px-3.5 py-3.5 text-sm last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2 font-medium text-foreground">
+          <span>{service.label}</span>
+          <Badge tone="neutral" className="shrink-0">
+            {service.statusLabel}
+          </Badge>
+        </div>
+        <div className="text-muted-foreground">{service.description}</div>
+        {service.accountLabel ? (
+          <div className="truncate text-muted-foreground">{service.accountLabel}</div>
+        ) : null}
+      </div>
+      {service.action ? (
+        <div className="shrink-0">
+          <AccountAction action={service.action} variant="secondary" />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/packages/product-ui/test/AccountSettingsPane.test.tsx
+++ b/apps/packages/product-ui/test/AccountSettingsPane.test.tsx
@@ -161,7 +161,7 @@ describe("AccountSettingsPane", () => {
       />,
     );
 
-    expect(screen.getByText("Email/password")).toBeTruthy();
+    expect(screen.getByText("Email & password")).toBeTruthy();
     expect(screen.getByText("Not set")).toBeTruthy();
     fireEvent.click(screen.getByText("Set password"));
     fireEvent.change(screen.getByLabelText("New password"), {


### PR DESCRIPTION
## Account settings

Rebuilt the information architecture of the shared `AccountSettingsPane` (desktop + web, no prop-API or consumer changes):

- **Profile header** simplified — name → email → summary, no key-value grid, no wrapper padding.
- **One "Sign-in methods" card** replacing the old button-wad "Account access" section + separate "Connected providers" list. GitHub / Google / SSO / Email & password each render as a media-object row (icon column + left-aligned title/description) carrying their own status badge and action.
- **Email & password** folded in as a row with an inline expand-in-place form.
- **Badges neutralized** — same tone across all states; removed the dead `providerStatusTone` helper.
- Dropped the "Manage access" action from the GitHub row (prop still accepted for compat).
- **Sign out** is a single bordered button at the bottom-left.

## Appearance

- Preview moved to the end as a titled `SettingsSection`, replacing the `FileDiffCard`/`DiffViewer` + "Preview"/"Git diff" micro-header with a clean line-numbered `HighlightedCodeBlock` that live-reflects the mode + code-font-size settings.

## Verification

- `pnpm --filter "@proliferate/product-ui" build` clean.
- 155/155 product-ui tests pass.
- Exercised in the running desktop app (signed-in GitHub state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)