### PR TITLE
feat(workflows): PR C — agent.emit typed output + named step refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +286,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -390,6 +410,7 @@ dependencies = [
  "fs2",
  "futures",
  "hmac",
+ "jsonschema",
  "jsonwebtoken",
  "nucleo-matcher",
  "portable-pty",
@@ -806,6 +827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +867,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1592,6 +1625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1756,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1921,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2378,6 +2452,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2949,6 +3025,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,6 +3326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,12 +3476,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3379,6 +3526,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3753,6 +3921,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -4624,6 +4798,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -6990,6 +7181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7156,6 +7353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7178,6 +7385,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ jsonwebtoken = "9"
 # OpenAPI / schema
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-axum = "0.2"
+jsonschema = { version = "0.46", default-features = false }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/anyharness/crates/anyharness-contract/src/v1/workflows.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/workflows.rs
@@ -70,8 +70,9 @@ pub struct WorkflowRunView {
     pub workspace_id: String,
     pub status: WorkflowRunStatus,
     pub step_cursor: i64,
+    /// Slot-keyed session map (B7): `slot -> session_id`.
     #[serde(default)]
-    pub session_ids: Vec<String>,
+    pub session_ids: std::collections::BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +139,10 @@ mod tests {
             workspace_id: "ws-1".to_string(),
             status: WorkflowRunStatus::Running,
             step_cursor: 1,
-            session_ids: vec!["session-1".to_string()],
+            session_ids: std::collections::BTreeMap::from([(
+                "triage".to_string(),
+                "session-1".to_string(),
+            )]),
             error_code: None,
             error_message: None,
             created_at: "2026-07-03T00:00:00Z".to_string(),
@@ -159,7 +163,7 @@ mod tests {
         let json = serde_json::to_value(&view).expect("serialize run view");
         assert_eq!(json["runId"], "run-1");
         assert_eq!(json["status"], "running");
-        assert_eq!(json["sessionIds"][0], "session-1");
+        assert_eq!(json["sessionIds"]["triage"], "session-1");
         assert_eq!(json["steps"][0]["kind"], "agent.prompt");
         assert_eq!(json["steps"][0]["status"], "completed");
         assert_eq!(json["steps"][0]["output"]["turnId"], "turn-1");

--- a/anyharness/crates/anyharness-lib/Cargo.toml
+++ b/anyharness/crates/anyharness-lib/Cargo.toml
@@ -17,6 +17,7 @@ serde_json.workspace = true
 jsonwebtoken.workspace = true
 utoipa.workspace = true
 utoipa-axum.workspace = true
+jsonschema.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/engine.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/engine.rs
@@ -47,6 +47,7 @@ pub struct StepExecContext {
 }
 
 /// The result of executing one step.
+#[derive(Debug)]
 pub enum StepOutcome {
     /// The step succeeded; `output` is the typed step output (also the source
     /// for `{{steps[N].output.*}}` late-binding by later steps).
@@ -63,6 +64,11 @@ pub enum StepOutcome {
     /// `descriptor` is persisted as the waiting step's output (message, kind,
     /// deadline) so the wait survives a restart.
     AwaitApproval { descriptor: serde_json::Value },
+    /// The step succeeded AND requested the run end here (a `branch` step whose
+    /// taken case is `end`, C11/E5): the step is recorded completed with
+    /// `output`, the run goes terminal `completed`, and every later step is
+    /// marked `skipped`. Not subject to the on_fail matrix — `end` is a success.
+    EndRun { output: serde_json::Value },
 }
 
 /// The decision the pure on-fail logic reaches for a completed executor call.
@@ -89,6 +95,11 @@ pub enum StepDecision {
     Suspend {
         descriptor: serde_json::Value,
     },
+    /// Complete this step and end the run early, marking every later step
+    /// `skipped` (branch `end`, C11/E5).
+    EndRun {
+        output: serde_json::Value,
+    },
 }
 
 /// How far the engine got on a single `run_next_step` call.
@@ -108,6 +119,9 @@ pub fn decide_after_step(on_fail: OnFail, attempt: i64, outcome: StepOutcome) ->
     match outcome {
         StepOutcome::Completed { output } => StepDecision::Complete { output },
         StepOutcome::AwaitApproval { descriptor } => StepDecision::Suspend { descriptor },
+        // `end` is a deliberate success route, never a failure — the on_fail
+        // matrix does not apply.
+        StepOutcome::EndRun { output } => StepDecision::EndRun { output },
         StepOutcome::Failed {
             code,
             message,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
+
 use anyharness_contract::v1::{WorkflowRunStatus, WorkflowStepStatus};
 
 /// The anyharness-local mirror of one delivered workflow run. The resolved plan
 /// is stored verbatim in `plan_json` (the actor never re-fetches a definition —
 /// the StartRun payload is the whole contract). `step_cursor` is the index of
-/// the step the actor is at; `session_ids` is the ordered list of sessions the
-/// run has opened (the harness-switch design opens a new one per harness).
+/// the step the actor is at; `session_ids` is the slot-keyed session map (B7):
+/// `{"triage": "sess_…"}` — one session per agent slot, opened lazily.
 #[derive(Debug, Clone)]
 pub struct WorkflowRunRecord {
     pub run_id: String,
@@ -17,7 +19,8 @@ pub struct WorkflowRunRecord {
     pub plan_json: String,
     pub status: WorkflowRunStatus,
     pub step_cursor: i64,
-    pub session_ids: Vec<String>,
+    /// Slot-keyed session map (B7): `slot -> session_id`.
+    pub session_ids: BTreeMap<String, String>,
     pub error_code: Option<String>,
     pub error_message: Option<String>,
     pub created_at: String,
@@ -29,9 +32,16 @@ impl WorkflowRunRecord {
         run_status_is_terminal(self.status)
     }
 
-    /// The session opened most recently (the run's current session, if any).
+    /// A live session of the run, for best-effort control (e.g. cancel's
+    /// in-flight-turn teardown). With slot-keyed sessions there is no single
+    /// "current" session; any bound session is a valid teardown target.
     pub fn current_session_id(&self) -> Option<&str> {
-        self.session_ids.last().map(String::as_str)
+        self.session_ids.values().next().map(String::as_str)
+    }
+
+    /// The slot-keyed session map (B7).
+    pub fn sessions(&self) -> &BTreeMap<String, String> {
+        &self.session_ids
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
@@ -58,31 +58,6 @@ impl ResolvedPlan {
     pub fn step_count(&self) -> usize {
         self.steps.len()
     }
-
-    /// Back-compat single-session view for the current (pre-multi-slot) executor.
-    ///
-    /// TODO(workflows phase C/F, B7): the executor must become slot-keyed —
-    /// a `slot -> session` map, no single "current" session. Until then this
-    /// derives one `PlanSetup` from the session of the first step's slot (falling
-    /// back to any session), preserving today's single-session behavior.
-    pub fn setup(&self) -> PlanSetup {
-        let slot = self.steps.first().map(|s| s.slot.as_str());
-        let session = slot
-            .and_then(|slot| self.sessions.get(slot))
-            .or_else(|| self.sessions.values().next());
-        match session {
-            Some(spec) => PlanSetup {
-                harness: spec.harness.clone(),
-                model: spec.model.clone(),
-                session_binding: spec.session_binding,
-            },
-            None => PlanSetup {
-                harness: String::new(),
-                model: None,
-                session_binding: SessionBinding::Fresh,
-            },
-        }
-    }
 }
 
 /// How one slot's session is provisioned (data-contract §4 `sessions[slot]`).
@@ -96,15 +71,6 @@ pub struct SessionSpec {
     /// L29: bind an existing session instead of creating a fresh one.
     #[serde(default)]
     pub bind_session_id: Option<String>,
-}
-
-/// The single-session view the current executor still consumes. Not deserialized
-/// directly — derived from `sessions` by [`ResolvedPlan::setup`].
-#[derive(Debug, Clone)]
-pub struct PlanSetup {
-    pub harness: String,
-    pub model: Option<String>,
-    pub session_binding: SessionBinding,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -216,13 +182,12 @@ pub struct RequiredInvocation {
     pub tool: String,
 }
 
-/// Sets the active agent harness and/or model for the steps below it. At least
-/// one of `harness` / `model` is present (enforced server-side); it executes
-/// instantly and never opens a session of its own.
+/// Sets the active model for the steps below it in the same slot. Model-only
+/// (A3): harness is fixed per slot, so a different harness is a different slot —
+/// there is no harness-switch. Executes instantly and never opens a session of
+/// its own.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentConfigStep {
-    #[serde(default)]
-    pub harness: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
 }
@@ -412,13 +377,12 @@ mod tests {
         assert_eq!(plan.version_n, Some(2));
         assert_eq!(plan.step_count(), 7);
 
-        // sessions map, keyed by slot; setup() derives the first step's slot session.
+        // sessions map, keyed by slot.
         assert_eq!(plan.sessions.len(), 2);
         assert_eq!(plan.sessions["fix"].bind_session_id.as_deref(), Some("sess_abc"));
         assert_eq!(plan.sessions["fix"].session_binding, SessionBinding::Headless);
-        let setup = plan.setup();
-        assert_eq!(setup.harness, "claude");
-        assert_eq!(setup.session_binding, SessionBinding::Fresh);
+        assert_eq!(plan.sessions["triage"].harness, "claude");
+        assert_eq!(plan.sessions["triage"].session_binding, SessionBinding::Fresh);
 
         // steps carry structured key + slot + label.
         assert_eq!(plan.steps[0].key, "0.-.0");
@@ -472,8 +436,8 @@ mod tests {
             }"#,
         )
         .expect("parse minimal plan");
-        assert_eq!(plan.setup().session_binding, SessionBinding::Headless);
-        assert!(plan.setup().model.is_none());
+        assert_eq!(plan.sessions["main"].session_binding, SessionBinding::Headless);
+        assert!(plan.sessions["main"].model.is_none());
         let StepKind::AgentPrompt(agent) = &plan.steps[0].kind else {
             panic!("expected agent.prompt");
         };

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
@@ -121,7 +121,7 @@ impl WorkflowService {
                 plan_json: plan_json.clone(),
                 status: WorkflowRunStatus::Running,
                 step_cursor: 0,
-                session_ids: Vec::new(),
+                session_ids: std::collections::BTreeMap::new(),
                 error_code: None,
                 error_message: None,
                 created_at: now.clone(),
@@ -159,16 +159,23 @@ impl WorkflowService {
         Ok(created)
     }
 
-    /// Record a session the run has opened (append-once, ordered).
-    pub fn append_session_id(&self, run_id: &str, session_id: &str) -> anyhow::Result<()> {
+    /// Record the session a slot is bound to for this run (B7 slot-keyed session
+    /// map). Idempotent on the (slot, session) pair; a slot only ever maps to one
+    /// live session for the run's lifetime.
+    pub fn set_session_for_slot(
+        &self,
+        run_id: &str,
+        slot: &str,
+        session_id: &str,
+    ) -> anyhow::Result<()> {
         self.store.with_tx_anyhow(|tx| {
             let Some(mut run) = WorkflowStore::find_run_tx(tx, run_id)? else {
                 return Ok(());
             };
-            if run.session_ids.iter().any(|id| id == session_id) {
+            if run.session_ids.get(slot).map(String::as_str) == Some(session_id) {
                 return Ok(());
             }
-            run.session_ids.push(session_id.to_string());
+            run.session_ids.insert(slot.to_string(), session_id.to_string());
             run.updated_at = now();
             WorkflowStore::update_run(tx, &run)?;
             Ok(())
@@ -343,6 +350,7 @@ impl WorkflowService {
             let mut run = WorkflowStore::find_run_tx(tx, run_id)?
                 .ok_or_else(|| anyhow::anyhow!("run vanished mid-decision"))?;
 
+            let mut end_run = false;
             let progress = match decision {
                 StepDecision::Complete { output } => {
                     finish_step(&mut step, WorkflowStepStatus::Completed, Some(output), None, None, &now);
@@ -401,10 +409,26 @@ impl WorkflowService {
                     run.updated_at = now.clone();
                     EngineProgress::SuspendedForApproval
                 }
+                // Branch `end` (C11/E5): the branch step completes with its
+                // taken-case output; the cursor jumps to the end; the run goes
+                // terminal `completed`; every later step is marked `skipped`.
+                StepDecision::EndRun { output } => {
+                    finish_step(&mut step, WorkflowStepStatus::Completed, Some(output), None, None, &now);
+                    run.step_cursor = step_count as i64;
+                    run.status = WorkflowRunStatus::Completed;
+                    run.updated_at = now.clone();
+                    end_run = true;
+                    EngineProgress::Finished(WorkflowRunStatus::Completed)
+                }
             };
 
             WorkflowStore::update_step_run(tx, &step)?;
             WorkflowStore::update_run(tx, &run)?;
+            // Skip the tail on an early end: mark every still-pending later step
+            // `skipped` so the checklist reflects the branch short-circuit (E5).
+            if end_run {
+                skip_tail(tx, run_id, step_index, step_count, &now)?;
+            }
             Ok(progress)
         })
     }
@@ -451,6 +475,31 @@ fn finish_step(
     step.error_message = error_message;
     step.ended_at = Some(now.to_string());
     step.updated_at = now.to_string();
+}
+
+/// Mark every step after `after_index` (up to `step_count`) that has not yet
+/// reached a terminal state as `skipped` — the tail a branch `end` cut off.
+fn skip_tail(
+    tx: &rusqlite::Connection,
+    run_id: &str,
+    after_index: i64,
+    step_count: usize,
+    now: &str,
+) -> anyhow::Result<()> {
+    for index in (after_index + 1)..(step_count as i64) {
+        if let Some(mut step) = WorkflowStore::find_step_run_tx(tx, run_id, index)? {
+            if matches!(
+                step.status,
+                WorkflowStepStatus::Pending | WorkflowStepStatus::Running | WorkflowStepStatus::Waiting
+            ) {
+                step.status = WorkflowStepStatus::Skipped;
+                step.ended_at = Some(now.to_string());
+                step.updated_at = now.to_string();
+                WorkflowStore::update_step_run(tx, &step)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn advance_or_finish(

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
@@ -82,6 +82,10 @@ fn failed(code: &str) -> StepOutcome {
     }
 }
 
+fn end_run(output: serde_json::Value) -> StepOutcome {
+    StepOutcome::EndRun { output }
+}
+
 /// Drive the run to a resting point (terminal or suspended), exactly like the
 /// actor loop.
 async fn drive(
@@ -281,6 +285,61 @@ async fn on_fail_retry_succeeds_on_second_attempt() {
 }
 
 // --------------------------------------------------------------------------
+// Branch continue / end + skipped tail (C11 / E5)
+// --------------------------------------------------------------------------
+
+#[tokio::test]
+async fn branch_continue_advances_to_the_next_step() {
+    let service = test_service();
+    let run_id = create(
+        &service,
+        r#"[{ "kind": "branch", "on": "{{steps[0].output.verdict}}",
+             "cases": { "ship": { "to": "continue" }, "wont_fix": { "to": "end" } } },
+            { "kind": "shell.run", "command": "deploy" }]"#,
+    );
+    // Branch continues (Completed), then the tail step runs.
+    let executor = FakeExecutor::script(vec![
+        completed(serde_json::json!({ "value": "ship", "target": "continue" })),
+        completed(serde_json::json!({ "exit_code": 0 })),
+    ]);
+    let progress = drive(&service, &run_id, &executor).await;
+    assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
+    let (run, steps) = service.get_run_with_steps(&run_id).unwrap().unwrap();
+    assert_eq!(run.step_cursor, 2);
+    assert!(steps.iter().all(|s| s.status == WorkflowStepStatus::Completed));
+}
+
+#[tokio::test]
+async fn branch_end_completes_run_and_skips_the_tail() {
+    let service = test_service();
+    let run_id = create(
+        &service,
+        r#"[{ "kind": "shell.run", "command": "lint" },
+            { "kind": "branch", "on": "{{steps[0].output.verdict}}",
+              "cases": { "ship": { "to": "continue" }, "wont_fix": { "to": "end" } } },
+            { "kind": "shell.run", "command": "deploy" },
+            { "kind": "notify", "slack_channel_id": "C1", "message": "done" }]"#,
+    );
+    let executor = FakeExecutor::script(vec![
+        completed(serde_json::json!({ "verdict": "wont_fix" })),
+        end_run(serde_json::json!({ "value": "wont_fix", "target": "end" })),
+    ]);
+    let progress = drive(&service, &run_id, &executor).await;
+    assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
+
+    let (run, steps) = service.get_run_with_steps(&run_id).unwrap().unwrap();
+    assert_eq!(run.status, WorkflowRunStatus::Completed);
+    // The branch step is recorded Completed with its taken-case output...
+    assert_eq!(steps[1].status, WorkflowStepStatus::Completed);
+    assert_eq!(steps[1].output_value().unwrap()["target"], "end");
+    // ...and every step after the end is Skipped, never executed.
+    assert_eq!(steps[2].status, WorkflowStepStatus::Skipped);
+    assert_eq!(steps[3].status, WorkflowStepStatus::Skipped);
+    // Only the two pre-end steps actually ran.
+    assert_eq!(executor.calls().len(), 2);
+}
+
+// --------------------------------------------------------------------------
 // Approval suspend / resolve / timeout
 // --------------------------------------------------------------------------
 
@@ -383,14 +442,17 @@ async fn resume_reenters_a_step_that_was_running() {
 }
 
 #[test]
-fn append_session_id_is_append_once() {
+fn set_session_for_slot_is_slot_keyed_and_idempotent() {
     let service = test_service();
     let run_id = create(&service, r#"[{ "kind": "shell.run", "command": "x" }]"#);
-    service.append_session_id(&run_id, "session-1").unwrap();
-    service.append_session_id(&run_id, "session-1").unwrap();
-    service.append_session_id(&run_id, "session-2").unwrap();
+    service.set_session_for_slot(&run_id, "triage", "session-1").unwrap();
+    // Same (slot, session) is a no-op; a second slot adds a key.
+    service.set_session_for_slot(&run_id, "triage", "session-1").unwrap();
+    service.set_session_for_slot(&run_id, "fix", "session-2").unwrap();
     let run = service.get_run(&run_id).unwrap().unwrap();
-    assert_eq!(run.session_ids, vec!["session-1".to_string(), "session-2".to_string()]);
+    assert_eq!(run.session_ids.len(), 2);
+    assert_eq!(run.session_ids["triage"], "session-1");
+    assert_eq!(run.session_ids["fix"], "session-2");
 }
 
 #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
@@ -222,11 +222,14 @@ impl WorkflowStore {
     }
 }
 
-fn encode_session_ids(session_ids: &[String]) -> String {
-    serde_json::to_string(session_ids).unwrap_or_else(|_| "[]".to_string())
+fn encode_session_ids(session_ids: &std::collections::BTreeMap<String, String>) -> String {
+    serde_json::to_string(session_ids).unwrap_or_else(|_| "{}".to_string())
 }
 
-fn decode_session_ids(raw: Option<String>) -> Vec<String> {
+/// Decode the slot-keyed session map. Tolerates a legacy JSON array (pre-B7
+/// ordered list) by dropping it to an empty map — no run predates the hard cut
+/// (E4), so this only guards against a hand-edited row.
+fn decode_session_ids(raw: Option<String>) -> std::collections::BTreeMap<String, String> {
     raw.as_deref()
         .and_then(|value| serde_json::from_str(value).ok())
         .unwrap_or_default()

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs
@@ -114,9 +114,8 @@ fn render_value(value: &serde_json::Value) -> String {
 /// late-bound against `outputs`.
 pub fn resolve_step(step: &PlanStep, outputs: &StepOutputs) -> PlanStep {
     let kind = match &step.kind {
-        // agent.config carries only literal harness/model ids — nothing to bind.
+        // agent.config carries only a literal model id — nothing to bind.
         StepKind::AgentConfig(config) => StepKind::AgentConfig(AgentConfigStep {
-            harness: config.harness.clone(),
             model: config.model.clone(),
         }),
         StepKind::AgentPrompt(agent) => StepKind::AgentPrompt(AgentPromptStep {

--- a/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
@@ -1,18 +1,19 @@
 //! The live [`WorkflowStepExecutor`] implementation: it drives real sessions,
-//! goals, shells, PRs, and notifications. It owns run-scoped session continuity
-//! (the harness-switch design opens a NEW session when a step's effective
-//! harness differs from the current session's) and awaits turn/goal completion
-//! off the live session's broadcast stream.
+//! goals, shells, PRs, and notifications. Sessions are slot-keyed (B7): each
+//! agent slot owns exactly one session for the run's lifetime (harness is fixed
+//! per slot — there is no harness-switch machinery), and turn/goal completion is
+//! awaited off the live session's broadcast stream.
 
-use std::path::PathBuf;
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyharness_contract::v1::{
-    Goal, GoalArmState, GoalSourceKind, GoalStatus, PromptInputBlock, SessionEvent,
+    ContentPart, Goal, GoalArmState, GoalSourceKind, GoalStatus, PromptInputBlock, SessionEvent,
     SessionEventEnvelope, SetSessionGoalRequest,
 };
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 use tokio::sync::broadcast;
 
 use super::commands;
@@ -24,8 +25,8 @@ use crate::domains::sessions::service::SessionService;
 use crate::domains::workflows::engine::{StepExecContext, StepOutcome, WorkflowStepExecutor};
 use crate::domains::workflows::model::WorkflowRunRecord;
 use crate::domains::workflows::plan::{
-    AgentConfigStep, AgentPromptStep, GoalSpec, OnBlocked, PlanSetup, PlanStep, ScmOpenPrStep,
-    ShellRunStep, StepKind,
+    AgentConfigStep, AgentEmitStep, AgentPromptStep, BranchStep, BranchTarget, GoalSpec, OnBlocked,
+    PlanStep, RequiredInvocation, ScmOpenPrStep, SessionSpec, ShellRunStep, StepKind,
 };
 use crate::domains::workflows::service::WorkflowService;
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
@@ -40,6 +41,12 @@ const TURN_BACKSTOP: Duration = Duration::from_secs(30 * 60);
 const GOAL_BACKSTOP_GRACE: Duration = Duration::from_secs(60);
 const VERIFY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const MAX_VERIFY_ATTEMPTS: u32 = 3;
+/// Bytes of the emit file retained in the failure output for debugging.
+const EMIT_RAW_TAIL: usize = 2 * 1024;
+/// The `required_invocation` gate (C14, arch §7.6) re-prompts this many times
+/// when the required provider+tool was not invoked within the turn before
+/// failing `invocation_missing`.
+const MAX_GATE_ATTEMPTS: u32 = 3;
 
 /// The shared, run-independent dependencies the executor needs.
 pub struct WorkflowExecDeps {
@@ -58,31 +65,29 @@ pub struct WorkflowExecDeps {
     pub workflow_owned_sessions: Arc<WorkflowOwnedSessions>,
 }
 
+#[derive(Clone)]
 struct CurrentSession {
     session_id: String,
+    #[allow(dead_code)]
     harness: String,
 }
 
-/// The run's *active agent config*: the harness/model that subsequent agent
-/// steps use. Seeded from Setup and mutated only by `agent.config` steps. It is
-/// never persisted separately — on crash-resume it is recomputed by replaying
-/// the plan prefix (see [`WorkflowStepExecutorImpl::recompute_active_config`]).
-#[derive(Clone)]
-struct ActiveConfig {
-    harness: String,
-    model: Option<String>,
-}
-
-/// One executor per run. `current` tracks the run's live session for harness
-/// continuity; `active` tracks the harness/model agent steps use. Both are
-/// hydrated from the run record on resume.
+/// One executor per run. Sessions are slot-keyed (B7): `current` maps each
+/// agent slot to the one live session it owns; `models` tracks the effective
+/// model per slot (seeded from the plan's `sessions[slot].model`, mutated by
+/// `agent.config` steps — which are model-only, A3). All maps are hydrated from
+/// the run record on resume.
 pub struct WorkflowStepExecutorImpl {
     deps: Arc<WorkflowExecDeps>,
     run_id: String,
     workspace_id: String,
-    setup: PlanSetup,
-    current: Mutex<Option<CurrentSession>>,
-    active: Mutex<ActiveConfig>,
+    /// Per-slot session provisioning, straight from the resolved plan.
+    sessions: BTreeMap<String, SessionSpec>,
+    /// slot -> the live session opened for it.
+    current: Mutex<HashMap<String, CurrentSession>>,
+    /// slot -> effective model (base `sessions[slot].model`, folded by
+    /// `agent.config`).
+    models: Mutex<HashMap<String, Option<String>>>,
 }
 
 impl WorkflowStepExecutorImpl {
@@ -90,109 +95,151 @@ impl WorkflowStepExecutorImpl {
         deps: Arc<WorkflowExecDeps>,
         run_id: String,
         workspace_id: String,
-        setup: PlanSetup,
+        sessions: BTreeMap<String, SessionSpec>,
     ) -> Self {
-        let active = ActiveConfig {
-            harness: setup.harness.clone(),
-            model: setup.model.clone(),
-        };
+        let models = sessions
+            .iter()
+            .map(|(slot, spec)| (slot.clone(), spec.model.clone()))
+            .collect();
         Self {
             deps,
             run_id,
             workspace_id,
-            setup,
-            current: Mutex::new(None),
-            active: Mutex::new(active),
+            sessions,
+            current: Mutex::new(HashMap::new()),
+            models: Mutex::new(models),
         }
     }
 
-    /// Restore the current-session pointer AND the active agent config from a run
-    /// record (crash-resume): the last opened session (harness read back from the
-    /// session row) and the config folded from the plan prefix up to the cursor.
+    /// Restore the per-slot session map AND per-slot models from a run record
+    /// (crash-resume): each slot's bound session (from the persisted slot map)
+    /// and the model folded from that slot's `agent.config` steps in the plan
+    /// prefix up to the cursor. Derives everything from the persisted plan +
+    /// cursor, so no extra state is stored on resume.
     pub fn hydrate_from_run(&self, run: &WorkflowRunRecord) {
-        self.recompute_active_config(run);
-        let Some(session_id) = run.current_session_id() else {
-            return;
-        };
-        if let Ok(Some(session)) = self.deps.session_service.get_session(session_id) {
-            // Re-arm the always-bypass safety net for the resumed session (the
-            // registry is in-memory, so a restart would otherwise drop it).
-            self.deps.workflow_owned_sessions.mark(session_id);
-            *self.current.lock().unwrap() = Some(CurrentSession {
-                session_id: session_id.to_string(),
-                harness: session.agent_kind,
-            });
+        self.recompute_models(run);
+        let mut current = self.current.lock().unwrap();
+        for (slot, session_id) in run.sessions() {
+            if let Ok(Some(session)) = self.deps.session_service.get_session(session_id) {
+                // Re-arm the always-bypass safety net for the resumed session
+                // (the registry is in-memory, so a restart would otherwise drop
+                // it).
+                self.deps.workflow_owned_sessions.mark(session_id);
+                current.insert(
+                    slot.clone(),
+                    CurrentSession {
+                        session_id: session_id.clone(),
+                        harness: session.agent_kind,
+                    },
+                );
+            }
         }
     }
 
-    /// Recompute the active config by folding every `agent.config` step in the
-    /// plan prefix `[0, step_cursor)` over the Setup seed. Derives state purely
-    /// from the persisted plan + cursor, so no extra state is stored on resume.
-    fn recompute_active_config(&self, run: &WorkflowRunRecord) {
-        let mut config = ActiveConfig {
-            harness: self.setup.harness.clone(),
-            model: self.setup.model.clone(),
-        };
+    /// Recompute per-slot models by folding each slot's `agent.config` steps in
+    /// the plan prefix `[0, step_cursor)` over the plan's per-slot seed.
+    fn recompute_models(&self, run: &WorkflowRunRecord) {
+        let mut models: HashMap<String, Option<String>> = self
+            .sessions
+            .iter()
+            .map(|(slot, spec)| (slot.clone(), spec.model.clone()))
+            .collect();
         if let Ok(plan) = crate::domains::workflows::plan::parse(&run.plan_json) {
             let cursor = run.step_cursor.max(0) as usize;
             for step in plan.steps.iter().take(cursor) {
                 if let StepKind::AgentConfig(cfg) = &step.kind {
-                    apply_config(&mut config, cfg);
+                    if let Some(model) = &cfg.model {
+                        models.insert(step.slot.clone(), Some(model.clone()));
+                    }
                 }
             }
         }
-        *self.active.lock().unwrap() = config;
+        *self.models.lock().unwrap() = models;
     }
 
-    async fn ensure_session(&self) -> Result<String, StepOutcome> {
-        let (effective_harness, model) = {
-            let active = self.active.lock().unwrap();
-            (active.harness.clone(), active.model.clone())
-        };
-        // Reuse the current session only when its harness matches.
-        {
-            let current = self.current.lock().unwrap();
-            if let Some(current) = current.as_ref() {
-                if current.harness == effective_harness {
-                    return Ok(current.session_id.clone());
-                }
-            }
+    /// The harness for a slot, from the resolved plan. A slot with no session
+    /// spec is a malformed plan (the server always emits one per referenced
+    /// slot).
+    fn harness_for_slot(&self, slot: &str) -> Result<String, StepOutcome> {
+        self.sessions
+            .get(slot)
+            .map(|spec| spec.harness.clone())
+            .ok_or_else(|| failed_msg("plan_malformed", format!("no session spec for slot {slot}")))
+    }
+
+    /// Ensure the (single, lifetime) session for `slot` exists, opening it lazily
+    /// on first use. Harness is fixed per slot — there is no harness-switch
+    /// machinery. A slot carrying `bind_session_id` (L29 / PR F) loads the
+    /// existing session instead of creating one; that field is always absent
+    /// until the session-plane PR lands.
+    async fn ensure_session(&self, slot: &str) -> Result<String, StepOutcome> {
+        if let Some(current) = self.current.lock().unwrap().get(slot) {
+            return Ok(current.session_id.clone());
         }
-        // Exec policy (goals-and-workflows-v1 §3.3 "always bypass"): open the
-        // session in the harness's native bypass-equivalent mode so agent turns
-        // and native-goal auto-continuation never stall on a permission prompt.
-        // `None` (harness with no native bypass mode) is covered by the
-        // auto-approve safety net below.
-        let mode = bypass_mode_for_kind(&effective_harness);
-        let record = self
-            .deps
-            .session_runtime
-            .create_and_start_session(
-                &self.workspace_id,
-                &effective_harness,
-                model.as_deref(),
-                mode,
-                None,
-                Vec::new(),
-                None,
-                false,
-                OriginContext::system_local_runtime(),
-            )
-            .await
-            .map_err(|error| failed_msg("session_start_failed", format!("{error:?}")))?;
+        let harness = self.harness_for_slot(slot)?;
+        let model = self
+            .models
+            .lock()
+            .unwrap()
+            .get(slot)
+            .cloned()
+            .flatten();
+        let bind_session_id = self
+            .sessions
+            .get(slot)
+            .and_then(|spec| spec.bind_session_id.clone());
+
+        let (session_id, session_harness) = if let Some(bind_id) = bind_session_id {
+            // Session binding (L29): load the pre-existing session. Owned by PR
+            // F; today `bind_session_id` is always absent, so this branch is a
+            // compiling path, not a live one.
+            let session = self
+                .deps
+                .session_service
+                .get_session(&bind_id)
+                .map_err(|error| failed_msg("session_bind_failed", error.to_string()))?
+                .ok_or_else(|| failed_msg("session_bind_missing", bind_id.clone()))?;
+            (bind_id, session.agent_kind)
+        } else {
+            // Exec policy (goals-and-workflows-v1 §3.3 "always bypass"): open the
+            // session in the harness's native bypass-equivalent mode so agent
+            // turns and native-goal auto-continuation never stall on a
+            // permission prompt. `None` (harness with no native bypass mode) is
+            // covered by the auto-approve safety net.
+            let mode = bypass_mode_for_kind(&harness);
+            let record = self
+                .deps
+                .session_runtime
+                .create_and_start_session(
+                    &self.workspace_id,
+                    &harness,
+                    model.as_deref(),
+                    mode,
+                    None,
+                    Vec::new(),
+                    None,
+                    false,
+                    OriginContext::system_local_runtime(),
+                )
+                .await
+                .map_err(|error| failed_msg("session_start_failed", format!("{error:?}")))?;
+            (record.id, harness)
+        };
         // Register the session as workflow-owned so the inbound permission
-        // advisor auto-approves for it (safety net for a harness without a
-        // native bypass mode). Done before the first prompt/turn is sent.
-        self.deps.workflow_owned_sessions.mark(&record.id);
+        // advisor auto-approves for it. Done before the first prompt/turn.
+        self.deps.workflow_owned_sessions.mark(&session_id);
         let _ = self
             .deps
             .workflow_service
-            .append_session_id(&self.run_id, &record.id);
-        *self.current.lock().unwrap() = Some(CurrentSession {
-            session_id: record.id.clone(),
-            harness: effective_harness,
-        });
-        Ok(record.id)
+            .set_session_for_slot(&self.run_id, slot, &session_id);
+        self.current.lock().unwrap().insert(
+            slot.to_string(),
+            CurrentSession {
+                session_id: session_id.clone(),
+                harness: session_harness,
+            },
+        );
+        Ok(session_id)
     }
 
     async fn send_prompt(&self, session_id: &str, text: &str) -> Result<Option<String>, StepOutcome> {
@@ -224,31 +271,58 @@ impl WorkflowStepExecutorImpl {
         Ok(handle.subscribe())
     }
 
-    async fn run_prompt(&self, agent: &AgentPromptStep) -> StepOutcome {
-        let session_id = match self.ensure_session().await {
+    async fn run_prompt(&self, slot: &str, agent: &AgentPromptStep) -> StepOutcome {
+        let session_id = match self.ensure_session(slot).await {
             Ok(id) => id,
             Err(outcome) => return outcome,
         };
-        // Subscribe BEFORE prompting so a fast TurnEnded is never missed.
-        let mut events = match self.subscribe(&session_id).await {
-            Ok(events) => events,
-            Err(outcome) => return outcome,
+        // No gate: a single turn suffices.
+        let Some(required) = &agent.required_invocation else {
+            let mut events = match self.subscribe(&session_id).await {
+                Ok(events) => events,
+                Err(outcome) => return outcome,
+            };
+            let turn_id = match self.send_prompt(&session_id, &agent.prompt).await {
+                Ok(turn_id) => turn_id,
+                Err(outcome) => return outcome,
+            };
+            return match await_turn_ended(&mut events, turn_id.as_deref(), TURN_BACKSTOP).await {
+                TurnWait::Ended => StepOutcome::Completed {
+                    output: json!({ "turn_id": turn_id, "session_id": session_id }),
+                },
+                TurnWait::SessionClosed => failed("session_closed"),
+                TurnWait::Timeout => failed("turn_timeout"),
+            };
         };
-        let turn_id = match self.send_prompt(&session_id, &agent.prompt).await {
-            Ok(turn_id) => turn_id,
-            Err(outcome) => return outcome,
-        };
-        match await_turn_ended(&mut events, turn_id.as_deref(), TURN_BACKSTOP).await {
-            TurnWait::Ended => StepOutcome::Completed {
-                output: json!({ "turn_id": turn_id, "session_id": session_id }),
+        // The C14 gate (arch §7.6): re-prompt up to MAX_GATE_ATTEMPTS until the
+        // provider+tool was invoked within the turn. The attempt budget +
+        // exhaustion decision lives in `run_gate_loop` so it can be driven
+        // directly by tests without a live session.
+        run_gate_loop(
+            MAX_GATE_ATTEMPTS,
+            &agent.prompt,
+            required,
+            &session_id,
+            |_attempt, prompt| {
+                let session_id = session_id.clone();
+                async move {
+                let mut events = self.subscribe(&session_id).await?;
+                let turn_id = self.send_prompt(&session_id, &prompt).await?;
+                match await_turn_ended_collecting(&mut events, turn_id.as_deref(), TURN_BACKSTOP)
+                    .await
+                {
+                    (TurnWait::Ended, invoked_tools) => Ok((turn_id, invoked_tools)),
+                    (TurnWait::SessionClosed, _) => Err(failed("session_closed")),
+                    (TurnWait::Timeout, _) => Err(failed("turn_timeout")),
+                }
+                }
             },
-            TurnWait::SessionClosed => failed("session_closed"),
-            TurnWait::Timeout => failed("turn_timeout"),
-        }
+        )
+        .await
     }
 
-    async fn run_goal(&self, agent: &AgentPromptStep, goal: &GoalSpec, step_index: usize) -> StepOutcome {
-        let session_id = match self.ensure_session().await {
+    async fn run_goal(&self, slot: &str, agent: &AgentPromptStep, goal: &GoalSpec, step_index: usize) -> StepOutcome {
+        let session_id = match self.ensure_session(slot).await {
             Ok(id) => id,
             Err(outcome) => return outcome,
         };
@@ -417,43 +491,26 @@ impl WorkflowStepExecutorImpl {
         commands::open_pr_step(&workspace_path, &env, step).await
     }
 
-    /// `agent.config` executes instantly: it folds the harness/model onto the
-    /// run's active config for every step below. Switching harness opens a NEW
-    /// session at the next agent step (`session_switched: true`). A model-only
-    /// change on an existing matching-harness session is applied LIVE via the
-    /// session's live-config path; with no live session yet it simply takes
-    /// effect at the next session creation.
-    async fn run_agent_config(&self, cfg: &AgentConfigStep) -> StepOutcome {
-        // The current session's harness, before we mutate the active config.
-        let (current_session_id, current_harness) = {
-            let current = self.current.lock().unwrap();
-            match current.as_ref() {
-                Some(session) => (Some(session.session_id.clone()), Some(session.harness.clone())),
-                None => (None, None),
-            }
-        };
-        // Fold the config change into the active state.
-        let new_active = {
-            let mut active = self.active.lock().unwrap();
-            apply_config(&mut active, cfg);
-            active.clone()
-        };
-
-        let harness_changed = current_harness
-            .as_deref()
-            .map(|h| h != new_active.harness)
-            .unwrap_or(false);
-
-        let mut session_switched = false;
-        if harness_changed {
-            // A new session will open on the next agent step (ensure_session
-            // sees the harness mismatch). Nothing to do now.
-            session_switched = true;
-        } else if cfg.model.is_some() {
-            // Harness unchanged and the model changed: apply it live to the
-            // current session if one exists, else it applies at next creation.
-            if let (Some(session_id), Some(model)) = (current_session_id, new_active.model.as_deref())
-            {
+    /// `agent.config` executes instantly and is model-only (A3): it folds the
+    /// model onto the step's slot for every later step in that slot. The change
+    /// is applied LIVE to the slot's session if one is already open, else it
+    /// takes effect at the slot's next session creation. Harness is fixed per
+    /// slot — a different harness is a different slot, so there is no
+    /// harness-switch machinery.
+    async fn run_agent_config(&self, slot: &str, cfg: &AgentConfigStep) -> StepOutcome {
+        if let Some(model) = &cfg.model {
+            self.models
+                .lock()
+                .unwrap()
+                .insert(slot.to_string(), Some(model.clone()));
+            // Apply live to the slot's session if it is already open.
+            let session_id = self
+                .current
+                .lock()
+                .unwrap()
+                .get(slot)
+                .map(|s| s.session_id.clone());
+            if let Some(session_id) = session_id {
                 let _ = self
                     .deps
                     .session_runtime
@@ -461,50 +518,128 @@ impl WorkflowStepExecutorImpl {
                     .await;
             }
         }
-
-        let mut output = Map::new();
-        if let Some(harness) = &cfg.harness {
-            output.insert("harness".to_string(), Value::String(harness.clone()));
-        }
+        let mut output = serde_json::Map::new();
         if let Some(model) = &cfg.model {
             output.insert("model".to_string(), Value::String(model.clone()));
         }
-        output.insert("session_switched".to_string(), Value::Bool(session_switched));
+        output.insert("slot".to_string(), Value::String(slot.to_string()));
         StepOutcome::Completed {
             output: Value::Object(output),
         }
     }
 
+    /// `agent.emit` (§7.3 + §7.4 file-drop): prompt the agent to write a JSON
+    /// object to a run/step-scoped file, await the turn, then read + validate
+    /// against the (optional) schema. Invalid or missing → re-prompt with the
+    /// concrete errors, up to the plan's `max_attempts` (C12: sourced from the
+    /// plan, no longer a hardcoded constant); the validated object becomes the
+    /// step's entire output. Exhaustion fails `emit_invalid`.
+    async fn run_emit(&self, slot: &str, step: &AgentEmitStep, step_index: usize) -> StepOutcome {
+        let session_id = match self.ensure_session(slot).await {
+            Ok(id) => id,
+            Err(outcome) => return outcome,
+        };
+        let (workspace_path, _env) = match self.workspace_ctx() {
+            Ok(ctx) => ctx,
+            Err(outcome) => return outcome,
+        };
+        let emit_path = emit_file_path(&workspace_path, &self.run_id, step_index);
+        // Ensure the drop directory exists and clear any stale file so a prior
+        // attempt/run can't be read as this attempt's output.
+        if let Some(parent) = emit_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::remove_file(&emit_path);
+
+        let initial_prompt = format!("{}\n\n{}", step.prompt, emit_instruction(&emit_path));
+        // C12: `max_attempts` is sourced from the plan (never hardcoded); the
+        // attempt-budget + exhaustion decision lives in `run_emit_loop` so it
+        // can be driven directly by tests without a live session.
+        let max_attempts = step.max_attempts.max(1);
+
+        run_emit_loop(max_attempts, initial_prompt, |_attempt, prompt| {
+            let session_id = session_id.clone();
+            let emit_path = emit_path.clone();
+            async move {
+                // Subscribe BEFORE prompting so a fast TurnEnded is never missed.
+                let mut events = self.subscribe(&session_id).await?;
+                let turn_id = self.send_prompt(&session_id, &prompt).await?;
+                match await_turn_ended(&mut events, turn_id.as_deref(), TURN_BACKSTOP).await {
+                    TurnWait::Ended => {}
+                    TurnWait::SessionClosed => return Err(failed("session_closed")),
+                    TurnWait::Timeout => return Err(failed("turn_timeout")),
+                }
+                match read_and_validate_emit(&emit_path, step.output_schema.as_ref()) {
+                    EmitCheck::Valid(value) => {
+                        let _ = std::fs::remove_file(&emit_path);
+                        Ok(EmitAttempt::Valid(value))
+                    }
+                    EmitCheck::Invalid { errors, raw_tail } => Ok(EmitAttempt::Invalid {
+                        next_prompt: emit_corrective_prompt(&emit_path, &errors),
+                        errors,
+                        raw_tail,
+                    }),
+                }
+            }
+        })
+        .await
+    }
+
+    /// `branch` (C11/D3): the `on` template was late-bound to a value by the
+    /// resolver, so it arrives as a literal here. Match it against the cases and
+    /// route: `continue` advances normally (`Completed`), `end` ends the run
+    /// (`EndRun`, E5). An unmatched value fails `branch_unmatched` (on_fail
+    /// applies).
+    fn run_branch(&self, step: &BranchStep) -> StepOutcome {
+        evaluate_branch(step)
+    }
+}
+
+/// `branch` (C11/D3), pure: match `step.on`'s (already late-bound) value
+/// against `step.cases` and route. `continue` advances normally
+/// (`Completed`); `end` ends the run (`EndRun`, E5). An unmatched value fails
+/// `branch_unmatched` (the step's `on_fail` policy applies from there). Free
+/// function (rather than a method) so it can be driven directly by tests
+/// without constructing a live executor.
+fn evaluate_branch(step: &BranchStep) -> StepOutcome {
+    let value = step.on.clone();
+    match step.cases.get(&value) {
+        Some(case) => {
+            let target_slug = match case.to {
+                BranchTarget::Continue => "continue",
+                BranchTarget::End => "end",
+            };
+            let output = json!({ "value": value, "target": target_slug });
+            match case.to {
+                BranchTarget::Continue => StepOutcome::Completed { output },
+                BranchTarget::End => StepOutcome::EndRun { output },
+            }
+        }
+        None => StepOutcome::Failed {
+            code: "branch_unmatched".to_string(),
+            message: Some(format!("branch value {value:?} matched no case")),
+            output: Some(json!({ "value": value })),
+        },
+    }
 }
 
 #[async_trait::async_trait]
 impl WorkflowStepExecutor for WorkflowStepExecutorImpl {
     async fn execute_step(&self, step: &PlanStep, ctx: &StepExecContext) -> StepOutcome {
+        let slot = step.slot.as_str();
         match &step.kind {
-            StepKind::AgentConfig(cfg) => self.run_agent_config(cfg).await,
+            StepKind::AgentConfig(cfg) => self.run_agent_config(slot, cfg).await,
             StepKind::AgentPrompt(agent) => match &agent.goal {
-                None => self.run_prompt(agent).await,
-                Some(goal) => self.run_goal(agent, goal, ctx.step_index).await,
+                None => self.run_prompt(slot, agent).await,
+                Some(goal) => self.run_goal(slot, agent, goal, ctx.step_index).await,
             },
+            StepKind::AgentEmit(emit) => self.run_emit(slot, emit, ctx.step_index).await,
             StepKind::ShellRun(shell) => self.run_shell(shell).await,
             StepKind::ScmOpenPr(pr) => self.run_scm(pr).await,
             StepKind::Notify(notify) => {
                 commands::notify_step(&notify.message, &notify.slack_channel_id)
             }
-            // TODO(workflows phase C/F): agent.emit re-ask loop (C12) and branch
-            // continue/end arm (C11). The plan carries them now; the engine
-            // executes them in a later phase. Fail loudly until then so a v2 plan
-            // using these can't silently no-op.
-            StepKind::AgentEmit(_) => StepOutcome::Failed {
-                code: "not_implemented".to_string(),
-                message: Some("agent.emit execution lands in a later phase".to_string()),
-                output: None,
-            },
-            StepKind::Branch(_) => StepOutcome::Failed {
-                code: "not_implemented".to_string(),
-                message: Some("branch execution lands in a later phase".to_string()),
-                output: None,
-            },
+            StepKind::Branch(branch) => self.run_branch(branch),
         }
     }
 }
@@ -537,6 +672,74 @@ async fn await_turn_ended(
             Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
             Ok(Err(broadcast::error::RecvError::Closed)) => return TurnWait::SessionClosed,
             Err(_) => return TurnWait::Timeout,
+        }
+    }
+}
+
+/// Like [`await_turn_ended`], but also collects the native tool names invoked
+/// during the turn (from `ToolCall` content parts on item events) so the C14
+/// gate can check whether the required provider+tool was invoked.
+async fn await_turn_ended_collecting(
+    events: &mut broadcast::Receiver<SessionEventEnvelope>,
+    turn_id: Option<&str>,
+    backstop: Duration,
+) -> (TurnWait, Vec<String>) {
+    let deadline = tokio::time::Instant::now() + backstop;
+    let mut tools: Vec<String> = Vec::new();
+    loop {
+        match tokio::time::timeout_at(deadline, events.recv()).await {
+            Ok(Ok(envelope)) => {
+                // Only collect tool calls that belong to this turn (or any, when
+                // the turn id is unknown).
+                if turn_id.is_none() || envelope.turn_id.as_deref() == turn_id {
+                    collect_tool_names(&envelope.event, &mut tools);
+                }
+                match &envelope.event {
+                    SessionEvent::TurnEnded(_)
+                        if turn_id.is_none() || envelope.turn_id.as_deref() == turn_id =>
+                    {
+                        return (TurnWait::Ended, tools)
+                    }
+                    SessionEvent::SessionEnded(_) => return (TurnWait::SessionClosed, tools),
+                    _ => {}
+                }
+            }
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(broadcast::error::RecvError::Closed)) => return (TurnWait::SessionClosed, tools),
+            Err(_) => return (TurnWait::Timeout, tools),
+        }
+    }
+}
+
+/// Push every `ToolCall` native tool name carried by an item event into `out`.
+fn collect_tool_names(event: &SessionEvent, out: &mut Vec<String>) {
+    let parts: &[ContentPart] = match event {
+        SessionEvent::ItemStarted(e) => &e.item.content_parts,
+        SessionEvent::ItemCompleted(e) => &e.item.content_parts,
+        SessionEvent::ItemDelta(e) => {
+            for parts in e
+                .delta
+                .replace_content_parts
+                .iter()
+                .chain(e.delta.append_content_parts.iter())
+            {
+                push_tool_names(parts, out);
+            }
+            return;
+        }
+        _ => return,
+    };
+    push_tool_names(parts, out);
+}
+
+fn push_tool_names(parts: &[ContentPart], out: &mut Vec<String>) {
+    for part in parts {
+        if let ContentPart::ToolCall {
+            native_tool_name: Some(name),
+            ..
+        } = part
+        {
+            out.push(name.clone());
         }
     }
 }
@@ -639,15 +842,262 @@ fn verify_feedback_tail(tail: &str) -> String {
     tail[start..].to_string()
 }
 
-/// Fold an `agent.config` step onto the active config: only present fields
-/// override; absent fields keep the prior active value.
-fn apply_config(active: &mut ActiveConfig, cfg: &AgentConfigStep) {
-    if let Some(harness) = &cfg.harness {
-        active.harness = harness.clone();
+// --- C14 required_invocation gate helpers (arch §7.6) ---
+
+/// Was the required provider+tool invoked among the turn's observed tool names?
+fn invocation_present(invoked_tools: &[String], required: &RequiredInvocation) -> bool {
+    invoked_tools
+        .iter()
+        .any(|name| invocation_matches(name, &required.provider, &required.tool))
+}
+
+/// Does a native tool name identify the given gateway provider+tool? The gateway
+/// exposes MCP tools as `mcp__<provider>__<tool>`; we also accept the bare
+/// `<provider>__<tool>` and `<provider>.<tool>` spellings different harnesses
+/// surface, matched case-insensitively.
+fn invocation_matches(native_tool_name: &str, provider: &str, tool: &str) -> bool {
+    let name = native_tool_name.to_ascii_lowercase();
+    let provider = provider.to_ascii_lowercase();
+    let tool = tool.to_ascii_lowercase();
+    let candidates = [
+        format!("mcp__{provider}__{tool}"),
+        format!("{provider}__{tool}"),
+        format!("{provider}.{tool}"),
+    ];
+    candidates.iter().any(|candidate| name == *candidate)
+        // Tolerate a provider-prefixed name whose suffix is the tool (e.g. a
+        // `mcp__sentry__` prefix followed by the tool with extra qualifiers).
+        || (name.contains(&provider) && name.ends_with(&tool))
+}
+
+/// The re-ask sent when the required invocation was not observed.
+fn gate_corrective_prompt(original: &str, required: &RequiredInvocation) -> String {
+    format!(
+        "{original}\n\nYou did not call the required tool `{}` from `{}`. You MUST invoke that \
+         tool before finishing.",
+        required.tool, required.provider
+    )
+}
+
+/// The C14 gate loop's attempt-budget + exhaustion control flow, decoupled from
+/// live I/O: `attempt(i, prompt)` performs one turn (send + await + collect
+/// invoked tool names) and returns `Ok((turn_id, invoked_tools))`, or `Err` on a
+/// hard failure (session closed / timeout / send failed) that ends the loop
+/// immediately. Colocated (rather than folded into `run_prompt`) so the
+/// attempt-count + exhaustion decision can be driven directly by tests without
+/// a live session.
+async fn run_gate_loop<Attempt, Fut>(
+    attempts: u32,
+    original_prompt: &str,
+    required: &RequiredInvocation,
+    session_id: &str,
+    mut attempt: Attempt,
+) -> StepOutcome
+where
+    Attempt: FnMut(u32, String) -> Fut,
+    Fut: std::future::Future<Output = Result<(Option<String>, Vec<String>), StepOutcome>>,
+{
+    let mut prompt = original_prompt.to_string();
+    for i in 0..attempts {
+        let (turn_id, invoked_tools) = match attempt(i, prompt.clone()).await {
+            Ok(v) => v,
+            Err(outcome) => return outcome,
+        };
+        if invocation_present(&invoked_tools, required) {
+            return StepOutcome::Completed {
+                output: json!({
+                    "turn_id": turn_id,
+                    "session_id": session_id,
+                    "required_invocation": { "provider": required.provider, "tool": required.tool },
+                }),
+            };
+        }
+        // Missing invocation: re-prompt with the concrete requirement, still
+        // counting against the gate budget.
+        if i + 1 < attempts {
+            prompt = gate_corrective_prompt(original_prompt, required);
+        }
     }
-    if let Some(model) = &cfg.model {
-        active.model = Some(model.clone());
+    gate_exhausted_outcome(attempts, required, session_id)
+}
+
+/// The terminal outcome when the C14 gate never observed the required
+/// invocation within the attempt budget.
+fn gate_exhausted_outcome(
+    attempts: u32,
+    required: &RequiredInvocation,
+    session_id: &str,
+) -> StepOutcome {
+    StepOutcome::Failed {
+        code: "invocation_missing".to_string(),
+        message: Some(format!(
+            "required invocation {}::{} was not observed after {} attempts",
+            required.provider, required.tool, attempts
+        )),
+        output: Some(json!({ "session_id": session_id })),
     }
+}
+
+// --- agent.emit file-drop helpers (§7.3 + §7.4) ---
+
+/// The file an `agent.emit` step's agent must drop its JSON object at:
+/// `<workspace>/.proliferate/emit-<run_id>-<step_index>.json`.
+fn emit_file_path(workspace_path: &Path, run_id: &str, step_index: usize) -> PathBuf {
+    workspace_path
+        .join(".proliferate")
+        .join(format!("emit-{run_id}-{step_index}.json"))
+}
+
+/// The §7.4 file-drop instruction appended to the emit prompt.
+fn emit_instruction(path: &Path) -> String {
+    format!(
+        "When you are done, write ONLY the JSON object (no prose, no code fences) to the file \
+         `{}`. Overwrite the file if it already exists.",
+        path.display()
+    )
+}
+
+/// The corrective message re-prompted after an invalid or missing emit, carrying
+/// the concrete validation errors so the agent can fix them.
+fn emit_corrective_prompt(path: &Path, errors: &[String]) -> String {
+    format!(
+        "The JSON object you wrote did not satisfy the required schema:\n{}\n\nPlease write ONLY a \
+         corrected JSON object (no prose, no code fences) to `{}`, overwriting it.",
+        errors.join("\n"),
+        path.display()
+    )
+}
+
+/// The terminal outcome when `agent.emit` never produced a schema-valid object.
+fn emit_exhausted_outcome(
+    max_attempts: u32,
+    errors: Vec<String>,
+    raw_tail: Option<String>,
+) -> StepOutcome {
+    StepOutcome::Failed {
+        code: "emit_invalid".to_string(),
+        message: Some(format!(
+            "agent did not emit a schema-valid object after {max_attempts} attempts"
+        )),
+        output: Some(json!({ "errors": errors, "raw_tail": raw_tail })),
+    }
+}
+
+/// Outcome of one `agent.emit` attempt fed to [`run_emit_loop`].
+enum EmitAttempt {
+    Valid(Value),
+    Invalid {
+        /// The corrective prompt for the next attempt.
+        next_prompt: String,
+        errors: Vec<String>,
+        raw_tail: Option<String>,
+    },
+}
+
+/// The `agent.emit` attempt loop's control flow (C12), decoupled from live
+/// I/O: `attempt(i, prompt)` performs one turn + reads/validates the emit
+/// file, returning `Ok(EmitAttempt)`, or `Err` on a hard failure (session
+/// closed / timeout / send failed) that ends the loop immediately.
+/// `max_attempts` is always sourced from the plan step, never hardcoded.
+/// Colocated so the attempt-budget + exhaustion decision can be driven
+/// directly by tests without a live session.
+async fn run_emit_loop<Attempt, Fut>(
+    max_attempts: u32,
+    initial_prompt: String,
+    mut attempt: Attempt,
+) -> StepOutcome
+where
+    Attempt: FnMut(u32, String) -> Fut,
+    Fut: std::future::Future<Output = Result<EmitAttempt, StepOutcome>>,
+{
+    let mut prompt = initial_prompt;
+    let mut last_errors: Vec<String> = Vec::new();
+    let mut last_raw_tail: Option<String> = None;
+    for i in 0..max_attempts {
+        match attempt(i, prompt).await {
+            Ok(EmitAttempt::Valid(value)) => return StepOutcome::Completed { output: value },
+            Ok(EmitAttempt::Invalid {
+                next_prompt,
+                errors,
+                raw_tail,
+            }) => {
+                prompt = next_prompt;
+                last_errors = errors;
+                last_raw_tail = raw_tail;
+            }
+            Err(outcome) => return outcome,
+        }
+    }
+    emit_exhausted_outcome(max_attempts, last_errors, last_raw_tail)
+}
+
+/// Outcome of reading + schema-validating the emit file.
+enum EmitCheck {
+    Valid(Value),
+    Invalid {
+        errors: Vec<String>,
+        /// Last ~2KB of the file, present only when the file existed.
+        raw_tail: Option<String>,
+    },
+}
+
+/// Read the emit file and validate it against `schema` (when one is present; a
+/// schema-less emit accepts any valid JSON value). A missing file, unparseable
+/// JSON, and schema-invalid content all map to `Invalid` with concrete,
+/// agent-actionable error strings.
+fn read_and_validate_emit(path: &Path, schema: Option<&Value>) -> EmitCheck {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(_) => {
+            return EmitCheck::Invalid {
+                errors: vec![format!("file not found at {}", path.display())],
+                raw_tail: None,
+            }
+        }
+    };
+    let raw_tail = Some(emit_raw_tail(&contents));
+    let value: Value = match serde_json::from_str(&contents) {
+        Ok(value) => value,
+        Err(error) => {
+            return EmitCheck::Invalid {
+                errors: vec![format!("emit file is not valid JSON: {error}")],
+                raw_tail,
+            }
+        }
+    };
+    let errors = match schema {
+        Some(schema) => validate_against_schema(&value, schema),
+        None => Vec::new(),
+    };
+    if errors.is_empty() {
+        EmitCheck::Valid(value)
+    } else {
+        EmitCheck::Invalid { errors, raw_tail }
+    }
+}
+
+/// Collect human-readable schema-validation errors (empty = valid). A schema
+/// that itself fails to compile surfaces as a single error rather than a panic.
+fn validate_against_schema(value: &Value, schema: &Value) -> Vec<String> {
+    match jsonschema::validator_for(schema) {
+        Ok(validator) => validator
+            .iter_errors(value)
+            .map(|error| error.to_string())
+            .collect(),
+        Err(error) => vec![format!("invalid output_schema: {error}")],
+    }
+}
+
+/// Keep the last `EMIT_RAW_TAIL` bytes of the file, on a char boundary.
+fn emit_raw_tail(text: &str) -> String {
+    if text.len() <= EMIT_RAW_TAIL {
+        return text.to_string();
+    }
+    let mut start = text.len() - EMIT_RAW_TAIL;
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    text[start..].to_string()
 }
 
 /// A throttleable snapshot of an in-flight goal's progress. Two snapshots are
@@ -721,27 +1171,107 @@ fn failed_msg(code: &str, message: impl Into<String>) -> StepOutcome {
 mod tests {
     use super::*;
 
-    fn cfg(harness: Option<&str>, model: Option<&str>) -> AgentConfigStep {
-        AgentConfigStep {
-            harness: harness.map(str::to_string),
-            model: model.map(str::to_string),
+    // --- C14 required_invocation gate ---
+
+    fn required(provider: &str, tool: &str) -> RequiredInvocation {
+        RequiredInvocation {
+            provider: provider.to_string(),
+            tool: tool.to_string(),
         }
     }
 
     #[test]
-    fn apply_config_only_overrides_present_fields() {
-        let mut active = ActiveConfig {
-            harness: "claude".to_string(),
-            model: Some("sonnet".to_string()),
+    fn invocation_matches_mcp_and_bare_spellings() {
+        assert!(invocation_matches("mcp__linear__update_status", "linear", "update_status"));
+        assert!(invocation_matches("linear__update_status", "linear", "update_status"));
+        assert!(invocation_matches("linear.update_status", "linear", "update_status"));
+        // Case-insensitive.
+        assert!(invocation_matches("MCP__Linear__Update_Status", "linear", "update_status"));
+        // Wrong tool / provider does not match.
+        assert!(!invocation_matches("mcp__linear__create_issue", "linear", "update_status"));
+        assert!(!invocation_matches("mcp__sentry__update_status", "linear", "update_status"));
+        assert!(!invocation_matches("read_file", "linear", "update_status"));
+    }
+
+    #[test]
+    fn invocation_present_scans_all_observed_tools() {
+        let tools = vec!["read_file".to_string(), "mcp__linear__update_status".to_string()];
+        assert!(invocation_present(&tools, &required("linear", "update_status")));
+        assert!(!invocation_present(&tools, &required("slack", "post_message")));
+        assert!(!invocation_present(&[], &required("linear", "update_status")));
+    }
+
+    // --- agent.emit schema validation ---
+
+    #[test]
+    fn emit_missing_file_is_invalid() {
+        let dir = std::env::temp_dir().join(format!("emit-test-{}", std::process::id()));
+        let path = emit_file_path(&dir, "run-x", 7);
+        match read_and_validate_emit(&path, None) {
+            EmitCheck::Invalid { errors, raw_tail } => {
+                assert!(errors[0].contains("file not found"));
+                assert!(raw_tail.is_none());
+            }
+            EmitCheck::Valid(_) => panic!("missing file must be invalid"),
+        }
+    }
+
+    #[test]
+    fn emit_validates_against_schema() {
+        let dir = std::env::temp_dir().join(format!("emit-ok-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.json");
+        std::fs::write(&path, r#"{"verdict": "ship"}"#).unwrap();
+        let schema = json!({
+            "type": "object",
+            "required": ["verdict"],
+            "properties": { "verdict": { "type": "string" } }
+        });
+        assert!(matches!(
+            read_and_validate_emit(&path, Some(&schema)),
+            EmitCheck::Valid(_)
+        ));
+        // A value that violates the schema is Invalid with concrete errors.
+        std::fs::write(&path, r#"{"verdict": 42}"#).unwrap();
+        match read_and_validate_emit(&path, Some(&schema)) {
+            EmitCheck::Invalid { errors, .. } => assert!(!errors.is_empty()),
+            EmitCheck::Valid(_) => panic!("schema violation must be invalid"),
+        }
+        // Schema-less emit accepts any valid JSON object.
+        assert!(matches!(
+            read_and_validate_emit(&path, None),
+            EmitCheck::Valid(_)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn collect_tool_names_pulls_from_item_events() {
+        use anyharness_contract::v1::{ItemCompletedEvent, TranscriptItemKind, TranscriptItemPayload, TranscriptItemStatus};
+        let item = TranscriptItemPayload {
+            kind: TranscriptItemKind::ToolInvocation,
+            status: TranscriptItemStatus::Completed,
+            source_agent_kind: "claude".to_string(),
+            is_transient: false,
+            message_id: None,
+            prompt_id: None,
+            title: None,
+            tool_call_id: None,
+            native_tool_name: None,
+            parent_tool_call_id: None,
+            raw_input: None,
+            raw_output: None,
+            content_parts: vec![ContentPart::ToolCall {
+                tool_call_id: "tc1".to_string(),
+                title: "Update status".to_string(),
+                tool_kind: None,
+                native_tool_name: Some("mcp__linear__update_status".to_string()),
+            }],
+            prompt_provenance: None,
         };
-        // Model-only change keeps the harness.
-        apply_config(&mut active, &cfg(None, Some("opus")));
-        assert_eq!(active.harness, "claude");
-        assert_eq!(active.model.as_deref(), Some("opus"));
-        // Harness-only change keeps the (now folded) model.
-        apply_config(&mut active, &cfg(Some("codex"), None));
-        assert_eq!(active.harness, "codex");
-        assert_eq!(active.model.as_deref(), Some("opus"));
+        let mut out = Vec::new();
+        collect_tool_names(&SessionEvent::ItemCompleted(ItemCompletedEvent { item }), &mut out);
+        assert_eq!(out, vec!["mcp__linear__update_status".to_string()]);
     }
 
     fn snapshot(status: GoalStatus, iterations: Option<i64>, tokens: Option<i64>) -> GoalSnapshot {
@@ -812,6 +1342,267 @@ mod tests {
                 assert!(reason.contains("invalid model"));
             }
             other => panic!("expected Failed on turn error, got {other:?}"),
+        }
+    }
+
+    // --- C11 branch (deny-path floor: run_branch driven directly) ---
+
+    fn branch_step(on: &str) -> BranchStep {
+        use crate::domains::workflows::plan::BranchCase;
+        let mut cases = BTreeMap::new();
+        cases.insert(
+            "ship".to_string(),
+            BranchCase {
+                to: BranchTarget::Continue,
+            },
+        );
+        cases.insert(
+            "wont_fix".to_string(),
+            BranchCase {
+                to: BranchTarget::End,
+            },
+        );
+        BranchStep {
+            on: on.to_string(),
+            cases,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn branch_continue_case_completes_with_continue_shape() {
+        let outcome = evaluate_branch(&branch_step("ship"));
+        match outcome {
+            StepOutcome::Completed { output } => {
+                assert_eq!(output["value"], "ship");
+                assert_eq!(output["target"], "continue");
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_end_case_ends_the_run() {
+        // E5: the taken `end` case must surface as EndRun (terminal `completed`,
+        // later steps `skipped`), not a plain Completed.
+        let outcome = evaluate_branch(&branch_step("wont_fix"));
+        match outcome {
+            StepOutcome::EndRun { output } => {
+                assert_eq!(output["value"], "wont_fix");
+                assert_eq!(output["target"], "end");
+            }
+            other => panic!("expected EndRun, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn branch_unmatched_value_fails() {
+        let outcome = evaluate_branch(&branch_step("neither_case"));
+        match outcome {
+            StepOutcome::Failed {
+                code,
+                message,
+                output,
+            } => {
+                assert_eq!(code, "branch_unmatched");
+                assert!(message.unwrap().contains("neither_case"));
+                assert_eq!(output.unwrap()["value"], "neither_case");
+            }
+            other => panic!("expected Failed(branch_unmatched), got {other:?}"),
+        }
+    }
+
+    // --- C14 gate loop (deny-path floor: run_gate_loop driven directly) ---
+
+    #[tokio::test]
+    async fn gate_loop_exhausts_invocation_missing_when_tool_never_called() {
+        let required = required("linear", "update_status");
+        let attempts_seen = std::sync::atomic::AtomicU32::new(0);
+        let outcome = run_gate_loop(
+            MAX_GATE_ATTEMPTS,
+            "do the thing",
+            &required,
+            "sess_1",
+            |attempt, _prompt| {
+                assert_eq!(attempt, attempts_seen.load(std::sync::atomic::Ordering::SeqCst));
+                attempts_seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // The tool is never invoked across any attempt.
+                async move { Ok((Some(format!("turn-{attempt}")), Vec::<String>::new())) }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            attempts_seen.load(std::sync::atomic::Ordering::SeqCst),
+            MAX_GATE_ATTEMPTS,
+            "the loop must exhaust the full attempt budget before failing"
+        );
+        match outcome {
+            StepOutcome::Failed {
+                code,
+                message,
+                output,
+            } => {
+                assert_eq!(code, "invocation_missing");
+                let message = message.unwrap();
+                assert!(message.contains("linear::update_status"));
+                assert!(message.contains(&MAX_GATE_ATTEMPTS.to_string()));
+                assert_eq!(output.unwrap()["session_id"], "sess_1");
+            }
+            other => panic!("expected Failed(invocation_missing), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_loop_re_prompts_with_corrective_text_between_attempts() {
+        let required = required("linear", "update_status");
+        let prompts_seen = std::sync::Mutex::new(Vec::<String>::new());
+        let _ = run_gate_loop(
+            MAX_GATE_ATTEMPTS,
+            "original prompt",
+            &required,
+            "sess_1",
+            |_attempt, prompt| {
+                prompts_seen.lock().unwrap().push(prompt);
+                async { Ok((None, Vec::<String>::new())) }
+            },
+        )
+        .await;
+        let prompts = prompts_seen.into_inner().unwrap();
+        assert_eq!(prompts.len() as u32, MAX_GATE_ATTEMPTS);
+        // Attempt 0 gets the original prompt verbatim...
+        assert_eq!(prompts[0], "original prompt");
+        // ...every subsequent attempt gets the corrective re-prompt naming the
+        // missing tool, and does NOT regress back to the original text.
+        for prompt in &prompts[1..] {
+            assert_ne!(prompt, "original prompt");
+            assert!(prompt.contains("update_status"));
+            assert!(prompt.contains("linear"));
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_loop_completes_when_invocation_observed() {
+        let required = required("linear", "update_status");
+        let outcome = run_gate_loop(
+            MAX_GATE_ATTEMPTS,
+            "do the thing",
+            &required,
+            "sess_1",
+            |_attempt, _prompt| async {
+                Ok((
+                    Some("turn-1".to_string()),
+                    vec!["mcp__linear__update_status".to_string()],
+                ))
+            },
+        )
+        .await;
+        match outcome {
+            StepOutcome::Completed { output } => {
+                assert_eq!(output["required_invocation"]["provider"], "linear");
+                assert_eq!(output["required_invocation"]["tool"], "update_status");
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
+    // --- C12 emit loop (deny-path floor: run_emit_loop driven directly) ---
+
+    #[tokio::test]
+    async fn emit_loop_exhausts_emit_invalid_using_the_plans_max_attempts() {
+        // Deliberately NOT the hardcoded-3 default used elsewhere, to prove
+        // max_attempts is plan-sourced (C12).
+        let plan_max_attempts: u32 = 5;
+        let attempts_seen = std::sync::atomic::AtomicU32::new(0);
+        let outcome = run_emit_loop(
+            plan_max_attempts,
+            "emit the verdict".to_string(),
+            |attempt, _prompt| {
+                assert_eq!(attempt, attempts_seen.load(std::sync::atomic::Ordering::SeqCst));
+                attempts_seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async move {
+                    // Output never validates, across every attempt.
+                    Ok(EmitAttempt::Invalid {
+                        next_prompt: format!("fix it (attempt {attempt})"),
+                        errors: vec!["missing required field verdict".to_string()],
+                        raw_tail: Some("{}".to_string()),
+                    })
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            attempts_seen.load(std::sync::atomic::Ordering::SeqCst),
+            plan_max_attempts,
+            "the loop must use the plan's max_attempts, not a hardcoded 3"
+        );
+        match outcome {
+            StepOutcome::Failed {
+                code,
+                message,
+                output,
+            } => {
+                assert_eq!(code, "emit_invalid");
+                assert!(message.unwrap().contains(&plan_max_attempts.to_string()));
+                let output = output.unwrap();
+                assert_eq!(output["errors"][0], "missing required field verdict");
+                assert_eq!(output["raw_tail"], "{}");
+            }
+            other => panic!("expected Failed(emit_invalid), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_loop_uses_the_corrective_prompt_on_retry() {
+        let seen_prompts = std::sync::Mutex::new(Vec::<String>::new());
+        let _ = run_emit_loop(3, "initial prompt".to_string(), |_attempt, prompt| {
+            seen_prompts.lock().unwrap().push(prompt);
+            async {
+                Ok(EmitAttempt::Invalid {
+                    next_prompt: "corrective prompt".to_string(),
+                    errors: vec!["bad".to_string()],
+                    raw_tail: None,
+                })
+            }
+        })
+        .await;
+        let prompts = seen_prompts.into_inner().unwrap();
+        assert_eq!(prompts, vec!["initial prompt", "corrective prompt", "corrective prompt"]);
+    }
+
+    #[tokio::test]
+    async fn emit_loop_completes_on_first_valid_attempt() {
+        let outcome = run_emit_loop(5, "emit".to_string(), |attempt, _prompt| async move {
+            if attempt == 0 {
+                Ok(EmitAttempt::Invalid {
+                    next_prompt: "retry".to_string(),
+                    errors: vec!["bad".to_string()],
+                    raw_tail: None,
+                })
+            } else {
+                Ok(EmitAttempt::Valid(json!({ "verdict": "ship" })))
+            }
+        })
+        .await;
+        match outcome {
+            StepOutcome::Completed { output } => assert_eq!(output["verdict"], "ship"),
+            other => panic!("expected Completed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_loop_propagates_hard_failure_immediately_without_exhausting_attempts() {
+        let attempts_seen = std::sync::atomic::AtomicU32::new(0);
+        let outcome = run_emit_loop(5, "emit".to_string(), |_attempt, _prompt| {
+            attempts_seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            async { Err(failed("session_closed")) }
+        })
+        .await;
+        assert_eq!(attempts_seen.load(std::sync::atomic::Ordering::SeqCst), 1);
+        match outcome {
+            StepOutcome::Failed { code, .. } => assert_eq!(code, "session_closed"),
+            other => panic!("expected Failed(session_closed), got {other:?}"),
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
@@ -120,7 +120,8 @@ impl WorkflowRunManager {
                 false
             }
         };
-        if let Some(session_id) = run.current_session_id() {
+        // Best-effort in-flight-turn teardown across every slot's session.
+        for session_id in run.sessions().values() {
             if let Some(handle) = self.deps.acp_manager.get_handle(session_id).await {
                 handle.cancel().await;
             }
@@ -238,7 +239,7 @@ impl WorkflowRunManager {
                 deps.clone(),
                 run_id.clone(),
                 run.workspace_id.clone(),
-                plan.setup(),
+                plan.sessions.clone(),
             );
             executor.hydrate_from_run(&run);
             let progress =

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -124,7 +124,8 @@ the server *pulling* `/refresh` (no worker→server push channel in v1).
 ```
 run_goal(agent, goal, step_index)                           executor.rs:250
   │
-  ├─ ensure_session()  ──── harness match? reuse : create in bypass mode   :147
+  ├─ ensure_session(slot)  ─ per-slot: reuse the slot's session or create it  :147
+  │     in bypass mode (harness fixed per slot — no harness-switch)
   ├─ arm_goal(session, goal)   ── SetSessionGoalRequest{status:Active,      :368
   │     source_kind:Workflow, source_run_id} → goal_runtime.set_goal
   │     (ONLY place that stamps GoalSourceKind::Workflow)
@@ -152,22 +153,40 @@ Goal-met is model judgment; `verify` is ground truth. The wall-clock deadline is
 backstop for a hung in-flight turn the goals-domain cap guard (fires only on turn
 boundaries) can't see. See [§5](#5-goals-substrate-it-depends-on).
 
-### 1c. `agent.config` → session-switch flow
+### 1c. `agent.config` → per-slot model change (model-only, A3)
 
 ```
-run_agent_config(cfg)   executor.rs:426     (executes instantly, opens NO session)
-  fold {harness?, model?} onto self.active (ActiveConfig)
-    ├─ harness changed  → session_switched:true
-    │      (a NEW session opens at the NEXT agent step, when ensure_session sees
-    │       active.harness != current.harness — NOT here)
-    └─ harness same, model changed → applied LIVE to current session:
+run_agent_config(slot, cfg)   executor.rs     (executes instantly, opens NO session)
+  agent.config is MODEL-ONLY (A3): harness is fixed per slot, so a different
+  harness is a different slot — the harness-switch machinery is DELETED.
+    model changed → fold onto self.models[slot]; applied LIVE to the slot's
+        session if one is already open:
            set_live_session_config_option(session_id, ACP_MODEL_COMPAT_CONFIG_ID, model)
-           (no live session yet ⇒ takes effect at next creation)
-  output: {harness?, model?, session_switched}
+           (slot's session not open yet ⇒ takes effect at its next creation)
+  output: {model?, slot}
 
-On resume: recompute_active_config folds every agent.config in plan prefix
-[0, cursor) over the Setup seed — derived purely from plan+cursor, NO persisted
-config row.   executor.rs:131
+On resume: recompute_models folds every agent.config in the plan prefix
+[0, cursor) over the plan's per-slot `sessions[slot].model` seed — derived purely
+from plan+cursor, NO persisted config row.   executor.rs
+```
+
+### 1d. slot-keyed sessions (B7) + the C14 required-invocation gate
+
+```
+Sessions are SLOT-KEYED: each agent slot owns exactly one session for the run's
+lifetime. `WorkflowStepExecutorImpl.current: HashMap<slot, CurrentSession>` and
+`models: HashMap<slot, Option<String>>` replace the old single pointer.
+`ensure_session(slot)` opens the slot's session lazily (harness from
+`plan.sessions[slot]`), or — if `bind_session_id` is set (L29 / PR F, always
+absent today) — loads an existing one. The slot→session_id map is persisted via
+`set_session_for_slot` into `session_ids_json` (was an ordered list; now a
+{"triage":"sess_…"} object).
+
+C14 gate (arch §7.6): when an `agent.prompt` carries `required_invocation
+{provider,tool}`, run_prompt re-prompts up to MAX_GATE_ATTEMPTS(3), collecting
+the turn's ToolCall native tool names and matching provider+tool
+(`mcp__<provider>__<tool>` and bare spellings). Exhaustion → `invocation_missing`
+(on_fail matrix applies).
 ```
 
 ---
@@ -601,26 +620,26 @@ pub enum StepKind {   // format v2 — human.approval removed (E1), agent.emit +
     #[serde(rename = "branch")]        Branch(BranchStep),      // {on, cases:{v:{to}}, reason?}
 }
 
-// PlanStep now carries key/slot/label; ResolvedPlan.setup is gone — replaced by
-// sessions:{slot -> SessionSpec{harness, model?, session_binding, bind_session_id?}}.
-// ResolvedPlan::setup() derives a single PlanSetup for the current (pre-multi-slot)
-// executor (TODO phase C/F: make the executor slot-keyed).
+// PlanStep carries key/slot/label; there is no single `setup` — the executor is
+// slot-keyed (B7), reading sessions:{slot -> SessionSpec{harness, model?,
+// session_binding, bind_session_id?}} directly.
 pub struct PlanStep { pub key: String, pub slot: String, pub label: String, pub on_fail: OnFail, /* flatten */ kind }
 pub struct AgentPromptStep { pub prompt: String, pub goal: Option<GoalSpec>, pub required_invocation: Option<RequiredInvocation> }
 pub struct AgentEmitStep { pub prompt: String, pub max_attempts: u32 /*default 3*/, pub output_schema: Option<Value> }
-pub struct AgentConfigStep { pub harness: Option<String> /*deprecated; server emits model only*/, pub model: Option<String> }
+pub struct AgentConfigStep { pub model: Option<String> }  // model-only (A3); harness fixed per slot
 pub enum BranchTarget { Continue, End }
 pub enum SessionBinding { Fresh, Headless }
 ```
 <sub>[plan.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs)</sub>
 
-The runtime **executor** carries the v2 plan types but its per-kind *behavior* is
-unchanged in this pass: `agent.emit` and `branch` return a `not_implemented`
-failure (execution lands in phase C/F, C11/C12); `notify` is Slack-only.
+The runtime **executor** implements every v2 kind: `agent.emit` runs the
+file-drop re-ask loop (C12, `max_attempts` from the plan), `branch` matches the
+resolved `on` value against `cases` and routes continue/end (C11/E5), `notify` is
+Slack-only.
 
-`PlanStep { on_fail: OnFail, #[serde(flatten)] kind: StepKind }`; `OnFail { kind:
-OnFailKind(Stop|Retry|Continue), n: u32 }`; `ResolvedPlan { run_id, …, setup: PlanSetup,
-args, steps: Vec<PlanStep> }` (line 21).
+`PlanStep { key, slot, label, on_fail: OnFail, #[serde(flatten)] kind: StepKind }`;
+`OnFail { kind: OnFailKind(Stop|Retry|Continue), n: u32 }`; `ResolvedPlan { run_id,
+…, sessions: BTreeMap<String, SessionSpec>, inputs, steps: Vec<PlanStep> }`.
 
 `NotifyStep` (line 183, PR A) gained `#[serde(default)] pub slack_channel_id:
 Option<String>` — old plans without the field still deserialize (defaults to
@@ -659,12 +678,16 @@ and tests fake.
   `apply_decision`.
 - `apply_decision` (line 338) — where the cursor moves: `Complete`/`Continue` →
   advance (Completed at end); `FailRun` → run Failed; `Retry` → step back to Pending
-  (cursor unchanged); `Suspend` → step `Waiting`, output = descriptor, run `WaitingApproval`.
+  (cursor unchanged); `Suspend` → step `Waiting`, output = descriptor, run `WaitingApproval`;
+  `EndRun` (branch `end`, C11/E5) → step Completed with taken-case output, cursor
+  jumps to the end, run `Completed`, and `skip_tail` marks every later still-pending
+  step `Skipped`.
 - `resolve_pending_approval` (line 249) — approve/deny/timeout. For a goal step parked
   on a block, **approve → `Retry`** (re-arm + continue waiting).
 - `record_step_goal_progress` (line 173) — live goal upsert; writes onto a **RUNNING**
   step's `output_json` only (a terminal write is never clobbered by a late snapshot).
-- `append_session_id` (line 154) — append-once, ordered.
+- `set_session_for_slot` (B7) — records `slot -> session_id` into the slot-keyed
+  `session_ids` map (replaces the old append-once ordered `append_session_id`).
 
 Late-binding: [templates.rs](../anyharness/crates/anyharness-lib/src/domains/workflows/templates.rs)
 resolves `{{steps[N].output.KEY.path}}` against completed outputs and unescapes
@@ -684,22 +707,27 @@ silently emptied) — the runtime half of the injection guard.
   `tokio::spawn`: load run, parse plan (bad plan ⇒ `mark_run_terminal(Failed, bad_plan)`),
   build executor, `hydrate_from_run`, `drive_run` (loop while `Advanced`), on
   `SuspendedForApproval` arm the approval-timeout timer.
-- `cancel` (line 105) — signal the live token, best-effort cancel the current session's
-  in-flight turn, directly `mark_run_terminal(Cancelled)` when no actor is driving.
+- `cancel` (line 105) — signal the live token, best-effort cancel every slot
+  session's in-flight turn, directly `mark_run_terminal(Cancelled)` when no actor is driving.
 - `resolve_approval` (line 144) → `resolve_pending_approval`; if it advanced, `spawn_actor`.
 - `spawn_startup_pass` (line 176) — crash-resume: loads non-terminal runs; `Running` ⇒
   respawn at the persisted cursor (re-enter, attempt bumped — idempotency is per-kind);
   `WaitingApproval` ⇒ left parked, timeout timer re-armed.
 
 **Executor** ([executor.rs](../anyharness/crates/anyharness-lib/src/live/workflows/executor.rs)),
-one per run. Holds `current: Option<CurrentSession>` (run session continuity) and
-`active: ActiveConfig{harness, model?}`. `WorkflowExecDeps` bundles session_runtime,
-goal_runtime, session_service, workspace_runtime, workflow_service, acp_manager,
-workflow_owned_sessions.
+one per run. Slot-keyed (B7): holds `current: HashMap<slot, CurrentSession>` (one
+session per agent slot for the run's lifetime) and `models: HashMap<slot,
+Option<String>>` (effective model per slot). `WorkflowExecDeps` bundles
+session_runtime, goal_runtime, session_service, workspace_runtime,
+workflow_service, acp_manager, workflow_owned_sessions.
 
-- `hydrate_from_run` (line 112) / `recompute_active_config` (line 131) — resume.
-- `ensure_session` (line 147) — reuse current session only if harness matches; else
-  create in bypass mode, mark workflow-owned *before* the first prompt, append id.
+- `hydrate_from_run` / `recompute_models` — resume: restore each slot's bound
+  session from the persisted slot map + fold per-slot `agent.config` models.
+- `ensure_session(slot)` — reuse the slot's session or create it in bypass mode
+  (harness from `sessions[slot]`, fixed per slot — no harness match/switch), mark
+  workflow-owned *before* the first prompt, persist via `set_session_for_slot`. A
+  slot carrying `bind_session_id` (L29 / PR F, always absent today) loads an
+  existing session instead of creating one.
 - `subscribe` (line 214) — the **await substrate**: `broadcast::Receiver<SessionEventEnvelope>`;
   every wait subscribes *before* prompting.
 
@@ -707,22 +735,24 @@ workflow_owned_sessions.
 
 | kind | method | summary |
 |---|---|---|
-| `agent.config` | `run_agent_config` :426 | instant; folds harness/model; live model-set or session_switched (see [§1c](#1c-agentconfig--session-switch-flow)) |
-| `agent.prompt` (no goal) | `run_prompt` :227 | ensure_session → subscribe → send_prompt → `await_turn_ended` (TURN_BACKSTOP 30m) |
-| `agent.prompt` (goal) | `run_goal` :250 | arm → await → verify → terminal (see [§1b](#1b-step-execution-for-agentprompt--goal-arm--await--verify--terminal)) |
+| `agent.config` | `run_agent_config(slot,…)` | instant; model-only (A3); folds model onto the slot + live model-set (see [§1c](#1c-agentconfig--per-slot-model-change-model-only-a3)) |
+| `agent.prompt` (no goal) | `run_prompt(slot,…)` | ensure_session(slot) → subscribe → send_prompt → `await_turn_ended`; with `required_invocation` runs the C14 gate loop (MAX_GATE_ATTEMPTS=3, `invocation_missing` on exhaustion) |
+| `agent.prompt` (goal) | `run_goal(slot,…)` | arm → await → verify → terminal (see [§1b](#1b-step-execution-for-agentprompt--goal-arm--await--verify--terminal)) |
 | `shell.run` | [commands.rs](../anyharness/crates/anyharness-lib/src/live/workflows/commands.rs) `run_shell_step` | `/bin/sh -lc` in workspace, scrubbed env, 8 KiB tail, default 600s |
 | `scm.open_pr` | `open_pr_step` | `git push` + `gh pr create`; missing gh → `scm_unavailable` |
-| `agent.emit` | — (phase C/F) | v2 kind; execution (re-ask loop, C12) not yet built — returns `not_implemented` for now |
+| `agent.emit` | `run_emit(slot,…)` | file-drop re-ask loop (C12): prompt → await turn → read `<ws>/.proliferate/emit-<run>-<step>.json` → jsonschema-validate (optional schema) → corrective re-prompt up to plan `max_attempts` → `emit_invalid` on exhaustion; validated object = whole step output |
 | `notify` | [commands.rs](../anyharness/crates/anyharness-lib/src/live/workflows/commands.rs) `notify_step` | Slack-only (E1b); never a hard failure; the runtime emits `{channel:"slack", message, slack_channel_id}`, the server-side effect claims from it |
-| `branch` | — (phase C/F) | v2 kind; continue/end arm (C11) not yet built — returns `not_implemented` for now |
+| `branch` | `run_branch` | match the resolved `on` value against `cases`: `continue` → `Completed` (advance); `end` → `EndRun` (run `completed`, later steps `skipped`, E5); unmatched → `branch_unmatched` (on_fail applies) |
 | ~~`human.approval`~~ | removed (E1) | step kind deleted; the `waiting_approval` status survives via `goal.on_blocked` |
 
 **output_json vocabulary per kind** (consumed by the run view + `{{steps[N].output}}`):
 
 | kind | output keys |
 |---|---|
-| agent.config | `harness?`, `model?`, `session_switched` |
-| agent.prompt (turn) | `turn_id`, `session_id` |
+| agent.config | `model?`, `slot` |
+| agent.prompt (turn) | `turn_id`, `session_id`, `required_invocation?` |
+| agent.emit | the validated JSON object verbatim |
+| branch | `value`, `target` (`continue`\|`end`) |
 | agent.prompt (goal) | `session_id`, `met_reason?`, `verified?`, `verify_attempts?`; while running `{goal:{objective,status,iterations,tokens_used}, session_id}` |
 | shell.run | `output_tail`, `exit_code`, `output_name?` |
 | scm.open_pr | `pr_url` |
@@ -991,9 +1021,10 @@ editor/run UI of its own (drift note #7).
   that doesn't exist; poll inherits the restriction for the same reason (PR B).
   (`service._validate_trigger_target_mode`.)
 - **Zero-step drafts.** `require_steps=False` on save, `True` on StartRun.
-- **`agent.config` as a step (not Setup-only).** Config changes are ordered events
-  (Claude fixes → Codex reviews), folded into the active config; harness switch opens
-  a new session at the next agent step. (`plan.rs::AgentConfigStep`, `run_agent_config`.)
+- **`agent.config` as a step (not Setup-only).** Model changes are ordered events
+  folded onto the step's slot (model-only, A3). Multi-agent chaining (Claude fixes →
+  Codex reviews) is expressed as distinct *slots* — each slot owns its own session;
+  there is no harness-switch. (`plan.rs::AgentConfigStep`, `run_agent_config`.)
 - **Hidden run sessions.** Workflow-run sessions don't appear in the normal session
   list; their home is the run view's "Open session" deep link.
 - **Notify in-app floor.** `notify` is never a hard failure. Slack delivery (PR A)


### PR DESCRIPTION
Third PR of the A–E arc (stacked on #1005, rebased 2026-07-08 over the actions rename; design of record \`codex/workflows-architecture.md\` §1.5/§7.3–7.5).

## What

**\`agent.emit\`** — the typed output channel (LOCKED: a workflow's completion event is just its last emit; no forced tool calls). Mechanism per the OPEN-2 ruling: **file-drop + validate + reprompt**.

- Runtime: \`run_emit\` prompts the session with the step prompt + an instruction to write ONLY the JSON object to \`<workspace>/.proliferate/emit-<run>-<step>.json\`; after TurnEnded it reads + validates against \`output_schema\` (new \`jsonschema\` dep, default-features off); invalid/missing → corrective re-prompt with the concrete errors, ≤3 attempts; exhausted → \`Failed\` code \`emit_invalid\` with \`{errors, raw_tail}\`. The validated object **verbatim** is the step's entire output. Stale-file pre-delete + subscribe-before-prompt.
- Server: \`_parse_agent_emit\` (prompt templatable; \`output_schema\` structurally-sane object schema).

**Named step refs** (OPEN-6): every step gains optional \`name\` (\`[a-z][a-z0-9_]*\`, unique, ≤64); \`{{steps.<name>.output.*}}\` alongside the index form on both sides; \`shell.run\`'s \`output_name\` deprecated into \`name\`.

**UI**: emit step editor, name field, named-form autocomplete, emit output chip. Docs (L13) updated in-PR.

## Verification
158 server workflow tests + 74 cargo workflow tests green on this tip; serde rename round-trip, old-plan back-compat, exhaustion shape covered by named tests; desktop tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)