### PR TITLE
feat(workflows): PR D — workflow composition by resolution-time inlining (L20)

### DIFF
--- a/apps/desktop/src/components/playground/workflows/WorkflowEditorFixtures.tsx
+++ b/apps/desktop/src/components/playground/workflows/WorkflowEditorFixtures.tsx
@@ -187,6 +187,7 @@ function PanelHost({ initial, title }: { initial: WorkflowStep; title: string })
           suggestions={SUGGESTIONS}
           slackConnected={false}
           slackChannels={[]}
+          includableWorkflows={[]}
           supportsGoals={() => true}
           onChange={setStep}
           onClose={() => undefined}

--- a/apps/desktop/src/components/workflows/editor/WorkflowStepPanel.tsx
+++ b/apps/desktop/src/components/workflows/editor/WorkflowStepPanel.tsx
@@ -1,14 +1,19 @@
-import { useMemo, type ReactNode } from "react";
-import type {
-  AgentConfigStep,
-  AgentPromptStep,
-  HumanApprovalStep,
-  NotifyStep,
-  ScmOpenPrStep,
-  ShellRunStep,
-  WorkflowApprovalOnTimeout,
-  WorkflowNotifyChannel,
-  WorkflowStep,
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  isWorkflowStepName,
+  parseWorkflowDefinition,
+  WORKFLOW_STEP_NAME_MAX_LENGTH,
+  type AgentConfigStep,
+  type AgentEmitStep,
+  type AgentPromptStep,
+  type HumanApprovalStep,
+  type NotifyStep,
+  type ScmOpenPrStep,
+  type ShellRunStep,
+  type WorkflowApprovalOnTimeout,
+  type WorkflowIncludeStep,
+  type WorkflowNotifyChannel,
+  type WorkflowStep,
 } from "@proliferate/product-domain/workflows/definition";
 import type { TemplateSuggestion } from "@proliferate/product-domain/workflows/interpolation";
 import { Input } from "@proliferate/ui/primitives/Input";
@@ -17,6 +22,7 @@ import { Switch } from "@proliferate/ui/primitives/Switch";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { X } from "@proliferate/ui/icons";
 import { WorkflowStepKindBadge } from "@proliferate/product-ui/workflows/WorkflowStepKindBadge";
+import { useWorkflowDetail } from "@/hooks/access/cloud/workflows/use-workflows";
 import { TemplateVarTextarea } from "./TemplateVarTextarea";
 import { WorkflowGoalAttachment } from "./WorkflowGoalAttachment";
 import { WorkflowSelect } from "./WorkflowSelect";
@@ -32,6 +38,11 @@ export interface EditorSlackChannel {
   name: string;
 }
 
+export interface EditorIncludableWorkflow {
+  id: string;
+  name: string;
+}
+
 export interface WorkflowStepPanelProps {
   step: WorkflowStep;
   /** The effective harness for this step — Setup harness folded through any
@@ -42,6 +53,8 @@ export interface WorkflowStepPanelProps {
   slackConnected: boolean;
   /** Channels the connected Slack account can post to; empty when not connected. */
   slackChannels: readonly EditorSlackChannel[];
+  /** Owner's non-archived workflows (this one excluded) — the include picker. */
+  includableWorkflows: readonly EditorIncludableWorkflow[];
   supportsGoals: (harnessKind: string) => boolean;
   onChange: (step: WorkflowStep) => void;
   onClose: () => void;
@@ -93,8 +106,15 @@ export function WorkflowStepPanel(props: WorkflowStepPanelProps) {
             slackChannels={props.slackChannels}
             onChange={onChange}
           />
-        ) : (
+        ) : step.kind === "human.approval" ? (
           <ApprovalEditor step={step} onChange={onChange} />
+        ) : (
+          <IncludeEditor
+            step={step}
+            suggestions={props.suggestions}
+            includableWorkflows={props.includableWorkflows}
+            onChange={onChange}
+          />
         )}
       </div>
     </div>
@@ -409,6 +429,81 @@ function ApprovalEditor({
         />
       </InlineRow>
       <p className="text-xs text-faint">Approver: the workflow owner.</p>
+    </div>
+  );
+}
+
+/**
+ * Composition editor (spec 3.5 / L20): pick a workflow to inline, then map its
+ * declared arguments to templated values written in THIS workflow's context. The
+ * target's steps run inline in this workflow's single run — there is no child run
+ * (the server splices them at StartRun, before delivery). The child's declared
+ * args are read from the existing workflow-detail hook once a target is picked.
+ */
+function IncludeEditor({
+  step,
+  suggestions,
+  includableWorkflows,
+  onChange,
+}: {
+  step: WorkflowIncludeStep;
+  suggestions: readonly TemplateSuggestion[];
+  includableWorkflows: readonly EditorIncludableWorkflow[];
+  onChange: (step: WorkflowStep) => void;
+}) {
+  const detailQuery = useWorkflowDetail(step.workflowId || null);
+  const childArgs = useMemo(() => {
+    const raw = detailQuery.data?.currentVersion?.definition;
+    return raw ? parseWorkflowDefinition(raw).args : [];
+  }, [detailQuery.data]);
+
+  const pickTarget = (workflowId: string) => {
+    // A new target has its own arg schema; drop stale mappings on switch.
+    onChange({ ...step, workflowId, args: {} });
+  };
+  const setArg = (name: string, value: string) => {
+    onChange({ ...step, args: { ...step.args, [name]: value } });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <InlineRow label="Workflow">
+        <WorkflowSelect
+          ariaLabel="Workflow to include"
+          value={step.workflowId || ""}
+          placeholder={includableWorkflows.length > 0 ? "Select a workflow" : "No other workflows"}
+          disabled={includableWorkflows.length === 0}
+          options={includableWorkflows.map((wf) => ({ value: wf.id, label: wf.name }))}
+          onChange={pickTarget}
+        />
+      </InlineRow>
+      {step.workflowId ? (
+        childArgs.length > 0 ? (
+          <div className="flex flex-col gap-3">
+            <FieldLabel>Arguments</FieldLabel>
+            {childArgs.map((arg) => (
+              <div key={arg.name} className="flex flex-col gap-1">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {arg.name}
+                  {arg.required ? <span className="text-destructive"> *</span> : null}
+                </span>
+                <TemplateVarTextarea
+                  value={step.args[arg.name] ?? ""}
+                  onChange={(value) => setArg(arg.name, value)}
+                  suggestions={suggestions}
+                  rows={2}
+                  placeholder={`{{args.…}} or a value for ${arg.name}`}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-faint">This workflow takes no arguments.</p>
+        )
+      ) : null}
+      <p className="text-xs text-faint">
+        Steps run inline in this workflow&apos;s single run.
+      </p>
     </div>
   );
 }

--- a/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
@@ -27,7 +27,7 @@ import { WorkflowStepKindBadge } from "@proliferate/product-ui/workflows/Workflo
 import { EmptyState } from "@proliferate/ui/layout/EmptyState";
 import { useCloudAgentCatalog } from "@/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog";
 import { useCloudRunTargetWorkspaces } from "@/hooks/access/cloud/workspaces/use-cloud-run-target-workspaces";
-import { useWorkflowDetail } from "@/hooks/access/cloud/workflows/use-workflows";
+import { useWorkflowDetail, useWorkflows } from "@/hooks/access/cloud/workflows/use-workflows";
 import { useWorkflowMutations } from "@/hooks/access/cloud/workflows/use-workflow-mutations";
 import { useWorkflowSlackChannels } from "@/hooks/access/cloud/workflows/use-workflow-slack-channels";
 import type { WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
@@ -56,7 +56,15 @@ interface Draft {
   definition: WorkflowDefinition;
 }
 
-const STEP_KINDS: WorkflowStepKind[] = ["agent.prompt", "agent.config", "shell.run", "scm.open_pr", "notify", "human.approval"];
+const STEP_KINDS: WorkflowStepKind[] = ["agent.prompt", "agent.emit", "agent.config", "shell.run", "scm.open_pr", "notify", "branch", "workflow.include"];
+
+/** The output_schema's top-level property names, or `[]` when not an object schema. */
+function emitOutputSchemaFields(outputSchema: Record<string, unknown>): string[] {
+  const properties = outputSchema.properties;
+  return properties && typeof properties === "object" && !Array.isArray(properties)
+    ? Object.keys(properties as Record<string, unknown>)
+    : [];
+}
 
 function stepOutputNames(step: WorkflowStep): string[] {
   switch (step.kind) {
@@ -100,6 +108,7 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
   const catalogQuery = useCloudAgentCatalog();
   const cloudTargetsQuery = useCloudRunTargetWorkspaces();
   const slackChannelsQuery = useWorkflowSlackChannels();
+  const workflowsQuery = useWorkflows();
   const { updateMutation } = useWorkflowMutations();
 
   const [draft, setDraft] = useState<Draft | null>(null);
@@ -145,9 +154,21 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
   const issues = useMemo(
     () =>
       draft
-        ? validateWorkflowDefinition(draft.definition, { harnessSupportsGoals: harnessSupportsGoals })
+        ? validateWorkflowDefinition(draft.definition, {
+            harnessSupportsGoals: harnessSupportsGoals,
+            workflowId,
+          })
         : [],
-    [draft],
+    [draft, workflowId],
+  );
+
+  // Owner's other non-archived workflows — the workflow.include picker source.
+  const includableWorkflows = useMemo(
+    () =>
+      (workflowsQuery.data?.workflows ?? [])
+        .filter((wf) => wf.id !== workflowId && wf.archivedAt === null)
+        .map((wf) => ({ id: wf.id, name: wf.name })),
+    [workflowsQuery.data, workflowId],
   );
 
   const effectiveConfigs = useMemo(
@@ -464,6 +485,7 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
                 suggestions={suggestions}
                 slackConnected={slackChannelsQuery.data?.connected ?? false}
                 slackChannels={slackChannelsQuery.data?.channels ?? []}
+                includableWorkflows={includableWorkflows}
                 supportsGoals={harnessSupportsGoals}
                 onChange={(next) => updateStep(selectedStep, next)}
                 onClose={() => setSelectedStep(null)}

--- a/apps/packages/product-domain/src/workflows/definition.ts
+++ b/apps/packages/product-domain/src/workflows/definition.ts
@@ -28,6 +28,7 @@ export const WORKFLOW_STEP_KINDS = [
   "scm.open_pr",
   "notify",
   "branch",
+  "workflow.include",
 ] as const;
 export type WorkflowStepKind = (typeof WORKFLOW_STEP_KINDS)[number];
 
@@ -174,6 +175,24 @@ export interface BranchStep extends StepBase {
   reason?: string;
 }
 
+/**
+ * Composition step (spec 3.5 / L20): inline another workflow's steps into this
+ * workflow's single resolved plan. Definition-only — the server's resolver
+ * splices the target's CURRENT version's steps at StartRun, before delivery, so
+ * the runtime never sees a `workflow.include` step (there is no child run). `args`
+ * maps the child's declared argument names to templated strings written in THIS
+ * workflow's context (they may reference `{{args.*}}` / `{{steps...}}` here).
+ */
+export interface WorkflowIncludeStep extends StepBase {
+  kind: "workflow.include";
+  /** The included workflow's id (its current version's steps are inlined). */
+  workflowId: string;
+  /** child-input-name -> templated value (in this workflow's interpolation context). */
+  args: Record<string, string>;
+  /** Include handle: prefixes the child's emit names at resolution (optional). */
+  name?: string;
+}
+
 export type WorkflowStep =
   | AgentPromptStep
   | AgentEmitStep
@@ -181,7 +200,8 @@ export type WorkflowStep =
   | ShellRunStep
   | ScmOpenPrStep
   | NotifyStep
-  | BranchStep;
+  | BranchStep
+  | WorkflowIncludeStep;
 
 export interface WorkflowAgentNode {
   slot: string;
@@ -230,6 +250,8 @@ export function createWorkflowStep(kind: WorkflowStepKind): WorkflowStep {
       return { kind, onFail: { ...DEFAULT_ON_FAIL }, slackChannelId: "", message: "" };
     case "branch":
       return { kind, onFail: { ...DEFAULT_ON_FAIL }, on: "", cases: {} };
+    case "workflow.include":
+      return { kind, onFail: { ...DEFAULT_ON_FAIL }, workflowId: "", args: {} };
   }
 }
 
@@ -409,6 +431,18 @@ function parseStep(raw: unknown): WorkflowStep | null {
       }
       return step;
     }
+    case "workflow.include": {
+      const rawArgs = asRecord(record.args);
+      const args: Record<string, string> = {};
+      if (rawArgs) {
+        for (const [key, value] of Object.entries(rawArgs)) {
+          if (typeof value === "string") {
+            args[key] = value;
+          }
+        }
+      }
+      return { kind, onFail, workflowId: asString(record.workflow_id) ?? "", args };
+    }
   }
 }
 
@@ -559,6 +593,11 @@ function serializeStep(step: WorkflowStep): Record<string, unknown> {
       if (step.reason !== undefined) {
         base.reason = step.reason;
       }
+      return base;
+    }
+    case "workflow.include": {
+      base.workflow_id = step.workflowId;
+      base.args = { ...step.args };
       return base;
     }
   }

--- a/apps/packages/product-domain/src/workflows/presentation.ts
+++ b/apps/packages/product-domain/src/workflows/presentation.ts
@@ -30,6 +30,7 @@ export const WORKFLOW_STEP_META: Record<WorkflowStepKind, WorkflowStepKindMeta> 
   "scm.open_pr": { glyph: "⇈", label: "Open PR", hint: "Open a pull request" },
   notify: { glyph: "🔔", label: "Notify", hint: "Send a notification" },
   "human.approval": { glyph: "⏸", label: "Approval", hint: "Wait for a human" },
+  "workflow.include": { glyph: "⧉", label: "Include", hint: "Inline a workflow" },
 };
 
 /** Glyph shown for a step in the home-card strip. Goal-armed prompts show `◎`. */
@@ -84,6 +85,8 @@ export function workflowStepPreview(step: WorkflowStep): string {
       return collapse(step.message) || WORKFLOW_STEP_META[step.kind].hint;
     case "human.approval":
       return collapse(step.message) || WORKFLOW_STEP_META[step.kind].hint;
+    case "workflow.include":
+      return WORKFLOW_STEP_META[step.kind].hint;
   }
 }
 
@@ -106,6 +109,8 @@ export function workflowStepExcerpt(step: WorkflowStep): string {
     case "notify":
     case "human.approval":
       return normalize(step.message);
+    case "workflow.include":
+      return "";
   }
 }
 

--- a/apps/packages/product-domain/src/workflows/run-status.ts
+++ b/apps/packages/product-domain/src/workflows/run-status.ts
@@ -262,6 +262,10 @@ function outputChipsFor(
       }
       return parts.length > 0 ? [{ kind: "text", label: parts.join(" · ") }] : [];
     }
+    case "workflow.include":
+      // Never present in a resolved plan: the server inlines it away at StartRun
+      // (L20), so a run view never sees one. Kept for exhaustiveness.
+      return [];
   }
 }
 

--- a/apps/packages/product-domain/src/workflows/validation.ts
+++ b/apps/packages/product-domain/src/workflows/validation.ts
@@ -43,6 +43,13 @@ export interface WorkflowIssue {
 
 export interface ValidateWorkflowOptions {
   harnessSupportsGoals?: (harness: string) => boolean;
+  /**
+   * The id of the workflow being edited, if it has one (spec 3.5). Used to flag a
+   * `workflow.include` that targets the workflow itself (self-include). The full
+   * include-graph CYCLE check is SERVER-ONLY: it must fetch other workflows'
+   * current versions, which the editor doesn't have — the server is the authority.
+   */
+  workflowId?: string;
 }
 
 interface TemplatedField {
@@ -83,6 +90,13 @@ function templatedFields(step: WorkflowStep): TemplatedField[] {
       return [{ field: "message", value: step.message }];
     case "branch":
       return [{ field: "on", value: step.on }];
+    case "workflow.include":
+      // Each input-mapping value is a templated string in THIS workflow's context
+      // (spec 3.5 obl. a) — validate its refs against the parent's inputs/emits.
+      return Object.entries(step.args).map(([key, value]) => ({
+        field: `args.${key}`,
+        value,
+      }));
   }
 }
 
@@ -270,6 +284,22 @@ function validateStep(
             location: { scope: "step", stepIndex, field: "cases" },
           });
         }
+      }
+      break;
+    }
+    case "workflow.include": {
+      if (step.workflowId.trim() === "") {
+        push({
+          code: "invalid_definition",
+          message: "Choose a workflow to include.",
+          location: { scope: "step", stepIndex, field: "workflowId" },
+        });
+      } else if (options.workflowId && step.workflowId === options.workflowId) {
+        push({
+          code: "self_include",
+          message: "A workflow cannot include itself.",
+          location: { scope: "step", stepIndex, field: "workflowId" },
+        });
       }
       break;
     }

--- a/apps/packages/product-ui/src/workflows/WorkflowStepKindBadge.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowStepKindBadge.tsx
@@ -3,6 +3,7 @@ import type { WorkflowStepKind } from "@proliferate/product-domain/workflows/def
 import { WORKFLOW_STEP_META } from "@proliferate/product-domain/workflows/presentation";
 import type { IconProps } from "@proliferate/ui/icons";
 import {
+  Blocks,
   GitPullRequest,
   Pause,
   Robot,
@@ -24,6 +25,7 @@ const KIND_ICON: Record<WorkflowStepKind, ComponentType<IconProps>> = {
   "scm.open_pr": GitPullRequest,
   notify: SendIcon,
   "human.approval": Pause,
+  "workflow.include": Blocks,
 };
 
 const PILL_TREATMENT = "border border-border bg-transparent text-foreground";

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -7,7 +7,7 @@
 >
 > Companion: [`workflows-architecture.md`](workflows-architecture.md) is the
 > **end-state** doc for the PR A–E arc (actions ledger + Slack delivery, poll
-> triggers, `agent.emit`, `workflow.run`, gateway function grants) — read it for
+> triggers, `agent.emit`, `workflow.include` composition, gateway function grants) — read it for
 > where the system is going and the [OPEN-n] decision log; read this for what is
 > built today.
 
@@ -373,6 +373,18 @@ uniqueness (whole definition) and *strictly-prior* ref visibility: `{{inputs.NAM
 must be a declared input; `{{EMIT.FIELD}}` must name an emit produced by an
 earlier step (earlier nodes in full, earlier steps in the same node).
 
+**`workflow.include` (§3.5, PR D)** — `_parse_workflow_include` validates the
+definition-only composition step's shape (a UUID `workflow_id`, an `args` mapping of
+child-arg identifiers → template strings). Its arg-mapping values are ordinary
+templated strings in the parent's context, so `_iter_step_strings` yields them and
+`_validate_references` checks them against the parent's args/earlier steps. That
+same reference pass now tracks which earlier steps are includes and rejects any
+`{{steps[i]...}}` / `{{steps.<name>...}}` that targets one (`include_step_reference`)
+— an include produces no output and referencing into the child is out of scope v1.
+The DB-backed checks (target ownership, arg coverage, cycles) live in the service
+layer, not here; the resolver ([composition.py](../server/proliferate/server/cloud/workflows/domain/composition.py))
+inlines it away at StartRun (§3.3).
+
 ### 3.2 Interpolation — [domain/interpolation.py](../server/proliferate/server/cloud/workflows/domain/interpolation.py)
 
 Stored grammar is `{{inputs.<name>}}` + `{{<emit>.<field>}}` (B6). Reserved
@@ -391,7 +403,8 @@ first-segments: `inputs`, `steps`, `fields`.
 
 `start_run(...)` (line 316): validate target_mode/trigger_kind → owner-scoped 404 →
 cloud target must be materialized (`target_workspace_not_ready` 409 before any row)
-→ pin version → `parse_definition` strict → `coerce_arguments` → `_resolve_plan`
+→ pin version → `parse_definition` strict → `coerce_arguments` →
+`resolve_included_agents` (composition, PR D — below) → `_resolve_plan`
 (line 262) → `store.create_run(status=pending_delivery)`. The run id is
 pre-generated so it is inside the payload before insert. `trigger_kind` accepts
 `'poll'` (PR B) exactly like `'schedule'` — from `start_run` onward a poll-fired
@@ -409,13 +422,76 @@ return {
     "target_mode": target_mode,
     "sessions": {slot: {harness, model, session_binding, bind_session_id?}},  # per-slot
     "inputs": coerced_inputs,                        # eager values, verbatim
-    "steps": [...],  # flattened spine; each step stamped key="<node>.-.<step>", slot, label;
-                     # {{inputs.*}} baked, {{emit.field}} rewritten to {{steps[n].output.field}}
+    "steps": [...],  # flattened spine, includes inlined FIRST (composition); each step
+                     # stamped key="<node>.-.<step>", slot, label; {{inputs.*}} baked,
+                     # {{emit.field}} rewritten to {{steps[n].output.field}}
 }
 ```
 `session_binding` defaults by trigger kind (manual/chat=fresh, schedule/poll=headless).
 StartRun wire (B9): `args`→`inputs`, `target` = `workspace_id` XOR `trigger_id`,
 optional `session_bindings:{slot:session_id}`.
+
+**Composition by inlining (PR D, L20)** — [domain/composition.py](../server/proliferate/server/cloud/workflows/domain/composition.py).
+A `workflow.include` step is **definition-only**: `resolve_included_steps` splices
+the target workflow's CURRENT version's steps into the parent's agents spine at
+StartRun, **before delivery** — one run, one plan, one cursor, one sandbox. There
+is no child run, no parent linkage, no spawn. **The runtime is COMPLETELY unchanged
+by D — there is no `plan.rs` change; the resolver eliminates every include step
+before the flatten pass, so the runtime never sees one. That is the design (the
+"no include kind in a resolved plan" property is asserted in
+`test_workflow_include.py`).**
+
+**Adapted to the v2 agents spine (this rebase):** a `workflow.include` step lives
+*inside an agent node's step list* and inlines the child definition's STEPS into
+that node (`resolve_included_agents` walks every node; `resolve_included_steps`
+expands one node's step list). Composition operates **purely on the v2 named-ref
+grammar** (`{{inputs.*}}` / `{{<emit>.<field>}}`) — it never touches indices. The
+*parent's* single flatten pass (`_resolve_plan`) later assigns structured step keys
+and rewrites every `{{<emit>.<field>}}` to the runtime's indexed
+`{{steps[n].output.<field>}}`, so the ref-namespacing obligation collapses to
+name-prefixing. Ordering is still load-bearing: inline FIRST, then the flatten
+pass's eager `{{inputs.*}}` + emit-index rewrite runs over the whole spine in one
+place. **A child definition with more than one agent node is REJECTED as an include
+target for now (`include_multi_agent`, PROPOSED per A3's include row)** — cross-spine
+inlining is the Part II composition pass's problem; the child's single node's
+harness/model are discarded (its steps run in the parent node's slot). The two
+resolver obligations (spec 3.5):
+
+- **Arg binding** — the include's `args` mapping becomes the child's input context:
+  each child `{{inputs.<name>}}` token is textually replaced by the mapping value
+  (no brace-escaping — both sides are author-written definition text, unlike a
+  user-supplied StartRun input). Mapping values may carry the PARENT's `{{inputs.*}}`
+  (eager-resolved by the flatten pass) and `{{<emit>.<field>}}` refs (stay
+  late-bound, rewritten to indexed form by the flatten pass); uncovered optional
+  child inputs fall back to their default.
+- **Emit-ref namespacing** — each child `agent.emit` `name` is prefixed
+  `<includeName>_` and every child `{{<emit>.<field>}}` ref to one of them is
+  rewritten to `{{<includeName>_<emit>.<field>}}` (includeName = the include's
+  `name`, else `w<parentStepIndex>`). Prefixing happens BEFORE arg binding so a
+  parent emit ref injected via the mapping (which names a PARENT emit) is never
+  itself prefixed. The parent's own refs to an include handle are rejected at save
+  (`include_step_reference`) — an include has no emit output, and cross-spine refs
+  into the child are out of scope v1.
+
+Nesting is recursive (B may include C — the child's emit names are prefixed at
+each level: `w2_w1_g`) and depth-capped at `WORKFLOW_MAX_INCLUDE_DEPTH=5`; a
+resolution-time breach fails the run cleanly (`include_depth_exceeded`) before any
+delivery. Save-time validation (`validate_includes`, called from
+`create_workflow`/`update_workflow`, walking every node's steps) proves the target
+exists / is same-owner / not archived / has exactly one agent node
+(`include_multi_agent`), is not self-included (`self_include`), that the mapping
+covers the child's required inputs and references only declared child inputs
+(`include_args_mismatch`), and that the include graph has no cycle (`include_cycle`,
+naming the path). A child changed since save (e.g. it grew a required input or a
+second agent node) re-fails at resolution with the same code.
+
+*Surface-syntax decisions STILL pending Pablo's veto (unchanged by this rebase —
+chosen by the orchestrator where §3.5 left the surface open):* the step kind is
+`workflow.include` (deliberately not `workflow.run` — no runtime verb); its shape
+is `{kind, workflow_id, args:{<child-input>: <template>}, name?}`; the arg mapping
+is a flat `{child-input-name: template-string}` object; child emit-name prefixing
+uses `<includeName>_<origName>` with `w<parentStepIndex>` as the default include
+name. These four remain VETO-PENDING.
 
 Also here: `report_run_status` (line 442; locks run, enforces `check_transition`,
 stamps started/finished, writes cursor/outputs/session ids/cost, then — after the

--- a/server/proliferate/constants/workflows.py
+++ b/server/proliferate/constants/workflows.py
@@ -122,6 +122,12 @@ WORKFLOW_STEP_SHELL_RUN: Final = "shell.run"
 WORKFLOW_STEP_SCM_OPEN_PR: Final = "scm.open_pr"
 WORKFLOW_STEP_NOTIFY: Final = "notify"
 WORKFLOW_STEP_BRANCH: Final = "branch"
+# Composition (spec 3.5 / L20): a definition-only step that names another workflow
+# whose CURRENT version's steps are inlined into this plan at resolution time. It
+# is deliberately NOT "workflow.run" — no runtime verb is implied. The server's
+# plan resolver eliminates it before delivery, so it never reaches the runtime
+# (the Rust plan.rs has no matching StepKind — that IS the L20 property).
+WORKFLOW_STEP_WORKFLOW_INCLUDE: Final = "workflow.include"
 SUPPORTED_WORKFLOW_STEP_KINDS: Final = frozenset(
     {
         WORKFLOW_STEP_AGENT_CONFIG,
@@ -131,11 +137,17 @@ SUPPORTED_WORKFLOW_STEP_KINDS: Final = frozenset(
         WORKFLOW_STEP_SCM_OPEN_PR,
         WORKFLOW_STEP_NOTIFY,
         WORKFLOW_STEP_BRANCH,
+        WORKFLOW_STEP_WORKFLOW_INCLUDE,
     }
 )
 
 # Default emit re-ask budget (executor MAX_EMIT_ATTEMPTS; overridable per emit).
 WORKFLOW_EMIT_DEFAULT_MAX_ATTEMPTS: Final = 3
+
+# Max workflow.include nesting depth (spec 3.5 / L20). A breach fails at save time
+# (cycle/depth walk) and, defensively, at resolution time (include_depth_exceeded)
+# BEFORE any delivery — the runtime never sees a partially-resolved plan.
+WORKFLOW_MAX_INCLUDE_DEPTH: Final = 5
 
 # --- branch targets (data-contract §1.2 / C11: narrowed to continue|end). ------
 WORKFLOW_BRANCH_TARGET_CONTINUE: Final = "continue"

--- a/server/proliferate/server/cloud/workflows/domain/composition.py
+++ b/server/proliferate/server/cloud/workflows/domain/composition.py
@@ -1,0 +1,514 @@
+"""Workflow composition by resolution-time inlining (spec 3.5 / L20), format v2.
+
+Using workflow B inside workflow A means B's steps are **inlined into A's single
+resolved plan at StartRun, server-side, before delivery** — one run, one plan,
+one cursor, one sandbox. There is no child run, no parent linkage, no spawn: the
+``workflow.include`` step (definition-only) is eliminated by
+:func:`resolve_included_agents` here, so the runtime never sees it (that is the
+L20 property; the Rust plan.rs has no matching StepKind).
+
+**Where includes live (v2 agents spine, A3/PROPOSED):** an ``workflow.include``
+step lives *inside an agent node's step list* and inlines the child definition's
+STEPS into that node. A child definition with more than one agent node is
+REJECTED as an include target for now — cross-spine inlining is the Part II
+composition pass's problem (``include_multi_agent``). The child's single node's
+harness/model are ignored: the included steps run in the *parent* node's slot.
+
+Two resolver obligations (§3.5), both operating purely on the v2 named-ref grammar
+(``{{inputs.<name>}}`` / ``{{<emit>.<field>}}``) — NOT on indices. The parent's
+flatten pass (service._resolve_plan) later assigns structured step keys and
+rewrites every ``{{<emit>.<field>}}`` to the runtime's indexed
+``{{steps[n].output.<field>}}`` form, so composition never touches indices:
+
+* **(a) Arg binding.** The include step's ``args`` mapping becomes the child's
+  input context: each child ``{{inputs.<name>}}`` token is replaced by the
+  mapping's value string. The substitution is **textual — no brace-escaping** —
+  because both the child field and the mapping value are author-written
+  definition text (unlike a user-supplied StartRun input, which is brace-escaped
+  by the eager pass). Mapping values may themselves carry the PARENT's
+  ``{{inputs.*}}`` (eager-resolved later by the flatten pass — inline FIRST, then
+  eager) and the parent's ``{{<emit>.<field>}}`` refs (which stay late-bound and
+  are rewritten to indexed form by the flatten pass).
+
+* **(b) Emit-ref namespacing.** A child's internal emit names are the ref
+  namespace, so each child ``agent.emit`` ``name`` is prefixed ``<includeName>_``
+  and every child ``{{<emit>.<field>}}`` reference to one of them is rewritten to
+  ``{{<includeName>_<emit>.<field>}}``. Prefixing happens BEFORE arg binding so a
+  parent emit ref injected via the mapping (which names a PARENT emit) is never
+  itself prefixed. The flatten pass then resolves the prefixed names to indices.
+
+Save-time validation (:func:`validate_includes`) additionally proves the target
+exists / is same-owner / not archived / has exactly one agent node, is not
+self-included, that the mapping covers the child's required inputs and references
+only declared child inputs, and that the include graph has no cycle (A→B→A) — all
+before a version is stored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.workflows import (
+    WORKFLOW_MAX_INCLUDE_DEPTH,
+    WORKFLOW_STEP_AGENT_EMIT,
+    WORKFLOW_STEP_WORKFLOW_INCLUDE,
+)
+from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store.cloud_workflows import WorkflowRecord
+from proliferate.server.cloud.workflows.domain.definition import parse_definition
+from proliferate.server.cloud.workflows.domain.interpolation import (
+    _PLACEHOLDER_RE,
+    _render_scalar,
+    ArgSpec,
+    EmitReference,
+    InputReference,
+    parse_reference,
+)
+
+
+class WorkflowCompositionError(Exception):
+    """Raised when a ``workflow.include`` cannot be validated or resolved."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _is_include(step: dict[str, object]) -> bool:
+    return step.get("kind") == WORKFLOW_STEP_WORKFLOW_INCLUDE
+
+
+def _single_agent_steps(
+    child_definition: dict[str, object], *, target_id: object
+) -> list[dict[str, object]]:
+    """Return the child's ONE agent node's steps, or reject a multi-node target.
+
+    Cross-spine inlining (a child with several agent nodes / slots) is a Part II
+    concept (A3/PROPOSED) — for now a multi-node include target fails cleanly.
+    """
+
+    agents = list(child_definition.get("agents", []))
+    if len(agents) != 1:
+        raise WorkflowCompositionError(
+            "include_multi_agent",
+            f"workflow.include target {target_id} must have exactly one agent node "
+            f"(it has {len(agents)}); including a multi-agent workflow is not "
+            "supported yet.",
+        )
+    return list(agents[0].get("steps", []))
+
+
+# --- pure string rewriting -----------------------------------------------------
+
+
+def _prefix_child_emit_refs(
+    value: str, *, child_emit_names: frozenset[str], prefix: str
+) -> str:
+    """Namespace a child string's OWN emit refs for splicing (§3.5 obl. b).
+
+    ``{{<emit>.<field>}}`` where ``emit`` is one of the child's emit names is
+    rewritten to ``{{<prefix>_<emit>.<field>}}``. Everything else (input refs,
+    which the arg-binding pass handles next) is left verbatim.
+    """
+
+    out: list[str] = []
+    last = 0
+    for match in _PLACEHOLDER_RE.finditer(value):
+        out.append(value[last : match.start()])
+        reference = parse_reference(match.group("ref"))
+        if isinstance(reference, EmitReference) and reference.emit in child_emit_names:
+            out.append(f"{{{{{prefix}_{reference.emit}.{reference.field}}}}}")
+        else:  # InputReference (bound below) / a parent emit ref — verbatim.
+            out.append(match.group(0))
+        last = match.end()
+    out.append(value[last:])
+    return "".join(out)
+
+
+def _bind_child_inputs(value: str, arg_context: dict[str, str]) -> str:
+    """Replace child ``{{inputs.<name>}}`` tokens with the include's mapping value.
+
+    Textual substitution, no brace-escaping (§3.5 obl. a): both sides are
+    author-written definition text. Already-namespaced emit refs are left verbatim.
+    """
+
+    out: list[str] = []
+    last = 0
+    for match in _PLACEHOLDER_RE.finditer(value):
+        out.append(value[last : match.start()])
+        reference = parse_reference(match.group("ref"))
+        if isinstance(reference, InputReference):
+            out.append(arg_context.get(reference.name, ""))
+        else:
+            out.append(match.group(0))
+        last = match.end()
+    out.append(value[last:])
+    return "".join(out)
+
+
+# ``label`` is skimmed English, ``name`` an identifier, ``output_schema`` a JSON
+# Schema, ``required_invocation`` a {provider, tool} literal — none are templated.
+_SKIP_KEYS = frozenset(
+    {"kind", "on_fail", "label", "name", "output_schema", "required_invocation"}
+)
+
+
+def _transform_step_strings(
+    step: dict[str, object], fn: Callable[[str], str]
+) -> dict[str, object]:
+    """Return a copy of ``step`` with ``fn`` applied to every templated string.
+
+    Recurses fully into nested dicts/lists (mirroring ``resolve_value``), so a
+    goal's ``verify.shell`` and a branch's ``on`` are rewritten too. The identifier
+    / schema fields in ``_SKIP_KEYS`` are left untouched.
+    """
+
+    def _walk(value: object) -> object:
+        if isinstance(value, str):
+            return fn(value)
+        if isinstance(value, list):
+            return [_walk(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _walk(item) for key, item in value.items()}
+        return value
+
+    result: dict[str, object] = {}
+    for key, value in step.items():
+        result[key] = value if key in _SKIP_KEYS else _walk(value)
+    return result
+
+
+def _splice_child(
+    child_steps: list[dict[str, object]],
+    *,
+    arg_context: dict[str, str],
+    name_prefix: str,
+) -> list[dict[str, object]]:
+    """Namespace emit refs + arg-bind a child's (already-flattened) steps.
+
+    The child's steps are returned unchanged in order; the parent flatten pass
+    positions them and rewrites their now-namespaced emit names to indices.
+    """
+
+    child_emit_names = frozenset(
+        step["name"]
+        for step in child_steps
+        if step.get("kind") == WORKFLOW_STEP_AGENT_EMIT and isinstance(step.get("name"), str)
+    )
+
+    def _rewrite(value: str) -> str:
+        # Namespace emit refs FIRST so a parent emit ref injected via arg binding
+        # (which names a PARENT emit) is not itself prefixed.
+        namespaced = _prefix_child_emit_refs(
+            value, child_emit_names=child_emit_names, prefix=name_prefix
+        )
+        return _bind_child_inputs(namespaced, arg_context)
+
+    spliced: list[dict[str, object]] = []
+    for step in child_steps:
+        transformed = _transform_step_strings(deepcopy(step), _rewrite)
+        # Only emit names live in the ref namespace, so only they are prefixed.
+        if transformed.get("kind") == WORKFLOW_STEP_AGENT_EMIT and isinstance(
+            transformed.get("name"), str
+        ):
+            transformed["name"] = f"{name_prefix}_{transformed['name']}"
+        spliced.append(transformed)
+    return spliced
+
+
+# --- arg-context (coverage) ----------------------------------------------------
+
+
+def _build_arg_context(
+    mapping: dict[str, object], child_specs: list[ArgSpec], *, error_code: str
+) -> dict[str, str]:
+    """Verify the include mapping against the child's input schema, return the context.
+
+    Coverage rule (save AND resolution): the mapping must reference only declared
+    child inputs and cover every REQUIRED child input. Uncovered optional inputs
+    fall back to their default (or the empty string when they have none) so no
+    dangling ``{{inputs.*}}`` survives into the flattened plan.
+    """
+
+    declared = {spec.name for spec in child_specs}
+    unknown = sorted(set(mapping) - declared)
+    if unknown:
+        raise WorkflowCompositionError(
+            error_code,
+            f"workflow.include args reference undeclared child input(s): {unknown}.",
+        )
+    missing = sorted(
+        spec.name for spec in child_specs if spec.required and spec.name not in mapping
+    )
+    if missing:
+        raise WorkflowCompositionError(
+            error_code,
+            f"workflow.include is missing required child input(s): {missing}.",
+        )
+    context: dict[str, str] = {}
+    for spec in child_specs:
+        if spec.name in mapping:
+            context[spec.name] = str(mapping[spec.name])
+        elif spec.has_default:
+            context[spec.name] = _render_scalar(spec.default)
+    return context
+
+
+def _child_arg_specs(version_definition: dict[str, object]) -> list[ArgSpec]:
+    _canonical, specs = parse_definition(version_definition, require_steps=False)
+    return specs
+
+
+# --- resolution-time inlining --------------------------------------------------
+
+
+async def _load_included_target(
+    db: AsyncSession, *, owner_user_id: UUID, workflow_id_str: object
+) -> tuple[WorkflowRecord, dict[str, object]]:
+    """Load an include target's current version, or raise the run-failing error.
+
+    The target must still exist, be owned by the run's owner, be un-archived, and
+    have a current version — a target changed/removed since save fails the run
+    cleanly, before any delivery.
+    """
+
+    try:
+        target_id = UUID(str(workflow_id_str))
+    except ValueError as exc:
+        raise WorkflowCompositionError(
+            "include_target_not_found", "workflow.include target id is invalid."
+        ) from exc
+    target = await store.get_workflow(db, target_id)
+    if target is None or target.owner_user_id != owner_user_id or target.archived_at is not None:
+        raise WorkflowCompositionError(
+            "include_target_not_found",
+            f"Included workflow {target_id} is not available.",
+        )
+    if target.current_version_id is None:
+        raise WorkflowCompositionError(
+            "include_target_not_found",
+            f"Included workflow {target_id} has no current version.",
+        )
+    version = await store.get_version(db, target.current_version_id)
+    if version is None:
+        raise WorkflowCompositionError(
+            "include_target_not_found",
+            f"Included workflow {target_id} has no current version.",
+        )
+    return target, version.definition_json
+
+
+async def resolve_included_steps(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    steps: list[dict[str, object]],
+    depth: int = 0,
+) -> list[dict[str, object]]:
+    """Flatten every ``workflow.include`` in one agent node's step list.
+
+    Recursive (B may include C) and depth-capped: a breach raises
+    ``include_depth_exceeded`` BEFORE any splicing, so the run fails before
+    delivery. The returned list contains no ``workflow.include`` steps (L20) and
+    only the v2 named-ref grammar (index rewriting is the flatten pass's job).
+    """
+
+    if depth > WORKFLOW_MAX_INCLUDE_DEPTH:
+        raise WorkflowCompositionError(
+            "include_depth_exceeded",
+            f"workflow.include nesting exceeds the limit of {WORKFLOW_MAX_INCLUDE_DEPTH}.",
+        )
+
+    output: list[dict[str, object]] = []
+    for orig_index, step in enumerate(steps):
+        if not _is_include(step):
+            output.append(deepcopy(step))
+            continue
+        target, child_definition = await _load_included_target(
+            db, owner_user_id=owner_user_id, workflow_id_str=step.get("workflow_id")
+        )
+        child_steps = _single_agent_steps(child_definition, target_id=target.id)
+        child_flat = await resolve_included_steps(
+            db,
+            owner_user_id=owner_user_id,
+            steps=child_steps,
+            depth=depth + 1,
+        )
+        arg_context = _build_arg_context(
+            dict(step.get("args") or {}),
+            _child_arg_specs(child_definition),
+            error_code="include_args_mismatch",
+        )
+        include_name = step.get("name")
+        prefix = include_name if isinstance(include_name, str) else f"w{orig_index}"
+        output.extend(
+            _splice_child(child_flat, arg_context=arg_context, name_prefix=prefix)
+        )
+    return output
+
+
+async def resolve_included_agents(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    agents: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Return the agents spine with every node's ``workflow.include`` inlined.
+
+    Each node keeps its slot/harness/model; only its step list is expanded (the
+    included steps run in the parent node's session). The result feeds the flatten
+    pass, which assigns keys and rewrites emit refs to indices.
+    """
+
+    resolved: list[dict[str, object]] = []
+    for node in agents:
+        steps = await resolve_included_steps(
+            db, owner_user_id=owner_user_id, steps=list(node.get("steps", []))
+        )
+        resolved.append({**node, "steps": steps})
+    return resolved
+
+
+# --- save-time validation ------------------------------------------------------
+
+
+def _include_steps_of_definition(definition: dict[str, object]) -> list[dict[str, object]]:
+    """Every ``workflow.include`` step across a v2 definition's agent nodes."""
+
+    includes: list[dict[str, object]] = []
+    for node in definition.get("agents", []):
+        for step in node.get("steps", []):
+            if step.get("kind") == WORKFLOW_STEP_WORKFLOW_INCLUDE:
+                includes.append(step)
+    return includes
+
+
+async def _include_targets_of(db: AsyncSession, workflow_id: UUID) -> list[UUID]:
+    """The include targets declared by a workflow's CURRENT version (for cycle walk)."""
+
+    workflow = await store.get_workflow(db, workflow_id)
+    if workflow is None or workflow.current_version_id is None:
+        return []
+    version = await store.get_version(db, workflow.current_version_id)
+    if version is None:
+        return []
+    targets: list[UUID] = []
+    for step in _include_steps_of_definition(version.definition_json):
+        try:
+            targets.append(UUID(str(step.get("workflow_id"))))
+        except ValueError:
+            continue
+    return targets
+
+
+async def _name_of(db: AsyncSession, workflow_id: UUID) -> str:
+    workflow = await store.get_workflow(db, workflow_id)
+    return workflow.name if workflow is not None else str(workflow_id)
+
+
+async def _check_cycle(
+    db: AsyncSession, *, root_id: UUID | None, root_targets: list[UUID]
+) -> None:
+    """Walk the include graph from the workflow being saved; raise on a cycle.
+
+    ``root_id`` is ``None`` at create (the workflow has no id yet, so it cannot be
+    reached — no cycle can involve it). A target that reaches ``root_id`` or that
+    reappears on the current DFS path is a cycle; the error names the path.
+    """
+
+    path: list[UUID] = []
+
+    async def visit(targets: list[UUID], depth: int) -> None:
+        if depth > WORKFLOW_MAX_INCLUDE_DEPTH:
+            raise WorkflowCompositionError(
+                "include_depth_exceeded",
+                f"workflow.include nesting exceeds the limit of {WORKFLOW_MAX_INCLUDE_DEPTH}.",
+            )
+        for target in targets:
+            if root_id is not None and target == root_id:
+                names = [await _name_of(db, node) for node in [root_id, *path, target]]
+                raise WorkflowCompositionError(
+                    "include_cycle",
+                    "workflow.include forms a cycle: " + " -> ".join(names) + ".",
+                )
+            if target in path:
+                start = path.index(target)
+                names = [await _name_of(db, node) for node in [*path[start:], target]]
+                raise WorkflowCompositionError(
+                    "include_cycle",
+                    "workflow.include forms a cycle: " + " -> ".join(names) + ".",
+                )
+            path.append(target)
+            await visit(await _include_targets_of(db, target), depth + 1)
+            path.pop()
+
+    await visit(root_targets, 1)
+
+
+async def validate_includes(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    workflow_id: UUID | None,
+    agents: list[dict[str, object]],
+) -> None:
+    """Save-time validation of every ``workflow.include`` in ``agents`` (spec 3.5).
+
+    ``workflow_id`` is the id of the workflow being saved (``None`` at create, when
+    it has no id yet). Raises :class:`WorkflowCompositionError` on any problem.
+    """
+
+    root_targets: list[UUID] = []
+    for node in agents:
+        for step in node.get("steps", []):
+            if not _is_include(step):
+                continue
+            try:
+                target_id = UUID(str(step.get("workflow_id")))
+            except ValueError as exc:
+                raise WorkflowCompositionError(
+                    "include_target_not_found", "workflow.include target id is invalid."
+                ) from exc
+            if workflow_id is not None and target_id == workflow_id:
+                raise WorkflowCompositionError(
+                    "self_include", "A workflow cannot include itself."
+                )
+            target = await store.get_workflow(db, target_id)
+            if (
+                target is None
+                or target.owner_user_id != owner_user_id
+                or target.archived_at is not None
+            ):
+                raise WorkflowCompositionError(
+                    "include_target_not_found",
+                    f"Included workflow {target_id} is not available.",
+                )
+            if target.current_version_id is None:
+                raise WorkflowCompositionError(
+                    "include_target_not_found",
+                    f"Included workflow {target_id} has no current version.",
+                )
+            version = await store.get_version(db, target.current_version_id)
+            if version is None:
+                raise WorkflowCompositionError(
+                    "include_target_not_found",
+                    f"Included workflow {target_id} has no current version.",
+                )
+            # A multi-agent child is not a legal include target (v1); catch it at
+            # save so the editor surfaces it before the run ever fails.
+            _single_agent_steps(version.definition_json, target_id=target_id)
+            # Coverage against the child's CURRENT input schema.
+            _build_arg_context(
+                dict(step.get("args") or {}),
+                _child_arg_specs(version.definition_json),
+                error_code="include_args_mismatch",
+            )
+            root_targets.append(target_id)
+
+    if root_targets:
+        await _check_cycle(db, root_id=workflow_id, root_targets=root_targets)

--- a/server/proliferate/server/cloud/workflows/domain/definition.py
+++ b/server/proliferate/server/cloud/workflows/domain/definition.py
@@ -16,6 +16,7 @@ gets stored in ``workflow_version.definition_json``.
 from __future__ import annotations
 
 import re
+import uuid
 from collections.abc import Iterator
 
 from proliferate.constants.workflows import (
@@ -40,6 +41,7 @@ from proliferate.constants.workflows import (
     WORKFLOW_STEP_NOTIFY,
     WORKFLOW_STEP_SCM_OPEN_PR,
     WORKFLOW_STEP_SHELL_RUN,
+    WORKFLOW_STEP_WORKFLOW_INCLUDE,
 )
 from proliferate.server.cloud.workflows.domain.interpolation import (
     ArgSpec,
@@ -64,6 +66,11 @@ class WorkflowDefinitionError(Exception):
 
 def _err(code: str, message: str) -> WorkflowDefinitionError:
     return WorkflowDefinitionError(code, message)
+
+
+# An input-mapping key on a ``workflow.include`` step: an identifier that must
+# name a declared child input (coverage checked in ``composition``).
+_ARG_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _require_dict(value: object, *, field: str) -> dict[str, object]:
@@ -460,6 +467,59 @@ def _parse_branch(step: dict[str, object], *, field: str) -> dict[str, object]:
     return canonical
 
 
+def _parse_workflow_include(step: dict[str, object], *, field: str) -> dict[str, object]:
+    """Composition step (spec 3.5 / L20): inline another workflow's steps.
+
+    Definition-only: the target workflow's CURRENT version's (single agent node's)
+    steps are spliced into THIS agent node by the server's resolver at
+    ``StartRun``, before delivery — the runtime never sees a ``workflow.include``
+    step. ``args`` maps the child's declared input names to templated strings
+    written in THIS workflow's context (so they may reference the parent's
+    ``{{inputs.*}}`` / ``{{<emit>.<field>}}``); the resolver binds them into the
+    child's ``{{inputs.*}}`` tokens (§3.5 obl. a).
+
+    Structural validation only here: the target's existence / ownership / archive
+    state and the arg-coverage + cycle checks need the DB and live in the service
+    layer (``composition.validate_includes``).
+    """
+
+    _reject_unknown_keys(step, {"kind", "on_fail", "name", "workflow_id", "args"}, field=field)
+    workflow_id = _require_str(step, "workflow_id", field=field)
+    try:
+        uuid.UUID(workflow_id)
+    except ValueError as exc:
+        raise _err("invalid_definition", f"'{field}.workflow_id' must be a UUID.") from exc
+    raw_args = step.get("args", {})
+    if raw_args is None:
+        raw_args = {}
+    if not isinstance(raw_args, dict):
+        raise _err("invalid_definition", f"'{field}.args' must be an object.")
+    args: dict[str, object] = {}
+    for key, value in raw_args.items():
+        if not isinstance(key, str) or not _ARG_NAME_RE.match(key):
+            raise _err("invalid_definition", f"'{field}.args' keys must be argument identifiers.")
+        if not isinstance(value, str):
+            raise _err(
+                "invalid_definition",
+                f"'{field}.args.{key}' must be a template string.",
+            )
+        args[key] = value
+    canonical: dict[str, object] = {"workflow_id": workflow_id, "args": args}
+    # ``name`` is the include handle: it prefixes the child's emit names at
+    # resolution (composition) and reserves a slot in the emit namespace so a
+    # parent ref that targets it is rejected (include_step_reference).
+    name = _optional_str(step, "name", field=field)
+    if name is not None:
+        if not _IDENTIFIER_RE.match(name):
+            raise _err("invalid_definition", f"'{field}.name' must be an identifier.")
+        if name in WORKFLOW_RESERVED_REF_SEGMENTS:
+            raise _err(
+                "invalid_definition", f"'{field}.name' '{name}' is a reserved reference segment."
+            )
+        canonical["name"] = name
+    return canonical
+
+
 _STEP_PARSERS = {
     WORKFLOW_STEP_AGENT_CONFIG: _parse_agent_config,
     WORKFLOW_STEP_AGENT_PROMPT: _parse_agent_prompt,
@@ -468,6 +528,7 @@ _STEP_PARSERS = {
     WORKFLOW_STEP_SCM_OPEN_PR: _parse_scm_open_pr,
     WORKFLOW_STEP_NOTIFY: _parse_notify,
     WORKFLOW_STEP_BRANCH: _parse_branch,
+    WORKFLOW_STEP_WORKFLOW_INCLUDE: _parse_workflow_include,
 }
 
 
@@ -569,12 +630,29 @@ def _validate_spine_references(
     agents: list[dict[str, object]], input_names: frozenset[str]
 ) -> None:
     """Walk the flattened run order enforcing emit-name uniqueness (whole
-    definition) and strictly-prior ref visibility, plus branch semantics."""
+    definition) and strictly-prior ref visibility, plus branch semantics.
+
+    ``workflow.include`` steps are validated too (their input-mapping values are
+    parent-context templates), but they produce no emit of their own — a parent
+    ref that names an include handle is rejected (``include_step_reference``); the
+    child's emits are namespaced away at resolution and are never visible here
+    (cross-spine refs are a Part II concern)."""
 
     prior_emits: set[str] = set()
+    include_names: set[str] = set()
     for node in agents:
         for step in node["steps"]:  # type: ignore[index]
             for value in _iter_step_strings(step):
+                for reference in iter_references(value):
+                    if (
+                        isinstance(reference, EmitReference)
+                        and reference.emit in include_names
+                    ):
+                        raise _err(
+                            "include_step_reference",
+                            f"Template references workflow.include step "
+                            f"'{reference.emit}', which has no output.",
+                        )
                 try:
                     validate_string_references(
                         value,
@@ -592,6 +670,10 @@ def _validate_spine_references(
                 if name in prior_emits:
                     raise _err("duplicate_emit", f"Duplicate emit name '{name}'.")
                 prior_emits.add(name)  # type: ignore[arg-type]
+            elif step["kind"] == WORKFLOW_STEP_WORKFLOW_INCLUDE:
+                include_name = step.get("name")
+                if isinstance(include_name, str):
+                    include_names.add(include_name)
 
 
 def _validate_branch_on(step: dict[str, object], prior_emits: set[str]) -> None:

--- a/server/proliferate/server/cloud/workflows/service.py
+++ b/server/proliferate/server/cloud/workflows/service.py
@@ -55,6 +55,11 @@ from proliferate.server.automations.domain.schedule import (
     normalize_schedule,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workflows.domain.composition import (
+    WorkflowCompositionError,
+    resolve_included_agents,
+    validate_includes,
+)
 from proliferate.server.cloud.workflows.domain.definition import (
     WorkflowDefinitionError,
     parse_definition,
@@ -121,6 +126,30 @@ def _validated_definition(raw: dict[str, object]) -> dict[str, object]:
     except WorkflowDefinitionError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
     return canonical
+
+
+async def _validate_workflow_includes(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    workflow_id: UUID | None,
+    definition: dict[str, object],
+) -> None:
+    """Save-time composition checks (spec 3.5): target ownership, arg coverage, cycles.
+
+    These need the DB (fetching each include target's current version), so they run
+    here rather than in the pure ``parse_definition``.
+    """
+
+    try:
+        await validate_includes(
+            db,
+            owner_user_id=owner_user_id,
+            workflow_id=workflow_id,
+            agents=list(definition.get("agents", [])),
+        )
+    except WorkflowCompositionError as exc:
+        raise CloudApiError(exc.code, exc.message, status_code=400) from exc
 
 
 async def visible_workflow(
@@ -190,6 +219,11 @@ async def create_workflow(
 ) -> tuple[WorkflowRecord, list[WorkflowVersionRecord]]:
     name = _clean_name(body.name)
     definition = _validated_definition(body.definition)
+    # workflow_id is None at create: the workflow has no id yet, so no include
+    # cycle can involve it — self-include only becomes possible on update.
+    await _validate_workflow_includes(
+        db, owner_user_id=user.id, workflow_id=None, definition=definition
+    )
     active_count = await store.count_active_workflows(db, owner_user_id=user.id)
     if not workflow_create_allowed(active_count, max_allowed=free_plan_workflow_limit()):
         raise CloudApiError(
@@ -220,6 +254,9 @@ async def update_workflow(
             "workflow_archived", "Cannot update an archived workflow.", status_code=409
         )
     definition = _validated_definition(body.definition)
+    await _validate_workflow_includes(
+        db, owner_user_id=user.id, workflow_id=workflow_id, definition=definition
+    )
     name = _clean_name(body.name) if body.name is not None else None
     update_description = "description" in body.model_fields_set
     result = await store.append_version(
@@ -285,6 +322,7 @@ def _resolve_plan(
     target_mode: str,
     coerced_inputs: dict[str, object],
     session_bindings: dict[str, str],
+    agents: list[dict[str, object]],
 ) -> dict[str, object]:
     """The single resolution pass (data-contract §4): flatten the agents spine
     into one ordered step list, stamp each step with its structured key + slot +
@@ -293,7 +331,10 @@ def _resolve_plan(
     """
 
     canonical = version.definition_json
-    agents = canonical.get("agents", [])
+    # ``agents`` arrives with every workflow.include already inlined into the
+    # owning node's step list (L20, composition.resolve_included_agents) and in the
+    # v2 named-ref grammar — this pass flattens it, assigns keys, and rewrites
+    # emit names to indices in one place (composition never touches indices).
     # E3/§2.6: the workflow-level integrations grant is stamped onto every slot
     # (per-slot narrowing is a later resolver-only change). Actual token mint +
     # all-tools scope expansion is PR E's phase.
@@ -446,6 +487,20 @@ async def start_run(
     except ArgumentError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
 
+    # Composition (L20): inline any workflow.include steps into the agents spine,
+    # server-side, before the flatten pass. This fails the run cleanly (no
+    # pending_delivery row) if an include target changed since save, exceeds the
+    # depth cap, is now multi-agent, or its arg mapping no longer covers the
+    # child's required inputs.
+    try:
+        resolved_agents = await resolve_included_agents(
+            db,
+            owner_user_id=workflow.owner_user_id,
+            agents=list(version.definition_json.get("agents", [])),
+        )
+    except WorkflowCompositionError as exc:
+        raise CloudApiError(exc.code, exc.message, status_code=400) from exc
+
     run_id = uuid4()
     resolved_plan = _resolve_plan(
         run_id=run_id,
@@ -455,6 +510,7 @@ async def start_run(
         target_mode=target_mode,
         coerced_inputs=coerced_inputs,
         session_bindings=session_bindings or {},
+        agents=resolved_agents,
     )
     return await store.create_run(
         db,

--- a/server/tests/unit/test_workflow_include.py
+++ b/server/tests/unit/test_workflow_include.py
@@ -1,0 +1,497 @@
+"""Workflow composition by resolution-time inlining (spec 3.5 / L20), format v2.
+
+``workflow.include`` is a definition-only step living inside an agent node's step
+list: the server's plan resolver splices the target workflow's CURRENT version's
+(single agent node's) steps into that node before the flatten pass, at StartRun,
+before delivery. The runtime never sees an include step (the L20 property,
+asserted below). Composition operates purely on the v2 named-ref grammar
+(``{{inputs.*}}`` / ``{{<emit>.<field>}}``); the flatten pass then assigns
+structured keys and rewrites emit names to the runtime's indexed
+``{{steps[n].output.<field>}}`` form. These are tier-1 tests: a real DB (the
+"current version" guarantee lives there) via the ``db_session`` fixture.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import User
+from proliferate.db.store import cloud_workflows as store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workflows import service
+from proliferate.server.cloud.workflows.domain.composition import (
+    WorkflowCompositionError,
+    validate_includes,
+)
+from proliferate.server.cloud.workflows.domain.definition import parse_definition
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"inc-{uuid.uuid4().hex}@example.com",
+        hashed_password="unused",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def _prompt(prompt: str) -> dict:
+    return {"kind": "agent.prompt", "prompt": prompt}
+
+
+def _emit(name: str, prompt: str) -> dict:
+    return {"kind": "agent.emit", "name": name, "prompt": prompt}
+
+
+def _include(workflow_id, *, args: dict | None = None, name: str | None = None) -> dict:
+    step: dict = {"kind": "workflow.include", "workflow_id": str(workflow_id), "args": args or {}}
+    if name is not None:
+        step["name"] = name
+    return step
+
+
+def _agent(steps: list[dict], *, slot: str = "main") -> dict:
+    return {"slot": slot, "harness": "claude", "model": "sonnet", "steps": steps}
+
+
+def _definition(steps: list[dict], *, inputs: list[dict] | None = None) -> dict:
+    return {
+        "version": 1,
+        "inputs": inputs or [],
+        "integrations": [],
+        "agents": [_agent(steps)],
+    }
+
+
+def _multi_agent_definition() -> dict:
+    return {
+        "version": 1,
+        "inputs": [],
+        "integrations": [],
+        "agents": [
+            _agent([_prompt("a")], slot="lane_a"),
+            _agent([_prompt("b")], slot="lane_b"),
+        ],
+    }
+
+
+async def _store_workflow(
+    db: AsyncSession, owner: User, definition: dict, *, name: str
+) -> store.WorkflowRecord:
+    """Create a workflow with a canonical (validated) definition, bypassing the cap.
+
+    The service enforces a 1-workflow free-plan cap; composition needs several, so
+    tests seed them directly through the store with parse-normalized definitions.
+    """
+
+    canonical, _specs = parse_definition(definition, require_steps=False)
+    workflow, _version = await store.create_workflow_with_version(
+        db,
+        owner_user_id=owner.id,
+        created_by_user_id=owner.id,
+        name=name,
+        description=None,
+        definition_json=canonical,
+    )
+    return workflow
+
+
+async def _run_steps(db: AsyncSession, user: User, workflow_id, inputs: dict) -> list[dict]:
+    run = await service.start_run(
+        db, user, workflow_id, inputs=inputs, target_mode="local"
+    )
+    return run.resolved_plan_json["steps"]
+
+
+# --- simple inline -------------------------------------------------------------
+
+
+async def test_simple_inline_places_child_steps_at_offset(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session, user, _definition([_prompt("child one"), _prompt("child two")]), name="child"
+    )
+    parent = await _store_workflow(
+        db_session,
+        user,
+        _definition([_prompt("parent head"), _include(child.id), _prompt("parent tail")]),
+        name="parent",
+    )
+
+    steps = await _run_steps(db_session, user, parent.id, {})
+    assert [s["kind"] for s in steps] == ["agent.prompt"] * 4
+    assert [s["prompt"] for s in steps] == [
+        "parent head",
+        "child one",
+        "child two",
+        "parent tail",
+    ]
+    # All spliced steps run in the parent node's slot.
+    assert all(s["slot"] == "main" for s in steps)
+
+
+async def test_resolved_plan_has_no_include_steps(db_session: AsyncSession) -> None:
+    """L20 property: the runtime never receives a workflow.include step."""
+
+    user = await _make_user(db_session)
+    child = await _store_workflow(db_session, user, _definition([_prompt("c")]), name="child")
+    parent = await _store_workflow(
+        db_session, user, _definition([_include(child.id), _prompt("p")]), name="parent"
+    )
+    steps = await _run_steps(db_session, user, parent.id, {})
+    assert all(s["kind"] != "workflow.include" for s in steps)
+
+
+# --- arg binding ---------------------------------------------------------------
+
+
+async def test_arg_binding_from_mapping_parent_input_and_emit_ref(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [_prompt("do {{inputs.task}} with {{inputs.ctx}}")],
+            inputs=[
+                {"name": "task", "type": "text", "required": True},
+                {"name": "ctx", "type": "text", "required": True},
+            ],
+        ),
+        name="child",
+    )
+    parent = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [
+                _emit("head", "summarize"),
+                # mapping value 1 = a parent-input ref (eager-resolved);
+                # mapping value 2 = a parent emit ref (rewritten to indexed form).
+                _include(
+                    child.id,
+                    args={"task": "{{inputs.goal}}", "ctx": "{{head.summary}}"},
+                ),
+            ],
+            inputs=[{"name": "goal", "type": "text", "required": True}],
+        ),
+        name="parent",
+    )
+
+    steps = await _run_steps(db_session, user, parent.id, {"goal": "ship it"})
+    # {{inputs.goal}} resolved by the eager pass; the parent emit ref survives as
+    # the runtime's indexed form pointing at head (flat index 0).
+    assert steps[1]["prompt"] == "do ship it with {{steps[0].output.summary}}"
+
+
+async def test_uncovered_optional_child_input_uses_default(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [_prompt("run in {{inputs.mode}}")],
+            inputs=[{"name": "mode", "type": "text", "default": "fast"}],
+        ),
+        name="child",
+    )
+    parent = await _store_workflow(
+        db_session, user, _definition([_include(child.id)]), name="parent"
+    )
+    steps = await _run_steps(db_session, user, parent.id, {})
+    assert steps[0]["prompt"] == "run in fast"
+
+
+# --- emit-ref namespacing ------------------------------------------------------
+
+
+async def test_child_internal_emit_refs_survive_splice(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session,
+        user,
+        _definition([_emit("build", "build it"), _prompt("ref {{build.result}}")]),
+        name="child",
+    )
+    parent = await _store_workflow(
+        db_session,
+        user,
+        _definition([_prompt("p0"), _prompt("p1"), _include(child.id)]),
+        name="parent",
+    )
+    steps = await _run_steps(db_session, user, parent.id, {})
+    # child block starts at flat index 2; the emit lands there and the ref points
+    # at it once the flatten pass rewrites the (prefixed) name to an index.
+    assert steps[2]["name"] == "w2_build"
+    assert steps[3]["prompt"] == "ref {{steps[2].output.result}}"
+
+
+async def test_parent_emit_ref_after_include_still_resolves(db_session: AsyncSession) -> None:
+    """A parent emit ref placed after an include resolves to the emit's flat index."""
+
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session, user, _definition([_prompt("c0"), _prompt("c1")]), name="child"
+    )
+    parent = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [_emit("out", "produce"), _include(child.id), _prompt("tail {{out.val}}")]
+        ),
+        name="parent",
+    )
+    steps = await _run_steps(db_session, user, parent.id, {})
+    # flat plan: [emit out(0), c0(1), c1(2), tail(3)]; the ref still points at out(0).
+    assert [s["prompt"] for s in steps] == [
+        "produce",
+        "c0",
+        "c1",
+        "tail {{steps[0].output.val}}",
+    ]
+
+
+# --- nested include ------------------------------------------------------------
+
+
+async def test_nested_include_double_prefix(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    grand = await _store_workflow(
+        db_session,
+        user,
+        _definition([_emit("g", "gc"), _prompt("gref {{g.v}}")]),
+        name="grand",
+    )
+    mid = await _store_workflow(
+        db_session,
+        user,
+        _definition([_prompt("mid head"), _include(grand.id)]),
+        name="mid",
+    )
+    top = await _store_workflow(
+        db_session,
+        user,
+        _definition([_prompt("top head"), _prompt("top head2"), _include(mid.id)]),
+        name="top",
+    )
+    steps = await _run_steps(db_session, user, top.id, {})
+    # flat: [top0, top1, mid_head(2), grand_emit(3), grand_ref(4)]
+    assert len(steps) == 5
+    # grand's emit is prefixed twice (w1 inside mid, then w2 inside top) and lands
+    # at flat index 3; its internal ref rewrites to that index.
+    assert steps[3]["name"] == "w2_w1_g"
+    assert steps[4]["prompt"] == "gref {{steps[3].output.v}}"
+    assert all(s["kind"] != "workflow.include" for s in steps)
+
+
+# --- multi-agent include target rejected (v2, A3/PROPOSED) ---------------------
+
+
+async def test_multi_agent_child_rejected_at_save(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session, user, _multi_agent_definition(), name="child"
+    )
+    agents = [_agent([_include(child.id)])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=None, agents=agents
+        )
+    assert exc.value.code == "include_multi_agent"
+
+
+async def test_multi_agent_child_rejected_at_resolution(db_session: AsyncSession) -> None:
+    """A child that grew a second agent node since save fails the run cleanly."""
+
+    user = await _make_user(db_session)
+    child = await _store_workflow(db_session, user, _definition([_prompt("ok")]), name="child")
+    parent = await _store_workflow(
+        db_session, user, _definition([_include(child.id)]), name="parent"
+    )
+    new_child, _specs = parse_definition(_multi_agent_definition())
+    await store.append_version(
+        db_session,
+        workflow_id=child.id,
+        definition_json=new_child,
+        created_by_user_id=user.id,
+        name=None,
+        description=None,
+        update_description=False,
+    )
+    with pytest.raises(CloudApiError) as exc:
+        await service.start_run(db_session, user, parent.id, inputs={}, target_mode="local")
+    assert exc.value.code == "include_multi_agent"
+
+
+# --- resolution depth cap ------------------------------------------------------
+
+
+async def test_resolution_depth_cap(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    # Build a chain deeper than the cap: w0 <- w1 <- ... <- w6 (w6 includes w5 …).
+    previous: uuid.UUID | None = None
+    for i in range(7):
+        steps: list[dict] = [_prompt(f"leaf {i}")]
+        if previous is not None:
+            steps = [_include(previous)]
+        wf = await _store_workflow(db_session, user, _definition(steps), name=f"w{i}")
+        previous = wf.id
+    assert previous is not None
+    with pytest.raises(CloudApiError) as exc:
+        await service.start_run(db_session, user, previous, inputs={}, target_mode="local")
+    assert exc.value.code == "include_depth_exceeded"
+
+
+# --- save-time cycle rejection -------------------------------------------------
+
+
+async def test_self_include_rejected_at_save(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    wf = await _store_workflow(db_session, user, _definition([_prompt("x")]), name="wf")
+    agents = [_agent([_include(wf.id)])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=wf.id, agents=agents
+        )
+    assert exc.value.code == "self_include"
+
+
+async def test_direct_cycle_rejected_naming_path(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    b = await _store_workflow(db_session, user, _definition([_prompt("b")]), name="Bee")
+    # A includes B.
+    a = await _store_workflow(
+        db_session, user, _definition([_include(b.id)]), name="Ay"
+    )
+    # Now saving B to include A closes the cycle A -> B -> A.
+    b_agents = [_agent([_include(a.id)])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=b.id, agents=b_agents
+        )
+    assert exc.value.code == "include_cycle"
+    assert "Ay" in exc.value.message and "Bee" in exc.value.message
+
+
+async def test_indirect_cycle_rejected(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    c = await _store_workflow(db_session, user, _definition([_prompt("c")]), name="Cee")
+    b = await _store_workflow(db_session, user, _definition([_include(c.id)]), name="Bee")
+    a = await _store_workflow(db_session, user, _definition([_include(b.id)]), name="Ay")
+    # Saving C to include A closes A -> B -> C -> A.
+    c_agents = [_agent([_include(a.id)])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=c.id, agents=c_agents
+        )
+    assert exc.value.code == "include_cycle"
+
+
+# --- arg coverage --------------------------------------------------------------
+
+
+async def test_missing_required_input_rejected_at_save(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [_prompt("{{inputs.need}}")],
+            inputs=[{"name": "need", "type": "text", "required": True}],
+        ),
+        name="child",
+    )
+    agents = [_agent([_include(child.id)])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=None, agents=agents
+        )
+    assert exc.value.code == "include_args_mismatch"
+
+
+async def test_undeclared_input_key_rejected_at_save(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    child = await _store_workflow(db_session, user, _definition([_prompt("hi")]), name="child")
+    agents = [_agent([_include(child.id, args={"nope": "x"})])]
+    with pytest.raises(WorkflowCompositionError) as exc:
+        await validate_includes(
+            db_session, owner_user_id=user.id, workflow_id=None, agents=agents
+        )
+    assert exc.value.code == "include_args_mismatch"
+
+
+async def test_arg_mismatch_at_resolution_when_child_changed(
+    db_session: AsyncSession,
+) -> None:
+    """A child version that grew a required input since save fails the run cleanly."""
+
+    user = await _make_user(db_session)
+    child = await _store_workflow(
+        db_session,
+        user,
+        _definition(
+            [_prompt("{{inputs.a}}")],
+            inputs=[{"name": "a", "type": "text", "required": True}],
+        ),
+        name="child",
+    )
+    parent = await _store_workflow(
+        db_session, user, _definition([_include(child.id, args={"a": "x"})]), name="parent"
+    )
+    # Child gains a new required input its callers don't bind.
+    new_child, _specs = parse_definition(
+        _definition(
+            [_prompt("{{inputs.a}} {{inputs.b}}")],
+            inputs=[
+                {"name": "a", "type": "text", "required": True},
+                {"name": "b", "type": "text", "required": True},
+            ],
+        )
+    )
+    await store.append_version(
+        db_session,
+        workflow_id=child.id,
+        definition_json=new_child,
+        created_by_user_id=user.id,
+        name=None,
+        description=None,
+        update_description=False,
+    )
+    with pytest.raises(CloudApiError) as exc:
+        await service.start_run(db_session, user, parent.id, inputs={}, target_mode="local")
+    assert exc.value.code == "include_args_mismatch"
+
+
+# --- refs into an include step -------------------------------------------------
+
+
+async def test_ref_pointing_at_include_step_rejected(db_session: AsyncSession) -> None:
+    """The validator rejects a parent ref that names an include handle (no output)."""
+
+    definition = {
+        "version": 1,
+        "inputs": [],
+        "integrations": [],
+        "agents": [
+            _agent(
+                [
+                    _include(uuid.uuid4(), name="inc"),
+                    _prompt("bad {{inc.result}}"),
+                ]
+            )
+        ],
+    }
+    with pytest.raises(Exception) as exc:
+        parse_definition(definition)
+    assert getattr(exc.value, "code", "") == "include_step_reference"


### PR DESCRIPTION
Fourth PR of the A–E arc (stacked on #1006). **Fully reworked 2026-07-08 per ruling L20** — the earlier fire-and-forget \`workflow.run\` / \`spawn_child_run\` / parent-linkage design on this branch was discarded wholesale (force-pushed).

## The design (L20, §3.5)

Composition is **nesting, not spawning**: using workflow B inside workflow A inlines B's steps into A's single resolved plan at StartRun, server-side, before delivery. One run, one plan, one cursor, one sandbox. No child run, no parent linkage, no cross-sandbox fan-out. **The runtime is completely unchanged by this PR — no \`plan.rs\` change, no migration. That is the design, not an omission**: the resolver eliminates the include before the runtime ever sees it, and there's a test asserting the L20 property (a resolved plan contains no include steps).

- **\`workflow.include\` step** (definition-only): \`{kind, workflow_id, args: {child-arg: template}, name?}\`. New \`domain/composition.py\` owns the resolver.
- **Arg binding (§3.5 obligation a)**: the include's args mapping becomes the child's interpolation context — textual substitution of the child's \`{{args.*}}\` (both sides are author-written definition text, so no brace-escaping, unlike user StartRun args). Mapping values may carry the parent's \`{{args.*}}\` (inline FIRST, then the normal eager pass) and parent step refs (stay late-bound).
- **Ref namespacing (§3.5 obligation b)**: child internal refs are renumbered to child-flattened positions, named refs rewritten to index form, then offset by the splice point — collision-free; child step names prefixed \`<includeName>_\`.
- **Save-time validation**: target exists/same-owner/not-archived, no self-include, required-arg coverage, and the **cycle check** (A→B→A fails at save with \`include_cycle\` naming the path). Resolution-time: depth cap 5 (\`include_depth_exceeded\`), arg mismatch when the child's current version drifted (\`include_args_mismatch\`) — both fail the run before delivery.
- Parent refs *at* an include step are rejected (an include has no output; referencing into the child from the parent is out of scope v1).
- **UI**: include editor (workflow picker + per-child-arg mapping, caption "Steps run inline in this workflow's single run"); run view needs nothing (inlined steps are ordinary steps).

## Surface-syntax decisions pending veto (the doc left these open; also recorded in the deep-dive doc)
1. Step kind named \`workflow.include\` (not \`workflow.run\` — no runtime verb implied).
2. Shape \`{kind, workflow_id, args, name?}\` with a flat \`{child-arg: template-string}\` mapping.
3. Child name prefixing \`<includeName>_<origName>\`, default include name \`w<parentIndex>\`.
4. Optional child args not covered by the mapping fall back to their declared default (no dangling \`{{args.*}}\` survives into the flattened plan).

## Verification
15 new tier-1 tests (real DB): splice/offset/namespacing, nested A→B→C double offset, depth cap, direct+indirect cycle naming the path, coverage at save + mismatch at resolution, refs-into-include rejected, and the L20 no-include-in-resolved-plan property. 173 workflow tests green on this tip; product-domain vitest 30 passed; desktop tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)