### PR TITLE
feat(chat): transcript polish — list spacing, shimmer, label sizes, streaming reveal, anchor fixes

### DIFF
--- a/apps/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
@@ -31,17 +31,17 @@ afterEach(() => {
 
 describe("ChatLaunchIntentPane", () => {
 
-  it("renders the pending 'Sending…' status outside the right-aligned user message", () => {
+  it("renders the pending 'Thinking' status outside the right-aligned user message", () => {
     useChatLaunchIntentStore.getState().begin(intent());
 
     render(<ChatLaunchIntentPane bottomInsetPx={0} />);
 
     expect(screen.getByText("Start cowork")).not.toBeNull();
-    // Launch dispatch says "Sending…", not the agent-work "Thinking". The
+    // Launch dispatch says "Thinking" (same voice as agent work). The
     // ThinkingText shimmer renders the label on a data-thinking-text span.
     expect(
       screen
-        .getByText("Sending…", { selector: "[data-thinking-text]" })
+        .getByText("Thinking", { selector: "[data-thinking-text]" })
         .closest("[data-chat-user-message]"),
     ).toBeNull();
   });

--- a/apps/desktop/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
@@ -125,7 +125,8 @@ function ToolActionRowContent({
         <div className="min-w-0 shrink-0 text-inherit">{label}</div>
         {renderInlineHint(hint)}
         {duration && (
-          <span className="ml-auto shrink-0 text-sm text-faint">
+          // Inherits the row's text-chat size so status suffixes match the label.
+          <span className="ml-auto shrink-0 text-faint">
             {duration}
           </span>
         )}
@@ -168,12 +169,13 @@ function renderInlineHint(hint?: ReactNode) {
   if (typeof hint === "string" || typeof hint === "number") {
     // Codex parity: commands/paths render as flat muted mono text in the row —
     // no chip/pill chrome (codex mono = `--codex-chat-code-font-size`, one step
-    // under chat text; ours = 11px `--text-base` per UX spec §6). Color
-    // inherits so hover brightens the command together with the label.
+    // under chat text; ours = `--text-chat-meta`, which tracks the transcript's
+    // chat size minus 2px). Color inherits so hover brightens the command
+    // together with the label.
     return (
       <span
         title={String(hint)}
-        className="max-w-[280px] min-w-0 shrink truncate text-base leading-none text-current"
+        className="max-w-[280px] min-w-0 shrink truncate text-[length:var(--text-chat-meta,11px)] leading-none text-current"
       >
         {hint}
       </span>

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
@@ -116,14 +116,13 @@ describe("resolveTurnTrailingStatus", () => {
 });
 
 describe("resolvePendingPromptTrailingStatus", () => {
-  it("says 'Sending…' — not 'Thinking' — while a prompt is dispatching", () => {
+  it("says 'Thinking' while a prompt is dispatching (same voice as agent work)", () => {
     const { container } = render(
       <>{resolvePendingPromptTrailingStatus(STARTED_AT, "working", true)}</>,
     );
 
     expect(container.querySelector("[data-trailing-status='sending']")).not.toBeNull();
-    expect(container.textContent).toContain("Sending…");
-    expect(container.textContent).not.toContain("Thinking");
+    expect(container.textContent).toContain("Thinking");
   });
 
   it("shows the awaiting-response marker when the outbox is waiting on input", () => {

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
@@ -136,7 +136,8 @@ export function resolvePendingPromptTrailingStatus(
   }
 
   if (forceWorking || sessionViewState === "working") {
-    // Outbox / launch dispatch — the truthful voice is "Sending…", not "Thinking".
+    // Outbox / launch dispatch — same "Thinking" voice as agent work (the
+    // send/queue distinction is plumbing, not something the user tracks).
     return (
       <TrailingStatusCrossfade statusKey="sending">
         <StreamingIndicator startedAt={queuedAt} label={CHAT_STREAMING_STATUS_LABELS.sending} />

--- a/apps/desktop/src/copy/chat/chat-copy.ts
+++ b/apps/desktop/src/copy/chat/chat-copy.ts
@@ -5,12 +5,12 @@ export const CHAT_COMPOSER_LABELS = {
   stop: "Stop run",
 } as const;
 
-// Context-appropriate labels for the animated streaming/status indicator. The
-// same shimmer used to say "Thinking" everywhere; callers now thread the label
-// that matches their context ("Thinking" is agent work only).
+// Labels for the animated streaming/status indicator. Dispatch and agent work
+// both read as "Thinking" — the send/queue distinction is plumbing the user
+// shouldn't have to care about, and one voice keeps the status line calm.
 export const CHAT_STREAMING_STATUS_LABELS = {
   thinking: "Thinking",
-  sending: "Sending…",
+  sending: "Thinking",
   restoringSession: "Restoring session…",
 } as const;
 

--- a/apps/desktop/src/pages/ChatPlaygroundPage.tsx
+++ b/apps/desktop/src/pages/ChatPlaygroundPage.tsx
@@ -52,7 +52,9 @@ export function ChatPlaygroundPage() {
           style={{ paddingBottom: scrollBottomInsetPx }}
         >
           <div className={CHAT_SURFACE_GUTTER_CLASSNAME}>
-            <div className={`${CHAT_COLUMN_CLASSNAME} flex flex-col gap-6`}>
+            {/* Mirror the transcript root's label-size override so fixtures
+                render at product parity (text-chat resolves to message size). */}
+            <div className={`${CHAT_COLUMN_CLASSNAME} flex flex-col gap-6 [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}>
               <PlaygroundTranscript
                 selection={selection}
                 replay={replay}

--- a/apps/packages/design/src/css/dom.css
+++ b/apps/packages/design/src/css/dom.css
@@ -222,16 +222,39 @@ body {
   }
 }
 
+/* ---- Stream word reveal ----
+   Word-level opacity fade for the live streaming tail. Each word mounts at
+   near-invisible and fades to full over 200ms. Opacity-only: cannot cause
+   layout shift, preserving the anchor invariant (newest content occupies its
+   final position instantly). Starts at 0.05 (not 0) so the bottom-most line
+   never looks empty while animating. */
+@keyframes stream-word-in {
+  from { opacity: 0.05; }
+  to { opacity: 1; }
+}
+
+.stream-word {
+  animation: stream-word-in 0.2s cubic-bezier(0.37, 0.55, 0.86, 0.88) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stream-word {
+    animation: none;
+  }
+}
+
 /* Thinking indicator — a light left→right gleam, compositor-only.
    The "agent is working" label sits at a dim muted base; a brighter highlight
-   sweeps across it left→right, momentarily lifting the passing slice to full
-   foreground — a light gleam, never a dark band. A masked band window
-   (.thinking-text-band) translates across while its glyph copy inside
-   counter-translates in lockstep, so the bright copy stays glyph-aligned; both
-   transforms run on the compositor and the soft-edge mask is static, so there
-   is no per-frame paint to jitter and no layout to bump. The gleam color is
-   --color-foreground, so it reads as "brighten to full" in either theme (light
-   on dark, dark on light). Reduced motion renders a static muted label. */
+   sweeps across it left→right with a comet-like trailing edge, momentarily
+   lifting the passing slice to full foreground — a light gleam, never a dark
+   band. A masked band window (.thinking-text-band) translates across while its
+   glyph copy inside counter-translates in lockstep, so the bright copy stays
+   glyph-aligned; both transforms run on the compositor and the soft-edge mask
+   is static, so there is no per-frame paint to jitter and no layout to bump.
+   The gleam color is --color-foreground, so it reads as "brighten to full" in
+   either theme (light on dark, dark on light). 1.8s duration + ease-in-out
+   keeps it alive without feeling frantic. Reduced motion renders a static
+   muted label. */
 @keyframes thinking-band-sweep {
   from {
     transform: translateX(-50%);
@@ -262,26 +285,25 @@ body {
   width: 100%;
   overflow: hidden;
   pointer-events: none;
-  /* A NARROW soft-edged highlight (~4% solid core) so the eye reads a distinct
-     bright spot travelling left→right, not the whole short word brightening at
-     once (which reads as a pulse). */
+  /* A wider trailing-edge tail so the sweep reads as a comet, not a thin line.
+     The solid core is ~10% wide, but the long fade-out behind it lingers. */
   -webkit-mask-image: linear-gradient(
     90deg,
-    transparent 8%,
-    black 18%,
-    black 22%,
-    transparent 32%
+    transparent 2%,
+    black 14%,
+    black 24%,
+    transparent 42%
   );
   mask-image: linear-gradient(
     90deg,
-    transparent 8%,
-    black 18%,
-    black 22%,
-    transparent 32%
+    transparent 2%,
+    black 14%,
+    black 24%,
+    transparent 42%
   );
   will-change: transform;
-  animation: thinking-band-sweep var(--thinking-text-duration, 2.4s)
-    var(--thinking-text-easing, linear) infinite;
+  animation: thinking-band-sweep var(--thinking-text-duration, 1.8s)
+    var(--thinking-text-easing, cubic-bezier(0.45, 0.05, 0.55, 0.95)) infinite;
 }
 
 .thinking-text-band-glyphs {
@@ -295,8 +317,8 @@ body {
   /* The gleam: the passing slice reaches full foreground contrast. */
   color: var(--color-foreground);
   will-change: transform;
-  animation: thinking-band-glyphs-sweep var(--thinking-text-duration, 2.4s)
-    var(--thinking-text-easing, linear) infinite;
+  animation: thinking-band-glyphs-sweep var(--thinking-text-duration, 1.8s)
+    var(--thinking-text-easing, cubic-bezier(0.45, 0.05, 0.55, 0.95)) infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
@@ -46,15 +46,16 @@ export function AssistantMessage({
   );
 }
 
-// ANCHOR INVARIANT (owner rule): the newest content must occupy the bottom
-// line the instant it exists — no typewriter reveal, no staggered fade. The
-// previous reveal pacing meant a burst of text (or a reconnect backlog) played
-// back over seconds, so the transcript's visible bottom kept crawling while
-// the true content already existed. Content now renders immediately; the
-// stable/live split is kept purely for markdown-parse efficiency (the stable
-// prefix parses once; only the small live tail re-parses per stream batch).
+// ANCHOR INVARIANT (owner rule): the newest content must occupy its final
+// layout position the INSTANT it exists. The word-level fade (revealText) is
+// opacity-only — layout commits instantly — and React's positional
+// reconciliation keeps previously-mounted word spans stable, so only
+// newly-appended words mount fresh and animate; nothing replays. The
+// stable/live split is kept for markdown-parse efficiency (the stable prefix
+// parses once; only the small live tail re-parses per stream batch).
 function AssistantMessageContent({
   content,
+  isStreaming,
   renderLink,
   renderInlineCode,
   renderCodeBlock,
@@ -95,6 +96,7 @@ function AssistantMessageContent({
             renderLink={renderLink}
             renderInlineCode={renderInlineCode}
             renderCodeBlock={renderCodeBlock}
+            revealText={isStreaming}
           />
         </div>
       )}

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   MarkdownBody,
   type MarkdownCodeBlockRenderer,
@@ -53,6 +53,12 @@ export function AssistantMessage({
 // newly-appended words mount fresh and animate; nothing replays. The
 // stable/live split is kept for markdown-parse efficiency (the stable prefix
 // parses once; only the small live tail re-parses per stream batch).
+//
+// BLIP FIX: `revealedUpTo` tracks how much of the live content was already
+// rendered in a prior frame. When the markdown structure changes (e.g. `**bo`
+// completing to `**bold**`), React may remount word spans. The offset ensures
+// remounted spans for already-seen text render WITHOUT the animation class,
+// preventing the visible opacity blip.
 function AssistantMessageContent({
   content,
   isStreaming,
@@ -66,10 +72,30 @@ function AssistantMessageContent({
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 }) {
+  // Track previous total content length to compute revealedUpTo for the live
+  // tree. Since rows are keyed by message id, this component mounts fresh per
+  // message — no cross-message reset needed.
+  const prevContentLengthRef = useRef(0);
+
   const splitContent = useMemo(
     () => splitAssistantContent(content),
     [content],
   );
+
+  // revealedUpTo in live-local coordinates: everything from the live tree that
+  // was already rendered in the previous frame. Handles the live→stable
+  // boundary migration because stableContent.length grows by exactly what
+  // migrated out of the live tree.
+  const revealedUpTo = Math.max(
+    0,
+    prevContentLengthRef.current - splitContent.stableContent.length,
+  );
+
+  // Update the ref AFTER render so next render sees the current length.
+  useEffect(() => {
+    prevContentLengthRef.current = content.length;
+  });
+
   const stableClassName = splitContent.liveContent
     ? "[&>*:first-child]:mt-0"
     : "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0";
@@ -97,6 +123,7 @@ function AssistantMessageContent({
             renderInlineCode={renderInlineCode}
             renderCodeBlock={renderCodeBlock}
             revealText={isStreaming}
+            revealedUpTo={revealedUpTo}
           />
         </div>
       )}

--- a/apps/packages/product-ui/src/chat/transcript/CloudChatTranscriptRowItems.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudChatTranscriptRowItems.tsx
@@ -135,7 +135,7 @@ export function CloudChatToolGroupRow({
         onClick={() => setExpanded((value) => !value)}
       />
       {row.status ? (
-        <div className="mt-0.5 text-center text-xs text-muted-foreground">
+        <div className="mt-0.5 text-center text-chat leading-[var(--text-chat--line-height)] text-muted-foreground">
           {row.status}
         </div>
       ) : null}
@@ -260,7 +260,7 @@ export function CloudChatSystemRow({
             setExpanded((value) => !value);
           }
         }}
-        className="flex h-auto w-full justify-start gap-2 rounded-none bg-transparent px-3 py-1.5 text-left font-sans text-xs text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground"
+        className="flex h-auto w-full justify-start gap-2 rounded-none bg-transparent px-3 py-1.5 text-left font-sans text-chat leading-[var(--text-chat--line-height)] text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground"
         aria-expanded={expanded}
       >
         <ChevronRight
@@ -316,7 +316,7 @@ export function CloudChatErrorRow({ row }: { row: CloudChatTranscriptRowView }) 
       {row.status || hasDetails ? (
         <div className="mt-2 flex flex-wrap items-center gap-2 pl-6">
           {row.status ? (
-            <span className="text-xs text-muted-foreground">{row.status}</span>
+            <span className="text-chat leading-[var(--text-chat--line-height)] text-muted-foreground">{row.status}</span>
           ) : null}
           {hasDetails ? (
             <Button
@@ -325,7 +325,7 @@ export function CloudChatErrorRow({ row }: { row: CloudChatTranscriptRowView }) 
               size="sm"
               data-chat-transcript-ignore
               onClick={() => setDetailsExpanded((value) => !value)}
-              className="gap-1 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+              className="gap-1 px-1.5 text-chat leading-[var(--text-chat--line-height)] text-muted-foreground hover:text-foreground"
               aria-expanded={detailsExpanded}
             >
               <ChevronRight

--- a/apps/packages/product-ui/src/chat/transcript/CloudChatTranscriptRows.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudChatTranscriptRows.tsx
@@ -53,7 +53,7 @@ export function CloudChatTranscriptRow({
       <article className="flex justify-start">
         <div className="flex min-w-0 max-w-full flex-col break-words" data-telemetry-mask>
           {row.title ? (
-            <div className="mb-1 text-xs font-medium text-muted-foreground">{row.title}</div>
+            <div className="mb-1 text-chat font-medium leading-[var(--text-chat--line-height)] text-muted-foreground">{row.title}</div>
           ) : null}
           <AssistantMessage
             content={row.body ?? ""}

--- a/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
@@ -59,7 +59,7 @@ export function CloudChatUserMessage({
           </div>
         ) : null}
         {visibleStatus ? (
-          <div className="inline-flex items-center gap-1 pr-1 text-xs text-muted-foreground">
+          <div className="inline-flex items-center gap-1 pr-1 text-chat leading-[var(--text-chat--line-height)] text-muted-foreground">
             {visibleStatus}
           </div>
         ) : null}

--- a/apps/packages/product-ui/src/chat/transcript/CloudTranscriptActionRow.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudTranscriptActionRow.tsx
@@ -105,7 +105,7 @@ function CloudTranscriptActionRowContent({
         <div className="min-w-0 shrink-0 text-inherit">{label}</div>
         {renderInlineHint(hint)}
         {statusLabel ? (
-          <span className="shrink-0 text-xs text-muted-foreground/80">
+          <span className="shrink-0 text-muted-foreground/80">
             {statusLabel}
           </span>
         ) : null}
@@ -235,7 +235,7 @@ function renderInlineHint(hint?: ReactNode) {
     return (
       <span
         title={value}
-        className="max-w-[260px] min-w-0 shrink truncate rounded-sm border border-border/60 bg-muted/45 px-1.5 py-0.5 text-[0.6rem] leading-none text-muted-foreground"
+        className="max-w-[260px] min-w-0 shrink truncate rounded-sm border border-border/60 bg-muted/45 px-1.5 py-0.5 text-chat leading-[var(--text-chat--line-height)] text-muted-foreground"
         data-telemetry-mask
       >
         {value}

--- a/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
@@ -244,7 +244,7 @@ export function FullTranscriptRowList({
             ref={selectionRootRef}
             data-chat-transcript-root="true"
             tabIndex={-1}
-            className={`${columnClassName} select-none outline-none`}
+            className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
           >
             {TRANSCRIPT_TOP_PADDING_PX > 0 && (
               <div aria-hidden="true" style={{ height: TRANSCRIPT_TOP_PADDING_PX }} />

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -10,7 +10,13 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
-import { MarkdownRevealContext, revealChildren } from "./MarkdownRevealText";
+import {
+  type HastNode,
+  type MarkdownRevealState,
+  MarkdownRevealContext,
+  REVEAL_DISABLED,
+  revealChildren,
+} from "./MarkdownRevealText";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ProviderLinkMention } from "./ProviderLinkMention";
@@ -24,6 +30,8 @@ interface MarkdownBodyProps {
   renderCodeBlock?: MarkdownCodeBlockRenderer;
   taskListItems?: MarkdownTaskListItemPresentation;
   revealText?: boolean;
+  /** Character offset into the source string: text before this was already rendered. */
+  revealedUpTo?: number;
 }
 
 /**
@@ -109,8 +117,8 @@ const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 // Factory: creates a stable component that reads reveal context and delegates.
 function mdComponent(tag: MdTag, className: string) {
   return (props: MdElementProps) => {
-    const r = useContext(MarkdownRevealContext);
-    return mdHtmlElement(tag, className, props, r);
+    const ctx = useContext(MarkdownRevealContext);
+    return mdHtmlElement(tag, className, props, ctx);
   };
 }
 
@@ -292,6 +300,7 @@ export const MarkdownBody = memo(function MarkdownBody({
   renderCodeBlock,
   taskListItems = "inline",
   revealText = false,
+  revealedUpTo = 0,
 }: MarkdownBodyProps) {
   const markdownClassName = [
     `${PROSE_TEXT} text-foreground break-words`,
@@ -320,8 +329,13 @@ export const MarkdownBody = memo(function MarkdownBody({
     ),
   }), [renderCodeBlock, renderInlineCode, renderLink, taskListItems]);
 
+  // Build reveal context value. Use a stable reference for the disabled case.
+  const revealState: MarkdownRevealState | null = revealText
+    ? { enabled: true, revealedUpTo }
+    : REVEAL_DISABLED;
+
   return (
-    <MarkdownRevealContext.Provider value={revealText}>
+    <MarkdownRevealContext.Provider value={revealState}>
       <div className={markdownClassName}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
@@ -389,14 +403,19 @@ export { MarkdownCodeBlockShell } from "./MarkdownCodeBlock";
 
 // mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
 // which ARE React component functions (hooks-valid call site). Each entry
-// calls useContext(MarkdownRevealContext) and passes revealText so word spans
-// can be applied without rebuilding the components map per render.
-function mdHtmlElement(tag: MdTag, baseClassName: string, props: MdElementProps, reveal = false) {
+// calls useContext(MarkdownRevealContext) and passes the context state so
+// word spans can be applied without rebuilding the components map per render.
+function mdHtmlElement(
+  tag: MdTag,
+  baseClassName: string,
+  props: MdElementProps,
+  ctx: MarkdownRevealState | null = null,
+) {
   const {
     children,
     dangerouslySetInnerHTML,
     className,
-    node: _node,
+    node,
     ...rest
   } = props;
   const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
@@ -408,6 +427,8 @@ function mdHtmlElement(tag: MdTag, baseClassName: string, props: MdElementProps,
       dangerouslySetInnerHTML,
     });
   }
-  const finalChildren = reveal ? revealChildren(children) : children;
+  const finalChildren = ctx?.enabled
+    ? revealChildren(children, node as HastNode | undefined, ctx)
+    : children;
   return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -4,17 +4,17 @@ import {
   createElement,
   isValidElement,
   memo,
+  useContext,
   useMemo,
-  useState,
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
 } from "react";
+import { MarkdownRevealContext, revealChildren } from "./MarkdownRevealText";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Button } from "@proliferate/ui/primitives/Button";
-import { Check, Copy } from "@proliferate/ui/icons";
 import { ProviderLinkMention } from "./ProviderLinkMention";
+import { MarkdownCodeBlockShell } from "./MarkdownCodeBlock";
 
 interface MarkdownBodyProps {
   content: string;
@@ -23,6 +23,7 @@ interface MarkdownBodyProps {
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
   taskListItems?: MarkdownTaskListItemPresentation;
+  revealText?: boolean;
 }
 
 /**
@@ -101,34 +102,30 @@ const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 // rendered node. They must be referentially stable across renders: a fresh
 // arrow function per render is a new component type, which makes React
 // unmount and remount the whole markdown DOM (visible as transcript jumps
-// while streams/sends re-render rows).
+// while streams/sends re-render rows). The reveal context is read inside each
+// component via useContext — the component identity stays stable, and the
+// context value flows from MarkdownBody's provider without rebuilding the map.
+
+// Factory: creates a stable component that reads reveal context and delegates.
+function mdComponent(tag: MdTag, className: string) {
+  return (props: MdElementProps) => {
+    const r = useContext(MarkdownRevealContext);
+    return mdHtmlElement(tag, className, props, r);
+  };
+}
+
 const STATIC_MARKDOWN_COMPONENTS = {
-  h1: (props: MdElementProps) =>
-    mdHtmlElement("h1", "mb-2.5 mt-5 text-[24px] font-semibold leading-[1.25] text-foreground", props),
-  h2: (props: MdElementProps) =>
-    mdHtmlElement("h2", "mb-2.5 mt-5 text-[20px] font-semibold leading-[1.25] text-foreground", props),
-  h3: (props: MdElementProps) =>
-    mdHtmlElement("h3", "mb-2.5 mt-5 text-[17px] font-semibold leading-[22px] text-foreground", props),
-  h4: (props: MdElementProps) =>
-    mdHtmlElement("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground", props),
-  h5: (props: MdElementProps) =>
-    mdHtmlElement("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground", props),
-  h6: (props: MdElementProps) =>
-    mdHtmlElement("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground", props),
-  p: (props: MdElementProps) =>
-    mdHtmlElement("p", `mb-[0.6875rem] mt-0 ${PROSE_TEXT} text-foreground`, props),
-  ul: (props: MdElementProps) =>
-    mdHtmlElement("ul", `my-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`, props),
-  ol: (props: MdElementProps) =>
-    mdHtmlElement("ol", `my-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`, props),
-  li: (props: MdElementProps) =>
-    mdHtmlElement("li", LI_CLASSNAME, props),
-  blockquote: (props: MdElementProps) =>
-    mdHtmlElement(
-      "blockquote",
-      `my-3 border-l-2 border-border pl-4 ${PROSE_TEXT} italic text-foreground`,
-      props,
-    ),
+  h1: mdComponent("h1", "mb-2.5 mt-5 text-[24px] font-semibold leading-[1.25] text-foreground"),
+  h2: mdComponent("h2", "mb-2.5 mt-5 text-[20px] font-semibold leading-[1.25] text-foreground"),
+  h3: mdComponent("h3", "mb-2.5 mt-5 text-[17px] font-semibold leading-[22px] text-foreground"),
+  h4: mdComponent("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground"),
+  h5: mdComponent("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground"),
+  h6: mdComponent("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground"),
+  p: mdComponent("p", `mb-[0.6875rem] mt-0 ${PROSE_TEXT} text-foreground`),
+  ul: mdComponent("ul", `mb-[0.6875rem] mt-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
+  ol: mdComponent("ol", `mb-[0.6875rem] mt-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
+  li: mdComponent("li", LI_CLASSNAME),
+  blockquote: mdComponent("blockquote", `my-3 border-l-2 border-border pl-4 ${PROSE_TEXT} italic text-foreground`),
   hr: () => <hr className="my-3 border-border" />,
   table: (props: MdElementProps) => (
     <div
@@ -145,10 +142,8 @@ const STATIC_MARKDOWN_COMPONENTS = {
       </div>
     </div>
   ),
-  th: (props: MdElementProps) =>
-    mdHtmlElement("th", `border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left ${PROSE_TEXT} font-semibold text-foreground`, props),
-  td: (props: MdElementProps) =>
-    mdHtmlElement("td", `border-b border-border px-2.5 py-1.5 align-top ${PROSE_TEXT}`, props),
+  th: mdComponent("th", `border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left ${PROSE_TEXT} font-semibold text-foreground`),
+  td: mdComponent("td", `border-b border-border px-2.5 py-1.5 align-top ${PROSE_TEXT}`),
   pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
@@ -296,14 +291,13 @@ export const MarkdownBody = memo(function MarkdownBody({
   renderInlineCode,
   renderCodeBlock,
   taskListItems = "inline",
+  revealText = false,
 }: MarkdownBodyProps) {
   const markdownClassName = [
     `${PROSE_TEXT} text-foreground break-words`,
     "[&_li>p]:my-0",
-    "[&_li>ol]:mt-2",
-    "[&_li>ul]:mt-2",
-    "[&>ol+p]:mt-4",
-    "[&>ul+p]:mt-4",
+    "[&_li>ol]:mt-2 [&_li>ol]:mb-0",
+    "[&_li>ul]:mt-2 [&_li>ul]:mb-0",
     // GFM task lists: drop the stray disc bullet and align the checkbox inline.
     // Descendant selector (not `>input`) so it also matches loose lists where
     // the checkbox sits inside a <p>; avoid flex so nested blocks still stack.
@@ -327,15 +321,17 @@ export const MarkdownBody = memo(function MarkdownBody({
   }), [renderCodeBlock, renderInlineCode, renderLink, taskListItems]);
 
   return (
-    <div className={markdownClassName}>
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        urlTransform={markdownUrlTransform}
-        components={components}
-      >
-        {content}
-      </ReactMarkdown>
-    </div>
+    <MarkdownRevealContext.Provider value={revealText}>
+      <div className={markdownClassName}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          urlTransform={markdownUrlTransform}
+          components={components}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+    </MarkdownRevealContext.Provider>
   );
 });
 
@@ -388,98 +384,14 @@ function markdownUrlTransform(value: string): string {
   return value;
 }
 
-/**
- * Codex-style code block card: bordered rounded shell with a header carrying
- * the language label and an always-visible copy icon button. `children`
- * overrides the rendered code content (e.g. app-injected highlighted HTML);
- * `code` remains the copy payload and the plain-text fallback.
- */
-export function MarkdownCodeBlockShell({
-  code,
-  label,
-  children,
-}: {
-  code: string;
-  label?: string | null;
-  children?: ReactNode;
-}) {
-  const [copied, setCopied] = useState(false);
+// Re-export for downstream consumers that import from this module.
+export { MarkdownCodeBlockShell } from "./MarkdownCodeBlock";
 
-  function copyCode() {
-    void writeClipboardText(code)
-      .then((copiedSuccessfully) => {
-        if (!copiedSuccessfully) {
-          return;
-        }
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1600);
-      });
-  }
-
-  return (
-    <div className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]">
-      <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
-        {label ? <span className="min-w-0 flex-1 truncate">{label}</span> : <span className="min-w-0 flex-1" />}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={copyCode}
-          className="size-6 shrink-0 rounded-md bg-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          aria-label="Copy code"
-        >
-          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-        </Button>
-      </div>
-      <div className="overflow-x-auto overflow-y-auto p-2 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--text-chat)] [&_code]:leading-[1.5]">
-        {children ?? (
-          <pre className="m-0 p-0">
-            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
-              {code}
-            </code>
-          </pre>
-        )}
-      </div>
-    </div>
-  );
-}
-
-async function writeClipboardText(value: string): Promise<boolean> {
-  if (writeClipboardTextFallback(value)) {
-    return true;
-  }
-  const clipboard = navigator.clipboard;
-  if (clipboard?.writeText) {
-    try {
-      await clipboard.writeText(value);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
-function writeClipboardTextFallback(value: string): boolean {
-  const input = document.createElement("textarea");
-  input.value = value;
-  input.setAttribute("readonly", "true");
-  input.style.position = "fixed";
-  input.style.left = "-9999px";
-  input.style.top = "0";
-  document.body.appendChild(input);
-  input.focus();
-  input.select();
-  try {
-    return document.execCommand("copy");
-  } catch {
-    return false;
-  } finally {
-    document.body.removeChild(input);
-  }
-}
-
-function mdHtmlElement(tag: MdTag, baseClassName: string, props: MdElementProps) {
+// mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
+// which ARE React component functions (hooks-valid call site). Each entry
+// calls useContext(MarkdownRevealContext) and passes revealText so word spans
+// can be applied without rebuilding the components map per render.
+function mdHtmlElement(tag: MdTag, baseClassName: string, props: MdElementProps, reveal = false) {
   const {
     children,
     dangerouslySetInnerHTML,
@@ -496,5 +408,6 @@ function mdHtmlElement(tag: MdTag, baseClassName: string, props: MdElementProps)
       dangerouslySetInnerHTML,
     });
   }
-  return createElement(tag, { ...rest, className: mergedClassName }, children);
+  const finalChildren = reveal ? revealChildren(children) : children;
+  return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -329,10 +329,13 @@ export const MarkdownBody = memo(function MarkdownBody({
     ),
   }), [renderCodeBlock, renderInlineCode, renderLink, taskListItems]);
 
-  // Build reveal context value. Use a stable reference for the disabled case.
-  const revealState: MarkdownRevealState | null = revealText
-    ? { enabled: true, revealedUpTo }
-    : REVEAL_DISABLED;
+  // Build reveal context value. Memoized so a re-render that changes neither
+  // flag nor offset doesn't push a fresh object through context; the disabled
+  // case shares one module-level reference.
+  const revealState: MarkdownRevealState | null = useMemo(
+    () => (revealText ? { enabled: true, revealedUpTo } : REVEAL_DISABLED),
+    [revealText, revealedUpTo],
+  );
 
   return (
     <MarkdownRevealContext.Provider value={revealState}>

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
@@ -1,0 +1,94 @@
+import { useState, type ReactNode } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Check, Copy } from "@proliferate/ui/icons";
+
+/**
+ * Codex-style code block card: bordered rounded shell with a header carrying
+ * the language label and an always-visible copy icon button. `children`
+ * overrides the rendered code content (e.g. app-injected highlighted HTML);
+ * `code` remains the copy payload and the plain-text fallback.
+ */
+export function MarkdownCodeBlockShell({
+  code,
+  label,
+  children,
+}: {
+  code: string;
+  label?: string | null;
+  children?: ReactNode;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  function copyCode() {
+    void writeClipboardText(code)
+      .then((copiedSuccessfully) => {
+        if (!copiedSuccessfully) {
+          return;
+        }
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1600);
+      });
+  }
+
+  return (
+    <div className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]">
+      <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
+        {label ? <span className="min-w-0 flex-1 truncate">{label}</span> : <span className="min-w-0 flex-1" />}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={copyCode}
+          className="size-6 shrink-0 rounded-md bg-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="Copy code"
+        >
+          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+        </Button>
+      </div>
+      <div className="overflow-x-auto overflow-y-auto p-2 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--text-chat)] [&_code]:leading-[1.5]">
+        {children ?? (
+          <pre className="m-0 p-0">
+            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
+              {code}
+            </code>
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+
+async function writeClipboardText(value: string): Promise<boolean> {
+  if (writeClipboardTextFallback(value)) {
+    return true;
+  }
+  const clipboard = navigator.clipboard;
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function writeClipboardTextFallback(value: string): boolean {
+  const input = document.createElement("textarea");
+  input.value = value;
+  input.setAttribute("readonly", "true");
+  input.style.position = "fixed";
+  input.style.left = "-9999px";
+  input.style.top = "0";
+  document.body.appendChild(input);
+  input.focus();
+  input.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(input);
+  }
+}

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MarkdownBody } from "./MarkdownBody";
+
+describe("MarkdownRevealText blip prevention", () => {
+  afterEach(cleanup);
+
+  it("words before revealedUpTo render without stream-word class", () => {
+    // Simulate: first render had "some **bo" (incomplete bold), second render
+    // has "some **bold** more" (completed bold). The first 9 characters
+    // ("some **bo") were already shown, so after the stable/live split those
+    // words must not re-animate.
+    const content = "some **bold** more";
+    // revealedUpTo = 9 means characters 0..8 were already rendered.
+    const { container } = render(
+      <MarkdownBody
+        content={content}
+        revealText={true}
+        revealedUpTo={9}
+      />,
+    );
+
+    const streamWords = container.querySelectorAll(".stream-word");
+    const allSpans = container.querySelectorAll("span");
+
+    // "more" should be animated (it's new text past offset 9).
+    const animatedTexts = Array.from(streamWords).map((el) => el.textContent);
+    expect(animatedTexts).toContain("more");
+
+    // "some" should NOT have stream-word class (it was already revealed).
+    const someSpan = Array.from(allSpans).find((el) => el.textContent === "some");
+    expect(someSpan).toBeTruthy();
+    expect(someSpan!.classList.contains("stream-word")).toBe(false);
+  });
+
+  it("with revealedUpTo=0 all words animate (first render)", () => {
+    const content = "hello world";
+    const { container } = render(
+      <MarkdownBody
+        content={content}
+        revealText={true}
+        revealedUpTo={0}
+      />,
+    );
+
+    const streamWords = container.querySelectorAll(".stream-word");
+    const texts = Array.from(streamWords).map((el) => el.textContent);
+    expect(texts).toContain("hello");
+    expect(texts).toContain("world");
+  });
+
+  it("with revealText=false no words get stream-word class", () => {
+    const content = "hello world";
+    const { container } = render(
+      <MarkdownBody
+        content={content}
+        revealText={false}
+      />,
+    );
+
+    const streamWords = container.querySelectorAll(".stream-word");
+    expect(streamWords.length).toBe(0);
+  });
+
+  it("structure change from plain to bold does not re-animate settled words", () => {
+    // First render: "Check this bo" (no bold yet, 13 chars)
+    // Second render: "Check this **bold** end" (bold completed)
+    // revealedUpTo=13 means first 13 chars were rendered previously.
+    const content = "Check this **bold** end";
+    const { container } = render(
+      <MarkdownBody
+        content={content}
+        revealText={true}
+        revealedUpTo={13}
+      />,
+    );
+
+    const streamWords = container.querySelectorAll(".stream-word");
+    const animatedTexts = Array.from(streamWords).map((el) => el.textContent);
+
+    // "Check" and "this" should NOT be animated — they were settled.
+    expect(animatedTexts).not.toContain("Check");
+    expect(animatedTexts).not.toContain("this");
+
+    // "end" is new text and should be animated.
+    expect(animatedTexts).toContain("end");
+  });
+
+  it("fully settled element renders children as plain text (no spans)", () => {
+    // Content is 11 chars; revealedUpTo > content length means everything settled.
+    const content = "hello world";
+    const { container } = render(
+      <MarkdownBody
+        content={content}
+        revealText={true}
+        revealedUpTo={100}
+      />,
+    );
+
+    const spans = container.querySelectorAll("span");
+    // No word spans at all — children rendered as plain text.
+    expect(spans.length).toBe(0);
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { AssistantMessage } from "./AssistantMessage";
 import { MarkdownBody } from "./MarkdownBody";
 
 describe("MarkdownRevealText blip prevention", () => {
@@ -101,5 +102,28 @@ describe("MarkdownRevealText blip prevention", () => {
     const spans = container.querySelectorAll("span");
     // No word spans at all — children rendered as plain text.
     expect(spans.length).toBe(0);
+  });
+
+  // The actual regression shape: stream two batches through AssistantMessage
+  // (which derives revealedUpTo from the previous render's content length) and
+  // assert the structure change does not re-animate already-seen words.
+  it("streaming rerender with completing bold does not re-animate seen words", () => {
+    const { container, rerender } = render(
+      <AssistantMessage content="Check this **bo" isStreaming />,
+    );
+    // First batch: all words are new and animate.
+    expect(
+      Array.from(container.querySelectorAll(".stream-word")).map((el) => el.textContent),
+    ).toContain("Check");
+
+    // Second batch completes the bold and appends — hast restructures the
+    // paragraph, remounting spans. Seen words must render static.
+    rerender(<AssistantMessage content="Check this **bold** end" isStreaming />);
+    const animated = Array.from(container.querySelectorAll(".stream-word")).map(
+      (el) => el.textContent,
+    );
+    expect(animated).not.toContain("Check");
+    expect(animated).not.toContain("this");
+    expect(animated).toContain("end");
   });
 });

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
@@ -1,0 +1,59 @@
+import { createContext, type ReactNode } from "react";
+
+/**
+ * Context that enables word-level fade-in on streamed text. When true,
+ * mdHtmlElement wraps each word in a `.stream-word` span so new words animate
+ * in via CSS (opacity-only, no layout shift). Only the LIVE MarkdownBody sets
+ * this to true; the stable prefix never animates.
+ */
+export const MarkdownRevealContext = createContext(false);
+
+/**
+ * Transform children for word-level reveal animation. Splits string children
+ * on whitespace boundaries: whitespace segments pass through as plain strings,
+ * non-whitespace segments get wrapped in `<span className="stream-word">`.
+ *
+ * Non-string children (elements like strong/em/code) pass through untouched —
+ * their OWN inner strings will get wrapped when they render through
+ * mdHtmlElement recursively.
+ */
+export function revealChildren(children: ReactNode): ReactNode {
+  if (typeof children === "string") {
+    return splitIntoWordSpans(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map((child) => {
+      if (typeof child === "string") {
+        return splitIntoWordSpans(child);
+      }
+      return child;
+    });
+  }
+  return children;
+}
+
+function splitIntoWordSpans(text: string): ReactNode[] {
+  // Whitespace-only strings pass through untouched.
+  if (/^\s*$/.test(text)) {
+    return [text];
+  }
+  const parts = text.split(/(\s+)/);
+  return parts.map((part, index) => {
+    // Whitespace segments stay as plain text (no span).
+    if (/^\s+$/.test(part)) {
+      return part;
+    }
+    if (part === "") {
+      return null;
+    }
+    // Index keys == positional reconciliation: the live tail only appends, so
+    // an existing word keeps its index, its span survives reconciliation, and
+    // its fade never replays (critical for the anchor invariant).
+    return (
+      <span className="stream-word" key={index}>
+        {part}
+      </span>
+    );
+  });
+}
+

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
@@ -1,30 +1,96 @@
 import { createContext, type ReactNode } from "react";
 
 /**
- * Context that enables word-level fade-in on streamed text. When true,
- * mdHtmlElement wraps each word in a `.stream-word` span so new words animate
- * in via CSS (opacity-only, no layout shift). Only the LIVE MarkdownBody sets
- * this to true; the stable prefix never animates.
+ * Reveal context value. `null` = disabled (no animation). When enabled,
+ * `revealedUpTo` is the character offset into the live content string:
+ * everything before it was already rendered in a prior frame and must render
+ * static (no animation class); words at/after it are new and animate.
  */
-export const MarkdownRevealContext = createContext(false);
+export interface MarkdownRevealState {
+  enabled: boolean;
+  revealedUpTo: number;
+}
+
+/** Stable default for non-reveal renders — avoids re-creating context value. */
+const DISABLED: MarkdownRevealState | null = null;
+
+export const MarkdownRevealContext = createContext<MarkdownRevealState | null>(
+  DISABLED,
+);
+
+/** Convenience: create a disabled context value without allocation. */
+export const REVEAL_DISABLED = DISABLED;
+
+/**
+ * Hast Element node shape (subset used for position offsets).
+ * react-markdown passes the hast `node` in props for custom components.
+ */
+export interface HastNode {
+  position?: {
+    start: { offset?: number };
+    end: { offset?: number };
+  };
+  children?: Array<{ type: string; value?: string; position?: HastNode["position"]; children?: HastNode["children"] }>;
+}
 
 /**
  * Transform children for word-level reveal animation. Splits string children
  * on whitespace boundaries: whitespace segments pass through as plain strings,
- * non-whitespace segments get wrapped in `<span className="stream-word">`.
+ * non-whitespace segments get wrapped in `<span className="stream-word">` if
+ * their estimated source offset is >= revealedUpTo (new text). Words before
+ * revealedUpTo render as plain `<span>` without animation class, preserving
+ * positional key parity so React doesn't remount animated siblings.
  *
  * Non-string children (elements like strong/em/code) pass through untouched —
  * their OWN inner strings will get wrapped when they render through
  * mdHtmlElement recursively.
  */
-export function revealChildren(children: ReactNode): ReactNode {
+export function revealChildren(
+  children: ReactNode,
+  node: HastNode | undefined,
+  ctx: MarkdownRevealState | null,
+): ReactNode {
+  // Fast path: no reveal context or disabled — return children as-is.
+  if (!ctx || !ctx.enabled) {
+    return children;
+  }
+
+  const elementStartOffset = node?.position?.start?.offset ?? undefined;
+  const elementEndOffset = node?.position?.end?.offset ?? undefined;
+
+  // If the entire element is before revealedUpTo, return children as plain
+  // text — no spans at all, zero overhead for settled elements.
+  if (
+    elementEndOffset !== undefined &&
+    elementEndOffset <= ctx.revealedUpTo
+  ) {
+    return children;
+  }
+
+  // If the entire element is new (starts at or after revealedUpTo), animate
+  // all words.
+  if (
+    elementStartOffset !== undefined &&
+    elementStartOffset >= ctx.revealedUpTo
+  ) {
+    return wrapAllAnimated(children);
+  }
+
+  // Element straddles the boundary. Walk children and estimate offsets.
+  return wrapStraddling(children, node, ctx);
+}
+
+/**
+ * All words in these children are new — wrap with stream-word class.
+ */
+function wrapAllAnimated(children: ReactNode): ReactNode {
   if (typeof children === "string") {
-    return splitIntoWordSpans(children);
+    return splitIntoWordSpans(children, true);
   }
   if (Array.isArray(children)) {
     return children.map((child) => {
       if (typeof child === "string") {
-        return splitIntoWordSpans(child);
+        return splitIntoWordSpans(child, true);
       }
       return child;
     });
@@ -32,7 +98,82 @@ export function revealChildren(children: ReactNode): ReactNode {
   return children;
 }
 
-function splitIntoWordSpans(text: string): ReactNode[] {
+/**
+ * Element straddles the revealedUpTo boundary. Estimate per-word offsets
+ * relative to the source string and decide animate vs. static.
+ */
+function wrapStraddling(
+  children: ReactNode,
+  node: HastNode | undefined,
+  ctx: MarkdownRevealState,
+): ReactNode {
+  const elementStart = node?.position?.start?.offset ?? 0;
+  let charAccumulator = elementStart;
+
+  if (typeof children === "string") {
+    return splitIntoWordSpansWithOffset(children, charAccumulator, ctx.revealedUpTo);
+  }
+
+  if (Array.isArray(children)) {
+    return children.map((child) => {
+      if (typeof child === "string") {
+        const result = splitIntoWordSpansWithOffset(child, charAccumulator, ctx.revealedUpTo);
+        charAccumulator += child.length;
+        return result;
+      }
+      // Non-string child (React element): advance accumulator by its source
+      // extent if available, else estimate via textContent.
+      const childNode = getHastNodeFromElement(child);
+      if (childNode?.position?.end?.offset !== undefined) {
+        charAccumulator = childNode.position.end.offset;
+      } else {
+        charAccumulator += estimateTextLength(child);
+      }
+      return child;
+    });
+  }
+
+  return children;
+}
+
+/**
+ * Split a string into word spans with offset-aware animation decisions.
+ * Words whose estimated start offset < revealedUpTo render static (span
+ * without animation class). Words at/after render animated.
+ */
+function splitIntoWordSpansWithOffset(
+  text: string,
+  startOffset: number,
+  revealedUpTo: number,
+): ReactNode[] {
+  if (/^\s*$/.test(text)) {
+    return [text];
+  }
+  const parts = text.split(/(\s+)/);
+  let localOffset = 0;
+  return parts.map((part, index) => {
+    if (/^\s+$/.test(part)) {
+      localOffset += part.length;
+      return part;
+    }
+    if (part === "") {
+      return null;
+    }
+    const wordStartOffset = startOffset + localOffset;
+    localOffset += part.length;
+    // Bias toward static: use < (not <=) so words exactly at boundary are
+    // treated as new, but any drift from markdown syntax chars means some
+    // new-ish words render static — acceptable (invisible vs. blip).
+    const isSettled = wordStartOffset < revealedUpTo;
+    return (
+      <span className={isSettled ? undefined : "stream-word"} key={index}>
+        {part}
+      </span>
+    );
+  });
+}
+
+function splitIntoWordSpans(text: string, animate: boolean): ReactNode[] {
   // Whitespace-only strings pass through untouched.
   if (/^\s*$/.test(text)) {
     return [text];
@@ -46,14 +187,57 @@ function splitIntoWordSpans(text: string): ReactNode[] {
     if (part === "") {
       return null;
     }
-    // Index keys == positional reconciliation: the live tail only appends, so
-    // an existing word keeps its index, its span survives reconciliation, and
-    // its fade never replays (critical for the anchor invariant).
+    if (animate) {
+      return (
+        <span className="stream-word" key={index}>
+          {part}
+        </span>
+      );
+    }
     return (
-      <span className="stream-word" key={index}>
+      <span key={index}>
         {part}
       </span>
     );
   });
 }
 
+/**
+ * Extract hast node from a React element's props (react-markdown passes it as
+ * `node` prop on custom components).
+ */
+function getHastNodeFromElement(element: unknown): HastNode | undefined {
+  if (
+    element &&
+    typeof element === "object" &&
+    "props" in element &&
+    (element as { props?: { node?: HastNode } }).props?.node
+  ) {
+    return (element as { props: { node: HastNode } }).props.node;
+  }
+  return undefined;
+}
+
+/**
+ * Cheap recursive textContent estimate for a React element (used when hast
+ * position is unavailable on a child element).
+ */
+function estimateTextLength(element: unknown): number {
+  if (typeof element === "string") return element.length;
+  if (typeof element === "number") return String(element).length;
+  if (!element || typeof element !== "object") return 0;
+  if ("props" in element) {
+    const props = (element as { props?: { children?: unknown } }).props;
+    if (!props?.children) return 0;
+    const children = props.children;
+    if (typeof children === "string") return children.length;
+    if (Array.isArray(children)) {
+      return children.reduce(
+        (sum: number, child: unknown) => sum + estimateTextLength(child),
+        0,
+      );
+    }
+    return estimateTextLength(children);
+  }
+  return 0;
+}

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
@@ -122,7 +122,11 @@ function wrapStraddling(
         return result;
       }
       // Non-string child (React element): advance accumulator by its source
-      // extent if available, else estimate via textContent.
+      // extent if available, else estimate via textContent. The textContent
+      // fallback UNDERcounts source length (markdown syntax chars, entities),
+      // which keeps drift on the safe side of the `< revealedUpTo` bias: too-low
+      // offsets can only classify new words as settled (a skipped fade, invisible)
+      // — never make an already-seen word look new and re-blip.
       const childNode = getHastNodeFromElement(child);
       if (childNode?.position?.end?.offset !== undefined) {
         charAccumulator = childNode.position.end.offset;

--- a/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptViewport.tsx
@@ -15,6 +15,7 @@ import type { TranscriptVirtualizationMode } from "@proliferate/product-domain/c
 
 export function VirtualTranscriptViewport({
   bottomSpacerHeight,
+  contentRef,
   measureElement,
   onViewportScroll,
   renderableRows,
@@ -29,6 +30,7 @@ export function VirtualTranscriptViewport({
 }: {
   bottomSpacerHeight: number;
   columnClassName?: string;
+  contentRef?: RefObject<HTMLDivElement | null>;
   gutterClassName?: string;
   measureElement: (element: Element | null) => void;
   onViewportScroll: (viewport: HTMLDivElement) => void;
@@ -47,6 +49,7 @@ export function VirtualTranscriptViewport({
       onViewportScroll={onViewportScroll}
     >
       <div
+        ref={contentRef}
         className={`${gutterClassName} min-h-full`}
         data-transcript-virtualization-mode="virtual"
         data-transcript-virtualization-setting={virtualizationMode}

--- a/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptViewport.tsx
@@ -55,7 +55,7 @@ export function VirtualTranscriptViewport({
           ref={selectionRootRef}
           data-chat-transcript-root="true"
           tabIndex={-1}
-          className={`${columnClassName} select-none outline-none`}
+          className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
         >
           {topSpacerHeight > 0 && (
             <div aria-hidden="true" style={{ height: topSpacerHeight }} />

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -65,6 +65,7 @@ export function VirtualizedTranscriptRowList({
   virtualizationMode,
 }: VirtualizedTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const pendingAnchorRef = useRef<VirtualScrollAnchor | null>(null);
   const pendingPrependAnchorRef = useRef<HistoryPrependScrollAnchor | null>(null);
   const lastOlderHistoryCursorRequestRef = useRef<number | null>(null);
@@ -300,6 +301,31 @@ export function VirtualizedTranscriptRowList({
     totalContentHeight,
   ]);
 
+  // Row content can grow between virtualizer measurements (tool-call output
+  // streaming, status flips, expanding panels). The snap effect above only
+  // fires when totalContentHeight changes — but with
+  // useAnimationFrameWithResizeObserver the virtualizer defers re-measurement
+  // by one frame, leaving a window where the DOM has grown but no snap runs.
+  // Bridge that gap with a ResizeObserver on the content wrapper (same pattern
+  // as FullTranscriptRowList) that re-snaps immediately on any size increase
+  // while pinned, regardless of whether the virtualizer has re-measured yet.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!pinnedRef.current) {
+        return;
+      }
+      scrollToBottom();
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [pinnedRef, scrollToBottom]);
+
   useLayoutEffect(() => () => {
     const viewport = scrollRef.current;
     if (!viewport || pinnedRef.current) {
@@ -346,6 +372,7 @@ export function VirtualizedTranscriptRowList({
       <VirtualTranscriptViewport
         bottomSpacerHeight={bottomSpacerHeight}
         columnClassName={columnClassName}
+        contentRef={contentRef}
         gutterClassName={gutterClassName}
         measureElement={virtualizer.measureElement}
         onViewportScroll={handleViewportScroll}

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -136,6 +136,18 @@ export function useTranscriptStickToBottom({
       return;
     }
 
+    // H2 hardening: when a programmatic marker is pending but the tolerance
+    // missed (scrollHeight changed between our write and this event, or a
+    // second snap overwrote the marker before the first event dispatched),
+    // treat the event as programmatic if the scroll moved downward. Unpinning
+    // here would be a false positive — the user never scrolled.
+    if (pending && pinnedRef.current && top >= pending.expectedTop - PROGRAMMATIC_MATCH_TOL_PX) {
+      cancelAnimationFrame(pending.frame);
+      programmaticRef.current = null;
+      onScrollSample({ programmatic: true });
+      return;
+    }
+
     const distance = resolveVirtualBottomDistance({
       scrollOffset: top,
       viewportSize: viewport.clientHeight,
@@ -152,7 +164,7 @@ export function useTranscriptStickToBottom({
       setPinned(false);
     }
     onScrollSample({ programmatic: false });
-  }, [onScrollSample, repinThresholdPx, setPinned]);
+  }, [onScrollSample, pinnedRef, repinThresholdPx, setPinned]);
 
   const startGlueLoop = useCallback(() => {
     if (typeof window === "undefined") {


### PR DESCRIPTION
## What

Four UX improvements to the chat transcript plus two follow-up fixes:

1. **List spacing** — bulleted/numbered lists now own their bottom margin (11px, symmetric with paragraphs) instead of relying on `ul+p` sibling selectors that the streaming stable/live split silently breaks. Text after a list no longer sits flush against the last bullet.
2. **Thinking shimmer** — 2.4s linear → 1.8s ease-in-out with a wider comet-tail gleam. Still compositor-only (transform + static mask).
3. **Unified label sizes** — tool rows, statuses, durations, the stopped notice, and turn separators resolve `text-chat` to the message-body size via a scoped override on the transcript root (`--text-chat: var(--text-message)`), matching the reference design where labels share the body size. Non-transcript `text-chat` consumers (scratch pad) untouched. Command hints stay one step down via `--text-chat-meta`.
4. **Streaming word reveal** — streamed text fades in word-by-word (0.2s opacity, live tail only). Anchor invariant preserved: layout commits instantly, animation is opacity-only. Already-revealed words are tracked by explicit character offset through hast source positions, so structure changes (bold completing, live→stable migration) can never replay the fade on seen text.
5. **Bottom-anchor fixes** — virtualized row list gains the full list's ResizeObserver re-snap (tool rows growing in place no longer rest below the fold during the virtualizer's deferred re-measure window); the stick engine no longer falsely unpins when two snaps race and the programmatic marker is overwritten. User escape (wheel-up etc.) untouched.
6. **Status copy** — outbox/dispatch shimmer says "Thinking" like agent work instead of "Sending…".

## Verification

- product-ui: build clean, 160/160 tests (5 new pinning the no-re-animate behavior)
- desktop: tsc clean, scoped vitest green
- Frame-level playwright probes against the live playground: 0 anchor violations, 0 re-animation blips across repeated streamed runs
- Repo shape / boundaries: no new violations (baseline identical to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)