### PR TITLE
feat(composer): rework command palette, slash command UX, and add-repo flow

### DIFF
--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -321,7 +321,7 @@ export function ChatInput({
   return (
     <DebugProfiler id="chat-composer">
       <div className="relative">
-        <div ref={setComposerOverlayHost} className="relative z-20 flex flex-col px-5" />
+        <div ref={setComposerOverlayHost} className="relative z-20 flex flex-col" />
         <ChatComposerSurface
           overflowMode="clip"
           onClick={handleComposerSurfaceClick}

--- a/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -71,6 +71,9 @@ export function ComposerLeadingControls({
     && deriveGoalBarState(sessionGoal.goal).kind !== "live";
 
   const effortControl = controlGroups.modelConfigControls.find((c) => c.key === "effort") ?? null;
+  const fastModeControl = controlGroups.modelConfigControls.find(
+    (c) => c.key === "fast_mode" && c.kind === "toggle",
+  ) ?? null;
 
   return (
     <>
@@ -82,6 +85,18 @@ export function ComposerLeadingControls({
       >
         <ComposerModelSelectorControl modelSelectorProps={modelSelectorProps} />
       </div>
+
+      {/* 2a. Fast mode toggle — sits before the reasoning bars so speed and
+          effort read as one model-tuning cluster */}
+      {fastModeControl && (
+        <span
+          className={`inline-flex shrink-0 ${
+            runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
+          }`}
+        >
+          <ComposerFastModeToggle control={fastModeControl} />
+        </span>
+      )}
 
       {/* 2. Reasoning effort bars */}
       {effortControl && (
@@ -144,8 +159,8 @@ export interface ComposerTrailingControlsProps {
 }
 
 /**
- * The trailing control cluster (attach, runtime pressure, overflow, fast
- * mode) — shared between chat and home like ComposerLeadingControls. Home
+ * The trailing control cluster (attach, runtime pressure, overflow) —
+ * shared between chat and home like ComposerLeadingControls. Home
  * passes supportsAttachments/canAttachFiles=false and gets the exact
  * disabled plus-button + "available after a session starts" detail that
  * chat's pre-session state shows.
@@ -173,10 +188,6 @@ export function ComposerTrailingControls({
         ? "Attachments are not supported by this agent"
         : "Attachments are available after a session starts"
       : "Chat is unavailable right now";
-
-  const fastModeControl = controlGroups.modelConfigControls.find(
-    (c) => c.key === "fast_mode" && c.kind === "toggle",
-  ) ?? null;
 
   return (
     <>
@@ -207,17 +218,6 @@ export function ComposerTrailingControls({
           controls={controlGroups.modelConfigControls}
         />
       </span>
-
-      {/* 9. Fast mode toggle */}
-      {fastModeControl && (
-        <span
-          className={`inline-flex shrink-0 ${
-            runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
-          }`}
-        >
-          <ComposerFastModeToggle control={fastModeControl} />
-        </span>
-      )}
     </>
   );
 }

--- a/apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.tsx
@@ -73,6 +73,10 @@ export function ComposerCommandEditor({
   const text = serializeChatDraftToPrompt(draft);
   const [selectionOffset, setSelectionOffset] = useState(text.length);
   const [searchSuppressed, setSearchSuppressed] = useState(false);
+  // IME composition renders in-progress glyphs inside the textarea itself; a
+  // transparent text color would hide them, so the highlight yields while
+  // composing.
+  const [isComposing, setIsComposing] = useState(false);
   const trigger = useMemo(() => {
     if (searchSuppressed || disabled) {
       return null;
@@ -186,7 +190,7 @@ export function ComposerCommandEditor({
   // Highlight a recognized command only when the popup is NOT open (the popup
   // handles the active-typing state; the highlight is for the settled state).
   const recognition = useSlashCommandHighlight(
-    !trigger ? text : "",
+    !trigger && !isComposing ? text : "",
     runnableCommands,
   );
 
@@ -270,13 +274,6 @@ export function ComposerCommandEditor({
         : searchTray}
       <ComposerTextareaFrame topInset={topInset}>
         <div className="relative">
-          {recognition ? (
-            <ComposerSlashHighlight
-              recognition={recognition}
-              text={text}
-              textareaRef={textareaRef}
-            />
-          ) : null}
           <ComposerTextarea
             data-chat-composer-editor
             data-telemetry-mask
@@ -288,6 +285,8 @@ export function ComposerCommandEditor({
             onSelect={updateSelection}
             onClick={updateSelection}
             onKeyUp={updateSelection}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
             placeholder={placeholder}
             readOnly={disabled}
             aria-disabled={disabled}
@@ -297,6 +296,15 @@ export function ComposerCommandEditor({
             autoCapitalize="off"
             className={`${disabled ? "opacity-60" : ""} ${recognition ? "text-transparent caret-foreground" : ""}`}
           />
+          {/* Rendered after the textarea so it paints on top — the layer is
+              pointer-events-none except the command span (tooltip hover). */}
+          {recognition ? (
+            <ComposerSlashHighlight
+              recognition={recognition}
+              text={text}
+              textareaRef={textareaRef}
+            />
+          ) : null}
         </div>
       </ComposerTextareaFrame>
     </>

--- a/apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.tsx
@@ -13,7 +13,9 @@ import {
   WORKSPACE_CHAT_COMPOSER_INPUT,
 } from "@/config/chat";
 import { useChatSlashCommandMenu } from "@/hooks/chat/ui/use-chat-slash-command-menu";
+import { useSlashCommandHighlight } from "@/hooks/chat/ui/use-slash-command-highlight";
 import { useComposerTextareaAutosize } from "@/hooks/chat/ui/use-composer-textarea-autosize";
+import { useRunnableSlashCommands } from "@/hooks/chat/ui/use-runnable-slash-commands";
 import {
   isComposerOverlaySelectKey,
   isRawComposerSubmitKey,
@@ -38,6 +40,7 @@ import { recordTypingKeystrokeLatency } from "@/lib/infra/measurement/typing-lat
 import { markTypingActivity } from "@/lib/infra/interaction/typing-activity-store";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { ComposerSlashCommandSearch } from "./ComposerSlashCommandSearch";
+import { ComposerSlashHighlight } from "./ComposerSlashHighlight";
 import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
 import { ComposerTextareaFrame, type ComposerTextareaFrameTopInset } from "@proliferate/ui/primitives/ComposerTextareaFrame";
 
@@ -179,6 +182,14 @@ export function ComposerCommandEditor({
     textareaRef.current?.focus({ preventScroll: true });
   }, [replaceText, text, trigger]);
 
+  const runnableCommands = useRunnableSlashCommands();
+  // Highlight a recognized command only when the popup is NOT open (the popup
+  // handles the active-typing state; the highlight is for the settled state).
+  const recognition = useSlashCommandHighlight(
+    !trigger ? text : "",
+    runnableCommands,
+  );
+
   const search = useChatSlashCommandMenu({
     open: !!trigger,
     query: trigger?.query ?? "",
@@ -249,7 +260,6 @@ export function ComposerCommandEditor({
       onSelect={handleSelectSearchResult}
       onRowMouseEnter={search.handleRowMouseEnter}
       setRowRef={search.setRowRef}
-      className={overlayHostElement ? "mx-0" : undefined}
     />
   ) : null;
 
@@ -259,26 +269,35 @@ export function ComposerCommandEditor({
         ? createPortal(searchTray, overlayHostElement)
         : searchTray}
       <ComposerTextareaFrame topInset={topInset}>
-        <ComposerTextarea
-          data-chat-composer-editor
-          data-telemetry-mask
-          ref={textareaRef}
-          rows={WORKSPACE_CHAT_COMPOSER_INPUT.minRows}
-          value={text}
-          onChange={(event) => handleChange(event.target.value, event.timeStamp)}
-          onKeyDown={handleKeyDown}
-          onSelect={updateSelection}
-          onClick={updateSelection}
-          onKeyUp={updateSelection}
-          placeholder={placeholder}
-          readOnly={disabled}
-          aria-disabled={disabled}
-          spellCheck={false}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          className={disabled ? "opacity-60" : ""}
-        />
+        <div className="relative">
+          {recognition ? (
+            <ComposerSlashHighlight
+              recognition={recognition}
+              text={text}
+              textareaRef={textareaRef}
+            />
+          ) : null}
+          <ComposerTextarea
+            data-chat-composer-editor
+            data-telemetry-mask
+            ref={textareaRef}
+            rows={WORKSPACE_CHAT_COMPOSER_INPUT.minRows}
+            value={text}
+            onChange={(event) => handleChange(event.target.value, event.timeStamp)}
+            onKeyDown={handleKeyDown}
+            onSelect={updateSelection}
+            onClick={updateSelection}
+            onKeyUp={updateSelection}
+            placeholder={placeholder}
+            readOnly={disabled}
+            aria-disabled={disabled}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            className={`${disabled ? "opacity-60" : ""} ${recognition ? "text-transparent caret-foreground" : ""}`}
+          />
+        </div>
       </ComposerTextareaFrame>
     </>
   );

--- a/apps/desktop/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
@@ -1,7 +1,7 @@
 import type { RefObject } from "react";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Keyboard } from "@proliferate/ui/icons";
+import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type {
   SessionSlashCommandGroup,
   SessionSlashCommandViewModel,
@@ -83,51 +83,56 @@ function SlashCommandRow({
   setRowRef: (index: number, element: HTMLButtonElement | null) => void;
 }) {
   const detail = command.description || command.inputHint;
+  // Rows truncate aggressively; the hover tooltip carries the full details.
+  const tooltipContent = [command.displayName, command.description, command.inputHint]
+    .filter(Boolean)
+    .join("\n");
 
   return (
     <>
       {showGroupLabel ? (
         <>
           <div data-slash-command-group-label-marker="" />
-          <div className="px-2 py-1 text-xs text-muted-foreground">
+          <div className="px-2.5 py-1 text-xs text-muted-foreground">
             {command.group}
           </div>
         </>
       ) : null}
-      <Button
-        ref={(element) => setRowRef(index, element)}
-        type="button"
-        variant="unstyled"
-        size="unstyled"
-        data-list-navigation-item
-        aria-selected={selected}
-        onMouseEnter={() => onRowMouseEnter(index)}
-        onMouseDown={(event) => {
-          event.preventDefault();
-        }}
-        onClick={() => onSelect(command)}
-        className={twMerge(
-          // Color-token hover promotion, not row opacity — opacity flips
-          // re-rasterize the glyphs and read as shimmer (styling.md).
-          "flex w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden whitespace-normal rounded-lg px-2 py-[5px] text-left text-composer text-popover-foreground/75 outline-none hover:bg-accent hover:text-popover-foreground focus:bg-accent",
-          selected && "bg-accent text-popover-foreground",
-        )}
-      >
-        <Keyboard className="size-4 shrink-0 text-muted-foreground" />
-        <span className="flex-none truncate">
-          {command.displayName}
-        </span>
-        {detail ? (
-          <span className="min-w-0 flex-1 truncate text-muted-foreground">
-            {detail}
+      <Tooltip content={tooltipContent} className="flex w-full">
+        <Button
+          ref={(element) => setRowRef(index, element)}
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          data-list-navigation-item
+          aria-selected={selected}
+          onMouseEnter={() => onRowMouseEnter(index)}
+          onMouseDown={(event) => {
+            event.preventDefault();
+          }}
+          onClick={() => onSelect(command)}
+          className={twMerge(
+            // Color-token hover promotion, not row opacity — opacity flips
+            // re-rasterize the glyphs and read as shimmer (styling.md).
+            "flex w-full shrink-0 cursor-pointer items-baseline gap-2 overflow-hidden whitespace-normal rounded-lg px-2.5 py-[5px] text-left text-composer outline-none hover:bg-accent focus:bg-accent",
+            selected && "bg-accent",
+          )}
+        >
+          <span className="flex-none truncate text-popover-foreground">
+            {command.displayName}
           </span>
-        ) : null}
-        {command.inputHint && command.description ? (
-          <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
-            {command.inputHint}
-          </span>
-        ) : null}
-      </Button>
+          {detail ? (
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {detail}
+            </span>
+          ) : null}
+          {command.inputHint && command.description ? (
+            <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+              {command.inputHint}
+            </span>
+          ) : null}
+        </Button>
+      </Tooltip>
     </>
   );
 }

--- a/apps/desktop/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
@@ -31,7 +31,7 @@ export function ComposerSlashCommandSearch({
       data-composer-overlay-floating-ui
       data-telemetry-mask
       className={twMerge(
-        "mb-2 overflow-hidden rounded-2xl border border-border bg-popover/95 p-1 text-sm text-popover-foreground shadow-floating backdrop-blur-sm",
+        "mb-2 overflow-hidden rounded-2xl border border-border bg-popover/90 p-1 text-popover-foreground shadow-popover backdrop-blur-sm",
         className,
       )}
     >
@@ -55,7 +55,7 @@ export function ComposerSlashCommandSearch({
               />
             ))
           ) : (
-            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+            <div className="px-2 py-4 text-center text-xs text-muted-foreground">
               No matching slash commands.
             </div>
           )}
@@ -89,7 +89,7 @@ function SlashCommandRow({
       {showGroupLabel ? (
         <>
           <div data-slash-command-group-label-marker="" />
-          <div className="px-3 py-1 text-xs text-muted-foreground">
+          <div className="px-2 py-1 text-xs text-muted-foreground">
             {command.group}
           </div>
         </>
@@ -109,26 +109,24 @@ function SlashCommandRow({
         className={twMerge(
           // Color-token hover promotion, not row opacity — opacity flips
           // re-rasterize the glyphs and read as shimmer (styling.md).
-          "flex w-full shrink-0 cursor-pointer justify-start overflow-hidden whitespace-normal rounded-lg px-3 py-2 text-left text-sm text-popover-foreground/75 outline-none hover:bg-accent hover:text-popover-foreground focus:bg-accent",
+          "flex w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden whitespace-normal rounded-lg px-2 py-[5px] text-left text-composer text-popover-foreground/75 outline-none hover:bg-accent hover:text-popover-foreground focus:bg-accent",
           selected && "bg-accent text-popover-foreground",
         )}
       >
-        <div className="flex w-full min-w-0 items-center gap-2">
-          <Keyboard className="size-4 shrink-0 text-muted-foreground" />
-          <div className="max-w-[60%] flex-none truncate font-medium">
-            {command.displayName}
-          </div>
-          {detail ? (
-            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-              {detail}
-            </span>
-          ) : null}
-          {command.inputHint && command.description ? (
-            <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
-              {command.inputHint}
-            </span>
-          ) : null}
-        </div>
+        <Keyboard className="size-4 shrink-0 text-muted-foreground" />
+        <span className="flex-none truncate">
+          {command.displayName}
+        </span>
+        {detail ? (
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            {detail}
+          </span>
+        ) : null}
+        {command.inputHint && command.description ? (
+          <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+            {command.inputHint}
+          </span>
+        ) : null}
       </Button>
     </>
   );

--- a/apps/desktop/src/components/workspace/chat/input/ComposerSlashHighlight.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerSlashHighlight.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type { RecognizedSlashCommand } from "@/lib/domain/chat/composer/slash-command-recognition";
 
@@ -41,6 +41,12 @@ export function ComposerSlashHighlight({
     textarea.addEventListener("scroll", syncScroll, { passive: true });
     return () => textarea.removeEventListener("scroll", syncScroll);
   }, [syncScroll, textareaRef]);
+
+  // Programmatic value changes (command replacement) and autosize height
+  // changes move scrollTop without firing a scroll event — re-sync on text.
+  useLayoutEffect(() => {
+    syncScroll();
+  }, [syncScroll, text]);
 
   const { command, start, end } = recognition;
   // Render the literal draft slice (not displayName): the overlay must mirror

--- a/apps/desktop/src/components/workspace/chat/input/ComposerSlashHighlight.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerSlashHighlight.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
+import type { RecognizedSlashCommand } from "@/lib/domain/chat/composer/slash-command-recognition";
+
+interface ComposerSlashHighlightProps {
+  recognition: RecognizedSlashCommand;
+  text: string;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/**
+ * Overlay decoration painted ABOVE the textarea (absolutely positioned, so it
+ * paints over the in-flow textarea, whose text turns transparent while a
+ * command is recognized). Mirrors the textarea's full text with identical font
+ * metrics; the recognized command token is styled with the link-foreground
+ * accent color, the rest in normal foreground. The layer is pointer-events-none
+ * so typing/caret/selection stay native; only the command span is
+ * pointer-events-auto so hover triggers the Tooltip. Mousedown on the span
+ * hands the caret back to the textarea (placed after the token).
+ */
+export function ComposerSlashHighlight({
+  recognition,
+  text,
+  textareaRef,
+}: ComposerSlashHighlightProps) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const syncScroll = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      setScrollTop((prev) => prev === textarea.scrollTop ? prev : textarea.scrollTop);
+    }
+  }, [textareaRef]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    textarea.addEventListener("scroll", syncScroll, { passive: true });
+    return () => textarea.removeEventListener("scroll", syncScroll);
+  }, [syncScroll, textareaRef]);
+
+  const { command, start, end } = recognition;
+  // Render the literal draft slice (not displayName): the overlay must mirror
+  // the textarea glyph-for-glyph or the two layers drift apart.
+  const token = text.slice(start, end);
+  const tooltipContent = command.description
+    ? `${command.displayName} — ${command.description}`
+    : `${command.displayName} — slash command`;
+
+  const before = text.slice(0, start);
+  const after = text.slice(end);
+
+  // The command span intercepts pointer events (for the tooltip), so clicking
+  // it must hand the caret back to the textarea, after the token.
+  const handleTokenMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.focus({ preventScroll: true });
+        textarea.setSelectionRange(end, end);
+      }
+    },
+    [end, textareaRef],
+  );
+
+  return (
+    <div
+      ref={overlayRef}
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      <div
+        className="whitespace-pre-wrap break-words text-composer leading-[var(--text-composer--line-height)] text-foreground"
+        style={{
+          padding: 0,
+          transform: `translateY(-${scrollTop}px)`,
+        }}
+      >
+        {before}
+        <Tooltip
+          content={tooltipContent}
+          singleLine
+          className="pointer-events-auto inline"
+        >
+          <span
+            className="cursor-text rounded-sm text-link-foreground"
+            onMouseDown={handleTokenMouseDown}
+          >
+            {token}
+          </span>
+        </Tooltip>
+        {after}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
+++ b/apps/desktop/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
@@ -15,9 +15,10 @@ import { useToastStore } from "@/stores/toast/toast-store";
 
 /**
  * App-level host for the unified add-repository flow (UX_SPEC §4).
- * Entry offers three options; local paths run the existing add-repo
- * workflow, the cloud path runs the authorize → pick → create sequence
- * as an in-dialog step backed by useAddCloudEnvironment.
+ * Entry offers three options; local paths immediately add after the
+ * native folder picker returns, the cloud path runs the authorize →
+ * pick → create sequence as an in-dialog step backed by
+ * useAddCloudEnvironment.
  */
 export function AddRepoFlowHost() {
   const open = useAddRepoFlowStore((state) => state.open);
@@ -30,8 +31,6 @@ export function AddRepoFlowHost() {
   const { openExternal, pickFolder } = useTauriShellActions();
   const showToast = useToastStore((state) => state.show);
   const [flowError, setFlowError] = useState<string | null>(null);
-
-  const canCreateCloudEnvironment = activeOrganizationId !== null;
 
   const cloudPicker = useAddCloudEnvironment({
     enabled: open && step.kind === "cloud",
@@ -61,23 +60,15 @@ export function AddRepoFlowHost() {
     }
     // "link-local" and "add-local" both start from the native folder picker;
     // they differ in intent copy only — the same registration flow backs both.
+    // The folder picker IS the intent signal; no confirmation step needed.
     void (async () => {
       const path = await pickFolder();
       if (!path) {
         return;
       }
-      setStep({ kind: "confirm-local", path });
-    })();
-  }, [pickFolder, setStep]);
-
-  const handleConfirmLocal = useCallback((options: { createCloudEnvironment: boolean }) => {
-    if (step.kind !== "confirm-local") {
-      return;
-    }
-    setFlowError(null);
-    void addRepoFromPath(step.path, {
-      createCloudEnvironment: canCreateCloudEnvironment && options.createCloudEnvironment,
-    }).then((result) => {
+      const result = await addRepoFromPath(path, {
+        createCloudEnvironment: false,
+      });
       if (result.succeeded) {
         // Read before closeFlow — close() clears the completion callback.
         const onCompleted = useAddRepoFlowStore.getState().onCompleted;
@@ -88,8 +79,8 @@ export function AddRepoFlowHost() {
       // Failures also toast from useAddRepo; surface the reason inline and
       // keep the dialog open so the user can retry or back out.
       setFlowError(result.error);
-    });
-  }, [addRepoFromPath, canCreateCloudEnvironment, closeFlow, step]);
+    })();
+  }, [addRepoFromPath, closeFlow, pickFolder, setStep]);
 
   const handleBack = useCallback(() => {
     setFlowError(null);
@@ -109,18 +100,11 @@ export function AddRepoFlowHost() {
   return (
     <AddRepoFlow
       open={open}
-      step={step.kind === "confirm-local"
-        ? {
-          kind: "confirm-local",
-          path: step.path,
-          canCreateCloudEnvironment,
-        }
-        : step}
-      confirming={isAddingRepo}
+      step={step}
+      adding={isAddingRepo}
       error={step.kind === "cloud" ? null : flowError}
       cloudPicker={step.kind === "cloud" ? cloudPicker : null}
       onPickOption={handlePickOption}
-      onConfirmLocal={handleConfirmLocal}
       onBack={handleBack}
       onClose={handleClose}
     />

--- a/apps/desktop/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx
+++ b/apps/desktop/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx
@@ -101,10 +101,10 @@ function WorkspaceCommandPaletteContent({
       label="Command palette"
       className="flex min-h-0 flex-1 flex-col"
     >
-      <div className="flex h-11 shrink-0 items-center border-b border-border/70 px-3">
+      <div className="flex shrink-0 items-center border-b border-border-light px-3 py-2.5">
         <CommandPaletteGlyph
           name="search"
-          className="mr-1 size-4 shrink-0 text-muted-foreground"
+          className="mr-2 size-4 shrink-0 text-muted-foreground"
           aria-hidden="true"
         />
         <CommandPaletteInput
@@ -184,13 +184,13 @@ function WorkspaceCommandPaletteRow({ entry }: { entry: CommandPaletteEntry }) {
         )}
       </span>
       {entry.disabledReason ? (
-        <span className="shrink-0 truncate text-base text-muted-foreground">
+        <span className="shrink-0 truncate text-ui-sm text-muted-foreground">
           {entry.disabledReason}
         </span>
       ) : entry.shortcut ? (
-        <span className="shrink-0 rounded border border-border/70 px-1.5 py-0.5 text-base leading-3 text-muted-foreground">
+        <kbd className="ml-auto flex h-4 shrink-0 items-center rounded-md bg-foreground/10 px-1.5 text-ui-sm leading-none text-muted-foreground">
           {entry.shortcut}
-        </span>
+        </kbd>
       ) : null}
     </CommandPaletteItem>
   );

--- a/apps/desktop/src/hooks/chat/ui/use-runnable-slash-commands.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-runnable-slash-commands.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+import { useActiveSessionTranscript } from "@/hooks/chat/derived/use-active-session-transcript-state";
+import {
+  filterDesktopRunnableSessionSlashCommands,
+  type SessionSlashCommandViewModel,
+} from "@/lib/domain/chat/composer/session-slash-command-policy";
+
+const EMPTY: readonly SessionSlashCommandViewModel[] = [];
+
+/**
+ * Returns the full list of desktop-runnable slash commands for the active
+ * session. Stable reference between renders unless the session's available
+ * commands actually change.
+ */
+export function useRunnableSlashCommands(): readonly SessionSlashCommandViewModel[] {
+  const transcript = useActiveSessionTranscript();
+  const raw = transcript?.availableCommands ?? EMPTY;
+  return useMemo(() => filterDesktopRunnableSessionSlashCommands(raw), [raw]);
+}

--- a/apps/desktop/src/hooks/chat/ui/use-slash-command-highlight.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-slash-command-highlight.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import {
+  recognizeLeadingSlashCommand,
+  type RecognizedSlashCommand,
+} from "@/lib/domain/chat/composer/slash-command-recognition";
+import type { SessionSlashCommandViewModel } from "@/lib/domain/chat/composer/session-slash-command-policy";
+
+/**
+ * Memoized recognition of a leading slash command in the draft text.
+ *
+ * Returns the recognition result (command + offsets) when the first token of
+ * the draft is an exact match against a known runnable command, or null
+ * otherwise. The command list is expected to be stable across renders (it only
+ * changes on session change).
+ */
+export function useSlashCommandHighlight(
+  text: string,
+  commands: readonly SessionSlashCommandViewModel[],
+): RecognizedSlashCommand | null {
+  return useMemo(
+    () => recognizeLeadingSlashCommand(text, commands),
+    [text, commands],
+  );
+}

--- a/apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.test.ts
+++ b/apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { recognizeLeadingSlashCommand } from "./slash-command-recognition";
+import type { SessionSlashCommandViewModel } from "./session-slash-command-policy";
+
+const COMMANDS: SessionSlashCommandViewModel[] = [
+  { id: "loop", name: "loop", displayName: "/loop", description: "Run repeatedly", inputHint: "interval", group: "Commands" },
+  { id: "review", name: "review", displayName: "/review", description: "Review changes", inputHint: null, group: "Commands" },
+  { id: "compact", name: "compact", displayName: "/compact", description: "Compact context", inputHint: null, group: "Commands" },
+];
+
+describe("recognizeLeadingSlashCommand", () => {
+  it("returns null when draft is empty", () => {
+    expect(recognizeLeadingSlashCommand("", COMMANDS)).toBeNull();
+  });
+
+  it("returns null when draft does not start with /", () => {
+    expect(recognizeLeadingSlashCommand("hello /loop", COMMANDS)).toBeNull();
+  });
+
+  it("recognizes a known command followed by space", () => {
+    const result = recognizeLeadingSlashCommand("/loop some args", COMMANDS);
+    expect(result).not.toBeNull();
+    expect(result!.command.name).toBe("loop");
+    expect(result!.start).toBe(0);
+    expect(result!.end).toBe(5);
+  });
+
+  it("recognizes a known command at end of string", () => {
+    const result = recognizeLeadingSlashCommand("/review", COMMANDS);
+    expect(result).not.toBeNull();
+    expect(result!.command.name).toBe("review");
+    expect(result!.start).toBe(0);
+    expect(result!.end).toBe(7);
+  });
+
+  it("is case-insensitive", () => {
+    const result = recognizeLeadingSlashCommand("/LOOP ", COMMANDS);
+    expect(result).not.toBeNull();
+    expect(result!.command.name).toBe("loop");
+  });
+
+  it("returns null for unknown commands", () => {
+    expect(recognizeLeadingSlashCommand("/unknown ", COMMANDS)).toBeNull();
+  });
+
+  it("returns null for partial prefix without trailing whitespace that is still the full draft", () => {
+    // "/loo" is only a prefix of "loop" — not an exact match, so null.
+    expect(recognizeLeadingSlashCommand("/loo", COMMANDS)).toBeNull();
+  });
+
+  it("handles leading whitespace before the slash", () => {
+    const result = recognizeLeadingSlashCommand("  /compact ", COMMANDS);
+    expect(result).not.toBeNull();
+    expect(result!.command.name).toBe("compact");
+    expect(result!.start).toBe(2);
+    expect(result!.end).toBe(10);
+  });
+
+  it("returns null for bare slash", () => {
+    expect(recognizeLeadingSlashCommand("/", COMMANDS)).toBeNull();
+    expect(recognizeLeadingSlashCommand("/ ", COMMANDS)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.ts
+++ b/apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.ts
@@ -1,0 +1,64 @@
+import type { SessionSlashCommandViewModel } from "./session-slash-command-policy";
+
+export interface RecognizedSlashCommand {
+  /** The command view-model that matched. */
+  command: SessionSlashCommandViewModel;
+  /** Byte offset of the "/" in the draft. */
+  start: number;
+  /** Byte offset just past the command token (before trailing whitespace/end). */
+  end: number;
+}
+
+/**
+ * Recognizes an exact slash command at the start of the draft.
+ *
+ * Returns null when the draft doesn't start with a known runnable command
+ * token, or when the token is only a prefix (the popup handles prefix matches).
+ * The match is case-insensitive on the command name.
+ *
+ * Pure, zero-allocation on the miss path (draft doesn't start with "/").
+ */
+export function recognizeLeadingSlashCommand(
+  draft: string,
+  commands: readonly SessionSlashCommandViewModel[],
+): RecognizedSlashCommand | null {
+  // Fast bail: no leading slash → no work.
+  const trimStart = countLeadingWhitespace(draft);
+  if (draft[trimStart] !== "/") {
+    return null;
+  }
+
+  // Extract the first token (from "/" up to whitespace or end).
+  const tokenStart = trimStart;
+  let tokenEnd = tokenStart + 1;
+  while (tokenEnd < draft.length && !/\s/u.test(draft[tokenEnd]!)) {
+    tokenEnd += 1;
+  }
+
+  // The token must be followed by whitespace or be at end-of-string to count
+  // as "recognized" (still typing = not yet recognized, leave to the popup).
+  if (tokenEnd < draft.length && !/\s/u.test(draft[tokenEnd]!)) {
+    return null;
+  }
+
+  const token = draft.slice(tokenStart + 1, tokenEnd).toLowerCase();
+  if (!token) {
+    return null;
+  }
+
+  for (const command of commands) {
+    if (command.name.toLowerCase() === token) {
+      return { command, start: tokenStart, end: tokenEnd };
+    }
+  }
+
+  return null;
+}
+
+function countLeadingWhitespace(text: string): number {
+  let i = 0;
+  while (i < text.length && /\s/u.test(text[i]!)) {
+    i += 1;
+  }
+  return i;
+}

--- a/apps/desktop/src/stores/ui/add-repo-flow-store.ts
+++ b/apps/desktop/src/stores/ui/add-repo-flow-store.ts
@@ -2,8 +2,7 @@ import { create } from "zustand";
 
 export type AddRepoFlowStoreStep =
   | { kind: "entry" }
-  | { kind: "cloud" }
-  | { kind: "confirm-local"; path: string };
+  | { kind: "cloud" };
 
 /** What the unified flow produced, for callers that select the new repo. */
 export type AddRepoFlowCompletion =

--- a/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
+++ b/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
@@ -1,7 +1,5 @@
 import {
   useCallback,
-  useEffect,
-  useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
@@ -14,8 +12,6 @@ import {
   DialogTitle,
 } from "@proliferate/ui/kit/Dialog";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Label } from "@proliferate/ui/primitives/Label";
-import { Switch } from "@proliferate/ui/primitives/Switch";
 import { CloudRepoPicker, type CloudRepoPickerProps } from "./CloudRepoPicker";
 
 /** Which of the three entry options was picked. */
@@ -23,24 +19,17 @@ export type AddRepoFlowOption = "link-local" | "cloud" | "add-local";
 
 export type AddRepoFlowStep =
   | { kind: "entry" }
-  | { kind: "cloud" }
-  | {
-    kind: "confirm-local";
-    path: string;
-    /** Hidden entirely when the org has no cloud configured. */
-    canCreateCloudEnvironment: boolean;
-  };
+  | { kind: "cloud" };
 
 export interface AddRepoFlowProps {
   open: boolean;
   step: AddRepoFlowStep;
-  /** True while the local confirm step is committing. */
-  confirming?: boolean;
+  /** True while a local add is committing (disables entry options). */
+  adding?: boolean;
   error?: string | null;
   /** View model for the cloud step, wired by the host's controller layer. */
   cloudPicker?: CloudRepoPickerProps | null;
   onPickOption: (option: AddRepoFlowOption) => void;
-  onConfirmLocal: (options: { createCloudEnvironment: boolean }) => void;
   onBack: () => void;
   onClose: () => void;
 }
@@ -69,24 +58,23 @@ const ENTRY_OPTIONS: EntryOption[] = [
     option: "add-local",
     icon: <FolderOpen size={16} aria-hidden />,
     label: "Add a local repo",
-    description: "Register a repository folder, optionally mirrored to cloud.",
+    description: "Register a repository folder from this machine.",
   },
 ];
 
 /**
  * Unified add-repository flow (UX_SPEC §4). Entry = three options; local
- * options confirm the picked path and offer the cloud-sandbox mirror prompt;
+ * options invoke the native folder picker and add immediately on selection;
  * the cloud option runs the authorize → pick → create sequence in place via
  * CloudRepoPicker, driven by the host's cloudPicker view model.
  */
 export function AddRepoFlow({
   open,
   step,
-  confirming = false,
+  adding = false,
   error = null,
   cloudPicker = null,
   onPickOption,
-  onConfirmLocal,
   onBack,
   onClose,
 }: AddRepoFlowProps) {
@@ -107,17 +95,9 @@ export function AddRepoFlow({
         data-telemetry-block
       >
         {step.kind === "entry" ? (
-          <AddRepoEntryStep onPickOption={onPickOption} />
-        ) : step.kind === "cloud" ? (
-          <AddRepoCloudStep cloudPicker={cloudPicker} onBack={onBack} />
+          <AddRepoEntryStep onPickOption={onPickOption} disabled={adding} />
         ) : (
-          <AddRepoConfirmLocalStep
-            path={step.path}
-            canCreateCloudEnvironment={step.canCreateCloudEnvironment}
-            confirming={confirming}
-            onConfirm={onConfirmLocal}
-            onBack={onBack}
-          />
+          <AddRepoCloudStep cloudPicker={cloudPicker} onBack={onBack} />
         )}
         {error ? (
           <p className="mt-3 text-xs leading-[1.45] text-destructive" role="alert">
@@ -131,17 +111,20 @@ export function AddRepoFlow({
 
 function AddRepoEntryStep({
   onPickOption,
+  disabled = false,
 }: {
   onPickOption: (option: AddRepoFlowOption) => void;
+  disabled?: boolean;
 }) {
   const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
     const index = Number.parseInt(event.key, 10) - 1;
     const entry = ENTRY_OPTIONS[index];
     if (entry) {
       event.preventDefault();
       onPickOption(entry.option);
     }
-  }, [onPickOption]);
+  }, [disabled, onPickOption]);
 
   return (
     <div onKeyDown={handleKeyDown}>
@@ -157,6 +140,7 @@ function AddRepoEntryStep({
             type="button"
             variant="unstyled"
             size="unstyled"
+            disabled={disabled}
             onClick={() => onPickOption(entry.option)}
             className={`flex w-full items-center justify-start gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
               index > 0 ? "border-t border-border/60" : ""
@@ -221,69 +205,3 @@ function AddRepoCloudStep({
   );
 }
 
-function AddRepoConfirmLocalStep({
-  path,
-  canCreateCloudEnvironment,
-  confirming,
-  onConfirm,
-  onBack,
-}: {
-  path: string;
-  canCreateCloudEnvironment: boolean;
-  confirming: boolean;
-  onConfirm: (options: { createCloudEnvironment: boolean }) => void;
-  onBack: () => void;
-}) {
-  const [createCloudEnvironment, setCreateCloudEnvironment] = useState(
-    canCreateCloudEnvironment,
-  );
-
-  useEffect(() => {
-    setCreateCloudEnvironment(canCreateCloudEnvironment);
-  }, [canCreateCloudEnvironment, path]);
-
-  return (
-    <div>
-      <DialogHeader>
-        <DialogTitle className="text-[15px] font-semibold leading-5">
-          Add this repository?
-        </DialogTitle>
-      </DialogHeader>
-      <div className="mt-3 rounded-lg bg-surface-control px-3 py-2 font-mono text-xs leading-5 text-foreground break-all">
-        {path}
-      </div>
-      {canCreateCloudEnvironment ? (
-        <Label className="mt-3 mb-0 flex items-center justify-between gap-3 rounded-lg border border-border bg-accent/50 px-3 py-2.5 text-ui text-foreground">
-          <span className="min-w-0">
-            <span className="block text-ui font-medium leading-5 text-foreground">
-              Also create this repo in your cloud sandbox?
-            </span>
-            <span className="block text-xs leading-[1.45] text-muted-foreground">
-              Keeps a cloud environment configured for this repository.
-            </span>
-          </span>
-          <Switch
-            checked={createCloudEnvironment}
-            onChange={setCreateCloudEnvironment}
-            size="compact"
-            aria-label="Also create this repo in your cloud sandbox"
-          />
-        </Label>
-      ) : null}
-      <div className="mt-4 flex justify-end gap-2">
-        <Button type="button" variant="secondary" size="md" onClick={onBack} disabled={confirming}>
-          Back
-        </Button>
-        <Button
-          type="button"
-          variant="primary"
-          size="md"
-          loading={confirming}
-          onClick={() => onConfirm({ createCloudEnvironment })}
-        >
-          Add repository
-        </Button>
-      </div>
-    </div>
-  );
-}

--- a/apps/packages/product-ui/test/AddRepoFlow.test.tsx
+++ b/apps/packages/product-ui/test/AddRepoFlow.test.tsx
@@ -26,7 +26,6 @@ function renderFlow(overrides: Partial<AddRepoFlowProps> = {}) {
     open: true,
     step: { kind: "entry" },
     onPickOption: vi.fn(),
-    onConfirmLocal: vi.fn(),
     onBack: vi.fn(),
     onClose: vi.fn(),
     ...overrides,

--- a/apps/packages/ui/src/primitives/CommandPalette.tsx
+++ b/apps/packages/ui/src/primitives/CommandPalette.tsx
@@ -138,7 +138,7 @@ export function CommandPaletteRoot({
           role="dialog"
           aria-modal="true"
           aria-label={label}
-          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[calc(100vw-16px)] max-w-[580px] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-popover/90 text-popover-foreground shadow-floating-dark ring-[0.5px] ring-popover-ring backdrop-blur-[16px]"
+          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[min(520px,92vw)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-popover/95 p-1 text-popover-foreground shadow-[0_16px_32px_-8px_rgba(0,0,0,0.19)] ring-[0.5px] ring-popover-ring"
           onKeyDown={onKeyDown}
         >
           <Command
@@ -164,7 +164,7 @@ export function CommandPaletteInput({
 }: CommandPaletteInputProps) {
   return (
     <Command.Input
-      className={`h-11 w-full min-w-0 bg-transparent text-ui text-foreground outline-none placeholder:text-muted-foreground ${className ?? ""}`}
+      className={`w-full min-w-0 bg-transparent text-composer text-foreground outline-none placeholder:text-muted-foreground ${className ?? ""}`}
       data-telemetry-mask
       {...props}
     />
@@ -179,7 +179,7 @@ export function CommandPaletteList({
 }: CommandPaletteListProps) {
   return (
     <Command.List
-      className={`max-h-[400px] min-h-0 overflow-y-auto px-1.5 py-1.5 ${className ?? ""}`}
+      className={`max-h-[400px] min-h-0 overflow-y-auto px-1 py-1 ${className ?? ""}`}
       data-telemetry-mask
       {...props}
     />
@@ -194,7 +194,7 @@ export function CommandPaletteGroup({
 }: CommandPaletteGroupProps) {
   return (
     <Command.Group
-      className={`py-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-1.5 [&_[cmdk-group-heading]]:text-ui-sm [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground ${className ?? ""}`}
+      className={`py-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-2 [&_[cmdk-group-heading]]:text-ui-sm [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground ${className ?? ""}`}
       {...props}
     />
   );
@@ -208,7 +208,7 @@ export function CommandPaletteItem({
 }: CommandPaletteItemProps) {
   return (
     <Command.Item
-      className={`flex h-9 cursor-default select-none items-center gap-2 rounded-lg px-2.5 text-ui text-foreground outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-45 data-[selected=true]:bg-list-hover ${className ?? ""}`}
+      className={`flex cursor-default select-none items-center gap-2 rounded-lg px-2 py-[5px] text-composer text-foreground outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-45 data-[selected=true]:bg-list-hover ${className ?? ""}`}
       {...props}
     />
   );

--- a/apps/packages/ui/src/primitives/CommandPalette.tsx
+++ b/apps/packages/ui/src/primitives/CommandPalette.tsx
@@ -138,7 +138,7 @@ export function CommandPaletteRoot({
           role="dialog"
           aria-modal="true"
           aria-label={label}
-          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[min(520px,92vw)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-popover/95 p-1 text-popover-foreground shadow-[0_16px_32px_-8px_rgba(0,0,0,0.19)] ring-[0.5px] ring-popover-ring"
+          className="fixed left-1/2 top-[20vh] flex max-h-[calc(100vh-1rem)] w-[min(520px,92vw)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl bg-popover p-1 text-popover-foreground shadow-floating-dark ring-[0.5px] ring-popover-ring"
           onKeyDown={onKeyDown}
         >
           <Command


### PR DESCRIPTION
Codex-style command palette + slash command recognition + add-repo confirmation removal.

**Changes:**
- Cmd-K palette restyled to Codex spec (520px, tighter rows, kbd chip styling)
- Slash popup matches composer width with Codex row anatomy
- Recognized leading slash commands highlighted via overlay with tooltip
- Add-repo local flow adds immediately after folder pick (confirm step removed)

**Verification:**
Verified end-to-end in a local dev profile (screenshots of palette, slash popup, blue token highlight + tooltip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)