### PR TITLE
fix(catalog): gateway enrichment join — normalizer gaps + cross-harness identity fallback

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
@@ -122,12 +122,24 @@ fn resolve_catalog_match<'a>(
         })
 }
 
-/// Enrich a resolved gateway model id by joining the bundled catalog row.
-/// Catalog-known → full object; probe-only → `{ id, provider? }`.
-fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModelEntry {
+/// Enrich a resolved gateway model id by joining the bundled catalog row(s).
+///
+/// - `own_match`: from the requesting harness's own catalog — contributes FULL
+///   enrichment (identity + behavioral controls: effort, modes, fast_mode, status).
+/// - `foreign_match`: from any other harness's catalog (cross-harness fallback) —
+///   contributes IDENTITY ONLY (displayName + description). Behavioral controls
+///   are harness-specific (e.g. codex users should not see claude-CLI thinking
+///   controls) so they are never bridged from a foreign harness.
+/// - Neither: probe-only sparse row `{ id, provider? }`.
+fn enrich_model(
+    id: String,
+    own_match: Option<&AgentCatalogModel>,
+    foreign_match: Option<&AgentCatalogModel>,
+) -> GatewayModelEntry {
     let provider = provider_for_model(&id).map(str::to_string);
-    match catalog {
-        Some(model) => GatewayModelEntry {
+    if let Some(model) = own_match {
+        // Full enrichment from own-harness catalog.
+        GatewayModelEntry {
             id,
             display_name: Some(model.display_name.clone()),
             description: model.description.clone(),
@@ -136,8 +148,22 @@ fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModel
             effort: model_effort(model),
             fast_mode: Some(model.controls.contains_key("fast_mode")),
             modes: model_modes(model),
-        },
-        None => GatewayModelEntry {
+        }
+    } else if let Some(model) = foreign_match {
+        // Identity-only enrichment from foreign-harness catalog.
+        GatewayModelEntry {
+            id,
+            display_name: Some(model.display_name.clone()),
+            description: model.description.clone(),
+            provider,
+            status: None,
+            effort: None,
+            fast_mode: None,
+            modes: None,
+        }
+    } else {
+        // Probe-only: no catalog entry anywhere.
+        GatewayModelEntry {
             id,
             display_name: None,
             description: None,
@@ -146,7 +172,7 @@ fn enrich_model(id: String, catalog: Option<&AgentCatalogModel>) -> GatewayModel
             effort: None,
             fast_mode: None,
             modes: None,
-        },
+        }
     }
 }
 
@@ -205,12 +231,18 @@ pub async fn get_gateway_models(
         GatewayModelSource::Probe { probed_at } => ("probe".to_string(), Some(probed_at)),
     };
     let catalog_models = state.gateway_model_resolver.catalog_models(&kind);
+    let all_catalog_models = state.gateway_model_resolver.catalog_models_all();
     let models = plan
         .models
         .into_iter()
         .map(|id| {
-            let catalog = resolve_catalog_match(&id, &catalog_models);
-            enrich_model(id, catalog)
+            let own_match = resolve_catalog_match(&id, &catalog_models);
+            let foreign_match = if own_match.is_none() {
+                resolve_catalog_match(&id, &all_catalog_models)
+            } else {
+                None
+            };
+            enrich_model(id, own_match, foreign_match)
         })
         .collect();
     Ok(Json(GatewayModelsResponse {
@@ -357,7 +389,7 @@ mod tests {
     #[test]
     fn catalog_known_model_is_fully_enriched() {
         let model = catalog_model("claude-sonnet-4-5");
-        let entry = enrich_model("claude-sonnet-4-5".to_string(), Some(&model));
+        let entry = enrich_model("claude-sonnet-4-5".to_string(), Some(&model), None);
 
         assert_eq!(entry.id, "claude-sonnet-4-5");
         assert_eq!(entry.display_name.as_deref(), Some("Claude Sonnet 4.5"));
@@ -382,7 +414,7 @@ mod tests {
     fn model_without_effort_or_fast_mode_omits_them() {
         let mut model = catalog_model("claude-sonnet-4-5");
         model.controls.clear();
-        let entry = enrich_model("claude-sonnet-4-5".to_string(), Some(&model));
+        let entry = enrich_model("claude-sonnet-4-5".to_string(), Some(&model), None);
 
         assert!(entry.effort.is_none());
         assert_eq!(entry.fast_mode, Some(false));
@@ -395,7 +427,7 @@ mod tests {
     #[test]
     fn probe_only_matched_id_is_sparse_with_provider() {
         // Not in the catalog (proxy serves it, catalog doesn't know it).
-        let entry = enrich_model("claude-future-9".to_string(), None);
+        let entry = enrich_model("claude-future-9".to_string(), None, None);
 
         assert_eq!(entry.id, "claude-future-9");
         assert_eq!(entry.provider.as_deref(), Some("anthropic"));
@@ -408,7 +440,7 @@ mod tests {
 
     #[test]
     fn probe_only_unmatched_id_omits_provider() {
-        let entry = enrich_model("mystery-model".to_string(), None);
+        let entry = enrich_model("mystery-model".to_string(), None, None);
 
         assert_eq!(entry.id, "mystery-model");
         assert!(entry.provider.is_none());
@@ -501,7 +533,7 @@ mod tests {
         assert_eq!(effort.default.as_deref(), Some("medium"));
 
         // Also test enrichment via enrich_model
-        let entry = enrich_model("codex-model".to_string(), Some(&model));
+        let entry = enrich_model("codex-model".to_string(), Some(&model), None);
         assert!(entry.effort.is_some());
         assert_eq!(entry.effort.unwrap().values, vec!["low", "medium", "high", "xhigh"]);
     }
@@ -513,5 +545,88 @@ mod tests {
         let effort = model_effort(&model).expect("effort should be present");
         assert_eq!(effort.values, vec!["low", "medium", "high"]);
         assert_eq!(effort.default.as_deref(), Some("medium"));
+    }
+
+    // --- Cross-harness fallback enrichment (identity-only from foreign harness) ---
+
+    #[test]
+    fn foreign_match_yields_identity_only() {
+        // Simulates: codex requesting `claude-sonnet-4-5`; own catalog has no
+        // match, but the opencode catalog has `anthropic/claude-sonnet-4-5`.
+        let foreign_model = catalog_model("anthropic/claude-sonnet-4-5");
+        let entry = enrich_model(
+            "claude-sonnet-4-5".to_string(),
+            None,
+            Some(&foreign_model),
+        );
+
+        // Identity fields bridged.
+        assert_eq!(entry.display_name.as_deref(), Some("Claude Sonnet 4.5"));
+        assert_eq!(entry.description.as_deref(), Some("Balanced coding model"));
+        assert_eq!(entry.provider.as_deref(), Some("anthropic"));
+        // Behavioral controls NOT bridged (harness-specific).
+        assert!(entry.status.is_none());
+        assert!(entry.effort.is_none());
+        assert!(entry.fast_mode.is_none());
+        assert!(entry.modes.is_none());
+    }
+
+    #[test]
+    fn own_match_takes_priority_over_foreign() {
+        // When both own and foreign match, own wins with full enrichment.
+        let own_model = catalog_model("claude-sonnet-4-5");
+        let foreign_model = catalog_model("anthropic/claude-sonnet-4-5");
+        let entry = enrich_model(
+            "claude-sonnet-4-5".to_string(),
+            Some(&own_model),
+            Some(&foreign_model),
+        );
+
+        // Full enrichment from own (status, effort, modes present).
+        assert!(entry.status.is_some());
+        assert!(entry.effort.is_some());
+        assert_eq!(entry.fast_mode, Some(true));
+        assert!(entry.modes.is_some());
+    }
+
+    #[test]
+    fn no_match_anywhere_stays_sparse() {
+        let entry = enrich_model("totally-unknown-model".to_string(), None, None);
+
+        assert_eq!(entry.id, "totally-unknown-model");
+        assert!(entry.display_name.is_none());
+        assert!(entry.description.is_none());
+        assert!(entry.provider.is_none());
+        assert!(entry.status.is_none());
+        assert!(entry.effort.is_none());
+        assert!(entry.fast_mode.is_none());
+        assert!(entry.modes.is_none());
+    }
+
+    #[test]
+    fn codex_requesting_claude_bridges_via_opencode_catalog_entry() {
+        // The real scenario: codex harness requests `claude-sonnet-4-5` via
+        // gateway; codex's own catalog doesn't know it, but opencode's catalog
+        // has `anthropic/claude-sonnet-4-5`. The normalizer strips the provider
+        // prefix, enabling the family-key bridge.
+        let opencode_catalog = vec![catalog_model("anthropic/claude-sonnet-4-5")];
+        let codex_catalog: Vec<AgentCatalogModel> = vec![];
+
+        // Own-harness miss.
+        let own = resolve_catalog_match("claude-sonnet-4-5", &codex_catalog);
+        assert!(own.is_none());
+
+        // Foreign-harness hit (family key: both normalize to `claude-sonnet-4-5`).
+        let foreign = resolve_catalog_match("claude-sonnet-4-5", &opencode_catalog);
+        assert!(foreign.is_some());
+        assert_eq!(foreign.unwrap().id, "anthropic/claude-sonnet-4-5");
+
+        // Enrichment is identity-only.
+        let entry = enrich_model("claude-sonnet-4-5".to_string(), own, foreign);
+        assert_eq!(entry.display_name.as_deref(), Some("Claude Sonnet 4.5"));
+        assert!(entry.status.is_none());
+        assert!(entry.effort.is_none());
+        assert!(entry.fast_mode.is_none());
+        assert!(entry.modes.is_none());
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
@@ -82,6 +82,12 @@ pub fn provider_for_model(model_id: &str) -> Option<&'static str> {
 /// family — so they stay unbridged by design (no guessy displayName matching).
 pub fn normalize_model_family(model_id: &str) -> String {
     let mut s = model_id.trim();
+    // (a) Strip a leading models.dev-style provider prefix (e.g.
+    // `anthropic/claude-sonnet-4-5` → `claude-sonnet-4-5`). Must run BEFORE
+    // the us.anthropic./global.anthropic. prefix handling.
+    if let Some(slash_idx) = s.find('/') {
+        s = &s[slash_idx + 1..];
+    }
     for prefix in ["us.anthropic.", "global.anthropic."] {
         if let Some(rest) = s.strip_prefix(prefix) {
             s = rest;
@@ -97,30 +103,70 @@ pub fn normalize_model_family(model_id: &str) -> String {
     s
 }
 
-/// Strip a trailing bedrock `-vN:M` version suffix (e.g. `-v1:0`). A bare `-vN`
-/// (no colon) is left intact — the catalog uses `claude-opus-4-6-v1` as a
-/// distinct family from `claude-opus-4-6`.
+/// Strip a trailing bedrock version suffix. Handles two forms:
+/// - `-vN:M` (e.g. `-v1:0`) — the classic Bedrock versioned id.
+/// - bare `-N:M` (e.g. `-1:0`, no `v`) — newer Bedrock ids like
+///   `openai.gpt-oss-120b-1:0`.
+/// A bare `-vN` (no colon) is left intact — the catalog uses
+/// `claude-opus-4-6-v1` as a distinct family from `claude-opus-4-6`.
 fn strip_bedrock_version_suffix(s: &str) -> String {
-    let Some(idx) = s.rfind("-v") else {
-        return s.to_string();
-    };
-    let tail = &s[idx + 2..];
-    let Some((n, m)) = tail.split_once(':') else {
-        return s.to_string();
-    };
-    if !n.is_empty()
-        && n.bytes().all(|b| b.is_ascii_digit())
-        && !m.is_empty()
-        && m.bytes().all(|b| b.is_ascii_digit())
-    {
-        s[..idx].to_string()
-    } else {
-        s.to_string()
+    // Try `-vN:M` first (colon-bearing with v).
+    if let Some(idx) = s.rfind("-v") {
+        let tail = &s[idx + 2..];
+        if let Some((n, m)) = tail.split_once(':') {
+            if !n.is_empty()
+                && n.bytes().all(|b| b.is_ascii_digit())
+                && !m.is_empty()
+                && m.bytes().all(|b| b.is_ascii_digit())
+            {
+                return s[..idx].to_string();
+            }
+        }
     }
+    // Try bare `-N:M` (no `v`, dash + digits + colon + digits at end).
+    if let Some(colon_idx) = s.rfind(':') {
+        let after_colon = &s[colon_idx + 1..];
+        if !after_colon.is_empty() && after_colon.bytes().all(|b| b.is_ascii_digit()) {
+            // Walk backwards from the colon to find the dash that starts `-N:M`.
+            let before_colon = &s[..colon_idx];
+            if let Some(dash_idx) = before_colon.rfind('-') {
+                let n_part = &before_colon[dash_idx + 1..];
+                if !n_part.is_empty()
+                    && n_part.bytes().all(|b| b.is_ascii_digit())
+                    // Ensure this isn't a `-vN:M` that we already checked (the
+                    // char before the digits after the dash would be 'v').
+                    && !before_colon[..dash_idx + 1].ends_with("-v")
+                {
+                    return s[..dash_idx].to_string();
+                }
+            }
+        }
+    }
+    s.to_string()
 }
 
-/// Strip a trailing `-YYYYMMDD` release date (dash + exactly 8 ASCII digits).
+/// Strip a trailing release date suffix. Handles two forms (checked in order):
+/// - ISO-8601 `-YYYY-MM-DD` (e.g. `-2025-12-11`) — three dash-separated groups.
+/// - Compact `-YYYYMMDD` (e.g. `-20250929`) — dash + exactly 8 ASCII digits.
 fn strip_release_date_suffix(s: &str) -> String {
+    // Try ISO-8601 form first: `-YYYY-MM-DD` (4+2+2 digits with dashes).
+    // Look for the pattern by finding a suffix that matches `-\d{4}-\d{2}-\d{2}`.
+    if s.len() >= 11 {
+        let candidate = &s[s.len() - 10..]; // "YYYY-MM-DD"
+        if candidate.as_bytes()[4] == b'-'
+            && candidate.as_bytes()[7] == b'-'
+            && candidate[..4].bytes().all(|b| b.is_ascii_digit())
+            && candidate[5..7].bytes().all(|b| b.is_ascii_digit())
+            && candidate[8..10].bytes().all(|b| b.is_ascii_digit())
+        {
+            // Verify the character before the date is a dash.
+            let prefix = &s[..s.len() - 10];
+            if prefix.ends_with('-') && prefix.len() > 1 {
+                return prefix[..prefix.len() - 1].to_string();
+            }
+        }
+    }
+    // Compact form: `-YYYYMMDD` (dash + exactly 8 ASCII digits).
     let Some(idx) = s.rfind('-') else {
         return s.to_string();
     };
@@ -189,6 +235,21 @@ impl GatewayModelResolver {
             .find(|agent| agent.kind == harness_kind)
             .map(|agent| agent.session.models.clone())
             .unwrap_or_default()
+    }
+
+    /// All agents' model rows across the entire catalog document (union of
+    /// every harness's `session.models`). Used for the cross-harness fallback
+    /// enrichment join — gateway model IDENTITY is provider-truth, so when the
+    /// own-harness catalog misses, any other harness's catalog entry can supply
+    /// displayName/description (identity-only enrichment).
+    pub fn catalog_models_all(&self) -> Vec<AgentCatalogModel> {
+        self.catalog_sync
+            .active()
+            .document
+            .agents
+            .iter()
+            .flat_map(|agent| agent.session.models.clone())
+            .collect()
     }
 
     /// The catalog's gateway policy + default model for a harness, if the
@@ -516,5 +577,128 @@ mod tests {
             normalize_model_family("claude-opus-4-8-20260101"),
             normalize_model_family("us.anthropic.claude-opus-4-8[1m]")
         );
+    }
+
+    // --- (a) Provider-prefix stripping (models.dev style `provider/model`) ---
+
+    #[test]
+    fn strip_provider_prefix_anthropic() {
+        assert_eq!(
+            normalize_model_family("anthropic/claude-sonnet-4-5"),
+            "claude-sonnet-4-5"
+        );
+        // Bridges to the plain gateway id.
+        assert_eq!(
+            normalize_model_family("anthropic/claude-sonnet-4-5"),
+            normalize_model_family("claude-sonnet-4-5")
+        );
+    }
+
+    #[test]
+    fn strip_provider_prefix_openai() {
+        assert_eq!(
+            normalize_model_family("openai/gpt-5.2"),
+            "gpt-5.2"
+        );
+        assert_eq!(
+            normalize_model_family("openai/gpt-5.2"),
+            normalize_model_family("gpt-5.2")
+        );
+    }
+
+    #[test]
+    fn strip_provider_prefix_combined_with_date() {
+        // `anthropic/claude-sonnet-4-5-20250929` should strip both the prefix
+        // and the trailing date.
+        assert_eq!(
+            normalize_model_family("anthropic/claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5"
+        );
+    }
+
+    #[test]
+    fn provider_prefix_does_not_affect_dotted_vendor() {
+        // If the id has BOTH a slash AND us.anthropic., the slash strips first,
+        // leaving the us.anthropic. prefix for the next step.
+        assert_eq!(
+            normalize_model_family("bedrock/us.anthropic.claude-opus-4-8[1m]"),
+            "claude-opus-4-8"
+        );
+    }
+
+    // --- (b) ISO-8601 date stripping (`-YYYY-MM-DD`) ---
+
+    #[test]
+    fn strip_iso_date_suffix() {
+        assert_eq!(
+            normalize_model_family("gpt-5.2-2025-12-11"),
+            "gpt-5.2"
+        );
+        assert_eq!(
+            normalize_model_family("gpt-5-mini-2025-08-07"),
+            "gpt-5-mini"
+        );
+    }
+
+    #[test]
+    fn iso_date_bridges_to_bare_id() {
+        assert_eq!(
+            normalize_model_family("gpt-5.2-2025-12-11"),
+            normalize_model_family("gpt-5.2")
+        );
+    }
+
+    #[test]
+    fn compact_date_still_works() {
+        // Regression: existing compact date stripping preserved.
+        assert_eq!(
+            normalize_model_family("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5"
+        );
+    }
+
+    // --- (c) Bare bedrock version `-N:M` (no `v`) ---
+
+    #[test]
+    fn strip_bare_bedrock_version_no_v() {
+        assert_eq!(
+            normalize_model_family("openai.gpt-oss-120b-1:0"),
+            "openai.gpt-oss-120b"
+        );
+    }
+
+    #[test]
+    fn bare_bedrock_version_bridges() {
+        assert_eq!(
+            normalize_model_family("openai.gpt-oss-120b-1:0"),
+            normalize_model_family("openai.gpt-oss-120b")
+        );
+    }
+
+    #[test]
+    fn dash_v_colon_still_stripped() {
+        // Regression: `-vN:M` form still works.
+        assert_eq!(
+            normalize_model_family("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+            "claude-haiku-4-5"
+        );
+    }
+
+    #[test]
+    fn bare_dash_v_still_not_stripped() {
+        // Regression: bare `-vN` (no colon) stays as a distinct family.
+        assert_eq!(
+            normalize_model_family("claude-opus-4-6-v1"),
+            "claude-opus-4-6-v1"
+        );
+    }
+
+    #[test]
+    fn selectors_normalize_to_themselves() {
+        // Regression: pure CLI selectors.
+        assert_eq!(normalize_model_family("sonnet"), "sonnet");
+        assert_eq!(normalize_model_family("haiku"), "haiku");
+        assert_eq!(normalize_model_family("opus"), "opus");
+        assert_eq!(normalize_model_family("default"), "default");
     }
 }


### PR DESCRIPTION
## What

The gateway All-Models table rendered most rows sparse (no displayName/thinking/modes) — on codex, everything except gpt-5.2. Validated per-harness end-to-end (5-agent trace); three real gaps, no merge regression:

1. **Join was harness-scoped, but gateway model identity is provider-truth.** Codex's catalog carries zero Claude entries, so every anthropic id the gateway serves to codex had nothing to join against. Same for grok (xai-native catalog) and opencode (`anthropic/`-prefixed ids).
2. **`normalize_model_family` gaps:** ISO dates (`gpt-5.2-2025-12-11` — only `-YYYYMMDD` stripped), bare bedrock versions (`openai.gpt-oss-120b-1:0` — only `-vN:M` stripped), `provider/` prefixes (`anthropic/claude-sonnet-4-5`).
3. #926 generation drift (config.yaml serves claude 4-5-gen API ids, claude catalog carries 4-6/4-7/4-8 bedrock gens) — mooted for display by the fallback join below; config/catalog realignment tracked separately.

## Fix

- **Normalizer:** strip `provider/` prefix (first), ISO `-YYYY-MM-DD` dates, bare `-N:M` bedrock versions. All existing invariants pinned by tests (bare `-v1` stays distinct, `[1m]`, `-vN:M`, compact dates, selectors unbridged).
- **Cross-harness fallback join:** own-harness match keeps full enrichment; when it misses, search the union of all harnesses' catalog models — but a foreign match enriches **identity only** (displayName + description). Behavioral fields (effort/modes/fastMode/status) stay `None` because they encode harness-specific behavior; showing codex users claude-CLI thinking controls would be wrong.

## Tests

12 new normalizer cases + 4 join cases (incl. codex→`claude-sonnet-4-5` bridging via an `anthropic/…` entry, identity-only). 909/909 anyharness-lib green, clippy no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)