### PR TITLE
fix(catalog): codex gateway policy — openai only, gpt-5.2 default

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -37,7 +37,7 @@ impl GatewayModelResolve for HarnessPlanResolver {
                 ..Default::default()
             },
             "codex" => GatewayModelPlan {
-                default_model: Some("claude-sonnet-4-5-20250929".to_string()),
+                default_model: Some("gpt-5.2".to_string()),
                 ..Default::default()
             },
             "opencode" => GatewayModelPlan {
@@ -186,7 +186,7 @@ fn codex_gateway_materializes_config_toml_and_sets_env() {
     // Explicit default model line: codex otherwise falls back to a codex-native
     // model id the gateway cannot serve (HARNESS-MATRIX codex recipe).
     assert!(
-        config.contains("model = \"claude-sonnet-4-5-20250929\""),
+        config.contains("model = \"gpt-5.2\""),
         "config.toml must pin a gateway-served default model, got:\n{config}"
     );
     assert!(config.contains("base_url = \"https://llm.proliferate.ai/v1\""));

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1431,7 +1431,7 @@
           "openai-api": "gpt-5.5",
           "openai-oauth": "gpt-5.5",
           "bedrock": "openai.gpt-5.5",
-          "gateway": "claude-sonnet-4-5-20250929"
+          "gateway": "gpt-5.2"
         },
         "observedDefaults": {
           "bedrock": "openai.gpt-oss-120b",
@@ -1440,7 +1440,6 @@
         },
         "gatewayPolicy": {
           "providers": [
-            "anthropic",
             "openai"
           ]
         }

--- a/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
+++ b/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
@@ -43,8 +43,8 @@ grok-build, grok-code-fast-1`. Compared against each agent's
   claude-haiku-4-5-20251001]` — all 4 present in the live list. **Match.**
 - **claude**: `gatewayPolicy` = `{providers:[anthropic], roles.small_fast:
   claude-haiku-4-5-20251001}` — model present. **Match.**
-- **codex**: `gatewayPolicy` = `{providers:[anthropic, openai]}` — both
-  providers represented in `model_list`. **Match.**
+- **codex**: `gatewayPolicy` = `{providers:[openai]}` — provider
+  represented in `model_list`. **Match.**
 - **grok**: `gatewayPolicy` = `{}` (deliberately empty). **Finding, not a
   mismatch:** grok is the one harness whose gatewayPolicy carries no
   `seedModels`/model ids to diff against the live list, because the CLI


### PR DESCRIPTION
## What

Product decision (Pablo, 2026-07-07): codex's gateway model list should carry **OpenAI models only** — no anthropic models in codex's picker via the gateway.

Two fields change together (codex render errors at launch if the plan has no default model, and the provider filter would drop a claude default):
- `gatewayPolicy.providers`: `["anthropic", "openai"]` → `["openai"]`
- `defaults.gateway`: `"claude-sonnet-4-5-20250929"` → `"gpt-5.2"` (served by the gateway config)

Also updates the HARNESS-MATRIX smoke doc line and the two Rust tests that hardcoded the old default (`render_tests.rs` plan resolver + config.toml assertion).

catalogVersion unchanged per recent catalog-edit precedent (7272578c3 et al.).

## Gates

- JS validator: OK (5 agents)
- `cargo test -p anyharness-lib --lib`: 893 passed, 0 failed
- Runtime is `include_str!`-bundled — deploys pick this up on next binary/catalog-convergence push

🤖 Generated with [Claude Code](https://claude.com/claude-code)