### PR TITLE
fix(auth): reject unknown fields on PATCH /users/me + allowlist gateway line growth

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4790,6 +4790,8 @@ export interface components {
          *     ``outreach_email`` is an optional override address for support/outreach
          *     follow-up. Sending ``null`` or an empty/whitespace string clears it (falls
          *     back to the account email); any other value must look like an email.
+         *     Unknown fields are rejected (422) so credential fields like ``password``
+         *     can never ride through this endpoint.
          */
         ProfileUpdateRequest: {
             /** Outreach Email */
@@ -5531,6 +5533,8 @@ export interface components {
             worker?: string | null;
             /** Anyharness */
             anyharness: string;
+            /** Catalogversion */
+            catalogVersion?: string | null;
         };
         /** WorkerEnrollRequest */
         WorkerEnrollRequest: {

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -10,7 +10,9 @@
 anyharness/crates/anyharness-contract/src/v1/events.rs 1129 existing AnyHarness contract oversized file
 anyharness/crates/anyharness-contract/src/v1/sessions.rs 787 existing AnyHarness contract oversized file
 anyharness/crates/anyharness-lib/src/api/openapi.rs 874 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1)
-anyharness/crates/anyharness-lib/src/api/router_tests.rs 1277 existing AnyHarness oversized test file (+hosting PR-status route tests)
+anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarness oversized test file (+hosting PR-status route tests, +catalog version + enrichment tests)
+anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
+anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1895 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1520 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file
@@ -37,13 +39,13 @@ server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read 
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
 server/tests/integration/test_agent_gateway_store.py 673 P1 auth rebuild rewrote store coverage for titled-key + agent_auth_selection model
-server/tests/integration/test_auth_flow.py 2118 existing server oversized integration test plus session-token-revocation coverage
+server/tests/integration/test_auth_flow.py 2130 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test
 apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx 492 existing markdown transcript renderer pending split
 apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pending split
-anyharness/crates/anyharness-lib/src/api/router.rs 606 AnyHarness router (+goals/loops/activity/feed routes)
+anyharness/crates/anyharness-lib/src/api/router.rs 610 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route)
 anyharness/crates/anyharness-lib/src/app/mod.rs 608 AnyHarness app wiring (+goal/loop/activity/feed services)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 861 loops runtime — native write path + emulated Codex scheduler
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 739 session startup (+goal/loop capability parsing, roster reconcile-on-attach)

--- a/server/proliferate/auth/profile_api.py
+++ b/server/proliferate/auth/profile_api.py
@@ -22,9 +22,11 @@ class ProfileUpdateRequest(BaseModel):
     ``outreach_email`` is an optional override address for support/outreach
     follow-up. Sending ``null`` or an empty/whitespace string clears it (falls
     back to the account email); any other value must look like an email.
+    Unknown fields are rejected (422) so credential fields like ``password``
+    can never ride through this endpoint.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     outreach_email: str | None = None
 

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -480,7 +480,19 @@ class TestPasswordAuthFlow:
             headers={"Authorization": f"Bearer {token}"},
             json={"password": "short"},
         )
-        assert bypass.status_code == 405
+        assert bypass.status_code == 422
+
+        # Prove the password was not changed.
+        original_login = await client.post(
+            "/auth/mobile/password/login",
+            json={"email": "users-me-password@example.com", "password": self.password},
+        )
+        assert original_login.status_code == 200
+        short_login = await client.post(
+            "/auth/mobile/password/login",
+            json={"email": "users-me-password@example.com", "password": "short"},
+        )
+        assert short_login.status_code == 401
 
     @pytest.mark.asyncio
     async def test_password_login_throttles_repeated_failures(


### PR DESCRIPTION
## Summary
- Add `extra="forbid"` to `ProfileUpdateRequest` so unknown fields (like `password`) are rejected with 422 instead of silently ignored
- Update `test_users_me_is_read_only_for_password_changes` to expect 422 (was 405 before #972 added PATCH support) and verify password wasn't changed via re-login attempts
- Regenerate cloud SDK openapi.ts (picks up docstring update + catalogVersion field)
- Update max_lines_allowlist.txt with 5 entries: router.rs (606→610), router_tests.rs (1277→1364), agent_gateway_catalog.rs (632), gateway_resolver.rs (704), test_auth_flow.py (2118→2130)

## Context
PR #972 added PATCH /users/me for outreach_email, which made the password read-only test stale (it expected 405 "method not allowed" but now gets 200). This exposed that unknown fields were silently ignored — a security gap where credential fields could potentially ride through. The `extra="forbid"` config closes this.

This unblocks the nightly release train's release-server/test job, which currently fails on main due to the stale 405 assertion.

## Test plan
- [x] `cd server && DEBUG=1 uv run pytest tests/integration/test_auth_flow.py -q` — all 64 tests pass
- [x] `python3 scripts/check_max_lines.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)