### PR TITLE
feat(chat): queued-message composer with steer, reorder, and edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.6"
+version = "0.3.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/anyharness/crates/anyharness-contract/src/v1/events.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/events.rs
@@ -76,6 +76,7 @@ pub enum SessionEvent {
     PendingPromptAdded(PendingPromptAddedPayload),
     PendingPromptUpdated(PendingPromptUpdatedPayload),
     PendingPromptRemoved(PendingPromptRemovedPayload),
+    PendingPromptsReordered(PendingPromptsReorderedPayload),
 
     #[serde(alias = "permission_requested")]
     InteractionRequested(InteractionRequestedEvent),
@@ -114,6 +115,7 @@ impl SessionEvent {
             Self::PendingPromptAdded(_) => "pending_prompt_added",
             Self::PendingPromptUpdated(_) => "pending_prompt_updated",
             Self::PendingPromptRemoved(_) => "pending_prompt_removed",
+            Self::PendingPromptsReordered(_) => "pending_prompts_reordered",
             Self::InteractionRequested(_) => "interaction_requested",
             Self::InteractionResolved(_) => "interaction_resolved",
             Self::Error(_) => "error",
@@ -814,6 +816,13 @@ pub struct PendingPromptRemovedPayload {
 pub enum PendingPromptRemovalReason {
     Executed,
     Deleted,
+    Steered,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingPromptsReorderedPayload {
+    pub pending_prompts: Vec<super::PendingPromptSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs
@@ -4,6 +4,7 @@ use axum::{
     http::{HeaderMap, HeaderValue},
     Extension, Json,
 };
+use serde::Deserialize;
 
 use super::access::assert_session_auth_scope;
 use super::error::ApiError;
@@ -12,6 +13,7 @@ use super::sessions_errors::map_pending_prompt_mutation_error;
 use super::sessions_leases::acquire_session_operation_lease;
 use crate::api::auth::AuthContext;
 use crate::app::AppState;
+use crate::domains::sessions::runtime::PendingPromptQueueError;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
 
 #[utoipa::path(
@@ -137,4 +139,96 @@ pub async fn get_prompt_attachment(
         .read_prompt_attachment_content(&attachment)
         .map_err(|error| ApiError::internal(error.to_string()))?;
     Ok((headers, content))
+}
+
+// ---------------------------------------------------------------------------
+// Reorder
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReorderPendingPromptsRequest {
+    pub seqs: Vec<i64>,
+}
+
+#[utoipa::path(
+    put,
+    path = "/v1/sessions/{session_id}/pending-prompts/order",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+    ),
+    request_body = inline(ReorderPendingPromptsRequest),
+    responses(
+        (status = 200, description = "Pending prompts reordered", body = Session),
+        (status = 400, description = "Invalid reorder request", body = anyharness_contract::v1::ProblemDetails),
+        (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
+    ),
+    tag = "sessions"
+)]
+pub async fn reorder_pending_prompts(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthContext>,
+    Path(session_id): Path<String>,
+    Json(req): Json<ReorderPendingPromptsRequest>,
+) -> Result<Json<Session>, ApiError> {
+    assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _lease =
+        acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
+            .await?;
+    let updated = state
+        .session_runtime
+        .reorder_pending_prompts(&session_id, req.seqs)
+        .await
+        .map_err(map_pending_prompt_queue_error)?;
+    Ok(Json(session_to_contract(&state, &updated).await?))
+}
+
+// ---------------------------------------------------------------------------
+// Steer
+// ---------------------------------------------------------------------------
+
+#[utoipa::path(
+    post,
+    path = "/v1/sessions/{session_id}/pending-prompts/{seq}/steer",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("seq" = i64, Path, description = "Queue row sequence number"),
+    ),
+    responses(
+        (status = 200, description = "Pending prompt steered", body = Session),
+        (status = 404, description = "Session or pending prompt not found", body = anyharness_contract::v1::ProblemDetails),
+    ),
+    tag = "sessions"
+)]
+pub async fn steer_pending_prompt(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthContext>,
+    Path((session_id, seq)): Path<(String, i64)>,
+) -> Result<Json<Session>, ApiError> {
+    assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _lease =
+        acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
+            .await?;
+    let updated = state
+        .session_runtime
+        .steer_pending_prompt(&session_id, seq)
+        .await
+        .map_err(map_pending_prompt_queue_error)?;
+    Ok(Json(session_to_contract(&state, &updated).await?))
+}
+
+fn map_pending_prompt_queue_error(error: PendingPromptQueueError) -> ApiError {
+    match error {
+        PendingPromptQueueError::SessionNotFound(session_id) => ApiError::not_found(
+            format!("Session not found: {session_id}"),
+            "SESSION_NOT_FOUND",
+        ),
+        PendingPromptQueueError::NotFound => {
+            ApiError::not_found("Pending prompt not found", "PENDING_PROMPT_NOT_FOUND")
+        }
+        PendingPromptQueueError::InvalidReorder(msg) => {
+            ApiError::bad_request(msg, "INVALID_REORDER")
+        }
+        PendingPromptQueueError::Internal(error) => ApiError::internal(error.to_string()),
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/api/router.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router.rs
@@ -436,9 +436,17 @@ pub fn build_router(state: AppState) -> Router {
             post(sessions_fork::fork_session),
         )
         .route(
+            "/sessions/{session_id}/pending-prompts/order",
+            put(sessions_pending::reorder_pending_prompts),
+        )
+        .route(
             "/sessions/{session_id}/pending-prompts/{seq}",
             patch(sessions_pending::edit_pending_prompt)
                 .delete(sessions_pending::delete_pending_prompt),
+        )
+        .route(
+            "/sessions/{session_id}/pending-prompts/{seq}/steer",
+            post(sessions_pending::steer_pending_prompt),
         )
         .route(
             "/sessions/{session_id}/prompt-attachments/{attachment_id}",

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
@@ -78,6 +78,13 @@ impl QueueDurable for SessionStore {
         SessionStore::insert_pending_prompt_payload(self, session_id, payload, prompt_id)
     }
 
+    fn list_pending_prompts(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<PendingPromptRecord>> {
+        SessionStore::list_pending_prompts(self, session_id)
+    }
+
     fn peek_head_pending_prompt(
         &self,
         session_id: &str,
@@ -112,6 +119,14 @@ impl QueueDurable for SessionStore {
         seq: i64,
     ) -> anyhow::Result<Option<PendingPromptRecord>> {
         SessionStore::delete_pending_prompt_record(self, session_id, seq)
+    }
+
+    fn reorder_pending_prompts(
+        &self,
+        session_id: &str,
+        ordered_seqs: &[i64],
+    ) -> anyhow::Result<Vec<PendingPromptRecord>> {
+        SessionStore::reorder_pending_prompts(self, session_id, ordered_seqs)
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -166,6 +166,14 @@ pub enum PendingPromptMutationError {
 }
 
 #[derive(Debug)]
+pub enum PendingPromptQueueError {
+    SessionNotFound(String),
+    NotFound,
+    InvalidReorder(String),
+    Internal(anyhow::Error),
+}
+
+#[derive(Debug)]
 pub enum SessionLifecycleError {
     SessionNotFound(String),
     Internal(anyhow::Error),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
@@ -6,7 +6,9 @@ use crate::domains::sessions::prompt::prepare::prepare_prompt;
 use crate::domains::sessions::prompt::PromptPrepareContext;
 use crate::live::sessions::{LiveSessionCommandError, QueueMutationError};
 
-use super::{PendingPromptMutationError, SessionLifecycleError, SessionRuntime};
+use super::{
+    PendingPromptMutationError, PendingPromptQueueError, SessionLifecycleError, SessionRuntime,
+};
 
 impl SessionRuntime {
     pub async fn edit_pending_prompt(
@@ -87,6 +89,11 @@ impl SessionRuntime {
                     );
                     PendingPromptMutationError::NotFound
                 }
+                LiveSessionCommandError::Rejected(QueueMutationError::InvalidReorder(_)) => {
+                    PendingPromptMutationError::Internal(anyhow::anyhow!(
+                        "unexpected reorder error in edit path"
+                    ))
+                }
             })?;
 
         self.session_service
@@ -137,11 +144,122 @@ impl SessionRuntime {
                 LiveSessionCommandError::Rejected(QueueMutationError::NotFound) => {
                     PendingPromptMutationError::NotFound
                 }
+                LiveSessionCommandError::Rejected(QueueMutationError::InvalidReorder(_)) => {
+                    PendingPromptMutationError::Internal(anyhow::anyhow!(
+                        "unexpected reorder error in delete path"
+                    ))
+                }
             })?;
 
         self.session_service
             .get_session(session_id)
             .map_err(PendingPromptMutationError::Internal)?
             .ok_or_else(|| PendingPromptMutationError::SessionNotFound(session_id.to_string()))
+    }
+
+    pub async fn reorder_pending_prompts(
+        &self,
+        session_id: &str,
+        ordered_seqs: Vec<i64>,
+    ) -> Result<SessionRecord, PendingPromptQueueError> {
+        self.access_gate
+            .assert_can_mutate_for_session(session_id)
+            .map_err(|error| {
+                PendingPromptQueueError::Internal(anyhow::anyhow!(error.to_string()))
+            })?;
+        let record = self
+            .get_session_or_not_found(session_id)
+            .map_err(|error| match error {
+                SessionLifecycleError::SessionNotFound(id) => {
+                    PendingPromptQueueError::SessionNotFound(id)
+                }
+                SessionLifecycleError::Internal(error) => {
+                    PendingPromptQueueError::Internal(error)
+                }
+            })?;
+        let handle = self
+            .ensure_live_session_handle(&record, None)
+            .await
+            .map_err(|error| {
+                PendingPromptQueueError::Internal(anyhow::anyhow!(
+                    "failed to ensure live session handle: {error:?}"
+                ))
+            })?;
+
+        handle
+            .reorder_pending_prompts(ordered_seqs)
+            .await
+            .map_err(|error| match error {
+                LiveSessionCommandError::ActorUnavailable => PendingPromptQueueError::Internal(
+                    anyhow::anyhow!("session actor channel closed"),
+                ),
+                LiveSessionCommandError::ResponseDropped => PendingPromptQueueError::Internal(
+                    anyhow::anyhow!("session actor dropped reorder response"),
+                ),
+                LiveSessionCommandError::Rejected(QueueMutationError::NotFound) => {
+                    PendingPromptQueueError::NotFound
+                }
+                LiveSessionCommandError::Rejected(QueueMutationError::InvalidReorder(msg)) => {
+                    PendingPromptQueueError::InvalidReorder(msg)
+                }
+            })?;
+
+        self.session_service
+            .get_session(session_id)
+            .map_err(PendingPromptQueueError::Internal)?
+            .ok_or_else(|| PendingPromptQueueError::SessionNotFound(session_id.to_string()))
+    }
+
+    pub async fn steer_pending_prompt(
+        &self,
+        session_id: &str,
+        seq: i64,
+    ) -> Result<SessionRecord, PendingPromptQueueError> {
+        self.access_gate
+            .assert_can_mutate_for_session(session_id)
+            .map_err(|error| {
+                PendingPromptQueueError::Internal(anyhow::anyhow!(error.to_string()))
+            })?;
+        let record = self
+            .get_session_or_not_found(session_id)
+            .map_err(|error| match error {
+                SessionLifecycleError::SessionNotFound(id) => {
+                    PendingPromptQueueError::SessionNotFound(id)
+                }
+                SessionLifecycleError::Internal(error) => {
+                    PendingPromptQueueError::Internal(error)
+                }
+            })?;
+        let handle = self
+            .ensure_live_session_handle(&record, None)
+            .await
+            .map_err(|error| {
+                PendingPromptQueueError::Internal(anyhow::anyhow!(
+                    "failed to ensure live session handle: {error:?}"
+                ))
+            })?;
+
+        handle
+            .steer_pending_prompt(seq)
+            .await
+            .map_err(|error| match error {
+                LiveSessionCommandError::ActorUnavailable => PendingPromptQueueError::Internal(
+                    anyhow::anyhow!("session actor channel closed"),
+                ),
+                LiveSessionCommandError::ResponseDropped => PendingPromptQueueError::Internal(
+                    anyhow::anyhow!("session actor dropped steer response"),
+                ),
+                LiveSessionCommandError::Rejected(QueueMutationError::NotFound) => {
+                    PendingPromptQueueError::NotFound
+                }
+                LiveSessionCommandError::Rejected(QueueMutationError::InvalidReorder(msg)) => {
+                    PendingPromptQueueError::InvalidReorder(msg)
+                }
+            })?;
+
+        self.session_service
+            .get_session(session_id)
+            .map_err(PendingPromptQueueError::Internal)?
+            .ok_or_else(|| PendingPromptQueueError::SessionNotFound(session_id.to_string()))
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/pending_prompts.rs
@@ -196,6 +196,67 @@ impl SessionStore {
             Ok(record)
         })
     }
+
+    /// Reorder existing pending prompts so their `seq` values match the given
+    /// order. `ordered_seqs` must contain exactly the set of seq values that
+    /// currently exist for this session (no duplicates, no extras, no missing).
+    /// Returns the full list of records in the new order.
+    pub fn reorder_pending_prompts(
+        &self,
+        session_id: &str,
+        ordered_seqs: &[i64],
+    ) -> anyhow::Result<Vec<PendingPromptRecord>> {
+        self.db.with_tx_anyhow(|tx| {
+            // Fetch all current seqs for validation.
+            let mut stmt = tx.prepare(
+                "SELECT seq FROM session_pending_prompts WHERE session_id = ?1 ORDER BY seq ASC",
+            )?;
+            let existing: Vec<i64> = stmt
+                .query_map([session_id], |row| row.get(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+
+            // Validate: same set (no duplicates, no extras, no missing).
+            let mut sorted_requested = ordered_seqs.to_vec();
+            sorted_requested.sort_unstable();
+            sorted_requested.dedup();
+            let mut sorted_existing = existing.clone();
+            sorted_existing.sort_unstable();
+            if sorted_requested != sorted_existing {
+                anyhow::bail!(
+                    "reorder seqs mismatch: expected {:?}, got {:?}",
+                    sorted_existing,
+                    sorted_requested
+                );
+            }
+
+            // Renumber: assign fresh seq values starting from 1, in the order
+            // specified by `ordered_seqs`. Use a temp negative offset to avoid
+            // UNIQUE constraint violations during reassignment.
+            for (idx, &old_seq) in ordered_seqs.iter().enumerate() {
+                let temp_seq = -(idx as i64 + 1);
+                tx.execute(
+                    "UPDATE session_pending_prompts SET seq = ?3 WHERE session_id = ?1 AND seq = ?2",
+                    params![session_id, old_seq, temp_seq],
+                )?;
+            }
+            for idx in 0..ordered_seqs.len() {
+                let temp_seq = -(idx as i64 + 1);
+                let new_seq = idx as i64 + 1;
+                tx.execute(
+                    "UPDATE session_pending_prompts SET seq = ?3 WHERE session_id = ?1 AND seq = ?2",
+                    params![session_id, temp_seq, new_seq],
+                )?;
+            }
+
+            // Return the records in new order.
+            let mut load_stmt = tx.prepare(
+                "SELECT * FROM session_pending_prompts WHERE session_id = ?1 ORDER BY seq ASC",
+            )?;
+            let rows = load_stmt.query_map([session_id], map_pending_prompt)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(Into::into)
+        })
+    }
 }
 
 fn map_pending_prompt(row: &rusqlite::Row) -> rusqlite::Result<PendingPromptRecord> {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/pending_prompts.rs
@@ -215,10 +215,23 @@ impl SessionStore {
                 .query_map([session_id], |row| row.get(0))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
 
-            // Validate: same set (no duplicates, no extras, no missing).
+            // Validate exact multiset equality: the request must be a
+            // permutation of the existing seqs — no duplicates, no extras, no
+            // missing. Do NOT dedup the request before comparing: deduping would
+            // let e.g. [2, 2, 1] over existing {1, 2} pass and corrupt the seq
+            // numbering. Reject on any count mismatch or any duplicate seq.
+            if ordered_seqs.len() != existing.len() {
+                anyhow::bail!(
+                    "reorder seqs count mismatch: expected {} rows, got {}",
+                    existing.len(),
+                    ordered_seqs.len()
+                );
+            }
             let mut sorted_requested = ordered_seqs.to_vec();
             sorted_requested.sort_unstable();
-            sorted_requested.dedup();
+            if sorted_requested.windows(2).any(|pair| pair[0] == pair[1]) {
+                anyhow::bail!("reorder seqs contain duplicates: {:?}", ordered_seqs);
+            }
             let mut sorted_existing = existing.clone();
             sorted_existing.sort_unstable();
             if sorted_requested != sorted_existing {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompts.rs
@@ -69,6 +69,131 @@ fn reorder_pending_prompts_rejects_mismatched_seqs() {
     assert!(result.is_err());
 }
 
+#[test]
+fn reorder_pending_prompts_rejects_duplicate_seqs_matching_existing_set() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    store
+        .insert_pending_prompt("session-1", "first", Some("p1"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "second", Some("p2"))
+        .expect("insert");
+
+    // Regression: [2, 2, 1] deduplicates to the existing set {1, 2}. A dedup
+    // -before-compare validation would accept it and corrupt the seq numbering.
+    // Exact multiset equality must reject it (length 3 != 2, and it contains a
+    // duplicate seq).
+    let result = store.reorder_pending_prompts("session-1", &[2, 2, 1]);
+    assert!(result.is_err());
+
+    // The queue must be untouched: still exactly two rows at seq 1 and 2.
+    let listed = store.list_pending_prompts("session-1").expect("list");
+    assert_eq!(listed.len(), 2);
+    assert_eq!(listed[0].seq, 1);
+    assert_eq!(listed[0].text, "first");
+    assert_eq!(listed[1].seq, 2);
+    assert_eq!(listed[1].text, "second");
+}
+
+#[test]
+fn reorder_promotes_target_to_head_like_steer() {
+    // Mirrors the reorder that handle_steer_pending_prompt builds: target first,
+    // then the remaining prompts in their original order. The full steer method
+    // (which also sends a CancelNotification and resolves pending interactions)
+    // can't be exercised here — the actor test harness has no fake ACP
+    // connection — so this covers the store-level promotion it relies on.
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    store
+        .insert_pending_prompt("session-1", "first", Some("p1"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "second", Some("p2"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "third", Some("p3"))
+        .expect("insert");
+
+    // Steer seq 3 to head: new order = [3, 1, 2].
+    let target = 3;
+    let current = store.list_pending_prompts("session-1").expect("list");
+    let mut new_order = vec![target];
+    for record in &current {
+        if record.seq != target {
+            new_order.push(record.seq);
+        }
+    }
+
+    let reordered = store
+        .reorder_pending_prompts("session-1", &new_order)
+        .expect("reorder");
+    assert_eq!(reordered[0].text, "third");
+    assert_eq!(reordered[0].seq, 1);
+    assert_eq!(reordered[1].text, "first");
+    assert_eq!(reordered[2].text, "second");
+
+    // The promoted prompt is now the drain head.
+    let head = store
+        .peek_head_pending_prompt("session-1")
+        .expect("peek")
+        .expect("head exists");
+    assert_eq!(head.text, "third");
+}
+
+#[test]
+fn reorder_pending_prompts_same_order_is_noop() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    store
+        .insert_pending_prompt("session-1", "first", Some("p1"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "second", Some("p2"))
+        .expect("insert");
+
+    let reordered = store
+        .reorder_pending_prompts("session-1", &[1, 2])
+        .expect("reorder");
+    assert_eq!(reordered.len(), 2);
+    assert_eq!(reordered[0].seq, 1);
+    assert_eq!(reordered[0].text, "first");
+    assert_eq!(reordered[1].seq, 2);
+    assert_eq!(reordered[1].text, "second");
+
+    let listed = store.list_pending_prompts("session-1").expect("list");
+    assert_eq!(listed[0].text, "first");
+    assert_eq!(listed[1].text, "second");
+}
+
+#[test]
+fn reorder_empty_queue_with_empty_request_is_noop() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    // Empty request against an empty queue is exact multiset equality (both
+    // empty) and must succeed as a no-op returning no records.
+    let reordered = store
+        .reorder_pending_prompts("session-1", &[])
+        .expect("reorder empty");
+    assert!(reordered.is_empty());
+
+    // A non-empty request against an empty queue is a count mismatch → error.
+    let result = store.reorder_pending_prompts("session-1", &[1]);
+    assert!(result.is_err());
+}
+
 /// Equality proof for the batched list-page queries: the bulk forms must
 /// return exactly what the per-session queries return, so the list endpoint's
 /// switch from N+1 to batched fetching cannot change the response.

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/pending_prompts.rs
@@ -2,6 +2,73 @@ use super::*;
 use crate::domains::sessions::model::SessionLiveConfigSnapshotRecord;
 use crate::domains::sessions::prompt::{provenance::PromptProvenance, PromptPayload};
 
+#[test]
+fn reorder_pending_prompts_renumbers_seq_values() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    // Insert three prompts: seq 1, 2, 3
+    store
+        .insert_pending_prompt("session-1", "first", Some("p1"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "second", Some("p2"))
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "third", Some("p3"))
+        .expect("insert");
+
+    // Reorder: [3, 1, 2] → "third" becomes seq 1, "first" becomes seq 2, "second" becomes seq 3
+    let reordered = store
+        .reorder_pending_prompts("session-1", &[3, 1, 2])
+        .expect("reorder");
+
+    assert_eq!(reordered.len(), 3);
+    assert_eq!(reordered[0].seq, 1);
+    assert_eq!(reordered[0].text, "third");
+    assert_eq!(reordered[1].seq, 2);
+    assert_eq!(reordered[1].text, "first");
+    assert_eq!(reordered[2].seq, 3);
+    assert_eq!(reordered[2].text, "second");
+
+    // Verify list also returns the reordered result
+    let listed = store
+        .list_pending_prompts("session-1")
+        .expect("list");
+    assert_eq!(listed[0].text, "third");
+    assert_eq!(listed[1].text, "first");
+    assert_eq!(listed[2].text, "second");
+}
+
+#[test]
+fn reorder_pending_prompts_rejects_mismatched_seqs() {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace(&db);
+    let store = SessionStore::new(db);
+    store.insert(&session_record()).expect("insert session");
+
+    store
+        .insert_pending_prompt("session-1", "first", None)
+        .expect("insert");
+    store
+        .insert_pending_prompt("session-1", "second", None)
+        .expect("insert");
+
+    // Missing seq 2
+    let result = store.reorder_pending_prompts("session-1", &[1]);
+    assert!(result.is_err());
+
+    // Extra seq 99
+    let result = store.reorder_pending_prompts("session-1", &[1, 2, 99]);
+    assert!(result.is_err());
+
+    // Duplicate
+    let result = store.reorder_pending_prompts("session-1", &[1, 1]);
+    assert!(result.is_err());
+}
+
 /// Equality proof for the batched list-page queries: the bulk forms must
 /// return exactly what the per-session queries return, so the list endpoint's
 /// switch from N+1 to batched fetching cannot change the response.

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
@@ -25,6 +25,7 @@ pub enum PromptAcceptance {
 #[derive(Debug)]
 pub enum QueueMutationError {
     NotFound,
+    InvalidReorder(String),
 }
 
 #[derive(Debug)]
@@ -135,6 +136,14 @@ pub(in crate::live::sessions) enum SessionCommand {
         respond_to: oneshot::Sender<Result<(), QueueMutationError>>,
     },
     DeletePendingPrompt {
+        seq: i64,
+        respond_to: oneshot::Sender<Result<(), QueueMutationError>>,
+    },
+    ReorderPendingPrompts {
+        ordered_seqs: Vec<i64>,
+        respond_to: oneshot::Sender<Result<(), QueueMutationError>>,
+    },
+    SteerPendingPrompt {
         seq: i64,
         respond_to: oneshot::Sender<Result<(), QueueMutationError>>,
     },

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
@@ -108,6 +108,14 @@ impl SessionActor {
                 let _ = respond_to.send(self.handle_delete_pending_prompt(seq).await);
                 None
             }
+            SessionCommand::ReorderPendingPrompts { ordered_seqs, respond_to } => {
+                let _ = respond_to.send(self.handle_reorder_pending_prompts(ordered_seqs).await);
+                None
+            }
+            SessionCommand::SteerPendingPrompt { seq, respond_to } => {
+                let _ = respond_to.send(self.handle_steer_pending_prompt(seq, false).await);
+                None
+            }
             SessionCommand::ResolveInteraction {
                 request_id,
                 resolution,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
@@ -241,6 +241,16 @@ impl SessionActor {
                                     self.handle_delete_pending_prompt(seq).await,
                                 );
                             }
+                            Some(SessionCommand::ReorderPendingPrompts { ordered_seqs, respond_to }) => {
+                                let _ = respond_to.send(
+                                    self.handle_reorder_pending_prompts(ordered_seqs).await,
+                                );
+                            }
+                            Some(SessionCommand::SteerPendingPrompt { seq, respond_to }) => {
+                                let _ = respond_to.send(
+                                    self.handle_steer_pending_prompt(seq, true).await,
+                                );
+                            }
                             Some(SessionCommand::ReplayAdvance { respond_to }) => {
                                 let _ = respond_to.send(Err(anyhow::anyhow!("session is not a replay session")));
                             }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
@@ -1,6 +1,7 @@
+use agent_client_protocol as acp;
 use anyharness_contract::v1::{
     PendingPromptAddedPayload, PendingPromptRemovalReason, PendingPromptRemovedPayload,
-    PendingPromptUpdatedPayload,
+    PendingPromptUpdatedPayload, PendingPromptsReorderedPayload,
 };
 
 use crate::domains::sessions::model::{PromptAttachmentRecord, PromptAttachmentState};
@@ -223,6 +224,121 @@ impl SessionActor {
                 Err(QueueMutationError::NotFound)
             }
         }
+    }
+
+    pub(in crate::live::sessions::actor) async fn handle_reorder_pending_prompts(
+        &self,
+        ordered_seqs: Vec<i64>,
+    ) -> Result<(), QueueMutationError> {
+        match self
+            .caps
+            .queue
+            .reorder_pending_prompts(&self.session_id, &ordered_seqs)
+        {
+            Ok(records) => {
+                let summaries = records.iter().map(|r| r.to_contract()).collect();
+                let mut sink = self.event_sink.lock().await;
+                sink.pending_prompts_reordered(PendingPromptsReorderedPayload {
+                    pending_prompts: summaries,
+                });
+                Ok(())
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    error = %error,
+                    "failed to reorder pending prompts",
+                );
+                Err(QueueMutationError::InvalidReorder(error.to_string()))
+            }
+        }
+    }
+
+    /// Steer: promote a queued prompt to immediate execution.
+    ///
+    /// Since native injection (sending a second session/prompt on an active ACP
+    /// connection) requires significant restructuring of the actor select loop
+    /// and careful management of a second prompt future, this implementation
+    /// uses the interrupt-based approach for all agents:
+    /// - Move the target prompt to queue head (reorder so it becomes seq 1).
+    /// - Send a CancelNotification to interrupt the current turn.
+    /// - The existing drain loop will pick up the promoted prompt after the
+    ///   cancelled turn finishes.
+    ///
+    /// When idle, just reorder to head; the next drain or prompt dispatch picks
+    /// it up.
+    pub(in crate::live::sessions::actor) async fn handle_steer_pending_prompt(
+        &self,
+        seq: i64,
+        is_busy: bool,
+    ) -> Result<(), QueueMutationError> {
+        // Verify the target prompt exists.
+        match self.caps.queue.find_pending_prompt(&self.session_id, seq) {
+            Ok(Some(_)) => {}
+            Ok(None) => return Err(QueueMutationError::NotFound),
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    seq,
+                    error = %error,
+                    "failed to find pending prompt for steer",
+                );
+                return Err(QueueMutationError::NotFound);
+            }
+        }
+
+        // List all current prompts and reorder so target is first.
+        let current = match self.caps.queue.list_pending_prompts(&self.session_id) {
+            Ok(list) => list,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    error = %error,
+                    "failed to list pending prompts for steer",
+                );
+                return Err(QueueMutationError::NotFound);
+            }
+        };
+
+        let current_seqs: Vec<i64> = current.iter().map(|r| r.seq).collect();
+        // Build new order: target first, then rest in original order.
+        let mut new_order = vec![seq];
+        for &s in &current_seqs {
+            if s != seq {
+                new_order.push(s);
+            }
+        }
+
+        match self
+            .caps
+            .queue
+            .reorder_pending_prompts(&self.session_id, &new_order)
+        {
+            Ok(records) => {
+                let summaries = records.iter().map(|r| r.to_contract()).collect();
+                let mut sink = self.event_sink.lock().await;
+                sink.pending_prompts_reordered(PendingPromptsReorderedPayload {
+                    pending_prompts: summaries,
+                });
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %self.session_id,
+                    error = %error,
+                    "failed to reorder for steer",
+                );
+                return Err(QueueMutationError::InvalidReorder(error.to_string()));
+            }
+        }
+
+        // If busy, cancel the current turn so drain picks up the promoted head.
+        if is_busy {
+            let _ = self.conn.send_notification(
+                acp::schema::CancelNotification::new(self.native_session_id.clone()),
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
@@ -7,7 +7,7 @@ use anyharness_contract::v1::{
 use crate::domains::sessions::model::{PromptAttachmentRecord, PromptAttachmentState};
 use crate::domains::sessions::prompt::PromptPayload;
 use crate::live::sessions::actor::command::{
-    PromptAcceptError, PromptAcceptance, QueueMutationError,
+    PromptAcceptError, PromptAcceptance, QueueMutationError, Resolution,
 };
 use crate::live::sessions::actor::state::SessionActor;
 use crate::live::sessions::model::AttachmentSource;
@@ -331,8 +331,14 @@ impl SessionActor {
             }
         }
 
-        // If busy, cancel the current turn so drain picks up the promoted head.
+        // If busy, mirror the Cancel arm in turn/active.rs exactly: resolve any
+        // pending interaction (Resolution::Cancelled) BEFORE sending the
+        // CancelNotification. Otherwise steering while a permission/plan prompt
+        // is pending would interrupt the turn but leave that interaction
+        // dangling. The CancelNotification then interrupts the current turn so
+        // the drain loop picks up the promoted head.
         if is_busy {
+            self.resolve_pending_interactions(Resolution::Cancelled).await;
             let _ = self.conn.send_notification(
                 acp::schema::CancelNotification::new(self.native_session_id.clone()),
             );

--- a/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
@@ -289,6 +289,25 @@ impl LiveSessionHandle {
             .await
     }
 
+    pub async fn reorder_pending_prompts(
+        &self,
+        ordered_seqs: Vec<i64>,
+    ) -> Result<(), LiveSessionCommandError<QueueMutationError>> {
+        self.send_request(|respond_to| SessionCommand::ReorderPendingPrompts {
+            ordered_seqs,
+            respond_to,
+        })
+        .await
+    }
+
+    pub async fn steer_pending_prompt(
+        &self,
+        seq: i64,
+    ) -> Result<(), LiveSessionCommandError<QueueMutationError>> {
+        self.send_request(|respond_to| SessionCommand::SteerPendingPrompt { seq, respond_to })
+            .await
+    }
+
     pub async fn set_config_option(
         &self,
         config_id: String,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -164,6 +164,10 @@ pub trait QueueDurable: Send + Sync {
         payload: &PromptPayload,
         prompt_id: Option<&str>,
     ) -> anyhow::Result<PendingPromptRecord>;
+    fn list_pending_prompts(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Vec<PendingPromptRecord>>;
     fn peek_head_pending_prompt(
         &self,
         session_id: &str,
@@ -185,6 +189,11 @@ pub trait QueueDurable: Send + Sync {
         session_id: &str,
         seq: i64,
     ) -> anyhow::Result<Option<PendingPromptRecord>>;
+    fn reorder_pending_prompts(
+        &self,
+        session_id: &str,
+        ordered_seqs: &[i64],
+    ) -> anyhow::Result<Vec<PendingPromptRecord>>;
 }
 
 /// Durable background-work tracker rows.

--- a/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
@@ -355,7 +355,9 @@ async fn handle_non_replay_command(
             None
         }
         SessionCommand::EditPendingPrompt { respond_to, .. }
-        | SessionCommand::DeletePendingPrompt { respond_to, .. } => {
+        | SessionCommand::DeletePendingPrompt { respond_to, .. }
+        | SessionCommand::ReorderPendingPrompts { respond_to, .. }
+        | SessionCommand::SteerPendingPrompt { respond_to, .. } => {
             let _ = respond_to.send(Err(QueueMutationError::NotFound));
             None
         }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
@@ -561,4 +561,46 @@ mod tests {
             RuntimeEventInjectionError::SessionReplaying
         ));
     }
+
+    #[tokio::test]
+    async fn replay_actor_rejects_reorder_pending_prompts() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let disposition = handle_non_replay_command(
+            SessionCommand::ReorderPendingPrompts {
+                ordered_seqs: vec![2, 1],
+                respond_to: tx,
+            },
+            false,
+        )
+        .await;
+
+        assert!(disposition.is_none());
+        let error = rx
+            .await
+            .expect("response")
+            .expect_err("replay should reject reorder");
+        assert!(matches!(error, QueueMutationError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn replay_actor_rejects_steer_pending_prompt() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let disposition = handle_non_replay_command(
+            SessionCommand::SteerPendingPrompt {
+                seq: 1,
+                respond_to: tx,
+            },
+            false,
+        )
+        .await;
+
+        assert!(disposition.is_none());
+        let error = rx
+            .await
+            .expect("response")
+            .expect_err("replay should reject steer");
+        assert!(matches!(error, QueueMutationError::NotFound));
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/pending_prompts.rs
@@ -1,7 +1,7 @@
 use super::SessionEventSink;
 use anyharness_contract::v1::{
     PendingPromptAddedPayload, PendingPromptRemovedPayload, PendingPromptUpdatedPayload,
-    SessionEvent,
+    PendingPromptsReorderedPayload, SessionEvent,
 };
 
 impl SessionEventSink {
@@ -15,5 +15,9 @@ impl SessionEventSink {
 
     pub fn pending_prompt_removed(&mut self, payload: PendingPromptRemovedPayload) {
         self.emit_with_ids(SessionEvent::PendingPromptRemoved(payload), None, None);
+    }
+
+    pub fn pending_prompts_reordered(&mut self, payload: PendingPromptsReorderedPayload) {
+        self.emit_with_ids(SessionEvent::PendingPromptsReordered(payload), None, None);
     }
 }

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -426,6 +426,46 @@ export function useDeletePendingPromptMutation(options?: { workspaceId?: string 
   });
 }
 
+export function useReorderPendingPromptsMutation(options?: { workspaceId?: string | null }) {
+  const workspace = useAnyHarnessWorkspaceContext();
+  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const queryClient = useQueryClient();
+  const workspaceId = options?.workspaceId ?? workspace.workspaceId;
+
+  return useMutation({
+    mutationFn: async (input: { sessionId: string; seqs: number[] }) => {
+      const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
+      const client = getAnyHarnessClient(resolved.connection);
+      return client.sessions.reorderPendingPrompts(input.sessionId, input.seqs);
+    },
+    onSuccess: async (_response, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+      });
+    },
+  });
+}
+
+export function useSteerPendingPromptMutation(options?: { workspaceId?: string | null }) {
+  const workspace = useAnyHarnessWorkspaceContext();
+  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const queryClient = useQueryClient();
+  const workspaceId = options?.workspaceId ?? workspace.workspaceId;
+
+  return useMutation({
+    mutationFn: async (input: { sessionId: string; seq: number }) => {
+      const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
+      const client = getAnyHarnessClient(resolved.connection);
+      return client.sessions.steerPendingPrompt(input.sessionId, input.seq);
+    },
+    onSuccess: async (_response, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+      });
+    },
+  });
+}
+
 export function useResumeSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const runtimeUrl = useWorkspaceRuntimeUrl();

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -159,6 +159,8 @@ export {
   useForkSessionMutation,
   useEditPendingPromptMutation,
   useDeletePendingPromptMutation,
+  useReorderPendingPromptsMutation,
+  useSteerPendingPromptMutation,
   useResumeSessionMutation,
   useUpdateSessionTitleMutation,
   useSetSessionGoalMutation,

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -12213,7 +12213,8 @@
         "type": "string",
         "enum": [
           "executed",
-          "deleted"
+          "deleted",
+          "steered"
         ]
       },
       "PendingPromptRemovedPayload": {
@@ -12315,6 +12316,20 @@
           },
           "text": {
             "type": "string"
+          }
+        }
+      },
+      "PendingPromptsReorderedPayload": {
+        "type": "object",
+        "required": [
+          "pendingPrompts"
+        ],
+        "properties": {
+          "pendingPrompts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PendingPromptSummary"
+            }
           }
         }
       },
@@ -15533,6 +15548,27 @@
                     "type": "string",
                     "enum": [
                       "pending_prompt_removed"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PendingPromptsReorderedPayload"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "pending_prompts_reordered"
                     ]
                   }
                 }

--- a/anyharness/sdk/src/client/sessions.ts
+++ b/anyharness/sdk/src/client/sessions.ts
@@ -309,6 +309,34 @@ export class SessionsClient {
     );
   }
 
+  async reorderPendingPrompts(
+    sessionId: string,
+    seqs: number[],
+    options?: AnyHarnessRequestOptions,
+  ): Promise<Session> {
+    return normalizeSession(
+      await this.transport.put<Session>(
+        `/v1/sessions/${encodeURIComponent(sessionId)}/pending-prompts/order`,
+        { seqs },
+        options,
+      ),
+    );
+  }
+
+  async steerPendingPrompt(
+    sessionId: string,
+    seq: number,
+    options?: AnyHarnessRequestOptions,
+  ): Promise<Session> {
+    return normalizeSession(
+      await this.transport.post<Session>(
+        `/v1/sessions/${encodeURIComponent(sessionId)}/pending-prompts/${encodeURIComponent(String(seq))}/steer`,
+        {},
+        options,
+      ),
+    );
+  }
+
   async resume(sessionId: string): Promise<Session>;
   async resume(sessionId: string, options?: AnyHarnessRequestOptions): Promise<Session>;
   async resume(

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -3296,7 +3296,7 @@ export interface components {
             text: string;
         };
         /** @enum {string} */
-        PendingPromptRemovalReason: "executed" | "deleted";
+        PendingPromptRemovalReason: "executed" | "deleted" | "steered";
         PendingPromptRemovedPayload: {
             promptId?: string | null;
             reason: components["schemas"]["PendingPromptRemovalReason"];
@@ -3319,6 +3319,9 @@ export interface components {
             /** Format: int64 */
             seq: number;
             text: string;
+        };
+        PendingPromptsReorderedPayload: {
+            pendingPrompts: components["schemas"]["PendingPromptSummary"][];
         };
         PermissionInteractionContext: {
             agentId?: string | null;
@@ -4043,6 +4046,9 @@ export interface components {
         }) | (components["schemas"]["PendingPromptRemovedPayload"] & {
             /** @enum {string} */
             type: "pending_prompt_removed";
+        }) | (components["schemas"]["PendingPromptsReorderedPayload"] & {
+            /** @enum {string} */
+            type: "pending_prompts_reordered";
         }) | (components["schemas"]["InteractionRequestedEvent"] & {
             /** @enum {string} */
             type: "interaction_requested";

--- a/anyharness/sdk/src/index.ts
+++ b/anyharness/sdk/src/index.ts
@@ -353,6 +353,7 @@ export type {
   PendingPromptAddedEvent,
   PendingPromptUpdatedEvent,
   PendingPromptRemovedEvent,
+  PendingPromptsReorderedEvent,
   PendingPromptRemovalReason,
   InteractionKind,
   InteractionSource,

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -8,7 +8,13 @@ import {
   selectPendingUserInputInteraction,
   selectPrimaryPendingInteraction,
 } from "../../index.js";
-import type { ContentPart, SessionEventEnvelope, ThoughtItem, ToolCallItem } from "../../index.js";
+import type {
+  ContentPart,
+  PromptProvenance,
+  SessionEventEnvelope,
+  ThoughtItem,
+  ToolCallItem,
+} from "../../index.js";
 
 describe("transcript reducer", () => {
   it("normalizes available slash commands at the reducer boundary", () => {
@@ -1620,6 +1626,35 @@ function pendingPromptRemoved(
       reason: "deleted",
     },
   };
+}
+
+function pendingPromptsReordered(
+  eventSeq: number,
+  pendingPrompts: Array<{
+    seq: number;
+    promptId: string | null;
+    text: string;
+    contentParts?: ContentPart[];
+    queuedAt?: string;
+    promptProvenance?: PromptProvenance | null;
+  }>,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq: eventSeq,
+    timestamp: `2026-04-04T00:00:0${eventSeq}Z`,
+    event: {
+      type: "pending_prompts_reordered",
+      pendingPrompts: pendingPrompts.map((prompt) => ({
+        seq: prompt.seq,
+        promptId: prompt.promptId,
+        text: prompt.text,
+        contentParts: prompt.contentParts ?? [{ type: "text", text: prompt.text }],
+        queuedAt: prompt.queuedAt ?? `2026-04-04T00:00:0${eventSeq}Z`,
+        promptProvenance: prompt.promptProvenance ?? null,
+      })),
+    },
+  } as unknown as SessionEventEnvelope;
 }
 
 function reasoningStarted(

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -304,6 +304,17 @@ export function reduceEvent(
       );
       break;
 
+    case "pending_prompts_reordered":
+      s.pendingPrompts = (evt.pendingPrompts ?? []).map((summary) => ({
+        seq: summary.seq,
+        promptId: summary.promptId ?? null,
+        text: summary.text,
+        contentParts: normalizeContentParts(summary.contentParts ?? []),
+        queuedAt: summary.queuedAt,
+        promptProvenance: summary.promptProvenance ?? null,
+      }));
+      break;
+
     case "interaction_requested":
       applyInteractionRequested(s, evt);
       break;

--- a/anyharness/sdk/src/types/events.ts
+++ b/anyharness/sdk/src/types/events.ts
@@ -145,6 +145,10 @@ export type PendingPromptUpdatedEvent = PendingPromptUpdatedPayload & {
 export type PendingPromptRemovedEvent = PendingPromptRemovedPayload & {
   type: "pending_prompt_removed";
 };
+export type PendingPromptsReorderedEvent = {
+  type: "pending_prompts_reordered";
+  pendingPrompts: PendingPromptSummary[];
+};
 export type PendingPromptRemovalReason =
   components["schemas"]["PendingPromptRemovalReason"];
 export type PendingPromptSummary = components["schemas"]["PendingPromptSummary"];
@@ -239,6 +243,7 @@ export type SessionEvent =
   | PendingPromptAddedEvent
   | PendingPromptUpdatedEvent
   | PendingPromptRemovedEvent
+  | PendingPromptsReorderedEvent
   | InteractionRequestedEvent
   | InteractionResolvedEvent
   | ErrorEvent;

--- a/apps/desktop/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx
+++ b/apps/desktop/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx
@@ -24,6 +24,7 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
           entries={pendingQueueRows(PENDING_PROMPTS_SINGLE)}
           steeringSeq={null}
           sessionMaterialized={true}
+          reorderInFlight={false}
           onBeginEdit={noop}
           onDelete={noop}
           onSteer={noop}
@@ -36,6 +37,7 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
           entries={pendingQueueRows(PENDING_PROMPTS_MULTI)}
           steeringSeq={null}
           sessionMaterialized={true}
+          reorderInFlight={false}
           onBeginEdit={noop}
           onDelete={noop}
           onSteer={noop}
@@ -48,6 +50,7 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
           entries={pendingQueueRows(PENDING_PROMPTS_WITH_EDITING)}
           steeringSeq={null}
           sessionMaterialized={true}
+          reorderInFlight={false}
           onBeginEdit={noop}
           onDelete={noop}
           onSteer={noop}
@@ -61,6 +64,7 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
           entries={pendingQueueRows(PLAYGROUND_SUBAGENT_WAKE_QUEUE)}
           steeringSeq={null}
           sessionMaterialized={true}
+          reorderInFlight={false}
           onBeginEdit={noop}
           onDelete={noop}
           onSteer={noop}

--- a/apps/desktop/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx
+++ b/apps/desktop/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx
@@ -22,24 +22,36 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
       return (
         <PendingPromptList
           entries={pendingQueueRows(PENDING_PROMPTS_SINGLE)}
+          steeringSeq={null}
+          sessionMaterialized={true}
           onBeginEdit={noop}
           onDelete={noop}
+          onSteer={noop}
+          onReorder={noop}
         />
       );
     case "pending-prompts-multi":
       return (
         <PendingPromptList
           entries={pendingQueueRows(PENDING_PROMPTS_MULTI)}
+          steeringSeq={null}
+          sessionMaterialized={true}
           onBeginEdit={noop}
           onDelete={noop}
+          onSteer={noop}
+          onReorder={noop}
         />
       );
     case "pending-prompts-editing":
       return (
         <PendingPromptList
           entries={pendingQueueRows(PENDING_PROMPTS_WITH_EDITING)}
+          steeringSeq={null}
+          sessionMaterialized={true}
           onBeginEdit={noop}
           onDelete={noop}
+          onSteer={noop}
+          onReorder={noop}
         />
       );
     case "subagents-queued-wake":
@@ -47,8 +59,12 @@ export function renderOutboundSlot(scenario: ScenarioKey): ReactNode | null {
       return (
         <PendingPromptList
           entries={pendingQueueRows(PLAYGROUND_SUBAGENT_WAKE_QUEUE)}
+          steeringSeq={null}
+          sessionMaterialized={true}
           onBeginEdit={noop}
           onDelete={noop}
+          onSteer={noop}
+          onReorder={noop}
         />
       );
     default:

--- a/apps/desktop/src/components/settings/panes/GeneralPane.tsx
+++ b/apps/desktop/src/components/settings/panes/GeneralPane.tsx
@@ -10,7 +10,7 @@ import { OpenTargetIcon } from "@/components/workspace/open-target/OpenTargetIco
 import { useAvailableEditors } from "@/hooks/access/tauri/shell/use-available-editors";
 import { resolvePreferredOpenTarget } from "@/lib/domain/chat/composer/preference-resolvers";
 import { emitTurnEnd } from "@/lib/infra/events/turn-end-events";
-import type { DefaultNewWorkspaceMode } from "@/lib/domain/preferences/user/model";
+import type { BusySendBehavior, DefaultNewWorkspaceMode } from "@/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 
 type SettingsOpenTargetIconId =
@@ -40,12 +40,17 @@ const NEW_WORKSPACE_MODE_OPTIONS: { id: DefaultNewWorkspaceMode; label: string }
   { id: "worktree", label: "Worktree" },
   { id: "local", label: "Local" },
 ];
+const BUSY_SEND_BEHAVIOR_OPTIONS: { id: BusySendBehavior; label: string }[] = [
+  { id: "queue", label: "Queue message" },
+  { id: "interrupt", label: "Interrupt & send" },
+];
 export function GeneralPane() {
   const { data: editors = EMPTY_EDITORS } = useAvailableEditors();
   const preferences = useUserPreferencesStore(useShallow((state) => ({
     defaultOpenInTargetId: state.defaultOpenInTargetId,
     branchPrefixType: state.branchPrefixType,
     defaultNewWorkspaceMode: state.defaultNewWorkspaceMode,
+    busySendBehavior: state.busySendBehavior,
     turnEndSoundEnabled: state.turnEndSoundEnabled,
     subagentsEnabled: state.subagentsEnabled,
     coworkWorkspaceDelegationEnabled: state.coworkWorkspaceDelegationEnabled,
@@ -74,6 +79,9 @@ export function GeneralPane() {
   const currentNewWorkspaceModeLabel = NEW_WORKSPACE_MODE_OPTIONS.find(
     (option) => option.id === preferences.defaultNewWorkspaceMode,
   )?.label ?? "Worktree";
+  const currentBusySendBehaviorLabel = BUSY_SEND_BEHAVIOR_OPTIONS.find(
+    (option) => option.id === preferences.busySendBehavior,
+  )?.label ?? "Queue message";
 
   return (
     <section className="space-y-6">
@@ -137,6 +145,26 @@ export function GeneralPane() {
                   label: option.label,
                   selected: preferences.defaultNewWorkspaceMode === option.id,
                   onSelect: () => preferences.set("defaultNewWorkspaceMode", option.id),
+                })),
+              }]}
+            />
+          </SettingsRow>
+
+          <SettingsRow
+            label="When the agent is busy"
+            description="What sending a message does mid-turn"
+          >
+            <SettingsMenu
+              label={currentBusySendBehaviorLabel}
+              className={SETTINGS_CONTROL_WIDTH_CLASS}
+              menuClassName={SETTINGS_CONTROL_WIDTH_CLASS}
+              groups={[{
+                id: "busy-send-behavior",
+                options: BUSY_SEND_BEHAVIOR_OPTIONS.map((option) => ({
+                  id: option.id,
+                  label: option.label,
+                  selected: preferences.busySendBehavior === option.id,
+                  onSelect: () => preferences.set("busySendBehavior", option.id),
                 })),
               }]}
             />

--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -124,9 +124,12 @@ export function ChatInput({
   const { beginEdit } = useQueuedPromptEditReader();
   const handleEditLastQueued = useCallback(() => {
     if (pendingPrompts.length === 0) return;
-    // Edit the newest queued message (last in the list).
+    // Edit the newest queued message (last in the list). Key the edit on the
+    // stable promptId so a reorder renumber can't retarget it; a prompt without
+    // one can't be safely tracked, so skip it.
     const last = pendingPrompts[pendingPrompts.length - 1];
-    beginEdit({ seq: last.seq, text: last.text });
+    if (!last.promptId) return;
+    beginEdit({ promptId: last.promptId, text: last.text });
   }, [beginEdit, pendingPrompts]);
   const planAttachments = usePlanDraftAttachments({
     workspaceUiKey,

--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -19,6 +19,7 @@ import {
   useActiveSessionCanCancelState,
   useActiveSessionRunningState,
 } from "@/hooks/chat/derived/use-active-session-identity";
+import { useActivePendingPrompts } from "@/hooks/chat/derived/use-active-pending-session-interactions";
 import { useChatAvailabilityState } from "@/hooks/chat/derived/use-chat-availability-state";
 import { useChatComposerKeyboard } from "@/hooks/chat/ui/use-chat-composer-keyboard";
 import { useChatDraftControls } from "@/hooks/chat/ui/use-chat-draft-state";
@@ -28,7 +29,7 @@ import type { PromptAttachmentController } from "@/hooks/chat/ui/use-chat-prompt
 import { useComposerSubmitGate } from "@/hooks/chat/ui/use-composer-submit-gate";
 import { usePlanDraftAttachments } from "@/hooks/plans/facade/use-plan-draft-attachments";
 import { useChatSessionControls } from "@/hooks/chat/facade/use-chat-session-controls";
-import { useQueuedPromptEdit } from "@/hooks/chat/ui/use-queued-prompt-edit";
+import { useQueuedPromptEdit, useQueuedPromptEditReader } from "@/hooks/chat/ui/use-queued-prompt-edit";
 import { useComposerTextareaAutosize } from "@/hooks/chat/ui/use-composer-textarea-autosize";
 import { focusChatInput } from "@/lib/domain/focus-zone";
 import { serializeChatDraftToPrompt } from "@/lib/domain/chat/composer/file-mention-draft-model";
@@ -119,6 +120,14 @@ export function ChatInput({
     commitEdit,
   } = useQueuedPromptEdit();
   const effectiveIsEditingQueuedPrompt = suppressActiveSessionState ? false : isEditingQueuedPrompt;
+  const pendingPrompts = useActivePendingPrompts();
+  const { beginEdit } = useQueuedPromptEditReader();
+  const handleEditLastQueued = useCallback(() => {
+    if (pendingPrompts.length === 0) return;
+    // Edit the newest queued message (last in the list).
+    const last = pendingPrompts[pendingPrompts.length - 1];
+    beginEdit({ seq: last.seq, text: last.text });
+  }, [beginEdit, pendingPrompts]);
   const planAttachments = usePlanDraftAttachments({
     workspaceUiKey,
     sdkWorkspaceId: materializedWorkspaceId,
@@ -220,6 +229,7 @@ export function ChatInput({
     modeControl: effectiveModeControl,
     isEditingQueuedPrompt: effectiveIsEditingQueuedPrompt,
     onCancelEdit: cancelEdit,
+    onEditLastQueued: pendingPrompts.length > 0 ? handleEditLastQueued : undefined,
   });
 
   const focusComposer = useCallback((): boolean => {

--- a/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
+import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { ArrowUpRight, Pencil, X } from "@proliferate/ui/icons";
 import { GripVertical } from "lucide-react";
 import { ThinkingText } from "@/components/feedback/ThinkingText";
@@ -187,7 +188,7 @@ function PendingPromptRow({
   return (
     <div
       data-reorder-item
-      className={`group/queue-row relative flex items-center justify-between gap-2 py-0.5 pl-4 text-sm transition-colors ${
+      className={`group/queue-row relative flex items-center justify-between gap-2 py-0.5 pl-4 transition-colors ${
         isDragging ? "opacity-50" : ""
       } ${isDropTarget ? "border-t border-accent" : ""}`}
     >
@@ -202,9 +203,10 @@ function PendingPromptRow({
         </div>
       )}
 
-      {/* Message text */}
+      {/* Message text — one step smaller than the chat input / transcript
+          message text (--text-message, aliased to --text-composer). */}
       <div
-        className={`min-w-0 flex-1 whitespace-pre-wrap leading-4 transition-colors line-clamp-2 ${
+        className={`min-w-0 flex-1 whitespace-pre-wrap text-ui leading-[var(--text-ui--line-height)] transition-colors line-clamp-2 ${
           isBeingEdited
             ? "text-muted-foreground/60"
             : "text-muted-foreground"
@@ -222,42 +224,45 @@ function PendingPromptRow({
       {!isSending && !isSteering && (
         <div className="flex shrink-0 items-center gap-1">
           {showSteerAction && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleSteer}
-              className="h-auto shrink-0 rounded-full border border-transparent px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:text-foreground"
-              aria-label="Run this message next"
-            >
-              <ArrowUpRight className="mr-0.5 size-3" />
-              Steer
-            </Button>
+            <Tooltip content="Send next — interrupts the current turn">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleSteer}
+                className={ROW_ACTION_CLASSNAME}
+                aria-label="Run this message next"
+              >
+                <ArrowUpRight className="size-3.5" />
+              </Button>
+            </Tooltip>
           )}
           {renderEditAction && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={!canEdit}
-              onClick={handleBeginEdit}
-              className={ROW_ACTION_CLASSNAME}
-              aria-label="Edit queued message"
-              title={editDisabledReason ?? "Edit queued message"}
-            >
-              <Pencil className="size-3.5" />
-            </Button>
+            <Tooltip content={editDisabledReason ?? "Edit message"}>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={!canEdit}
+                onClick={handleBeginEdit}
+                className={ROW_ACTION_CLASSNAME}
+                aria-label="Edit queued message"
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+            </Tooltip>
           )}
           {renderDeleteAction && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={!canDelete}
-              onClick={handleDelete}
-              className={ROW_ACTION_CLASSNAME}
-              aria-label="Delete queued message"
-              title={deleteDisabledReason ?? "Delete queued message"}
-            >
-              <X className="size-3.5" />
-            </Button>
+            <Tooltip content={deleteDisabledReason ?? "Remove from queue"}>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={!canDelete}
+                onClick={handleDelete}
+                className={ROW_ACTION_CLASSNAME}
+                aria-label="Delete queued message"
+              >
+                <X className="size-3.5" />
+              </Button>
+            </Tooltip>
           )}
         </div>
       )}

--- a/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
@@ -1,122 +1,133 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { Pencil, X } from "@proliferate/ui/icons";
+import { ArrowUpRight, Pencil, X } from "@proliferate/ui/icons";
+import { GripVertical } from "lucide-react";
 import { ThinkingText } from "@/components/feedback/ThinkingText";
-import { useActiveSessionId } from "@/hooks/chat/derived/use-active-session-identity";
-import { usePromptOutboxActions } from "@/hooks/chat/workflows/use-prompt-outbox-actions";
-import { useQueuedPromptEditReader } from "@/hooks/chat/ui/use-queued-prompt-edit";
-import { useDeletePendingPrompt } from "@/hooks/sessions/workflows/use-delete-pending-prompt";
+import { useVerticalReorder } from "@/hooks/chat/ui/use-vertical-reorder";
+import { usePendingPromptQueue } from "@/hooks/chat/ui/use-pending-prompt-queue";
 import { CHAT_STREAMING_STATUS_LABELS } from "@/copy/chat/chat-copy";
-import {
-  derivePendingPromptQueueRow,
-  type PendingPromptQueueRow,
-} from "@proliferate/product-domain/chats/pending-prompts/pending-prompt-queue";
+import type { PendingPromptQueueRow } from "@proliferate/product-domain/chats/pending-prompts/pending-prompt-queue";
 
 export interface PendingPromptListProps {
   entries: PendingPromptQueueRow[];
+  steeringSeq: number | null;
+  sessionMaterialized: boolean;
   onBeginEdit: (seq: number) => void;
   onDelete: (entry: PendingPromptQueueRow) => void;
+  onSteer: (entry: PendingPromptQueueRow) => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
 }
 
 /**
- * Pure presentational queue list. Takes all data as props so it can be
- * rendered in isolation (e.g. from the dev playground). Production callers
- * should use `ConnectedPendingPromptList` which wires it to the chat-input
- * store and the pending-prompt projection.
+ * Presentational queue list. Shows queued messages with drag-reorder,
+ * steer, edit, and delete affordances.
  */
 export function PendingPromptList({
   entries,
+  steeringSeq,
+  sessionMaterialized,
   onBeginEdit,
   onDelete,
+  onSteer,
+  onReorder,
 }: PendingPromptListProps) {
+  const { dragIndex, dropIndex, handleDragStart } = useVerticalReorder({
+    itemCount: entries.length,
+    onReorder,
+  });
+
   if (entries.length === 0) {
     return null;
   }
 
   return (
     <div
-      // Queue panel rides the shared dock-panel shell (see
-      // ComposerAttachedPanel): 13px top radius docking into the composer,
-      // 0.5px border, 2% foreground tint. No backdrop blur — the dock bans
-      // blur over the transcript (ChatComposerDock PERF note).
-      className="relative flex flex-col overflow-clip rounded-t-[13px] border-x-[0.5px] border-t-[0.5px] border-border bg-[color:color-mix(in_oklab,var(--color-foreground)_2%,var(--color-background))] px-1.5 py-1.5"
+      className="relative flex flex-col overflow-clip rounded-t-[13px] border-x-[0.5px] border-t-[0.5px] border-border bg-[color:color-mix(in_oklab,var(--color-foreground)_2%,var(--color-background))]"
       data-telemetry-mask
       aria-label="Queued messages"
     >
-      {entries.map((entry) => (
-        <PendingPromptRow
-          key={entry.key}
-          entry={entry}
-          onBeginEdit={onBeginEdit}
-          onDelete={onDelete}
-        />
-      ))}
+      <div
+        className="vertical-scroll-fade-mask flex max-h-[30dvh] flex-col gap-px overflow-y-auto px-3 py-1.5 scrollbar-none [--edge-fade-distance:8px]"
+        data-reorder-container
+      >
+        {entries.map((entry, index) => (
+          <PendingPromptRow
+            key={entry.key}
+            entry={entry}
+            index={index}
+            totalCount={entries.length}
+            sessionMaterialized={sessionMaterialized}
+            isSteering={steeringSeq === entry.seq}
+            isDragging={dragIndex === index}
+            isDropTarget={dropIndex === index && dragIndex !== null && dragIndex !== index}
+            onBeginEdit={onBeginEdit}
+            onDelete={onDelete}
+            onSteer={onSteer}
+            onDragStart={handleDragStart}
+          />
+        ))}
+      </div>
     </div>
   );
 }
 
 export function ConnectedPendingPromptList() {
-  const activeSessionId = useActiveSessionId();
-  const { visiblePendingPrompts, beginEdit } = useQueuedPromptEditReader();
-  const deletePendingPrompt = useDeletePendingPrompt();
-  const { cancelBeforeDispatch, dismissPrompt } = usePromptOutboxActions();
-  const rows = useMemo(
-    () => visiblePendingPrompts.map(derivePendingPromptQueueRow),
-    [visiblePendingPrompts],
-  );
+  const {
+    rows,
+    steeringSeq,
+    sessionMaterialized,
+    onBeginEdit,
+    onDelete,
+    onSteer,
+    onReorder,
+  } = usePendingPromptQueue();
 
-  const handleDelete = useCallback(
-    (entry: PendingPromptQueueRow) => {
-      if (entry.deleteAction === "cancel_local" && entry.promptId) {
-        cancelBeforeDispatch(entry.promptId);
-        return;
-      }
-      if (entry.deleteAction === "dismiss_local" && entry.promptId) {
-        dismissPrompt(entry.promptId);
-        return;
-      }
-      if (!activeSessionId || entry.deleteAction !== "runtime") return;
-      void deletePendingPrompt(activeSessionId, entry.seq);
-    },
-    [activeSessionId, cancelBeforeDispatch, deletePendingPrompt, dismissPrompt],
-  );
-  const handleBeginEdit = useCallback(
-    (seq: number) => {
-      const entry = visiblePendingPrompts.find((candidate) => candidate.seq === seq);
-      if (!entry) return;
-      beginEdit({ seq: entry.seq, text: entry.text });
-    },
-    [beginEdit, visiblePendingPrompts],
-  );
-
-  if (!activeSessionId) {
+  if (rows.length === 0) {
     return null;
   }
 
   return (
     <PendingPromptList
       entries={rows}
-      onBeginEdit={handleBeginEdit}
-      onDelete={handleDelete}
+      steeringSeq={steeringSeq}
+      sessionMaterialized={sessionMaterialized}
+      onBeginEdit={onBeginEdit}
+      onDelete={onDelete}
+      onSteer={onSteer}
+      onReorder={onReorder}
     />
   );
 }
 
 interface PendingPromptRowProps {
   entry: PendingPromptQueueRow;
+  index: number;
+  totalCount: number;
+  sessionMaterialized: boolean;
+  isSteering: boolean;
+  isDragging: boolean;
+  isDropTarget: boolean;
   onBeginEdit: (seq: number) => void;
   onDelete: (entry: PendingPromptQueueRow) => void;
+  onSteer: (entry: PendingPromptQueueRow) => void;
+  onDragStart: (index: number, event: React.PointerEvent) => void;
 }
 
-// Hover-reveal for the row's edit/remove affordances: keep the queue calm at
-// rest instead of striping every row with always-on icon buttons.
-const QUEUE_ROW_ACTION_CLASSNAME =
-  "size-6 shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/queue-row:opacity-100 group-focus-within/queue-row:opacity-100";
+const ROW_ACTION_CLASSNAME =
+  "shrink-0 rounded-full p-0.5 text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground";
 
 function PendingPromptRow({
   entry,
+  index,
+  totalCount,
+  sessionMaterialized,
+  isSteering,
+  isDragging,
+  isDropTarget,
   onBeginEdit,
   onDelete,
+  onSteer,
+  onDragStart,
 }: PendingPromptRowProps) {
   const {
     seq,
@@ -130,9 +141,10 @@ function PendingPromptRow({
     canDelete,
     deleteDisabledReason,
   } = entry;
-  // While the entry is in flight the edit affordance is meaningless — the
-  // "Sending…" hint owns the trailing slot. Delete stays only when it can
-  // still act (cancel while preparing); a dead disabled X is just clutter.
+
+  const isRuntimeConfirmed = seq > 0;
+  const showSteerAction = isRuntimeConfirmed && sessionMaterialized && !isSending && !isBeingEdited;
+  const canDragReorder = isRuntimeConfirmed && sessionMaterialized && totalCount > 1;
   const renderEditAction = showEditAction && !isBeingEdited && !isSending;
   const renderDeleteAction = showDeleteAction && (!isSending || canDelete);
 
@@ -146,11 +158,21 @@ function PendingPromptRow({
     onDelete(entry);
   }, [canDelete, entry, onDelete]);
 
-  // One trailing state hint per row: sending shimmer > editing note > actions.
-  const stateHint = isSending
+  const handleSteer = useCallback(() => {
+    onSteer(entry);
+  }, [entry, onSteer]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      onDragStart(index, event);
+    },
+    [index, onDragStart],
+  );
+
+  const stateHint = isSending || isSteering
     ? (
       <ThinkingText
-        text={CHAT_STREAMING_STATUS_LABELS.sending}
+        text={isSteering ? "Steering…" : CHAT_STREAMING_STATUS_LABELS.sending}
         className="shrink-0 text-ui-sm font-normal leading-[var(--text-ui-sm--line-height)]"
       />
     )
@@ -163,43 +185,81 @@ function PendingPromptRow({
       : null;
 
   return (
-    <div className="group/queue-row flex min-h-7 items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-accent">
+    <div
+      data-reorder-item
+      className={`group/queue-row relative flex items-center justify-between gap-2 py-0.5 pl-4 text-sm transition-colors ${
+        isDragging ? "opacity-50" : ""
+      } ${isDropTarget ? "border-t border-accent" : ""}`}
+    >
+      {/* Drag handle — left gutter, hover-reveal only */}
+      {canDragReorder && (
+        <div
+          className="absolute left-0 flex cursor-grab items-center opacity-0 transition-opacity active:cursor-grabbing group-hover/queue-row:opacity-70"
+          onPointerDown={handlePointerDown}
+          aria-label="Reorder"
+        >
+          <GripVertical className="size-3.5 text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Message text */}
       <div
-        className={`min-w-0 flex-1 truncate text-ui leading-[var(--text-ui--line-height)] transition-colors ${
+        className={`min-w-0 flex-1 whitespace-pre-wrap leading-4 transition-colors line-clamp-2 ${
           isBeingEdited
             ? "text-muted-foreground/60"
-            : "text-muted-foreground group-hover/queue-row:text-foreground"
+            : "text-muted-foreground"
         }`}
         title={label}
       >
         {label}
       </div>
+
+      {/* Trailing state hint or actions */}
       {stateHint}
-      {renderEditAction && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          disabled={!canEdit}
-          onClick={handleBeginEdit}
-          className={QUEUE_ROW_ACTION_CLASSNAME}
-          aria-label="Edit queued message"
-          title={editDisabledReason ?? "Edit queued message"}
-        >
-          <Pencil className="size-3.5" />
-        </Button>
-      )}
-      {renderDeleteAction && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          disabled={!canDelete}
-          onClick={handleDelete}
-          className={QUEUE_ROW_ACTION_CLASSNAME}
-          aria-label="Delete queued message"
-          title={deleteDisabledReason ?? "Delete queued message"}
-        >
-          <X className="size-3.5" />
-        </Button>
+
+      {/* Actions: hidden while sending (stateHint takes over), but delete
+          stays visible alongside the "Editing..." hint. */}
+      {!isSending && !isSteering && (
+        <div className="flex shrink-0 items-center gap-1">
+          {showSteerAction && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSteer}
+              className="h-auto shrink-0 rounded-full border border-transparent px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:text-foreground"
+              aria-label="Run this message next"
+            >
+              <ArrowUpRight className="mr-0.5 size-3" />
+              Steer
+            </Button>
+          )}
+          {renderEditAction && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={!canEdit}
+              onClick={handleBeginEdit}
+              className={ROW_ACTION_CLASSNAME}
+              aria-label="Edit queued message"
+              title={editDisabledReason ?? "Edit queued message"}
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+          )}
+          {renderDeleteAction && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={!canDelete}
+              onClick={handleDelete}
+              className={ROW_ACTION_CLASSNAME}
+              aria-label="Delete queued message"
+              title={deleteDisabledReason ?? "Delete queued message"}
+            >
+              <X className="size-3.5" />
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx
@@ -13,7 +13,8 @@ export interface PendingPromptListProps {
   entries: PendingPromptQueueRow[];
   steeringSeq: number | null;
   sessionMaterialized: boolean;
-  onBeginEdit: (seq: number) => void;
+  reorderInFlight: boolean;
+  onBeginEdit: (entry: PendingPromptQueueRow) => void;
   onDelete: (entry: PendingPromptQueueRow) => void;
   onSteer: (entry: PendingPromptQueueRow) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
@@ -27,6 +28,7 @@ export function PendingPromptList({
   entries,
   steeringSeq,
   sessionMaterialized,
+  reorderInFlight,
   onBeginEdit,
   onDelete,
   onSteer,
@@ -61,10 +63,12 @@ export function PendingPromptList({
             isSteering={steeringSeq === entry.seq}
             isDragging={dragIndex === index}
             isDropTarget={dropIndex === index && dragIndex !== null && dragIndex !== index}
+            reorderInFlight={reorderInFlight}
             onBeginEdit={onBeginEdit}
             onDelete={onDelete}
             onSteer={onSteer}
             onDragStart={handleDragStart}
+            onReorder={onReorder}
           />
         ))}
       </div>
@@ -77,6 +81,7 @@ export function ConnectedPendingPromptList() {
     rows,
     steeringSeq,
     sessionMaterialized,
+    reorderInFlight,
     onBeginEdit,
     onDelete,
     onSteer,
@@ -92,6 +97,7 @@ export function ConnectedPendingPromptList() {
       entries={rows}
       steeringSeq={steeringSeq}
       sessionMaterialized={sessionMaterialized}
+      reorderInFlight={reorderInFlight}
       onBeginEdit={onBeginEdit}
       onDelete={onDelete}
       onSteer={onSteer}
@@ -108,10 +114,12 @@ interface PendingPromptRowProps {
   isSteering: boolean;
   isDragging: boolean;
   isDropTarget: boolean;
-  onBeginEdit: (seq: number) => void;
+  reorderInFlight: boolean;
+  onBeginEdit: (entry: PendingPromptQueueRow) => void;
   onDelete: (entry: PendingPromptQueueRow) => void;
   onSteer: (entry: PendingPromptQueueRow) => void;
   onDragStart: (index: number, event: React.PointerEvent) => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
 }
 
 const ROW_ACTION_CLASSNAME =
@@ -125,10 +133,12 @@ function PendingPromptRow({
   isSteering,
   isDragging,
   isDropTarget,
+  reorderInFlight,
   onBeginEdit,
   onDelete,
   onSteer,
   onDragStart,
+  onReorder,
 }: PendingPromptRowProps) {
   const {
     seq,
@@ -151,8 +161,8 @@ function PendingPromptRow({
 
   const handleBeginEdit = useCallback(() => {
     if (!canEdit) return;
-    onBeginEdit(seq);
-  }, [canEdit, onBeginEdit, seq]);
+    onBeginEdit(entry);
+  }, [canEdit, entry, onBeginEdit]);
 
   const handleDelete = useCallback(() => {
     if (!canDelete) return;
@@ -170,10 +180,23 @@ function PendingPromptRow({
     [index, onDragStart],
   );
 
+  const handleReorderKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "ArrowUp" && index > 0) {
+        event.preventDefault();
+        onReorder(index, index - 1);
+      } else if (event.key === "ArrowDown" && index < totalCount - 1) {
+        event.preventDefault();
+        onReorder(index, index + 1);
+      }
+    },
+    [index, onReorder, totalCount],
+  );
+
   const stateHint = isSending || isSteering
     ? (
       <ThinkingText
-        text={isSteering ? "Steering…" : CHAT_STREAMING_STATUS_LABELS.sending}
+        text={isSteering ? CHAT_STREAMING_STATUS_LABELS.steering : CHAT_STREAMING_STATUS_LABELS.sending}
         className="shrink-0 text-ui-sm font-normal leading-[var(--text-ui-sm--line-height)]"
       />
     )
@@ -190,14 +213,18 @@ function PendingPromptRow({
       data-reorder-item
       className={`group/queue-row relative flex items-center justify-between gap-2 py-0.5 pl-4 transition-colors ${
         isDragging ? "opacity-50" : ""
-      } ${isDropTarget ? "border-t border-accent" : ""}`}
+      } ${isDropTarget ? "border-t border-primary" : ""}`}
     >
-      {/* Drag handle — left gutter, hover-reveal only */}
+      {/* Drag handle — left gutter, hover-reveal only. Keyboard-operable:
+          focus and press ArrowUp/ArrowDown to move the row one position. */}
       {canDragReorder && (
         <div
-          className="absolute left-0 flex cursor-grab items-center opacity-0 transition-opacity active:cursor-grabbing group-hover/queue-row:opacity-70"
+          role="button"
+          tabIndex={0}
+          aria-label="Reorder message"
+          className="absolute left-0 flex cursor-grab items-center opacity-0 transition-opacity focus-visible:opacity-70 active:cursor-grabbing group-hover/queue-row:opacity-70"
           onPointerDown={handlePointerDown}
-          aria-label="Reorder"
+          onKeyDown={handleReorderKeyDown}
         >
           <GripVertical className="size-3.5 text-muted-foreground" />
         </div>
@@ -228,9 +255,10 @@ function PendingPromptRow({
               <Button
                 variant="ghost"
                 size="icon-sm"
+                disabled={reorderInFlight}
                 onClick={handleSteer}
                 className={ROW_ACTION_CLASSNAME}
-                aria-label="Run this message next"
+                aria-label="Send next — interrupts the current turn"
               >
                 <ArrowUpRight className="size-3.5" />
               </Button>
@@ -241,7 +269,7 @@ function PendingPromptRow({
               <Button
                 variant="ghost"
                 size="icon-sm"
-                disabled={!canEdit}
+                disabled={!canEdit || reorderInFlight}
                 onClick={handleBeginEdit}
                 className={ROW_ACTION_CLASSNAME}
                 aria-label="Edit queued message"
@@ -255,7 +283,7 @@ function PendingPromptRow({
               <Button
                 variant="ghost"
                 size="icon-sm"
-                disabled={!canDelete}
+                disabled={!canDelete || reorderInFlight}
                 onClick={handleDelete}
                 className={ROW_ACTION_CLASSNAME}
                 aria-label="Delete queued message"

--- a/apps/desktop/src/config/playground.test.ts
+++ b/apps/desktop/src/config/playground.test.ts
@@ -136,11 +136,10 @@ describe("playground scenarios", () => {
     expect(html).not.toContain('aria-label="Edit queued message"');
   });
 
-  it("keeps queued rows single-line and hides edit on the active edit row", () => {
+  it("keeps queued rows compact and hides edit on the active edit row", () => {
     const plainHtml = renderToStaticMarkup(renderOutboundSlot("pending-prompts-multi"));
-    expect(plainHtml).toContain("truncate");
+    expect(plainHtml).toContain("line-clamp-2");
     expect(plainHtml).toContain("min-w-0");
-    expect(plainHtml).not.toContain("whitespace-pre-wrap");
     // Head-of-queue entry is dispatching: it shows the "Sending…" shimmer
     // state hint and drops the edit affordance while in flight.
     expect(plainHtml).toContain("Sending…");

--- a/apps/desktop/src/config/shortcuts/composer-shortcuts.ts
+++ b/apps/desktop/src/config/shortcuts/composer-shortcuts.ts
@@ -17,6 +17,11 @@ export const COMPOSER_SHORTCUTS = {
     label: "Esc",
     description: "Stop running session",
   },
+  editLastQueued: {
+    key: "ArrowUp",
+    label: "↑",
+    description: "Edit last queued message",
+  },
 } as const satisfies Record<string, ComposerShortcutDef>;
 
 export type ComposerShortcutKey = keyof typeof COMPOSER_SHORTCUTS;

--- a/apps/desktop/src/config/shortcuts/groups.ts
+++ b/apps/desktop/src/config/shortcuts/groups.ts
@@ -80,6 +80,7 @@ export const COMPOSER_SHORTCUT_GROUPS = [
       "submitMessage",
       "previousMode",
       "stopSession",
+      "editLastQueued",
     ],
   },
 ] as const satisfies readonly ComposerShortcutGroup[];

--- a/apps/desktop/src/copy/chat/chat-copy.ts
+++ b/apps/desktop/src/copy/chat/chat-copy.ts
@@ -11,6 +11,7 @@ export const CHAT_COMPOSER_LABELS = {
 export const CHAT_STREAMING_STATUS_LABELS = {
   thinking: "Thinking",
   sending: "Sending…",
+  steering: "Steering…",
   restoringSession: "Restoring session…",
 } as const;
 

--- a/apps/desktop/src/hooks/chat/ui/use-chat-composer-keyboard.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-chat-composer-keyboard.ts
@@ -15,6 +15,7 @@ interface UseChatComposerKeyboardArgs {
   modeControl: LiveSessionControlDescriptor | null;
   isEditingQueuedPrompt?: boolean;
   onCancelEdit?: () => void;
+  onEditLastQueued?: () => void;
 }
 
 export function useChatComposerKeyboard({
@@ -25,6 +26,7 @@ export function useChatComposerKeyboard({
   modeControl,
   isEditingQueuedPrompt = false,
   onCancelEdit,
+  onEditLastQueued,
 }: UseChatComposerKeyboardArgs) {
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (
@@ -68,6 +70,27 @@ export function useChatComposerKeyboard({
       }
     }
 
+    if (
+      event.key === COMPOSER_SHORTCUTS.editLastQueued.key
+      && !event.shiftKey
+      && !event.altKey
+      && !event.ctrlKey
+      && !event.metaKey
+      && !event.nativeEvent.isComposing
+      && !isEditingQueuedPrompt
+      && onEditLastQueued
+    ) {
+      const textarea = event.currentTarget;
+      const hasSelection = textarea.selectionStart !== textarea.selectionEnd;
+      const caretAtStart = textarea.selectionStart === 0 && textarea.selectionEnd === 0;
+      const isEmpty = textarea.value.length === 0;
+      if (!hasSelection && (caretAtStart || isEmpty)) {
+        event.preventDefault();
+        onEditLastQueued();
+        return;
+      }
+    }
+
     if (isRepeatedComposerSubmitKey(event)) {
       event.preventDefault();
       return;
@@ -77,7 +100,7 @@ export function useChatComposerKeyboard({
       event.preventDefault();
       void handleSubmit();
     }
-  }, [canSubmit, handleCancel, handleSubmit, isEditingQueuedPrompt, isRunning, modeControl, onCancelEdit]);
+  }, [canSubmit, handleCancel, handleSubmit, isEditingQueuedPrompt, isRunning, modeControl, onCancelEdit, onEditLastQueued]);
 
   return {
     handleKeyDown,

--- a/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
+++ b/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
@@ -5,6 +5,7 @@ import { WorkspaceArrivalAttachedPanel } from "@/components/workspace/chat/surfa
 import { TodoTrackerPanel, TodoTrackerStrip } from "@/components/workspace/chat/input/TodoTrackerPanel";
 import { ConnectedApprovalCard } from "@/components/workspace/chat/input/ApprovalCard";
 import { ConnectedMcpElicitationCard } from "@/components/workspace/chat/input/McpElicitationCard";
+import { ConnectedPendingPromptList } from "@/components/workspace/chat/input/PendingPromptList";
 import { DelegatedWorkComposerPanel } from "@/components/workspace/chat/input/DelegatedWorkComposerPanel";
 import { DelegatedWorkComposerControl } from "@/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl";
 import { ConnectedUserInputCard } from "@/components/workspace/chat/input/UserInputCard";
@@ -143,17 +144,18 @@ export function useComposerDockSlots(options?: {
       : null
   ), [ambientContextSlot, delegatedWorkSlot, sessionActivitySlot]);
 
+  const outboundSlot = useMemo<ReactNode | null>(() => (
+    dockSlotResolution.outboundSlot?.kind === "pending_prompts"
+      ? <ConnectedPendingPromptList />
+      : null
+  ), [dockSlotResolution.outboundSlot?.kind]);
+
   return useMemo(() => ({
-    // Queued prompts now render IN THE TRANSCRIPT (renderableOutboxEntriesFor-
-    // Transcript includes queue-placed entries), so the dock's pending list is
-    // retired — rendering both would show the same message twice. NOTE: this
-    // also retires the dock's queued-prompt edit affordance (beginEdit was
-    // only reachable from that list); re-home it on the transcript pending row
-    // if we want it back.
-    outboundSlot: null,
+    outboundSlot,
     activeSlot: activeAgentSlot,
     attachedSlot,
   }), [
+    outboundSlot,
     activeAgentSlot,
     attachedSlot,
   ]);

--- a/apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.ts
@@ -13,7 +13,8 @@ export interface PendingPromptQueueState {
   rows: PendingPromptQueueRow[];
   steeringSeq: number | null;
   sessionMaterialized: boolean;
-  onBeginEdit: (seq: number) => void;
+  reorderInFlight: boolean;
+  onBeginEdit: (entry: PendingPromptQueueRow) => void;
   onDelete: (entry: PendingPromptQueueRow) => void;
   onSteer: (entry: PendingPromptQueueRow) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
@@ -32,34 +33,51 @@ export function usePendingPromptQueue(): PendingPromptQueueState {
   const steerPendingPrompt = useSteerPendingPrompt();
   const { cancelBeforeDispatch, dismissPrompt } = usePromptOutboxActions();
   const [steeringSeq, setSteeringSeq] = useState<number | null>(null);
+  const [reorderInFlight, setReorderInFlight] = useState(false);
   const optimisticOrderRef = useRef<string[] | null>(null);
 
   const rows = useMemo(() => {
     const derived = visiblePendingPrompts.map(derivePendingPromptQueueRow);
-    // Apply optimistic reorder if active (between user drag and server ack).
-    if (optimisticOrderRef.current) {
-      const keyMap = new Map(derived.map((row) => [row.key, row]));
-      const reordered: PendingPromptQueueRow[] = [];
-      for (const key of optimisticOrderRef.current) {
-        const row = keyMap.get(key);
-        if (row) {
-          reordered.push(row);
-        }
+    const order = optimisticOrderRef.current;
+    // Apply the optimistic order only while the reorder round-trip is in
+    // flight. The ref is cleared when the mutation settles (see handleReorder),
+    // after which we always fall back to the server-driven order — so later
+    // server reorders (e.g. Steer promotions) are no longer overridden by a
+    // stale drag-time order. `reorderInFlight` is included in the deps so the
+    // clear re-renders this memo back to the reconciled order.
+    if (!order) return derived;
+    const keyMap = new Map(derived.map((row) => [row.key, row]));
+    const reordered: PendingPromptQueueRow[] = [];
+    for (const key of order) {
+      const row = keyMap.get(key);
+      if (row) {
+        reordered.push(row);
       }
-      // Include any rows not in the optimistic order (new arrivals).
-      for (const row of derived) {
-        if (!optimisticOrderRef.current.includes(row.key)) {
-          reordered.push(row);
-        }
-      }
-      // If server has reconciled (lengths match, keys stable), clear optimistic.
-      if (reordered.length === derived.length) {
-        return reordered;
-      }
-      optimisticOrderRef.current = null;
     }
-    return derived;
-  }, [visiblePendingPrompts]);
+    // Include any rows not in the optimistic order (new arrivals).
+    for (const row of derived) {
+      if (!order.includes(row.key)) {
+        reordered.push(row);
+      }
+    }
+    return reordered;
+  }, [visiblePendingPrompts, reorderInFlight]);
+
+  // Resolve the current runtime seq for a row from its stable promptId against
+  // the latest pendingPrompts — never the row snapshot. A reorder renumbers the
+  // same seq set into a permutation, so a seq captured at render time can point
+  // at the wrong prompt by action time. Returns null when the promptId is gone
+  // (just executed/deleted) so the caller no-ops.
+  const resolveLiveSeq = useCallback(
+    (entry: PendingPromptQueueRow): number | null => {
+      if (!entry.promptId) {
+        return entry.seq > 0 ? entry.seq : null;
+      }
+      const live = visiblePendingPrompts.find((p) => p.promptId === entry.promptId);
+      return live ? live.seq : null;
+    },
+    [visiblePendingPrompts],
+  );
 
   const handleDelete = useCallback(
     (entry: PendingPromptQueueRow) => {
@@ -72,25 +90,30 @@ export function usePendingPromptQueue(): PendingPromptQueueState {
         return;
       }
       if (!activeSessionId || entry.deleteAction !== "runtime") return;
-      void deletePendingPrompt(activeSessionId, entry.seq);
+      const seq = resolveLiveSeq(entry);
+      if (seq == null || seq <= 0) return;
+      void deletePendingPrompt(activeSessionId, seq);
     },
-    [activeSessionId, cancelBeforeDispatch, deletePendingPrompt, dismissPrompt],
+    [activeSessionId, cancelBeforeDispatch, deletePendingPrompt, dismissPrompt, resolveLiveSeq],
   );
 
   const handleBeginEdit = useCallback(
-    (seq: number) => {
-      const entry = visiblePendingPrompts.find((candidate) => candidate.seq === seq);
-      if (!entry) return;
-      beginEdit({ seq: entry.seq, text: entry.text });
+    (entry: PendingPromptQueueRow) => {
+      if (!entry.promptId) return;
+      const live = visiblePendingPrompts.find((p) => p.promptId === entry.promptId);
+      if (!live) return;
+      beginEdit({ promptId: live.promptId ?? null, text: live.text });
     },
     [beginEdit, visiblePendingPrompts],
   );
 
   const handleSteer = useCallback(
     (entry: PendingPromptQueueRow) => {
-      if (!activeSessionId || !sessionMaterialized || entry.seq <= 0) return;
-      setSteeringSeq(entry.seq);
-      steerPendingPrompt(activeSessionId, entry.seq)
+      if (!activeSessionId || !sessionMaterialized) return;
+      const seq = resolveLiveSeq(entry);
+      if (seq == null || seq <= 0) return;
+      setSteeringSeq(seq);
+      steerPendingPrompt(activeSessionId, seq)
         .catch(() => {
           // Errors are surfaced via the mutation's onError or silently absorbed
           // when the session is not yet materialized (graceful no-op).
@@ -99,7 +122,7 @@ export function usePendingPromptQueue(): PendingPromptQueueState {
           setSteeringSeq(null);
         });
     },
-    [activeSessionId, sessionMaterialized, steerPendingPrompt],
+    [activeSessionId, sessionMaterialized, resolveLiveSeq, steerPendingPrompt],
   );
 
   const handleReorder = useCallback(
@@ -107,17 +130,27 @@ export function usePendingPromptQueue(): PendingPromptQueueState {
       if (!activeSessionId || !sessionMaterialized || fromIndex === toIndex) return;
       const currentRows = [...rows];
       const [moved] = currentRows.splice(fromIndex, 1);
+      if (!moved) return;
       currentRows.splice(toIndex, 0, moved);
       // Only runtime-confirmed rows (seq > 0) can be reordered server-side.
       const runtimeSeqs = currentRows
         .filter((row) => row.seq > 0)
         .map((row) => row.seq);
       if (runtimeSeqs.length === 0) return;
-      // Apply optimistic order immediately.
+      // Apply optimistic order immediately, and clear it once the round-trip
+      // settles (success or failure) so the server order takes over.
       optimisticOrderRef.current = currentRows.map((row) => row.key);
-      reorderPendingPrompts(activeSessionId, runtimeSeqs).catch(() => {
-        optimisticOrderRef.current = null;
-      });
+      setReorderInFlight(true);
+      reorderPendingPrompts(activeSessionId, runtimeSeqs)
+        .then(() => {
+          optimisticOrderRef.current = null;
+        })
+        .catch(() => {
+          optimisticOrderRef.current = null;
+        })
+        .finally(() => {
+          setReorderInFlight(false);
+        });
     },
     [activeSessionId, sessionMaterialized, reorderPendingPrompts, rows],
   );
@@ -126,6 +159,7 @@ export function usePendingPromptQueue(): PendingPromptQueueState {
     rows,
     steeringSeq,
     sessionMaterialized,
+    reorderInFlight,
     onBeginEdit: handleBeginEdit,
     onDelete: handleDelete,
     onSteer: handleSteer,

--- a/apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.ts
@@ -1,0 +1,134 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { PendingPromptQueueRow } from "@proliferate/product-domain/chats/pending-prompts/pending-prompt-queue";
+import { derivePendingPromptQueueRow } from "@proliferate/product-domain/chats/pending-prompts/pending-prompt-queue";
+import { useActiveSessionId } from "@/hooks/chat/derived/use-active-session-identity";
+import { usePromptOutboxActions } from "@/hooks/chat/workflows/use-prompt-outbox-actions";
+import { useQueuedPromptEditReader } from "@/hooks/chat/ui/use-queued-prompt-edit";
+import { useDeletePendingPrompt } from "@/hooks/sessions/workflows/use-delete-pending-prompt";
+import { useReorderPendingPrompts } from "@/hooks/sessions/workflows/use-reorder-pending-prompts";
+import { useSteerPendingPrompt } from "@/hooks/sessions/workflows/use-steer-pending-prompt";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+export interface PendingPromptQueueState {
+  rows: PendingPromptQueueRow[];
+  steeringSeq: number | null;
+  sessionMaterialized: boolean;
+  onBeginEdit: (seq: number) => void;
+  onDelete: (entry: PendingPromptQueueRow) => void;
+  onSteer: (entry: PendingPromptQueueRow) => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
+}
+
+export function usePendingPromptQueue(): PendingPromptQueueState {
+  const activeSessionId = useActiveSessionId();
+  const sessionMaterialized = useSessionDirectoryStore((state) =>
+    activeSessionId
+      ? Boolean(state.entriesById[activeSessionId]?.materializedSessionId)
+      : false,
+  );
+  const { visiblePendingPrompts, beginEdit } = useQueuedPromptEditReader();
+  const deletePendingPrompt = useDeletePendingPrompt();
+  const reorderPendingPrompts = useReorderPendingPrompts();
+  const steerPendingPrompt = useSteerPendingPrompt();
+  const { cancelBeforeDispatch, dismissPrompt } = usePromptOutboxActions();
+  const [steeringSeq, setSteeringSeq] = useState<number | null>(null);
+  const optimisticOrderRef = useRef<string[] | null>(null);
+
+  const rows = useMemo(() => {
+    const derived = visiblePendingPrompts.map(derivePendingPromptQueueRow);
+    // Apply optimistic reorder if active (between user drag and server ack).
+    if (optimisticOrderRef.current) {
+      const keyMap = new Map(derived.map((row) => [row.key, row]));
+      const reordered: PendingPromptQueueRow[] = [];
+      for (const key of optimisticOrderRef.current) {
+        const row = keyMap.get(key);
+        if (row) {
+          reordered.push(row);
+        }
+      }
+      // Include any rows not in the optimistic order (new arrivals).
+      for (const row of derived) {
+        if (!optimisticOrderRef.current.includes(row.key)) {
+          reordered.push(row);
+        }
+      }
+      // If server has reconciled (lengths match, keys stable), clear optimistic.
+      if (reordered.length === derived.length) {
+        return reordered;
+      }
+      optimisticOrderRef.current = null;
+    }
+    return derived;
+  }, [visiblePendingPrompts]);
+
+  const handleDelete = useCallback(
+    (entry: PendingPromptQueueRow) => {
+      if (entry.deleteAction === "cancel_local" && entry.promptId) {
+        cancelBeforeDispatch(entry.promptId);
+        return;
+      }
+      if (entry.deleteAction === "dismiss_local" && entry.promptId) {
+        dismissPrompt(entry.promptId);
+        return;
+      }
+      if (!activeSessionId || entry.deleteAction !== "runtime") return;
+      void deletePendingPrompt(activeSessionId, entry.seq);
+    },
+    [activeSessionId, cancelBeforeDispatch, deletePendingPrompt, dismissPrompt],
+  );
+
+  const handleBeginEdit = useCallback(
+    (seq: number) => {
+      const entry = visiblePendingPrompts.find((candidate) => candidate.seq === seq);
+      if (!entry) return;
+      beginEdit({ seq: entry.seq, text: entry.text });
+    },
+    [beginEdit, visiblePendingPrompts],
+  );
+
+  const handleSteer = useCallback(
+    (entry: PendingPromptQueueRow) => {
+      if (!activeSessionId || !sessionMaterialized || entry.seq <= 0) return;
+      setSteeringSeq(entry.seq);
+      steerPendingPrompt(activeSessionId, entry.seq)
+        .catch(() => {
+          // Errors are surfaced via the mutation's onError or silently absorbed
+          // when the session is not yet materialized (graceful no-op).
+        })
+        .finally(() => {
+          setSteeringSeq(null);
+        });
+    },
+    [activeSessionId, sessionMaterialized, steerPendingPrompt],
+  );
+
+  const handleReorder = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (!activeSessionId || !sessionMaterialized || fromIndex === toIndex) return;
+      const currentRows = [...rows];
+      const [moved] = currentRows.splice(fromIndex, 1);
+      currentRows.splice(toIndex, 0, moved);
+      // Only runtime-confirmed rows (seq > 0) can be reordered server-side.
+      const runtimeSeqs = currentRows
+        .filter((row) => row.seq > 0)
+        .map((row) => row.seq);
+      if (runtimeSeqs.length === 0) return;
+      // Apply optimistic order immediately.
+      optimisticOrderRef.current = currentRows.map((row) => row.key);
+      reorderPendingPrompts(activeSessionId, runtimeSeqs).catch(() => {
+        optimisticOrderRef.current = null;
+      });
+    },
+    [activeSessionId, sessionMaterialized, reorderPendingPrompts, rows],
+  );
+
+  return {
+    rows,
+    steeringSeq,
+    sessionMaterialized,
+    onBeginEdit: handleBeginEdit,
+    onDelete: handleDelete,
+    onSteer: handleSteer,
+    onReorder: handleReorder,
+  };
+}

--- a/apps/desktop/src/hooks/chat/ui/use-queued-prompt-edit.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-queued-prompt-edit.ts
@@ -22,27 +22,40 @@ export interface VisiblePendingPromptEntry extends PendingPromptEntry {
 interface DerivedEditingState {
   activeSessionId: string | null;
   pendingPrompts: readonly PendingPromptEntry[];
-  storedEditingSeq: number | null;
-  editingSeq: number | null;
-  isStoredSeqLive: boolean;
+  storedEditingPromptId: string | null;
+  editingPromptId: string | null;
+  editingPrompt: PendingPromptEntry | null;
+  isStoredPromptLive: boolean;
 }
 
 /**
  * Pure derivation of "is this edit still live": reconciles the raw stored
- * seq against the current pendingPrompts. A stale pointer (drained or
- * concurrently deleted row) naturally falls to `editingSeq = null` on the
- * next render without any sync bookkeeping.
+ * promptId against the current pendingPrompts. Tracking by the stable
+ * promptId (rather than the volatile runtime seq) means a server reorder
+ * renumber can no longer silently retarget an in-flight edit. A stale
+ * pointer (drained, concurrently deleted, or just executed row) naturally
+ * falls to `editingPromptId = null` on the next render without any sync
+ * bookkeeping.
  */
 function useDerivedEditingState(): DerivedEditingState {
   const activeSessionId = useActiveSessionId();
   const pendingPrompts = useActivePendingPrompts();
-  const storedEditingSeq = useChatInputStore((state) =>
-    activeSessionId ? state.editingQueueSeqBySessionId[activeSessionId] ?? null : null,
+  const storedEditingPromptId = useChatInputStore((state) =>
+    activeSessionId ? state.editingQueuePromptIdBySessionId[activeSessionId] ?? null : null,
   );
-  const isStoredSeqLive = storedEditingSeq != null
-    && pendingPrompts.some((p) => p.seq === storedEditingSeq);
-  const editingSeq = isStoredSeqLive ? storedEditingSeq : null;
-  return { activeSessionId, pendingPrompts, storedEditingSeq, editingSeq, isStoredSeqLive };
+  const editingPrompt = storedEditingPromptId != null
+    ? pendingPrompts.find((p) => p.promptId === storedEditingPromptId) ?? null
+    : null;
+  const isStoredPromptLive = editingPrompt != null;
+  const editingPromptId = isStoredPromptLive ? storedEditingPromptId : null;
+  return {
+    activeSessionId,
+    pendingPrompts,
+    storedEditingPromptId,
+    editingPromptId,
+    editingPrompt,
+    isStoredPromptLive,
+  };
 }
 
 /**
@@ -53,27 +66,29 @@ function useDerivedEditingState(): DerivedEditingState {
  */
 export function useQueuedPromptEditReader(): {
   visiblePendingPrompts: VisiblePendingPromptEntry[];
-  beginEdit: (args: { seq: number; text: string }) => void;
+  beginEdit: (args: { promptId: string | null; text: string }) => void;
 } {
-  const { activeSessionId, pendingPrompts, editingSeq } = useDerivedEditingState();
+  const { activeSessionId, pendingPrompts, editingPromptId } = useDerivedEditingState();
   const setEditDraft = useChatInputStore((state) => state.setEditDraft);
-  const setEditingQueueSeq = useChatInputStore((state) => state.setEditingQueueSeq);
+  const setEditingQueuePromptId = useChatInputStore((state) => state.setEditingQueuePromptId);
 
   const visiblePendingPrompts = useMemo<VisiblePendingPromptEntry[]>(
     () => pendingPrompts.map((entry) => ({
       ...entry,
-      isBeingEdited: entry.seq === editingSeq,
+      isBeingEdited: entry.promptId != null && entry.promptId === editingPromptId,
     })),
-    [pendingPrompts, editingSeq],
+    [pendingPrompts, editingPromptId],
   );
 
   const beginEdit = useCallback(
-    ({ seq, text }: { seq: number; text: string }) => {
-      if (!activeSessionId) return;
+    ({ promptId, text }: { promptId: string | null; text: string }) => {
+      // The edit pointer is keyed on the stable promptId; a prompt without one
+      // cannot be safely re-targeted across a reorder renumber, so ignore it.
+      if (!activeSessionId || !promptId) return;
       setEditDraft(activeSessionId, text);
-      setEditingQueueSeq(activeSessionId, seq);
+      setEditingQueuePromptId(activeSessionId, promptId);
     },
-    [activeSessionId, setEditDraft, setEditingQueueSeq],
+    [activeSessionId, setEditDraft, setEditingQueuePromptId],
   );
 
   return { visiblePendingPrompts, beginEdit };
@@ -82,8 +97,8 @@ export function useQueuedPromptEditReader(): {
 export function useQueuedPromptEditStatus(): {
   isEditing: boolean;
 } {
-  const { editingSeq } = useDerivedEditingState();
-  const isEditing = editingSeq != null;
+  const { editingPromptId } = useDerivedEditingState();
+  const isEditing = editingPromptId != null;
   return useMemo(() => ({ isEditing }), [isEditing]);
 }
 
@@ -95,7 +110,6 @@ export function useQueuedPromptEditStatus(): {
  */
 export function useQueuedPromptEdit(): {
   isEditing: boolean;
-  editingSeq: number | null;
   editDraft: string;
   setEditDraftText: (value: string) => void;
   cancelEdit: () => void;
@@ -104,18 +118,18 @@ export function useQueuedPromptEdit(): {
   const {
     activeSessionId,
     pendingPrompts,
-    storedEditingSeq,
-    editingSeq,
-    isStoredSeqLive,
+    storedEditingPromptId,
+    editingPromptId,
+    isStoredPromptLive,
   } = useDerivedEditingState();
   const editDraft = useChatInputStore((state) =>
     activeSessionId ? state.editDraftBySessionId[activeSessionId] ?? "" : "",
   );
   const setEditDraft = useChatInputStore((state) => state.setEditDraft);
-  const setEditingQueueSeq = useChatInputStore((state) => state.setEditingQueueSeq);
+  const setEditingQueuePromptId = useChatInputStore((state) => state.setEditingQueuePromptId);
   const editPendingPrompt = useEditPendingPrompt();
 
-  const isEditing = editingSeq != null;
+  const isEditing = editingPromptId != null;
 
   // Intentional exception to the "no watch-to-set" guideline
   // (specs/codebase/structures/frontend/guides/state.md). The trigger is SSE arrival
@@ -123,11 +137,11 @@ export function useQueuedPromptEdit(): {
   // Mounted only in ChatInput so the effect runs once per store transition.
   useEffect(() => {
     if (!activeSessionId) return;
-    if (storedEditingSeq != null && !isStoredSeqLive) {
+    if (storedEditingPromptId != null && !isStoredPromptLive) {
       setEditDraft(activeSessionId, "");
-      setEditingQueueSeq(activeSessionId, null);
+      setEditingQueuePromptId(activeSessionId, null);
     }
-  }, [activeSessionId, isStoredSeqLive, setEditDraft, setEditingQueueSeq, storedEditingSeq]);
+  }, [activeSessionId, isStoredPromptLive, setEditDraft, setEditingQueuePromptId, storedEditingPromptId]);
 
   const setEditDraftText = useCallback(
     (value: string) => {
@@ -140,41 +154,47 @@ export function useQueuedPromptEdit(): {
   const cancelEdit = useCallback(() => {
     if (!activeSessionId) return;
     setEditDraft(activeSessionId, "");
-    setEditingQueueSeq(activeSessionId, null);
-  }, [activeSessionId, setEditDraft, setEditingQueueSeq]);
+    setEditingQueuePromptId(activeSessionId, null);
+  }, [activeSessionId, setEditDraft, setEditingQueuePromptId]);
 
   const commitEdit = useCallback(async () => {
-    if (!activeSessionId || editingSeq == null) return;
+    if (!activeSessionId || editingPromptId == null) return;
     const trimmed = editDraft.trim();
     if (!trimmed) {
       cancelEdit();
       return;
     }
-    const editingPrompt = pendingPrompts.find((prompt) => prompt.seq === editingSeq);
+    // Resolve the prompt fresh at commit time from its stable promptId, then
+    // derive the live seq. If the prompt vanished (executed/deleted while the
+    // edit was open) cancel gracefully rather than editing the wrong row.
+    const editingPrompt = pendingPrompts.find((prompt) => prompt.promptId === editingPromptId);
+    if (!editingPrompt) {
+      cancelEdit();
+      return;
+    }
     try {
       if (isLocallyEditableOutboxPrompt(editingPrompt)) {
         patchLocalOutboxPrompt(editingPrompt.promptId, trimmed);
       } else {
-        await editPendingPrompt(activeSessionId, editingSeq, trimmed);
+        await editPendingPrompt(activeSessionId, editingPrompt.seq, trimmed);
       }
     } finally {
       setEditDraft(activeSessionId, "");
-      setEditingQueueSeq(activeSessionId, null);
+      setEditingQueuePromptId(activeSessionId, null);
     }
   }, [
     activeSessionId,
     cancelEdit,
     editDraft,
     editPendingPrompt,
-    editingSeq,
+    editingPromptId,
     pendingPrompts,
     setEditDraft,
-    setEditingQueueSeq,
+    setEditingQueuePromptId,
   ]);
 
   return {
     isEditing,
-    editingSeq,
     editDraft,
     setEditDraftText,
     cancelEdit,

--- a/apps/desktop/src/hooks/chat/ui/use-vertical-reorder.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-vertical-reorder.ts
@@ -1,0 +1,104 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface VerticalReorderState {
+  dragIndex: number | null;
+  dropIndex: number | null;
+  handleDragStart: (index: number, event: React.PointerEvent) => void;
+}
+
+/**
+ * Lightweight pointer-event-based vertical reorder for small lists.
+ * Returns drag/drop indices for visual feedback and invokes `onReorder`
+ * when the user releases at a different position.
+ */
+export function useVerticalReorder(options: {
+  itemCount: number;
+  onReorder: (fromIndex: number, toIndex: number) => void;
+}): VerticalReorderState {
+  const { itemCount, onReorder } = options;
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+  const itemHeightsRef = useRef<number[]>([]);
+  const startYRef = useRef(0);
+  const fromIndexRef = useRef(0);
+
+  const handleDragStart = useCallback(
+    (index: number, event: React.PointerEvent) => {
+      const target = event.currentTarget as HTMLElement;
+      const container = target.closest("[data-reorder-container]") as HTMLElement | null;
+      if (!container) return;
+
+      event.preventDefault();
+      target.setPointerCapture(event.pointerId);
+      fromIndexRef.current = index;
+      startYRef.current = event.clientY;
+
+      // Snapshot item heights for hit-testing.
+      const items = container.querySelectorAll("[data-reorder-item]");
+      itemHeightsRef.current = Array.from(items).map((el) => el.getBoundingClientRect().height);
+
+      setDragIndex(index);
+      setDropIndex(index);
+
+      const dropRef = { current: index };
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const deltaY = moveEvent.clientY - startYRef.current;
+        const heights = itemHeightsRef.current;
+        let newIndex = fromIndexRef.current;
+        let accumulated = 0;
+
+        if (deltaY > 0) {
+          for (let i = fromIndexRef.current + 1; i < heights.length; i++) {
+            accumulated += heights[i];
+            if (deltaY > accumulated - heights[i] / 2) {
+              newIndex = i;
+            } else {
+              break;
+            }
+          }
+        } else if (deltaY < 0) {
+          for (let i = fromIndexRef.current - 1; i >= 0; i--) {
+            accumulated -= heights[i];
+            if (deltaY < accumulated + heights[i] / 2) {
+              newIndex = i;
+            } else {
+              break;
+            }
+          }
+        }
+
+        const clamped = Math.max(0, Math.min(newIndex, itemCount - 1));
+        dropRef.current = clamped;
+        setDropIndex(clamped);
+      };
+
+      const handleEnd = () => {
+        target.releasePointerCapture(event.pointerId);
+        target.removeEventListener("pointermove", handleMove);
+        target.removeEventListener("pointerup", handleEnd);
+        target.removeEventListener("pointercancel", handleEnd);
+
+        const finalFrom = fromIndexRef.current;
+        const finalTo = dropRef.current;
+        setDragIndex(null);
+        setDropIndex(null);
+
+        if (finalFrom !== finalTo) {
+          onReorder(finalFrom, finalTo);
+        }
+      };
+
+      target.addEventListener("pointermove", handleMove);
+      target.addEventListener("pointerup", handleEnd);
+      target.addEventListener("pointercancel", handleEnd);
+    },
+    [itemCount, onReorder],
+  );
+
+  return {
+    dragIndex,
+    dropIndex,
+    handleDragStart,
+  };
+}

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   patchSessionRecord: vi.fn(),
   promptAttachmentSnapshotsToBlocks: vi.fn(),
   rehydrateSessionSlotFromHistory: vi.fn(),
+  steerPendingPrompt: vi.fn(),
   waitForSessionMaterialization: vi.fn(),
 }));
 
@@ -66,6 +67,7 @@ describe("dispatchPromptIntent", () => {
     });
     mocks.getSessionRecord.mockReturnValue({ lastPromptAt: "2026-06-04T09:00:00Z" });
     mocks.waitForSessionMaterialization.mockResolvedValue("session-1");
+    mocks.steerPendingPrompt.mockResolvedValue(undefined);
   });
 
   it("marks the prompt attempt on the session record before dispatching the request", async () => {
@@ -171,6 +173,47 @@ describe("dispatchPromptIntent", () => {
     expect(deps.maybeGenerateWorkspaceName).not.toHaveBeenCalled();
   });
 
+  it("auto-steers a queued prompt flagged autoSteerOnQueue", async () => {
+    const entry = useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "client-session-1",
+      workspaceId: "workspace-1",
+      text: "Interrupt please",
+      blocks: [{ type: "text", text: "Interrupt please" }],
+      placement: "queue",
+      autoSteerOnQueue: true,
+    });
+    mocks.mutateAsync.mockResolvedValue({
+      session: { id: "session-1" },
+      status: "queued",
+      queuedSeq: 7,
+    });
+
+    await dispatchPromptIntent(entry, createDeps());
+
+    expect(mocks.steerPendingPrompt).toHaveBeenCalledWith("client-session-1", 7);
+  });
+
+  it("does not auto-steer when the queued prompt is not flagged", async () => {
+    const entry = useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "client-session-1",
+      workspaceId: "workspace-1",
+      text: "Just queue",
+      blocks: [{ type: "text", text: "Just queue" }],
+      placement: "queue",
+    });
+    mocks.mutateAsync.mockResolvedValue({
+      session: { id: "session-1" },
+      status: "queued",
+      queuedSeq: 7,
+    });
+
+    await dispatchPromptIntent(entry, createDeps());
+
+    expect(mocks.steerPendingPrompt).not.toHaveBeenCalled();
+  });
+
   it("dispatches cloud sandbox gateway prompts through AnyHarness", async () => {
     mocks.getSessionClientAndWorkspace.mockResolvedValue({
       connection: {
@@ -225,6 +268,7 @@ function createDeps(): PromptIntentDispatchDeps {
     promptSessionMutation: {
       mutateAsync: mocks.mutateAsync,
     } as unknown as PromptIntentDispatchDeps["promptSessionMutation"],
+    steerPendingPrompt: mocks.steerPendingPrompt,
     rehydrateSessionSlotFromHistory: mocks.rehydrateSessionSlotFromHistory,
     upsertWorkspaceSessionRecord: vi.fn(),
   };

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
@@ -52,6 +52,12 @@ export interface PromptIntentDispatchDeps {
     firstUserMessage: string;
   }) => Promise<void> | void;
   promptSessionMutation: PromptSessionMutation;
+  /**
+   * Steers a queued prompt to the head of the queue (cancelling the running
+   * turn). Used to honour the "Interrupt & send" busy-send preference; resolves
+   * the materialized session id and no-ops when the session isn't materialized.
+   */
+  steerPendingPrompt: (clientSessionId: string, seq: number) => Promise<void>;
   rehydrateSessionSlotFromHistory: (
     sessionId: string,
     options?: {
@@ -183,6 +189,16 @@ export async function dispatchPromptIntent(
         clientPromptId: entry.clientPromptId,
         requestHeaders,
         rehydrateSessionSlotFromHistory: deps.rehydrateSessionSlotFromHistory,
+      });
+    } else if (entry.autoSteerOnQueue && typeof response.queuedSeq === "number" && response.queuedSeq > 0) {
+      // Busy-send preference = "Interrupt & send": the server queued this prompt,
+      // so steer it to the head to cancel the running turn and run it next.
+      // Fire-and-forget (matching the manual Steer button); the drain loop
+      // delivers the promoted prompt. Eligibility (empty queue at submit time)
+      // was decided at enqueue — see use-session-intent-actions.
+      void deps.steerPendingPrompt(entry.clientSessionId, response.queuedSeq).catch(() => {
+        // Swallowed: a lost steer race just leaves the prompt queued (its manual
+        // Steer button still works), which is the safe fallback.
       });
     }
 

--- a/apps/desktop/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
@@ -13,6 +13,7 @@ import type {
   SessionIntent,
 } from "@proliferate/product-domain/sessions/intents/session-intent-model";
 import { useSessionHistoryHydration } from "@/hooks/sessions/lifecycle/use-session-history-hydration";
+import { useSteerPendingPrompt } from "@/hooks/sessions/workflows/use-steer-pending-prompt";
 import { useSessionSummaryActions } from "@/hooks/sessions/workflows/use-session-summary-actions";
 import { useSessionTitleActions } from "@/hooks/sessions/workflows/use-session-title-actions";
 import { useWorkspaceNameActions } from "@/hooks/workspaces/workflows/use-workspace-name-actions";
@@ -44,6 +45,7 @@ export function useSessionIntentDispatcher(): void {
   const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
   const { upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
   const promptSessionMutation = usePromptSessionMutation();
+  const steerPendingPrompt = useSteerPendingPrompt();
   const setSessionConfigOptionMutation = useSetSessionConfigOptionMutation();
   const resolveInteractionMutation = useResolveSessionInteractionMutation();
   const editPendingPromptMutation = useEditPendingPromptMutation();
@@ -74,6 +76,7 @@ export function useSessionIntentDispatcher(): void {
           maybeGenerateSessionTitle,
           maybeGenerateWorkspaceName,
           promptSessionMutation,
+          steerPendingPrompt,
           rehydrateSessionSlotFromHistory,
           upsertWorkspaceSessionRecord,
         });
@@ -103,6 +106,7 @@ export function useSessionIntentDispatcher(): void {
     maybeGenerateSessionTitle,
     maybeGenerateWorkspaceName,
     promptSessionMutation,
+    steerPendingPrompt,
     rehydrateSessionSlotFromHistory,
     resolveInteractionMutation,
     setSessionConfigOptionMutation,

--- a/apps/desktop/src/hooks/sessions/workflows/use-reorder-pending-prompts.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-reorder-pending-prompts.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useReorderPendingPromptsMutation } from "@anyharness/sdk-react";
+import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { trackProductEvent } from "@/lib/integrations/telemetry/client";
+import { getMaterializedSessionId, getSessionRecord } from "@/stores/sessions/session-records";
+
+export function useReorderPendingPrompts() {
+  const mutation = useReorderPendingPromptsMutation();
+
+  return useCallback(
+    async (sessionId: string, seqs: number[]) => {
+      const materializedSessionId = getMaterializedSessionId(sessionId);
+      if (!materializedSessionId) {
+        return;
+      }
+      const slot = getSessionRecord(sessionId);
+      const workspaceId = slot?.workspaceId ?? null;
+      await mutation.mutateAsync({ sessionId: materializedSessionId, seqs });
+      trackProductEvent("chat_pending_prompts_reordered", {
+        agent_kind: slot?.agentKind ?? "unknown",
+        workspace_kind: workspaceId && parseCloudWorkspaceSyntheticId(workspaceId)
+          ? "cloud"
+          : "local",
+        count: seqs.length,
+      });
+    },
+    [mutation],
+  );
+}

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionIntentActions } from "@/hooks/sessions/workflows/use-session-intent-actions";
+import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+const mocks = vi.hoisted(() => ({
+  getSessionRecord: vi.fn(),
+  patchSessionRecord: vi.fn(),
+}));
+
+vi.mock("@/stores/sessions/session-records", () => ({
+  getSessionRecord: mocks.getSessionRecord,
+  patchSessionRecord: mocks.patchSessionRecord,
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-interaction-resolution-actions", () => ({
+  useSessionInteractionResolutionActions: () => ({
+    resolvePermission: vi.fn(),
+    resolveMcpElicitation: vi.fn(),
+    resolveUserInput: vi.fn(),
+    revealMcpElicitationUrl: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/infra/measurement/debug-measurement", () => ({
+  finishOrCancelMeasurementOperation: vi.fn(),
+  markOperationForNextCommit: vi.fn(),
+  recordMeasurementWorkflowStep: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/measurement/latency-flow", () => ({
+  finishLatencyFlow: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/measurement/debug-latency", () => ({
+  logLatency: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/scheduling/schedule-after-next-paint", () => ({
+  scheduleAfterNextPaint: (cb: () => void) => cb(),
+}));
+
+const SESSION_ID = "client-session-1";
+
+interface SlotOverrides {
+  materialized?: boolean;
+  isStreaming?: boolean;
+  runtimePendingPromptCount?: number;
+}
+
+function setSlot({
+  materialized = true,
+  isStreaming = true,
+  runtimePendingPromptCount = 0,
+}: SlotOverrides = {}) {
+  mocks.getSessionRecord.mockReturnValue({
+    workspaceId: "workspace-1",
+    materializedSessionId: materialized ? "session-1" : null,
+    status: "running",
+    streamConnectionState: "open",
+    executionSummary: null,
+    transcript: {
+      isStreaming,
+      pendingInteractions: [],
+      pendingPrompts: Array.from({ length: runtimePendingPromptCount }, (_, i) => ({
+        seq: i + 1,
+      })),
+      turnOrder: [],
+      turnsById: {},
+    },
+  });
+}
+
+function autoSteerFor(promptId: string): boolean {
+  const entry = useSessionIntentStore.getState().entriesById[promptId];
+  if (!entry || entry.kind !== "send_prompt") {
+    throw new Error(`no send_prompt intent for ${promptId}`);
+  }
+  return entry.autoSteerOnQueue;
+}
+
+async function send(promptId: string) {
+  const { result } = renderHook(() => useSessionIntentActions());
+  await result.current.sendPrompt({
+    sessionId: SESSION_ID,
+    text: promptId,
+    promptId,
+  });
+}
+
+describe("useSessionIntentActions auto-steer eligibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionIntentStore.getState().clear();
+    useUserPreferencesStore.getState().set("busySendBehavior", "interrupt");
+    setSlot();
+  });
+
+  it("auto-steers only the first prompt of a burst into a busy, materialized session", async () => {
+    setSlot({ materialized: true, isStreaming: true, runtimePendingPromptCount: 0 });
+
+    await send("p1");
+    await send("p2");
+    await send("p3");
+
+    expect(autoSteerFor("p1")).toBe(true);
+    expect(autoSteerFor("p2")).toBe(false);
+    expect(autoSteerFor("p3")).toBe(false);
+  });
+
+  it("does not auto-steer when runtime pending prompts already exist (empty outbox)", async () => {
+    setSlot({ materialized: true, isStreaming: false, runtimePendingPromptCount: 1 });
+
+    await send("p1");
+
+    expect(autoSteerFor("p1")).toBe(false);
+  });
+
+  it("does not auto-steer when the session is not yet materialized", async () => {
+    setSlot({ materialized: false, isStreaming: true, runtimePendingPromptCount: 0 });
+
+    await send("p1");
+
+    expect(autoSteerFor("p1")).toBe(false);
+  });
+
+  it("does not auto-steer when the busy-send preference is 'queue'", async () => {
+    useUserPreferencesStore.getState().set("busySendBehavior", "queue");
+    setSlot({ materialized: true, isStreaming: true, runtimePendingPromptCount: 0 });
+
+    await send("p1");
+
+    expect(autoSteerFor("p1")).toBe(false);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts
@@ -6,8 +6,10 @@ import type { PromptAttachmentSnapshot } from "@proliferate/product-domain/chats
 import { createPromptId } from "@/lib/domain/chat/composer/prompt-id";
 import {
   isPromptOutboxPlacementBusy,
+  queuedOutboxEntriesForSession,
   resolvePromptOutboxPlacement,
 } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import {
   promptIntentsForSession,
 } from "@proliferate/product-domain/sessions/intents/session-intent-state";
@@ -89,6 +91,21 @@ export function useSessionIntentActions() {
       isSessionMaterialized: Boolean(slot?.materializedSessionId),
       existingEntries: existingPromptIntents,
     });
+    // Auto-steer rule (busy-send preference = "Interrupt & send"): steer this
+    // prompt to the head + cancel the running turn only when it lands in an
+    // *empty* queue at submit time — i.e. no runtime pending prompts and no
+    // other in-flight/queued outbox prompts for this session. This is the
+    // cleanest correct rule for bursts: firing 3 messages fast auto-steers only
+    // the first (the 2nd/3rd see a non-empty queue and stay queued), which
+    // avoids cancel storms and steering while another steer is already in
+    // flight. Only meaningful when the prompt is actually queued (busy session).
+    const queueEmptyAtSubmit =
+      (slot?.transcript?.pendingPrompts?.length ?? 0) === 0
+      && queuedOutboxEntriesForSession(existingPromptIntents).length === 0;
+    const autoSteerOnQueue =
+      outboxPlacement === "queue"
+      && queueEmptyAtSubmit
+      && useUserPreferencesStore.getState().busySendBehavior === "interrupt";
     const enqueuePrompt = () => {
       intentStore.enqueuePrompt({
         clientPromptId,
@@ -100,6 +117,7 @@ export function useSessionIntentActions() {
         attachmentSnapshots,
         contentParts: optimisticContentParts,
         placement: outboxPlacement,
+        autoSteerOnQueue,
         latencyFlowId,
       });
     };

--- a/apps/desktop/src/hooks/sessions/workflows/use-steer-pending-prompt.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-steer-pending-prompt.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useSteerPendingPromptMutation } from "@anyharness/sdk-react";
+import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import { trackProductEvent } from "@/lib/integrations/telemetry/client";
+import { getMaterializedSessionId, getSessionRecord } from "@/stores/sessions/session-records";
+
+export function useSteerPendingPrompt() {
+  const mutation = useSteerPendingPromptMutation();
+
+  return useCallback(
+    async (sessionId: string, seq: number) => {
+      const materializedSessionId = getMaterializedSessionId(sessionId);
+      if (!materializedSessionId) {
+        return;
+      }
+      const slot = getSessionRecord(sessionId);
+      const workspaceId = slot?.workspaceId ?? null;
+      await mutation.mutateAsync({ sessionId: materializedSessionId, seq });
+      trackProductEvent("chat_pending_prompt_steered", {
+        agent_kind: slot?.agentKind ?? "unknown",
+        workspace_kind: workspaceId && parseCloudWorkspaceSyntheticId(workspaceId)
+          ? "cloud"
+          : "local",
+      });
+    },
+    [mutation],
+  );
+}

--- a/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
+++ b/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
@@ -60,6 +60,7 @@ export function selectPersistedUserPreferencesSlice(
     defaultOpenInTargetId: preferences.defaultOpenInTargetId,
     branchPrefixType: preferences.branchPrefixType,
     defaultNewWorkspaceMode: preferences.defaultNewWorkspaceMode,
+    busySendBehavior: preferences.busySendBehavior,
     turnEndSoundEnabled: preferences.turnEndSoundEnabled,
     turnEndSoundId: preferences.turnEndSoundId,
     transparentChromeEnabled: preferences.transparentChromeEnabled,

--- a/apps/desktop/src/lib/domain/preferences/user/migration.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.ts
@@ -106,6 +106,14 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
     changed = true;
   }
 
+  if (
+    next.busySendBehavior !== "queue"
+    && next.busySendBehavior !== "interrupt"
+  ) {
+    next.busySendBehavior = PERSISTED_RECORD_BACKFILL.busySendBehavior;
+    changed = true;
+  }
+
   const sanitizedDefaultOpenInTargetId = typeof next.defaultOpenInTargetId === "string"
     ? next.defaultOpenInTargetId.trim()
     : "";

--- a/apps/desktop/src/lib/domain/preferences/user/model.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/model.ts
@@ -18,6 +18,12 @@ import { DEFAULT_OPEN_IN_TARGET_ID } from "@/config/open-target-defaults";
 export type BranchPrefixType = "none" | "proliferate" | "github_username";
 export type TurnEndSoundId = "ding";
 export type DefaultNewWorkspaceMode = "worktree" | "local";
+/**
+ * What sending a message does while the agent is mid-turn:
+ * - "queue": append it to the pending-prompt queue (delivered after the turn).
+ * - "interrupt": steer it to the head and cancel the running turn so it runs next.
+ */
+export type BusySendBehavior = "queue" | "interrupt";
 
 /**
  * The app ships a single Mono theme. The persisted key survives (pinned to
@@ -40,6 +46,7 @@ export interface UserPreferences {
   defaultOpenInTargetId: string;
   branchPrefixType: BranchPrefixType;
   defaultNewWorkspaceMode: DefaultNewWorkspaceMode;
+  busySendBehavior: BusySendBehavior;
   turnEndSoundEnabled: boolean;
   turnEndSoundId: TurnEndSoundId;
   transparentChromeEnabled: boolean;
@@ -65,6 +72,7 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   defaultOpenInTargetId: DEFAULT_OPEN_IN_TARGET_ID,
   branchPrefixType: "none",
   defaultNewWorkspaceMode: "worktree",
+  busySendBehavior: "queue",
   turnEndSoundEnabled: false,
   turnEndSoundId: "ding",
   transparentChromeEnabled: false,
@@ -90,6 +98,7 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   defaultOpenInTargetId: DEFAULT_OPEN_IN_TARGET_ID,
   branchPrefixType: "none",
   defaultNewWorkspaceMode: "worktree",
+  busySendBehavior: "queue",
   turnEndSoundEnabled: false,
   turnEndSoundId: "ding",
   // Existing persisted records keep the legacy transparent chrome default;

--- a/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
@@ -14,6 +14,7 @@ const USER_PREFERENCE_KEYS = [
   "defaultOpenInTargetId",
   "branchPrefixType",
   "defaultNewWorkspaceMode",
+  "busySendBehavior",
   "turnEndSoundEnabled",
   "turnEndSoundId",
   "transparentChromeEnabled",

--- a/apps/desktop/src/lib/domain/telemetry/events.ts
+++ b/apps/desktop/src/lib/domain/telemetry/events.ts
@@ -96,6 +96,15 @@ export interface DesktopProductEventMap {
     agent_kind: string;
     workspace_kind: DesktopWorkspaceKind;
   };
+  chat_pending_prompts_reordered: {
+    agent_kind: string;
+    workspace_kind: DesktopWorkspaceKind;
+    count: number;
+  };
+  chat_pending_prompt_steered: {
+    agent_kind: string;
+    workspace_kind: DesktopWorkspaceKind;
+  };
   chat_prompt_submitted: {
     agent_kind: string;
     reuse_session: boolean;

--- a/apps/desktop/src/lib/workflows/preferences/user-preferences-persistence.ts
+++ b/apps/desktop/src/lib/workflows/preferences/user-preferences-persistence.ts
@@ -98,6 +98,7 @@ async function readLegacyUserPreferences(): Promise<LegacyUserPreferencesInput> 
       defaults.defaultLiveSessionControlValuesByAgentKind,
     defaultOpenInTargetId: legacyDefaultOpenInTargetId ?? defaults.defaultOpenInTargetId,
     branchPrefixType: legacyBranchPrefixType ?? defaults.branchPrefixType,
+    busySendBehavior: defaults.busySendBehavior,
     turnEndSoundEnabled: defaults.turnEndSoundEnabled,
     turnEndSoundId: defaults.turnEndSoundId,
     transparentChromeEnabled: defaults.transparentChromeEnabled,

--- a/apps/desktop/src/stores/chat/chat-input-store.test.ts
+++ b/apps/desktop/src/stores/chat/chat-input-store.test.ts
@@ -10,7 +10,7 @@ describe("chat input store", () => {
     useChatInputStore.setState({
       draftByWorkspaceId: {},
       editDraftBySessionId: {},
-      editingQueueSeqBySessionId: {},
+      editingQueuePromptIdBySessionId: {},
       focusRequestNonce: 0,
     });
   });

--- a/apps/desktop/src/stores/chat/chat-input-store.ts
+++ b/apps/desktop/src/stores/chat/chat-input-store.ts
@@ -10,21 +10,21 @@ import {
 interface ChatInputState {
   draftByWorkspaceId: Record<string, ChatComposerDraft>;
   editDraftBySessionId: Record<string, string>;
-  editingQueueSeqBySessionId: Record<string, number>;
+  editingQueuePromptIdBySessionId: Record<string, string>;
   focusRequestNonce: number;
   setDraft: (workspaceId: string, value: ChatComposerDraft) => void;
   setDraftText: (workspaceId: string, value: string) => void;
   appendDraftText: (workspaceId: string, value: string) => void;
   clearDraft: (workspaceId: string) => void;
   setEditDraft: (sessionId: string, value: string) => void;
-  setEditingQueueSeq: (sessionId: string, seq: number | null) => void;
+  setEditingQueuePromptId: (sessionId: string, promptId: string | null) => void;
   requestFocus: () => void;
 }
 
 export const useChatInputStore = create<ChatInputState>((set) => ({
   draftByWorkspaceId: {},
   editDraftBySessionId: {},
-  editingQueueSeqBySessionId: {},
+  editingQueuePromptIdBySessionId: {},
   focusRequestNonce: 0,
 
   setDraft: (workspaceId, value) => set((state) => {
@@ -102,19 +102,19 @@ export const useChatInputStore = create<ChatInputState>((set) => ({
     };
   }),
 
-  setEditingQueueSeq: (sessionId, seq) => set((state) => {
-    const nextEditing = { ...state.editingQueueSeqBySessionId };
-    if (seq == null) {
+  setEditingQueuePromptId: (sessionId, promptId) => set((state) => {
+    const nextEditing = { ...state.editingQueuePromptIdBySessionId };
+    if (promptId == null) {
       if (!(sessionId in nextEditing)) {
         return state;
       }
       delete nextEditing[sessionId];
     } else {
-      nextEditing[sessionId] = seq;
+      nextEditing[sessionId] = promptId;
     }
 
     return {
-      editingQueueSeqBySessionId: nextEditing,
+      editingQueuePromptIdBySessionId: nextEditing,
     };
   }),
 

--- a/apps/packages/product-domain/src/sessions/intents/session-intent-model.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent-model.ts
@@ -68,6 +68,13 @@ export interface SessionSendPromptIntent extends SessionIntentBase {
   deliveryState: PromptOutboxDeliveryState;
   latencyFlowId: string | null;
   echoedAt: string | null;
+  /**
+   * When true, the dispatcher steers this prompt to the head of the queue
+   * (cancelling the running turn) the moment the server acks it as queued.
+   * Set only for the first message submitted into an empty queue while the
+   * "Interrupt & send" busy-send preference is on — see the submit path.
+   */
+  autoSteerOnQueue: boolean;
 }
 
 export type PromptOutboxEntry = SessionSendPromptIntent;
@@ -125,6 +132,7 @@ export interface PromptOutboxCreateInput {
   contentParts?: readonly ContentPart[];
   promptProvenance?: PromptProvenance | null;
   placement?: PromptOutboxPlacement;
+  autoSteerOnQueue?: boolean;
   latencyFlowId?: string | null;
   now?: string;
 }
@@ -148,6 +156,7 @@ export function createSendPromptIntent(input: PromptOutboxCreateInput): SessionS
     promptProvenance: input.promptProvenance ?? null,
     queuedSeq: null,
     placement: input.placement ?? "transcript",
+    autoSteerOnQueue: input.autoSteerOnQueue ?? false,
     status: "queued",
     deliveryState: "waiting_for_session",
     latencyFlowId: input.latencyFlowId ?? null,

--- a/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent-selectors.ts
@@ -89,12 +89,13 @@ export function renderableOutboxEntriesForTranscript(
       renderableEntries.push(entry);
       continue;
     }
-    // A submitted message must NEVER be invisible: queue-placed entries
-    // (sends while the session is busy) render in the transcript exactly like
-    // transcript-placed ones, in outbox order, until the real user_message
-    // echo replaces them. Placement still controls DELIVERY semantics (when
-    // the prompt dispatches) — previously queue-placed sends vanished from
-    // the conversation until the current turn finished.
+    // Queue-placed entries render in the dock's pending-prompt list, NOT in
+    // the transcript — showing them here would double-render. Only
+    // transcript-placed entries (immediate sends, in-flight prompts) and
+    // failed-before-dispatch entries render in-thread.
+    if (entry.placement === "queue") {
+      continue;
+    }
     if (!isTerminal && !isEchoed) {
       renderableEntries.push(entry);
     }

--- a/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
@@ -67,7 +67,7 @@ export function FullTranscriptRowList({
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
-  } = useTranscriptStickToBottom({ scrollRef, onScrollSample });
+  } = useTranscriptStickToBottom({ scrollRef, onScrollSample, bottomInsetPx });
 
   const logPrefetchDecision = useCallback((
     trigger: HistoryPrefetchTrigger,

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -79,7 +79,7 @@ export function VirtualizedTranscriptRowList({
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
-  } = useTranscriptStickToBottom({ scrollRef, onScrollSample });
+  } = useTranscriptStickToBottom({ scrollRef, onScrollSample, bottomInsetPx });
   const renderableRows = useMemo(
     () => buildRenderableRows(rows, isLoadingOlderHistory),
     [isLoadingOlderHistory, rows],

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.test.tsx
@@ -41,12 +41,17 @@ interface HarnessHandle {
   viewport: HTMLDivElement;
 }
 
-function renderHarness(onScrollSample = vi.fn()) {
+interface RenderableHarness {
+  current: HarnessHandle;
+  setInset: (bottomInsetPx: number) => void;
+}
+
+function renderHarness(onScrollSample = vi.fn(), initialInsetPx = 0): RenderableHarness {
   const handle: { current: HarnessHandle | null } = { current: null };
 
-  function Harness() {
+  function Harness({ bottomInsetPx }: { bottomInsetPx: number }) {
     const scrollRef = useRef<HTMLDivElement>(null);
-    const api = useTranscriptStickToBottom({ scrollRef, onScrollSample });
+    const api = useTranscriptStickToBottom({ scrollRef, onScrollSample, bottomInsetPx });
     return (
       <div
         ref={(node) => {
@@ -60,10 +65,16 @@ function renderHarness(onScrollSample = vi.fn()) {
     );
   }
 
-  render(<Harness />);
+  const { rerender } = render(<Harness bottomInsetPx={initialInsetPx} />);
   // Drain the mount snap (resetForSession is not called on mount; the snap
   // comes from consumers — here we just want a clean queue).
-  return handle as { current: HarnessHandle };
+  const result = handle as unknown as RenderableHarness;
+  result.setInset = (bottomInsetPx: number) => {
+    act(() => {
+      rerender(<Harness bottomInsetPx={bottomInsetPx} />);
+    });
+  };
+  return result;
 }
 
 function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
@@ -285,5 +296,100 @@ describe("useTranscriptStickToBottom", () => {
       flushRafRound();
     });
     expect(viewport.scrollTop).toBe(700);
+  });
+
+  describe("suppressed pin (bottomInsetPx growth/shrink)", () => {
+    it("suppresses the snap when the inset grows while pinned", () => {
+      const handle = renderHarness(vi.fn(), 0);
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+
+      // Dock card grows the bottom inset while pinned: freeze, don't snap.
+      handle.setInset(80);
+
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(handle.current.api.pinnedRef.current).toBe(false);
+      // No scroll write happened — the viewport must not have moved.
+      expect(viewport.scrollTop).toBe(1000);
+    });
+
+    it("restores pin and snaps when the inset shrinks back while suppressed and the user hasn't scrolled", () => {
+      const handle = renderHarness(vi.fn(), 0);
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+
+      handle.setInset(80);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // Content grew while suppressed too (e.g. streaming continued) — the
+      // bottom keeps moving, but the frozen viewport shouldn't have followed.
+      setMetrics(viewport, { scrollHeight: 1400, clientHeight: 300, scrollTop: 1000 });
+
+      // Dock card closes: inset shrinks back to 0.
+      handle.setInset(0);
+
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      expect(handle.current.api.pinnedRef.current).toBe(true);
+      expect(viewport.scrollTop).toBe(viewport.scrollHeight);
+    });
+
+    it("clears suppression on a real user scroll, so a later shrink does not snap", () => {
+      const handle = renderHarness(vi.fn(), 0);
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+
+      handle.setInset(80);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // The user scrolls (moves away) while suppressed — this must clear
+      // suppression regardless of where they land.
+      userScroll(handle, 600);
+      const scrollTopAfterUserScroll = viewport.scrollTop;
+
+      // Dock card closes: inset shrinks back, but since suppression was
+      // cleared by the user's scroll, this must NOT snap.
+      handle.setInset(0);
+
+      expect(viewport.scrollTop).toBe(scrollTopAfterUserScroll);
+    });
+
+    it("keeps resetForSession's identity stable across inset changes", () => {
+      const handle = renderHarness(vi.fn(), 0);
+      const firstResetForSession = handle.current.api.resetForSession;
+
+      handle.setInset(40);
+      const secondResetForSession = handle.current.api.resetForSession;
+
+      handle.setInset(0);
+      const thirdResetForSession = handle.current.api.resetForSession;
+
+      expect(secondResetForSession).toBe(firstResetForSession);
+      expect(thirdResetForSession).toBe(firstResetForSession);
+    });
+
+    it("does not snap on content growth while suppressed (viewport freeze is intentional)", () => {
+      const handle = renderHarness(vi.fn(), 0);
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+
+      handle.setInset(80);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // Simulate a tab/window resume glue attempt firing while suppressed —
+      // this stands in for any content-driven autoscroll trigger. It must
+      // bail without moving the viewport: the freeze while suppressed is a
+      // deliberate product decision, not a bug.
+      setMetrics(viewport, { scrollHeight: 2200, clientHeight: 300, scrollTop: 1000 });
+      act(() => {
+        fireEvent(document, new Event("visibilitychange"));
+      });
+      act(() => {
+        flushRafRound();
+      });
+
+      expect(viewport.scrollTop).toBe(1000);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+    });
   });
 });

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 
 /** Classification of a viewport scroll event: our own snap vs the user. */
 export interface TranscriptScrollSample {
@@ -82,6 +82,11 @@ export function useTranscriptStickToBottom({
   // snapping but remember we were pinned so we can restore on shrink.
   const lastInsetRef = useRef(bottomInsetPx);
   const suppressedPinRef = useRef(false);
+  // Latest-value ref for bottomInsetPx, kept current every render (not via
+  // effect) so resetForSession can read the current inset without taking a
+  // dependency on the prop itself — see resetForSession below.
+  const bottomInsetPxRef = useRef(bottomInsetPx);
+  bottomInsetPxRef.current = bottomInsetPx;
 
   const setPinned = useCallback((next: boolean) => {
     if (pinnedRef.current === next) {
@@ -220,16 +225,36 @@ export function useTranscriptStickToBottom({
     programmaticRef.current = null;
     lastScrollTopRef.current = 0;
     suppressedPinRef.current = false;
-    lastInsetRef.current = bottomInsetPx;
+    // Read the current inset from the ref, not the bottomInsetPx closure
+    // value: this callback's identity must stay stable across inset changes
+    // (see dep array below), so it cannot depend on the latest prop directly.
+    lastInsetRef.current = bottomInsetPxRef.current;
     setPinned(true);
     scrollToBottom();
     startGlueLoop();
-  }, [bottomInsetPx, scrollToBottom, setPinned, startGlueLoop]);
+    // Deliberately omits bottomInsetPx: consumers (FullTranscriptRowList,
+    // VirtualizedTranscriptRowList) key session-reset layout effects on this
+    // callback's identity alongside session/workspace id. If it changed on
+    // every dock-height change, those effects would re-fire and unconditionally
+    // snap on every inset change, reintroducing jumps while a dock card is up.
+  }, [scrollToBottom, setPinned, startGlueLoop]);
 
   // Inset tracking: when the inset grows while pinned, suppress the snap and
   // remember we were pinned. When it shrinks back and we're still suppressed
   // (user didn't scroll away), restore pinning with a snap.
-  useEffect(() => {
+  //
+  // This must run as a layout effect, not a passive one: consumers'
+  // bottomInsetPx-dependent useLayoutEffects (virtualizer paddingEnd, etc.) run
+  // after this hook's effects because the hook is called before them in both
+  // consumers, but layout effects run before passive effects across a commit.
+  // If this stayed a passive effect, the first inset growth could let a
+  // consumer's layout effect snap before suppression engages here.
+  //
+  // Design ruling: while suppressed, content-driven autoscroll (the glue loop)
+  // is frozen intentionally — the product wants the viewport to hold perfectly
+  // still while a dock card is up, even if new content streams in. Do not
+  // "fix" that by letting content growth snap through suppression.
+  useLayoutEffect(() => {
     const previous = lastInsetRef.current;
     const current = bottomInsetPx;
     lastInsetRef.current = current;

--- a/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useTranscriptStickToBottom.ts
@@ -32,6 +32,12 @@ export interface UseTranscriptStickToBottomOptions {
   onScrollSample: (sample?: TranscriptScrollSample) => void;
   /** px from the bottom within which a user scroll re-pins. */
   repinThresholdPx?: number;
+  /**
+   * Bottom inset (spacer height). The engine tracks changes to suppress snaps
+   * when the inset grows (permission cards, etc.) while keeping the viewport
+   * stable, then restores pinning when the inset shrinks back.
+   */
+  bottomInsetPx?: number;
 }
 
 export interface TranscriptStickToBottom {
@@ -64,12 +70,18 @@ export function useTranscriptStickToBottom({
   scrollRef,
   onScrollSample,
   repinThresholdPx = REPIN_BOTTOM_THRESHOLD_PX,
+  bottomInsetPx = 0,
 }: UseTranscriptStickToBottomOptions): TranscriptStickToBottom {
   const pinnedRef = useRef(true);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
   const lastScrollTopRef = useRef(0);
   const programmaticRef = useRef<{ expectedTop: number; frame: number } | null>(null);
   const glueFrameRef = useRef<number | null>(null);
+
+  // Suppressed-pin tracking: when the inset grows while pinned, we suppress
+  // snapping but remember we were pinned so we can restore on shrink.
+  const lastInsetRef = useRef(bottomInsetPx);
+  const suppressedPinRef = useRef(false);
 
   const setPinned = useCallback((next: boolean) => {
     if (pinnedRef.current === next) {
@@ -136,6 +148,11 @@ export function useTranscriptStickToBottom({
       return;
     }
 
+    // User scroll: clear suppression so shrink won't re-pin (they moved away).
+    if (suppressedPinRef.current) {
+      suppressedPinRef.current = false;
+    }
+
     const distance = resolveVirtualBottomDistance({
       scrollOffset: top,
       viewportSize: viewport.clientHeight,
@@ -166,8 +183,9 @@ export function useTranscriptStickToBottom({
     let totalFrames = 0;
     const tick = () => {
       const viewport = scrollRef.current;
-      // Bail the moment the user reclaims control (an intent listener unpins).
-      if (!viewport || !pinnedRef.current) {
+      // Bail the moment the user reclaims control (an intent listener unpins)
+      // or we enter suppressed state (inset grew).
+      if (!viewport || !pinnedRef.current || suppressedPinRef.current) {
         glueFrameRef.current = null;
         return;
       }
@@ -201,10 +219,37 @@ export function useTranscriptStickToBottom({
     }
     programmaticRef.current = null;
     lastScrollTopRef.current = 0;
+    suppressedPinRef.current = false;
+    lastInsetRef.current = bottomInsetPx;
     setPinned(true);
     scrollToBottom();
     startGlueLoop();
-  }, [scrollToBottom, setPinned, startGlueLoop]);
+  }, [bottomInsetPx, scrollToBottom, setPinned, startGlueLoop]);
+
+  // Inset tracking: when the inset grows while pinned, suppress the snap and
+  // remember we were pinned. When it shrinks back and we're still suppressed
+  // (user didn't scroll away), restore pinning with a snap.
+  useEffect(() => {
+    const previous = lastInsetRef.current;
+    const current = bottomInsetPx;
+    lastInsetRef.current = current;
+
+    if (current === previous) {
+      return;
+    }
+
+    const delta = current - previous;
+    if (delta > 0 && pinnedRef.current) {
+      // Inset grew while pinned: suppress (freeze viewport, no snap).
+      suppressedPinRef.current = true;
+      setPinned(false);
+    } else if (delta < 0 && suppressedPinRef.current) {
+      // Inset shrank while suppressed: restore pinning and snap back to bottom.
+      suppressedPinRef.current = false;
+      setPinned(true);
+      scrollToBottom();
+    }
+  }, [bottomInsetPx, scrollToBottom, setPinned]);
 
   // Pre-emptive intent-to-leave: flip the pin ref synchronously when the user
   // acts, BEFORE the next per-frame snap effect reads it, so the snap bails and
@@ -221,6 +266,8 @@ export function useTranscriptStickToBottom({
     // would strand the engine unpinned (no scroll event follows to re-pin).
     const onWheel = (event: WheelEvent) => {
       if (event.deltaY < 0 && viewportCanScroll(viewport)) {
+        // User scrolling up: clear suppression and unpin.
+        suppressedPinRef.current = false;
         setPinned(false);
       }
     };
@@ -229,6 +276,7 @@ export function useTranscriptStickToBottom({
         (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") &&
         viewportCanScroll(viewport)
       ) {
+        suppressedPinRef.current = false;
         setPinned(false);
       }
     };
@@ -239,6 +287,7 @@ export function useTranscriptStickToBottom({
       const y = event.touches[0]?.clientY ?? touchStartY;
       // Finger dragging down reveals content above (scrolls toward history).
       if (y - touchStartY > DIRECTION_EPSILON_PX && viewportCanScroll(viewport)) {
+        suppressedPinRef.current = false;
         setPinned(false);
       }
     };

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -5531,6 +5531,8 @@ export interface components {
             worker?: string | null;
             /** Anyharness */
             anyharness: string;
+            /** Catalogversion */
+            catalogVersion?: string | null;
         };
         /** WorkerEnrollRequest */
         WorkerEnrollRequest: {


### PR DESCRIPTION
## Summary
- Restore the queued-messages panel in the composer dock (Codex-style rows: drag-reorder, steer, edit, delete; ArrowUp edits the newest queued message)
- Runtime: `PUT /pending-prompts/order` (transactional seq renumber) and `POST /pending-prompts/{seq}/steer` (promote to head + cancel; drain loop delivers) with `pending_prompts_reordered` event; SDK client methods + reducer support
- Queued entries render in the dock, not the transcript; executed prompts appear in-thread via the real `user_message` echo
- Transcript no longer jumps when dock cards (permissions/questions) appear: pin is suppressed on inset growth and restored when the card resolves

## Verification
- `cargo test` — 1095 pass
- SDK `tsc` clean
- Desktop typecheck + tests pass
- Boundaries/structure checks — no new violations
- Live E2E verified queue/steer/reorder/edit/delete/ArrowUp with zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)