### PR TITLE
feat(workflows): PR A — step-actions ledger + Slack notify delivery

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
@@ -40,6 +40,9 @@ impl WorkflowRunRecord {
 pub struct WorkflowStepRunRecord {
     pub run_id: String,
     pub step_index: i64,
+    /// Structured step key "<node>.<lane>.<step>" (B5) — the step's stable
+    /// identity; outputs are reported keyed by this.
+    pub step_key: String,
     pub kind: String,
     pub status: WorkflowStepStatus,
     pub attempt: i64,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
@@ -6,6 +6,8 @@
 //! [`super::templates`] late-binds against completed step outputs at execution
 //! time. Deserialization is strict: an unknown step `kind` is rejected.
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 
 #[derive(Debug, thiserror::Error)]
@@ -16,10 +18,19 @@ pub enum PlanError {
     Malformed(String),
 }
 
-/// The fully-resolved plan the actor executes.
+/// The fully-resolved plan the actor executes (format v2, data-contract §4).
+///
+/// The definition's `agents` spine is flattened server-side into one ordered
+/// `steps` list; each step carries its structured `key` and its `slot` (an opaque
+/// session-affinity string). Per-slot session provisioning is described by
+/// `sessions` (replacing the old single `setup`). The runtime never learns the
+/// words "agents", "integrations", or a named ref — those were resolved away.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ResolvedPlan {
     pub run_id: String,
+    /// Document-format version; strict parsers may reject unknown versions.
+    #[serde(default)]
+    pub plan_version: Option<i64>,
     #[serde(default)]
     pub workflow_id: Option<String>,
     #[serde(default)]
@@ -30,10 +41,12 @@ pub struct ResolvedPlan {
     pub trigger_kind: Option<String>,
     #[serde(default)]
     pub target_mode: Option<String>,
-    pub setup: PlanSetup,
-    /// Server-interpolated arg values, kept verbatim for the run record.
+    /// Per-slot session provisioning, keyed by the step's `slot`.
     #[serde(default)]
-    pub args: serde_json::Value,
+    pub sessions: BTreeMap<String, SessionSpec>,
+    /// Server-resolved input values, kept verbatim for the run record.
+    #[serde(default, alias = "args")]
+    pub inputs: serde_json::Value,
     pub steps: Vec<PlanStep>,
 }
 
@@ -45,12 +58,51 @@ impl ResolvedPlan {
     pub fn step_count(&self) -> usize {
         self.steps.len()
     }
+
+    /// Back-compat single-session view for the current (pre-multi-slot) executor.
+    ///
+    /// TODO(workflows phase C/F, B7): the executor must become slot-keyed —
+    /// a `slot -> session` map, no single "current" session. Until then this
+    /// derives one `PlanSetup` from the session of the first step's slot (falling
+    /// back to any session), preserving today's single-session behavior.
+    pub fn setup(&self) -> PlanSetup {
+        let slot = self.steps.first().map(|s| s.slot.as_str());
+        let session = slot
+            .and_then(|slot| self.sessions.get(slot))
+            .or_else(|| self.sessions.values().next());
+        match session {
+            Some(spec) => PlanSetup {
+                harness: spec.harness.clone(),
+                model: spec.model.clone(),
+                session_binding: spec.session_binding,
+            },
+            None => PlanSetup {
+                harness: String::new(),
+                model: None,
+                session_binding: SessionBinding::Fresh,
+            },
+        }
+    }
 }
 
+/// How one slot's session is provisioned (data-contract §4 `sessions[slot]`).
 #[derive(Debug, Clone, Deserialize)]
-pub struct PlanSetup {
+pub struct SessionSpec {
     pub harness: String,
     #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default = "SessionBinding::default_fresh")]
+    pub session_binding: SessionBinding,
+    /// L29: bind an existing session instead of creating a fresh one.
+    #[serde(default)]
+    pub bind_session_id: Option<String>,
+}
+
+/// The single-session view the current executor still consumes. Not deserialized
+/// directly — derived from `sessions` by [`ResolvedPlan::setup`].
+#[derive(Debug, Clone)]
+pub struct PlanSetup {
+    pub harness: String,
     pub model: Option<String>,
     pub session_binding: SessionBinding,
 }
@@ -64,9 +116,27 @@ pub enum SessionBinding {
     Headless,
 }
 
-/// One plan step: its kind-specific payload plus the per-step failure policy.
+impl SessionBinding {
+    fn default_fresh() -> Self {
+        SessionBinding::Fresh
+    }
+}
+
+/// One plan step: its structured identity + slot + failure policy + kind payload.
+///
+/// `key` is the structured step key "<node>.<lane>.<step>" (B5); `slot` is the
+/// step's session-affinity handle. Both are stamped by the server resolver and
+/// carried through to the observed step-run row. They are `serde(default)` at the
+/// wire boundary for resilience — the server (the authority) always populates
+/// them.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PlanStep {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub slot: String,
+    #[serde(default)]
+    pub label: String,
     #[serde(default)]
     pub on_fail: OnFail,
     #[serde(flatten)]
@@ -87,14 +157,16 @@ pub enum StepKind {
     AgentConfig(AgentConfigStep),
     #[serde(rename = "agent.prompt")]
     AgentPrompt(AgentPromptStep),
+    #[serde(rename = "agent.emit")]
+    AgentEmit(AgentEmitStep),
     #[serde(rename = "shell.run")]
     ShellRun(ShellRunStep),
     #[serde(rename = "scm.open_pr")]
     ScmOpenPr(ScmOpenPrStep),
     #[serde(rename = "notify")]
     Notify(NotifyStep),
-    #[serde(rename = "human.approval")]
-    HumanApproval(HumanApprovalStep),
+    #[serde(rename = "branch")]
+    Branch(BranchStep),
 }
 
 impl StepKind {
@@ -102,10 +174,11 @@ impl StepKind {
         match self {
             StepKind::AgentConfig(_) => "agent.config",
             StepKind::AgentPrompt(_) => "agent.prompt",
+            StepKind::AgentEmit(_) => "agent.emit",
             StepKind::ShellRun(_) => "shell.run",
             StepKind::ScmOpenPr(_) => "scm.open_pr",
             StepKind::Notify(_) => "notify",
-            StepKind::HumanApproval(_) => "human.approval",
+            StepKind::Branch(_) => "branch",
         }
     }
 }
@@ -115,6 +188,32 @@ pub struct AgentPromptStep {
     pub prompt: String,
     #[serde(default)]
     pub goal: Option<GoalSpec>,
+    /// L27 gate: after the turn, require this provider+tool was invoked. The gate
+    /// loop (C14) lands with the session plane; the plan carries it now.
+    #[serde(default)]
+    pub required_invocation: Option<RequiredInvocation>,
+}
+
+/// Write-output step (§1.2): prompts, then captures a schema-shaped output. The
+/// emit `name` is resolved away server-side (refs are already indexed), so the
+/// runtime only needs the re-ask budget + optional schema.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentEmitStep {
+    pub prompt: String,
+    #[serde(default = "default_max_attempts")]
+    pub max_attempts: u32,
+    #[serde(default)]
+    pub output_schema: Option<serde_json::Value>,
+}
+
+fn default_max_attempts() -> u32 {
+    3
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequiredInvocation {
+    pub provider: String,
+    pub tool: String,
 }
 
 /// Sets the active agent harness and/or model for the steps below it. At least
@@ -179,34 +278,37 @@ pub struct ScmOpenPrStep {
     pub draft: bool,
 }
 
+/// Slack-only notify (E1b): the server sends it (`slack_notify` action);
+/// template-only in v1. No channel discriminator, no in-app variant.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NotifyStep {
-    pub channel: NotifyChannel,
+    pub slack_channel_id: String,
     pub message: String,
+}
+
+/// Branch step (C11/D3): switch on a prior emit's field (already rewritten to an
+/// indexed ref) and route each case to continue|end. The engine arm lands in a
+/// later phase; the plan carries the shape now.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BranchStep {
+    pub on: String,
+    pub cases: BTreeMap<String, BranchCase>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BranchCase {
+    pub to: BranchTarget,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum NotifyChannel {
-    InApp,
-    Slack,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct HumanApprovalStep {
-    pub message: String,
-    #[serde(default)]
-    pub on_timeout: OnTimeout,
-    #[serde(default)]
-    pub timeout_secs: Option<u64>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum OnTimeout {
-    #[default]
-    Fail,
+pub enum BranchTarget {
+    /// Normal advance to the next step.
     Continue,
+    /// The run goes terminal (`completed`); later steps are marked skipped (E5).
+    End,
 }
 
 /// Per-step failure policy. Defaults to `stop`.
@@ -256,18 +358,26 @@ mod tests {
     fn full_plan_json() -> &'static str {
         r#"{
             "run_id": "run-1",
+            "plan_version": 1,
             "workflow_id": "wf-1",
             "workflow_version_id": "wfv-1",
             "version_n": 2,
             "trigger_kind": "manual",
             "target_mode": "local",
-            "setup": { "harness": "claude", "model": "sonnet", "session_binding": "fresh" },
-            "args": { "ticket": "ABC-1" },
+            "sessions": {
+                "triage": { "harness": "claude", "model": "sonnet", "session_binding": "fresh" },
+                "fix": { "harness": "codex", "model": "opus", "session_binding": "headless",
+                         "bind_session_id": "sess_abc" }
+            },
+            "inputs": { "ticket": "ABC-1" },
             "steps": [
-                { "kind": "agent.config", "harness": "codex", "model": "opus" },
+                { "key": "0.-.0", "slot": "triage", "label": "set model",
+                  "kind": "agent.config", "model": "opus" },
                 {
+                    "key": "0.-.1", "slot": "triage", "label": "investigate",
                     "kind": "agent.prompt",
-                    "prompt": "fix {{steps[0].output.thing}}",
+                    "prompt": "fix {{steps[2].output.thing}}",
+                    "required_invocation": { "provider": "linear", "tool": "update_status" },
                     "goal": {
                         "objective": "make CI green",
                         "max_turns": 25,
@@ -277,10 +387,19 @@ mod tests {
                     },
                     "on_fail": { "kind": "retry", "n": 2 }
                 },
-                { "kind": "shell.run", "command": "cargo build", "timeout_secs": 600, "output_name": "build" },
-                { "kind": "scm.open_pr", "title": "Fix", "body": "done", "draft": true },
-                { "kind": "notify", "channel": "slack", "message": "shipped" },
-                { "kind": "human.approval", "message": "ok?", "on_timeout": "continue", "timeout_secs": 3600 }
+                { "key": "0.-.2", "slot": "triage", "kind": "agent.emit",
+                  "prompt": "summarize", "max_attempts": 5,
+                  "output_schema": { "type": "object" } },
+                { "key": "1.-.0", "slot": "fix", "kind": "shell.run",
+                  "command": "cargo build", "timeout_secs": 600, "output_name": "build" },
+                { "key": "1.-.1", "slot": "fix", "kind": "scm.open_pr",
+                  "title": "Fix", "body": "done", "draft": true },
+                { "key": "1.-.2", "slot": "fix", "kind": "notify",
+                  "slack_channel_id": "C123", "message": "shipped" },
+                { "key": "1.-.3", "slot": "fix", "kind": "branch",
+                  "on": "{{steps[2].output.verdict}}",
+                  "cases": { "ship": { "to": "continue" }, "wont_fix": { "to": "end" } },
+                  "reason": "route" }
             ]
         }"#
     }
@@ -289,47 +408,58 @@ mod tests {
     fn parses_a_full_plan_with_all_step_kinds() {
         let plan = parse(full_plan_json()).expect("parse full plan");
         assert_eq!(plan.run_id, "run-1");
+        assert_eq!(plan.plan_version, Some(1));
         assert_eq!(plan.version_n, Some(2));
-        assert_eq!(plan.setup.harness, "claude");
-        assert_eq!(plan.setup.session_binding, SessionBinding::Fresh);
-        assert_eq!(plan.step_count(), 6);
+        assert_eq!(plan.step_count(), 7);
+
+        // sessions map, keyed by slot; setup() derives the first step's slot session.
+        assert_eq!(plan.sessions.len(), 2);
+        assert_eq!(plan.sessions["fix"].bind_session_id.as_deref(), Some("sess_abc"));
+        assert_eq!(plan.sessions["fix"].session_binding, SessionBinding::Headless);
+        let setup = plan.setup();
+        assert_eq!(setup.harness, "claude");
+        assert_eq!(setup.session_binding, SessionBinding::Fresh);
+
+        // steps carry structured key + slot + label.
+        assert_eq!(plan.steps[0].key, "0.-.0");
+        assert_eq!(plan.steps[0].slot, "triage");
+        assert_eq!(plan.steps[0].label, "set model");
 
         let StepKind::AgentConfig(config) = &plan.steps[0].kind else {
             panic!("expected agent.config");
         };
-        assert_eq!(config.harness.as_deref(), Some("codex"));
         assert_eq!(config.model.as_deref(), Some("opus"));
         assert_eq!(plan.steps[0].kind_slug(), "agent.config");
-        // agent.config with no explicit on_fail defaults to stop.
         assert_eq!(plan.steps[0].on_fail.kind, OnFailKind::Stop);
 
         let StepKind::AgentPrompt(agent) = &plan.steps[1].kind else {
             panic!("expected agent.prompt");
         };
+        let inv = agent.required_invocation.as_ref().expect("required_invocation");
+        assert_eq!(inv.provider, "linear");
+        assert_eq!(inv.tool, "update_status");
         let goal = agent.goal.as_ref().expect("goal");
         assert_eq!(goal.max_turns, 25);
         assert_eq!(goal.on_blocked, OnBlocked::PauseForApproval);
-        assert_eq!(goal.verify.as_ref().expect("verify").expect_exit, 0);
         assert_eq!(plan.steps[1].on_fail.kind, OnFailKind::Retry);
         assert_eq!(plan.steps[1].on_fail.n, 2);
 
-        let StepKind::ShellRun(shell) = &plan.steps[2].kind else {
-            panic!("expected shell.run");
+        let StepKind::AgentEmit(emit) = &plan.steps[2].kind else {
+            panic!("expected agent.emit");
         };
-        assert_eq!(shell.command, "cargo build");
-        assert_eq!(shell.timeout_secs, Some(600));
-        // stop is the default failure policy
-        assert_eq!(plan.steps[2].on_fail.kind, OnFailKind::Stop);
+        assert_eq!(emit.max_attempts, 5);
+        assert!(emit.output_schema.is_some());
 
-        let StepKind::Notify(notify) = &plan.steps[4].kind else {
+        let StepKind::Notify(notify) = &plan.steps[5].kind else {
             panic!("expected notify");
         };
-        assert_eq!(notify.channel, NotifyChannel::Slack);
+        assert_eq!(notify.slack_channel_id, "C123");
 
-        let StepKind::HumanApproval(approval) = &plan.steps[5].kind else {
-            panic!("expected human.approval");
+        let StepKind::Branch(branch) = &plan.steps[6].kind else {
+            panic!("expected branch");
         };
-        assert_eq!(approval.on_timeout, OnTimeout::Continue);
+        assert_eq!(branch.cases["ship"].to, BranchTarget::Continue);
+        assert_eq!(branch.cases["wont_fix"].to, BranchTarget::End);
     }
 
     #[test]
@@ -337,43 +467,35 @@ mod tests {
         let plan = parse(
             r#"{
                 "run_id": "run-2",
-                "setup": { "harness": "codex", "session_binding": "headless" },
-                "steps": [ { "kind": "agent.prompt", "prompt": "hi" } ]
+                "sessions": { "main": { "harness": "codex", "session_binding": "headless" } },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "agent.prompt", "prompt": "hi" } ]
             }"#,
         )
         .expect("parse minimal plan");
-        assert_eq!(plan.setup.session_binding, SessionBinding::Headless);
-        assert!(plan.setup.model.is_none());
+        assert_eq!(plan.setup().session_binding, SessionBinding::Headless);
+        assert!(plan.setup().model.is_none());
         let StepKind::AgentPrompt(agent) = &plan.steps[0].kind else {
             panic!("expected agent.prompt");
         };
         assert!(agent.goal.is_none());
+        assert!(agent.required_invocation.is_none());
         assert_eq!(plan.steps[0].on_fail.kind, OnFailKind::Stop);
     }
 
     #[test]
-    fn parses_agent_config_with_partial_fields() {
+    fn agent_emit_max_attempts_defaults_to_three() {
         let plan = parse(
             r#"{
-                "run_id": "run-cfg",
-                "setup": { "harness": "claude", "session_binding": "fresh" },
-                "steps": [
-                    { "kind": "agent.config", "harness": "codex" },
-                    { "kind": "agent.config", "model": "opus" }
-                ]
+                "run_id": "run-emit",
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "agent.emit", "prompt": "go" } ]
             }"#,
         )
-        .expect("parse agent.config plan");
-        let StepKind::AgentConfig(harness_only) = &plan.steps[0].kind else {
-            panic!("expected agent.config");
+        .expect("parse emit plan");
+        let StepKind::AgentEmit(emit) = &plan.steps[0].kind else {
+            panic!("expected agent.emit");
         };
-        assert_eq!(harness_only.harness.as_deref(), Some("codex"));
-        assert!(harness_only.model.is_none());
-        let StepKind::AgentConfig(model_only) = &plan.steps[1].kind else {
-            panic!("expected agent.config");
-        };
-        assert!(model_only.harness.is_none());
-        assert_eq!(model_only.model.as_deref(), Some("opus"));
+        assert_eq!(emit.max_attempts, 3);
     }
 
     #[test]
@@ -381,8 +503,8 @@ mod tests {
         let error = parse(
             r#"{
                 "run_id": "run-3",
-                "setup": { "harness": "claude", "session_binding": "fresh" },
-                "steps": [ { "kind": "tool.call", "tool": "x" } ]
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "human.approval", "message": "x" } ]
             }"#,
         )
         .expect_err("unknown kind must reject");
@@ -395,8 +517,8 @@ mod tests {
         let error = parse(
             r#"{
                 "run_id": "run-4",
-                "setup": { "harness": "claude", "session_binding": "fresh" },
-                "steps": [ { "kind": "agent.prompt" } ]
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "agent.prompt" } ]
             }"#,
         )
         .expect_err("missing prompt must reject");

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
@@ -5,7 +5,7 @@ use super::engine::{
     WorkflowStepExecutor,
 };
 use super::model::{WorkflowRunRecord, WorkflowStepRunRecord};
-use super::plan::{self, OnTimeout, PlanError, StepKind};
+use super::plan::{self, PlanError, StepKind};
 use super::store::WorkflowStore;
 use super::templates::{self, StepOutputs};
 
@@ -129,9 +129,18 @@ impl WorkflowService {
             };
             WorkflowStore::insert_run(tx, &run)?;
             for (index, step) in plan.steps.iter().enumerate() {
+                // v2 plans stamp a structured key; be resilient to a keyless
+                // plan by synthesizing a unique flat key (the SQLite unique index
+                // on (run_id, step_key) would otherwise collide on empty keys).
+                let step_key = if step.key.is_empty() {
+                    format!("0.-.{index}")
+                } else {
+                    step.key.clone()
+                };
                 let step_run = WorkflowStepRunRecord {
                     run_id: run_id.clone(),
                     step_index: index as i64,
+                    step_key,
                     kind: step.kind_slug().to_string(),
                     status: WorkflowStepStatus::Pending,
                     attempt: 0,
@@ -267,25 +276,10 @@ impl WorkflowService {
         let attempt = step_run.attempt;
 
         let decision = match (&step.kind, input) {
-            (StepKind::HumanApproval(_), ApprovalInput::Approve) => StepDecision::Complete {
-                output: serde_json::json!({ "approved": true }),
-            },
-            (StepKind::HumanApproval(human), ApprovalInput::Timeout) => match human.on_timeout {
-                OnTimeout::Continue => StepDecision::Complete {
-                    output: serde_json::json!({ "approved": false, "timedOut": true, "resolution": "continue" }),
-                },
-                OnTimeout::Fail => decide_after_step(
-                    step.on_fail,
-                    attempt,
-                    failed_outcome("approval_timeout", "approval timed out"),
-                ),
-            },
-            (StepKind::HumanApproval(_), ApprovalInput::Deny) => decide_after_step(
-                step.on_fail,
-                attempt,
-                failed_outcome("approval_denied", "approval denied"),
-            ),
-            // An `agent.goal` step parked on a block: approve re-runs the step
+            // human.approval is removed (E1); the only park path left is a goal
+            // step blocked with on_blocked=pause_for_approval, which keeps the
+            // waiting_approval status. An `agent.goal` step parked on a block:
+            // approve re-runs the step
             // (re-arm + continue waiting), deny/timeout fails per on_fail.
             (StepKind::AgentPrompt(_), ApprovalInput::Approve) => StepDecision::Retry,
             (StepKind::AgentPrompt(_), _) => decide_after_step(

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
@@ -103,10 +103,13 @@ async fn drive(
 }
 
 fn plan_json(steps: &str) -> String {
+    // v2 shape: a per-slot `sessions` map (replaces `setup`). These engine tests
+    // pass keyless steps; the service seeds synthetic flat keys for them.
     format!(
         r#"{{
             "run_id": "run-1",
-            "setup": {{ "harness": "claude", "session_binding": "fresh" }},
+            "plan_version": 1,
+            "sessions": {{ "main": {{ "harness": "claude", "session_binding": "fresh" }} }},
             "steps": {steps}
         }}"#
     )
@@ -287,65 +290,9 @@ fn suspend(message: &str) -> StepOutcome {
     }
 }
 
-#[tokio::test]
-async fn human_approval_approve_advances() {
-    let service = test_service();
-    let run_id = create(
-        &service,
-        r#"[{ "kind": "human.approval", "message": "ok?" }, { "kind": "shell.run", "command": "y" }]"#,
-    );
-    let executor = FakeExecutor::script(vec![suspend("ok?"), completed(serde_json::json!({}))]);
-    let progress = drive(&service, &run_id, &executor).await;
-    assert_eq!(progress, EngineProgress::SuspendedForApproval);
-    let run = service.get_run(&run_id).unwrap().unwrap();
-    assert_eq!(run.status, WorkflowRunStatus::WaitingApproval);
-
-    let outcome = service
-        .resolve_pending_approval(&run_id, ApprovalInput::Approve)
-        .expect("resolve");
-    assert!(outcome.resume);
-    // Actor resumes the loop after an approve that advanced the run.
-    let progress = drive(&service, &run_id, &executor).await;
-    assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
-}
-
-#[tokio::test]
-async fn human_approval_deny_with_stop_fails_run() {
-    let service = test_service();
-    let run_id = create(
-        &service,
-        r#"[{ "kind": "human.approval", "message": "ok?", "on_fail": { "kind": "stop" } }]"#,
-    );
-    let executor = FakeExecutor::script(vec![suspend("ok?")]);
-    drive(&service, &run_id, &executor).await;
-    let outcome = service
-        .resolve_pending_approval(&run_id, ApprovalInput::Deny)
-        .expect("resolve");
-    assert_eq!(
-        outcome.progress,
-        EngineProgress::Finished(WorkflowRunStatus::Failed)
-    );
-    let run = service.get_run(&run_id).unwrap().unwrap();
-    assert_eq!(run.error_code.as_deref(), Some("approval_denied"));
-}
-
-#[tokio::test]
-async fn human_approval_timeout_continue_advances() {
-    let service = test_service();
-    let run_id = create(
-        &service,
-        r#"[{ "kind": "human.approval", "message": "ok?", "on_timeout": "continue" }]"#,
-    );
-    let executor = FakeExecutor::script(vec![suspend("ok?")]);
-    drive(&service, &run_id, &executor).await;
-    let outcome = service
-        .resolve_pending_approval(&run_id, ApprovalInput::Timeout)
-        .expect("resolve");
-    assert_eq!(
-        outcome.progress,
-        EngineProgress::Finished(WorkflowRunStatus::Completed)
-    );
-}
+// human.approval step tests were removed with the step kind (E1). The remaining
+// park/resume path is a goal step blocked with on_blocked=pause_for_approval,
+// which still reaches waiting_approval — exercised below.
 
 #[tokio::test]
 async fn goal_block_approve_reruns_the_step() {

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
@@ -166,12 +166,13 @@ impl WorkflowStore {
     ) -> rusqlite::Result<()> {
         tx.execute(
             "INSERT INTO workflow_step_runs (
-                run_id, step_index, kind, status, attempt, output_json, error_code,
+                run_id, step_index, step_key, kind, status, attempt, output_json, error_code,
                 error_message, started_at, ended_at, created_at, updated_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 step.run_id,
                 step.step_index,
+                step.step_key,
                 step.kind,
                 step_status_to_db(step.status),
                 step.attempt,
@@ -271,6 +272,7 @@ fn map_step_run(row: &Row<'_>) -> rusqlite::Result<WorkflowStepRunRecord> {
     Ok(WorkflowStepRunRecord {
         run_id: row.get("run_id")?,
         step_index: row.get("step_index")?,
+        step_key: row.get("step_key")?,
         kind: row.get("kind")?,
         status,
         attempt: row.get("attempt")?,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use super::plan::{
-    AgentConfigStep, AgentPromptStep, GoalSpec, HumanApprovalStep, NotifyStep, PlanStep,
+    AgentConfigStep, AgentEmitStep, AgentPromptStep, BranchStep, GoalSpec, NotifyStep, PlanStep,
     ScmOpenPrStep, ShellRunStep, StepKind, VerifySpec,
 };
 
@@ -122,6 +122,12 @@ pub fn resolve_step(step: &PlanStep, outputs: &StepOutputs) -> PlanStep {
         StepKind::AgentPrompt(agent) => StepKind::AgentPrompt(AgentPromptStep {
             prompt: resolve_string(&agent.prompt, outputs),
             goal: agent.goal.as_ref().map(|goal| resolve_goal(goal, outputs)),
+            required_invocation: agent.required_invocation.clone(),
+        }),
+        StepKind::AgentEmit(emit) => StepKind::AgentEmit(AgentEmitStep {
+            prompt: resolve_string(&emit.prompt, outputs),
+            max_attempts: emit.max_attempts,
+            output_schema: emit.output_schema.clone(),
         }),
         StepKind::ShellRun(shell) => StepKind::ShellRun(ShellRunStep {
             command: resolve_string(&shell.command, outputs),
@@ -135,16 +141,19 @@ pub fn resolve_step(step: &PlanStep, outputs: &StepOutputs) -> PlanStep {
             draft: pr.draft,
         }),
         StepKind::Notify(notify) => StepKind::Notify(NotifyStep {
-            channel: notify.channel,
+            slack_channel_id: notify.slack_channel_id.clone(),
             message: resolve_string(&notify.message, outputs),
         }),
-        StepKind::HumanApproval(approval) => StepKind::HumanApproval(HumanApprovalStep {
-            message: resolve_string(&approval.message, outputs),
-            on_timeout: approval.on_timeout,
-            timeout_secs: approval.timeout_secs,
+        StepKind::Branch(branch) => StepKind::Branch(BranchStep {
+            on: resolve_string(&branch.on, outputs),
+            cases: branch.cases.clone(),
+            reason: branch.reason.clone(),
         }),
     };
     PlanStep {
+        key: step.key.clone(),
+        slot: step.slot.clone(),
+        label: step.label.clone(),
         on_fail: step.on_fail,
         kind,
     }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/commands.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/commands.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use serde_json::json;
 
 use crate::domains::workflows::engine::StepOutcome;
-use crate::domains::workflows::plan::{NotifyChannel, ScmOpenPrStep, ShellRunStep};
+use crate::domains::workflows::plan::{ScmOpenPrStep, ShellRunStep};
 
 /// Bytes of combined output tail retained per shell step.
 const MAX_OUTPUT_TAIL: usize = 8 * 1024;
@@ -194,16 +194,16 @@ pub async fn open_pr_step(
     }
 }
 
-/// Execute a `notify` step. Never a hard failure: the in-app record is the floor.
-pub fn notify_step(channel: NotifyChannel, message: &str) -> StepOutcome {
-    let channel = match channel {
-        NotifyChannel::InApp => "in_app",
-        // Slack delivery is a W4 integration concern; the in-app record still
-        // lands so the run history shows the intended notification.
-        NotifyChannel::Slack => "slack_unavailable",
-    };
+/// Execute a `notify` step. Slack-only (E1b): the runtime records the rendered
+/// message + channel as the step output; the server performs the actual send
+/// (`slack_notify` action). Never a hard failure.
+pub fn notify_step(message: &str, slack_channel_id: &str) -> StepOutcome {
     StepOutcome::Completed {
-        output: json!({ "channel": channel, "message": message }),
+        output: json!({
+            "channel": "slack",
+            "message": message,
+            "slack_channel_id": slack_channel_id,
+        }),
     }
 }
 
@@ -270,11 +270,13 @@ mod tests {
     }
 
     #[test]
-    fn notify_slack_is_not_a_failure() {
-        let outcome = notify_step(NotifyChannel::Slack, "hi");
+    fn notify_slack_outputs_channel_and_message() {
+        let outcome = notify_step("hi", "C12345");
         let StepOutcome::Completed { output } = outcome else {
             panic!("notify must not fail");
         };
-        assert_eq!(output["channel"], "slack_unavailable");
+        assert_eq!(output["channel"], "slack");
+        assert_eq!(output["message"], "hi");
+        assert_eq!(output["slack_channel_id"], "C12345");
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
@@ -24,8 +24,8 @@ use crate::domains::sessions::service::SessionService;
 use crate::domains::workflows::engine::{StepExecContext, StepOutcome, WorkflowStepExecutor};
 use crate::domains::workflows::model::WorkflowRunRecord;
 use crate::domains::workflows::plan::{
-    AgentConfigStep, AgentPromptStep, GoalSpec, HumanApprovalStep, OnBlocked, OnTimeout, PlanSetup,
-    PlanStep, ScmOpenPrStep, ShellRunStep, StepKind,
+    AgentConfigStep, AgentPromptStep, GoalSpec, OnBlocked, PlanSetup, PlanStep, ScmOpenPrStep,
+    ShellRunStep, StepKind,
 };
 use crate::domains::workflows::service::WorkflowService;
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
@@ -475,24 +475,6 @@ impl WorkflowStepExecutorImpl {
         }
     }
 
-    fn human_approval(&self, step: &HumanApprovalStep) -> StepOutcome {
-        let deadline_at = step.timeout_secs.map(|secs| {
-            (chrono::Utc::now() + chrono::Duration::seconds(secs as i64)).to_rfc3339()
-        });
-        let on_timeout = match step.on_timeout {
-            OnTimeout::Fail => "fail",
-            OnTimeout::Continue => "continue",
-        };
-        StepOutcome::AwaitApproval {
-            descriptor: json!({
-                "kind": "human_approval",
-                "message": step.message,
-                "on_timeout": on_timeout,
-                "timeout_secs": step.timeout_secs,
-                "deadline_at": deadline_at,
-            }),
-        }
-    }
 }
 
 #[async_trait::async_trait]
@@ -506,8 +488,23 @@ impl WorkflowStepExecutor for WorkflowStepExecutorImpl {
             },
             StepKind::ShellRun(shell) => self.run_shell(shell).await,
             StepKind::ScmOpenPr(pr) => self.run_scm(pr).await,
-            StepKind::Notify(notify) => commands::notify_step(notify.channel, &notify.message),
-            StepKind::HumanApproval(approval) => self.human_approval(approval),
+            StepKind::Notify(notify) => {
+                commands::notify_step(&notify.message, &notify.slack_channel_id)
+            }
+            // TODO(workflows phase C/F): agent.emit re-ask loop (C12) and branch
+            // continue/end arm (C11). The plan carries them now; the engine
+            // executes them in a later phase. Fail loudly until then so a v2 plan
+            // using these can't silently no-op.
+            StepKind::AgentEmit(_) => StepOutcome::Failed {
+                code: "not_implemented".to_string(),
+                message: Some("agent.emit execution lands in a later phase".to_string()),
+                output: None,
+            },
+            StepKind::Branch(_) => StepOutcome::Failed {
+                code: "not_implemented".to_string(),
+                message: Some("branch execution lands in a later phase".to_string()),
+                output: None,
+            },
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
@@ -238,7 +238,7 @@ impl WorkflowRunManager {
                 deps.clone(),
                 run_id.clone(),
                 run.workspace_id.clone(),
-                plan.setup.clone(),
+                plan.setup(),
             );
             executor.hydrate_from_run(&run);
             let progress =

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0053_workflow_runs.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0053_workflow_runs.sql
@@ -27,9 +27,14 @@ CREATE INDEX idx_workflow_runs_workspace_created
 CREATE INDEX idx_workflow_runs_status
     ON workflow_runs(status);
 
+-- `step_key` is the format-v2 structured step key "<node>.<lane>.<step>" (B5,
+-- lane "-" for the flat case). The PK stays (run_id, step_index) — the cursor is
+-- pure sequencing — but the key is the step's stable *identity* (outputs are
+-- reported by key), enforced unique per run.
 CREATE TABLE workflow_step_runs (
     run_id TEXT NOT NULL REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
     step_index INTEGER NOT NULL,
+    step_key TEXT NOT NULL,
     kind TEXT NOT NULL,
     status TEXT NOT NULL,
     attempt INTEGER NOT NULL DEFAULT 0,
@@ -42,3 +47,6 @@ CREATE TABLE workflow_step_runs (
     updated_at TEXT NOT NULL,
     PRIMARY KEY (run_id, step_index)
 );
+
+CREATE UNIQUE INDEX idx_workflow_step_runs_key
+    ON workflow_step_runs(run_id, step_key);

--- a/apps/desktop/src/components/playground/workflows/WorkflowEditorFixtures.tsx
+++ b/apps/desktop/src/components/playground/workflows/WorkflowEditorFixtures.tsx
@@ -186,6 +186,7 @@ function PanelHost({ initial, title }: { initial: WorkflowStep; title: string })
           agents={AGENTS}
           suggestions={SUGGESTIONS}
           slackConnected={false}
+          slackChannels={[]}
           supportsGoals={() => true}
           onChange={setStep}
           onClose={() => undefined}

--- a/apps/desktop/src/components/workflows/editor/WorkflowStepPanel.tsx
+++ b/apps/desktop/src/components/workflows/editor/WorkflowStepPanel.tsx
@@ -27,6 +27,11 @@ export interface EditorAgent {
   models: { id: string; label: string }[];
 }
 
+export interface EditorSlackChannel {
+  id: string;
+  name: string;
+}
+
 export interface WorkflowStepPanelProps {
   step: WorkflowStep;
   /** The effective harness for this step — Setup harness folded through any
@@ -35,6 +40,8 @@ export interface WorkflowStepPanelProps {
   agents: readonly EditorAgent[];
   suggestions: readonly TemplateSuggestion[];
   slackConnected: boolean;
+  /** Channels the connected Slack account can post to; empty when not connected. */
+  slackChannels: readonly EditorSlackChannel[];
   supportsGoals: (harnessKind: string) => boolean;
   onChange: (step: WorkflowStep) => void;
   onClose: () => void;
@@ -79,7 +86,13 @@ export function WorkflowStepPanel(props: WorkflowStepPanelProps) {
         ) : step.kind === "scm.open_pr" ? (
           <OpenPrEditor step={step} suggestions={props.suggestions} onChange={onChange} />
         ) : step.kind === "notify" ? (
-          <NotifyEditor step={step} suggestions={props.suggestions} slackConnected={props.slackConnected} onChange={onChange} />
+          <NotifyEditor
+            step={step}
+            suggestions={props.suggestions}
+            slackConnected={props.slackConnected}
+            slackChannels={props.slackChannels}
+            onChange={onChange}
+          />
         ) : (
           <ApprovalEditor step={step} onChange={onChange} />
         )}
@@ -279,13 +292,16 @@ function NotifyEditor({
   step,
   suggestions,
   slackConnected,
+  slackChannels,
   onChange,
 }: {
   step: NotifyStep;
   suggestions: readonly TemplateSuggestion[];
   slackConnected: boolean;
+  slackChannels: readonly EditorSlackChannel[];
   onChange: (step: WorkflowStep) => void;
 }) {
+  const isSlack = step.channel === "slack";
   return (
     <div className="flex flex-col gap-4">
       <InlineRow label="Channel">
@@ -301,10 +317,34 @@ function NotifyEditor({
               disabled: !slackConnected,
             },
           ]}
-          onChange={(value) => onChange({ ...step, channel: value as WorkflowNotifyChannel })}
+          onChange={(value) =>
+            onChange({
+              ...step,
+              channel: value as WorkflowNotifyChannel,
+              slackChannelId: value === "slack" ? step.slackChannelId : undefined,
+            })
+          }
         />
       </InlineRow>
       <p className="-mt-1 text-xs text-faint">Always recorded in-app and in run history.</p>
+      {isSlack ? (
+        <InlineRow label="Slack channel">
+          {slackConnected ? (
+            <WorkflowSelect
+              ariaLabel="Slack channel"
+              value={step.slackChannelId ?? ""}
+              placeholder="Choose a channel"
+              options={slackChannels.map((channel) => ({
+                value: channel.id,
+                label: `#${channel.name}`,
+              }))}
+              onChange={(slackChannelId) => onChange({ ...step, slackChannelId })}
+            />
+          ) : (
+            <span className="text-xs text-faint">Connect Slack in Settings → Integrations</span>
+          )}
+        </InlineRow>
+      ) : null}
       <div className="flex flex-col gap-1.5">
         <FieldLabel>Message</FieldLabel>
         <TemplateVarTextarea

--- a/apps/desktop/src/components/workflows/run/WorkflowRunView.tsx
+++ b/apps/desktop/src/components/workflows/run/WorkflowRunView.tsx
@@ -18,10 +18,12 @@ import { WorkflowRunTimelineRow } from "@proliferate/product-ui/workflows/Workfl
 import { WorkflowStatusPill } from "@proliferate/product-ui/workflows/WorkflowStatusPill";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ArrowLeft } from "@proliferate/ui/icons";
-import type { WorkflowRunResponse } from "@/hooks/access/cloud/workflows/types";
+import type { StepActionResponse, WorkflowRunResponse } from "@/hooks/access/cloud/workflows/types";
 
 export interface WorkflowRunViewProps {
   run: WorkflowRunResponse;
+  /** The run's step-action ledger rows (spec 1.2) — feeds delivery chips. */
+  stepActions: readonly StepActionResponse[];
   definition: WorkflowDefinition;
   workflowName: string | null;
   /** Live approve/deny for local runs; cloud-run approvals are read-only in v1. */
@@ -36,6 +38,7 @@ export interface WorkflowRunViewProps {
 /** The run observability view (spec 3.6): header + typed step timeline. */
 export function WorkflowRunView({
   run,
+  stepActions,
   definition,
   workflowName,
   approvalEnabled = false,
@@ -61,8 +64,9 @@ export function WorkflowRunView({
         stepCursor: run.stepCursor,
         stepOutputs: run.stepOutputs as Record<string, unknown> | null,
         anyharnessWorkspaceId: run.anyharnessWorkspaceId,
+        stepActions,
       }),
-    [definition, status, run.stepCursor, run.stepOutputs, run.anyharnessWorkspaceId],
+    [definition, status, run.stepCursor, run.stepOutputs, run.anyharnessWorkspaceId, stepActions],
   );
 
   return (

--- a/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
@@ -29,6 +29,7 @@ import { useCloudAgentCatalog } from "@/hooks/access/cloud/agent-catalog/use-clo
 import { useCloudRunTargetWorkspaces } from "@/hooks/access/cloud/workspaces/use-cloud-run-target-workspaces";
 import { useWorkflowDetail } from "@/hooks/access/cloud/workflows/use-workflows";
 import { useWorkflowMutations } from "@/hooks/access/cloud/workflows/use-workflow-mutations";
+import { useWorkflowSlackChannels } from "@/hooks/access/cloud/workflows/use-workflow-slack-channels";
 import type { WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
 import { harnessSupportsGoals } from "@/lib/domain/workflows/goal-capability";
 import { WorkflowMetaCard } from "../editor/WorkflowMetaCard";
@@ -98,6 +99,7 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
   const detailQuery = useWorkflowDetail(workflowId);
   const catalogQuery = useCloudAgentCatalog();
   const cloudTargetsQuery = useCloudRunTargetWorkspaces();
+  const slackChannelsQuery = useWorkflowSlackChannels();
   const { updateMutation } = useWorkflowMutations();
 
   const [draft, setDraft] = useState<Draft | null>(null);
@@ -459,7 +461,8 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
                 effectiveHarness={effectiveHarnessAt(definition, selectedStep)}
                 agents={agents}
                 suggestions={suggestions}
-                slackConnected={false}
+                slackConnected={slackChannelsQuery.data?.connected ?? false}
+                slackChannels={slackChannelsQuery.data?.channels ?? []}
                 supportsGoals={harnessSupportsGoals}
                 onChange={(next) => updateStep(selectedStep, next)}
                 onClose={() => setSelectedStep(null)}

--- a/apps/desktop/src/components/workflows/screen/WorkflowRunScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowRunScreen.tsx
@@ -27,7 +27,8 @@ export function WorkflowRunScreen({ workflowId, runId }: WorkflowRunScreenProps)
   const detailQuery = useWorkflowDetail(workflowId);
   const approvalMutation = useResolveWorkflowApproval();
 
-  const run = runQuery.data ?? null;
+  const run = runQuery.data?.run ?? null;
+  const stepActions = runQuery.data?.stepActions ?? [];
   const workflowName = detailQuery.data?.workflow.name ?? null;
 
   const isCloudRun = run?.targetMode === "personal_cloud";
@@ -60,6 +61,7 @@ export function WorkflowRunScreen({ workflowId, runId }: WorkflowRunScreenProps)
         ) : (
           <WorkflowRunView
             run={run}
+            stepActions={stepActions}
             definition={definition}
             workflowName={workflowName}
             approvalEnabled={isLocalRun}

--- a/apps/desktop/src/hooks/access/cloud/workflows/query-keys.ts
+++ b/apps/desktop/src/hooks/access/cloud/workflows/query-keys.ts
@@ -23,3 +23,7 @@ export function workflowRunDetailKey(runId: string | null) {
 export function workflowTriggersKey(workflowId: string | null) {
   return [...workflowsRootKey(), "triggers", workflowId] as const;
 }
+
+export function workflowSlackChannelsKey() {
+  return [...workflowsRootKey(), "slack-channels"] as const;
+}

--- a/apps/desktop/src/hooks/access/cloud/workflows/types.ts
+++ b/apps/desktop/src/hooks/access/cloud/workflows/types.ts
@@ -5,11 +5,15 @@
  */
 
 export type {
+  SlackChannelResponse,
+  SlackChannelsResponse,
   StartRunRequest,
+  StepActionResponse,
   WorkflowCreateRequest,
   WorkflowDetailResponse,
   WorkflowListResponse,
   WorkflowResponse,
+  WorkflowRunDetailResponse,
   WorkflowRunListResponse,
   WorkflowRunResponse,
   WorkflowUpdateRequest,

--- a/apps/desktop/src/hooks/access/cloud/workflows/use-cloud-run-refresh.ts
+++ b/apps/desktop/src/hooks/access/cloud/workflows/use-cloud-run-refresh.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 // Side-effect: registers the auth-aware desktop cloud client factory.
 import "@/lib/access/cloud/client";
-import { refreshWorkflowRun } from "@/lib/access/cloud/workflows";
+import { refreshWorkflowRun, type WorkflowRunDetailResponse } from "@/lib/access/cloud/workflows";
 import { workflowRunDetailKey } from "./query-keys";
 
 const CLOUD_REFRESH_INTERVAL_MS = 3000;
@@ -25,7 +25,12 @@ export function useCloudRunRefreshPoll(runId: string | null, enabled: boolean): 
       try {
         const run = await refreshWorkflowRun(runId);
         if (!cancelled) {
-          queryClient.setQueryData(workflowRunDetailKey(runId), run);
+          // The refresh endpoint returns the bare run (no step-actions); keep
+          // whatever action rows are already cached until the next full poll.
+          queryClient.setQueryData<WorkflowRunDetailResponse>(
+            workflowRunDetailKey(runId),
+            (prev) => ({ run, stepActions: prev?.stepActions ?? [] }),
+          );
         }
       } catch {
         // Transient gateway/sandbox error — retry on the next tick.

--- a/apps/desktop/src/hooks/access/cloud/workflows/use-workflow-slack-channels.ts
+++ b/apps/desktop/src/hooks/access/cloud/workflows/use-workflow-slack-channels.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+// Side-effect: registers the auth-aware desktop cloud client factory.
+import "@/lib/access/cloud/client";
+import { listSlackChannels } from "@/lib/access/cloud/workflows";
+import type { SlackChannelsResponse } from "./types";
+import { workflowSlackChannelsKey } from "./query-keys";
+
+/**
+ * The connected Slack account's channels (spec 8.2, PR A): backs the notify
+ * step's Slack channel picker. `connected: false` means no ready Slack
+ * account — the editor shows a "Connect Slack" caption instead of a picker.
+ */
+export function useWorkflowSlackChannels(enabled = true) {
+  return useQuery<SlackChannelsResponse>({
+    queryKey: workflowSlackChannelsKey(),
+    queryFn: () => listSlackChannels(),
+    enabled,
+  });
+}

--- a/apps/desktop/src/hooks/access/cloud/workflows/use-workflows.ts
+++ b/apps/desktop/src/hooks/access/cloud/workflows/use-workflows.ts
@@ -8,8 +8,8 @@ import {
   listWorkflows,
   type WorkflowDetailResponse,
   type WorkflowListResponse,
+  type WorkflowRunDetailResponse,
   type WorkflowRunListResponse,
-  type WorkflowRunResponse,
 } from "@/lib/access/cloud/workflows";
 import { coerceRunStatus, shouldPollRun } from "@proliferate/product-domain/workflows/run-status";
 import {
@@ -49,16 +49,17 @@ export function useWorkflowRuns(workflowId: string | null = null, enabled = true
 }
 
 /**
- * A single run, polled on an interval while it is non-terminal (spec 3.6:
- * simple interval, no streaming in v1). Polling stops once the run resolves.
+ * A single run (+ its step-effect ledger, spec 1.2), polled on an interval
+ * while it is non-terminal (spec 3.6: simple interval, no streaming in v1).
+ * Polling stops once the run resolves.
  */
 export function useWorkflowRun(runId: string | null, enabled = true) {
-  return useQuery<WorkflowRunResponse>({
+  return useQuery<WorkflowRunDetailResponse>({
     queryKey: workflowRunDetailKey(runId),
     queryFn: () => getWorkflowRun(runId!),
     enabled: enabled && runId !== null,
     refetchInterval: (query) => {
-      const status = query.state.data?.status;
+      const status = query.state.data?.run.status;
       if (status && !shouldPollRun(coerceRunStatus(status))) {
         return false;
       }

--- a/apps/desktop/src/lib/access/cloud/workflows.ts
+++ b/apps/desktop/src/lib/access/cloud/workflows.ts
@@ -19,6 +19,8 @@ export type WorkflowDetailResponse = Schemas["WorkflowDetailResponse"];
 export type WorkflowListResponse = Schemas["WorkflowListResponse"];
 export type WorkflowRunResponse = Schemas["WorkflowRunResponse"];
 export type WorkflowRunListResponse = Schemas["WorkflowRunListResponse"];
+export type WorkflowRunDetailResponse = Schemas["WorkflowRunDetailResponse"];
+export type StepActionResponse = Schemas["StepActionResponse"];
 export type WorkflowCreateRequest = Schemas["WorkflowCreateRequest"];
 export type WorkflowUpdateRequest = Schemas["WorkflowUpdateRequest"];
 export type StartRunRequest = Schemas["StartRunRequest"];
@@ -27,6 +29,8 @@ export type WorkflowTriggerResponse = Schemas["WorkflowTriggerResponse"];
 export type WorkflowTriggerListResponse = Schemas["WorkflowTriggerListResponse"];
 export type WorkflowTriggerCreateRequest = Schemas["WorkflowTriggerCreateRequest"];
 export type WorkflowTriggerUpdateRequest = Schemas["WorkflowTriggerUpdateRequest"];
+export type SlackChannelResponse = Schemas["SlackChannelResponse"];
+export type SlackChannelsResponse = Schemas["SlackChannelsResponse"];
 
 export async function listWorkflows(includeArchived = false): Promise<WorkflowListResponse> {
   return getProliferateClient().requestJson<WorkflowListResponse>({
@@ -84,8 +88,8 @@ export async function listWorkflowRuns(
   });
 }
 
-export async function getWorkflowRun(runId: string): Promise<WorkflowRunResponse> {
-  return getProliferateClient().requestJson<WorkflowRunResponse>({
+export async function getWorkflowRun(runId: string): Promise<WorkflowRunDetailResponse> {
+  return getProliferateClient().requestJson<WorkflowRunDetailResponse>({
     method: "GET",
     path: "/v1/cloud/workflows/runs/{run_id}",
     pathParams: { run_id: runId },
@@ -141,6 +145,14 @@ export async function refreshWorkflowRun(runId: string): Promise<WorkflowRunResp
     method: "GET",
     path: "/v1/cloud/workflows/runs/{run_id}/refresh",
     pathParams: { run_id: runId },
+  });
+}
+
+/** The Slack channels the connected account can post to (spec 8.2, PR A). */
+export async function listSlackChannels(): Promise<SlackChannelsResponse> {
+  return getProliferateClient().requestJson<SlackChannelsResponse>({
+    method: "GET",
+    path: "/v1/cloud/workflows/slack/channels",
   });
 }
 

--- a/apps/packages/product-domain/src/workflows/definition.ts
+++ b/apps/packages/product-domain/src/workflows/definition.ts
@@ -1,35 +1,39 @@
 /**
- * Pure workflow-definition model (spec 3.3 / 3.6).
+ * Pure workflow-definition model — format v2 (data-contract §1).
  *
- * This is the client-side mirror of the server definition schema
- * (`server/.../workflows/domain/definition.py` + `constants/workflows.py`).
- * The on-the-wire definition dict is **snake_case** (it is validated verbatim
- * by the control plane); the in-memory model here is **camelCase** for editor
- * ergonomics. `parseWorkflowDefinition` reads the wire dict into the model and
- * `serializeWorkflowDefinition` writes it back — the two are inverse.
+ * Client-side mirror of the server schema (`server/.../workflows/domain/
+ * definition.py` + `constants/workflows.py`). The v2 top-level shape is
+ * `{version, name?, description?, inputs, integrations, agents}`: an ordered
+ * spine of agent nodes (`{slot, harness, model, steps}`). There is no top-level
+ * `steps` and no `setup` — slot = session affinity; `session_binding` is a
+ * run-context property stamped on the resolved plan, never authored.
  *
- * The editor edits a `WorkflowDefinition` directly (drag steps, toggle goals,
- * etc.); `validation.ts` reproduces the server's strict checks for live
- * feedback; the server remains the authority on save.
+ * The on-the-wire definition dict is snake_case (validated verbatim by the
+ * control plane); the in-memory model here is camelCase for editor ergonomics.
+ * `validation.ts` reproduces the server's strict checks for live feedback; the
+ * server remains the authority on save.
+ *
+ * NOTE: the desktop editor components and sibling product-domain modules
+ * (model.ts, presentation.ts, effective-config.ts, templates.ts) still consume
+ * the v1 shape and are migrated in the editor phase.
  */
 
 // --- Enumerations (mirror constants/workflows.py) ------------------------------
 
 export const WORKFLOW_STEP_KINDS = [
   "agent.prompt",
+  "agent.emit",
   "agent.config",
   "shell.run",
   "scm.open_pr",
   "notify",
-  "human.approval",
+  "branch",
 ] as const;
 export type WorkflowStepKind = (typeof WORKFLOW_STEP_KINDS)[number];
 
-export const WORKFLOW_ARG_TYPES = ["string", "number", "boolean", "enum"] as const;
-export type WorkflowArgType = (typeof WORKFLOW_ARG_TYPES)[number];
-
-export const WORKFLOW_SESSION_BINDINGS = ["fresh", "headless"] as const;
-export type WorkflowSessionBinding = (typeof WORKFLOW_SESSION_BINDINGS)[number];
+// E2: text|number|choice|boolean (string->text, enum->choice).
+export const WORKFLOW_INPUT_TYPES = ["text", "number", "choice", "boolean"] as const;
+export type WorkflowInputType = (typeof WORKFLOW_INPUT_TYPES)[number];
 
 export const WORKFLOW_ON_FAIL_KINDS = ["stop", "retry", "continue"] as const;
 export type WorkflowOnFailKind = (typeof WORKFLOW_ON_FAIL_KINDS)[number];
@@ -37,50 +41,51 @@ export type WorkflowOnFailKind = (typeof WORKFLOW_ON_FAIL_KINDS)[number];
 export const WORKFLOW_GOAL_ON_BLOCKED = ["notify", "pause_for_approval", "fail"] as const;
 export type WorkflowGoalOnBlocked = (typeof WORKFLOW_GOAL_ON_BLOCKED)[number];
 
-export const WORKFLOW_NOTIFY_CHANNELS = ["in_app", "slack"] as const;
-export type WorkflowNotifyChannel = (typeof WORKFLOW_NOTIFY_CHANNELS)[number];
-
-export const WORKFLOW_APPROVAL_ON_TIMEOUT = ["fail", "continue"] as const;
-export type WorkflowApprovalOnTimeout = (typeof WORKFLOW_APPROVAL_ON_TIMEOUT)[number];
+// D3: branch cases narrow to continue|end.
+export const WORKFLOW_BRANCH_TARGETS = ["continue", "end"] as const;
+export type WorkflowBranchTarget = (typeof WORKFLOW_BRANCH_TARGETS)[number];
 
 // --- Sizing / caps (mirror constants/workflows.py) -----------------------------
 
 export const WORKFLOW_SHORT_TEXT_MAX_LENGTH = 255;
 export const WORKFLOW_MAX_STEPS = 50;
 export const WORKFLOW_MAX_ARGS = 25;
+export const WORKFLOW_MAX_AGENTS = 20;
+export const WORKFLOW_EMIT_DEFAULT_MAX_ATTEMPTS = 3;
 
-/** Spec 3.6: default goal caps offered in the editor (25 turns / 90m / 400k). */
+/** Reserved reference first-segments (never legal emit names). */
+export const WORKFLOW_RESERVED_REF_SEGMENTS = ["inputs", "steps", "fields"] as const;
+
 export const WORKFLOW_GOAL_DEFAULT_MAX_TURNS = 25;
 export const WORKFLOW_GOAL_DEFAULT_MAX_WALL_SECS = 90 * 60;
 export const WORKFLOW_GOAL_DEFAULT_TOKEN_BUDGET = 400_000;
 
-/** Spec 6: free-plan cap, enforced client-side + server-side. */
 export const FREE_PLAN_MAX_WORKFLOWS_PER_USER = 1;
 
 const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const SLOT_RE = /^[a-z][a-z0-9_]*$/;
 
-/** Whether a string is a legal arg / output identifier (server rule). */
+/** Whether a string is a legal input / output / emit identifier (server rule). */
 export function isWorkflowIdentifier(value: string): boolean {
   return IDENTIFIER_RE.test(value);
 }
 
-// --- Model ---------------------------------------------------------------------
-
-export type WorkflowArgDefault = string | number | boolean;
-
-export interface WorkflowArgSpec {
-  name: string;
-  type: WorkflowArgType;
-  required: boolean;
-  default?: WorkflowArgDefault;
-  /** Only meaningful for `type: "enum"`. */
-  enum?: string[];
+/** Whether a string is a legal agent slot (server rule ^[a-z][a-z0-9_]*$). */
+export function isWorkflowSlot(value: string): boolean {
+  return SLOT_RE.test(value);
 }
 
-export interface WorkflowSetup {
-  harness: string;
-  model: string;
-  sessionBinding: WorkflowSessionBinding;
+// --- Model ---------------------------------------------------------------------
+
+export type WorkflowInputDefault = string | number | boolean;
+
+export interface WorkflowInputSpec {
+  name: string;
+  type: WorkflowInputType;
+  required: boolean;
+  default?: WorkflowInputDefault;
+  /** Only meaningful for `type: "choice"`. */
+  choices?: string[];
 }
 
 export interface WorkflowOnFail {
@@ -103,34 +108,46 @@ export interface WorkflowGoal {
   verify?: WorkflowGoalVerify;
 }
 
+export interface WorkflowRequiredInvocation {
+  provider: string;
+  tool: string;
+}
+
 interface StepBase {
   onFail: WorkflowOnFail;
+  /** The one-line skim register (plain English). */
+  label?: string;
 }
 
 export interface AgentPromptStep extends StepBase {
   kind: "agent.prompt";
   prompt: string;
-  /** Goal attachment — arms a native goal for this prompt. */
   goal?: WorkflowGoal;
+  /** L27 gate: require this provider+tool was invoked during the turn. */
+  requiredInvocation?: WorkflowRequiredInvocation;
 }
 
-/**
- * Sets the active agent (harness and/or model) for every step below it, until
- * the next `agent.config`. Switching harness opens a new session; a model-only
- * change applies at the next session creation. At least one of harness/model is
- * required (the editor + server enforce this).
- */
+export interface AgentEmitStep extends StepBase {
+  kind: "agent.emit";
+  prompt: string;
+  /** The output handle refs address (required, unique across the definition). */
+  name: string;
+  /** JSON Schema for the captured output. */
+  outputSchema?: Record<string, unknown>;
+  /** Re-ask budget (default 3). */
+  maxAttempts?: number;
+}
+
+/** Switch-model step: narrows to `{model}` only (same-harness rule, A3). */
 export interface AgentConfigStep extends StepBase {
   kind: "agent.config";
-  harness?: string;
-  model?: string;
+  model: string;
 }
 
 export interface ShellRunStep extends StepBase {
   kind: "shell.run";
   command: string;
   timeoutSecs?: number;
-  /** Named output capture for `{{steps[N].output.<name>}}`. */
   outputName?: string;
 }
 
@@ -142,31 +159,44 @@ export interface ScmOpenPrStep extends StepBase {
   draft?: boolean;
 }
 
+/** Slack-only notify (E1b): no channel discriminator. */
 export interface NotifyStep extends StepBase {
   kind: "notify";
-  channel: WorkflowNotifyChannel;
+  slackChannelId: string;
   message: string;
 }
 
-export interface HumanApprovalStep extends StepBase {
-  kind: "human.approval";
-  message: string;
-  onTimeout: WorkflowApprovalOnTimeout;
-  timeoutSecs?: number;
+/** Branch (C11/D3): switch on a prior emit's field; each case is continue|end. */
+export interface BranchStep extends StepBase {
+  kind: "branch";
+  on: string;
+  cases: Record<string, { to: WorkflowBranchTarget }>;
+  reason?: string;
 }
 
 export type WorkflowStep =
   | AgentPromptStep
+  | AgentEmitStep
   | AgentConfigStep
   | ShellRunStep
   | ScmOpenPrStep
   | NotifyStep
-  | HumanApprovalStep;
+  | BranchStep;
+
+export interface WorkflowAgentNode {
+  slot: string;
+  harness: string;
+  model: string;
+  steps: WorkflowStep[];
+}
 
 export interface WorkflowDefinition {
-  args: WorkflowArgSpec[];
-  setup: WorkflowSetup;
-  steps: WorkflowStep[];
+  version: 1;
+  name?: string;
+  description?: string;
+  inputs: WorkflowInputSpec[];
+  integrations: string[];
+  agents: WorkflowAgentNode[];
 }
 
 // --- Constructors --------------------------------------------------------------
@@ -188,21 +218,23 @@ export function createWorkflowStep(kind: WorkflowStepKind): WorkflowStep {
   switch (kind) {
     case "agent.prompt":
       return { kind, onFail: { ...DEFAULT_ON_FAIL }, prompt: "" };
+    case "agent.emit":
+      return { kind, onFail: { ...DEFAULT_ON_FAIL }, prompt: "", name: "" };
     case "agent.config":
-      return { kind, onFail: { ...DEFAULT_ON_FAIL } };
+      return { kind, onFail: { ...DEFAULT_ON_FAIL }, model: "" };
     case "shell.run":
       return { kind, onFail: { ...DEFAULT_ON_FAIL }, command: "" };
     case "scm.open_pr":
       return { kind, onFail: { ...DEFAULT_ON_FAIL }, title: "" };
     case "notify":
-      return { kind, onFail: { ...DEFAULT_ON_FAIL }, channel: "in_app", message: "" };
-    case "human.approval":
-      return { kind, onFail: { ...DEFAULT_ON_FAIL }, message: "", onTimeout: "fail" };
+      return { kind, onFail: { ...DEFAULT_ON_FAIL }, slackChannelId: "", message: "" };
+    case "branch":
+      return { kind, onFail: { ...DEFAULT_ON_FAIL }, on: "", cases: {} };
   }
 }
 
-export function createEmptyDefinition(setup: WorkflowSetup): WorkflowDefinition {
-  return { args: [], setup, steps: [createWorkflowStep("agent.prompt")] };
+export function createEmptyDefinition(node: WorkflowAgentNode): WorkflowDefinition {
+  return { version: 1, inputs: [], integrations: [], agents: [node] };
 }
 
 // --- Parse (wire dict -> model) ------------------------------------------------
@@ -225,8 +257,7 @@ function parseOnFail(raw: unknown): WorkflowOnFail {
   const record = asRecord(raw);
   const kind = record?.kind;
   if (kind === "retry") {
-    const n = asPositiveInt(record?.n) ?? 1;
-    return { kind: "retry", n };
+    return { kind: "retry", n: asPositiveInt(record?.n) ?? 1 };
   }
   if (kind === "continue") {
     return { kind: "continue" };
@@ -234,23 +265,19 @@ function parseOnFail(raw: unknown): WorkflowOnFail {
   return { kind: "stop" };
 }
 
-function parseArg(raw: unknown): WorkflowArgSpec | null {
+function parseInput(raw: unknown): WorkflowInputSpec | null {
   const record = asRecord(raw);
   if (!record) {
     return null;
   }
   const name = asString(record.name);
   const type = record.type;
-  if (name === undefined || !isWorkflowArgType(type)) {
+  if (name === undefined || !isWorkflowInputType(type)) {
     return null;
   }
-  const spec: WorkflowArgSpec = {
-    name,
-    type,
-    required: record.required === true,
-  };
-  if (type === "enum" && Array.isArray(record.enum)) {
-    spec.enum = record.enum.filter((v): v is string => typeof v === "string");
+  const spec: WorkflowInputSpec = { name, type, required: record.required === true };
+  if (type === "choice" && Array.isArray(record.choices)) {
+    spec.choices = record.choices.filter((v): v is string => typeof v === "string");
   }
   const rawDefault = record.default;
   if (
@@ -295,31 +322,45 @@ function parseStep(raw: unknown): WorkflowStep | null {
     return null;
   }
   const onFail = parseOnFail(record.on_fail);
+  const label = asString(record.label);
+  const base = label !== undefined ? { onFail, label } : { onFail };
   switch (kind) {
     case "agent.prompt": {
-      const step: AgentPromptStep = { kind, onFail, prompt: asString(record.prompt) ?? "" };
-      const goal = record.goal === undefined || record.goal === null
-        ? undefined
-        : parseGoal(record.goal);
+      const step: AgentPromptStep = { kind, ...base, prompt: asString(record.prompt) ?? "" };
+      const goal = record.goal == null ? undefined : parseGoal(record.goal);
       if (goal) {
         step.goal = goal;
       }
-      return step;
-    }
-    case "agent.config": {
-      const step: AgentConfigStep = { kind, onFail };
-      const harness = asString(record.harness);
-      if (harness !== undefined) {
-        step.harness = harness;
-      }
-      const model = asString(record.model);
-      if (model !== undefined) {
-        step.model = model;
+      const inv = asRecord(record.required_invocation);
+      if (inv) {
+        step.requiredInvocation = {
+          provider: asString(inv.provider) ?? "",
+          tool: asString(inv.tool) ?? "",
+        };
       }
       return step;
     }
+    case "agent.emit": {
+      const step: AgentEmitStep = {
+        kind,
+        ...base,
+        prompt: asString(record.prompt) ?? "",
+        name: asString(record.name) ?? "",
+      };
+      const schema = asRecord(record.output_schema);
+      if (schema) {
+        step.outputSchema = schema;
+      }
+      const maxAttempts = asPositiveInt(record.max_attempts);
+      if (maxAttempts !== undefined) {
+        step.maxAttempts = maxAttempts;
+      }
+      return step;
+    }
+    case "agent.config":
+      return { kind, ...base, model: asString(record.model) ?? "" };
     case "shell.run": {
-      const step: ShellRunStep = { kind, onFail, command: asString(record.command) ?? "" };
+      const step: ShellRunStep = { kind, ...base, command: asString(record.command) ?? "" };
       const timeoutSecs = asPositiveInt(record.timeout_secs);
       if (timeoutSecs !== undefined) {
         step.timeoutSecs = timeoutSecs;
@@ -331,10 +372,10 @@ function parseStep(raw: unknown): WorkflowStep | null {
       return step;
     }
     case "scm.open_pr": {
-      const step: ScmOpenPrStep = { kind, onFail, title: asString(record.title) ?? "" };
-      const base = asString(record.base);
-      if (base !== undefined) {
-        step.base = base;
+      const step: ScmOpenPrStep = { kind, ...base, title: asString(record.title) ?? "" };
+      const b = asString(record.base);
+      if (b !== undefined) {
+        step.base = b;
       }
       const body = asString(record.body);
       if (body !== undefined) {
@@ -345,65 +386,87 @@ function parseStep(raw: unknown): WorkflowStep | null {
       }
       return step;
     }
-    case "notify": {
-      const channel = isNotifyChannel(record.channel) ? record.channel : "in_app";
-      return { kind, onFail, channel, message: asString(record.message) ?? "" };
-    }
-    case "human.approval": {
-      const step: HumanApprovalStep = {
+    case "notify":
+      return {
         kind,
-        onFail,
+        ...base,
+        slackChannelId: asString(record.slack_channel_id) ?? "",
         message: asString(record.message) ?? "",
-        onTimeout: isApprovalOnTimeout(record.on_timeout) ? record.on_timeout : "fail",
       };
-      const timeoutSecs = asPositiveInt(record.timeout_secs);
-      if (timeoutSecs !== undefined) {
-        step.timeoutSecs = timeoutSecs;
+    case "branch": {
+      const rawCases = asRecord(record.cases) ?? {};
+      const cases: Record<string, { to: WorkflowBranchTarget }> = {};
+      for (const [value, target] of Object.entries(rawCases)) {
+        const to = asRecord(target)?.to;
+        if (isBranchTarget(to)) {
+          cases[value] = { to };
+        }
+      }
+      const step: BranchStep = { kind, ...base, on: asString(record.on) ?? "", cases };
+      const reason = asString(record.reason);
+      if (reason !== undefined) {
+        step.reason = reason;
       }
       return step;
     }
   }
 }
 
-function parseSetup(raw: unknown): WorkflowSetup {
+function parseAgentNode(raw: unknown): WorkflowAgentNode | null {
   const record = asRecord(raw);
-  const binding = record?.session_binding;
+  if (!record) {
+    return null;
+  }
+  const steps = Array.isArray(record.steps)
+    ? record.steps.map(parseStep).filter((s): s is WorkflowStep => s !== null)
+    : [];
   return {
-    harness: asString(record?.harness) ?? "",
-    model: asString(record?.model) ?? "",
-    sessionBinding: isSessionBinding(binding) ? binding : "fresh",
+    slot: asString(record.slot) ?? "",
+    harness: asString(record.harness) ?? "",
+    model: asString(record.model) ?? "",
+    steps,
   };
 }
 
 /**
- * Lenient parse of a stored/template definition dict into the model. Unknown or
- * malformed steps/args are dropped (they never occur in practice — the server
- * validated on write). Never throws.
+ * Lenient parse of a stored definition dict into the model. Never throws.
  */
 export function parseWorkflowDefinition(raw: unknown): WorkflowDefinition {
   const record = asRecord(raw);
-  const args = Array.isArray(record?.args)
-    ? record.args.map(parseArg).filter((a): a is WorkflowArgSpec => a !== null)
+  const inputs = Array.isArray(record?.inputs)
+    ? record.inputs.map(parseInput).filter((a): a is WorkflowInputSpec => a !== null)
     : [];
-  const steps = Array.isArray(record?.steps)
-    ? record.steps.map(parseStep).filter((s): s is WorkflowStep => s !== null)
+  const integrations = Array.isArray(record?.integrations)
+    ? record.integrations.filter((v): v is string => typeof v === "string")
     : [];
-  return { args, setup: parseSetup(record?.setup), steps };
+  const agents = Array.isArray(record?.agents)
+    ? record.agents.map(parseAgentNode).filter((n): n is WorkflowAgentNode => n !== null)
+    : [];
+  const def: WorkflowDefinition = { version: 1, inputs, integrations, agents };
+  const name = asString(record?.name);
+  if (name !== undefined) {
+    def.name = name;
+  }
+  const description = asString(record?.description);
+  if (description !== undefined) {
+    def.description = description;
+  }
+  return def;
 }
 
 // --- Serialize (model -> wire dict) --------------------------------------------
 
-function serializeArg(arg: WorkflowArgSpec): Record<string, unknown> {
+function serializeInput(input: WorkflowInputSpec): Record<string, unknown> {
   const out: Record<string, unknown> = {
-    name: arg.name,
-    type: arg.type,
-    required: arg.required,
+    name: input.name,
+    type: input.type,
+    required: input.required,
   };
-  if (arg.type === "enum" && arg.enum) {
-    out.enum = [...arg.enum];
+  if (input.type === "choice" && input.choices) {
+    out.choices = [...input.choices];
   }
-  if (arg.default !== undefined) {
-    out.default = arg.default;
+  if (input.default !== undefined) {
+    out.default = input.default;
   }
   return out;
 }
@@ -430,23 +493,37 @@ function serializeGoal(goal: WorkflowGoal): Record<string, unknown> {
 
 function serializeStep(step: WorkflowStep): Record<string, unknown> {
   const base: Record<string, unknown> = { kind: step.kind, on_fail: serializeOnFail(step.onFail) };
+  if (step.label !== undefined) {
+    base.label = step.label;
+  }
   switch (step.kind) {
     case "agent.prompt": {
       base.prompt = step.prompt;
       if (step.goal) {
         base.goal = serializeGoal(step.goal);
       }
-      return base;
-    }
-    case "agent.config": {
-      if (step.harness !== undefined) {
-        base.harness = step.harness;
-      }
-      if (step.model !== undefined) {
-        base.model = step.model;
+      if (step.requiredInvocation) {
+        base.required_invocation = {
+          provider: step.requiredInvocation.provider,
+          tool: step.requiredInvocation.tool,
+        };
       }
       return base;
     }
+    case "agent.emit": {
+      base.prompt = step.prompt;
+      base.name = step.name;
+      if (step.outputSchema) {
+        base.output_schema = step.outputSchema;
+      }
+      if (step.maxAttempts !== undefined) {
+        base.max_attempts = step.maxAttempts;
+      }
+      return base;
+    }
+    case "agent.config":
+      base.model = step.model;
+      return base;
     case "shell.run": {
       base.command = step.command;
       if (step.timeoutSecs !== undefined) {
@@ -470,35 +547,49 @@ function serializeStep(step: WorkflowStep): Record<string, unknown> {
       }
       return base;
     }
-    case "notify": {
-      base.channel = step.channel;
+    case "notify":
+      base.slack_channel_id = step.slackChannelId;
       base.message = step.message;
       return base;
-    }
-    case "human.approval": {
-      base.message = step.message;
-      base.on_timeout = step.onTimeout;
-      if (step.timeoutSecs !== undefined) {
-        base.timeout_secs = step.timeoutSecs;
+    case "branch": {
+      base.on = step.on;
+      base.cases = Object.fromEntries(
+        Object.entries(step.cases).map(([value, target]) => [value, { to: target.to }]),
+      );
+      if (step.reason !== undefined) {
+        base.reason = step.reason;
       }
       return base;
     }
   }
 }
 
+function serializeAgentNode(node: WorkflowAgentNode): Record<string, unknown> {
+  return {
+    slot: node.slot,
+    harness: node.harness,
+    model: node.model,
+    steps: node.steps.map(serializeStep),
+  };
+}
+
 /** The snake_case definition dict to POST/PATCH. Inverse of parse. */
 export function serializeWorkflowDefinition(
   definition: WorkflowDefinition,
 ): Record<string, unknown> {
-  return {
-    args: definition.args.map(serializeArg),
-    setup: {
-      harness: definition.setup.harness,
-      model: definition.setup.model,
-      session_binding: definition.setup.sessionBinding,
-    },
-    steps: definition.steps.map(serializeStep),
+  const out: Record<string, unknown> = {
+    version: 1,
+    inputs: definition.inputs.map(serializeInput),
+    integrations: [...definition.integrations],
+    agents: definition.agents.map(serializeAgentNode),
   };
+  if (definition.name !== undefined) {
+    out.name = definition.name;
+  }
+  if (definition.description !== undefined) {
+    out.description = definition.description;
+  }
+  return out;
 }
 
 // --- Type guards ---------------------------------------------------------------
@@ -507,28 +598,14 @@ export function isWorkflowStepKind(value: unknown): value is WorkflowStepKind {
   return typeof value === "string" && (WORKFLOW_STEP_KINDS as readonly string[]).includes(value);
 }
 
-export function isWorkflowArgType(value: unknown): value is WorkflowArgType {
-  return typeof value === "string" && (WORKFLOW_ARG_TYPES as readonly string[]).includes(value);
-}
-
-function isSessionBinding(value: unknown): value is WorkflowSessionBinding {
-  return (
-    typeof value === "string" && (WORKFLOW_SESSION_BINDINGS as readonly string[]).includes(value)
-  );
+export function isWorkflowInputType(value: unknown): value is WorkflowInputType {
+  return typeof value === "string" && (WORKFLOW_INPUT_TYPES as readonly string[]).includes(value);
 }
 
 function isGoalOnBlocked(value: unknown): value is WorkflowGoalOnBlocked {
   return typeof value === "string" && (WORKFLOW_GOAL_ON_BLOCKED as readonly string[]).includes(value);
 }
 
-function isNotifyChannel(value: unknown): value is WorkflowNotifyChannel {
-  return (
-    typeof value === "string" && (WORKFLOW_NOTIFY_CHANNELS as readonly string[]).includes(value)
-  );
-}
-
-function isApprovalOnTimeout(value: unknown): value is WorkflowApprovalOnTimeout {
-  return (
-    typeof value === "string" && (WORKFLOW_APPROVAL_ON_TIMEOUT as readonly string[]).includes(value)
-  );
+function isBranchTarget(value: unknown): value is WorkflowBranchTarget {
+  return typeof value === "string" && (WORKFLOW_BRANCH_TARGETS as readonly string[]).includes(value);
 }

--- a/apps/packages/product-domain/src/workflows/interpolation.ts
+++ b/apps/packages/product-domain/src/workflows/interpolation.ts
@@ -1,66 +1,62 @@
 /**
- * Pure template placeholder parsing + validation for workflow definitions.
+ * Pure template placeholder parsing + validation — format v2 (data-contract §1.3).
  *
- * Mirrors the server grammar (`server/.../workflows/domain/interpolation.py`)
- * exactly so the editor surfaces the same errors the control plane would reject
- * on save:
+ * Mirrors the server grammar (`server/.../workflows/domain/interpolation.py`):
  *
- *     {{args.<name>}}               -> a workflow argument
- *     {{steps[<n>].output.<name>}}  -> the public output of an earlier step
+ *     {{inputs.<name>}}       -> a workflow input (eager at StartRun)
+ *     {{<emit_name>.<field>}}  -> a field of an earlier `agent.emit` step
  *
  * Rules (identical to the server):
- *   - an arg reference must name a declared argument;
- *   - a step-output reference must point at a step that runs strictly earlier
- *     (`index < stepIndex`).
+ *   - an input reference must name a declared input;
+ *   - an emit reference must name an emit produced *strictly earlier* in run
+ *     order (earlier nodes in full, earlier steps in the same node);
+ *   - `inputs`, `steps`, `fields` are reserved first-segments (illegal emits).
  *
- * This module is presentation-adjacent but pure: it never throws for editor
- * feedback (it returns structured issues), and additionally exposes match
- * positions + autocomplete suggestions the panel editors consume.
+ * Pure and non-throwing for editor feedback: returns structured issues plus
+ * match positions + autocomplete suggestions the panel editors consume.
  */
+
+import { WORKFLOW_RESERVED_REF_SEGMENTS } from "./definition";
 
 /** A placeholder that is `{{` (not backslash-escaped), a body, then `}}`. */
 const PLACEHOLDER_RE = /(?<!\\)\{\{\s*([^{}]*?)\s*\}\}/g;
-const ARG_REF_RE = /^args\.([A-Za-z_][A-Za-z0-9_]*)$/;
-const STEP_REF_RE = /^steps\[(\d+)\]\.output\.([A-Za-z_][A-Za-z0-9_]*)$/;
+const INPUT_REF_RE = /^inputs\.([A-Za-z_][A-Za-z0-9_]*)$/;
+const EMIT_REF_RE = /^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$/;
+
+const RESERVED = new Set<string>(WORKFLOW_RESERVED_REF_SEGMENTS);
 
 export type WorkflowReference =
-  | { kind: "arg"; name: string }
-  | { kind: "stepOutput"; index: number; name: string };
+  | { kind: "input"; name: string }
+  | { kind: "emit"; emit: string; field: string };
 
 export interface PlaceholderMatch {
-  /** The full matched text, e.g. `{{args.repo}}`. */
   raw: string;
-  /** The trimmed reference body, e.g. `args.repo`. */
   body: string;
-  /** Parsed reference, or null when the body is not a valid reference. */
   reference: WorkflowReference | null;
-  /** Start offset of the match within the source string. */
   start: number;
-  /** End offset (exclusive) of the match within the source string. */
   end: number;
 }
 
 export type TemplateReferenceCode =
   | "invalid_template_reference"
-  | "unknown_arg_reference"
-  | "forward_step_reference";
+  | "unknown_input_reference"
+  | "forward_emit_reference";
 
 export interface TemplateReferenceIssue {
   code: TemplateReferenceCode;
   message: string;
-  /** Which placeholder in the string this issue is about. */
   match: PlaceholderMatch;
 }
 
 /** Parse a placeholder body into a typed reference, or null if malformed. */
 export function parseReference(body: string): WorkflowReference | null {
-  const argMatch = ARG_REF_RE.exec(body);
-  if (argMatch) {
-    return { kind: "arg", name: argMatch[1]! };
+  const inputMatch = INPUT_REF_RE.exec(body);
+  if (inputMatch) {
+    return { kind: "input", name: inputMatch[1]! };
   }
-  const stepMatch = STEP_REF_RE.exec(body);
-  if (stepMatch) {
-    return { kind: "stepOutput", index: Number(stepMatch[1]), name: stepMatch[2]! };
+  const emitMatch = EMIT_REF_RE.exec(body);
+  if (emitMatch && !RESERVED.has(emitMatch[1]!)) {
+    return { kind: "emit", emit: emitMatch[1]!, field: emitMatch[2]! };
   }
   return null;
 }
@@ -96,13 +92,13 @@ export function iterReferences(value: string): WorkflowReference[] {
 }
 
 /**
- * Validate every placeholder in one templated string field. `stepIndex` is the
- * index of the step the field belongs to; a step-output reference must point
- * strictly earlier. Returns issues rather than throwing (editor feedback).
+ * Validate every placeholder in one templated string field. `priorEmitNames` is
+ * the set of emit names produced strictly before this field's step in run order.
+ * Returns issues rather than throwing (editor feedback).
  */
 export function validateStringReferences(
   value: string,
-  options: { argNames: ReadonlySet<string>; stepIndex: number },
+  options: { inputNames: ReadonlySet<string>; priorEmitNames: ReadonlySet<string> },
 ): TemplateReferenceIssue[] {
   const issues: TemplateReferenceIssue[] = [];
   for (const placeholder of iterPlaceholders(value)) {
@@ -112,25 +108,25 @@ export function validateStringReferences(
         code: "invalid_template_reference",
         message:
           `'${placeholder.raw}' is not a valid template reference `
-          + "(expected {{args.NAME}} or {{steps[N].output.NAME}}).",
+          + "(expected {{inputs.NAME}} or {{EMIT.FIELD}}).",
         match: placeholder,
       });
       continue;
     }
-    if (reference.kind === "arg") {
-      if (!options.argNames.has(reference.name)) {
+    if (reference.kind === "input") {
+      if (!options.inputNames.has(reference.name)) {
         issues.push({
-          code: "unknown_arg_reference",
-          message: `Template references unknown argument '${reference.name}'.`,
+          code: "unknown_input_reference",
+          message: `Template references unknown input '${reference.name}'.`,
           match: placeholder,
         });
       }
-    } else if (reference.index >= options.stepIndex) {
+    } else if (!options.priorEmitNames.has(reference.emit)) {
       issues.push({
-        code: "forward_step_reference",
+        code: "forward_emit_reference",
         message:
-          `Step ${options.stepIndex} references output of step `
-          + `${reference.index}, which does not run before it.`,
+          `Template references emit '${reference.emit}', which is not produced `
+          + "by an earlier step in run order.",
         match: placeholder,
       });
     }
@@ -140,60 +136,52 @@ export function validateStringReferences(
 
 // --- Editor autocomplete -------------------------------------------------------
 
-export type TemplateSuggestionKind = "arg" | "stepOutput";
+export type TemplateSuggestionKind = "input" | "emit";
 
 export interface TemplateSuggestion {
-  /** The token to insert, e.g. `{{args.repo}}`. */
+  /** The token to insert, e.g. `{{inputs.repo}}`. */
   token: string;
-  /** Short label shown in the menu, e.g. `args.repo`. */
   label: string;
-  /** Longer hint, e.g. the arg type or the producing step. */
   detail: string;
   kind: TemplateSuggestionKind;
 }
 
-export interface StepOutputSuggestionSource {
-  /** Index of the earlier step. */
-  index: number;
-  /** Human label for the producing step (e.g. `Script`). */
+export interface EmitSuggestionSource {
+  /** The emit name. */
+  emit: string;
+  /** Human label for the producing step. */
   stepLabel: string;
-  /** Named outputs the step publishes (e.g. `["diff", "exit_code"]`). */
-  outputNames: readonly string[];
+  /** Fields the emit publishes (from its output_schema). */
+  fieldNames: readonly string[];
 }
 
 export interface TemplateSuggestionInput {
-  /** Declared workflow arguments (name + display type). */
-  args: readonly { name: string; type: string }[];
-  /** The index of the step currently being edited. */
-  stepIndex: number;
-  /** Outputs published by steps that run before this one. */
-  priorStepOutputs: readonly StepOutputSuggestionSource[];
+  inputs: readonly { name: string; type: string }[];
+  /** Emits produced by steps that run strictly before this one. */
+  priorEmits: readonly EmitSuggestionSource[];
 }
 
 /**
  * The set of valid `{{...}}` tokens available at a given step: every declared
- * argument, plus every named output of a strictly-earlier step.
+ * input, plus every field of a strictly-earlier emit.
  */
 export function templateSuggestions(input: TemplateSuggestionInput): TemplateSuggestion[] {
   const suggestions: TemplateSuggestion[] = [];
-  for (const arg of input.args) {
+  for (const inp of input.inputs) {
     suggestions.push({
-      token: `{{args.${arg.name}}}`,
-      label: `args.${arg.name}`,
-      detail: arg.type,
-      kind: "arg",
+      token: `{{inputs.${inp.name}}}`,
+      label: `inputs.${inp.name}`,
+      detail: inp.type,
+      kind: "input",
     });
   }
-  for (const source of input.priorStepOutputs) {
-    if (source.index >= input.stepIndex) {
-      continue;
-    }
-    for (const name of source.outputNames) {
+  for (const source of input.priorEmits) {
+    for (const field of source.fieldNames) {
       suggestions.push({
-        token: `{{steps[${source.index}].output.${name}}}`,
-        label: `steps[${source.index}].output.${name}`,
-        detail: `from step ${source.index + 1} · ${source.stepLabel}`,
-        kind: "stepOutput",
+        token: `{{${source.emit}.${field}}}`,
+        label: `${source.emit}.${field}`,
+        detail: `from ${source.stepLabel}`,
+        kind: "emit",
       });
     }
   }

--- a/apps/packages/product-domain/src/workflows/run-status.ts
+++ b/apps/packages/product-domain/src/workflows/run-status.ts
@@ -8,7 +8,7 @@
  * (W3/W4) owns the exact output shapes.
  */
 
-import type { WorkflowDefinition, WorkflowStepKind } from "./definition";
+import type { WorkflowDefinition, WorkflowStep, WorkflowStepKind } from "./definition";
 import { workflowStepKindLabel, WORKFLOW_STEP_META } from "./presentation";
 
 // --- Run status ----------------------------------------------------------------
@@ -151,12 +151,23 @@ export function stepRunDotKind(status: WorkflowStepRunStatus): WorkflowStepDotKi
 
 // --- Typed step outputs --------------------------------------------------------
 
+/** Delivery status for a notify-step chip (spec 8.4: rendered only from real observed data). */
+export type WorkflowNotifyDeliveryStatus = "sent" | "pending" | "failed";
+
 export type WorkflowStepOutputChip =
   | { kind: "exit"; label: string; ok: boolean }
   | { kind: "pr"; label: string; href: string | null }
-  | { kind: "notify"; label: string; delivered: boolean }
+  | { kind: "notify"; label: string; status: WorkflowNotifyDeliveryStatus; title?: string }
   | { kind: "approval"; label: string; approved: boolean }
   | { kind: "text"; label: string };
+
+/** A step-action ledger row (spec 1.2), as returned by the run-detail endpoint. */
+export interface WorkflowStepActionSummary {
+  stepIndex: number;
+  actionKind: string;
+  status: string;
+  errorMessage: string | null;
+}
 
 export interface WorkflowGoalLine {
   objective: string;
@@ -176,7 +187,33 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function outputChipsFor(kind: WorkflowStepKind, output: Record<string, unknown> | null): WorkflowStepOutputChip[] {
+function outputChipsFor(
+  step: WorkflowStep,
+  output: Record<string, unknown> | null,
+  action: WorkflowStepActionSummary | null,
+): WorkflowStepOutputChip[] {
+  const kind = step.kind;
+  if (kind === "notify" && step.channel === "slack") {
+    // The runtime's own output never claims delivery for Slack — only the
+    // server-observed action row (spec 8.4) does. No row yet ⇒ no chip.
+    if (!action) {
+      return [];
+    }
+    if (action.status === "done") {
+      return [{ kind: "notify", label: "Sent · slack", status: "sent" }];
+    }
+    if (action.status === "failed") {
+      return [
+        {
+          kind: "notify",
+          label: "Failed · slack",
+          status: "failed",
+          title: action.errorMessage ?? undefined,
+        },
+      ];
+    }
+    return [{ kind: "notify", label: "Pending · slack", status: "pending" }];
+  }
   if (!output) {
     return [];
   }
@@ -196,9 +233,10 @@ function outputChipsFor(kind: WorkflowStepKind, output: Record<string, unknown> 
       return [];
     }
     case "notify": {
-      const delivered = output.delivered === true;
+      // In-app has no delivery ledger — recording the step output IS the
+      // delivery (spec: "always recorded in-app and in run history").
       const channel = typeof output.channel === "string" ? output.channel : "notification";
-      return [{ kind: "notify", label: delivered ? `Sent · ${channel}` : channel, delivered }];
+      return [{ kind: "notify", label: `Sent · ${channel}`, status: "sent" }];
     }
     case "human.approval": {
       if (output.decision === "approved" || output.decision === "denied") {
@@ -276,6 +314,8 @@ export interface DeriveStepRunViewsInput {
   /** Opaque per-step outputs keyed by step index (string or number keys). */
   stepOutputs?: Record<string, unknown> | null;
   anyharnessWorkspaceId?: string | null;
+  /** The run's step-action ledger rows (spec 1.2), for delivery-status chips. */
+  stepActions?: readonly WorkflowStepActionSummary[] | null;
 }
 
 function baseStepStatus(
@@ -324,7 +364,7 @@ function stepOutputRecord(
  * carries a goal) and later steps are pending.
  */
 export function deriveStepRunViews(input: DeriveStepRunViewsInput): WorkflowStepRunView[] {
-  const { definition, runStatus, stepOutputs } = input;
+  const { definition, runStatus, stepOutputs, stepActions } = input;
   const terminalCompleted = runStatus === "completed";
   const cursor = input.stepCursor ?? (terminalCompleted ? definition.steps.length : 0);
 
@@ -334,6 +374,7 @@ export function deriveStepRunViews(input: DeriveStepRunViewsInput): WorkflowStep
       ? "completed"
       : baseStepStatus(index, cursor, runStatus, isGoalStep);
     const output = stepOutputRecord(stepOutputs, index);
+    const action = stepActions?.find((a) => a.stepIndex === index) ?? null;
     return {
       index,
       kind: step.kind,
@@ -341,7 +382,7 @@ export function deriveStepRunViews(input: DeriveStepRunViewsInput): WorkflowStep
       label: workflowStepKindLabel(step.kind),
       status,
       dotKind: stepRunDotKind(status),
-      chips: outputChipsFor(step.kind, output),
+      chips: outputChipsFor(step, output, action),
       goalLine: isGoalStep ? goalLineFor(output) : null,
       sessionLink: sessionLinkFor(output, input.anyharnessWorkspaceId ?? null),
     };

--- a/apps/packages/product-domain/src/workflows/templates.ts
+++ b/apps/packages/product-domain/src/workflows/templates.ts
@@ -118,7 +118,9 @@ const SENTRY_TRIAGE: WorkflowTemplate = {
       {
         kind: "notify",
         onFail: { kind: "continue" },
-        channel: "slack",
+        // Slack requires a channel pick post-connect (no slack_channel_id at
+        // template-authoring time); default to in-app so the template saves.
+        channel: "in_app",
         message: "Sentry triage finished for {{args.issue_url}}.",
       },
     ],
@@ -227,7 +229,9 @@ const WEEKLY_DIGEST: WorkflowTemplate = {
       {
         kind: "notify",
         onFail: { kind: "continue" },
-        channel: "slack",
+        // Slack requires a channel pick post-connect (no slack_channel_id at
+        // template-authoring time); default to in-app so the template saves.
+        channel: "in_app",
         message: "Weekly digest:\n{{steps[2].output.digest}}",
       },
     ],

--- a/apps/packages/product-domain/src/workflows/validation.ts
+++ b/apps/packages/product-domain/src/workflows/validation.ts
@@ -1,30 +1,37 @@
 /**
- * Editor-facing validation of a workflow definition (spec 3.3 / 3.6).
+ * Editor-facing validation of a workflow definition — format v2 (data-contract §1).
  *
- * Reproduces the server's strict rules (`parse_definition`) so the two-pane
- * editor can surface "bad refs, missing objective caps, empty steps" before a
- * save round-trip. The server remains the authority; this is fast local
- * feedback with the same shape of error.
+ * Reproduces the server's strict rules (`parse_definition`) so the editor can
+ * surface bad refs, missing caps, duplicate slots/emits, and uncovered branch
+ * cases before a save round-trip. The server remains the authority.
  *
  * Every issue carries a `location` so the editor can attach it to the offending
- * step card, arg row, or panel field.
+ * agent node, step card, or input row. Steps are addressed by their *flattened*
+ * run-order index across the whole spine.
  */
 
 import {
   isWorkflowIdentifier,
+  isWorkflowSlot,
+  WORKFLOW_BRANCH_TARGETS,
+  WORKFLOW_MAX_AGENTS,
   WORKFLOW_MAX_ARGS,
   WORKFLOW_MAX_STEPS,
-  type WorkflowArgSpec,
+  WORKFLOW_RESERVED_REF_SEGMENTS,
+  type WorkflowAgentNode,
   type WorkflowDefinition,
+  type WorkflowInputSpec,
   type WorkflowStep,
 } from "./definition";
-import { validateStringReferences } from "./interpolation";
+import { iterReferences, validateStringReferences } from "./interpolation";
 
 export interface WorkflowIssueLocation {
-  scope: "steps" | "args" | "setup" | "step" | "arg";
+  scope: "inputs" | "integrations" | "agents" | "agent" | "step" | "input";
+  /** Flattened run-order step index (across the whole spine). */
   stepIndex?: number;
-  argIndex?: number;
-  /** Panel field the issue is about (e.g. `prompt`, `goal.objective`). */
+  /** Agent node index. */
+  nodeIndex?: number;
+  inputIndex?: number;
   field?: string;
 }
 
@@ -35,11 +42,6 @@ export interface WorkflowIssue {
 }
 
 export interface ValidateWorkflowOptions {
-  /**
-   * Whether a given harness advertises `supports_goals`. Used to flag a goal
-   * attached to a step whose effective harness cannot iterate. When omitted,
-   * goal-capability is not checked (the editor gates the UI separately).
-   */
   harnessSupportsGoals?: (harness: string) => boolean;
 }
 
@@ -61,6 +63,8 @@ function templatedFields(step: WorkflowStep): TemplatedField[] {
       }
       return fields;
     }
+    case "agent.emit":
+      return [{ field: "prompt", value: step.prompt }];
     case "agent.config":
       return [];
     case "shell.run":
@@ -77,82 +81,54 @@ function templatedFields(step: WorkflowStep): TemplatedField[] {
     }
     case "notify":
       return [{ field: "message", value: step.message }];
-    case "human.approval":
-      return [{ field: "message", value: step.message }];
+    case "branch":
+      return [{ field: "on", value: step.on }];
   }
 }
 
-function validateArgs(args: WorkflowArgSpec[]): WorkflowIssue[] {
+function validateInputs(inputs: WorkflowInputSpec[]): WorkflowIssue[] {
   const issues: WorkflowIssue[] = [];
-  if (args.length > WORKFLOW_MAX_ARGS) {
+  if (inputs.length > WORKFLOW_MAX_ARGS) {
     issues.push({
       code: "too_many_args",
-      message: `A workflow may declare at most ${WORKFLOW_MAX_ARGS} arguments.`,
-      location: { scope: "args" },
+      message: `A workflow may declare at most ${WORKFLOW_MAX_ARGS} inputs.`,
+      location: { scope: "inputs" },
     });
   }
   const seen = new Set<string>();
-  args.forEach((arg, argIndex) => {
-    if (arg.name.trim() === "") {
+  inputs.forEach((input, inputIndex) => {
+    if (input.name.trim() === "" || !isWorkflowIdentifier(input.name)) {
       issues.push({
         code: "invalid_definition",
-        message: "Argument name is required.",
-        location: { scope: "arg", argIndex, field: "name" },
-      });
-    } else if (!isWorkflowIdentifier(arg.name)) {
-      issues.push({
-        code: "invalid_definition",
-        message: `Argument name '${arg.name}' must be an identifier.`,
-        location: { scope: "arg", argIndex, field: "name" },
+        message: `Input name '${input.name}' must be an identifier.`,
+        location: { scope: "input", inputIndex, field: "name" },
       });
     }
-    if (seen.has(arg.name)) {
+    if (seen.has(input.name)) {
       issues.push({
         code: "duplicate_arg",
-        message: `Duplicate argument name '${arg.name}'.`,
-        location: { scope: "arg", argIndex, field: "name" },
+        message: `Duplicate input name '${input.name}'.`,
+        location: { scope: "input", inputIndex, field: "name" },
       });
     }
-    seen.add(arg.name);
-    if (arg.type === "enum") {
-      const values = arg.enum ?? [];
+    seen.add(input.name);
+    if (input.type === "choice") {
+      const values = input.choices ?? [];
       if (values.length === 0) {
         issues.push({
           code: "invalid_definition",
-          message: `Enum argument '${arg.name}' requires at least one value.`,
-          location: { scope: "arg", argIndex, field: "enum" },
+          message: `Choice input '${input.name}' requires at least one value.`,
+          location: { scope: "input", inputIndex, field: "choices" },
         });
-      } else if (
-        typeof arg.default === "string"
-        && !values.includes(arg.default)
-      ) {
+      } else if (typeof input.default === "string" && !values.includes(input.default)) {
         issues.push({
           code: "invalid_definition",
-          message: `Default for enum argument '${arg.name}' is not an allowed value.`,
-          location: { scope: "arg", argIndex, field: "default" },
+          message: `Default for choice input '${input.name}' is not an allowed value.`,
+          location: { scope: "input", inputIndex, field: "default" },
         });
       }
     }
   });
-  return issues;
-}
-
-function validateSetup(definition: WorkflowDefinition): WorkflowIssue[] {
-  const issues: WorkflowIssue[] = [];
-  if (definition.setup.harness.trim() === "") {
-    issues.push({
-      code: "invalid_definition",
-      message: "An agent (harness) is required.",
-      location: { scope: "setup", field: "harness" },
-    });
-  }
-  if (definition.setup.model.trim() === "") {
-    issues.push({
-      code: "invalid_definition",
-      message: "A default model is required.",
-      location: { scope: "setup", field: "model" },
-    });
-  }
   return issues;
 }
 
@@ -171,7 +147,8 @@ function validateStep(
   step: WorkflowStep,
   stepIndex: number,
   options: ValidateWorkflowOptions,
-  effectiveHarness: string,
+  harness: string,
+  priorEmitNames: ReadonlySet<string>,
 ): WorkflowIssue[] {
   const issues: WorkflowIssue[] = [];
   const push = (issue: WorkflowIssue | null) => {
@@ -204,28 +181,38 @@ function validateStep(
         }
         if (
           options.harnessSupportsGoals
-          && effectiveHarness.trim() !== ""
-          && !options.harnessSupportsGoals(effectiveHarness)
+          && harness.trim() !== ""
+          && !options.harnessSupportsGoals(harness)
         ) {
           push({
             code: "goal_unsupported_harness",
-            message: `Goal iteration is not supported by ${effectiveHarness}.`,
+            message: `Goal iteration is not supported by ${harness}.`,
             location: { scope: "step", stepIndex, field: "goal" },
           });
         }
       }
       break;
     }
-    case "agent.config": {
-      if (!(step.harness?.trim() || step.model?.trim())) {
+    case "agent.emit": {
+      push(requireText(step.prompt, "Prompt text is required.", stepIndex, "prompt"));
+      if (step.name.trim() === "" || !isWorkflowIdentifier(step.name)) {
         push({
           code: "invalid_definition",
-          message: "Choose an agent or a model for this step.",
-          location: { scope: "step", stepIndex, field: "harness" },
+          message: "Emit name must be an identifier.",
+          location: { scope: "step", stepIndex, field: "name" },
+        });
+      } else if ((WORKFLOW_RESERVED_REF_SEGMENTS as readonly string[]).includes(step.name)) {
+        push({
+          code: "invalid_definition",
+          message: `Emit name '${step.name}' is reserved.`,
+          location: { scope: "step", stepIndex, field: "name" },
         });
       }
       break;
     }
+    case "agent.config":
+      push(requireText(step.model, "A model is required.", stepIndex, "model"));
+      break;
     case "shell.run": {
       push(requireText(step.command, "A command is required.", stepIndex, "command"));
       if (step.outputName !== undefined && !isWorkflowIdentifier(step.outputName)) {
@@ -242,10 +229,84 @@ function validateStep(
       break;
     case "notify":
       push(requireText(step.message, "A message is required.", stepIndex, "message"));
+      if (!step.slackChannelId.trim()) {
+        push({
+          code: "invalid_definition",
+          message: "Choose a Slack channel.",
+          location: { scope: "step", stepIndex, field: "slackChannelId" },
+        });
+      }
       break;
-    case "human.approval":
-      push(requireText(step.message, "An approval message is required.", stepIndex, "message"));
+    case "branch": {
+      // `on` must be exactly one emit ref, visible strictly earlier.
+      const refs = iterReferences(step.on);
+      const emitRefs = refs.filter((r) => r.kind === "emit");
+      if (refs.length !== 1 || emitRefs.length !== 1) {
+        push({
+          code: "invalid_definition",
+          message: "Branch must switch on exactly one {{EMIT.FIELD}} reference.",
+          location: { scope: "step", stepIndex, field: "on" },
+        });
+      } else if (!priorEmitNames.has((emitRefs[0] as { emit: string }).emit)) {
+        push({
+          code: "forward_emit_reference",
+          message: "Branch references an emit not produced by an earlier step.",
+          location: { scope: "step", stepIndex, field: "on" },
+        });
+      }
+      const caseKeys = Object.keys(step.cases);
+      if (caseKeys.length === 0) {
+        push({
+          code: "invalid_definition",
+          message: "A branch needs at least one case.",
+          location: { scope: "step", stepIndex, field: "cases" },
+        });
+      }
+      for (const [value, target] of Object.entries(step.cases)) {
+        if (!(WORKFLOW_BRANCH_TARGETS as readonly string[]).includes(target.to)) {
+          push({
+            code: "invalid_definition",
+            message: `Branch case '${value}' must route to continue or end.`,
+            location: { scope: "step", stepIndex, field: "cases" },
+          });
+        }
+      }
       break;
+    }
+  }
+  return issues;
+}
+
+function validateNode(node: WorkflowAgentNode, nodeIndex: number, seenSlots: Set<string>): WorkflowIssue[] {
+  const issues: WorkflowIssue[] = [];
+  if (node.slot.trim() === "" || !isWorkflowSlot(node.slot)) {
+    issues.push({
+      code: "invalid_definition",
+      message: `Slot '${node.slot}' must match ^[a-z][a-z0-9_]*$.`,
+      location: { scope: "agent", nodeIndex, field: "slot" },
+    });
+  }
+  if (seenSlots.has(node.slot)) {
+    issues.push({
+      code: "duplicate_slot",
+      message: `Duplicate agent slot '${node.slot}'.`,
+      location: { scope: "agent", nodeIndex, field: "slot" },
+    });
+  }
+  seenSlots.add(node.slot);
+  if (node.harness.trim() === "") {
+    issues.push({
+      code: "invalid_definition",
+      message: "An agent (harness) is required.",
+      location: { scope: "agent", nodeIndex, field: "harness" },
+    });
+  }
+  if (node.model.trim() === "") {
+    issues.push({
+      code: "invalid_definition",
+      message: "A model is required.",
+      location: { scope: "agent", nodeIndex, field: "model" },
+    });
   }
   return issues;
 }
@@ -257,43 +318,68 @@ export function validateWorkflowDefinition(
 ): WorkflowIssue[] {
   const issues: WorkflowIssue[] = [];
 
-  issues.push(...validateArgs(definition.args));
-  issues.push(...validateSetup(definition));
+  issues.push(...validateInputs(definition.inputs));
 
-  if (definition.steps.length === 0) {
+  if (definition.agents.length === 0) {
     issues.push({
       code: "invalid_definition",
-      message: "A workflow needs at least one step.",
-      location: { scope: "steps" },
+      message: "A workflow needs at least one agent node.",
+      location: { scope: "agents" },
     });
   }
-  if (definition.steps.length > WORKFLOW_MAX_STEPS) {
+  if (definition.agents.length > WORKFLOW_MAX_AGENTS) {
+    issues.push({
+      code: "too_many_agents",
+      message: `A workflow may declare at most ${WORKFLOW_MAX_AGENTS} agent nodes.`,
+      location: { scope: "agents" },
+    });
+  }
+
+  const inputNames = new Set(definition.inputs.map((input) => input.name));
+  const seenSlots = new Set<string>();
+  const seenEmits = new Set<string>();
+  const priorEmits = new Set<string>();
+  let totalSteps = 0;
+  let flatIndex = 0;
+
+  definition.agents.forEach((node, nodeIndex) => {
+    issues.push(...validateNode(node, nodeIndex, seenSlots));
+    totalSteps += node.steps.length;
+    node.steps.forEach((step) => {
+      const stepIndex = flatIndex;
+      issues.push(...validateStep(step, stepIndex, options, node.harness, priorEmits));
+      for (const { field, value } of templatedFields(step)) {
+        for (const refIssue of validateStringReferences(value, { inputNames, priorEmitNames: priorEmits })) {
+          issues.push({
+            code: refIssue.code,
+            message: refIssue.message,
+            location: { scope: "step", stepIndex, field },
+          });
+        }
+      }
+      // Register this step's emit AFTER validating its own refs.
+      if (step.kind === "agent.emit" && step.name.trim() !== "") {
+        if (seenEmits.has(step.name)) {
+          issues.push({
+            code: "duplicate_emit",
+            message: `Duplicate emit name '${step.name}'.`,
+            location: { scope: "step", stepIndex, field: "name" },
+          });
+        }
+        seenEmits.add(step.name);
+        priorEmits.add(step.name);
+      }
+      flatIndex += 1;
+    });
+  });
+
+  if (totalSteps > WORKFLOW_MAX_STEPS) {
     issues.push({
       code: "too_many_steps",
       message: `A workflow may declare at most ${WORKFLOW_MAX_STEPS} steps.`,
-      location: { scope: "steps" },
+      location: { scope: "agents" },
     });
   }
-
-  const argNames = new Set(definition.args.map((arg) => arg.name));
-  // The effective harness for goal-capability checks folds forward through any
-  // `agent.config` steps (the active-agent model the runtime uses), seeded from Setup.
-  let effectiveHarness = definition.setup.harness;
-  definition.steps.forEach((step, stepIndex) => {
-    if (step.kind === "agent.config" && step.harness?.trim()) {
-      effectiveHarness = step.harness;
-    }
-    issues.push(...validateStep(step, stepIndex, options, effectiveHarness));
-    for (const { field, value } of templatedFields(step)) {
-      for (const refIssue of validateStringReferences(value, { argNames, stepIndex })) {
-        issues.push({
-          code: refIssue.code,
-          message: refIssue.message,
-          location: { scope: "step", stepIndex, field },
-        });
-      }
-    }
-  });
 
   return issues;
 }
@@ -306,7 +392,7 @@ export function isWorkflowDefinitionValid(
   return validateWorkflowDefinition(definition, options).length === 0;
 }
 
-/** First issue attached to a given step (for the card error affordance). */
+/** First issue attached to a given flattened step index (card error affordance). */
 export function stepIssues(issues: readonly WorkflowIssue[], stepIndex: number): WorkflowIssue[] {
   return issues.filter((issue) => issue.location.stepIndex === stepIndex);
 }

--- a/apps/packages/product-ui/src/workflows/WorkflowRunTimelineRow.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunTimelineRow.tsx
@@ -38,7 +38,17 @@ function OutputChip({ chip }: { chip: WorkflowStepOutputChip }) {
       );
     case "notify":
       return (
-        <span className={twMerge(base, chip.delivered ? "border-border text-muted-foreground" : "border-border text-faint")}>
+        <span
+          title={chip.title}
+          className={twMerge(
+            base,
+            chip.status === "sent"
+              ? "border-border text-muted-foreground"
+              : chip.status === "failed"
+                ? "border-destructive/35 text-destructive"
+                : "border-border text-faint",
+          )}
+        >
           {chip.label}
         </span>
       );

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1692,6 +1692,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/workflows/slack/channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Slack Channels Endpoint */
+        get: operations["list_slack_channels_endpoint_v1_cloud_workflows_slack_channels_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workflows/{workflow_id}": {
         parameters: {
             query?: never;
@@ -4951,6 +4968,20 @@ export interface components {
             /** Enabled */
             enabled: boolean;
         };
+        /** SlackChannelResponse */
+        SlackChannelResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+        };
+        /** SlackChannelsResponse */
+        SlackChannelsResponse: {
+            /** Channels */
+            channels: components["schemas"]["SlackChannelResponse"][];
+            /** Connected */
+            connected: boolean;
+        };
         /** SsoDiscoveryResponse */
         SsoDiscoveryResponse: {
             /** Enabled */
@@ -5011,8 +5042,8 @@ export interface components {
         };
         /** StartRunRequest */
         StartRunRequest: {
-            /** Args */
-            args?: {
+            /** Inputs */
+            inputs?: {
                 [key: string]: unknown;
             };
             /**
@@ -5022,8 +5053,11 @@ export interface components {
             targetMode: "local" | "personal_cloud";
             /** Versionid */
             versionId?: string | null;
-            /** Targetworkspaceid */
-            targetWorkspaceId?: string | null;
+            target: components["schemas"]["WorkflowRunTarget"];
+            /** Sessionbindings */
+            sessionBindings?: {
+                [key: string]: string;
+            };
         };
         /** StartSsoAuthRequest */
         StartSsoAuthRequest: {
@@ -5080,6 +5114,23 @@ export interface components {
             connectionId?: string | null;
             /** Organizationid */
             organizationId?: string | null;
+        };
+        /** StepActionResponse */
+        StepActionResponse: {
+            /** Stepkey */
+            stepKey: string;
+            /** Actionkind */
+            actionKind: string;
+            /** Status */
+            status: string;
+            /** Resultjson */
+            resultJson: {
+                [key: string]: unknown;
+            } | null;
+            /** Errormessage */
+            errorMessage: string | null;
+            /** Attemptcount */
+            attemptCount: number;
         };
         /** StripeWebhookAck */
         StripeWebhookAck: {
@@ -5341,6 +5392,12 @@ export interface components {
             /** Updatedat */
             updatedAt: string;
         };
+        /** WorkflowRunDetailResponse */
+        WorkflowRunDetailResponse: {
+            run: components["schemas"]["WorkflowRunResponse"];
+            /** Stepactions */
+            stepActions: components["schemas"]["StepActionResponse"][];
+        };
         /** WorkflowRunListResponse */
         WorkflowRunListResponse: {
             /** Runs */
@@ -5402,6 +5459,18 @@ export interface components {
             startedAt: string | null;
             /** Finishedat */
             finishedAt: string | null;
+        };
+        /**
+         * WorkflowRunTarget
+         * @description Where a run works (data-contract §3): exactly one of a workspace (manual/
+         *     chat — the workspace you're in) or a trigger (schedule/poll — the server
+         *     derives the pinned workspace from the trigger row; derivation itself is PR G).
+         */
+        WorkflowRunTarget: {
+            /** Workspaceid */
+            workspaceId?: string | null;
+            /** Triggerid */
+            triggerId?: string | null;
         };
         /** WorkflowTriggerCreateRequest */
         WorkflowTriggerCreateRequest: {
@@ -9160,7 +9229,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowRunResponse"];
+                    "application/json": components["schemas"]["WorkflowRunDetailResponse"];
                 };
             };
             /** @description Validation Error */
@@ -9298,6 +9367,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_slack_channels_endpoint_v1_cloud_workflows_slack_channels_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlackChannelsResponse"];
                 };
             };
         };

--- a/codex/workflows-architecture.md
+++ b/codex/workflows-architecture.md
@@ -4,8 +4,17 @@
 after the five blessed build items land. It is the alignment surface: every
 design point is tagged. **All eight [OPEN-n] questions were ruled by Pablo on
 2026-07-07** — each ruling is recorded inline as **RULED** at its section and in
-the §9 table. This doc is now the design of record for the arc: PRs A–E, plus a
-UX PR F that is gated on its own design pass (§8.3).
+the §9 table. Three further amendments were ruled the same day, 2026-07-07,
+on mechanisms the doc had not yet surfaced as [OPEN-n] — recorded inline as
+**Amendment** at their section and appended to the §9 log as L16–L18. This
+doc is now the design of record for the arc: PRs A–E, plus a
+UX PR F that is gated on its own design pass (§8.3). A further ruling pass,
+same day, 2026-07-07: four sequencing rules (L19) that rename the "effects"
+mechanism to **server-performed actions** and reverse the chaining design
+(L20 — composition is nesting, not spawning, superseding PR D as designed
+below), plus six rulings out of the function-invocations and
+integration-scoping design passes (L21–L26, §6, §5). These are recorded
+inline at their owning sections and in §9.
 
 **Companion docs — cross-linked, not duplicated:**
 - [`workflows-deep-dive.md`](workflows-deep-dive.md) — the **current-state**
@@ -29,17 +38,28 @@ UX PR F that is gated on its own design pass (§8.3).
   recommendation, and one paragraph of tradeoff. All eight were ruled
   2026-07-07; the tags remain for traceability, with the ruling recorded
   inline and in §9.
+- **Amendment** — a ruling made 2026-07-07, same pass as the [OPEN-n]
+  rulings, but on a mechanism the doc had not named as open — no options
+  table, just the ruled shape. Recorded inline at its section and as a new
+  L-numbered row in §9.
 
 **The five build items** (LOCKED — Pablo ruling 2026-07-06, "your load-bearing
 set is blessed, with one amendment"; build order A→B→C→D→E):
 
 | PR | Item | One line |
 |---|---|---|
-| **A** | Effects ledger + Slack notify delivery | server observes a completed step → performs a side effect exactly once; `notify(slack)` becomes real |
+| **A** | Actions ledger + Slack notify delivery | server observes a completed step → performs a server-performed action exactly once; `notify(slack)` becomes real |
 | **B** | Poll trigger primitive | Proliferate polls a conforming endpoint, spawns one run per new item, idempotently |
 | **C** | `agent.emit` typed output | agent must produce schema-validated JSON that lands in `{{steps[n].output.*}}` |
-| **D** | `workflow.run` fire-and-forget chaining | a step that spawns a child run via the PR-A observer |
+| **D** | ~~`workflow.run` fire-and-forget chaining~~ — **SUPERSEDED by L20** | ~~a step that spawns a child run via the PR-A observer~~ — redirected to composition-by-inlining, resolved server-side at StartRun; no child run, see §3.5, §9 L20 |
 | **E** | Gateway function grants | workflow definitions name allowed gateway tools; gateway enforces scope + audit at call time |
+
+**PR D is being actively built against the chaining/spawn design below — it
+must be redirected per L20 before it lands.** "Effects" is renamed
+**server-performed actions** throughout this doc per L19 (Rule 3); table
+`workflow_step_effect` → `workflow_step_action`, column `effect_kind` →
+`action_kind`, module `effects.py` → `actions.py` — builder task, tracked in
+the PR A row of §2 and the PR sections below.
 
 Sequencing against the existing stack (LOCKED, from the standing merge plan):
 sidecars #12/#24 → catalog pin bump → #909 (`goals/phase-a`) → #921
@@ -106,40 +126,62 @@ Run status enum + transition guard: `constants/workflows.py:38-99`,
 `domain/run_status.py:25-51` (`check_transition`; same-status = idempotent
 no-op; terminal has no outgoing edges). Unchanged by A–E.
 
-### 1.2 NEW: the step-effects ledger (PLANNED A)
+### 1.2 NEW: the step-actions ledger (PLANNED A)
 
-The shared mechanism under PR A (Slack sends) and PR D (child spawns): *the
-server observes a completed step in reported/refreshed run state and performs a
-side effect at most once per (run, step, kind), with retry for never-started
-effects.* One table, one CAS:
+**Amendment (Pablo, 2026-07-07 — L19, Rule 3): renamed from "step-effects" to
+"step-actions."** "Effect" implied reactive causality — a thing that runs
+*because* some other thing ran — which is the framing that let `spawn_child_run`
+masquerade as just another consequence of a completed step. The correct frame:
+an **action** is a step's own verb, declared in the plan at author time,
+performed by the server only because the credential never enters a sandbox
+(the Slack bot token) or the target is a server-owned object. The runtime
+executes the step up to producing its validated output; the server performs
+the step's *declared action* with exactly-once claim semantics. Agent output
+supplies only the arguments, never the verb — an action whose job would be
+deciding or causing *what executes next* is invalid by definition, because
+that is sequencing, and sequencing is Rule 2's property (§3.1), never the
+server's. This is a rename, not a redesign, applied as a global terminology
+sweep across this doc's own prose and code blocks: table
+`workflow_step_effect` → `workflow_step_action`, column `effect_kind` →
+`action_kind`, module `server/proliferate/server/cloud/workflows/effects.py`
+→ `actions.py` — nothing is merged to main yet, so the rename is cheap now and
+never again (builder task, tracked against PR A). Ledger contents, post-rename:
+`slack_notify` now, `function_call` later (§6.6/L18/L23) — **`spawn_child_run`
+is removed outright**, not renamed: L20 (§3.5) supersedes child spawning
+entirely, so there is no action of that kind to carry forward.
+
+The shared mechanism under PR A (Slack sends) — and, per L18/L23, `function_call`
+later: *the server observes a completed step in reported/refreshed run state
+and performs a server-performed action at most once per (run, step, kind),
+with retry for never-started actions.* One table, one CAS:
 
 ```python
 # server/proliferate/db/models/cloud/workflows.py  (PR A)
-class WorkflowStepEffect(Base):
-    """Server-side effects claimed off observed step completions.
+class WorkflowStepAction(Base):
+    """Server-performed actions claimed off observed step completions.
 
-    The (run_id, step_index, effect_kind) unique constraint IS the claim: the
-    transaction that inserts the row owns the effect. status walks
+    The (run_id, step_index, action_kind) unique constraint IS the claim: the
+    transaction that inserts the row owns the action. status walks
     pending -> done | failed; a sweeper retries stale 'pending' rows (an owner
     that crashed before performing) and transient 'failed' rows.
     """
 
-    __tablename__ = "workflow_step_effect"
+    __tablename__ = "workflow_step_action"
     __table_args__ = (
         UniqueConstraint(
-            "run_id", "step_index", "effect_kind",
-            name="uq_workflow_step_effect_claim",
+            "run_id", "step_index", "action_kind",
+            name="uq_workflow_step_action_claim",
         ),
         CheckConstraint(
-            "effect_kind IN ('slack_notify', 'spawn_child_run')",
-            name="ck_workflow_step_effect_kind",
+            "action_kind IN ('slack_notify')",
+            name="ck_workflow_step_action_kind",
         ),
         CheckConstraint(
             "status IN ('pending', 'done', 'failed')",
-            name="ck_workflow_step_effect_status",
+            name="ck_workflow_step_action_status",
         ),
         Index(
-            "ix_workflow_step_effect_sweep",
+            "ix_workflow_step_action_sweep",
             "updated_at",
             postgresql_where=text("status = 'pending'"),
         ),
@@ -150,44 +192,50 @@ class WorkflowStepEffect(Base):
         ForeignKey("workflow_run.id", ondelete="CASCADE"),
     )
     step_index: Mapped[int] = mapped_column(Integer)
-    effect_kind: Mapped[str] = mapped_column(String(32))
+    action_kind: Mapped[str] = mapped_column(String(32))
     status: Mapped[str] = mapped_column(String(16), default="pending")
     attempt_count: Mapped[int] = mapped_column(Integer, default=0)
-    # slack_notify: {channel_id, message_ts} | spawn_child_run: {child_run_id}
+    # slack_notify: {channel_id, message_ts} — function_call joins later (§6.6/L23)
     result_json: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at / updated_at  # house pattern
 ```
 
+**~~`spawn_child_run` (PLANNED D, SUPERSEDED by L20)~~** — the CHECK above
+previously admitted a second kind, `spawn_child_run`, with `result_json` shape
+`{child_run_id}`, backing PR D's fire-and-forget chaining (old §3.5). L20
+(§3.5, §9) rules that workflow composition is nesting at plan-resolution time,
+not a runtime-observed spawn, so there is no child run and nothing for an
+action to claim. Kept here only for provenance; do not build it.
+
 The claim CAS (§3.4 shows it in flow context):
 
 ```python
-# server/proliferate/server/cloud/workflows/effects.py  (PR A)
-async def claim_step_effect(
-    db: AsyncSession, *, run_id: UUID, step_index: int, effect_kind: str
+# server/proliferate/server/cloud/workflows/actions.py  (PR A)
+async def claim_step_action(
+    db: AsyncSession, *, run_id: UUID, step_index: int, action_kind: str
 ) -> UUID | None:
-    """INSERT ... ON CONFLICT DO NOTHING. Returns the new effect id when this
+    """INSERT ... ON CONFLICT DO NOTHING. Returns the new action id when this
     caller won the claim, None when another observer already owns it."""
     stmt = (
-        pg_insert(WorkflowStepEffect)
+        pg_insert(WorkflowStepAction)
         .values(id=uuid4(), run_id=run_id, step_index=step_index,
-                effect_kind=effect_kind, status="pending", attempt_count=0)
-        .on_conflict_do_nothing(constraint="uq_workflow_step_effect_claim")
-        .returning(WorkflowStepEffect.id)
+                action_kind=action_kind, status="pending", attempt_count=0)
+        .on_conflict_do_nothing(constraint="uq_workflow_step_action_claim")
+        .returning(WorkflowStepAction.id)
     )
     return (await db.execute(stmt)).scalar_one_or_none()
 ```
 
 **Honest guarantee statement** (PLANNED A — this wording should survive into
-the code docstring): the ledger gives *exactly-once claim*. Effect execution is
-*at-least-once completion* via the sweeper. A crash inside the effect window
+the code docstring): the ledger gives *exactly-once claim*. Action execution is
+*at-least-once completion* via the sweeper. A crash inside the action window
 (after the Slack POST succeeded, before `status='done'` committed) can
 duplicate a send — the same guarantee class as every non-transactional external
-side effect. For **child spawns** we close even that gap: the child
-`run_id` is pre-generated and stored on the effect row *before* `start_run` is
-called with it, and `start_run` gains an optional explicit `run_id` — a
-sweeper retry then re-creates the same child id and the insert conflicts
-harmlessly. True exactly-once for spawns; Slack keeps the honest weaker class.
+side effect. (The stronger, pre-generated-id trick that used to close this gap
+for child spawns no longer applies — there are no child spawns under L20;
+`function_call`'s guarantee class, when it is built, is a question for that
+design pass, §6.6/L23.)
 
 ### 1.3 NEW: poll trigger config + seen-set (PLANNED B)
 
@@ -240,10 +288,17 @@ class WorkflowTriggerItem(Base):
     received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 ```
 
-### 1.4 NEW: parent↔child linkage (PLANNED D)
+### 1.4 ~~NEW: parent↔child linkage (PLANNED D)~~ — SUPERSEDED by L20 (§9)
+
+**Superseded (Pablo, 2026-07-07 — L20, §9).** There is no child run under the
+nesting-composition ruling: composing workflow B inside workflow A inlines B's
+steps into A's single resolved plan at StartRun, server-side. One run, one
+plan, one cursor, one sandbox — no `parent_run_id`, no `parent_step_index`, no
+cross-run linkage of any kind. The migration and column below are not built;
+kept for provenance only.
 
 ```python
-# alembic: <rev>_workflow_run_parent.py  (PR D)
+# ~~alembic: <rev>_workflow_run_parent.py  (PR D)~~ — NOT BUILT, superseded by L20
 op.add_column("workflow_run", sa.Column(
     "parent_run_id", sa.Uuid(),
     sa.ForeignKey("workflow_run.id", ondelete="SET NULL"), nullable=True))
@@ -252,8 +307,9 @@ op.create_index("ix_workflow_run_parent", "workflow_run", ["parent_run_id"],
                 postgresql_where=sa.text("parent_run_id IS NOT NULL"))
 ```
 
-Child provenance (`trigger_kind` value, executor identity, target workspace) is
-[OPEN-7] — see §3.6.
+Child provenance (`trigger_kind` value, executor identity, target workspace)
+was [OPEN-7] — see §3.6, itself superseded by L20: there is no child run left
+to have provenance.
 
 ### 1.5 Definition-JSON vocabulary growth (PLANNED C, E — no new tables)
 
@@ -264,7 +320,7 @@ Two extensions to the canonical definition dict stored in
 {
   "args": [...],                       // exists today
   "setup": {...},                      // exists today
-  "functions": [                       // NEW (PR E): gateway tool grants
+  "functions": [                       // NEW (PR E): gateway tool grants — L22, L24
     { "provider": "issues", "tools": ["claim", "search_issues", "update_status"] }
   ],
   "steps": [
@@ -275,7 +331,7 @@ Two extensions to the canonical definition dict stored in
       "output_schema": { "type": "object", "required": ["pr_title"], "properties": { "pr_title": {"type": "string"} } },
       "on_fail": { "kind": "stop" }
     },
-    {                                  // NEW (PR D): chaining step
+    {                                  // ~~NEW (PR D): chaining step~~ — SUPERSEDED by L20, see below
       "kind": "workflow.run",
       "workflow_id": "…uuid…",
       "args": { "issue_id": "{{steps[0].output.issue_id}}" }
@@ -284,19 +340,45 @@ Two extensions to the canonical definition dict stored in
 }
 ```
 
+**~~`workflow.run` (PLANNED D)~~ — SUPERSEDED by L20 (Pablo, 2026-07-07, §9).**
+This step kind, as a runtime-executed "spawn a child run" verb, is not built.
+L20 rules that composing workflow B inside workflow A means **B's steps are
+inlined into A's resolved plan at resolution time**, server-side, before
+delivery — see §3.5 for the full ruling and the two resolver obligations
+(arg binding, step-ref namespacing) this implies for
+[definition.py](../server/proliferate/server/cloud/workflows/domain/definition.py).
+Whatever surface syntax replaces the `workflow.run` step above (a "compose"
+block, an inline-reference field — undesigned) must resolve to inlined steps,
+never to a runtime step kind that produces a "spawn requested" output.
+
+**L22/L24 on the `functions` block (Pablo, 2026-07-07):** `functions` is a
+**declared allow-list**, validated at save time against the owner's visible
+integration definitions and resolved at `StartRun` — not a static registry,
+not runtime discovery. `StartRun` **fails the run** if a declared provider has
+no ready account; it never silently narrows the grant. There is no workflow
+"kind" taxonomy (triage vs. fix vs. anything else) that pre-sizes scope —
+each definition's own `functions[]` independently sizes its grant, full stop.
+First providers exposed this way (L21): the **issues service** (`api_key`
+seed, §6.1) and **Slack** (`api_key`-style, credential path already exercised
+by `slack_notify`) — both have no mid-run OAuth-refresh failure mode.
+OAuth-DCR providers (Linear, Notion, Supabase) are deferred until the frozen
+per-run scope has a mid-run reauth story; see §6 for the full ruling.
+
 Validator: `SUPPORTED_WORKFLOW_STEP_KINDS` in
 [constants/workflows.py:113-129](../server/proliferate/constants/workflows.py)
-gains `agent.emit` + `workflow.run`; new `_parse_agent_emit` / `_parse_workflow_run`
-register in `_STEP_PARSERS`
+gains `agent.emit` (PR C) — **not** `workflow.run` (superseded by L20; whatever
+replaces it is undesigned); new `_parse_agent_emit` registers in
+`_STEP_PARSERS`
 ([definition.py](../server/proliferate/server/cloud/workflows/domain/definition.py),
 pattern: deep dive reading-path ①). `functions` joins `args`/`setup`/`steps` in
 the top-level allowed keys; each entry validates provider = a registered
 integration-definition namespace visible to the owner, tools = non-empty
-strings. Rust mirror: two `StepKind` variants in
+strings. Rust mirror: **one** `StepKind` variant (`AgentEmit`) in
 [plan.rs:67-98](../anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs)
-(internally-tagged enum — old runtimes hard-fail on unknown kinds, which is
-correct: a plan with steps the runtime can't execute must not half-run; the
-catalog/runtime rebuild ships in the same PR).
+— not two; `WorkflowRun` is not added (internally-tagged enum — old runtimes
+hard-fail on unknown kinds, which is correct: a plan with steps the runtime
+can't execute must not half-run; the catalog/runtime rebuild ships in the
+same PR).
 
 ---
 
@@ -306,29 +388,34 @@ Every file the system touches after A–E. Legend: ✅ exists today (see deep di
 for role detail) · **A**/**B**/**C**/**D**/**E** arrives in that PR · Δ modified
 in that PR.
 
+Renames per L19 (Rule 3) and strikes per L20 applied below — **D's rows are
+kept for provenance and marked superseded, not deleted**; whatever replaces
+composition (inlining, resolved server-side at StartRun) is undesigned and
+will need its own file-tree entries when it lands.
+
 ```
 server/proliferate/
-├── constants/workflows.py                              ✅ ΔC ΔD (step-kind slugs) ΔE (functions caps)
-├── db/models/cloud/workflows.py                        ✅ ΔA (WorkflowStepEffect) ΔB (trigger poll cols, WorkflowTriggerItem) ΔD (parent cols)
-├── db/store/cloud_workflows.py                         ✅ ΔA (effect CRUD+sweep scan) ΔD (start_run explicit run_id, children query)
+├── constants/workflows.py                              ✅ ΔC (step-kind slugs) ΔE (functions caps) — ΔD superseded (L20; no workflow.run slug)
+├── db/models/cloud/workflows.py                        ✅ ΔA (WorkflowStepAction, renamed from WorkflowStepEffect — L19) ΔB (trigger poll cols, WorkflowTriggerItem) — ΔD superseded (L20; no parent cols)
+├── db/store/cloud_workflows.py                         ✅ ΔA (action CRUD+sweep scan) — ΔD superseded (L20; no explicit run_id/children query — no children)
 ├── db/store/cloud_workflow_triggers.py                 ✅ ΔB (claim_due_poll_trigger, item seen-set CAS, cursor persist)
 ├── alembic/versions/
 │   ├── e4f7a2b9c6d1_workflow_entities.py               ✅
 │   ├── b2d4f6a8c0e1_workflow_trigger.py                ✅
-│   ├── <rev>_workflow_step_effect.py                   A
+│   ├── <rev>_workflow_step_action.py                   A   (renamed from <rev>_workflow_step_effect.py — L19)
 │   ├── <rev>_workflow_poll_trigger.py                  B
-│   ├── <rev>_workflow_run_parent.py                    D
-│   └── <rev>_workflow_run_gateway_token.py             E   (shape depends on OPEN-3)
+│   ├── ~~<rev>_workflow_run_parent.py~~                ~~D~~ — SUPERSEDED by L20, not built
+│   └── <rev>_workflow_run_gateway_token.py             E   (shape per L25/OPEN-3)
 ├── server/cloud/workflows/
 │   ├── api.py                                          ✅ ΔA (GET slack channels for picker) ΔB (poll-trigger CRUD passthrough)
-│   ├── models.py                                       ✅ ΔA ΔB ΔC ΔD ΔE (request/response mirrors)
-│   ├── service.py                                      ✅ ΔB (poll trigger validate) ΔD (start_run run_id param, parent linkage)
-│   ├── delivery.py                                     ✅ ΔA (refresh path calls effects.apply)
-│   ├── scheduler.py                                    ✅ ΔA (phase 3: refresh in-flight scheduled cloud runs + effect sweeper) ΔB (imports poller into the same beat)
-│   ├── effects.py                                      A   (claim CAS, slack_notify performer, spawn_child performer(D), sweeper)
+│   ├── models.py                                       ✅ ΔA ΔB ΔC ΔE (request/response mirrors) — ΔD superseded (L20)
+│   ├── service.py                                      ✅ ΔB (poll trigger validate) — ΔD's run_id param/parent linkage superseded (L20); inlining resolver work lands in domain/definition.py instead
+│   ├── delivery.py                                     ✅ ΔA (refresh path calls actions.apply)
+│   ├── scheduler.py                                    ✅ ΔA (phase 3: refresh in-flight scheduled cloud runs + action sweeper) ΔB (imports poller into the same beat)
+│   ├── actions.py                                      A   (renamed from effects.py — L19; claim CAS, slack_notify performer, sweeper — no spawn_child performer, superseded by L20)
 │   ├── poller.py                                       B   (poll loop: fetch → validate → dedup → spawn → cursor persist)
 │   └── domain/
-│       ├── definition.py                               ✅ ΔC ΔD (parsers) ΔE (functions block)
+│       ├── definition.py                               ✅ ΔC (parsers) ΔE (functions block, allow-list validation — L22) — ΔD's workflow.run parser superseded (L20); resolver gains cycle/depth-check + arg-binding + step-ref-namespacing obligations when nesting composition is designed
 │       ├── interpolation.py                            ✅ (unchanged — grammar already supports everything C needs)
 │       ├── run_status.py                               ✅
 │       ├── policy.py                                   ✅
@@ -337,34 +424,34 @@ server/proliferate/
 │   ├── anyharness/workflow_runs.py                     ✅
 │   └── slack/{client,messages,webhooks,errors}.py      ✅ (reused as-is by A: chat_post_message client.py:91, list_channels client.py:115)
 └── server/cloud/integration_gateway/
-    ├── api.py · dependencies.py · service.py           ✅ ΔE (grant carries run scope; tools/list + tools/call filtered by grant scope)
+    ├── api.py · dependencies.py · service.py           ✅ ΔE (grant carries run scope — L25 two-layer composition; tools/list + tools/call filtered by grant scope)
     └── domain/{json_rpc,tool_args,virtual_tools}.py    ✅ ΔE
 
 anyharness/crates/anyharness-lib/src/
 ├── domains/workflows/
-│   ├── plan.rs                                         ✅ ΔC (AgentEmitStep) ΔD (WorkflowRunStep)
+│   ├── plan.rs                                         ✅ ΔC (AgentEmitStep) — ΔD's WorkflowRunStep superseded (L20; not added)
 │   ├── engine.rs · model.rs · store.rs                 ✅
 │   ├── service.rs                                      ✅
-│   └── templates.rs                                    ✅ ΔC (resolve_step arm for emit; workflow.run args late-bind)
+│   └── templates.rs                                    ✅ ΔC (resolve_step arm for emit) — ΔD's workflow.run args late-bind superseded (L20; nesting resolves args server-side at plan-resolution time, not late-bound at runtime)
 ├── live/workflows/
-│   ├── executor.rs                                     ✅ ΔC (run_emit: prompt→await→read→validate→reprompt) ΔD (instant-complete arm) ΔE (per-run gateway launch extra if OPEN-3=a)
+│   ├── executor.rs                                     ✅ ΔC (run_emit: prompt→await→read→validate→reprompt) ΔE (per-run gateway launch extra if OPEN-3=a) — ΔD's instant-complete arm superseded (L20)
 │   ├── commands.rs                                     ✅ ΔA (notify_step: channel:"slack" + slack_channel_id passthrough — 5 lines)
 │   ├── actor.rs · manager.rs · exec_policy.rs          ✅
 ├── persistence/sql/0053_workflow_runs.sql              ✅ (number may shift on merge-collision renumber)
 └── api/http/workflow_runs.rs                           ✅
 
 apps/packages/product-domain/src/workflows/
-├── definition.ts · validation.ts                       ✅ ΔC ΔD ΔE (step kinds + functions mirror)
-├── run-status.ts                                       ✅ ΔC ΔD (output chips: emit payload, child-run link)
+├── definition.ts · validation.ts                       ✅ ΔC ΔE (step kinds + functions mirror) — ΔD superseded (L20)
+├── run-status.ts                                       ✅ ΔC (output chips: emit payload) — ΔD's child-run link superseded (L20; no child run)
 ├── interpolation.ts · effective-config.ts              ✅
-├── model.ts · presentation.ts · templates.ts           ✅ ΔB (poll trigger label) ΔD (chained templates)
+├── model.ts · presentation.ts · templates.ts           ✅ ΔB (poll trigger label) — ΔD's chained templates superseded (L20)
 
 apps/desktop/src/
 ├── components/workflows/editor/
-│   ├── WorkflowStepPanel.tsx                           ✅ ΔA (slack channel picker) ΔC (emit editor: prompt + schema) ΔD (workflow picker + args)
+│   ├── WorkflowStepPanel.tsx                           ✅ ΔA (slack channel picker) ΔC (emit editor: prompt + schema) — ΔD's workflow picker + args superseded (L20; nesting UI is undesigned)
 │   ├── WorkflowTriggersCard.tsx                        ✅ ΔB (poll config: url/header/secret/interval/schema/mapping)
 │   ├── WorkflowSetupCard.tsx                           ✅ Δ(OPEN-1) 
-│   └── (rest of editor/, home/, run/, screen/)         ✅ ΔD (run view parent↔child links)
+│   └── (rest of editor/, home/, run/, screen/)         ✅ — ΔD's run view parent↔child links superseded (L20; no child run)
 ├── hooks/access/cloud/workflows/                       ✅ ΔA ΔB (new endpoints)
 └── lib/access/cloud/workflows.ts                       ✅ ΔA ΔB
 
@@ -438,7 +525,25 @@ require later, for the record: a lane-keyed cursor (per-lane
 `workflow_step_runs` partitioning), concurrent session management per lane in
 the executor, lane-aware on-fail semantics (does lane 2 die when lane 1
 fails?), and a two-dimensional run timeline. Nothing in A–E forecloses it; the
-chaining story below is the v1 pressure valve.
+composition story below (§3.5 — nesting, per L20, not the old chaining
+design) is the v1 pressure valve.
+
+**Amendment (Pablo, 2026-07-07 — L19, Rules 1 & 2, §9):** the paragraph above
+already states these two rules; L19 formalizes rather than changes them, so
+they are recorded here rather than rewritten. **Rule 1 — one workflow, one
+plan JSON, delivered whole:** the server resolves a workflow into a single
+complete plan at `StartRun` (exactly the "resolution point" language above)
+and hands the entire thing to the runtime in one delivery; after handoff the
+server only observes (§3.2). **Rule 2 — the runtime owns sequencing, with no
+exceptions:** step N → N+1 is decided and executed by `run_next_step` against
+its own SQLite cursor, above, in full; the server never advances, triggers, or
+selects a step — if the server vanished mid-run, the plan would still execute
+to completion. Server-side machinery that looks like it participates in
+sequencing — the ping handler (§3.7) and the scheduler refresh (§4.1) — is
+read-only observation, not a second driver. Rule 2 is the reason L20 (§3.5)
+rules composition as resolution-time inlining rather than a runtime step that
+spawns and waits: anything that decides "what runs next" has to happen before
+the plan is delivered, never during.
 
 ### 3.2 Observed state → server (LOCKED — shipped)
 
@@ -453,33 +558,40 @@ ids/cost. Cloud lane: `GET /runs/{id}/refresh` → `_sync_run_from_view`
 
 ### 3.3 NEW — the observer hook (PLANNED A)
 
+**Renamed per L19 (Rule 3):** `effects` → `actions` throughout — module,
+function names, and the `_STEP_KINDS` map. `workflow.run`/`spawn_child_run`
+is dropped from the map outright (SUPERSEDED by L20 — there is nothing left
+for the observer to spawn; composition is resolved server-side at StartRun,
+before the runtime ever sees the plan, so there is no completed step for the
+observer to react to).
+
 Both ingest paths gain one call after they persist observed state:
 
 ```python
 # at the end of report_run_status(...) and _sync_run_from_view(...):
-await effects.apply_step_effects(db, run=updated)
+await actions.apply_step_actions(db, run=updated)
 ```
 
 ```python
-# server/proliferate/server/cloud/workflows/effects.py  (PR A; D adds the second arm)
-EFFECT_STEP_KINDS = {"notify": "slack_notify", "workflow.run": "spawn_child_run"}
+# server/proliferate/server/cloud/workflows/actions.py  (PR A)
+ACTION_STEP_KINDS = {"notify": "slack_notify"}   # function_call joins later, §6.6/L23 — no workflow.run entry (L20)
 
-async def apply_step_effects(db: AsyncSession, *, run: WorkflowRunRecord) -> None:
-    """Scan observed step outputs for effect-bearing completed steps; claim and
+async def apply_step_actions(db: AsyncSession, *, run: WorkflowRunRecord) -> None:
+    """Scan observed step outputs for action-bearing completed steps; claim and
     perform any not yet owned. Safe to call on every report/refresh: the ledger
     CAS makes re-observation free."""
     plan_steps = (run.resolved_plan_json or {}).get("steps", [])
     for index_str, output in (run.step_outputs_json or {}).items():
         index = int(index_str)
         step = plan_steps[index] if index < len(plan_steps) else {}
-        effect_kind = _effect_kind_for(step, output)      # notify+slack / workflow.run only
-        if effect_kind is None:
+        action_kind = _action_kind_for(step, output)      # notify+slack only
+        if action_kind is None:
             continue
-        effect_id = await claim_step_effect(
-            db, run_id=run.id, step_index=index, effect_kind=effect_kind)
-        if effect_id is None:
+        action_id = await claim_step_action(
+            db, run_id=run.id, step_index=index, action_kind=action_kind)
+        if action_id is None:
             continue                                       # another observer owns it
-        await _perform(db, effect_id, effect_kind, run=run, step=step, output=output)
+        await _perform(db, action_id, action_kind, run=run, step=step, output=output)
 ```
 
 `_perform("slack_notify")` resolves the owner's ready Slack integration account
@@ -488,21 +600,37 @@ async def apply_step_effects(db: AsyncSession, *, run: WorkflowRunRecord) -> Non
 decrypts the bundle, and calls the **existing first-class client**
 `chat_post_message(bot_token=…, channel_id=step["slack_channel_id"], text=output["message"], …)`
 ([integrations/slack/client.py:91-112](../server/proliferate/integrations/slack/client.py)).
-No new Slack machinery is built. Runtime side is a 5-line change in
+No new Slack machinery is built.
+
+**Defect found during the pass-2 research, recorded as a builder obligation
+on this file, now (not deferred to PR E):** `_perform_slack_notify` calls
+`get_ready_account_for_provider` **without `organization_id`**, silently
+bypassing org policy. Fix: thread the run's org id through
+`_perform`/`_perform_slack_notify` into the account lookup — belongs in the
+actions stack (this section), not in PR E.
+
+Runtime side is a 5-line change in
 [commands.rs:197-208](../anyharness/crates/anyharness-lib/src/live/workflows/commands.rs):
 `NotifyChannel::Slack` now outputs `{channel: "slack", message, slack_channel_id}`
-instead of `"slack_unavailable"` — the *effect* is the server's job; the in-app
+instead of `"slack_unavailable"` — the *action* is the server's job (§1.2/L19:
+the step's own declared verb, not a reaction to what ran); the in-app
 record remains the floor and the step still never hard-fails (LOCKED — shipped
 stance, deep dive §7).
 
 **The unattended-cloud gap this design must close** (PLANNED A — load-bearing):
 cloud `/refresh` is UI-driven; a scheduled/poll-fired cloud run nobody is
-watching would never be observed, so effects would never fire. Therefore the
+watching would never be observed, so actions would never fire. Therefore the
 workflow scheduler tick gains **phase 3**: refresh in-flight
 (`delivered`/`running`/`waiting_approval`) scheduled+polled cloud runs, capped
-per tick, plus the effect sweeper (retry `pending` effects older than 60s,
+per tick, plus the action sweeper (retry `pending` actions older than 60s,
 `attempt_count`-bounded). Local-lane runs keep the desktop relay as their
-observer (app-open-only — the known v1 gap stands).
+observer (app-open-only — the known v1 gap stands). Per §3.7/L16, this is
+now a backstop behind the per-run completion ping, not the primary mechanism
+— unaffected by L19/L20, restated here only for the cross-reference.
+
+A second pre-existing defect, found during the same pass-2 research, is
+recorded as a builder obligation against §5.3/OPEN-5 (the local-lane gateway
+gap that section already describes) rather than here.
 
 ### 3.4 Crash-resume walkthrough (LOCKED — shipped; extended by A)
 
@@ -522,26 +650,81 @@ between a notify step completing and the Slack send*:
 runtime: notify step completes → output_json = {channel:"slack", slack_channel_id, message}
 relay/refresh: POST /status carries step_outputs["3"]
 server: report_run_status persists outputs
-        → apply_step_effects → claim CAS inserts (run, 3, slack_notify) 'pending'
+        → apply_step_actions → claim CAS inserts (run, 3, slack_notify) 'pending'
         → ☠ server crashes before chat_post_message
 server restarts:
-  relay re-reports (same signature) → apply_step_effects → CAS conflicts → skip  ✓ no double claim
-  scheduler phase-3 sweeper: finds 'pending' effect, age > 60s, attempt_count 0
+  relay re-reports (same signature) → apply_step_actions → CAS conflicts → skip  ✓ no double claim
+  scheduler phase-3 sweeper: finds 'pending' action, age > 60s, attempt_count 0
         → re-performs chat_post_message → status='done', result_json={message_ts}  ✓ delivered once
-run view: renders the delivery chip from the effect row (sent / pending / failed)
+run view: renders the delivery chip from the action row (sent / pending / failed)
 ```
 
-And for PR D's child spawn: the effect row gets `result_json={"child_run_id": <pre-generated uuid>}`
-*in the claim transaction*; `start_run(..., run_id=child_run_id)` is called
-after. A sweeper retry calls `start_run` with the same id → PK conflict →
-treat as already-spawned. Exactly-once, provably.
+**~~And for PR D's child spawn: the effect row gets `result_json={"child_run_id":
+<pre-generated uuid>}` in the claim transaction; `start_run(...,
+run_id=child_run_id)` is called after. A sweeper retry calls `start_run` with
+the same id → PK conflict → treat as already-spawned. Exactly-once,
+provably.~~ — SUPERSEDED by L20 (§9).** There is no child spawn to make
+exactly-once: composition under L20 is resolved into one plan at StartRun,
+before delivery, so the crash-resume story for a nested step is identical to
+the crash-resume story for any other step in that one plan — no separate
+trace needed.
 
-### 3.5 Chaining: `workflow.run` fire-and-forget (PLANNED D; semantics LOCKED 2026-07-06)
+### 3.5 ~~Chaining: `workflow.run` fire-and-forget (PLANNED D; semantics LOCKED 2026-07-06)~~ — SUPERSEDED by L20 (§9)
 
-Runtime arm — instant, like `agent.config`:
+**Superseded (Pablo, 2026-07-07 — L20/Rule 4, §9).** Everything below this
+line, to the end of §3.6, described the old design: a runtime step kind that
+requests a spawn, observed and performed by the PR-A observer as a
+`spawn_child_run` action. **That mechanism is not being built.** PR D, as
+currently in flight, must be redirected to the ruling that follows before it
+lands.
+
+**The ruling, stated positively:** using workflow B inside workflow A means
+**B's steps are inlined into A's resolved plan at resolution time,
+server-side, before delivery.** One run, one plan, one cursor, one sandbox.
+There is no child run, no parent linkage, no `spawn_child_run` action, no
+cross-sandbox fan-out — in v1, none of that exists. This follows directly
+from L19's Rule 2 (the runtime owns sequencing, no exceptions) and Rule 4
+itself: a step whose job is deciding or causing what executes next is
+sequencing, and sequencing is not a server-performed action's job — so
+composition cannot be modeled as a step that "requests" a spawn observed
+after the fact. It has to be resolved into the sequence before the runtime
+ever sees it.
+
+Two named resolver obligations, both **resolution-time problems in the
+server's plan resolver** ([definition.py](../server/proliferate/server/cloud/workflows/domain/definition.py)),
+undesigned beyond this framing:
+
+- **(a) Arg binding** — the composing step's arg mapping becomes the
+  interpolation context for the inlined steps. Whatever syntax names "run B
+  here with these args" (undesigned; the old `workflow.run` step shape is not
+  it, since it produced a runtime-observed output rather than resolving
+  inline), its `args` mapping must feed B's `{{args.*}}` the same way
+  `StartRun` feeds a top-level run's args today (§3.1).
+- **(b) Step-ref namespacing** — B's internal `steps[n]`/named refs (§7.5/L6,
+  once named refs land) must not collide with A's once inlined into one flat
+  step list. This is a straightforward but real rewrite pass over B's
+  templated fields at inlining time.
+
+**Save-time validation gains a cycle/depth check:** A includes B includes A
+must fail at **save**, not at run — the mirror image of the old runtime
+chain-depth cap below, moved earlier because there's no runtime spawn left to
+cap.
+
+**If a genuinely-needed "start a run from a run" case appears later** (the
+one thing fire-and-forget chaining bought that inlining does not: a truly
+independent child run, its own record/actor/timeline/cost line, parent
+indifferent to its fate) **it requires a new explicit ruling that must clear
+Rule 3** (§9/L19) — a step that starts another run is, definitionally, an
+action whose job is causing what executes next, which Rule 3 rules out by
+construction unless a future ruling carves an explicit exception. It is not
+a default outcome of iterating on this design; someone has to rule it again.
+
+**Below this line: the old design, kept for provenance only. Not built.**
+
+~~Runtime arm — instant, like `agent.config`:~~
 
 ```rust
-// plan.rs (PR D)
+// ~~plan.rs (PR D)~~ — NOT BUILT, superseded by L20
 #[serde(rename = "workflow.run")]
 WorkflowRun(WorkflowRunStep),
 
@@ -559,7 +742,7 @@ StepKind::WorkflowRun(spawn) => StepOutcome::Completed {
 },
 ```
 
-The runtime performs nothing; the PR-A observer sees the completed step and
+~~The runtime performs nothing; the PR-A observer sees the completed step and
 spawns the child through the ledger (§3.4). **What fire-and-forget does and
 does not guarantee (state this in the editor UI copy too):** the child run is
 created exactly once with the interpolated args, has its own run record, actor,
@@ -570,17 +753,26 @@ using B's results*" across workflows in one plan — that composition needs
 await-child, which is deliberately v2 (awkward with one-shot plan delivery;
 LOCKED deferral, 2026-07-06). **No mid-run plan mutation, ever** (LOCKED —
 2026-07-06: "no await-child in v1; no mid-run plan mutation ever"): appending
-steps to a delivered plan is ruled out.
+steps to a delivered plan is ruled out.~~ Note: "no mid-run plan mutation,
+ever" survives L20 intact — inlining happens entirely before delivery, at
+resolution time, which is the strongest possible version of that rule, not an
+exception to it.
 
-Guard rails (PLANNED D): validator rejects `workflow_id` = the defining
+~~Guard rails (PLANNED D): validator rejects `workflow_id` = the defining
 workflow's own id (direct self-spawn); the spawner enforces a chain-depth cap
 (walk `parent_run_id`, max 5) against indirect cycles — a depth breach records
 the effect as `failed` with `error_message="chain_depth_exceeded"`, visible in
-the parent's run view.
+the parent's run view.~~ Replaced by the save-time cycle/depth check above.
 
-### 3.6 [OPEN-7] Child-run provenance — RULED (a) (Pablo, 2026-07-07)
+### 3.6 ~~[OPEN-7] Child-run provenance — RULED (a) (Pablo, 2026-07-07)~~ — SUPERSEDED by L20 (§9)
 
-**Ruling: new `'workflow'` trigger_kind (CHECK widened in the PR D migration);
+**Superseded (Pablo, 2026-07-07 — L20, §9).** There is no child run left to
+have provenance: `trigger_kind`, `executor_user_id`, and target-workspace
+inheritance were all questions about a second run record that no longer
+exists. Kept below for provenance only — this ruling does not apply to
+anything built under L20.
+
+~~**Ruling: new `'workflow'` trigger_kind (CHECK widened in the PR D migration);
 child inherits the parent's workspace; executor = owner.** Original options,
 for the record:
 
@@ -603,7 +795,69 @@ ambiguity. Inheriting the parent workspace avoids workspace provisioning in the
 observer (which has no UI context to pick one) at the cost that a chained
 workflow designed for a clean tree may see the parent's dirt — mitigated
 because chained definitions declare their own Setup and can open fresh
-sessions, and the fresh-tree question is the same one OPEN-4 answers for polls.
+sessions, and the fresh-tree question is the same one OPEN-4 answers for polls.~~
+
+### 3.7 Amendment (Pablo, 2026-07-07): the completion ping is the run-report credential
+
+**Ruling: every run's delivery mints a per-run gateway token, even when the
+plan needs no integration scopes at all (empty `scope_json` is legal) — and
+that token doubles as the run-report credential.** The mechanism §6.4 built
+to answer "how does a workflow's agent call a gateway tool" now also answers
+"how does the runtime tell the server a step finished," for exactly the
+cloud-lane runs nobody is watching — the gap named in §3.3.
+
+Runtime side: after each step transition is applied by the workflow actor —
+`apply_decision` in `live/workflows/actor.rs` — fire-and-forget
+`POST /runs/{run_id}/ping`, authorized by the per-run token: a spawned task,
+result ignored. A failed ping never changes engine state — the cursor has
+already moved by the time the ping fires; the ping is a nudge, not a
+transition.
+
+Server side: the handler validates the token, requires the token's `run_id`
+to match the path (so run A's token can't ping run B), and triggers the
+existing refresh path — `_sync_run_from_view` in `delivery.py` — which pulls
+the authoritative run view from the runtime. No new state machine, no new
+ingest path; the ping just wakes the one that already exists (§3.2).
+
+The ping body carries nothing load-bearing: it is a stateless nudge.
+Duplicate, stale, and lost pings are all safe, because refresh is
+reconcile-shaped and run-status transitions are monotonic (same-status is a
+no-op per `check_transition`). **Consequence:** the scheduler's phase-3
+refresh-in-flight-runs sweep (§3.3) demotes from primary mechanism to
+backstop cadence — see §4.1.
+
+Test obligations (per `specs/developing/testing/README.md`): Rust tier-1 via
+an injected recording ping sink (assert a ping is attempted after every
+transition; assert ping failure is inert); Python tier-1 for token scoping
+(run A's token cannot ping run B), idempotency, and no status regression when
+a ping arrives after the scheduler has already refreshed; a new golden
+contract fixture under `fixtures/contracts/run-ping/`.
+
+### 3.8 Amendment (Pablo, 2026-07-07): session lockout is an engine invariant, not UI politeness
+
+**Ruling: a session referenced by a non-terminal workflow run rejects user
+prompts at the runtime session service layer.** This is engine-enforced, not
+a UI convention the run view happens to apply.
+
+Mechanism: a new `WorkflowHeld { run_id }` variant on `SendPromptError`
+(`domains/sessions/runtime/mod.rs`), mapped in `api/http/sessions_errors.rs`
+to `409` with wire code `SESSION_WORKFLOW_HELD` — the file's
+non-exhaustive-match convention forces the mapping to be written, not
+skipped. The same variant pattern gates `SetSessionConfigOptionError` and
+`ForkSessionError`, so a held session can't be prompted, reconfigured, or
+forked out from under the run that's driving it.
+
+Guard implementation: a workflows-store query,
+`is_session_held_by_active_run(session_id)`. The run row IS the lock —
+non-terminal status holds, terminal status releases; there is no separate
+lock state to leak or sweep. `human.approval` is explicitly unaffected:
+approvals resolve via the run API, never the session handle.
+
+Test obligations: Rust tier-1 store/service reject-then-release (insert an
+active run holding the session → prompt rejected → mark the run terminal →
+prompt accepted), plus the wire-code mapping assertion; tier-2 flow-registry
+row (composer locked while the run is active → run completes → composer
+unlocked).
 
 ---
 
@@ -630,10 +884,18 @@ The workflow beat ticks every 15s
 - Loop wrapper: exponential backoff ×2 cap 300s, Sentry after 3 consecutive
   failures.
 
-PR A adds **phase 3** (observer refresh + effect sweeper, §3.3). PR B adds the
-poll loop *into the same beat* — a third gathered coroutine, same
-backoff/Sentry pattern, so operationally there is still exactly one worker
-process to run and monitor.
+PR A adds **phase 3** (observer refresh + action sweeper, §3.3 — renamed
+from "effect sweeper" per L19) — originally designed as the primary way an
+unwatched cloud run gets observed. **Amended 2026-07-07 (§3.7): phase 3 is now
+the backstop behind the per-run completion ping, not the primary mechanism.**
+The ping fires after every step transition, so in steady state phase 3's
+refresh sweep is redundant with it; phase 3 only earns its keep when a ping is
+lost, delayed, or races the runtime's own state write — the same "backstop
+cadence, not the load-bearing path" role the action sweeper already plays for
+actions. PR B adds the poll
+loop *into the same beat* — a third gathered coroutine, same backoff/Sentry
+pattern, so operationally there is still exactly one worker process to run
+and monitor.
 
 ### 4.2 The poll contract (LOCKED — restated verbatim from issue-autofix-system-v1 §2, not re-derived)
 
@@ -767,9 +1029,9 @@ and it is why no ack callback exists anywhere.
 |---|---|---|
 | schedule triggers | **cloud only** | `_validate_trigger_target_mode` rejects local at create (`schedule_local_unsupported`) — no server→desktop claim protocol exists |
 | poll triggers (B) | **cloud only** | same machinery, same reason; inherits the restriction |
-| effect observer via scheduler phase 3 (A) | cloud runs | local runs are observed by the desktop relay (app-open-only) |
-| Slack notify effect (A) | **both** — the effect runs on the *server*, fed by either lane's observed state | local lane caveat: app closed ⇒ report delayed ⇒ send delayed (not lost) |
-| gateway dotfile (`integration-gateway.json`) | **cloud only** | written solely by `proliferate-worker` at enroll ([integration_gateway.rs:21-45](../anyharness/crates/proliferate-worker/src/integration_gateway.rs)); nothing in the desktop lane writes it (verified — see OPEN-5) |
+| action observer via scheduler phase 3 (A) | cloud runs | local runs are observed by the desktop relay (app-open-only); renamed from "effect observer" per L19 |
+| Slack notify action (A) | **both** — the action runs on the *server*, fed by either lane's observed state | local lane caveat: app closed ⇒ report delayed ⇒ send delayed (not lost); renamed from "Slack notify effect" per L19 |
+| gateway dotfile (`integration-gateway.json`) | **cloud only** | written solely by `proliferate-worker` at enroll ([integration_gateway.rs:21-45](../anyharness/crates/proliferate-worker/src/integration_gateway.rs)); nothing in the desktop lane writes it (verified — see §5.3/OPEN-5; builder obligation added there per pass-2 research: surface this loudly as an explicit error, not silence, even while local support stays deferred) |
 | manual + chat-triggered runs | both | client-initiated; the desktop delivers locally itself |
 
 ### 5.2 [OPEN-4] Poll-trigger run target — RULED (a) (Pablo, 2026-07-07)
@@ -815,7 +1077,10 @@ latency on a 50-item burst ≈ 50 × 3 min ≈ 2.5h for the tail — acceptable 
 triage (5-min poll cadence already sets the latency floor, and the fix
 workflow's deeper runs are fewer). Recommendation: **(a) for v1**, with (c)'s
 door left open in the trigger schema. Tradeoff: (a)'s single workspace means
-poll-fired runs share a tree — same dirt concern as OPEN-7; the triage/fix
+poll-fired runs share a tree — the same dirt concern that composition-by-nesting
+now inherits by construction, since L20 (§3.5) puts an inlined workflow B in
+the *same* sandbox and session context as A, tighter than the old
+inherit-the-parent's-workspace OPEN-7 ruling it superseded; the triage/fix
 workflows mitigate by starting fresh sessions and not depending on tree state,
 but a customer workflow that edits code in a pinned workspace must handle its
 own hygiene (`shell.run` git-clean step, or declare fresh-tree-needed — a v2
@@ -849,6 +1114,34 @@ trigger. If (a), the gap must be loud in the UI, not discovered at runtime.
 Note: if OPEN-3 resolves to per-run tokens *in the plan*, local parity gets
 dramatically cheaper (the token rides the payload; no dotfile, no enrollment)
 — worth weighing the two rulings together.
+
+**Builder obligation, pass-2 research, recorded 2026-07-07 (second of the two
+pre-existing defects found during that pass):** the "zero gateway tools,
+silently" fact stated above is not just a v1 scoping gap, it's a silent
+failure mode today. Full local support stays deferred per this ruling, but
+the runtime/executor must, at minimum, raise an **explicit error** the moment
+a local run's plan declares `functions` scope it cannot honor — never let it
+pass through as a no-op the way the dotfile-absent case does today. This is
+independent of, and ships ahead of, whatever local parity work (b) would
+require.
+
+### 5.4 Amendment (Pablo, 2026-07-07 — L26): sandbox "purpose" is a stamped enum, not inferred
+
+**Ruling: `CloudSandbox` gains a first-class `purpose` column — `interactive`
+vs. `workflow-run` — set once at creation time and never inferred from caller
+context.** This is the same reasoning that rejected "trust the caller's
+header" for run identity everywhere else in this system (OPEN-3's tradeoff
+paragraph, §6.4, made the identical call for gateway grants: a credential or a
+stamped fact proves identity/purpose, a header or inferred context only
+claims it). A sandbox's purpose is knowable with certainty at the moment it is
+created — who asked for it and why — so there is no reason to fall back to
+inference later, and every reason not to: an inferred purpose is a claim a
+caller could get wrong or, in a prompt-injection scenario, a claim an agent
+could exploit. Consequence for L25 (§6.7): the worker-level scope allowlist
+(`cloud_integration_gateway_token.scope_json`) can eventually key off
+`purpose` too, once there's a reason to give `workflow-run` sandboxes a
+different default worker-level allowlist than `interactive` ones — not built
+in A–E, noted so the enum isn't designed twice.
 
 ---
 
@@ -884,6 +1177,12 @@ gateway, period.** The runtime's only involvement is the already-shipped launch
 extension that points sessions at the gateway URL; per-workflow scoping is
 gateway *configuration*, enforced at call time.
 
+**Amendment (Pablo, 2026-07-07 — L21):** the issues service, registered here,
+and Slack (already-shipped, §3.3) are **the only two integrations exposed at
+launch** — both `api_key`-style with no mid-run OAuth-refresh failure mode.
+OAuth-DCR providers are named but deliberately deferred; see §6.6 for the
+reauth-story reasoning.
+
 ### 6.2 How a tool call flows today (LOCKED — shipped)
 
 ```
@@ -916,6 +1215,27 @@ only *sees* granted tools — least astonishment) and `tools/call` (defense in
 depth). Scoping example from the mission (LOCKED — issues-service-v1 §5):
 triage workflow → `claim, get_issue, search_issues, update_status,
 mark_duplicate, mark_dismissed`; fix workflow → all tools.
+
+**Amendment (Pablo, 2026-07-07 — L22, exposition mechanism):** `functions[]`
+is a **declared allow-list** on `definition_json`, validated at **save time**
+against the owner's visible integration definitions (the same check §1.5
+already describes: provider = a registered namespace visible to the owner,
+tools = non-empty strings) and **resolved at `StartRun`**. This is not a
+static registry (the set of exposable providers can grow without a code
+change once a definition is registered, §6.1) and not runtime discovery (the
+agent never asks the gateway what's available and gets handed a grant back —
+the grant is fixed before the sandbox exists). **`StartRun` fails the run**
+outright if a declared provider has no ready account for the owner — it never
+silently narrows the grant to whatever happens to be ready, because a
+silently-narrowed grant is a workflow that appears to work while quietly
+doing less than its author specified.
+
+**Amendment (Pablo, 2026-07-07 — L24, no kind taxonomy):** there is no
+workflow "kind" (triage vs. fix vs. anything else) that pre-sizes a scope
+template. Each definition's `functions[]` independently sizes its own grant —
+the triage/fix split in the example above is just two definitions that
+happen to declare different lists, not two instances of a "triage-kind" and
+"fix-kind" that the system distinguishes.
 
 ### 6.4 [OPEN-3] The scoping key — RULED (a) (Pablo, 2026-07-07)
 
@@ -995,6 +1315,93 @@ service's `events` with the calling run's identity. These are the issues
 service's obligations; Proliferate's obligation is delivering trustworthy run
 identity (OPEN-3) and scoping (§6.3).
 
+### 6.6 Amendment (Pablo, 2026-07-07): `function.call` — recorded as a follow-up, not built
+
+**Ruling: a future step kind, `function.call`, is recorded here for
+traceability. It is not designed and not built in A–E.** The shape, stated so
+it isn't lost: the harness emits schema-valid arguments via the existing
+`agent.emit` machinery (§7.3); the **server** performs the integration call
+through the actions ledger (§1.2 — renamed from "effects ledger" per L19) —
+`action_kind = 'function_call'`, exactly-once claim CAS, authorized by the
+per-run token's scope (§6.4).
+
+This is compatible with L9: there are no harness-level forced tool calls; the
+harness only writes JSON, the server acts on it — `function.call` is a second
+consumer of the emit channel, not an exception to "no forced tool calls."
+
+Explicit compatibility requirement on PR E, stated here so it isn't
+rediscovered later: **the per-run token's `scope_json` must be honored for
+server-side action performers, not only sandbox-originated calls** — the
+gateway checks scope, not caller location. If PR E's implementation of §6.4
+ever assumes the caller is always an agent inside the sandbox, that
+assumption breaks the day `function.call` is built.
+
+The design content this section deferred — which integrations are exposed,
+the exposition method, forcing rules, per-workflow-kind differences — came
+back from the function-invocations and integration-scoping design passes
+(`codex/passes/pass-2-function-invocations.md`,
+`codex/passes/pass-5-integration-scoping.md`) and was ruled 2026-07-07, L21–L26:
+
+**L21 — first exposed integrations (Pablo, 2026-07-07):** the **issues
+service** (`api_key` seed, §6.1) and **Slack** — both `api_key`-style, both
+with no mid-run OAuth-refresh failure mode; Slack's credential path is
+already exercised by the `slack_notify` performer, and the issues service is
+the driving mission. **OAuth-DCR providers (Linear, Notion, Supabase) are
+deferred** until the frozen per-run scope (§6.4/OPEN-3(a): scope frozen at
+mint, expires at terminal status) has a mid-run reauth story — a frozen scope
+and a token that can go stale mid-run are in tension the moment refresh is
+involved, and that tension isn't resolved yet.
+
+**L23 — forcing rules (Pablo, 2026-07-07):** **never force at the agent
+level** — L9 stands unchanged. Agent-judgment calls are normal MCP tool use,
+gated by scope visibility (the agent only *sees* what §6.3/L22's allow-list
+grants, per the existing `tools/list` filtering). **Forced calls** are a
+`function_call` server-performed action (§1.2/L19's vocabulary: this is a
+step's own declared verb, not a reaction) claimed off an `agent.emit` step's
+validated output — the provider+tool is **step config, fixed at author time**;
+only the *arguments* come from the agent's emitted JSON. **The emitted JSON
+must never name the tool to call** — naming the tool would let agent output
+decide what executes, which is exactly the sequencing property Rule 2/Rule 3
+(L19) reserve for the runtime and for author-time step config, never for
+agent output.
+
+Design content still open when `function.call` is actually built: the
+guarantee-class question (§1.2 flagged that the pre-generated-id trick that
+gave spawns true exactly-once no longer has an analogue here) and the
+concrete `_STEP_PARSERS`/`StepKind` wiring. Not ruled here; next pass.
+
+### 6.7 Amendment (Pablo, 2026-07-07 — L25): two-layer scope composition
+
+**Ruling: scope is enforced in two layers — a coarse worker-level allowlist,
+and the fine per-run token (§6.4/OPEN-3) as a subset of it — with both layers
+re-checked, not just the outer one trusted once.**
+
+**Layer 1 — sandbox/worker-level scope.** An additive, nullable `scope_json`
+column on the existing `cloud_integration_gateway_token` row
+([runtime_workers.py:109-138](../server/proliferate/db/models/cloud/runtime_workers.py)):
+a **provider-namespace allowlist**. `NULL` means unscoped — today's behavior,
+unchanged — and is never conflated with "empty" (empty would mean "grants
+nothing"; NULL means "the allowlist concept doesn't apply to this worker").
+**No backfill**: existing workers keep working exactly as they do today until
+they naturally re-enroll and pick up a `scope_json` value.
+
+**Layer 2 — the per-run token.** Its `scope_json` (the `functions[]` shape
+per §6.4/OPEN-3(a)) **must be a subset of the worker's scope** — enforced as a
+set intersection **at mint time**, i.e. at `StartRun`.
+
+**Enforcement is asymmetric across the two layers, deliberately:** mint time
+decides what *may* be requested (the intersection above); request time
+**re-checks on every call**, mirroring the existing per-request org-membership
+re-validation pattern already in the gateway (§6.2's `_call_virtual_tool`
+path) — a worker-level scope narrowed *after* a run's token was minted must
+still bite on the next call, not only at mint time.
+
+**Admin UX:** extend the existing `CloudIntegrationPolicy` table with a
+nullable scope key, rather than stand up a parallel table — the same
+LOCKED/shipped pattern (§6.1: "no new registration machinery") applies to
+scope administration too: reuse the row that already carries org policy for
+a provider, don't duplicate it.
+
 ---
 
 ## 7. Typed I/O
@@ -1071,11 +1478,15 @@ run_emit(step, ctx):
 
 The validated object becomes the step's *entire* output, so
 `{{steps[n].output.pr_title}}` navigates into it with the existing dot-path
-resolution — zero new grammar. This is what makes notify messages, chained
-`workflow.run` args, and the autofix Slack ping ("issue, evidence, who's
-affected, PR link") all expressible today-shaped. A workflow's "completion
-event with schema" is, by construction, its last `agent.emit` — no separate
-concept exists.
+resolution — zero new grammar. This is what makes notify messages and the
+autofix Slack ping ("issue, evidence, who's affected, PR link") expressible
+today-shaped. (It also feeds the composing step's arg mapping under L20's
+nesting ruling, §3.5 — that mapping is exactly this same dot-path resolution,
+just consumed by the resolver at composition time instead of by a runtime
+step; the old wording here named `workflow.run` args specifically, which no
+longer exists as a runtime-visible concept.) A workflow's "completion event
+with schema" is, by construction, its last `agent.emit` — no separate concept
+exists.
 
 ### 7.4 [OPEN-2] The emit mechanism — RULED (a) (Pablo, 2026-07-07)
 
@@ -1119,7 +1530,9 @@ mirror, and autocomplete (~a day inside PR C, where the grammar files are
 already open) and makes definitions durable under editing — the template/FDE
 motion writes definitions that get edited by others; (b) is free now but every
 reorder is a landmine and editor-rewrite has its own edge cases (refs inside
-`workflow.run` args). Recommendation: **(a), inside PR C.**
+a composing step's arg mapping — the concern that used to be phrased as
+"`workflow.run` args" before L20 redirected composition to resolution-time
+inlining, §3.5). Recommendation: **(a), inside PR C.**
 
 ---
 
@@ -1141,10 +1554,10 @@ Open-session deep link, local-lane approve/deny), playground fixtures. Routes:
 
 | PR | surface |
 |---|---|
-| A | notify step panel: Slack channel picker (new `GET /v1/cloud/workflows/slack/channels` wrapping [client.py:115 list_channels](../server/proliferate/integrations/slack/client.py)); `slackConnected` flag → "Connect Slack in Settings → Integrations" caption when absent; run-view delivery chip fed by the effect row (sent ✓ / pending / failed + reason) |
+| A | notify step panel: Slack channel picker (new `GET /v1/cloud/workflows/slack/channels` wrapping [client.py:115 list_channels](../server/proliferate/integrations/slack/client.py)); `slackConnected` flag → "Connect Slack in Settings → Integrations" caption when absent; run-view delivery chip fed by the action row (sent ✓ / pending / failed + reason) — renamed from "effect row" per L19 |
 | B | triggers card: poll config form (url, auth header name+secret, interval, item schema, args mapping with per-arg path fields); trigger row surfaces `last_poll_error` + per-item table (spawned/invalid) linked from the trigger |
 | C | emit step editor: prompt + schema editor (JSON textarea with validation, template chips for common shapes); run-view output chip renders the emitted object (collapsed JSON) |
-| D | step panel: workflow picker (owner's non-archived workflows) + args editor with `{{steps…}}` autocomplete; run view: "Spawned run →" link on the step row, "Started by <parent> step N ↗" banner on the child |
+| D | ~~step panel: workflow picker (owner's non-archived workflows) + args editor with `{{steps…}}` autocomplete; run view: "Spawned run →" link on the step row, "Started by <parent> step N ↗" banner on the child~~ — **SUPERSEDED by L20** (§9): no child run, no "Spawned run →" link, no parent/child banner. Whatever UI composition needs (an inline-reference picker into a nested workflow's steps?) is undesigned. |
 | E | editor: Functions section (provider + tool multi-select from the gateway's tool cache); local-launch caption per OPEN-5 |
 
 ### 8.3 Concept-doc intents → disposition ([OPEN-8] — RULED (a), Pablo 2026-07-07)
@@ -1178,8 +1591,9 @@ is the intent inventory that design pass expands from:
 mocking stuff we don't have")
 
 Every chip/line in the run view renders from real observed data (`output_json`,
-effect rows). No invented intermediate states. `goal_iterating` stays the only
-client-derived status (from real cursor + goal-armed fact).
+action rows — renamed from "effect rows" per L19). No invented intermediate
+states. `goal_iterating` stays the only client-derived status (from real
+cursor + goal-armed fact).
 
 ---
 
@@ -1198,12 +1612,23 @@ client-derived status (from real cursor + goal-armed fact).
 | L7 | Poll contract: at-least-once, opaque cursor, id idempotency, schema-validated data, no queue-pop | issue-autofix-system-v1 §2; Pablo ruling 2026-07-06 |
 | L8 | Functions = MCP tools through the integrations gateway; **no session-level MCP injection concept, ever**; per-workflow scoping is gateway config | issue-autofix-system-v1 §3; Pablo rulings 2026-07-06 (×2) |
 | L9 | No forced tool calls; `agent.emit` (schema-validated) is the typed output channel; completion event = last emit | Pablo ruling 2026-07-06 |
-| L10 | Parallel lanes deferred; chaining = fire-and-forget `workflow.run` via server-observed spawn; no await-child v1; **no mid-run plan mutation ever** | Pablo ruling 2026-07-06 |
+| L10 | Parallel lanes deferred; ~~chaining = fire-and-forget `workflow.run` via server-observed spawn~~ **SUPERSEDED by L20** — composition is resolution-time nesting, not a runtime-observed spawn (§3.5); no await-child v1 (survives); **no mid-run plan mutation ever** (survives, and is strengthened by L20 — inlining happens entirely before delivery) | Pablo ruling 2026-07-06; superseded in part 2026-07-07 (L20) |
 | L11 | Flaky-test handling out of v1 entirely; unresolvable test failures → `needs-human` | issue-autofix-system-v1 §5.3/§8 |
 | L12 | Slack notify delivery graduates to required (critical path); server-observed delivery, runtime never blocks on it | Pablo ruling 2026-07-06 (amendment) |
 | L13 | Build order A→B→C→D→E; PR A holds until #921 lands; docs updated in the same PR as code | Pablo rulings 2026-07-06 |
 | L14 | Run view renders only real observed data (no mocked states) | Pablo, UI gallery round 2 |
 | L15 | Schedule (and by inheritance poll) triggers are cloud-only until a server→desktop claim protocol exists | shipped `_validate_trigger_target_mode` |
+| L16 | Completion ping is the run-report credential: every run mints a per-run gateway token at delivery (empty `scope_json` legal); runtime fires `POST /runs/{run_id}/ping` after each `apply_decision` transition (fire-and-forget, failure inert); server validates token↔run_id match and re-runs `_sync_run_from_view`; scheduler phase 3 demotes to backstop | Pablo amendment, 2026-07-07 (§3.7, §4.1) |
+| L17 | Session lockout is an engine invariant: a non-terminal workflow run holds its session at the runtime session-service layer (`WorkflowHeld` on `SendPromptError`/`SetSessionConfigOptionError`/`ForkSessionError` → 409 `SESSION_WORKFLOW_HELD`); the run row IS the lock, no separate lock state; `human.approval` unaffected | Pablo amendment, 2026-07-07 (§3.8) |
+| L18 | `function.call` step kind recorded as a follow-up, not built: harness emits via `agent.emit`, server performs the integration call through the actions ledger (`action_kind='function_call'`, exactly-once claim CAS, scoped by the per-run token); compatible with L9; scope enforcement applies to server-side performers too, not only sandbox callers; design deferred to the function-invocations pass — that pass's rulings landed 2026-07-07 as L21–L26 | Pablo amendment, 2026-07-07 (§6.6); ledger vocabulary renamed same day, L19 |
+| L19 | Sequencing invariants, four rules: (1) one workflow = one plan JSON, delivered whole at StartRun, server observes only after handoff; (2) the runtime owns sequencing with no exceptions — server-side machinery (ping §3.7, scheduler refresh §4.1) is read-only observation; (3) server-performed **actions**, not "effects" — renamed vocabulary (table `workflow_step_effect`→`workflow_step_action`, column `effect_kind`→`action_kind`, module `effects.py`→`actions.py`, full prose sweep); an action is a step's own author-time-declared verb, never a decider of what runs next; ledger contents: `slack_notify` now, `function_call` later (L18/L23), nothing else — `spawn_child_run` dropped outright; (4) composition is nesting, not spawning — see L20 | Pablo ruling, 2026-07-07 (§1.2, §3.1, §3.3) |
+| L20 | Composition is nesting, not spawning: using workflow B inside A inlines B's steps into A's single resolved plan at StartRun, server-side, before delivery — one run, one plan, one cursor, one sandbox; no child run, no parent linkage, no `spawn_child_run` action, no cross-sandbox fan-out in v1. Save-time validation gains a cycle/depth check (A includes B includes A fails at save). Two resolver obligations: (a) arg binding — composing step's arg mapping becomes the inlined steps' interpolation context; (b) step-ref namespacing — B's internal refs must not collide with A's. **SUPERSEDES** the `workflow.run` fire-and-forget chaining design (PR D, old §3.5), the `spawn_child_run` action kind, and the child-run-provenance ruling (old §3.6/OPEN-7). A future start-a-run-from-a-run case needs a new explicit ruling that clears Rule 3 (L19) — not a default. **PR D must be redirected before it lands.** | Pablo ruling, 2026-07-07 (§3.5, §9) |
+| L21 | First exposed integrations: the issues service (`api_key` seed) + Slack — both `api_key`-style, no mid-run OAuth-refresh failure mode. OAuth-DCR providers (Linear, Notion, Supabase) deferred until the frozen per-run scope has a mid-run reauth story | Pablo ruling, 2026-07-07, function-invocations pass (§6.1, §6.6) |
+| L22 | Exposition mechanism: a declared `functions[]` allow-list on `definition_json`, validated at save time against the owner's visible integration definitions, resolved at StartRun. Not a static registry, not runtime discovery. StartRun **fails the run** if a declared provider has no ready account, rather than silently narrowing | Pablo ruling, 2026-07-07, function-invocations pass (§6.3) |
+| L23 | Forcing rules: never force at the agent level (L9 stands) — agent-judgment calls are normal MCP tool use gated by scope visibility. Forced calls are a `function_call` server-performed action claimed off an `agent.emit` step's validated output; provider+tool is step config fixed at author time, only arguments come from agent output; the emitted JSON must never name the tool to call | Pablo ruling, 2026-07-07, function-invocations pass (§6.6) |
+| L24 | No workflow "kind" taxonomy — scope lives entirely on the definition; each `definition_json.functions[]` independently sizes its own grant | Pablo ruling, 2026-07-07, function-invocations pass (§6.3) |
+| L25 | Two-layer scope composition: sandbox/worker-level scope is a provider-namespace allowlist (additive nullable `scope_json` on `cloud_integration_gateway_token`; NULL = unscoped/today's behavior, never "empty"; no backfill). The per-run token's `scope_json` must be a subset of the worker's scope, enforced as set intersection at mint time (StartRun). Enforcement is asymmetric: mint time decides what may be requested, request time re-checks every call. Admin UX extends `CloudIntegrationPolicy` with a nullable scope key, not a parallel table | Pablo ruling, 2026-07-07, integration-scoping pass (§6.7) |
+| L26 | Sandbox "purpose" is a first-class stamped enum column on `CloudSandbox` (`interactive` vs. `workflow-run`), set at creation, never inferred from caller context — same reasoning that rejected trust-the-header run identity in OPEN-3 | Pablo ruling, 2026-07-07, integration-scoping pass (§5.4) |
 
 ### OPEN — all ruled by Pablo, 2026-07-07
 
@@ -1215,7 +1640,7 @@ client-derived status (from real cursor + goal-armed fact).
 | OPEN-4 | Poll-trigger run target (§5.2) | (a) pinned cloud workspace per trigger + queue (schedule-trigger shape reused) · (b) fresh headless workspace per item · (c) configurable, (a) default | **(a)** pinned workspace + queue, (c)'s door open in schema; fix workflow opens with a git-hygiene step; throughput ceiling noted — revisit at volume |
 | OPEN-5 | Local-lane gateway functions (§5.3) | (a) cloud-only v1, loud UI caption · (b) local parity (dotfile/token on laptop) | **(a)** cloud-only v1; loud caption at definition save AND local launch |
 | OPEN-6 | Named step-output refs (§7.5) | (a) optional step `name` + `{{steps.<name>.output.*}}`, inside PR C · (b) index-only, editor rewrites on reorder | **(a)** named refs inside PR C; `output_name` deprecated into `name` |
-| OPEN-7 | Child-run provenance (§3.6) | trigger_kind: (a) new `'workflow'` · (b) reuse `'agent'`; workspace: inherit parent's (rec.); executor = owner (stated) | **(a)** new `'workflow'` trigger_kind; inherit parent workspace; executor = owner |
+| OPEN-7 | Child-run provenance (§3.6) — **SUPERSEDED by L20**: there is no child run left to have provenance | trigger_kind: (a) new `'workflow'` · (b) reuse `'agent'`; workspace: inherit parent's (rec.); executor = owner (stated) | ~~**(a)** new `'workflow'` trigger_kind; inherit parent workspace; executor = owner~~ — moot under L20, kept for provenance only |
 | OPEN-8 | UX-surface sequencing (§8.3): new-chat recommended strip, in-chat trigger modal, tab-grouped run sessions, session input-lockout during runs, seeded org templates, seeded workspaces | (a) separate UX PR F after E · (b) fold selected items into A–E · (c) later | **(a)** separate UX PR F after E — full bundle incl. Stop/cancel (+ server-side cancel endpoint) and NEW seeded-workspaces item; F gated on its own engine-depth design doc |
 
 ---
@@ -1232,7 +1657,7 @@ requires it). Server unit suites ride each PR
 (`cd server && uv run --extra dev pytest tests/unit/test_workflow_*.py -q`);
 these scripts are the *behavioral* pass on top.
 
-### PR A — effects ledger + Slack
+### PR A — actions ledger + Slack (renamed from "effects ledger" per L19)
 
 1. Settings → Integrations → connect Slack (real OAuth against the seeded
    `slack` definition; needs `CLOUD_MCP_SLACK_*` env in the profile).
@@ -1240,16 +1665,22 @@ these scripts are the *behavioral* pass on top.
    the panel should list real channels; pick a test channel. Run (local lane).
 3. **Expect:** message in the channel within ~5s of the step completing; run
    view shows the delivery chip `sent ✓`; exactly one
-   `workflow_step_effect` row (`status='done'`, `result_json.message_ts` set).
+   `workflow_step_action` row (`status='done'`, `result_json.message_ts` set).
 4. **Crash drill:** re-run; the moment the prompt step completes, `kill -9` the
    server (`make run` supervisor restarts it, or restart manually). **Expect:**
    after restart the sweeper (scheduler phase 3) delivers; the channel shows
-   **exactly one** message for that run; effect row `attempt_count ≥ 1`.
+   **exactly one** message for that run; action row `attempt_count ≥ 1`.
 5. **Replay drill:** POST the same `/status` body twice (curl, bearer from
    login). **Expect:** second call is a no-op (CAS conflict), no second send.
 6. Cloud lane: same workflow on a schedule trigger, one-shot RRULE, **close the
    run view** (nobody polls `/refresh`). **Expect:** message still arrives —
    phase 3 observed the run without a UI.
+7. **Org-policy drill (covers the §3.3 defect fix):** as an org member whose
+   org has Slack policy-disabled but who personally has a ready Slack
+   account, run the workflow inside that org. **Expect:** the send is blocked
+   by org policy — proving `_perform_slack_notify` now passes the run's
+   `organization_id` into `get_ready_account_for_provider` instead of
+   silently bypassing it.
 
 ### PR B — poll trigger
 
@@ -1298,9 +1729,17 @@ def poll(request: Request, cursor: str = "", limit: int = 50):
    (`attempt` field), then step `failed` with code `emit_invalid` and the
    validation errors in the output — no infinite loop, no fabricated pass.
 
-### PR D — workflow.run
+### PR D — ~~workflow.run~~ — SUPERSEDED by L20 (§9); script kept for provenance, not runnable against the ruled design
 
-1. Child workflow `W2`: arg `title:string`, one prompt step. Parent `W1`:
+**This script validates the fire-and-forget chaining design L20 replaces.**
+It is not runnable against the nesting-composition ruling (§3.5) because
+there is no child run, no `workflow.run` step, and no `spawn_child_run`
+action to exercise. A replacement script belongs to whatever PR builds
+composition-by-inlining, once that design exists beyond the resolver
+obligations named in §3.5. Kept below verbatim so the old guarantees being
+given up are visible.
+
+~~1. Child workflow `W2`: arg `title:string`, one prompt step. Parent `W1`:
    `agent.emit` (emits `{"title": ...}`) → `workflow.run(W2, args:{title:"{{steps[0].output.title}}"})`.
 2. Run `W1`. **Expect:** `W1` completes immediately after the spawn step
    (fire-and-forget); a `W2` run appears with the interpolated arg, linked both
@@ -1311,7 +1750,7 @@ def poll(request: Request, cursor: str = "", limit: int = 50):
    child id makes the retry conflict).
 4. **Cycle drill:** point a workflow at itself → validator rejects; build an
    A→B→A indirect loop → chain stops at depth 5 with
-   `chain_depth_exceeded` on the effect row.
+   `chain_depth_exceeded` on the effect row.~~
 
 ### PR E — function grants
 
@@ -1338,8 +1777,10 @@ a fix workflow (wide set) whose last steps are `agent.emit` → `notify(slack)`.
 the service's `events`; duplicate poll deliveries produce zero duplicate runs;
 Slack pings arrive with emitted fields filled in; every state transition in the
 service was made through gateway tool calls attributable to a run. That
-demonstration — poll + functions + emit + chaining + Slack, on the real
-contracts — is the definition of done for this arc.
+demonstration — poll + functions + emit + Slack, on the real contracts — is
+the definition of done for this arc. (The original list here also said
+"chaining" — dropped: PR D as scoped for this demo doesn't exist under L20,
+and nothing in this acceptance test depends on workflow composition.)
 
 ---
 

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -6,7 +6,7 @@
 > are relative to this file (`codex/`).
 >
 > Companion: [`workflows-architecture.md`](workflows-architecture.md) is the
-> **end-state** doc for the PR A–E arc (effects ledger + Slack delivery, poll
+> **end-state** doc for the PR A–E arc (actions ledger + Slack delivery, poll
 > triggers, `agent.emit`, `workflow.run`, gateway function grants) — read it for
 > where the system is going and the [OPEN-n] decision log; read this for what is
 > built today.
@@ -180,16 +180,17 @@ File tree:
 
 ```
 server/proliferate/
-├── db/models/cloud/workflows.py        # ORM: Workflow, WorkflowVersion, WorkflowRun, WorkflowTrigger
-├── db/store/cloud_workflows.py         # async data-access for workflow/version/run
+├── db/models/cloud/workflows.py        # ORM: Workflow, WorkflowVersion, WorkflowRun, WorkflowTrigger, WorkflowStepAction
+├── db/store/cloud_workflows.py         # async data-access for workflow/version/run/step-action
 ├── db/store/cloud_workflow_triggers.py # trigger store incl. claim_due_schedule_trigger (FOR UPDATE SKIP LOCKED)
 ├── constants/workflows.py              # status enums, transition table, step-kind set, caps, free-plan limit
 └── alembic/versions/
     ├── e4f7a2b9c6d1_workflow_entities.py   # workflow + version + run tables (down_rev c9b8a7d6e5f4)
-    └── b2d4f6a8c0e1_workflow_trigger.py    # workflow_trigger + trigger_id/scheduled_for on run (down_rev e4f7a2b9c6d1)
+    ├── b2d4f6a8c0e1_workflow_trigger.py    # workflow_trigger + trigger_id/scheduled_for on run (down_rev e4f7a2b9c6d1)
+    └── c3a5e7f9d1b2_workflow_step_action.py # workflow_step_action table (down_rev b2d4f6a8c0e1) — PR A
 ```
 
-Both migrations are idempotent (guarded `_has_table`/`_has_index`/`_has_column`).
+All three migrations are idempotent (guarded `_has_table`/`_has_index`/`_has_column`).
 
 **Tables** ([db/models/cloud/workflows.py](../server/proliferate/db/models/cloud/workflows.py)):
 
@@ -232,6 +233,17 @@ Index("uq_workflow_run_trigger_slot", "trigger_id", "scheduled_for", unique=True
   a cloud⇒workspace / local⇒null constraint (line 225), and `ck_workflow_trigger_schedule_fields`
   (line 231 — a `schedule` must carry rrule + timezone + next_run_at). Scheduler
   due-scan index `ix_workflow_trigger_scheduler_due` (line 242).
+- **`workflow_step_action`** (line 299, PR A) — the step-actions ledger: server-side
+  actions (Slack sends today) claimed off *observed* step completions. An action
+  performs the side effect of a step the runtime already executed; it never decides
+  what runs next (L19). `UniqueConstraint(run_id, step_key, action_kind)` (B5)
+  **is** the claim — whichever observer's `INSERT ... ON CONFLICT DO NOTHING` lands
+  owns performing the action. `status` CHECK `pending|done|failed` (line 324); partial
+  index `ix_workflow_step_action_sweep … WHERE status = 'pending'` (line 328) drives
+  the sweeper. Honest guarantee (stated in the model docstring): **exactly-once
+  claim, at-least-once completion** — a crash between a successful Slack POST and
+  the `status='done'` commit can duplicate a send, the same class as any
+  non-transactional external side effect.
 
 ### 2b. Run status enum + transition table
 
@@ -261,8 +273,12 @@ has no outgoing edges.
 - `workflow_runs(run_id PK, …, workspace_id NOT NULL REFERENCES workspaces ON DELETE
   CASCADE, plan_json NOT NULL, status NOT NULL, step_cursor DEFAULT 0, session_ids_json?,
   …)` + indexes on `(workspace_id, created_at DESC)` and `(status)`.
-- `workflow_step_runs(run_id FK CASCADE, step_index, kind, status, attempt DEFAULT 0,
-  output_json?, error_code?, error_message?, …, PRIMARY KEY(run_id, step_index))`.
+- `workflow_step_runs(run_id FK CASCADE, step_index, step_key NOT NULL, kind, status,
+  attempt DEFAULT 0, output_json?, …, PRIMARY KEY(run_id, step_index))` + a unique
+  index on `(run_id, step_key)`. `step_key` is the format-v2 structured key
+  "<node>.<lane>.<step>" (B5); the cursor stays an integer position, but the key
+  is the step's stable identity (outputs are reported by key). The Postgres
+  `workflow_step_action` claim is `(run_id, step_key, action_kind)`.
 
 Rust status mirrors ([model.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/model.rs)):
 `WorkflowRunStatus = Running|WaitingApproval|Completed|Failed|Cancelled` (terminal:
@@ -281,7 +297,8 @@ cloud/workflows/
 ├── models.py       # Pydantic request/response (populate_by_name, camelCase wire aliases)
 ├── service.py      # workflow/version CRUD, trigger CRUD, StartRun + _resolve_plan
 ├── delivery.py     # cloud lane: deliver_cloud_run, refresh_cloud_run
-├── scheduler.py    # second beat: fire due triggers + deliver eligible cloud runs
+├── scheduler.py    # second beat: fire due triggers + deliver eligible cloud runs + refresh/sweep (PR A phase 3)
+├── actions.py      # PR A: step-actions ledger — claim_step_action, apply_step_actions, sweep_pending_actions
 └── domain/         # pure, unit-tested, no DB
     ├── definition.py     # strict validator: raw dict → canonical dict
     ├── interpolation.py  # template grammar + arg coercion + injection guard
@@ -294,29 +311,43 @@ Integration boundary (raw HTTP to anyharness, kept out of the product domain):
 
 ### 3.1 Validator — [domain/definition.py](../server/proliferate/server/cloud/workflows/domain/definition.py)
 
-`parse_definition(raw, *, require_steps=True)` (line 443) → `(canonical, [ArgSpec])`.
-Rejects unknown kinds *and* unknown fields (`_reject_unknown_keys`, line 61).
-Top-level keys: `args`, `setup`, `steps`. Steps dispatched by `kind` through
-`_STEP_PARSERS` (line 376). **Zero-step draft rule**: `require_steps=False` on
-create/update (save-but-don't-run); `StartRun` always parses with `require_steps=True`.
-`_parse_goal` (line 241) parses the goal *attachment*; `_parse_agent_config` (line 288)
-requires ≥1 of harness/model. `_validate_references` (line 431) runs
-`validate_string_references` — `{{args.NAME}}` must be a declared arg; `{{steps[N].output.NAME}}`
-must point strictly earlier.
+**Format v2 (PR A — data-contract §1).** `parse_definition(raw, *,
+require_steps=True)` → `(canonical, [ArgSpec])`. Rejects unknown kinds *and*
+unknown fields. Top-level keys are now `{version, name?, description?, inputs,
+integrations, agents}` — a hard cut from the old `{args, setup, steps}` (no dual
+parser, no migration; E4). The spine is `agents: [{slot, harness, model, steps}]`
+(≥1 node, slot unique `^[a-z][a-z0-9_]*$`); there is no top-level `steps` and no
+`setup` (slot = session affinity; `session_binding` is stamped on the resolved
+plan, not authored). **Zero-agent draft rule**: `require_steps=False` on
+create/update; `StartRun` always parses with `require_steps=True`.
 
-**No `agent.goal` step kind** — the goal is an attachment on `agent.prompt`
-(drift note #1). Supported kinds ([constants/workflows.py:120](../server/proliferate/constants/workflows.py#L120)):
-`agent.config`, `agent.prompt`, `shell.run`, `scm.open_pr`, `notify`, `human.approval`.
+Step kinds ([constants/workflows.py](../server/proliferate/constants/workflows.py)):
+`agent.config` (narrowed to `{model}` only — same-harness rule), `agent.prompt`
+(+`required_invocation?{provider,tool}`), **`agent.emit`** (NEW: `name` required +
+unique, `output_schema?`, `max_attempts` default 3), `shell.run`, `scm.open_pr`,
+**`branch`** (NEW: `on` = one prior-emit ref, `cases:{value:{to:continue|end}}`,
+`reason?`), `notify` (Slack-only — `{slack_channel_id, message}`, the `channel`
+discriminator and `in_app` are removed, E1b). **`human.approval` is removed (E1)**
+— the `waiting_approval` run status survives via `goal.on_blocked`.
+
+`_validate_spine_references` walks the flattened run order enforcing emit-name
+uniqueness (whole definition) and *strictly-prior* ref visibility: `{{inputs.NAME}}`
+must be a declared input; `{{EMIT.FIELD}}` must name an emit produced by an
+earlier step (earlier nodes in full, earlier steps in the same node).
 
 ### 3.2 Interpolation — [domain/interpolation.py](../server/proliferate/server/cloud/workflows/domain/interpolation.py)
 
-- `coerce_arguments` (line 188) — strict (rejects unknown args), fills defaults,
-  enforces required, coerces to declared type.
-- `interpolate_args` (line 251) — eager `{{args.*}}` substitution, **segment-based
-  (never re-scanned)**; `_escape_braces` (line 219) backslash-escapes every `{`/`}`
-  in a substituted value so an arg literally containing `{{steps[0].output.x}}` can't
-  survive as a live step-output token. The runtime unescapes in
-  [templates.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs).
+Stored grammar is `{{inputs.<name>}}` + `{{<emit>.<field>}}` (B6). Reserved
+first-segments: `inputs`, `steps`, `fields`.
+
+- `coerce_arguments` (unchanged machinery) — strict (rejects unknown inputs),
+  fills defaults, enforces required, coerces to declared type (text|number|
+  choice|boolean, E2).
+- `resolve_string` / `resolve_value` — the resolver's single pass: eager
+  `{{inputs.*}}` substitution (segment-based; `_escape_braces` backslash-escapes
+  `{`/`}` so an input value can't inject a live token) **and** rewrites
+  `{{<emit>.<field>}}` → `{{steps[n].output.<field>}}` using the emit→flat-index
+  map. templates.rs stays on the indexed grammar (unchanged) and unescapes.
 
 ### 3.3 Service — [service.py](../server/proliferate/server/cloud/workflows/service.py)
 
@@ -330,20 +361,26 @@ pre-generated so it is inside the payload before insert.
 ```python
 return {
     "run_id": str(run_id),
+    "plan_version": 1,
     "workflow_id": str(workflow_id),
     "workflow_version_id": str(version.id),
     "version_n": version.version_n,
     "trigger_kind": trigger_kind,
     "target_mode": target_mode,
-    "setup": canonical.get("setup", {}),            # {harness, model, session_binding}
-    "args": coerced_args,                            # eager values, verbatim
-    "steps": interpolate_args(canonical["steps"], coerced_args),  # {{args.*}} baked; {{steps[n].*}} late-bound
+    "sessions": {slot: {harness, model, session_binding, bind_session_id?}},  # per-slot
+    "inputs": coerced_inputs,                        # eager values, verbatim
+    "steps": [...],  # flattened spine; each step stamped key="<node>.-.<step>", slot, label;
+                     # {{inputs.*}} baked, {{emit.field}} rewritten to {{steps[n].output.field}}
 }
 ```
-<sub>[service.py:262-272](../server/proliferate/server/cloud/workflows/service.py#L262)</sub>
+`session_binding` defaults by trigger kind (manual/chat=fresh, schedule/poll=headless).
+StartRun wire (B9): `args`→`inputs`, `target` = `workspace_id` XOR `trigger_id`,
+optional `session_bindings:{slot:session_id}`.
 
-Also here: `report_run_status` (locks run, enforces `check_transition`, stamps
-started/finished, writes cursor/outputs/session ids/cost), `mark_run_delivered`
+Also here: `report_run_status` (line 434; locks run, enforces `check_transition`,
+stamps started/finished, writes cursor/outputs/session ids/cost, then — after the
+status write commits — calls `actions.apply_step_actions` in a try/except so an
+action failure never breaks status ingestion, line 475), `mark_run_delivered`
 (idempotent), owner-scoped `list_runs`/`get_run`, and trigger CRUD. **Local schedule
 triggers are rejected at create** (`_validate_trigger_target_mode` →
 `schedule_local_unsupported`) — there's no server→desktop claim protocol.
@@ -357,34 +394,53 @@ wake the sandbox in-request). No outbox/Celery.
   `ensure_cloud_sandbox_gateway_access`, POSTs `/v1/workflow-runs {plan, workspaceId}`
   (expects 202) → `mark_run_delivered`. Any error → `_record_delivery_failure`
   (line 65; `error_code='delivery_failed'`, status stays `pending_delivery` for retry).
-- `refresh_cloud_run` (line 214) — the UI's cloud poll path. `read_workflow_run`
-  (GET through gateway) → `_parse_sandbox_run_view` (line 136, camelCase) →
-  `_sync_run_from_view` (line 166): a **lenient reconciling read** that applies the
+- `refresh_cloud_run` (line 225) — the UI's cloud poll path (also called
+  unattended by scheduler phase 3, §3.5 below). `read_workflow_run`
+  (GET through gateway) → `_parse_sandbox_run_view` (line 139, camelCase) →
+  `_sync_run_from_view` (line 169): a **lenient reconciling read** that applies the
   observed snapshot but **skips the strict transition guard**, yet refuses to
   overwrite a run the server already considers terminal. A 404 leaves the ledger
-  untouched.
+  untouched. After the write commits it also calls `actions.apply_step_actions`
+  (line 216, try/except-isolated, PR A) — the poll-driven twin of the
+  `report_run_status` hook, so an unattended cloud run without a live UI tab still
+  gets its Slack actions performed via scheduler phase 3.
 
 ### 3.5 Scheduler — [scheduler.py](../server/proliferate/server/cloud/workflows/scheduler.py)
 
 A second beat beside the automations scheduler, launched in
 [automations/worker/main.py](../server/proliferate/server/automations/worker/main.py)
 `_amain` via `asyncio.gather(run_scheduler_loop(...), run_workflow_scheduler_loop(...))`
-(lines 50–57). Two phases per tick:
+(lines 50–57). Three phases per tick:
 
-- **Phase 1 — fire due triggers.** `_fire_due_triggers` (line 180) →
-  `_fire_one_trigger` (line 96): `claim_due_schedule_trigger` (`FOR UPDATE SKIP LOCKED`,
+- **Phase 1 — fire due triggers.** `_fire_due_triggers` (line 181) →
+  `_fire_one_trigger` (line 97): `claim_due_schedule_trigger` (`FOR UPDATE SKIP LOCKED`,
   [cloud_workflow_triggers.py:235](../server/proliferate/db/store/cloud_workflow_triggers.py#L235))
   → archived-workflow guard → concurrency (`skip` drops + records reason + advances
   cursor; `queue` always creates) → `start_run` wrapped in `db.begin_nested()` so a
   StartRun error rolls back just the run insert.
-- **Phase 2 — deliver eligible cloud runs.** `_deliver_pending_runs` (line 220) →
-  `_deliver_one_run` (line 200): delivers **only the FIFO-first non-terminal run per
+- **Phase 2 — deliver eligible cloud runs.** `_deliver_pending_runs` (line 221) →
+  `_deliver_one_run` (line 201): delivers **only the FIFO-first non-terminal run per
   trigger** (`earliest_non_terminal_run_id_for_trigger`,
   [cloud_workflows.py:435](../server/proliferate/db/store/cloud_workflows.py#L435)) —
   one rule expresses both the immediate case and `queue` deferral. Capped per tick
   (each wakes a sandbox).
+- **Phase 3 — refresh in-flight + sweep actions** (line 245, PR A). Added so
+  Slack actions still fire for a triggered cloud run with nobody watching the run
+  view (the UI's own `/refresh` poll is what drives `apply_step_actions` the rest
+  of the time). `_refresh_in_flight_runs` (line 245) →
+  `store.list_in_flight_triggered_cloud_runs`
+  ([cloud_workflows.py:561](../server/proliferate/db/store/cloud_workflows.py#L561);
+  `delivered|running|waiting_approval`, target_mode=personal_cloud, trigger_id not
+  null) capped at
+  `_MAX_REFRESHES_PER_TICK=10` and filtered to `delivered_before=tick_start` (skips
+  a run this same tick just delivered — it needs time to execute before a refresh
+  is useful) → `refresh_cloud_run` per run, which reconciles the ledger and calls
+  `apply_step_actions`. `_sweep_actions` (line 269) → `actions.sweep_pending_actions`.
+  Both sub-phases are exception-isolated from Phase 1/2 and from each other
+  (`run_workflow_scheduler_tick`, line 288–295) — an actions bug never stalls
+  trigger firing or delivery.
 
-`run_workflow_scheduler_loop` (line 254): exponential backoff (×2, cap 300s), Sentry
+`run_workflow_scheduler_loop` (line 300): exponential backoff (×2, cap 300s), Sentry
 after 3 consecutive failures.
 
 ### 3.6 API — [api.py](../server/proliferate/server/cloud/workflows/api.py)
@@ -400,11 +456,13 @@ after 3 consecutive failures.
 |---|---|---|
 | GET | `/workflows?includeArchived` | list |
 | POST | `/workflows` | create (enforces free-plan cap) |
-| GET | `/workflows/runs?workflowId` · `/workflows/runs/{run_id}` | run reads |
+| GET | `/workflows/runs?workflowId` | run list |
+| GET | `/workflows/runs/{run_id}` | run detail — `WorkflowRunDetailResponse{run, stepActions[]}` (PR A; `step_actions` from `store.list_actions_for_run`) |
 | POST | `/workflows/runs/{run_id}/delivered` | **local** lane marks its delivery done |
-| POST | `/workflows/runs/{run_id}/status` | **local relay** reports observed state |
+| POST | `/workflows/runs/{run_id}/status` | **local relay** reports observed state; also triggers `apply_step_actions` |
 | POST | `/workflows/runs/{run_id}/deliver` | **cloud** lane retry of stuck `pending_delivery` |
-| GET | `/workflows/runs/{run_id}/refresh` | **cloud** lane pull; syncs ledger |
+| GET | `/workflows/runs/{run_id}/refresh` | **cloud** lane pull; syncs ledger; also triggers `apply_step_actions` |
+| GET | `/workflows/slack/channels` | PR A — `{channels:[{id,name}], connected}`; `connected:false` + empty list when the actor has no ready Slack account ([integrations accounts store](../server/proliferate/db/store/integrations/accounts.py)) |
 | GET/PATCH/DELETE | `/workflows/{workflow_id}` | detail / update (append version) / archive |
 | POST | `/workflows/{workflow_id}/runs` | **StartRun**; personal_cloud also calls `deliver_cloud_run` in-request |
 | GET/POST · GET/PATCH/DELETE | `/workflows/{workflow_id}/triggers[/{trigger_id}]` | trigger CRUD |
@@ -455,30 +513,42 @@ deserialize error.
 
 ```rust
 #[serde(tag = "kind")]
-pub enum StepKind {
+pub enum StepKind {   // format v2 — human.approval removed (E1), agent.emit + branch added
     #[serde(rename = "agent.config")]  AgentConfig(AgentConfigStep),
     #[serde(rename = "agent.prompt")]  AgentPrompt(AgentPromptStep),
+    #[serde(rename = "agent.emit")]    AgentEmit(AgentEmitStep),
     #[serde(rename = "shell.run")]     ShellRun(ShellRunStep),
     #[serde(rename = "scm.open_pr")]   ScmOpenPr(ScmOpenPrStep),
-    #[serde(rename = "notify")]        Notify(NotifyStep),
-    #[serde(rename = "human.approval")]HumanApproval(HumanApprovalStep),
+    #[serde(rename = "notify")]        Notify(NotifyStep),      // {slack_channel_id, message}
+    #[serde(rename = "branch")]        Branch(BranchStep),      // {on, cases:{v:{to}}, reason?}
 }
 
-pub struct AgentPromptStep { pub prompt: String, #[serde(default)] pub goal: Option<GoalSpec> }
-pub struct AgentConfigStep { pub harness: Option<String>, pub model: Option<String> }  // ≥1 present
-pub struct GoalSpec {
-    pub objective: String, pub max_turns: u32, pub max_wall_secs: u64,
-    pub token_budget: Option<i64>, pub on_blocked: OnBlocked, pub verify: Option<VerifySpec>,
-}
-pub enum OnBlocked { Notify, PauseForApproval, Fail }        // default Notify
-pub struct VerifySpec { pub shell: String, pub expect_exit: i32 }
+// PlanStep now carries key/slot/label; ResolvedPlan.setup is gone — replaced by
+// sessions:{slot -> SessionSpec{harness, model?, session_binding, bind_session_id?}}.
+// ResolvedPlan::setup() derives a single PlanSetup for the current (pre-multi-slot)
+// executor (TODO phase C/F: make the executor slot-keyed).
+pub struct PlanStep { pub key: String, pub slot: String, pub label: String, pub on_fail: OnFail, /* flatten */ kind }
+pub struct AgentPromptStep { pub prompt: String, pub goal: Option<GoalSpec>, pub required_invocation: Option<RequiredInvocation> }
+pub struct AgentEmitStep { pub prompt: String, pub max_attempts: u32 /*default 3*/, pub output_schema: Option<Value> }
+pub struct AgentConfigStep { pub harness: Option<String> /*deprecated; server emits model only*/, pub model: Option<String> }
+pub enum BranchTarget { Continue, End }
 pub enum SessionBinding { Fresh, Headless }
 ```
-<sub>[plan.rs:84-160](../anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs#L84)</sub>
+<sub>[plan.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs)</sub>
+
+The runtime **executor** carries the v2 plan types but its per-kind *behavior* is
+unchanged in this pass: `agent.emit` and `branch` return a `not_implemented`
+failure (execution lands in phase C/F, C11/C12); `notify` is Slack-only.
 
 `PlanStep { on_fail: OnFail, #[serde(flatten)] kind: StepKind }`; `OnFail { kind:
 OnFailKind(Stop|Retry|Continue), n: u32 }`; `ResolvedPlan { run_id, …, setup: PlanSetup,
 args, steps: Vec<PlanStep> }` (line 21).
+
+`NotifyStep` (line 183, PR A) gained `#[serde(default)] pub slack_channel_id:
+Option<String>` — old plans without the field still deserialize (defaults to
+`None`); [templates.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs)
+`resolve_step` (line 140) carries it through late-binding untouched (it's never a
+template target).
 
 ### 4.2 Engine — pure on-fail decision ([engine.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/engine.rs))
 
@@ -564,8 +634,10 @@ workflow_owned_sessions.
 | `agent.prompt` (goal) | `run_goal` :250 | arm → await → verify → terminal (see [§1b](#1b-step-execution-for-agentprompt--goal-arm--await--verify--terminal)) |
 | `shell.run` | [commands.rs](../anyharness/crates/anyharness-lib/src/live/workflows/commands.rs) `run_shell_step` | `/bin/sh -lc` in workspace, scrubbed env, 8 KiB tail, default 600s |
 | `scm.open_pr` | `open_pr_step` | `git push` + `gh pr create`; missing gh → `scm_unavailable` |
-| `notify` | `notify_step` | never a hard failure; Slack → `slack_unavailable` |
-| `human.approval` | `human_approval` (executor) | returns `AwaitApproval`; manager arms timeout timer |
+| `agent.emit` | — (phase C/F) | v2 kind; execution (re-ask loop, C12) not yet built — returns `not_implemented` for now |
+| `notify` | [commands.rs](../anyharness/crates/anyharness-lib/src/live/workflows/commands.rs) `notify_step` | Slack-only (E1b); never a hard failure; the runtime emits `{channel:"slack", message, slack_channel_id}`, the server-side effect claims from it |
+| `branch` | — (phase C/F) | v2 kind; continue/end arm (C11) not yet built — returns `not_implemented` for now |
+| ~~`human.approval`~~ | removed (E1) | step kind deleted; the `waiting_approval` status survives via `goal.on_blocked` |
 
 **output_json vocabulary per kind** (consumed by the run view + `{{steps[N].output}}`):
 
@@ -576,8 +648,7 @@ workflow_owned_sessions.
 | agent.prompt (goal) | `session_id`, `met_reason?`, `verified?`, `verify_attempts?`; while running `{goal:{objective,status,iterations,tokens_used}, session_id}` |
 | shell.run | `output_tail`, `exit_code`, `output_name?` |
 | scm.open_pr | `pr_url` |
-| notify | `channel`, `message` |
-| human.approval | descriptor `{kind:"human_approval", message, on_timeout, timeout_secs, deadline_at}`; on resolve `{approved, …}` |
+| notify | `channel:"slack"`, `message`, `slack_channel_id` — what the server's step-actions observer keys off (claim key is `(run_id, step_key, action_kind)`) |
 | goal block (await) | `{kind:"goal_block", session_id, message}` |
 
 **Live goal-progress snapshots.** `run_goal`'s `on_progress` closure fires on every
@@ -752,19 +823,26 @@ product-domain/src/workflows/
 
 **TS `WorkflowDefinition`** ([definition.ts:166](../apps/packages/product-domain/src/workflows/definition.ts#L166)):
 
+Format v2 (PR A) — the model mirrors the server spine. Refs use `{{inputs.*}}`
++ `{{emit.field}}`; the three grammar/kind files (definition.ts, validation.ts,
+interpolation.ts) are cut to v2. **Follow-up:** the desktop editor components and
+the sibling product-domain modules (model.ts, presentation.ts, effective-config.ts,
+templates.ts, workflows.test.ts) still reference the v1 shape and are migrated in
+the editor phase — the built dist does not compile until then.
+
 ```ts
-export interface WorkflowDefinition { args: WorkflowArgSpec[]; setup: WorkflowSetup; steps: WorkflowStep[] }
-export interface WorkflowSetup { harness: string; model: string; sessionBinding: WorkflowSessionBinding }
-export interface WorkflowGoal {
-  objective: string; maxTurns: number; maxWallSecs: number;
-  tokenBudget?: number; onBlocked: WorkflowGoalOnBlocked; verify?: WorkflowGoalVerify;
+export interface WorkflowDefinition {
+  version: 1; name?: string; description?: string;
+  inputs: WorkflowInputSpec[]; integrations: string[]; agents: WorkflowAgentNode[];
 }
-export interface AgentPromptStep extends StepBase { kind: "agent.prompt"; prompt: string; goal?: WorkflowGoal }
-export interface AgentConfigStep extends StepBase { kind: "agent.config"; harness?: string; model?: string }
+export interface WorkflowAgentNode { slot: string; harness: string; model: string; steps: WorkflowStep[] }
+export interface AgentEmitStep extends StepBase { kind: "agent.emit"; prompt: string; name: string; outputSchema?; maxAttempts? }
+export interface NotifyStep extends StepBase { kind: "notify"; slackChannelId: string; message: string }
+export interface BranchStep extends StepBase { kind: "branch"; on: string; cases: Record<string,{to:"continue"|"end"}>; reason? }
 export type WorkflowStep =
-  | AgentPromptStep | AgentConfigStep | ShellRunStep | ScmOpenPrStep | NotifyStep | HumanApprovalStep;
+  | AgentPromptStep | AgentEmitStep | AgentConfigStep | ShellRunStep | ScmOpenPrStep | NotifyStep | BranchStep;
 ```
-<sub>[definition.ts:80-170](../apps/packages/product-domain/src/workflows/definition.ts#L80)</sub>
+<sub>[definition.ts](../apps/packages/product-domain/src/workflows/definition.ts)</sub>
 
 `parseWorkflowDefinition` is lenient (never throws, drops malformed steps — the
 server validated on write); `serializeWorkflowDefinition` is its snake_case inverse.
@@ -839,7 +917,11 @@ editor/run UI of its own (drift note #7).
   a new session at the next agent step. (`plan.rs::AgentConfigStep`, `run_agent_config`.)
 - **Hidden run sessions.** Workflow-run sessions don't appear in the normal session
   list; their home is the run view's "Open session" deep link.
-- **Notify in-app floor.** `notify` is never a hard failure; Slack is a later integration.
+- **Notify in-app floor.** `notify` is never a hard failure. Slack delivery (PR A)
+  is a server-side action claimed off the observed output, not a runtime concern —
+  the runtime's job stops at emitting `{channel:"slack", message, slack_channel_id}`;
+  the send itself, retries, and idempotency live in the step-actions ledger
+  ([§2a](#2a-postgres-control-plane), [§3](#3-server-layer-control-plane)).
 
 ---
 
@@ -855,7 +937,11 @@ editor/run UI of its own (drift note #7).
 7. **No workflow-`scope` column, no Automation→trigger migration** — web `/workflows` still routes to automations.
 8. **No server-side cancel/pause endpoint** — cancel is a runtime endpoint only.
 9. **`goal_iterating` and `cancelled` are client-only step statuses** (runtime `WorkflowStepStatus` lacks them).
-10. **Notify/Slack + scm/gh are stubs** (`slack_unavailable` / `scm_unavailable`).
+10. ~~**Notify/Slack + scm/gh are stubs** (`slack_unavailable` / `scm_unavailable`).~~
+    **Slack resolved by PR A** (this tree): `notify`+slack now performs a real send
+    via the server-side step-actions ledger ([§2a](#2a-postgres-control-plane),
+    [§3](#3-server-layer-control-plane)); `scm.open_pr`'s `scm_unavailable` (missing
+    `gh`) is still a stub — unchanged.
 
 **Gaps / sequencing:**
 - **Sidecar pin bump (release blocker).** GoalPort/LoopPort ride the forked

--- a/server/alembic/versions/c3a5e7f9d1b2_workflow_step_action.py
+++ b/server/alembic/versions/c3a5e7f9d1b2_workflow_step_action.py
@@ -1,0 +1,82 @@
+"""workflow_step_action table
+
+Revision ID: c3a5e7f9d1b2
+Revises: b2d4f6a8c0e1
+Create Date: 2026-07-07 00:00:00.000000
+
+Adds the step-actions ledger (PR A): server-observed step completions claim a
+side effect exactly once via (run_id, step_key, action_kind) unique constraint.
+The claim key is the structured step key "<node>.<lane>.<step>" (format v2, B5),
+not a bare integer index.
+A sweeper retries stale pending actions and transient failed actions; the
+partial index on updated_at WHERE status IN ('pending', 'failed') powers that
+scan.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3a5e7f9d1b2"
+down_revision: str | Sequence[str] | None = "b2d4f6a8c0e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _has_table("workflow_step_action"):
+        op.create_table(
+            "workflow_step_action",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("run_id", sa.Uuid(), nullable=False),
+            sa.Column("step_key", sa.String(length=64), nullable=False),
+            sa.Column("action_kind", sa.String(length=32), nullable=False),
+            sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+            sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("result_json", JSONB(), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.UniqueConstraint(
+                "run_id", "step_key", "action_kind",
+                name="uq_workflow_step_action_claim",
+            ),
+            sa.CheckConstraint(
+                "action_kind IN ('slack_notify')",
+                name="ck_workflow_step_action_kind",
+            ),
+            sa.CheckConstraint(
+                "status IN ('pending', 'done', 'failed')",
+                name="ck_workflow_step_action_status",
+            ),
+            sa.ForeignKeyConstraint(["run_id"], ["workflow_run.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _has_index("workflow_step_action", "ix_workflow_step_action_sweep"):
+        op.create_index(
+            "ix_workflow_step_action_sweep",
+            "workflow_step_action",
+            ["updated_at"],
+            postgresql_where=sa.text("status IN ('pending', 'failed')"),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("workflow_step_action"):
+        if _has_index("workflow_step_action", "ix_workflow_step_action_sweep"):
+            op.drop_index("ix_workflow_step_action_sweep", table_name="workflow_step_action")
+        op.drop_table("workflow_step_action")

--- a/server/proliferate/constants/workflows.py
+++ b/server/proliferate/constants/workflows.py
@@ -110,22 +110,36 @@ WORKFLOW_RUN_OBSERVABLE_STATUSES: Final = frozenset(
     }
 )
 
-# --- Step kinds (spec 3.3). ----------------------------------------------------
+# --- Step kinds (definition format v2; data-contract §1.2). --------------------
+# human.approval is REMOVED (E1); agent.emit and branch are NEW (A3/C11). The
+# waiting_approval run status survives via goal.on_blocked, not a step kind.
 WORKFLOW_STEP_AGENT_CONFIG: Final = "agent.config"
 WORKFLOW_STEP_AGENT_PROMPT: Final = "agent.prompt"
+WORKFLOW_STEP_AGENT_EMIT: Final = "agent.emit"
 WORKFLOW_STEP_SHELL_RUN: Final = "shell.run"
 WORKFLOW_STEP_SCM_OPEN_PR: Final = "scm.open_pr"
 WORKFLOW_STEP_NOTIFY: Final = "notify"
-WORKFLOW_STEP_HUMAN_APPROVAL: Final = "human.approval"
+WORKFLOW_STEP_BRANCH: Final = "branch"
 SUPPORTED_WORKFLOW_STEP_KINDS: Final = frozenset(
     {
         WORKFLOW_STEP_AGENT_CONFIG,
         WORKFLOW_STEP_AGENT_PROMPT,
+        WORKFLOW_STEP_AGENT_EMIT,
         WORKFLOW_STEP_SHELL_RUN,
         WORKFLOW_STEP_SCM_OPEN_PR,
         WORKFLOW_STEP_NOTIFY,
-        WORKFLOW_STEP_HUMAN_APPROVAL,
+        WORKFLOW_STEP_BRANCH,
     }
+)
+
+# Default emit re-ask budget (executor MAX_EMIT_ATTEMPTS; overridable per emit).
+WORKFLOW_EMIT_DEFAULT_MAX_ATTEMPTS: Final = 3
+
+# --- branch targets (data-contract §1.2 / C11: narrowed to continue|end). ------
+WORKFLOW_BRANCH_TARGET_CONTINUE: Final = "continue"
+WORKFLOW_BRANCH_TARGET_END: Final = "end"
+SUPPORTED_WORKFLOW_BRANCH_TARGETS: Final = frozenset(
+    {WORKFLOW_BRANCH_TARGET_CONTINUE, WORKFLOW_BRANCH_TARGET_END}
 )
 
 # --- Per-step on_fail policy (spec 3.3). ---------------------------------------
@@ -148,35 +162,36 @@ SUPPORTED_WORKFLOW_GOAL_ON_BLOCKED: Final = frozenset(
     }
 )
 
-# --- notify channels (spec 3.3: Slack v1, in-app is the floor). ----------------
-WORKFLOW_NOTIFY_CHANNEL_IN_APP: Final = "in_app"
+# --- notify: Slack-only (E1b). No channel discriminator; template-only v1. -----
+# Retained slug for the server-side slack_notify action kind.
 WORKFLOW_NOTIFY_CHANNEL_SLACK: Final = "slack"
-SUPPORTED_WORKFLOW_NOTIFY_CHANNELS: Final = frozenset(
-    {WORKFLOW_NOTIFY_CHANNEL_IN_APP, WORKFLOW_NOTIFY_CHANNEL_SLACK}
-)
 
-# --- human.approval on_timeout (spec 3.3). -------------------------------------
-WORKFLOW_APPROVAL_ON_TIMEOUT_FAIL: Final = "fail"
-WORKFLOW_APPROVAL_ON_TIMEOUT_CONTINUE: Final = "continue"
-SUPPORTED_WORKFLOW_APPROVAL_ON_TIMEOUT: Final = frozenset(
-    {WORKFLOW_APPROVAL_ON_TIMEOUT_FAIL, WORKFLOW_APPROVAL_ON_TIMEOUT_CONTINUE}
-)
-
-# --- Workflow-level args schema (spec 3.3 / 3.6 Setup). ------------------------
-WORKFLOW_ARG_TYPE_STRING: Final = "string"
-WORKFLOW_ARG_TYPE_NUMBER: Final = "number"
-WORKFLOW_ARG_TYPE_BOOLEAN: Final = "boolean"
-WORKFLOW_ARG_TYPE_ENUM: Final = "enum"
-SUPPORTED_WORKFLOW_ARG_TYPES: Final = frozenset(
+# --- Input types (data-contract §1 / E2). text|number|choice|boolean. ----------
+# string->text, enum->choice; the coercion machinery is unchanged.
+WORKFLOW_INPUT_TYPE_TEXT: Final = "text"
+WORKFLOW_INPUT_TYPE_NUMBER: Final = "number"
+WORKFLOW_INPUT_TYPE_CHOICE: Final = "choice"
+WORKFLOW_INPUT_TYPE_BOOLEAN: Final = "boolean"
+SUPPORTED_WORKFLOW_INPUT_TYPES: Final = frozenset(
     {
-        WORKFLOW_ARG_TYPE_STRING,
-        WORKFLOW_ARG_TYPE_NUMBER,
-        WORKFLOW_ARG_TYPE_BOOLEAN,
-        WORKFLOW_ARG_TYPE_ENUM,
+        WORKFLOW_INPUT_TYPE_TEXT,
+        WORKFLOW_INPUT_TYPE_NUMBER,
+        WORKFLOW_INPUT_TYPE_CHOICE,
+        WORKFLOW_INPUT_TYPE_BOOLEAN,
     }
 )
 
-# --- setup.session_binding (spec 3.3). -----------------------------------------
+# --- slot / agent-node grammar (data-contract §1.1 / A4). ----------------------
+WORKFLOW_MAX_AGENTS: Final = 20
+
+# --- reserved reference first-segments (data-contract §1.3 / B6). --------------
+# `inputs` = eager run inputs; `steps` = the runtime's rewritten indexed target;
+# `fields` = reserved for the notify agent-filled follow-up. None may be an emit
+# name (emit names share the ref namespace).
+WORKFLOW_RESERVED_REF_SEGMENTS: Final = frozenset({"inputs", "steps", "fields"})
+
+# --- session_binding: defaulted per-slot in the resolved plan by trigger kind
+# (manual/chat=fresh, schedule/poll=headless); no longer an authored field. -----
 WORKFLOW_SESSION_BINDING_FRESH: Final = "fresh"
 WORKFLOW_SESSION_BINDING_HEADLESS: Final = "headless"
 SUPPORTED_WORKFLOW_SESSION_BINDINGS: Final = frozenset(

--- a/server/proliferate/db/models/cloud/workflows.py
+++ b/server/proliferate/db/models/cloud/workflows.py
@@ -294,3 +294,63 @@ class WorkflowTrigger(Base):
         default=utcnow,
         onupdate=utcnow,
     )
+
+
+class WorkflowStepAction(Base):
+    """Server-side actions claimed off observed step completions.
+
+    An action performs the side effect of a step the runtime already executed;
+    it never decides or causes what executes next (L19).
+
+    The (run_id, step_key, action_kind) unique constraint IS the claim: the
+    transaction that inserts the row owns the action. status walks
+    pending -> done | failed; a sweeper retries stale 'pending' rows (an owner
+    that crashed before performing) and transient 'failed' rows (below the
+    attempt cap).
+
+    Honest guarantee: the ledger gives *exactly-once claim*. Action execution is
+    *at-least-once completion* via the sweeper. A crash inside the action window
+    (after the Slack POST succeeded, before status='done' committed) can
+    duplicate a send -- the same guarantee class as every non-transactional
+    external side effect.
+    """
+
+    __tablename__ = "workflow_step_action"
+    __table_args__ = (
+        UniqueConstraint(
+            "run_id", "step_key", "action_kind",
+            name="uq_workflow_step_action_claim",
+        ),
+        CheckConstraint(
+            "action_kind IN ('slack_notify')",
+            name="ck_workflow_step_action_kind",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'done', 'failed')",
+            name="ck_workflow_step_action_status",
+        ),
+        Index(
+            "ix_workflow_step_action_sweep",
+            "updated_at",
+            postgresql_where=text("status IN ('pending', 'failed')"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("workflow_run.id", ondelete="CASCADE"),
+    )
+    # B5 (D2): the structured step key "<node>.<lane>.<step>" — the step's stable
+    # identity across the format (bare integer indices are gone).
+    step_key: Mapped[str] = mapped_column(String(64))
+    action_kind: Mapped[str] = mapped_column(String(32))
+    status: Mapped[str] = mapped_column(String(16), default="pending")
+    attempt_count: Mapped[int] = mapped_column(Integer, default=0)
+    result_json: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/cloud_workflows.py
+++ b/server/proliferate/db/store/cloud_workflows.py
@@ -16,7 +16,12 @@ from proliferate.constants.workflows import (
     WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
     WORKFLOW_TRIGGER_SCHEDULE,
 )
-from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+from proliferate.db.models.cloud.workflows import (
+    Workflow,
+    WorkflowRun,
+    WorkflowStepAction,
+    WorkflowVersion,
+)
 from proliferate.utils.time import utcnow
 
 
@@ -477,4 +482,103 @@ async def list_pending_scheduled_cloud_runs(
         .scalars()
         .all()
     )
+    return tuple(_run_record(row) for row in rows)
+
+
+# --- step actions (PR A) ---------------------------------------------------------
+
+_IN_FLIGHT_STATUSES = ("delivered", "running", "waiting_approval")
+
+
+@dataclass(frozen=True)
+class StepActionRecord:
+    id: UUID
+    run_id: UUID
+    step_key: str
+    action_kind: str
+    status: str
+    attempt_count: int
+    result_json: dict[str, object] | None
+    error_message: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _action_record(row: WorkflowStepAction) -> StepActionRecord:
+    return StepActionRecord(
+        id=row.id,
+        run_id=row.run_id,
+        step_key=row.step_key,
+        action_kind=row.action_kind,
+        status=row.status,
+        attempt_count=row.attempt_count,
+        result_json=dict(row.result_json) if row.result_json else None,
+        error_message=row.error_message,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def list_retryable_actions(
+    db: AsyncSession, *, before: datetime, max_attempts: int, limit: int = 50
+) -> tuple[StepActionRecord, ...]:
+    """Pending or transiently-failed actions older than ``before`` and still
+    under ``max_attempts`` (the sweep scan). Covers both a crashed owner
+    (stale 'pending') and a transient failure (e.g. Slack API error, 'failed')."""
+    rows = (
+        (
+            await db.execute(
+                select(WorkflowStepAction)
+                .where(
+                    WorkflowStepAction.status.in_(("pending", "failed")),
+                    WorkflowStepAction.attempt_count < max_attempts,
+                    WorkflowStepAction.updated_at < before,
+                )
+                .order_by(WorkflowStepAction.updated_at.asc())
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_action_record(row) for row in rows)
+
+
+async def list_actions_for_run(
+    db: AsyncSession, *, run_id: UUID
+) -> tuple[StepActionRecord, ...]:
+    rows = (
+        (
+            await db.execute(
+                select(WorkflowStepAction)
+                .where(WorkflowStepAction.run_id == run_id)
+                .order_by(WorkflowStepAction.step_key.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return tuple(_action_record(row) for row in rows)
+
+
+async def list_in_flight_triggered_cloud_runs(
+    db: AsyncSession, *, limit: int, delivered_before: datetime | None = None
+) -> tuple[WorkflowRunRecord, ...]:
+    """In-flight cloud runs originated by triggers (scheduled/polled) for phase-3 refresh.
+
+    ``delivered_before`` excludes runs delivered after the given timestamp (skip
+    runs just delivered this tick -- they need time to execute).
+    """
+    stmt = (
+        select(WorkflowRun)
+        .where(
+            WorkflowRun.status.in_(_IN_FLIGHT_STATUSES),
+            WorkflowRun.target_mode == WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
+            WorkflowRun.trigger_id.is_not(None),
+        )
+    )
+    if delivered_before is not None:
+        stmt = stmt.where(WorkflowRun.delivered_at < delivered_before)
+    stmt = stmt.order_by(WorkflowRun.updated_at.asc()).limit(max(1, limit))
+    rows = (await db.execute(stmt)).scalars().all()
     return tuple(_run_record(row) for row in rows)

--- a/server/proliferate/db/store/integrations/accounts.py
+++ b/server/proliferate/db/store/integrations/accounts.py
@@ -10,12 +10,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.cloud.integrations import (
     CloudIntegrationAccount,
     CloudIntegrationDefinition,
+    CloudIntegrationPolicy,
 )
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.utils.time import utcnow
@@ -132,24 +133,47 @@ async def get_ready_account_for_provider(
     db: AsyncSession,
     user_id: UUID,
     namespace: str,
+    *,
+    organization_id: UUID | None = None,
 ) -> tuple[IntegrationAccountRecord, definitions_store.IntegrationDefinitionRecord] | None:
-    """The user's enabled, ready account whose non-archived definition matches ``namespace``."""
+    """The user's enabled, ready account whose non-archived definition matches ``namespace``.
+
+    When ``organization_id`` is given the org's integration policy is enforced:
+    an account is excluded when the org has disabled that definition (a policy
+    row with ``enabled = false``, or no policy row and the definition is not
+    ``enabled_by_default``). Callers with a real org context must pass it so a
+    personally-connected account cannot bypass an org's disable decision.
+    """
+    stmt = (
+        select(CloudIntegrationAccount, CloudIntegrationDefinition)
+        .join(
+            CloudIntegrationDefinition,
+            CloudIntegrationDefinition.id == CloudIntegrationAccount.definition_id,
+        )
+        .where(
+            CloudIntegrationAccount.owner_user_id == user_id,
+            CloudIntegrationAccount.enabled.is_(True),
+            CloudIntegrationAccount.status == "ready",
+            CloudIntegrationDefinition.namespace == namespace,
+            CloudIntegrationDefinition.archived_at.is_(None),
+        )
+    )
+    if organization_id is not None:
+        # LEFT JOIN the org's policy row for this definition; enabled state is the
+        # policy's when present, else the definition's default. Disabled => excluded.
+        stmt = stmt.outerjoin(
+            CloudIntegrationPolicy,
+            (CloudIntegrationPolicy.definition_id == CloudIntegrationDefinition.id)
+            & (CloudIntegrationPolicy.organization_id == organization_id),
+        ).where(
+            func.coalesce(
+                CloudIntegrationPolicy.enabled,
+                CloudIntegrationDefinition.enabled_by_default,
+            ).is_(True)
+        )
     row = (
         await db.execute(
-            select(CloudIntegrationAccount, CloudIntegrationDefinition)
-            .join(
-                CloudIntegrationDefinition,
-                CloudIntegrationDefinition.id == CloudIntegrationAccount.definition_id,
-            )
-            .where(
-                CloudIntegrationAccount.owner_user_id == user_id,
-                CloudIntegrationAccount.enabled.is_(True),
-                CloudIntegrationAccount.status == "ready",
-                CloudIntegrationDefinition.namespace == namespace,
-                CloudIntegrationDefinition.archived_at.is_(None),
-            )
-            .order_by(CloudIntegrationAccount.created_at.asc())
-            .limit(1)
+            stmt.order_by(CloudIntegrationAccount.created_at.asc()).limit(1)
         )
     ).first()
     if row is None:

--- a/server/proliferate/server/cloud/workflows/actions.py
+++ b/server/proliferate/server/cloud/workflows/actions.py
@@ -1,0 +1,250 @@
+"""Step-actions ledger: claim, perform, and sweep server-side actions.
+
+Invariant (L19): actions perform side effects of steps the runtime already
+executed; they never decide or cause what executes next.
+
+The ledger gives *exactly-once claim*. Action execution is *at-least-once
+completion* via the sweeper, which retries stale 'pending' rows (an owner that
+crashed before performing) and transient 'failed' rows (e.g. a Slack API
+error), up to a max attempt count. A crash inside the action window (after the
+Slack POST succeeded, before status='done' committed) can duplicate a send --
+the same guarantee class as every non-transactional external side effect.
+Slack keeps that honest weaker class.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from uuid import UUID, uuid4
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.workflows import (
+    WORKFLOW_STEP_NOTIFY,
+)
+from proliferate.db.models.cloud.workflows import WorkflowStepAction
+from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store import organizations as organizations_store
+from proliferate.db.store.cloud_workflows import WorkflowRunRecord
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.integrations.slack import client as slack_client
+from proliferate.utils.crypto import decrypt_json
+from proliferate.utils.time import utcnow
+
+logger = logging.getLogger(__name__)
+
+ACTION_STEP_KINDS: dict[str, str] = {
+    "notify-with-channel-slack": "slack_notify",
+}
+
+_SWEEP_STALE_THRESHOLD = timedelta(seconds=60)
+_MAX_ATTEMPTS = 5
+
+
+async def claim_step_action(
+    db: AsyncSession, *, run_id: UUID, step_key: str, action_kind: str
+) -> UUID | None:
+    """INSERT ... ON CONFLICT DO NOTHING. Returns the new action id when this
+    caller won the claim, None when another observer already owns it."""
+    action_id = uuid4()
+    now = utcnow()
+    stmt = (
+        pg_insert(WorkflowStepAction)
+        .values(
+            id=action_id,
+            run_id=run_id,
+            step_key=step_key,
+            action_kind=action_kind,
+            status="pending",
+            attempt_count=0,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(constraint="uq_workflow_step_action_claim")
+        .returning(WorkflowStepAction.id)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+def _action_kind_for(step: dict[str, object], output: object) -> str | None:
+    # notify is Slack-only in v2 (E1b) — no channel discriminator.
+    if step.get("kind") == WORKFLOW_STEP_NOTIFY:
+        return "slack_notify"
+    return None
+
+
+async def _organization_id_for_run(
+    db: AsyncSession, *, run: WorkflowRunRecord
+) -> UUID | None:
+    """The run owner's current organization — the org whose integration policy
+    governs this run's actions. In v1 the executor equals the workflow owner, so
+    the owner's current membership is the run's org context. Returns None when
+    the owner has no active membership (a bare personal user)."""
+    membership = await organizations_store.get_current_membership_for_user(
+        db, run.executor_user_id
+    )
+    return membership.organization.id if membership is not None else None
+
+
+async def apply_step_actions(db: AsyncSession, *, run: WorkflowRunRecord) -> None:
+    """Scan observed step outputs for action-bearing completed steps; claim and
+    perform any not yet owned. Safe to call on every report/refresh: the ledger
+    CAS makes re-observation free."""
+    steps_by_key = _steps_by_key(run)
+    for step_key, output in (run.step_outputs_json or {}).items():
+        step = steps_by_key.get(step_key, {})
+        action_kind = _action_kind_for(step, output)
+        if action_kind is None:
+            continue
+        action_id = await claim_step_action(
+            db, run_id=run.id, step_key=step_key, action_kind=action_kind
+        )
+        if action_id is None:
+            continue
+        await _perform(db, action_id, action_kind, run=run, step=step, output=output)
+
+
+def _steps_by_key(run: WorkflowRunRecord) -> dict[str, dict[str, object]]:
+    """Resolved-plan steps indexed by their structured ``key`` (B5). Step outputs
+    are reported keyed by ``step_key``; this maps a key back to its plan step."""
+    steps = (run.resolved_plan_json or {}).get("steps", [])
+    return {step["key"]: step for step in steps if isinstance(step, dict) and "key" in step}
+
+
+async def _perform(
+    db: AsyncSession,
+    action_id: UUID,
+    action_kind: str,
+    *,
+    run: WorkflowRunRecord,
+    step: dict[str, object],
+    output: object,
+) -> None:
+    try:
+        if action_kind == "slack_notify":
+            organization_id = await _organization_id_for_run(db, run=run)
+            await _perform_slack_notify(
+                db, action_id, run=run, step=step, output=output, organization_id=organization_id
+            )
+        else:
+            await _mark_action_failed(
+                db, action_id, error_message=f"Unknown action kind: {action_kind}"
+            )
+    except Exception:
+        logger.exception("action perform failed action_id=%s kind=%s", action_id, action_kind)
+        await _mark_action_failed(db, action_id, error_message="Unexpected error during perform")
+
+
+async def _perform_slack_notify(
+    db: AsyncSession,
+    action_id: UUID,
+    *,
+    run: WorkflowRunRecord,
+    step: dict[str, object],
+    output: object,
+    organization_id: UUID | None,
+) -> None:
+    slack_channel_id = step.get("slack_channel_id")
+    if not slack_channel_id or not isinstance(slack_channel_id, str):
+        await _mark_action_failed(db, action_id, error_message="Missing slack_channel_id on step")
+        return
+
+    message = output.get("message") if isinstance(output, dict) else None
+    if not message or not isinstance(message, str):
+        await _mark_action_failed(db, action_id, error_message="No message in step output")
+        return
+
+    # Pass the run's org context so org integration policy is honored: a Slack
+    # account the owner holds personally is still blocked if their org disabled
+    # the Slack integration.
+    account_pair = await accounts_store.get_ready_account_for_provider(
+        db, run.executor_user_id, "slack", organization_id=organization_id
+    )
+    if account_pair is None:
+        await _mark_action_failed(db, action_id, error_message="No ready Slack account")
+        return
+
+    account, _definition = account_pair
+    try:
+        bundle = decrypt_json(account.credential_ciphertext)
+    except Exception:
+        await _mark_action_failed(db, action_id, error_message="Failed to decrypt Slack credentials")
+        return
+
+    bot_token = bundle.get("bot_token") or bundle.get("access_token")
+    if not bot_token:
+        await _mark_action_failed(db, action_id, error_message="No bot_token in credential bundle")
+        return
+
+    try:
+        result = await slack_client.chat_post_message(
+            bot_token=bot_token,
+            channel_id=slack_channel_id,
+            text=message,
+            blocks=[],
+            thread_ts=None,
+        )
+    except Exception as exc:
+        await _mark_action_failed(db, action_id, error_message=str(exc)[:480])
+        return
+
+    await _mark_action_done(
+        db, action_id, result_json={"channel_id": result.channel_id, "message_ts": result.message_ts}
+    )
+
+
+async def _mark_action_done(
+    db: AsyncSession, action_id: UUID, *, result_json: dict[str, object]
+) -> None:
+    action = await db.get(WorkflowStepAction, action_id)
+    if action is None:
+        return
+    action.status = "done"
+    action.result_json = result_json
+    action.attempt_count += 1
+    action.updated_at = utcnow()
+    await db.flush()
+
+
+async def _mark_action_failed(
+    db: AsyncSession, action_id: UUID, *, error_message: str
+) -> None:
+    action = await db.get(WorkflowStepAction, action_id)
+    if action is None:
+        return
+    action.status = "failed"
+    action.error_message = error_message
+    action.attempt_count += 1
+    action.updated_at = utcnow()
+    await db.flush()
+
+
+async def sweep_pending_actions(db: AsyncSession) -> int:
+    """Retry stale 'pending' rows (an owner that crashed before performing) and
+    transient 'failed' rows, both older than the stale threshold and below the
+    max attempt count. Rows that exhaust their attempts simply rest at
+    'failed' with their real error_message -- the store scan excludes them
+    from future sweeps.
+
+    Returns the number of actions retried.
+    """
+    stale_before = utcnow() - _SWEEP_STALE_THRESHOLD
+    actions = await store.list_retryable_actions(
+        db, before=stale_before, max_attempts=_MAX_ATTEMPTS, limit=50
+    )
+    retried = 0
+    for action_row in actions:
+        run = await store.get_run(db, action_row.run_id)
+        if run is None:
+            await _mark_action_failed(db, action_row.id, error_message="Run not found")
+            retried += 1
+            continue
+        step = _steps_by_key(run).get(action_row.step_key, {})
+        output_raw = (run.step_outputs_json or {}).get(action_row.step_key, {})
+        await _perform(
+            db, action_row.id, action_row.action_kind, run=run, step=step, output=output_raw
+        )
+        retried += 1
+    return retried

--- a/server/proliferate/server/cloud/workflows/api.py
+++ b/server/proliferate/server/cloud/workflows/api.py
@@ -17,14 +17,21 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.constants.workflows import WORKFLOW_TARGET_MODE_PERSONAL_CLOUD
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.integrations.slack import client as slack_client
 from proliferate.server.cloud.workflows.delivery import deliver_cloud_run, refresh_cloud_run
 from proliferate.server.cloud.workflows.models import (
     RunStatusRequest,
+    SlackChannelResponse,
+    SlackChannelsResponse,
     StartRunRequest,
+    StepActionResponse,
     WorkflowCreateRequest,
     WorkflowDetailResponse,
     WorkflowListResponse,
     WorkflowResponse,
+    WorkflowRunDetailResponse,
     WorkflowRunListResponse,
     WorkflowRunResponse,
     WorkflowTriggerCreateRequest,
@@ -54,6 +61,7 @@ from proliferate.server.cloud.workflows.service import (
     update_trigger,
     update_workflow,
 )
+from proliferate.utils.crypto import decrypt_json
 
 router = APIRouter(prefix="/workflows", tags=["cloud-workflows"])
 
@@ -88,13 +96,28 @@ async def list_runs_endpoint(
     return WorkflowRunListResponse(runs=[run_payload(r) for r in runs])
 
 
-@router.get("/runs/{run_id}", response_model=WorkflowRunResponse)
+@router.get("/runs/{run_id}", response_model=WorkflowRunDetailResponse)
 async def get_run_endpoint(
     run_id: UUID,
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
-) -> WorkflowRunResponse:
-    return run_payload(await get_run(db, user, run_id))
+) -> WorkflowRunDetailResponse:
+    run = await get_run(db, user, run_id)
+    actions = await store.list_actions_for_run(db, run_id=run.id)
+    return WorkflowRunDetailResponse(
+        run=run_payload(run),
+        step_actions=[
+            StepActionResponse(
+                step_key=a.step_key,
+                action_kind=a.action_kind,
+                status=a.status,
+                result_json=a.result_json,
+                error_message=a.error_message,
+                attempt_count=a.attempt_count,
+            )
+            for a in actions
+        ],
+    )
 
 
 @router.post("/runs/{run_id}/delivered", response_model=WorkflowRunResponse)
@@ -144,6 +167,32 @@ async def refresh_run_endpoint(
     return run_payload(await refresh_cloud_run(db, user, run))
 
 
+@router.get("/slack/channels", response_model=SlackChannelsResponse)
+async def list_slack_channels_endpoint(
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> SlackChannelsResponse:
+    account_pair = await accounts_store.get_ready_account_for_provider(db, user.id, "slack")
+    if account_pair is None:
+        return SlackChannelsResponse(channels=[], connected=False)
+    account, _definition = account_pair
+    try:
+        bundle = decrypt_json(account.credential_ciphertext)
+    except Exception:
+        return SlackChannelsResponse(channels=[], connected=False)
+    bot_token = bundle.get("bot_token") or bundle.get("access_token")
+    if not bot_token:
+        return SlackChannelsResponse(channels=[], connected=False)
+    try:
+        channels = await slack_client.list_channels(bot_token=bot_token)
+    except Exception:
+        return SlackChannelsResponse(channels=[], connected=True)
+    return SlackChannelsResponse(
+        channels=[SlackChannelResponse(id=c.id, name=c.name) for c in channels],
+        connected=True,
+    )
+
+
 @router.get("/{workflow_id}", response_model=WorkflowDetailResponse)
 async def get_workflow_endpoint(
     workflow_id: UUID,
@@ -185,10 +234,12 @@ async def start_run_endpoint(
         db,
         user,
         workflow_id,
-        args=body.args,
+        inputs=body.inputs,
         target_mode=body.target_mode,
         version_id=body.version_id,
         target_workspace_id=body.target_workspace_id,
+        trigger_id=body.trigger_id,
+        session_bindings=body.session_bindings,
     )
     # Cloud lane: the server delivers gateway-direct to sandbox anyharness in the
     # request (wake + POST). Local lane: the desktop client delivers to its own

--- a/server/proliferate/server/cloud/workflows/delivery.py
+++ b/server/proliferate/server/cloud/workflows/delivery.py
@@ -19,10 +19,13 @@ failure leaves the run *pending_delivery* (non-terminal) with a
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from proliferate.auth.authorization import ActorIdentity
 from proliferate.constants.workflows import (
@@ -208,6 +211,14 @@ async def _sync_run_from_view(
         finished_at=finished_at,
     )
     assert updated is not None
+
+    try:
+        from proliferate.server.cloud.workflows.actions import apply_step_actions
+
+        await apply_step_actions(db, run=updated)
+    except Exception:
+        logger.exception("apply_step_actions failed run_id=%s", run_id)
+
     return updated
 
 

--- a/server/proliferate/server/cloud/workflows/domain/definition.py
+++ b/server/proliferate/server/cloud/workflows/domain/definition.py
@@ -1,42 +1,56 @@
-"""Pure workflow-definition schema and strict validation (spec 3.3).
+"""Workflow-definition schema and strict validation — format v2 (data-contract §1).
 
-Parses a raw definition dict into a normalized, canonical dict. Validation is
-**strict**: unknown kinds and unknown fields are rejected. Template references are
-validated to resolve (args must exist; a step-output reference must point at an
-earlier step). The canonical dict is what gets stored in ``workflow_version``.
+Parses a raw definition dict into a normalized, canonical dict. The v2 top-level
+shape is ``{version, name?, description?, inputs, integrations, agents}``: an
+ordered spine of *agent nodes* (``{slot, harness, model, steps}``), each running
+its steps in one session. There is no top-level ``steps`` and no ``setup`` — slot
+= session affinity, and ``session_binding`` is a run-context property stamped on
+the resolved plan (service._resolve_plan), never authored here.
+
+Validation is **strict**: unknown kinds and unknown fields are rejected. Template
+references (``{{inputs.<name>}}`` / ``{{<emit>.<field>}}``) are validated for
+existence and *strictly-prior* run-order visibility. The canonical dict is what
+gets stored in ``workflow_version.definition_json``.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 
 from proliferate.constants.workflows import (
-    SUPPORTED_WORKFLOW_APPROVAL_ON_TIMEOUT,
-    SUPPORTED_WORKFLOW_ARG_TYPES,
+    SUPPORTED_WORKFLOW_BRANCH_TARGETS,
     SUPPORTED_WORKFLOW_GOAL_ON_BLOCKED,
-    SUPPORTED_WORKFLOW_NOTIFY_CHANNELS,
+    SUPPORTED_WORKFLOW_INPUT_TYPES,
     SUPPORTED_WORKFLOW_ON_FAIL_KINDS,
-    SUPPORTED_WORKFLOW_SESSION_BINDINGS,
     SUPPORTED_WORKFLOW_STEP_KINDS,
-    WORKFLOW_ARG_TYPE_ENUM,
+    WORKFLOW_EMIT_DEFAULT_MAX_ATTEMPTS,
+    WORKFLOW_INPUT_TYPE_CHOICE,
+    WORKFLOW_MAX_AGENTS,
     WORKFLOW_MAX_ARGS,
     WORKFLOW_MAX_STEPS,
     WORKFLOW_ON_FAIL_RETRY,
     WORKFLOW_ON_FAIL_STOP,
-    WORKFLOW_SESSION_BINDING_FRESH,
+    WORKFLOW_RESERVED_REF_SEGMENTS,
     WORKFLOW_SHORT_TEXT_MAX_LENGTH,
     WORKFLOW_STEP_AGENT_CONFIG,
+    WORKFLOW_STEP_AGENT_EMIT,
     WORKFLOW_STEP_AGENT_PROMPT,
-    WORKFLOW_STEP_HUMAN_APPROVAL,
+    WORKFLOW_STEP_BRANCH,
     WORKFLOW_STEP_NOTIFY,
     WORKFLOW_STEP_SCM_OPEN_PR,
     WORKFLOW_STEP_SHELL_RUN,
 )
 from proliferate.server.cloud.workflows.domain.interpolation import (
     ArgSpec,
+    EmitReference,
     TemplateReferenceError,
+    iter_references,
     validate_string_references,
 )
+
+_SLOT_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class WorkflowDefinitionError(Exception):
@@ -116,74 +130,92 @@ def _int_field(obj: dict[str, object], key: str, *, field: str) -> int:
     return value
 
 
-# --- args schema ---------------------------------------------------------------
+def _optional_label(step: dict[str, object], *, field: str) -> str | None:
+    label = _optional_str(step, "label", field=field)
+    if label is not None and len(label) > WORKFLOW_SHORT_TEXT_MAX_LENGTH:
+        raise _err(
+            "invalid_definition",
+            f"'{field}.label' must be at most {WORKFLOW_SHORT_TEXT_MAX_LENGTH} characters.",
+        )
+    return label
 
 
-def _parse_args(raw: object) -> tuple[list[dict[str, object]], list[ArgSpec]]:
+# --- inputs schema -------------------------------------------------------------
+
+
+def _parse_inputs(raw: object) -> tuple[list[dict[str, object]], list[ArgSpec]]:
     if raw is None:
         return [], []
     if not isinstance(raw, list):
-        raise _err("invalid_definition", "'args' must be a list.")
+        raise _err("invalid_definition", "'inputs' must be a list.")
     if len(raw) > WORKFLOW_MAX_ARGS:
         raise _err(
-            "too_many_args", f"A workflow may declare at most {WORKFLOW_MAX_ARGS} arguments."
+            "too_many_args", f"A workflow may declare at most {WORKFLOW_MAX_ARGS} inputs."
         )
     canonical: list[dict[str, object]] = []
     specs: list[ArgSpec] = []
     seen: set[str] = set()
     for item in raw:
-        arg = _require_dict(item, field="args[]")
-        _reject_unknown_keys(arg, {"name", "type", "default", "required", "enum"}, field="args[]")
-        name = _require_str(arg, "name", field="args[]", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH)
-        if not name.replace("_", "").isalnum() or not (name[0].isalpha() or name[0] == "_"):
-            raise _err("invalid_definition", f"Argument name '{name}' must be an identifier.")
+        inp = _require_dict(item, field="inputs[]")
+        _reject_unknown_keys(
+            inp, {"name", "type", "default", "required", "choices"}, field="inputs[]"
+        )
+        name = _require_str(
+            inp, "name", field="inputs[]", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH
+        )
+        if not _IDENTIFIER_RE.match(name):
+            raise _err("invalid_definition", f"Input name '{name}' must be an identifier.")
         if name in seen:
-            raise _err("duplicate_arg", f"Duplicate argument name '{name}'.")
+            raise _err("duplicate_arg", f"Duplicate input name '{name}'.")
         seen.add(name)
-        arg_type = arg.get("type")
-        if arg_type not in SUPPORTED_WORKFLOW_ARG_TYPES:
+        input_type = inp.get("type")
+        if input_type not in SUPPORTED_WORKFLOW_INPUT_TYPES:
             raise _err(
-                "invalid_definition", f"Argument '{name}' has unsupported type '{arg_type}'."
+                "invalid_definition", f"Input '{name}' has unsupported type '{input_type}'."
             )
-        required = arg.get("required", False)
+        required = inp.get("required", False)
         if not isinstance(required, bool):
             raise _err(
-                "invalid_definition", f"Argument '{name}' field 'required' must be a boolean."
+                "invalid_definition", f"Input '{name}' field 'required' must be a boolean."
             )
         enum_values: tuple[str, ...] = ()
-        canonical_arg: dict[str, object] = {"name": name, "type": arg_type, "required": required}
-        if arg_type == WORKFLOW_ARG_TYPE_ENUM:
-            raw_enum = arg.get("enum")
-            if not isinstance(raw_enum, list) or not raw_enum:
+        canonical_input: dict[str, object] = {
+            "name": name,
+            "type": input_type,
+            "required": required,
+        }
+        if input_type == WORKFLOW_INPUT_TYPE_CHOICE:
+            raw_choices = inp.get("choices")
+            if not isinstance(raw_choices, list) or not raw_choices:
                 raise _err(
                     "invalid_definition",
-                    f"Enum argument '{name}' requires a non-empty 'enum' list.",
+                    f"Choice input '{name}' requires a non-empty 'choices' list.",
                 )
-            if not all(isinstance(v, str) and v for v in raw_enum):
+            if not all(isinstance(v, str) and v for v in raw_choices):
                 raise _err(
                     "invalid_definition",
-                    f"Enum argument '{name}' values must be non-empty strings.",
+                    f"Choice input '{name}' values must be non-empty strings.",
                 )
-            enum_values = tuple(raw_enum)
-            canonical_arg["enum"] = list(enum_values)
-        elif "enum" in arg:
+            enum_values = tuple(raw_choices)
+            canonical_input["choices"] = list(enum_values)
+        elif "choices" in inp:
             raise _err(
-                "unknown_field", f"Argument '{name}' declares 'enum' but is not an enum type."
+                "unknown_field", f"Input '{name}' declares 'choices' but is not a choice type."
             )
-        has_default = "default" in arg and arg["default"] is not None
-        default = arg.get("default")
+        has_default = "default" in inp and inp["default"] is not None
+        default = inp.get("default")
         if has_default:
-            if arg_type == WORKFLOW_ARG_TYPE_ENUM and default not in enum_values:
+            if input_type == WORKFLOW_INPUT_TYPE_CHOICE and default not in enum_values:
                 raise _err(
                     "invalid_definition",
-                    f"Default for enum argument '{name}' is not an allowed value.",
+                    f"Default for choice input '{name}' is not an allowed value.",
                 )
-            canonical_arg["default"] = default
-        canonical.append(canonical_arg)
+            canonical_input["default"] = default
+        canonical.append(canonical_input)
         specs.append(
             ArgSpec(
                 name=name,
-                type=str(arg_type),
+                type=str(input_type),
                 required=required,
                 has_default=has_default,
                 default=default,
@@ -193,24 +225,30 @@ def _parse_args(raw: object) -> tuple[list[dict[str, object]], list[ArgSpec]]:
     return canonical, specs
 
 
-# --- setup ---------------------------------------------------------------------
+# --- integrations (namespace-only, E3) -----------------------------------------
 
 
-def _parse_setup(raw: object) -> dict[str, object]:
-    setup = _require_dict(raw, field="setup")
-    _reject_unknown_keys(setup, {"harness", "model", "session_binding"}, field="setup")
-    harness = _require_str(
-        setup, "harness", field="setup", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH
-    )
-    model = _require_str(setup, "model", field="setup", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH)
-    session_binding = setup.get("session_binding", WORKFLOW_SESSION_BINDING_FRESH)
-    if session_binding not in SUPPORTED_WORKFLOW_SESSION_BINDINGS:
-        allowed = sorted(SUPPORTED_WORKFLOW_SESSION_BINDINGS)
-        raise _err(
-            "invalid_definition",
-            f"'setup.session_binding' must be one of {allowed}.",
-        )
-    return {"harness": harness, "model": model, "session_binding": session_binding}
+def _parse_integrations(raw: object) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise _err("invalid_definition", "'integrations' must be a list of namespace strings.")
+    seen: set[str] = set()
+    canonical: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise _err(
+                "invalid_definition", "Each integration must be a non-empty namespace string."
+            )
+        if not _IDENTIFIER_RE.match(item):
+            raise _err(
+                "invalid_definition", f"Integration namespace '{item}' must be an identifier."
+            )
+        if item in seen:
+            raise _err("duplicate_integration", f"Duplicate integration '{item}'.")
+        seen.add(item)
+        canonical.append(item)
+    return canonical
 
 
 # --- on_fail -------------------------------------------------------------------
@@ -274,43 +312,84 @@ def _parse_goal(raw: object, *, field: str) -> dict[str, object]:
     return canonical
 
 
+# --- required_invocation (agent.prompt gate, §6) -------------------------------
+
+
+def _parse_required_invocation(raw: object, *, field: str) -> dict[str, object]:
+    inv = _require_dict(raw, field=f"{field}.required_invocation")
+    _reject_unknown_keys(inv, {"provider", "tool"}, field=f"{field}.required_invocation")
+    return {
+        "provider": _require_str(inv, "provider", field=f"{field}.required_invocation"),
+        "tool": _require_str(inv, "tool", field=f"{field}.required_invocation"),
+    }
+
+
 # --- steps ---------------------------------------------------------------------
 
 
 def _parse_agent_prompt(step: dict[str, object], *, field: str) -> dict[str, object]:
-    _reject_unknown_keys(step, {"kind", "on_fail", "prompt", "goal"}, field=field)
+    _reject_unknown_keys(
+        step,
+        {"kind", "on_fail", "label", "prompt", "goal", "required_invocation"},
+        field=field,
+    )
     canonical: dict[str, object] = {"prompt": _require_str(step, "prompt", field=field)}
     if "goal" in step and step["goal"] is not None:
         canonical["goal"] = _parse_goal(step["goal"], field=field)
-    return canonical
-
-
-def _parse_agent_config(step: dict[str, object], *, field: str) -> dict[str, object]:
-    """Agent config step: sets the harness and/or model for the steps below it.
-
-    At least one of ``harness`` / ``model`` must be present; each, when present,
-    must be a non-empty string.
-    """
-
-    _reject_unknown_keys(step, {"kind", "on_fail", "harness", "model"}, field=field)
-    canonical: dict[str, object] = {}
-    for key in ("harness", "model"):
-        value = _optional_str(step, key, field=field)
-        if value is not None:
-            if not value.strip():
-                raise _err("invalid_definition", f"'{field}.{key}' must be a non-empty string.")
-            canonical[key] = value
-    if not canonical:
-        raise _err(
-            "invalid_definition",
-            f"'{field}' requires at least one of 'harness' or 'model'.",
+    if "required_invocation" in step and step["required_invocation"] is not None:
+        canonical["required_invocation"] = _parse_required_invocation(
+            step["required_invocation"], field=field
         )
     return canonical
 
 
+def _parse_agent_emit(step: dict[str, object], *, field: str) -> dict[str, object]:
+    """Write-output step: prompts, then captures a named, schema-shaped output.
+
+    ``name`` is REQUIRED (it is the output handle refs address); ``max_attempts``
+    is the re-ask budget (default 3).
+    """
+
+    _reject_unknown_keys(
+        step,
+        {"kind", "on_fail", "label", "prompt", "name", "output_schema", "max_attempts"},
+        field=field,
+    )
+    name = _require_str(step, "name", field=field)
+    if not _IDENTIFIER_RE.match(name):
+        raise _err("invalid_definition", f"'{field}.name' must be an identifier.")
+    if name in WORKFLOW_RESERVED_REF_SEGMENTS:
+        raise _err(
+            "invalid_definition",
+            f"'{field}.name' '{name}' is a reserved reference segment.",
+        )
+    canonical: dict[str, object] = {
+        "prompt": _require_str(step, "prompt", field=field),
+        "name": name,
+        "max_attempts": _positive_int(step, "max_attempts", field=field, required=False)
+        or WORKFLOW_EMIT_DEFAULT_MAX_ATTEMPTS,
+    }
+    if "output_schema" in step and step["output_schema"] is not None:
+        canonical["output_schema"] = _require_dict(
+            step["output_schema"], field=f"{field}.output_schema"
+        )
+    return canonical
+
+
+def _parse_agent_config(step: dict[str, object], *, field: str) -> dict[str, object]:
+    """Switch-model step: narrows to ``{model}`` only (same-harness rule).
+
+    Harness never changes mid-slot — a different harness is a different slot (A4).
+    """
+
+    _reject_unknown_keys(step, {"kind", "on_fail", "label", "model"}, field=field)
+    model = _require_str(step, "model", field=field)
+    return {"model": model}
+
+
 def _parse_shell_run(step: dict[str, object], *, field: str) -> dict[str, object]:
     _reject_unknown_keys(
-        step, {"kind", "on_fail", "command", "timeout_secs", "output_name"}, field=field
+        step, {"kind", "on_fail", "label", "command", "timeout_secs", "output_name"}, field=field
     )
     canonical: dict[str, object] = {"command": _require_str(step, "command", field=field)}
     timeout_secs = _positive_int(step, "timeout_secs", field=field, required=False)
@@ -318,16 +397,16 @@ def _parse_shell_run(step: dict[str, object], *, field: str) -> dict[str, object
         canonical["timeout_secs"] = timeout_secs
     output_name = _optional_str(step, "output_name", field=field)
     if output_name is not None:
-        if not output_name.replace("_", "").isalnum() or not (
-            output_name[0].isalpha() or output_name[0] == "_"
-        ):
+        if not _IDENTIFIER_RE.match(output_name):
             raise _err("invalid_definition", f"'{field}.output_name' must be an identifier.")
         canonical["output_name"] = output_name
     return canonical
 
 
 def _parse_scm_open_pr(step: dict[str, object], *, field: str) -> dict[str, object]:
-    _reject_unknown_keys(step, {"kind", "on_fail", "base", "title", "body", "draft"}, field=field)
+    _reject_unknown_keys(
+        step, {"kind", "on_fail", "label", "base", "title", "body", "draft"}, field=field
+    )
     canonical: dict[str, object] = {"title": _require_str(step, "title", field=field)}
     base = _optional_str(step, "base", field=field)
     if base is not None:
@@ -342,83 +421,141 @@ def _parse_scm_open_pr(step: dict[str, object], *, field: str) -> dict[str, obje
 
 
 def _parse_notify(step: dict[str, object], *, field: str) -> dict[str, object]:
-    _reject_unknown_keys(step, {"kind", "on_fail", "channel", "message"}, field=field)
-    channel = step.get("channel")
-    if channel not in SUPPORTED_WORKFLOW_NOTIFY_CHANNELS:
-        raise _err(
-            "invalid_definition",
-            f"'{field}.channel' must be one of {sorted(SUPPORTED_WORKFLOW_NOTIFY_CHANNELS)}.",
-        )
-    return {"channel": channel, "message": _require_str(step, "message", field=field)}
+    """Slack-only notify (E1b): ``{slack_channel_id, message}``, template-only v1."""
 
-
-def _parse_human_approval(step: dict[str, object], *, field: str) -> dict[str, object]:
     _reject_unknown_keys(
-        step, {"kind", "on_fail", "message", "on_timeout", "timeout_secs"}, field=field
+        step, {"kind", "on_fail", "label", "message", "slack_channel_id"}, field=field
     )
-    on_timeout = step.get("on_timeout")
-    if on_timeout not in SUPPORTED_WORKFLOW_APPROVAL_ON_TIMEOUT:
-        allowed = sorted(SUPPORTED_WORKFLOW_APPROVAL_ON_TIMEOUT)
-        raise _err(
-            "invalid_definition",
-            f"'{field}.on_timeout' must be one of {allowed}.",
-        )
-    canonical: dict[str, object] = {
+    return {
+        "slack_channel_id": _require_str(step, "slack_channel_id", field=field),
         "message": _require_str(step, "message", field=field),
-        "on_timeout": on_timeout,
     }
-    timeout_secs = _positive_int(step, "timeout_secs", field=field, required=False)
-    if timeout_secs is not None:
-        canonical["timeout_secs"] = timeout_secs
+
+
+def _parse_branch(step: dict[str, object], *, field: str) -> dict[str, object]:
+    """Branch step (C11/D3): switch on a prior emit's field; each case is
+    continue|end (narrowed from arbitrary goto)."""
+
+    _reject_unknown_keys(step, {"kind", "on_fail", "label", "on", "cases", "reason"}, field=field)
+    on = _require_str(step, "on", field=field)
+    raw_cases = step.get("cases")
+    if not isinstance(raw_cases, dict) or not raw_cases:
+        raise _err("invalid_definition", f"'{field}.cases' must be a non-empty object.")
+    cases: dict[str, object] = {}
+    for value, target in raw_cases.items():
+        target_dict = _require_dict(target, field=f"{field}.cases['{value}']")
+        _reject_unknown_keys(target_dict, {"to"}, field=f"{field}.cases['{value}']")
+        to = target_dict.get("to")
+        if to not in SUPPORTED_WORKFLOW_BRANCH_TARGETS:
+            raise _err(
+                "invalid_definition",
+                f"'{field}.cases['{value}'].to' must be one of "
+                f"{sorted(SUPPORTED_WORKFLOW_BRANCH_TARGETS)}.",
+            )
+        cases[value] = {"to": to}
+    canonical: dict[str, object] = {"on": on, "cases": cases}
+    reason = _optional_str(step, "reason", field=field)
+    if reason is not None:
+        canonical["reason"] = reason
     return canonical
 
 
 _STEP_PARSERS = {
     WORKFLOW_STEP_AGENT_CONFIG: _parse_agent_config,
     WORKFLOW_STEP_AGENT_PROMPT: _parse_agent_prompt,
+    WORKFLOW_STEP_AGENT_EMIT: _parse_agent_emit,
     WORKFLOW_STEP_SHELL_RUN: _parse_shell_run,
     WORKFLOW_STEP_SCM_OPEN_PR: _parse_scm_open_pr,
     WORKFLOW_STEP_NOTIFY: _parse_notify,
-    WORKFLOW_STEP_HUMAN_APPROVAL: _parse_human_approval,
+    WORKFLOW_STEP_BRANCH: _parse_branch,
 }
 
 
-def _parse_steps(raw: object, *, require_steps: bool = True) -> list[dict[str, object]]:
+def _parse_step(item: object, *, field: str) -> dict[str, object]:
+    step = _require_dict(item, field=field)
+    kind = step.get("kind")
+    if kind not in SUPPORTED_WORKFLOW_STEP_KINDS:
+        raise _err("unknown_step_kind", f"'{field}.kind' is not a supported step kind: {kind!r}.")
+    parser = _STEP_PARSERS[kind]
+    canonical: dict[str, object] = {
+        "kind": kind,
+        "on_fail": _parse_on_fail(step.get("on_fail"), field=field),
+    }
+    label = _optional_label(step, field=field)
+    if label is not None:
+        canonical["label"] = label
+    canonical.update(parser(step, field=field))
+    return canonical
+
+
+# --- agents spine (A4) ---------------------------------------------------------
+
+
+def _parse_agents(raw: object, *, require_steps: bool) -> list[dict[str, object]]:
     if raw is None and not require_steps:
         return []
     if not isinstance(raw, list):
-        raise _err("invalid_definition", "'steps' must be a list.")
+        raise _err("invalid_definition", "'agents' must be a list.")
     if not raw and require_steps:
-        raise _err("invalid_definition", "'steps' must be a non-empty list.")
-    if len(raw) > WORKFLOW_MAX_STEPS:
-        raise _err("too_many_steps", f"A workflow may declare at most {WORKFLOW_MAX_STEPS} steps.")
-    canonical_steps: list[dict[str, object]] = []
-    for index, item in enumerate(raw):
-        field = f"steps[{index}]"
-        step = _require_dict(item, field=field)
-        kind = step.get("kind")
-        if kind not in SUPPORTED_WORKFLOW_STEP_KINDS:
+        raise _err("invalid_definition", "A workflow requires at least one agent node.")
+    if len(raw) > WORKFLOW_MAX_AGENTS:
+        raise _err(
+            "too_many_agents", f"A workflow may declare at most {WORKFLOW_MAX_AGENTS} agent nodes."
+        )
+    total_steps = 0
+    seen_slots: set[str] = set()
+    canonical_agents: list[dict[str, object]] = []
+    for node_index, item in enumerate(raw):
+        node = _require_dict(item, field=f"agents[{node_index}]")
+        _reject_unknown_keys(
+            node, {"slot", "harness", "model", "steps"}, field=f"agents[{node_index}]"
+        )
+        slot = _require_str(node, "slot", field=f"agents[{node_index}]")
+        if not _SLOT_RE.match(slot):
             raise _err(
-                "unknown_step_kind", f"'{field}.kind' is not a supported step kind: {kind!r}."
+                "invalid_definition",
+                f"agents[{node_index}].slot '{slot}' must match ^[a-z][a-z0-9_]*$.",
             )
-        parser = _STEP_PARSERS[kind]
-        canonical: dict[str, object] = {
-            "kind": kind,
-            "on_fail": _parse_on_fail(step.get("on_fail"), field=field),
-        }
-        canonical.update(parser(step, field=field))
-        canonical_steps.append(canonical)
-    return canonical_steps
+        if slot in seen_slots:
+            raise _err("duplicate_slot", f"Duplicate agent slot '{slot}'.")
+        seen_slots.add(slot)
+        harness = _require_str(
+            node, "harness", field=f"agents[{node_index}]", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH
+        )
+        model = _require_str(
+            node, "model", field=f"agents[{node_index}]", max_length=WORKFLOW_SHORT_TEXT_MAX_LENGTH
+        )
+        raw_steps = node.get("steps")
+        if not isinstance(raw_steps, list) or (require_steps and not raw_steps):
+            raise _err(
+                "invalid_definition",
+                f"agents[{node_index}].steps must be a non-empty list.",
+            )
+        steps: list[dict[str, object]] = []
+        for step_index, step_item in enumerate(raw_steps):
+            steps.append(
+                _parse_step(step_item, field=f"agents[{node_index}].steps[{step_index}]")
+            )
+        total_steps += len(steps)
+        if total_steps > WORKFLOW_MAX_STEPS:
+            raise _err(
+                "too_many_steps",
+                f"A workflow may declare at most {WORKFLOW_MAX_STEPS} steps.",
+            )
+        canonical_agents.append(
+            {"slot": slot, "harness": harness, "model": model, "steps": steps}
+        )
+    return canonical_agents
 
 
-# --- template reference validation --------------------------------------------
+# --- template reference + emit validation --------------------------------------
 
 
 def _iter_step_strings(step: dict[str, object]) -> Iterator[str]:
     """Yield every templated string field within a canonical step."""
 
     for key, value in step.items():
-        if key in {"kind", "on_fail"}:
+        if key in {"kind", "on_fail", "label", "name", "output_schema", "required_invocation"}:
             continue
         if isinstance(value, str):
             yield value
@@ -428,13 +565,48 @@ def _iter_step_strings(step: dict[str, object]) -> Iterator[str]:
                     yield sub
 
 
-def _validate_references(steps: list[dict[str, object]], arg_names: frozenset[str]) -> None:
-    for index, step in enumerate(steps):
-        for value in _iter_step_strings(step):
-            try:
-                validate_string_references(value, arg_names=arg_names, step_index=index)
-            except TemplateReferenceError as exc:
-                raise _err(exc.code, exc.message) from exc
+def _validate_spine_references(
+    agents: list[dict[str, object]], input_names: frozenset[str]
+) -> None:
+    """Walk the flattened run order enforcing emit-name uniqueness (whole
+    definition) and strictly-prior ref visibility, plus branch semantics."""
+
+    prior_emits: set[str] = set()
+    for node in agents:
+        for step in node["steps"]:  # type: ignore[index]
+            for value in _iter_step_strings(step):
+                try:
+                    validate_string_references(
+                        value,
+                        input_names=input_names,
+                        prior_emit_names=frozenset(prior_emits),
+                    )
+                except TemplateReferenceError as exc:
+                    raise _err(exc.code, exc.message) from exc
+            if step["kind"] == WORKFLOW_STEP_BRANCH:
+                _validate_branch_on(step, prior_emits)
+            # Register this step's emit AFTER validating its own refs (a step
+            # can never reference its own output).
+            if step["kind"] == WORKFLOW_STEP_AGENT_EMIT:
+                name = step["name"]
+                if name in prior_emits:
+                    raise _err("duplicate_emit", f"Duplicate emit name '{name}'.")
+                prior_emits.add(name)  # type: ignore[arg-type]
+
+
+def _validate_branch_on(step: dict[str, object], prior_emits: set[str]) -> None:
+    refs = iter_references(step["on"])  # type: ignore[arg-type]
+    emit_refs = [r for r in refs if isinstance(r, EmitReference)]
+    if len(refs) != 1 or len(emit_refs) != 1:
+        raise _err(
+            "invalid_definition",
+            "'branch.on' must be exactly one {{EMIT.FIELD}} reference.",
+        )
+    if emit_refs[0].emit not in prior_emits:
+        raise _err(
+            "forward_emit_reference",
+            f"branch references emit '{emit_refs[0].emit}', not produced by an earlier step.",
+        )
 
 
 # --- public entrypoint ---------------------------------------------------------
@@ -443,21 +615,41 @@ def _validate_references(steps: list[dict[str, object]], arg_names: frozenset[st
 def parse_definition(
     raw: object, *, require_steps: bool = True
 ) -> tuple[dict[str, object], list[ArgSpec]]:
-    """Validate a raw definition and return its canonical dict + parsed arg specs.
+    """Validate a raw v2 definition and return its canonical dict + parsed input specs.
 
     Raises :class:`WorkflowDefinitionError` on any structural or reference problem.
 
-    ``require_steps=False`` permits a zero-step *draft* — used when saving a
+    ``require_steps=False`` permits a zero-agent *draft* — used when saving a
     workflow that the user will still build in the editor. Running a workflow
     (StartRun) always parses with ``require_steps=True``, so an empty draft can
     be saved but not run.
     """
 
     definition = _require_dict(raw, field="definition")
-    _reject_unknown_keys(definition, {"args", "setup", "steps"}, field="definition")
-    canonical_args, arg_specs = _parse_args(definition.get("args"))
-    setup = _parse_setup(definition.get("setup"))
-    steps = _parse_steps(definition.get("steps"), require_steps=require_steps)
-    _validate_references(steps, frozenset(spec.name for spec in arg_specs))
-    canonical: dict[str, object] = {"args": canonical_args, "setup": setup, "steps": steps}
+    _reject_unknown_keys(
+        definition,
+        {"version", "name", "description", "inputs", "integrations", "agents"},
+        field="definition",
+    )
+    version = definition.get("version")
+    if version != 1:
+        raise _err("invalid_definition", "'version' must be 1.")
+
+    canonical_inputs, arg_specs = _parse_inputs(definition.get("inputs"))
+    integrations = _parse_integrations(definition.get("integrations"))
+    agents = _parse_agents(definition.get("agents"), require_steps=require_steps)
+    _validate_spine_references(agents, frozenset(spec.name for spec in arg_specs))
+
+    canonical: dict[str, object] = {
+        "version": 1,
+        "inputs": canonical_inputs,
+        "integrations": integrations,
+        "agents": agents,
+    }
+    name = _optional_str(definition, "name", field="definition")
+    if name is not None:
+        canonical["name"] = name
+    description = _optional_str(definition, "description", field="definition")
+    if description is not None:
+        canonical["description"] = description
     return canonical, arg_specs

--- a/server/proliferate/server/cloud/workflows/domain/interpolation.py
+++ b/server/proliferate/server/cloud/workflows/domain/interpolation.py
@@ -1,14 +1,21 @@
-"""Pure template interpolation and argument coercion for workflow plans.
+"""Pure template interpolation and input coercion for workflow plans (format v2).
 
-Template placeholder grammar (spec 3.3): every templated string field may contain
+Stored template grammar (data-contract §1.3 / B6): every templated string field
+may contain
 
-    {{args.<name>}}              -> a workflow argument
-    {{steps[<n>].output.<name>}} -> the public output of an earlier step
+    {{inputs.<name>}}          -> a workflow input (eager, resolved at StartRun)
+    {{<emit_name>.<field>}}     -> a field of an earlier ``agent.emit`` step
 
-``StartRun`` resolves ``{{args.*}}`` **eagerly** (the values are known at run
-creation) and leaves ``{{steps[n].output.*}}`` **late-bound** for the runtime.
+``StartRun`` resolves ``{{inputs.*}}`` **eagerly** (the values are known at run
+creation) and **rewrites** ``{{<emit>.<field>}}`` to the runtime's indexed form
+``{{steps[<n>].output.<field>}}`` at flatten time — so the runtime keeps its
+existing indexed grammar (templates.rs is unchanged) and never learns emit names.
 
-Escaping: substitution is segment-based and never re-scanned. A substituted arg
+Reserved first segments (never legal emit names): ``inputs``, ``steps``,
+``fields``. ``steps`` is reserved so the rewrite target can never collide with an
+emit name; ``fields`` is reserved for the notify agent-filled follow-up.
+
+Escaping: substitution is segment-based and never re-scanned. A substituted input
 value additionally has every ``{`` / ``}`` backslash-escaped so a value that
 literally contains ``{{steps[0].output.x}}`` can never survive resolution as a
 live step-output token (injection guard). The runtime unescapes ``\\{`` / ``\\}``
@@ -21,16 +28,23 @@ import re
 from dataclasses import dataclass
 
 from proliferate.constants.workflows import (
-    WORKFLOW_ARG_TYPE_BOOLEAN,
-    WORKFLOW_ARG_TYPE_ENUM,
-    WORKFLOW_ARG_TYPE_NUMBER,
-    WORKFLOW_ARG_TYPE_STRING,
+    WORKFLOW_INPUT_TYPE_BOOLEAN,
+    WORKFLOW_INPUT_TYPE_CHOICE,
+    WORKFLOW_INPUT_TYPE_NUMBER,
+    WORKFLOW_INPUT_TYPE_TEXT,
+    WORKFLOW_RESERVED_REF_SEGMENTS,
 )
 
 # A placeholder is ``{{`` not preceded by a backslash, then a reference, then
 # ``}}``. References never contain braces, so ``[^{}]`` keeps matching greedy-safe.
 _PLACEHOLDER_RE = re.compile(r"(?<!\\)\{\{\s*(?P<ref>[^{}]*?)\s*\}\}")
-_ARG_REF_RE = re.compile(r"^args\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)$")
+_INPUT_REF_RE = re.compile(r"^inputs\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)$")
+# {{<emit_name>.<field>}} — a two-segment ref whose first segment is not reserved.
+_EMIT_REF_RE = re.compile(
+    r"^(?P<emit>[A-Za-z_][A-Za-z0-9_]*)\.(?P<field>[A-Za-z_][A-Za-z0-9_]*)$"
+)
+# The runtime's indexed form — the *output* of the rewrite, kept parseable so a
+# rewritten string still validates and re-emits verbatim.
 _STEP_REF_RE = re.compile(r"^steps\[(?P<index>\d+)\]\.output\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)$")
 
 
@@ -44,8 +58,14 @@ class TemplateReferenceError(Exception):
 
 
 @dataclass(frozen=True)
-class ArgReference:
+class InputReference:
     name: str
+
+
+@dataclass(frozen=True)
+class EmitReference:
+    emit: str
+    field: str
 
 
 @dataclass(frozen=True)
@@ -54,25 +74,34 @@ class StepOutputReference:
     name: str
 
 
-Reference = ArgReference | StepOutputReference
+Reference = InputReference | EmitReference | StepOutputReference
 
 
 def parse_reference(ref: str) -> Reference:
     """Parse a placeholder body into a typed reference, or raise."""
 
-    arg_match = _ARG_REF_RE.match(ref)
-    if arg_match is not None:
-        return ArgReference(name=arg_match.group("name"))
+    input_match = _INPUT_REF_RE.match(ref)
+    if input_match is not None:
+        return InputReference(name=input_match.group("name"))
     step_match = _STEP_REF_RE.match(ref)
     if step_match is not None:
         return StepOutputReference(
             index=int(step_match.group("index")),
             name=step_match.group("name"),
         )
+    emit_match = _EMIT_REF_RE.match(ref)
+    if emit_match is not None:
+        emit = emit_match.group("emit")
+        if emit in WORKFLOW_RESERVED_REF_SEGMENTS:
+            raise TemplateReferenceError(
+                "invalid_template_reference",
+                f"'{{{{{ref}}}}}' uses reserved first segment '{emit}'.",
+            )
+        return EmitReference(emit=emit, field=emit_match.group("field"))
     raise TemplateReferenceError(
         "invalid_template_reference",
         f"'{{{{{ref}}}}}' is not a valid template reference "
-        "(expected {{args.NAME}} or {{steps[N].output.NAME}}).",
+        "(expected {{inputs.NAME}} or {{EMIT.FIELD}}).",
     )
 
 
@@ -85,44 +114,48 @@ def iter_references(value: str) -> list[Reference]:
 def validate_string_references(
     value: str,
     *,
-    arg_names: frozenset[str],
-    step_index: int,
+    input_names: frozenset[str],
+    prior_emit_names: frozenset[str],
 ) -> None:
-    """Validate every placeholder in one step string field.
+    """Validate every placeholder in one stored (pre-resolution) step string field.
 
-    ``step_index`` is the index of the step the field belongs to; a step-output
-    reference must point strictly earlier (``index < step_index``). Setup fields
-    pass ``step_index=0`` so any step-output reference is rejected.
+    ``prior_emit_names`` is the set of ``agent.emit`` names that appear strictly
+    before this field's step in run order (earlier spine nodes in full, earlier
+    steps in the same node) — the visibility rule (data-contract §1.3). An emit
+    ref must name one of them; an input ref must name a declared input. Indexed
+    step-output refs are illegal in stored definitions (they are the resolver's
+    output, not an authored form).
     """
 
     for reference in iter_references(value):
-        if isinstance(reference, ArgReference):
-            if reference.name not in arg_names:
+        if isinstance(reference, InputReference):
+            if reference.name not in input_names:
                 raise TemplateReferenceError(
-                    "unknown_arg_reference",
-                    f"Template references unknown argument '{reference.name}'.",
+                    "unknown_input_reference",
+                    f"Template references unknown input '{reference.name}'.",
                 )
-        else:
-            if reference.index >= step_index:
+        elif isinstance(reference, EmitReference):
+            if reference.emit not in prior_emit_names:
                 raise TemplateReferenceError(
-                    "forward_step_reference",
+                    "forward_emit_reference",
                     (
-                        f"Step {step_index} references output of step "
-                        f"{reference.index}, which does not run before it."
+                        f"Template references emit '{reference.emit}', which is not "
+                        "produced by an earlier step in run order."
                     ),
                 )
-            if reference.index < 0:
-                raise TemplateReferenceError(
-                    "invalid_step_reference",
-                    "Step output reference index must be non-negative.",
-                )
+        else:  # StepOutputReference
+            raise TemplateReferenceError(
+                "invalid_template_reference",
+                "Indexed step-output references are not allowed in a stored definition; "
+                "use {{EMIT.FIELD}}.",
+            )
 
 
-# --- Argument coercion ---------------------------------------------------------
+# --- Input coercion ------------------------------------------------------------
 
 
 class ArgumentError(Exception):
-    """Raised when provided run arguments do not satisfy the args schema."""
+    """Raised when provided run inputs do not satisfy the inputs schema."""
 
     def __init__(self, code: str, message: str) -> None:
         self.code = code
@@ -142,7 +175,7 @@ class ArgSpec:
 
 def _coerce_number(name: str, value: object) -> float | int:
     if isinstance(value, bool):
-        raise ArgumentError("invalid_argument", f"Argument '{name}' must be a number.")
+        raise ArgumentError("invalid_argument", f"Input '{name}' must be a number.")
     if isinstance(value, (int, float)):
         return value
     if isinstance(value, str):
@@ -152,9 +185,9 @@ def _coerce_number(name: str, value: object) -> float | int:
             return float(value)
         except ValueError as exc:
             raise ArgumentError(
-                "invalid_argument", f"Argument '{name}' must be a number."
+                "invalid_argument", f"Input '{name}' must be a number."
             ) from exc
-    raise ArgumentError("invalid_argument", f"Argument '{name}' must be a number.")
+    raise ArgumentError("invalid_argument", f"Input '{name}' must be a number.")
 
 
 def _coerce_boolean(name: str, value: object) -> bool:
@@ -162,33 +195,33 @@ def _coerce_boolean(name: str, value: object) -> bool:
         return value
     if isinstance(value, str) and value.strip().lower() in {"true", "false"}:
         return value.strip().lower() == "true"
-    raise ArgumentError("invalid_argument", f"Argument '{name}' must be a boolean.")
+    raise ArgumentError("invalid_argument", f"Input '{name}' must be a boolean.")
 
 
 def _coerce_one(spec: ArgSpec, value: object) -> object:
-    if spec.type == WORKFLOW_ARG_TYPE_STRING:
+    if spec.type == WORKFLOW_INPUT_TYPE_TEXT:
         if isinstance(value, (dict, list)):
-            raise ArgumentError("invalid_argument", f"Argument '{spec.name}' must be a string.")
+            raise ArgumentError("invalid_argument", f"Input '{spec.name}' must be text.")
         return value if isinstance(value, str) else str(value)
-    if spec.type == WORKFLOW_ARG_TYPE_NUMBER:
+    if spec.type == WORKFLOW_INPUT_TYPE_NUMBER:
         return _coerce_number(spec.name, value)
-    if spec.type == WORKFLOW_ARG_TYPE_BOOLEAN:
+    if spec.type == WORKFLOW_INPUT_TYPE_BOOLEAN:
         return _coerce_boolean(spec.name, value)
-    if spec.type == WORKFLOW_ARG_TYPE_ENUM:
+    if spec.type == WORKFLOW_INPUT_TYPE_CHOICE:
         text = value if isinstance(value, str) else str(value)
         if text not in spec.enum_values:
             raise ArgumentError(
                 "invalid_argument",
-                f"Argument '{spec.name}' must be one of {list(spec.enum_values)}.",
+                f"Input '{spec.name}' must be one of {list(spec.enum_values)}.",
             )
         return text
-    raise ArgumentError("invalid_argument", f"Argument '{spec.name}' has an unknown type.")
+    raise ArgumentError("invalid_argument", f"Input '{spec.name}' has an unknown type.")
 
 
 def coerce_arguments(arg_specs: list[ArgSpec], provided: dict[str, object]) -> dict[str, object]:
-    """Coerce and validate provided run arguments against the args schema.
+    """Coerce and validate provided run inputs against the inputs schema.
 
-    Rejects unknown arguments (strict), fills defaults, enforces required, and
+    Rejects unknown inputs (strict), fills defaults, enforces required, and
     coerces each value to its declared type.
     """
 
@@ -197,7 +230,7 @@ def coerce_arguments(arg_specs: list[ArgSpec], provided: dict[str, object]) -> d
     if unknown:
         raise ArgumentError(
             "unknown_argument",
-            f"Unknown workflow argument(s): {sorted(unknown)}.",
+            f"Unknown workflow input(s): {sorted(unknown)}.",
         )
     resolved: dict[str, object] = {}
     for spec in arg_specs:
@@ -208,12 +241,12 @@ def coerce_arguments(arg_specs: list[ArgSpec], provided: dict[str, object]) -> d
         elif spec.required:
             raise ArgumentError(
                 "missing_argument",
-                f"Required workflow argument '{spec.name}' was not provided.",
+                f"Required workflow input '{spec.name}' was not provided.",
             )
     return resolved
 
 
-# --- Eager args interpolation --------------------------------------------------
+# --- Eager inputs interpolation + emit-ref rewrite -----------------------------
 
 
 def _escape_braces(rendered: str) -> str:
@@ -226,11 +259,21 @@ def _render_scalar(value: object) -> str:
     return str(value)
 
 
-def interpolate_args_in_string(value: str, args: dict[str, object]) -> str:
-    """Replace ``{{args.*}}`` with coerced values; keep step-output tokens verbatim.
+def resolve_string(
+    value: str,
+    *,
+    inputs: dict[str, object],
+    emit_index: dict[str, int],
+) -> str:
+    """Resolve one templated string at flatten time (the resolver's single pass).
+
+    - ``{{inputs.*}}`` is interpolated eagerly (values brace-escaped so they can
+      never introduce a new live token).
+    - ``{{<emit>.<field>}}`` is rewritten to ``{{steps[<n>].output.<field>}}``
+      using ``emit_index`` (emit name -> flattened step index). The runtime
+      late-binds the indexed form.
 
     Segment-based (no re-scanning): replacements are concatenated as literal text.
-    Arg values are brace-escaped so they cannot introduce new live tokens.
     """
 
     out: list[str] = []
@@ -238,23 +281,33 @@ def interpolate_args_in_string(value: str, args: dict[str, object]) -> str:
     for match in _PLACEHOLDER_RE.finditer(value):
         out.append(value[last : match.start()])
         reference = parse_reference(match.group("ref"))
-        if isinstance(reference, ArgReference):
-            out.append(_escape_braces(_render_scalar(args[reference.name])))
-        else:
-            # Re-emit in canonical form for the runtime's late-bound pass.
+        if isinstance(reference, InputReference):
+            out.append(_escape_braces(_render_scalar(inputs[reference.name])))
+        elif isinstance(reference, EmitReference):
+            index = emit_index[reference.emit]
+            out.append(f"{{{{steps[{index}].output.{reference.field}}}}}")
+        else:  # already-indexed StepOutputReference — re-emit canonical
             out.append(f"{{{{steps[{reference.index}].output.{reference.name}}}}}")
         last = match.end()
     out.append(value[last:])
     return "".join(out)
 
 
-def interpolate_args(value: object, args: dict[str, object]) -> object:
-    """Recursively interpolate ``{{args.*}}`` in every string within a JSON value."""
+def resolve_value(
+    value: object,
+    *,
+    inputs: dict[str, object],
+    emit_index: dict[str, int],
+) -> object:
+    """Recursively resolve every string within a JSON value (see ``resolve_string``)."""
 
     if isinstance(value, str):
-        return interpolate_args_in_string(value, args)
+        return resolve_string(value, inputs=inputs, emit_index=emit_index)
     if isinstance(value, list):
-        return [interpolate_args(item, args) for item in value]
+        return [resolve_value(item, inputs=inputs, emit_index=emit_index) for item in value]
     if isinstance(value, dict):
-        return {key: interpolate_args(item, args) for key, item in value.items()}
+        return {
+            key: resolve_value(item, inputs=inputs, emit_index=emit_index)
+            for key, item in value.items()
+        }
     return value

--- a/server/proliferate/server/cloud/workflows/models.py
+++ b/server/proliferate/server/cloud/workflows/models.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from proliferate.db.store.cloud_workflow_triggers import WorkflowTriggerRecord
 from proliferate.db.store.cloud_workflows import (
@@ -45,14 +45,41 @@ class WorkflowUpdateRequest(WorkflowBaseModel):
     definition: dict[str, object]
 
 
+class WorkflowRunTarget(WorkflowBaseModel):
+    """Where a run works (data-contract §3): exactly one of a workspace (manual/
+    chat — the workspace you're in) or a trigger (schedule/poll — the server
+    derives the pinned workspace from the trigger row; derivation itself is PR G)."""
+
+    workspace_id: UUID | None = Field(default=None, alias="workspaceId")
+    trigger_id: UUID | None = Field(default=None, alias="triggerId")
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> WorkflowRunTarget:
+        if (self.workspace_id is None) == (self.trigger_id is None):
+            raise ValueError("target must set exactly one of workspace_id or trigger_id.")
+        return self
+
+
 class StartRunRequest(WorkflowBaseModel):
-    args: dict[str, object] = Field(default_factory=dict)
+    # B9: ``args`` -> ``inputs``. Freeform values coerced against the inputs schema.
+    inputs: dict[str, object] = Field(default_factory=dict)
     target_mode: WorkflowTargetMode = Field(alias="targetMode")
     version_id: UUID | None = Field(default=None, alias="versionId")
-    # Required for ``personal_cloud`` runs: the cloud workspace the server delivers
-    # the resolved plan into (validated for ownership). Ignored for ``local`` runs,
-    # whose workspace is picked client-side and handed to the local runtime.
-    target_workspace_id: UUID | None = Field(default=None, alias="targetWorkspaceId")
+    # B9 target = workspace_id XOR trigger_id (validated exactly-one). For a
+    # ``personal_cloud`` run the workspace is the delivery destination; for a
+    # trigger-fired run the workspace is derived server-side (PR G).
+    target: WorkflowRunTarget
+    # L29: optional per-slot session binding (slot -> session_id). Bind-time
+    # validation (same-harness, not held) lands with the session plane.
+    session_bindings: dict[str, str] = Field(default_factory=dict, alias="sessionBindings")
+
+    @property
+    def target_workspace_id(self) -> UUID | None:
+        return self.target.workspace_id
+
+    @property
+    def trigger_id(self) -> UUID | None:
+        return self.target.trigger_id
 
 
 class RunStatusRequest(WorkflowBaseModel):
@@ -129,8 +156,32 @@ class WorkflowRunResponse(WorkflowBaseModel):
     finished_at: str | None = Field(alias="finishedAt")
 
 
+class StepActionResponse(WorkflowBaseModel):
+    step_key: str = Field(alias="stepKey")
+    action_kind: str = Field(alias="actionKind")
+    status: str
+    result_json: dict[str, object] | None = Field(alias="resultJson")
+    error_message: str | None = Field(alias="errorMessage")
+    attempt_count: int = Field(alias="attemptCount")
+
+
+class WorkflowRunDetailResponse(WorkflowBaseModel):
+    run: WorkflowRunResponse
+    step_actions: list[StepActionResponse] = Field(alias="stepActions")
+
+
 class WorkflowRunListResponse(WorkflowBaseModel):
     runs: list[WorkflowRunResponse]
+
+
+class SlackChannelResponse(WorkflowBaseModel):
+    id: str
+    name: str
+
+
+class SlackChannelsResponse(WorkflowBaseModel):
+    channels: list[SlackChannelResponse]
+    connected: bool
 
 
 # --- constructors --------------------------------------------------------------

--- a/server/proliferate/server/cloud/workflows/scheduler.py
+++ b/server/proliferate/server/cloud/workflows/scheduler.py
@@ -57,7 +57,8 @@ from proliferate.server.automations.domain.schedule import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.workflows import service
-from proliferate.server.cloud.workflows.delivery import deliver_cloud_run
+from proliferate.server.cloud.workflows.delivery import deliver_cloud_run, refresh_cloud_run
+from proliferate.server.cloud.workflows.actions import sweep_pending_actions
 from proliferate.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
@@ -154,7 +155,7 @@ async def _fire_one_trigger(
                     db,
                     actor,
                     trigger.workflow_id,
-                    args=trigger.args_json,
+                    inputs=trigger.args_json,
                     target_mode=trigger.target_mode,
                     trigger_kind=WORKFLOW_TRIGGER_KIND_SCHEDULE,
                     target_workspace_id=trigger.target_workspace_id,
@@ -236,6 +237,40 @@ async def _deliver_pending_runs(
     return delivered
 
 
+# --- Phase 3: refresh in-flight + sweep actions --------------------------------
+
+_MAX_REFRESHES_PER_TICK = 10
+
+
+async def _refresh_in_flight_runs(
+    session_factory: SchedulerSessionFactory, *, tick_start: datetime
+) -> int:
+    """Refresh in-flight triggered cloud runs so actions fire for unattended runs.
+
+    Only refreshes runs delivered before this tick started (skip runs we just
+    delivered -- they need time to execute before a refresh is useful).
+    """
+    async with session_factory() as db:
+        candidates = await store.list_in_flight_triggered_cloud_runs(
+            db, limit=_MAX_REFRESHES_PER_TICK, delivered_before=tick_start
+        )
+    refreshed = 0
+    for run in candidates:
+        try:
+            async with session_factory() as db, db.begin():
+                actor = _SchedulerActor(id=run.executor_user_id)
+                await refresh_cloud_run(db, actor, run)
+                refreshed += 1
+        except Exception:
+            logger.exception("workflow scheduler refresh failed run_id=%s", run.id)
+    return refreshed
+
+
+async def _sweep_actions(session_factory: SchedulerSessionFactory) -> int:
+    async with session_factory() as db, db.begin():
+        return await sweep_pending_actions(db)
+
+
 # --- tick + loop ---------------------------------------------------------------
 
 
@@ -248,6 +283,17 @@ async def run_workflow_scheduler_tick(
     now = utcnow()
     created = await _fire_due_triggers(session_factory, now=now, batch_size=batch_size)
     delivered = await _deliver_pending_runs(session_factory, max_deliveries=max_deliveries)
+
+    # Phase 3: refresh in-flight triggered cloud runs + sweep stale actions.
+    try:
+        await _refresh_in_flight_runs(session_factory, tick_start=now)
+    except Exception:
+        logger.exception("workflow scheduler phase 3 refresh failed")
+    try:
+        await _sweep_actions(session_factory)
+    except Exception:
+        logger.exception("workflow scheduler phase 3 sweep failed")
+
     return WorkflowSchedulerTickResult(created_runs=created, delivered_runs=delivered)
 
 

--- a/server/proliferate/server/cloud/workflows/service.py
+++ b/server/proliferate/server/cloud/workflows/service.py
@@ -8,11 +8,14 @@ a ``pending_delivery`` run whose id is the delivery idempotency key.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from proliferate.auth.authorization import ActorIdentity
 from proliferate.constants.workflows import (
@@ -24,9 +27,13 @@ from proliferate.constants.workflows import (
     WORKFLOW_RUN_STATUS_DELIVERED,
     WORKFLOW_RUN_STATUS_PENDING_DELIVERY,
     WORKFLOW_RUN_STATUS_RUNNING,
+    WORKFLOW_SESSION_BINDING_FRESH,
+    WORKFLOW_SESSION_BINDING_HEADLESS,
     WORKFLOW_SHORT_TEXT_MAX_LENGTH,
+    WORKFLOW_STEP_AGENT_EMIT,
     WORKFLOW_TARGET_MODE_LOCAL,
     WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
+    WORKFLOW_TRIGGER_CHAT,
     WORKFLOW_TRIGGER_KIND_SCHEDULE,
     WORKFLOW_TRIGGER_MANUAL,
 )
@@ -53,7 +60,7 @@ from proliferate.server.cloud.workflows.domain.interpolation import (
     ArgSpec,
     ArgumentError,
     coerce_arguments,
-    interpolate_args,
+    resolve_value,
 )
 from proliferate.server.cloud.workflows.domain.policy import (
     free_plan_workflow_limit,
@@ -248,6 +255,15 @@ async def archive_workflow(
 # --- StartRun ------------------------------------------------------------------
 
 
+def _default_session_binding(trigger_kind: str) -> str:
+    """Per-slot session visibility default (A1): manual/chat = fresh (deep-linked
+    in the run view), schedule/poll = headless (no UI focus)."""
+
+    if trigger_kind in (WORKFLOW_TRIGGER_MANUAL, WORKFLOW_TRIGGER_CHAT):
+        return WORKFLOW_SESSION_BINDING_FRESH
+    return WORKFLOW_SESSION_BINDING_HEADLESS
+
+
 def _resolve_plan(
     *,
     run_id: UUID,
@@ -255,20 +271,70 @@ def _resolve_plan(
     version: WorkflowVersionRecord,
     trigger_kind: str,
     target_mode: str,
-    coerced_args: dict[str, object],
+    coerced_inputs: dict[str, object],
+    session_bindings: dict[str, str],
 ) -> dict[str, object]:
+    """The single resolution pass (data-contract §4): flatten the agents spine
+    into one ordered step list, stamp each step with its structured key + slot +
+    label, build the per-slot sessions map, and resolve template refs (eager
+    ``{{inputs.*}}`` + rewrite ``{{emit.field}}`` -> ``{{steps[n].output.field}}``).
+    """
+
     canonical = version.definition_json
-    interpolated_steps = interpolate_args(canonical.get("steps", []), coerced_args)
+    agents = canonical.get("agents", [])
+    # E3/§2.6: the workflow-level integrations grant is stamped onto every slot
+    # (per-slot narrowing is a later resolver-only change). Actual token mint +
+    # all-tools scope expansion is PR E's phase.
+    integrations = list(canonical.get("integrations", []))
+
+    # First pass: assign each step its flattened index and build the
+    # emit-name -> flat-index map the ref rewrite needs.
+    emit_index: dict[str, int] = {}
+    flat_position = 0
+    for node in agents:
+        for step in node["steps"]:
+            if step.get("kind") == WORKFLOW_STEP_AGENT_EMIT:
+                emit_index[step["name"]] = flat_position
+            flat_position += 1
+
+    default_binding = _default_session_binding(trigger_kind)
+    sessions: dict[str, object] = {}
+    steps: list[dict[str, object]] = []
+    for node_index, node in enumerate(agents):
+        slot = node["slot"]
+        session_entry: dict[str, object] = {
+            "harness": node["harness"],
+            "model": node["model"],
+            "session_binding": default_binding,
+            "integrations": list(integrations),
+        }
+        bound = session_bindings.get(slot)
+        if bound is not None:
+            session_entry["bind_session_id"] = bound
+        sessions[slot] = session_entry
+
+        for step_index, step in enumerate(node["steps"]):
+            # Lane "-" for the flat (non-parallel) case; the "<node>.<lane>.<step>"
+            # shape (§4) is adopted now so lanes never re-key the contract.
+            key = f"{node_index}.-.{step_index}"
+            resolved = resolve_value(step, inputs=coerced_inputs, emit_index=emit_index)
+            assert isinstance(resolved, dict)
+            resolved["key"] = key
+            resolved["slot"] = slot
+            resolved.setdefault("label", step.get("label", ""))
+            steps.append(resolved)
+
     return {
         "run_id": str(run_id),
+        "plan_version": 1,
         "workflow_id": str(workflow_id),
         "workflow_version_id": str(version.id),
         "version_n": version.version_n,
         "trigger_kind": trigger_kind,
         "target_mode": target_mode,
-        "setup": canonical.get("setup", {}),
-        "args": coerced_args,
-        "steps": interpolated_steps,
+        "sessions": sessions,
+        "inputs": coerced_inputs,
+        "steps": steps,
     }
 
 
@@ -307,13 +373,14 @@ async def start_run(
     user: ActorIdentity,
     workflow_id: UUID,
     *,
-    args: dict[str, object],
+    inputs: dict[str, object],
     target_mode: str,
     trigger_kind: str = WORKFLOW_TRIGGER_MANUAL,
     version_id: UUID | None = None,
     target_workspace_id: UUID | None = None,
     trigger_id: UUID | None = None,
     scheduled_for: datetime | None = None,
+    session_bindings: dict[str, str] | None = None,
 ) -> WorkflowRunRecord:
     if target_mode not in SUPPORTED_WORKFLOW_TARGET_MODES:
         raise CloudApiError(
@@ -363,7 +430,7 @@ async def start_run(
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
 
     try:
-        coerced_args = coerce_arguments(arg_specs, args)
+        coerced_inputs = coerce_arguments(arg_specs, inputs)
     except ArgumentError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
 
@@ -374,7 +441,8 @@ async def start_run(
         version=version,
         trigger_kind=trigger_kind,
         target_mode=target_mode,
-        coerced_args=coerced_args,
+        coerced_inputs=coerced_inputs,
+        session_bindings=session_bindings or {},
     )
     return await store.create_run(
         db,
@@ -383,7 +451,7 @@ async def start_run(
         workflow_version_id=version.id,
         trigger_kind=trigger_kind,
         executor_user_id=workflow.owner_user_id,
-        args_json=coerced_args,
+        args_json=coerced_inputs,
         target_mode=target_mode,
         resolved_plan_json=resolved_plan,
         anyharness_workspace_id=cloud_anyharness_workspace_id,
@@ -468,6 +536,14 @@ async def report_run_status(
         finished_at=finished_at,
     )
     assert updated is not None
+
+    try:
+        from proliferate.server.cloud.workflows.actions import apply_step_actions
+
+        await apply_step_actions(db, run=updated)
+    except Exception:
+        logger.exception("apply_step_actions failed run_id=%s", run_id)
+
     return updated
 
 

--- a/server/tests/unit/test_workflow_actions.py
+++ b/server/tests/unit/test_workflow_actions.py
@@ -1,0 +1,813 @@
+"""Step-actions ledger tests (PR A): claim CAS, apply idempotency, slack perform,
+failure handling, sweeper, org-policy enforcement, notify validator, slack
+channels endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_OWNER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.workflows import WorkflowStepAction
+from proliferate.db.store.cloud_workflows import WorkflowRunRecord
+from proliferate.server.cloud.workflows.domain.definition import (
+    WorkflowDefinitionError,
+    parse_definition,
+)
+from proliferate.server.cloud.workflows.actions import (
+    _MAX_ATTEMPTS,
+    apply_step_actions,
+    claim_step_action,
+    sweep_pending_actions,
+)
+from proliferate.utils.time import utcnow
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"wf-fx-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="unused",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def _make_run_record(
+    *,
+    run_id: uuid.UUID | None = None,
+    executor_user_id: uuid.UUID | None = None,
+    step_outputs_json: dict | None = None,
+    resolved_plan_json: dict | None = None,
+) -> WorkflowRunRecord:
+    now = utcnow()
+    return WorkflowRunRecord(
+        id=run_id or uuid.uuid4(),
+        workflow_id=uuid.uuid4(),
+        workflow_version_id=uuid.uuid4(),
+        trigger_kind="manual",
+        trigger_id=None,
+        scheduled_for=None,
+        executor_user_id=executor_user_id or uuid.uuid4(),
+        args_json={},
+        target_mode="local",
+        resolved_plan_json=resolved_plan_json or {},
+        status="completed",
+        step_cursor=1,
+        step_outputs_json=step_outputs_json,
+        anyharness_workspace_id=None,
+        anyharness_session_ids=None,
+        error_code=None,
+        error_message=None,
+        cost_usd=None,
+        cost_tokens=None,
+        created_at=now,
+        updated_at=now,
+        delivered_at=None,
+        started_at=now,
+        finished_at=now,
+    )
+
+
+# --- claim CAS wins-once --------------------------------------------------------
+
+
+async def test_claim_cas_wins_once(db_session: AsyncSession) -> None:
+    """Two claims for the same (run, step, kind): only the first succeeds."""
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+
+    user = await _make_user(db_session)
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name="test",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={"version": 1, "inputs": [], "integrations": [], "agents": []},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run = WorkflowRun(
+        id=uuid.uuid4(),
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={},
+        status="completed",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run)
+    await db_session.flush()
+
+    first = await claim_step_action(
+        db_session, run_id=run.id, step_key="0.-.0", action_kind="slack_notify"
+    )
+    assert first is not None
+
+    second = await claim_step_action(
+        db_session, run_id=run.id, step_key="0.-.0", action_kind="slack_notify"
+    )
+    assert second is None
+
+
+# --- apply_step_actions idempotent on re-report ----------------------------------
+
+
+async def test_apply_step_actions_idempotent(db_session: AsyncSession) -> None:
+    """Calling apply_step_actions twice on the same run does not claim twice."""
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+
+    user = await _make_user(db_session)
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name="test-idem",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run_id = uuid.uuid4()
+    run_row = WorkflowRun(
+        id=run_id,
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hello", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        status="completed",
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "hello"}},
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run_row)
+    await db_session.flush()
+
+    run_record = _make_run_record(
+        run_id=run_id,
+        executor_user_id=user.id,
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hello", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "hello"}},
+    )
+
+    with patch(
+        "proliferate.server.cloud.workflows.actions._perform_slack_notify",
+        new_callable=AsyncMock,
+    ) as mock_perform:
+        await apply_step_actions(db_session, run=run_record)
+        assert mock_perform.call_count == 1
+
+        await apply_step_actions(db_session, run=run_record)
+        assert mock_perform.call_count == 1
+
+
+# --- slack perform success path -------------------------------------------------
+
+
+async def test_perform_slack_notify_success(db_session: AsyncSession) -> None:
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+    from proliferate.integrations.slack.client import SlackPostMessageResult
+
+    user = await _make_user(db_session)
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name="test-slack",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run_id = uuid.uuid4()
+    run_row = WorkflowRun(
+        id=run_id,
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hi", "slack_channel_id": "C123", "key": "0.-.0"}
+            ]
+        },
+        status="completed",
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "workflow done"}},
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run_row)
+    await db_session.flush()
+
+    run_record = _make_run_record(
+        run_id=run_id,
+        executor_user_id=user.id,
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hi", "slack_channel_id": "C123", "key": "0.-.0"}
+            ]
+        },
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "workflow done"}},
+    )
+
+    mock_result = SlackPostMessageResult(channel_id="C123", message_ts="1234.5678")
+
+    with (
+        patch(
+            "proliferate.server.cloud.workflows.actions.accounts_store.get_ready_account_for_provider",
+            new_callable=AsyncMock,
+            return_value=(
+                type(
+                    "FakeAccount",
+                    (),
+                    {"credential_ciphertext": "encrypted"},
+                )(),
+                type("FakeDef", (), {})(),
+            ),
+        ),
+        patch(
+            "proliferate.server.cloud.workflows.actions.decrypt_json",
+            return_value={"bot_token": "xoxb-test"},
+        ),
+        patch(
+            "proliferate.server.cloud.workflows.actions.slack_client.chat_post_message",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_chat,
+    ):
+        await apply_step_actions(db_session, run=run_record)
+
+    mock_chat.assert_called_once_with(
+        bot_token="xoxb-test",
+        channel_id="C123",
+        text="workflow done",
+        blocks=[],
+        thread_ts=None,
+    )
+
+    action = (await db_session.get(WorkflowStepAction, (await db_session.execute(
+        __import__("sqlalchemy").select(WorkflowStepAction).where(
+            WorkflowStepAction.run_id == run_id
+        )
+    )).scalar_one().id))
+    assert action.status == "done"
+    assert action.result_json == {"channel_id": "C123", "message_ts": "1234.5678"}
+
+
+# --- perform failure records 'failed' -------------------------------------------
+
+
+async def test_perform_failure_records_failed(db_session: AsyncSession) -> None:
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+
+    user = await _make_user(db_session)
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name="test-fail",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run_id = uuid.uuid4()
+    run_row = WorkflowRun(
+        id=run_id,
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "x", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        status="completed",
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "x"}},
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run_row)
+    await db_session.flush()
+
+    run_record = _make_run_record(
+        run_id=run_id,
+        executor_user_id=user.id,
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "x", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "x"}},
+    )
+
+    with patch(
+        "proliferate.server.cloud.workflows.actions.accounts_store.get_ready_account_for_provider",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await apply_step_actions(db_session, run=run_record)
+
+    from sqlalchemy import select
+
+    action = (
+        await db_session.execute(
+            select(WorkflowStepAction).where(WorkflowStepAction.run_id == run_id)
+        )
+    ).scalar_one()
+    assert action.status == "failed"
+    assert "No ready Slack account" in (action.error_message or "")
+
+
+# --- org policy blocks a personally-connected account ---------------------------
+
+
+async def test_org_policy_disabled_blocks_slack_notify(db_session: AsyncSession) -> None:
+    """Owner personally holds a ready Slack account, but their org has disabled the
+    Slack integration by policy => the notify action is blocked (no send).
+
+    The guarantee lives in the DB: ``get_ready_account_for_provider`` is called
+    with the run's real org id and its policy join excludes the account. Only the
+    Slack network client is mocked (it must never be reached)."""
+    from proliferate.db.models.cloud.integrations import (
+        CloudIntegrationAccount,
+        CloudIntegrationDefinition,
+        CloudIntegrationPolicy,
+    )
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+    from proliferate.db.models.organizations import Organization, OrganizationMembership
+
+    user = await _make_user(db_session)
+
+    # The owner's org, with the owner as an active member (this is how the run's
+    # org context is resolved — v1 executor == workflow owner).
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(org)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=org.id,
+            user_id=user.id,
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=utcnow(),
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+    )
+
+    # Seed Slack definition, enabled by default, but the org policy disables it.
+    definition = CloudIntegrationDefinition(
+        id=uuid.uuid4(),
+        source="seed",
+        namespace="slack",
+        display_name="Slack",
+        organization_id=None,
+        auth_kind="oauth2",
+        enabled_by_default=True,
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(definition)
+    await db_session.flush()
+    db_session.add(
+        CloudIntegrationPolicy(
+            organization_id=org.id,
+            definition_id=definition.id,
+            enabled=False,
+            updated_by_user_id=user.id,
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+    )
+    # Owner personally has a ready Slack account for that same definition.
+    db_session.add(
+        CloudIntegrationAccount(
+            id=uuid.uuid4(),
+            definition_id=definition.id,
+            owner_user_id=user.id,
+            owner_scope="personal",
+            enabled=True,
+            status="ready",
+            auth_kind="oauth2",
+            credential_ciphertext="encrypted",
+            created_at=utcnow(),
+            updated_at=utcnow(),
+        )
+    )
+    await db_session.flush()
+
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name="test-policy",
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run_id = uuid.uuid4()
+    run_row = WorkflowRun(
+        id=run_id,
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hi", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        status="completed",
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "hi"}},
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run_row)
+    await db_session.flush()
+
+    run_record = _make_run_record(
+        run_id=run_id,
+        executor_user_id=user.id,
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "hi", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "hi"}},
+    )
+
+    with patch(
+        "proliferate.server.cloud.workflows.actions.slack_client.chat_post_message",
+        new_callable=AsyncMock,
+    ) as mock_chat:
+        await apply_step_actions(db_session, run=run_record)
+
+    mock_chat.assert_not_called()
+
+    from sqlalchemy import select
+
+    action = (
+        await db_session.execute(
+            select(WorkflowStepAction).where(WorkflowStepAction.run_id == run_id)
+        )
+    ).scalar_one()
+    assert action.status == "failed"
+    assert "No ready Slack account" in (action.error_message or "")
+
+
+# --- sweeper retries stale pending/failed and respects attempt bound ------------
+
+
+async def _make_sweep_run(db_session: AsyncSession, *, name: str) -> uuid.UUID:
+    from proliferate.db.models.cloud.workflows import Workflow, WorkflowRun, WorkflowVersion
+
+    user = await _make_user(db_session)
+    wf = Workflow(
+        owner_user_id=user.id,
+        created_by_user_id=user.id,
+        name=name,
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(wf)
+    await db_session.flush()
+    ver = WorkflowVersion(
+        workflow_id=wf.id,
+        version_n=1,
+        definition_json={},
+        created_by_user_id=user.id,
+        created_at=utcnow(),
+    )
+    db_session.add(ver)
+    await db_session.flush()
+    run_id = uuid.uuid4()
+    run_row = WorkflowRun(
+        id=run_id,
+        workflow_id=wf.id,
+        workflow_version_id=ver.id,
+        trigger_kind="manual",
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json={
+            "steps": [
+                {"kind": "notify", "message": "s", "slack_channel_id": "C1", "key": "0.-.0"}
+            ]
+        },
+        status="completed",
+        step_outputs_json={"0.-.0": {"channel": "slack", "message": "s"}},
+        created_at=utcnow(),
+        updated_at=utcnow(),
+    )
+    db_session.add(run_row)
+    await db_session.flush()
+    return run_id
+
+
+async def test_sweeper_retries_stale_pending_and_respects_bound(
+    db_session: AsyncSession,
+) -> None:
+    run_id = await _make_sweep_run(db_session, name="test-sweep-pending")
+
+    stale_time = utcnow() - timedelta(seconds=120)
+    action = WorkflowStepAction(
+        id=uuid.uuid4(),
+        run_id=run_id,
+        step_key="0.-.0",
+        action_kind="slack_notify",
+        status="pending",
+        attempt_count=_MAX_ATTEMPTS,
+        created_at=stale_time,
+        updated_at=stale_time,
+    )
+    db_session.add(action)
+    await db_session.flush()
+
+    # A row already at the attempt cap is not selected by the sweep at all.
+    retried = await sweep_pending_actions(db_session)
+    assert retried == 0
+
+    await db_session.refresh(action)
+    assert action.status == "pending"
+    assert action.attempt_count == _MAX_ATTEMPTS
+
+
+async def test_sweeper_retries_transient_failed_below_cap(
+    db_session: AsyncSession,
+) -> None:
+    """A 'failed' row below the attempt cap gets retried by the sweep, and a
+    successful retry lands 'done' without clobbering the prior error_message
+    logic (it's overwritten by the real result on success)."""
+    run_id = await _make_sweep_run(db_session, name="test-sweep-failed")
+
+    stale_time = utcnow() - timedelta(seconds=120)
+    action = WorkflowStepAction(
+        id=uuid.uuid4(),
+        run_id=run_id,
+        step_key="0.-.0",
+        action_kind="slack_notify",
+        status="failed",
+        attempt_count=1,
+        error_message="Transient Slack API error",
+        created_at=stale_time,
+        updated_at=stale_time,
+    )
+    db_session.add(action)
+    await db_session.flush()
+
+    from proliferate.integrations.slack.client import SlackPostMessageResult
+
+    mock_result = SlackPostMessageResult(channel_id="C1", message_ts="1111.2222")
+
+    with (
+        patch(
+            "proliferate.server.cloud.workflows.actions.accounts_store.get_ready_account_for_provider",
+            new_callable=AsyncMock,
+            return_value=(
+                type("FakeAccount", (), {"credential_ciphertext": "encrypted"})(),
+                type("FakeDef", (), {})(),
+            ),
+        ),
+        patch(
+            "proliferate.server.cloud.workflows.actions.decrypt_json",
+            return_value={"bot_token": "xoxb-test"},
+        ),
+        patch(
+            "proliferate.server.cloud.workflows.actions.slack_client.chat_post_message",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ),
+    ):
+        retried = await sweep_pending_actions(db_session)
+
+    assert retried == 1
+
+    await db_session.refresh(action)
+    assert action.status == "done"
+    assert action.attempt_count == 2
+
+
+async def test_sweeper_does_not_select_action_at_attempt_cap(
+    db_session: AsyncSession,
+) -> None:
+    """A row at attempt_count == _MAX_ATTEMPTS is not selected by the sweep,
+    regardless of status, and its error_message is left untouched."""
+    run_id = await _make_sweep_run(db_session, name="test-sweep-cap")
+
+    stale_time = utcnow() - timedelta(seconds=120)
+    action = WorkflowStepAction(
+        id=uuid.uuid4(),
+        run_id=run_id,
+        step_key="0.-.0",
+        action_kind="slack_notify",
+        status="failed",
+        attempt_count=_MAX_ATTEMPTS,
+        error_message="Original transient error",
+        created_at=stale_time,
+        updated_at=stale_time,
+    )
+    db_session.add(action)
+    await db_session.flush()
+
+    retried = await sweep_pending_actions(db_session)
+    assert retried == 0
+
+    await db_session.refresh(action)
+    assert action.status == "failed"
+    assert action.error_message == "Original transient error"
+
+
+# --- notify-step validator requires slack_channel_id for slack channel -----------
+
+
+def _notify_definition(step: dict) -> dict:
+    return {
+        "version": 1,
+        "inputs": [],
+        "integrations": ["slack"],
+        "agents": [
+            {"slot": "main", "harness": "claude", "model": "sonnet", "steps": [step]},
+        ],
+    }
+
+
+def test_notify_validator_requires_slack_channel_id() -> None:
+    definition = _notify_definition({"kind": "notify", "message": "hello"})
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert "slack_channel_id" in exc.value.message
+
+
+def test_notify_validator_accepts_slack_channel_id() -> None:
+    definition = _notify_definition(
+        {"kind": "notify", "message": "hello", "slack_channel_id": "C1234"}
+    )
+    canonical, _specs = parse_definition(definition)
+    assert canonical["agents"][0]["steps"][0]["slack_channel_id"] == "C1234"
+
+
+def test_notify_validator_rejects_channel_discriminator() -> None:
+    # E1b: the channel discriminator (and in_app) are gone — notify is Slack-only.
+    definition = _notify_definition(
+        {"kind": "notify", "channel": "in_app", "message": "hi", "slack_channel_id": "C1"}
+    )
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "unknown_field"
+
+
+# --- channels endpoint connected / not-connected --------------------------------
+
+
+async def test_slack_channels_endpoint_not_connected(client) -> None:  # type: ignore[no-untyped-def]
+    """When no slack account, returns connected=false with empty list."""
+    from proliferate.db import engine as engine_module
+
+    session_factory = engine_module.async_session_factory
+    async with session_factory() as db:
+        user = await _make_user(db)
+        await db.commit()
+
+    from proliferate.server.cloud.workflows.api import list_slack_channels_endpoint
+
+    # Direct unit test of the logic
+    async with session_factory() as db:
+        with patch(
+            "proliferate.server.cloud.workflows.api.accounts_store.get_ready_account_for_provider",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await list_slack_channels_endpoint(db=db, user=user)
+    assert result.connected is False
+    assert result.channels == []
+
+
+async def test_slack_channels_endpoint_connected(client) -> None:  # type: ignore[no-untyped-def]
+    """When slack account exists, returns connected=true with channels."""
+    from proliferate.db import engine as engine_module
+    from proliferate.integrations.slack.client import SlackChannelSummary
+
+    session_factory = engine_module.async_session_factory
+    async with session_factory() as db:
+        user = await _make_user(db)
+        await db.commit()
+
+    fake_account = type("FakeAccount", (), {"credential_ciphertext": "enc"})()
+    fake_def = type("FakeDef", (), {})()
+    fake_channels = [
+        SlackChannelSummary(
+            id="C1", name="general", is_channel=True, is_private=False, is_archived=False
+        ),
+        SlackChannelSummary(
+            id="C2", name="random", is_channel=True, is_private=False, is_archived=False
+        ),
+    ]
+
+    from proliferate.server.cloud.workflows.api import list_slack_channels_endpoint
+
+    async with session_factory() as db:
+        with (
+            patch(
+                "proliferate.server.cloud.workflows.api.accounts_store.get_ready_account_for_provider",
+                new_callable=AsyncMock,
+                return_value=(fake_account, fake_def),
+            ),
+            patch(
+                "proliferate.server.cloud.workflows.api.decrypt_json",
+                return_value={"bot_token": "xoxb-test"},
+            ),
+            patch(
+                "proliferate.server.cloud.workflows.api.slack_client.list_channels",
+                new_callable=AsyncMock,
+                return_value=fake_channels,
+            ),
+        ):
+            result = await list_slack_channels_endpoint(db=db, user=user)
+    assert result.connected is True
+    assert len(result.channels) == 2
+    assert result.channels[0].id == "C1"

--- a/server/tests/unit/test_workflow_definition.py
+++ b/server/tests/unit/test_workflow_definition.py
@@ -1,4 +1,4 @@
-"""Strict workflow-definition validation (spec 3.3)."""
+"""Strict workflow-definition validation — format v2 (data-contract §1)."""
 
 from __future__ import annotations
 
@@ -13,54 +13,107 @@ from proliferate.server.cloud.workflows.domain.definition import (
 
 
 def _valid_definition() -> dict:
+    """A two-node spine covering the v2 kind union, refs, and the emit namespace."""
     return {
-        "args": [
-            {"name": "issue", "type": "string", "required": True},
+        "version": 1,
+        "name": "Sentry triage & fix",
+        "description": "…",
+        "inputs": [
+            {"name": "issue", "type": "text", "required": True},
             {"name": "tries", "type": "number", "default": 3},
-            {"name": "env", "type": "enum", "enum": ["prod", "staging"], "default": "staging"},
-        ],
-        "setup": {"harness": "claude", "model": "sonnet", "session_binding": "fresh"},
-        "steps": [
             {
-                "kind": "agent.prompt",
-                "prompt": "Fix {{args.issue}} in {{args.env}}",
-                "goal": {
-                    "objective": "tests green for {{args.issue}}",
-                    "max_turns": 25,
-                    "max_wall_secs": 5400,
-                    "on_blocked": "pause_for_approval",
-                    "verify": {"shell": "make test", "expect_exit": 0},
-                },
+                "name": "env",
+                "type": "choice",
+                "choices": ["prod", "staging"],
+                "default": "staging",
             },
-            {"kind": "shell.run", "command": "make test", "output_name": "test"},
+        ],
+        "integrations": ["sentry", "linear", "slack"],
+        "agents": [
             {
-                "kind": "notify",
-                "channel": "in_app",
-                "message": "done: {{steps[1].output.test}}",
-                "on_fail": {"kind": "continue"},
+                "slot": "triage",
+                "harness": "claude",
+                "model": "claude-sonnet-5",
+                "steps": [
+                    {
+                        "kind": "agent.prompt",
+                        "label": "Investigate",
+                        "prompt": "Fix {{inputs.issue}} in {{inputs.env}}",
+                        "required_invocation": {"provider": "linear", "tool": "update_status"},
+                        "goal": {
+                            "objective": "tests green for {{inputs.issue}}",
+                            "max_turns": 25,
+                            "max_wall_secs": 5400,
+                            "on_blocked": "pause_for_approval",
+                            "verify": {"shell": "make test", "expect_exit": 0},
+                        },
+                    },
+                    {
+                        "kind": "agent.emit",
+                        "name": "verdict",
+                        "prompt": "classify {{inputs.issue}}",
+                        "output_schema": {"type": "object"},
+                    },
+                ],
+            },
+            {
+                "slot": "fix",
+                "harness": "claude",
+                "model": "claude-opus-4-8",
+                "steps": [
+                    {"kind": "shell.run", "command": "make test", "output_name": "test"},
+                    {
+                        "kind": "agent.config",
+                        "model": "claude-opus-4-8",
+                    },
+                    {
+                        "kind": "notify",
+                        "slack_channel_id": "C123",
+                        "message": "root cause: {{verdict.root_cause}}",
+                        "on_fail": {"kind": "continue"},
+                    },
+                    {
+                        "kind": "branch",
+                        "on": "{{verdict.decision}}",
+                        "cases": {"ship": {"to": "continue"}, "wont_fix": {"to": "end"}},
+                    },
+                ],
             },
         ],
     }
+
+
+def _first_node(canonical: dict) -> dict:
+    return canonical["agents"][0]
+
+
+# --- shape ---------------------------------------------------------------------
 
 
 def test_parse_valid_definition_returns_canonical_and_specs() -> None:
     canonical, specs = parse_definition(_valid_definition())
     assert [s.name for s in specs] == ["issue", "tries", "env"]
-    assert canonical["setup"] == {
-        "harness": "claude",
-        "model": "sonnet",
-        "session_binding": "fresh",
-    }
-    # on_fail defaults to stop when omitted.
-    assert canonical["steps"][0]["on_fail"] == {"kind": "stop"}
-    assert canonical["steps"][2]["on_fail"] == {"kind": "continue"}
+    assert canonical["version"] == 1
+    assert canonical["integrations"] == ["sentry", "linear", "slack"]
+    assert [n["slot"] for n in canonical["agents"]] == ["triage", "fix"]
+    # on_fail defaults to stop; the continue on the notify step survives.
+    assert _first_node(canonical)["steps"][0]["on_fail"] == {"kind": "stop"}
+    assert canonical["agents"][1]["steps"][2]["on_fail"] == {"kind": "continue"}
 
 
-def test_default_session_binding_is_fresh() -> None:
+def test_version_must_be_one() -> None:
     definition = _valid_definition()
-    del definition["setup"]["session_binding"]
-    canonical, _ = parse_definition(definition)
-    assert canonical["setup"]["session_binding"] == "fresh"
+    definition["version"] = 2
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_setup_and_top_level_steps_are_removed() -> None:
+    definition = _valid_definition()
+    definition["setup"] = {"harness": "claude", "model": "x"}
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "unknown_field"
 
 
 def test_unknown_top_level_key_rejected() -> None:
@@ -71,148 +124,232 @@ def test_unknown_top_level_key_rejected() -> None:
     assert exc.value.code == "unknown_field"
 
 
+# --- agents spine (A4) ---------------------------------------------------------
+
+
+def test_at_least_one_agent_required() -> None:
+    definition = _valid_definition()
+    definition["agents"] = []
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_empty_agents_allowed_as_draft() -> None:
+    definition = _valid_definition()
+    definition["agents"] = []
+    canonical, _ = parse_definition(definition, require_steps=False)
+    assert canonical["agents"] == []
+
+
+def test_slot_must_match_grammar() -> None:
+    definition = _valid_definition()
+    definition["agents"][0]["slot"] = "Triage"  # uppercase illegal
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_duplicate_slot_rejected() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["slot"] = "triage"
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "duplicate_slot"
+
+
+# --- step-kind union -----------------------------------------------------------
+
+
 def test_unknown_step_kind_rejected() -> None:
     definition = _valid_definition()
-    definition["steps"][0]["kind"] = "agent.magic"
+    definition["agents"][0]["steps"][0]["kind"] = "agent.magic"
     with pytest.raises(WorkflowDefinitionError) as exc:
         parse_definition(definition)
     assert exc.value.code == "unknown_step_kind"
 
 
-def test_unknown_step_field_rejected() -> None:
+def test_human_approval_kind_is_gone() -> None:
     definition = _valid_definition()
-    definition["steps"][1]["nonsense"] = True
+    definition["agents"][0]["steps"].append(
+        {"kind": "human.approval", "message": "ship?", "on_timeout": "fail"}
+    )
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "unknown_step_kind"
+
+
+def test_notify_is_slack_only_no_channel() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["steps"][2]["channel"] = "in_app"
     with pytest.raises(WorkflowDefinitionError) as exc:
         parse_definition(definition)
     assert exc.value.code == "unknown_field"
 
 
-def test_empty_steps_rejected() -> None:
+def test_notify_requires_slack_channel_id() -> None:
     definition = _valid_definition()
-    definition["steps"] = []
+    del definition["agents"][1]["steps"][2]["slack_channel_id"]
     with pytest.raises(WorkflowDefinitionError):
         parse_definition(definition)
 
 
-def test_empty_steps_allowed_as_draft() -> None:
-    # Saving a workflow permits a zero-step draft (built in the editor after
-    # create); running it still requires steps.
+def test_agent_config_narrows_to_model_only() -> None:
     definition = _valid_definition()
-    definition["steps"] = []
-    canonical, _specs = parse_definition(definition, require_steps=False)
-    assert canonical["steps"] == []
-    # Omitted steps key is also tolerated for drafts.
-    del definition["steps"]
-    canonical2, _ = parse_definition(definition, require_steps=False)
-    assert canonical2["steps"] == []
-
-
-def test_arg_reference_to_unknown_arg_rejected() -> None:
-    definition = _valid_definition()
-    definition["steps"][0]["prompt"] = "hi {{args.nope}}"
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "unknown_arg_reference"
-
-
-def test_forward_step_reference_rejected() -> None:
-    definition = _valid_definition()
-    # Step 0 cannot reference the output of step 1 (does not run before it).
-    definition["steps"][0]["prompt"] = "use {{steps[1].output.test}}"
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "forward_step_reference"
-
-
-def test_self_step_reference_rejected() -> None:
-    definition = _valid_definition()
-    definition["steps"][1]["command"] = "echo {{steps[1].output.test}}"
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "forward_step_reference"
-
-
-def test_malformed_reference_rejected() -> None:
-    definition = _valid_definition()
-    definition["steps"][0]["prompt"] = "hi {{ args . issue }}"
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "invalid_template_reference"
-
-
-def test_enum_arg_requires_enum_list() -> None:
-    definition = _valid_definition()
-    definition["args"][2] = {"name": "env", "type": "enum"}
-    with pytest.raises(WorkflowDefinitionError):
-        parse_definition(definition)
-
-
-def test_enum_default_must_be_allowed() -> None:
-    definition = _valid_definition()
-    definition["args"][2]["default"] = "dev"
-    with pytest.raises(WorkflowDefinitionError):
-        parse_definition(definition)
-
-
-def test_non_enum_arg_rejects_enum_field() -> None:
-    definition = _valid_definition()
-    definition["args"][0]["enum"] = ["a", "b"]
+    definition["agents"][1]["steps"][1]["harness"] = "codex"
     with pytest.raises(WorkflowDefinitionError) as exc:
         parse_definition(definition)
     assert exc.value.code == "unknown_field"
 
 
-def test_duplicate_arg_name_rejected() -> None:
+def test_agent_config_requires_model() -> None:
     definition = _valid_definition()
-    definition["args"].append({"name": "issue", "type": "string"})
+    definition["agents"][1]["steps"][1] = {"kind": "agent.config"}
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_scm_open_pr_step_parses() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["steps"].append(
+        {"kind": "scm.open_pr", "title": "Fix {{inputs.issue}}", "base": "main", "draft": True}
+    )
+    canonical, _ = parse_definition(definition)
+    step = canonical["agents"][1]["steps"][-1]
+    assert step["title"] == "Fix {{inputs.issue}}"
+    assert step["draft"] is True
+
+
+# --- emit + refs ---------------------------------------------------------------
+
+
+def test_emit_name_required_and_unique() -> None:
+    definition = _valid_definition()
+    # duplicate the emit name in the second node
+    definition["agents"][1]["steps"].insert(
+        0, {"kind": "agent.emit", "name": "verdict", "prompt": "again"}
+    )
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "duplicate_emit"
+
+
+def test_emit_max_attempts_defaults_to_three() -> None:
+    canonical, _ = parse_definition(_valid_definition())
+    emit = _first_node(canonical)["steps"][1]
+    assert emit["name"] == "verdict"
+    assert emit["max_attempts"] == 3
+
+
+def test_emit_name_cannot_be_reserved_segment() -> None:
+    definition = _valid_definition()
+    definition["agents"][0]["steps"][1]["name"] = "inputs"
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_input_reference_to_unknown_input_rejected() -> None:
+    definition = _valid_definition()
+    definition["agents"][0]["steps"][0]["prompt"] = "hi {{inputs.nope}}"
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "unknown_input_reference"
+
+
+def test_forward_emit_reference_rejected() -> None:
+    definition = _valid_definition()
+    # The triage prompt (before the `verdict` emit) cannot see `verdict`.
+    definition["agents"][0]["steps"][0]["prompt"] = "use {{verdict.root_cause}}"
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "forward_emit_reference"
+
+
+def test_emit_cannot_reference_itself() -> None:
+    definition = _valid_definition()
+    definition["agents"][0]["steps"][1]["prompt"] = "self {{verdict.x}}"
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "forward_emit_reference"
+
+
+def test_prior_emit_is_visible_across_nodes() -> None:
+    # `verdict` (triage node) is visible to the fix node's notify — the baseline
+    # definition already exercises this; assert it parses clean.
+    parse_definition(_valid_definition())
+
+
+# --- branch (C11/D3) -----------------------------------------------------------
+
+
+def test_branch_cases_must_be_continue_or_end() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["steps"][3]["cases"]["ship"] = {"to": "goto_notify"}
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_branch_on_must_be_a_single_emit_ref() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["steps"][3]["on"] = "{{inputs.env}}"
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_branch_on_forward_emit_rejected() -> None:
+    definition = _valid_definition()
+    definition["agents"][1]["steps"][3]["on"] = "{{later.x}}"
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "forward_emit_reference"
+
+
+# --- inputs schema (E2) --------------------------------------------------------
+
+
+def test_choice_input_requires_choices_list() -> None:
+    definition = _valid_definition()
+    definition["inputs"][2] = {"name": "env", "type": "choice"}
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_choice_default_must_be_allowed() -> None:
+    definition = _valid_definition()
+    definition["inputs"][2]["default"] = "dev"
+    with pytest.raises(WorkflowDefinitionError):
+        parse_definition(definition)
+
+
+def test_non_choice_input_rejects_choices_field() -> None:
+    definition = _valid_definition()
+    definition["inputs"][0]["choices"] = ["a", "b"]
+    with pytest.raises(WorkflowDefinitionError) as exc:
+        parse_definition(definition)
+    assert exc.value.code == "unknown_field"
+
+
+def test_duplicate_input_name_rejected() -> None:
+    definition = _valid_definition()
+    definition["inputs"].append({"name": "issue", "type": "text"})
     with pytest.raises(WorkflowDefinitionError) as exc:
         parse_definition(definition)
     assert exc.value.code == "duplicate_arg"
 
 
+# --- on_fail + goal ------------------------------------------------------------
+
+
 def test_on_fail_retry_requires_positive_n() -> None:
     definition = _valid_definition()
-    definition["steps"][1]["on_fail"] = {"kind": "retry"}
+    definition["agents"][1]["steps"][0]["on_fail"] = {"kind": "retry"}
     with pytest.raises(WorkflowDefinitionError):
         parse_definition(definition)
-
-    definition["steps"][1]["on_fail"] = {"kind": "retry", "n": 2}
-    canonical, _ = parse_definition(definition)
-    assert canonical["steps"][1]["on_fail"] == {"kind": "retry", "n": 2}
 
 
 def test_goal_requires_caps_and_on_blocked() -> None:
     definition = _valid_definition()
-    del definition["steps"][0]["goal"]["max_turns"]
+    del definition["agents"][0]["steps"][0]["goal"]["max_turns"]
     with pytest.raises(WorkflowDefinitionError):
         parse_definition(definition)
-
-
-def test_notify_channel_validated() -> None:
-    definition = _valid_definition()
-    definition["steps"][2]["channel"] = "email"
-    with pytest.raises(WorkflowDefinitionError):
-        parse_definition(definition)
-
-
-def test_human_approval_step_parses() -> None:
-    definition = _valid_definition()
-    definition["steps"].append(
-        {"kind": "human.approval", "message": "ship?", "on_timeout": "fail", "timeout_secs": 600}
-    )
-    canonical, _ = parse_definition(definition)
-    assert canonical["steps"][3]["kind"] == "human.approval"
-    assert canonical["steps"][3]["on_timeout"] == "fail"
-
-
-def test_scm_open_pr_step_parses() -> None:
-    definition = _valid_definition()
-    definition["steps"].append(
-        {"kind": "scm.open_pr", "title": "Fix {{args.issue}}", "base": "main", "draft": True}
-    )
-    canonical, _ = parse_definition(definition)
-    assert canonical["steps"][3]["title"] == "Fix {{args.issue}}"
-    assert canonical["steps"][3]["draft"] is True
 
 
 def test_parse_does_not_mutate_input() -> None:
@@ -220,61 +357,3 @@ def test_parse_does_not_mutate_input() -> None:
     before = copy.deepcopy(definition)
     parse_definition(definition)
     assert definition == before
-
-
-# --- agent.config step (agent/model config is its own step) --------------------
-
-
-@pytest.mark.parametrize(
-    "config",
-    [
-        {"kind": "agent.config", "harness": "codex"},
-        {"kind": "agent.config", "model": "opus"},
-        {"kind": "agent.config", "harness": "codex", "model": "opus"},
-    ],
-)
-def test_agent_config_step_parses(config: dict) -> None:
-    definition = _valid_definition()
-    definition["steps"].insert(0, config)
-    canonical, _ = parse_definition(definition)
-    step = canonical["steps"][0]
-    assert step["kind"] == "agent.config"
-    assert step["on_fail"] == {"kind": "stop"}
-    for key in ("harness", "model"):
-        if key in config:
-            assert step[key] == config[key]
-        else:
-            assert key not in step
-
-
-def test_agent_config_requires_harness_or_model() -> None:
-    definition = _valid_definition()
-    definition["steps"].insert(0, {"kind": "agent.config"})
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "invalid_definition"
-
-
-def test_agent_config_rejects_empty_harness() -> None:
-    definition = _valid_definition()
-    definition["steps"].insert(0, {"kind": "agent.config", "harness": "  "})
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "invalid_definition"
-
-
-def test_agent_config_rejects_unknown_field() -> None:
-    definition = _valid_definition()
-    definition["steps"].insert(0, {"kind": "agent.config", "harness": "codex", "temperature": 1})
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "unknown_field"
-
-
-@pytest.mark.parametrize("field", ["model_override", "harness_override"])
-def test_agent_prompt_rejects_removed_overrides(field: str) -> None:
-    definition = _valid_definition()
-    definition["steps"][0][field] = "opus"
-    with pytest.raises(WorkflowDefinitionError) as exc:
-        parse_definition(definition)
-    assert exc.value.code == "unknown_field"

--- a/server/tests/unit/test_workflow_delivery.py
+++ b/server/tests/unit/test_workflow_delivery.py
@@ -44,8 +44,17 @@ async def _make_user(db: AsyncSession) -> User:
 
 def _definition() -> dict:
     return {
-        "setup": {"harness": "claude", "model": "sonnet", "session_binding": "fresh"},
-        "steps": [{"kind": "agent.prompt", "prompt": "do the thing"}],
+        "version": 1,
+        "inputs": [],
+        "integrations": [],
+        "agents": [
+            {
+                "slot": "main",
+                "harness": "claude",
+                "model": "sonnet",
+                "steps": [{"kind": "agent.prompt", "prompt": "do the thing"}],
+            }
+        ],
     }
 
 
@@ -420,7 +429,7 @@ async def test_start_run_cloud_requires_target_workspace(db_session: AsyncSessio
     workflow = await _make_workflow(db_session, user)
     with pytest.raises(CloudApiError) as exc:
         await service.start_run(
-            db_session, user, workflow.id, args={}, target_mode="personal_cloud"
+            db_session, user, workflow.id, inputs={}, target_mode="personal_cloud"
         )
     assert exc.value.code == "target_workspace_required"
     assert exc.value.status_code == 400
@@ -438,7 +447,7 @@ async def test_start_run_cloud_rejects_unowned_workspace(db_session: AsyncSessio
             db_session,
             user,
             workflow.id,
-            args={},
+            inputs={},
             target_mode="personal_cloud",
             target_workspace_id=foreign_ws.id,
         )
@@ -455,7 +464,7 @@ async def test_start_run_cloud_rejects_unmaterialized_workspace(db_session: Asyn
             db_session,
             user,
             workflow.id,
-            args={},
+            inputs={},
             target_mode="personal_cloud",
             target_workspace_id=workspace.id,
         )
@@ -473,7 +482,7 @@ async def test_start_run_cloud_stamps_sandbox_workspace_id(db_session: AsyncSess
         db_session,
         user,
         workflow.id,
-        args={},
+        inputs={},
         target_mode="personal_cloud",
         target_workspace_id=workspace.id,
     )

--- a/server/tests/unit/test_workflow_interpolation.py
+++ b/server/tests/unit/test_workflow_interpolation.py
@@ -1,4 +1,8 @@
-"""Argument coercion and eager ``{{args.*}}`` interpolation (spec 3.3)."""
+"""Input coercion + v2 template resolution (data-contract §1.3 / B6).
+
+Stored grammar is ``{{inputs.<name>}}`` (eager) and ``{{<emit>.<field>}}``
+(rewritten to the runtime's indexed ``{{steps[n].output.<field>}}`` at flatten
+time). Input types are text|number|choice|boolean (E2)."""
 
 from __future__ import annotations
 
@@ -7,9 +11,8 @@ import pytest
 from proliferate.server.cloud.workflows.domain.interpolation import (
     ArgSpec,
     ArgumentError,
-    coerce_arguments,
-    interpolate_args,
-    interpolate_args_in_string,
+    resolve_string,
+    resolve_value,
 )
 
 
@@ -26,9 +29,18 @@ def _spec(
     )
 
 
+def _resolve(value: str, inputs=None, emit_index=None) -> str:
+    return resolve_string(value, inputs=inputs or {}, emit_index=emit_index or {})
+
+
+# --- coercion (renamed types, unchanged machinery) -----------------------------
+
+
 def test_coerce_fills_defaults_and_coerces_types() -> None:
+    from proliferate.server.cloud.workflows.domain.interpolation import coerce_arguments
+
     specs = [
-        _spec("issue", "string", required=True),
+        _spec("issue", "text", required=True),
         _spec("tries", "number", default=3, has_default=True),
         _spec("dry", "boolean", default=False, has_default=True),
     ]
@@ -36,65 +48,54 @@ def test_coerce_fills_defaults_and_coerces_types() -> None:
     assert coerced == {"issue": "PROJ-1", "tries": 5, "dry": True}
 
 
-def test_missing_required_argument_rejected() -> None:
-    specs = [_spec("issue", "string", required=True)]
-    with pytest.raises(ArgumentError) as exc:
-        coerce_arguments(specs, {})
-    assert exc.value.code == "missing_argument"
+def test_choice_input_validated() -> None:
+    from proliferate.server.cloud.workflows.domain.interpolation import coerce_arguments
 
-
-def test_unknown_argument_rejected() -> None:
-    specs = [_spec("issue", "string", required=True)]
-    with pytest.raises(ArgumentError) as exc:
-        coerce_arguments(specs, {"issue": "x", "bogus": 1})
-    assert exc.value.code == "unknown_argument"
-
-
-def test_enum_argument_validated() -> None:
-    specs = [_spec("env", "enum", required=True, enum=("prod", "staging"))]
+    specs = [_spec("env", "choice", required=True, enum=("prod", "staging"))]
     assert coerce_arguments(specs, {"env": "prod"}) == {"env": "prod"}
     with pytest.raises(ArgumentError):
         coerce_arguments(specs, {"env": "dev"})
 
 
-def test_number_rejects_non_numeric_and_bool() -> None:
-    specs = [_spec("n", "number", required=True)]
-    with pytest.raises(ArgumentError):
-        coerce_arguments(specs, {"n": "abc"})
-    with pytest.raises(ArgumentError):
-        coerce_arguments(specs, {"n": True})
+# --- resolution ----------------------------------------------------------------
 
 
-def test_interpolate_replaces_args_and_preserves_step_tokens() -> None:
-    out = interpolate_args_in_string(
-        "Fix {{args.issue}} then check {{steps[1].output.test}}",
-        {"issue": "PROJ-1"},
+def test_resolves_inputs_and_rewrites_emit_refs() -> None:
+    out = _resolve(
+        "Fix {{inputs.issue}} using {{verdict.root_cause}}",
+        inputs={"issue": "PROJ-1"},
+        emit_index={"verdict": 2},
     )
-    assert out == "Fix PROJ-1 then check {{steps[1].output.test}}"
+    assert out == "Fix PROJ-1 using {{steps[2].output.root_cause}}"
 
 
 def test_boolean_and_number_render_predictably() -> None:
-    assert interpolate_args_in_string("{{args.flag}}", {"flag": True}) == "true"
-    assert interpolate_args_in_string("{{args.n}}", {"n": 5}) == "5"
+    assert _resolve("{{inputs.flag}}", {"flag": True}) == "true"
+    assert _resolve("{{inputs.n}}", {"n": 5}) == "5"
 
 
-def test_arg_value_cannot_inject_a_live_step_token() -> None:
-    # An arg value that literally contains a step token must be neutralized so the
-    # runtime's later step-output pass cannot pick it up as a live reference.
-    out = interpolate_args_in_string("{{args.evil}}", {"evil": "{{steps[0].output.x}}"})
+def test_input_value_cannot_inject_a_live_step_token() -> None:
+    out = _resolve("{{inputs.evil}}", {"evil": "{{steps[0].output.x}}"})
     assert "{{steps[0].output.x}}" not in out
     assert out == "\\{\\{steps[0].output.x\\}\\}"
 
 
-def test_interpolate_is_recursive_over_json() -> None:
+def test_resolve_is_recursive_over_json() -> None:
     plan = {
         "steps": [
-            {"prompt": "hi {{args.name}}"},
-            {"message": "later {{steps[0].output.z}}", "n": 3, "flag": True},
+            {"prompt": "hi {{inputs.name}}"},
+            {"message": "later {{verdict.z}}", "n": 3, "flag": True},
         ]
     }
-    out = interpolate_args(plan, {"name": "Ada"})
+    out = resolve_value(plan, inputs={"name": "Ada"}, emit_index={"verdict": 0})
     assert out["steps"][0]["prompt"] == "hi Ada"
     assert out["steps"][1]["message"] == "later {{steps[0].output.z}}"
     assert out["steps"][1]["n"] == 3
     assert out["steps"][1]["flag"] is True
+
+
+def test_reserved_first_segment_is_rejected() -> None:
+    from proliferate.server.cloud.workflows.domain.interpolation import TemplateReferenceError
+
+    with pytest.raises(TemplateReferenceError):
+        _resolve("{{fields.x}}", {}, {"x": 0})

--- a/server/tests/unit/test_workflow_service.py
+++ b/server/tests/unit/test_workflow_service.py
@@ -35,15 +35,23 @@ async def _make_user(db: AsyncSession) -> User:
 
 def _definition() -> dict:
     return {
-        "args": [
-            {"name": "issue", "type": "string", "required": True},
-            {"name": "env", "type": "enum", "enum": ["prod", "staging"], "default": "staging"},
+        "version": 1,
+        "inputs": [
+            {"name": "issue", "type": "text", "required": True},
+            {"name": "env", "type": "choice", "choices": ["prod", "staging"], "default": "staging"},
         ],
-        "setup": {"harness": "claude", "model": "sonnet", "session_binding": "fresh"},
-        "steps": [
-            {"kind": "agent.prompt", "prompt": "Fix {{args.issue}} on {{args.env}}"},
-            {"kind": "shell.run", "command": "make test", "output_name": "test"},
-            {"kind": "notify", "channel": "in_app", "message": "done {{steps[1].output.test}}"},
+        "integrations": ["slack"],
+        "agents": [
+            {
+                "slot": "main",
+                "harness": "claude",
+                "model": "sonnet",
+                "steps": [
+                    {"kind": "agent.prompt", "prompt": "Fix {{inputs.issue}} on {{inputs.env}}"},
+                    {"kind": "agent.emit", "name": "check", "prompt": "run tests"},
+                    {"kind": "notify", "slack_channel_id": "C1", "message": "done {{check.result}}"},
+                ],
+            }
         ],
     }
 
@@ -83,7 +91,7 @@ async def test_update_creates_new_version_and_preserves_old(db_session: AsyncSes
     v1 = versions_v1[0]
 
     new_definition = _definition()
-    new_definition["steps"][0]["prompt"] = "Rewritten {{args.issue}}"
+    new_definition["agents"][0]["steps"][0]["prompt"] = "Rewritten {{inputs.issue}}"
     updated, versions = await service.update_workflow(
         db_session, user, workflow.id, WorkflowUpdateRequest(definition=new_definition)
     )
@@ -94,7 +102,7 @@ async def test_update_creates_new_version_and_preserves_old(db_session: AsyncSes
     # v1 is immutable: its stored definition is unchanged.
     original = next(v for v in versions if v.version_n == 1)
     assert original.id == v1.id
-    assert original.definition_json["steps"][0]["prompt"] == "Fix {{args.issue}} on {{args.env}}"
+    assert original.definition_json["agents"][0]["steps"][0]["prompt"] == "Fix {{inputs.issue}} on {{inputs.env}}"
 
 
 async def test_start_run_resolves_plan_and_records_pending_delivery(
@@ -107,7 +115,7 @@ async def test_start_run_resolves_plan_and_records_pending_delivery(
         db_session,
         user,
         workflow.id,
-        args={"issue": "PROJ-9", "env": "prod"},
+        inputs={"issue": "PROJ-9", "env": "prod"},
         target_mode="local",
     )
 
@@ -119,15 +127,15 @@ async def test_start_run_resolves_plan_and_records_pending_delivery(
     assert plan["run_id"] == str(run.id)
     assert plan["steps"][0]["prompt"] == "Fix PROJ-9 on prod"
     # Step-output references stay late-bound for the runtime.
-    assert plan["steps"][2]["message"] == "done {{steps[1].output.test}}"
-    assert plan["setup"]["harness"] == "claude"
+    assert plan["steps"][2]["message"] == "done {{steps[1].output.result}}"
+    assert plan["sessions"]["main"]["harness"] == "claude"
 
 
 async def test_start_run_rejects_missing_required_arg(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow, _ = await _create_workflow(db_session, user)
     with pytest.raises(CloudApiError) as exc:
-        await service.start_run(db_session, user, workflow.id, args={}, target_mode="local")
+        await service.start_run(db_session, user, workflow.id, inputs={}, target_mode="local")
     assert exc.value.code == "missing_argument"
 
 
@@ -136,7 +144,7 @@ async def test_start_run_rejects_bad_target_mode(db_session: AsyncSession) -> No
     workflow, _ = await _create_workflow(db_session, user)
     with pytest.raises(CloudApiError) as exc:
         await service.start_run(
-            db_session, user, workflow.id, args={"issue": "x"}, target_mode="shared_cloud"
+            db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="shared_cloud"
         )
     assert exc.value.code == "invalid_target_mode"
 
@@ -145,7 +153,7 @@ async def test_delivery_then_status_lifecycle(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow, _ = await _create_workflow(db_session, user)
     run = await service.start_run(
-        db_session, user, workflow.id, args={"issue": "x"}, target_mode="local"
+        db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="local"
     )
 
     delivered = await service.mark_run_delivered(db_session, user, run.id)
@@ -175,7 +183,7 @@ async def test_status_guard_rejects_illegal_transition(db_session: AsyncSession)
     user = await _make_user(db_session)
     workflow, _ = await _create_workflow(db_session, user)
     run = await service.start_run(
-        db_session, user, workflow.id, args={"issue": "x"}, target_mode="local"
+        db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="local"
     )
     # pending_delivery -> running is not a legal observed transition.
     with pytest.raises(CloudApiError) as exc:
@@ -190,7 +198,7 @@ async def test_status_rejects_reports_after_terminal(db_session: AsyncSession) -
     user = await _make_user(db_session)
     workflow, _ = await _create_workflow(db_session, user)
     run = await service.start_run(
-        db_session, user, workflow.id, args={"issue": "x"}, target_mode="local"
+        db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="local"
     )
     await service.mark_run_delivered(db_session, user, run.id)
     await service.report_run_status(db_session, user, run.id, RunStatusRequest(status="running"))
@@ -208,7 +216,7 @@ async def test_cannot_run_archived_workflow(db_session: AsyncSession) -> None:
     await service.archive_workflow(db_session, user, workflow.id)
     with pytest.raises(CloudApiError) as exc:
         await service.start_run(
-            db_session, user, workflow.id, args={"issue": "x"}, target_mode="local"
+            db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="local"
         )
     assert exc.value.code == "workflow_archived"
 

--- a/server/tests/unit/test_workflow_triggers.py
+++ b/server/tests/unit/test_workflow_triggers.py
@@ -63,11 +63,18 @@ async def _make_user(db: AsyncSession) -> User:
 
 
 def _definition(*, required_arg: bool = False) -> dict:
-    args = [{"name": "issue", "type": "string", "required": required_arg}]
     return {
-        "args": args,
-        "setup": {"harness": "claude", "model": "sonnet", "session_binding": "fresh"},
-        "steps": [{"kind": "agent.prompt", "prompt": "Fix {{args.issue}}"}],
+        "version": 1,
+        "inputs": [{"name": "issue", "type": "text", "required": required_arg}],
+        "integrations": [],
+        "agents": [
+            {
+                "slot": "main",
+                "harness": "claude",
+                "model": "sonnet",
+                "steps": [{"kind": "agent.prompt", "prompt": "Fix {{inputs.issue}}"}],
+            }
+        ],
     }
 
 

--- a/specs/generated/anyharness-db-schema.sql
+++ b/specs/generated/anyharness-db-schema.sql
@@ -510,6 +510,7 @@ CREATE TABLE workflow_runs (
 CREATE TABLE workflow_step_runs (
     run_id TEXT NOT NULL REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
     step_index INTEGER NOT NULL,
+    step_key TEXT NOT NULL,
     kind TEXT NOT NULL,
     status TEXT NOT NULL,
     attempt INTEGER NOT NULL DEFAULT 0,
@@ -762,6 +763,10 @@ CREATE INDEX idx_workflow_runs_status
 -- index: idx_workflow_runs_workspace_created
 CREATE INDEX idx_workflow_runs_workspace_created
     ON workflow_runs(workspace_id, created_at DESC);
+
+-- index: idx_workflow_step_runs_key
+CREATE UNIQUE INDEX idx_workflow_step_runs_key
+    ON workflow_step_runs(run_id, step_key);
 
 -- index: idx_workspaces_path
 CREATE INDEX idx_workspaces_path ON workspaces(path);


### PR DESCRIPTION
First PR of the A–E arc (design of record \`codex/workflows-architecture.md\`, all rulings through L26 applied — the ruled doc rides this branch).

**History rewritten 2026-07-08 per rulings L16–L26** (nothing was merged, so renamed in-stack): "effects" → **server-performed actions** (L19 Rule 3) and the org-policy defect fixed.

## What

The server observes completed \`notify(slack)\` steps in reported/refreshed run state and performs the send with an **exactly-once claim, at-least-once completion** guarantee:

- **\`workflow_step_action\` ledger** (migration \`c3a5e7f9d1b2\`): \`(run_id, step_index, action_kind)\` unique constraint IS the claim — \`INSERT … ON CONFLICT DO NOTHING\` CAS. \`action_kind IN ('slack_notify')\` only (\`spawn_child_run\` removed outright per L20; \`function_call\` joins later per L18/L23). L19 invariant in the module docstring: actions perform side effects of steps the runtime already executed; they never decide or cause what executes next.
- **\`actions.py\`**: claim CAS, \`apply_step_actions\` observer, Slack performer via the existing first-class client, sweeper retrying stale \`pending\` + transient \`failed\` rows (attempt-bounded).
- **Org-policy defect fix (§3.3)**: \`_perform_slack_notify\` now threads the run owner's \`organization_id\` into \`get_ready_account_for_provider\`, which gained an org-policy join (\`coalesce(policy.enabled, definition.enabled_by_default)\`) — previously the send silently bypassed org policy. Tier-1 test with real org/policy/account rows proves a policy-disabled org blocks the send.
- **Observer hooks** at the end of \`report_run_status\` + \`_sync_run_from_view\`; failures never break status ingestion. **Scheduler phase 3**: refresh in-flight triggered cloud runs + action sweeper (per §4.1 this is the backstop behind PR E's completion ping).
- **Runtime**: \`notify(slack)\` completes with \`{channel, message, slack_channel_id}\` instead of the \`slack_unavailable\` stub.
- **UI**: Slack channel picker, delivery chip from real action rows (\`stepActions\` on run detail). Docs (L13): deep-dive updated in-PR.

## Verification
98 workflow tests green on this tip (267 with the full filter on the verifier pass); rename-grep clean across server/apps/anyharness (only the unrelated \`StepEffectiveConfig\` symbol remains, correctly untouched); single alembic head; desktop tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)