### PR TITLE
specs: testing standard + flow registry + scenarios

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -53,6 +53,7 @@ migration exception and state the canonical owner/rule directly.
 | Cloud provisioning, workspace creation, commands, auth, MCPs, billing, claiming | `specs/codebase/primitives/README.md`; focused primitive specs under `specs/codebase/primitives/`, including `specs/codebase/primitives/workspace-provisioning.md` for managed workspace creation read order |
 | Product workflows and surfaces | `specs/codebase/features/README.md`; focused feature specs under `specs/codebase/features/`; `specs/codebase/features/support-reporting.md` for Desktop support report uploads |
 | Local dev, CI/CD, deployment, env vars, debugging, analytics, QA | `specs/developing/README.md`; focused process docs under `specs/developing/local/`, `specs/developing/deploying/`, `specs/developing/debugging/`, `specs/developing/analytics/`, `specs/developing/qa/`, `specs/developing/runbooks/`, and `specs/developing/reference/` |
+| Automated testing standard + flow registry | `specs/developing/testing/README.md` (tiers, placement, gates), `specs/developing/testing/flows.md` (flows that must never break) |
 | Draft planning notes | `specs/tbd/README.md`; files under `specs/tbd/` are non-authoritative until promoted. |
 
 ## Spec Rules

--- a/specs/developing/README.md
+++ b/specs/developing/README.md
@@ -21,8 +21,12 @@ the area docs under `specs/codebase/structures/**`.
 - [analytics/README.md](analytics/README.md)
   - Customer.io, Metabase, PostHog, Sentry, anonymous telemetry, ownership, and
     freshness expectations
+- [testing/README.md](testing/README.md)
+  - automated testing standard: the four tiers, per-language placement,
+    merge-vs-release gates, contract fixtures, and the flow registry
+    ([testing/flows.md](testing/flows.md))
 - [qa/README.md](qa/README.md)
-  - release QA process and per-surface verification checklist
+  - manual release QA process and per-surface verification checklist
 - [runbooks/README.md](runbooks/README.md)
   - specific, repeatable operational runbooks (billing promo codes, Stripe
     webhook failures, E2B template rollback, and future cloud/worker/sandbox
@@ -40,6 +44,7 @@ the area docs under `specs/codebase/structures/**`.
 | Developing locally with profiles, Stripe, and mobile | [local/README.md](local/README.md), [local/dev-profiles.md](local/dev-profiles.md), [local/stripe-local-testing.md](local/stripe-local-testing.md), and [local/mobile.md](local/mobile.md). |
 | Debugging and support issue triage | [debugging/README.md](debugging/README.md), [debugging/support-reports.md](debugging/support-reports.md), and [debugging/performance-profiling.md](debugging/performance-profiling.md). |
 | Analytics and keeping observability fresh | [analytics/README.md](analytics/README.md) plus the Customer.io, Metabase, PostHog, Sentry, and anonymous telemetry docs in that folder. |
+| Automated testing standard and flow registry | [testing/README.md](testing/README.md) and [testing/flows.md](testing/flows.md). |
 | QA and release verification | [qa/README.md](qa/README.md), with feature-specific acceptance criteria under [../codebase/features/](../codebase/features/) and primitive smoke expectations under [../codebase/primitives/](../codebase/primitives/). |
 
 PR title, label, release-note, and checklist rules live in

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -1,0 +1,232 @@
+# Testing Standard
+
+How tests are organized across the repo: what each tier owns, where test files
+live, what gates merges vs releases, and how a change decides which tests it
+must add. `flows.md` (sibling) is the registry of end-to-end flows that must
+never break; this doc is the law those flows are enforced under.
+
+Companion: `specs/developing/qa/README.md` owns *manual* release QA. This doc
+owns automated testing. A flow covered by an automated tier here does not also
+need a manual QA checklist entry.
+
+---
+
+## The model
+
+Code is state and logic. Every test is defined by which state is real and
+where the boundary to fakes sits. Four tiers:
+
+| Tier | What is real | What is faked | Runs | Gates |
+| --- | --- | --- | --- | --- |
+| **1 — Unit / contract** | Logic; Postgres/SQLite where the guarantee lives in the DB | Everything across a network | Every PR, seconds | **Merge** |
+| **2 — Mocked intent** | Server + desktop web frontend + real Postgres, booted on a port | AnyHarness, sandbox provider, LLM, IdP, email, Slack — every third party | Every PR, minutes | **Merge** |
+| **3 — Live end-to-end** | Everything: real E2B template for the version, real AnyHarness binary, real agents on cheap models | Nothing (cheap LLM + cheap sandbox tier, but real) | Release train + nightly | **Release** |
+| **4 — Upgrade path** | An N−1 install upgraded in place to N | The update feed (stub server; the artifacts it serves are real) | Release train | **Release** |
+
+**The gate rule (hard):** the merge gate is tiers 1–2 only. No real LLM, real
+sandbox, or real third party ever runs in the merge gate. A flaky merge gate
+poisons agent-driven merging; tier 3/4 failures block the *release* and file
+issues into the issues service — they never block a merge.
+
+**Real-LLM tests assert outcomes, not transcripts.** "Run reached `completed`,
+file exists, emit validated against schema" — never "the agent said X."
+
+---
+
+## Tier 1 — unit / contract
+
+Three sub-kinds, in every language:
+
+- **Pure logic (no state).** State-machine transition guards, decision
+  matrices, interpolation/escaping, arg coercion, billing math, catalog
+  layering, policy checks. Enumerate the matrix, not just the cells you
+  thought about.
+- **Logic against real state.** When the guarantee IS a property of the
+  database (unique index, `ON CONFLICT`, savepoint, transaction boundary,
+  crash-resume cursor), the DB must be real — Postgres for server tests,
+  SQLite for runtime tests. Fake everything across a network. A crash drill is
+  expressed as calling the construction twice (claim CAS returns `None` the
+  second time), not as killing processes.
+- **Contract fixtures.** Shared JSON shapes that cross a language boundary
+  (workflow plan JSON, run status reports, poll pages, catalog entries) get a
+  golden fixture under `fixtures/contracts/`. The producing language asserts
+  it produces the fixture; each consuming language asserts it parses it. A
+  shape change is made by changing the fixture, which mechanically breaks the
+  other side's test until it is updated. Hand-maintained "mirror" validators
+  are a migration exception, not a pattern to extend.
+
+### Placement (codifies existing convention; nothing moves)
+
+| Language | Location | Invocation |
+| --- | --- | --- |
+| Rust | Colocated `*_tests.rs` / `tests.rs` submodule next to the module | `cargo test --workspace` |
+| Python | `server/tests/unit/` (logic, DB-backed unit), `server/tests/integration/` (HTTP-level via ASGI against real Postgres) | `cd server && uv run pytest -q` |
+| TypeScript | Colocated `*.test.ts(x)` next to source (desktop, packages, SDKs) | `pnpm --filter <pkg> test` |
+| Contract fixtures | `fixtures/contracts/<contract-name>/*.json` | Asserted from each language's tier-1 suite |
+
+Rust engine tests that need a step executor use a scripted fake implementing
+`WorkflowStepExecutor` (and equivalent seams elsewhere) — never a real agent.
+
+---
+
+## Tier 2 — mocked intent
+
+Real server + real desktop **web frontend** served on a port, seeded Postgres,
+Playwright driving a browser. **There is no fake sandbox provider and no mock
+LLM (deliberate ruling, 2026-07-07):** flows that need a sandbox or an LLM are
+tier 3 by definition; building and maintaining those two fakes costs more than
+the per-merge coverage they buy, and tier 1 already owns the logic in those
+paths. If nightly/promotion gaps in agent/workflow flows bite repeatedly, that
+evidence — not speculation — justifies building a fake then.
+
+The fakes that do exist are cheap and stable:
+
+| Dependency | Fake |
+| --- | --- |
+| SSO IdP | Mock OIDC container (asserts any identity on demand) |
+| Invite/notification email | Token capture (test-only endpoint), no send |
+| Stripe | Stripe test mode + test clocks |
+| Poll feeds | Stub feed (replaying, per the poll contract) |
+
+Lives in `tests/intent/`: one stack-boot fixture (`stack/`), fakes as
+pluggable slots (`fakes/`), one spec file per flow (`specs/`). Seeding wraps
+the existing three-layer local auth story
+(`specs/developing/local/feature-worktree-auth.md`).
+
+Tier 2 covers auth, invitation (including expired/reused/wrong-email
+negatives), SSO round-trip and negatives, org/user CRUD, repo add, secrets
+CRUD, and billing flows. For sandbox-adjacent flows, tier 2 tests **up to the
+seam**: workflow create/edit/trigger asserts "run created, plan resolved,
+delivery attempted"; cloud workspace create asserts the request path and UI
+state — never sandbox readiness or run completion, which are tier 3.
+
+---
+
+## Tier 3 — live end-to-end
+
+Tests the **deploy artifact, not just the code**: build (or cache-resolve) the
+E2B template for the version, run the real AnyHarness binary, drive real
+agents on cheap models through core flows — provision/pause/resume/connect,
+chat per cataloged agent × auth method, workflow services live (schedule +
+poll triggers, emit, chaining, Slack delivery), config updates applied by live
+agents, local↔cloud migration, billing metering integrity.
+
+- Lives in `tests/release/` as **one runner CLI with lane flags**
+  (`make release-e2e LANE=... DESKTOP=web|native AGENTS=...`). GitHub Actions
+  is one caller of it; the runner must work identically from a laptop. No
+  CI-only setup steps in workflow YAML.
+- Desktop web-port mode is the default lane; native-shell smoke is a separate
+  nightly/pre-release lane that reuses the release build's artifact in CI and
+  the local dev build locally.
+- The E2B template build is cached by content hash of its inputs (runtime
+  binary, Dockerfile, agent pins); unchanged inputs resolve to the
+  already-uploaded template.
+- Tier 3 is also the **per-agent catalog bump gate**: a candidate agent
+  version bump runs that agent's smoke on staging; failure means the agent
+  stays pinned to last-good and an issue is filed.
+
+### Tier-3 environment (the wired-in infrastructure)
+
+The tier-3 stack is a real deployment, not a laptop assembly: sandbox-mode
+Stripe, the real LLM gateway configured with cheap models, the real API
+server, desktop (web-port lane by default), real agents in real E2B
+sandboxes. Two constraints:
+
+- **The API server must be publicly reachable** — sandboxes call back into it
+  for integrations, gateway auth, and the worker control loop. Staging
+  satisfies this; a purely local tier-3 lane still needs a tunnel or a
+  reachable server URL.
+- Credentials the runner burns (cheap-LLM key, E2B team, test Slack
+  workspace, test provider accounts) are named in
+  `specs/developing/reference/env-vars.yaml`, never hardcoded in scenarios.
+
+---
+
+## Tier 4 — upgrade path
+
+Fresh-install testing never catches a broken updater, and a broken updater
+strands every existing user. There is no single "upgrade path" — five distinct
+mechanisms exist, and each is tested at its own seam. The general pattern:
+boot N−1 from kept artifacts with seeded N−1 data, stub the *feed* (the
+artifacts it serves are real), trigger the mechanism, assert convergence.
+
+| Mechanism | Learns via | Feed knob | Testable today? |
+| --- | --- | --- | --- |
+| Worker self-update (sandbox only) | Heartbeat `desiredVersions.worker` | Server pins (`WORKER_VERSION`) + CDN base `DESKTOP_DOWNLOADS_BASE_URL` — both **server-side** env vars (the worker asks the API server, which 302-redirects to the CDN base; stub by pointing the base at a file server the sandbox can reach, e.g. via ngrok) | **Yes** — the priority scenario |
+| Agent catalog convergence (existing sandboxes + local runtimes) | Heartbeat `desiredVersions.catalogVersion` → worker pushes catalog → runtime reconcile reinstalls drifted CLIs | Server catalog version | **Yes** — full-chain test; today only per-hop units exist |
+| Desktop app (Tauri updater; bundles anyharness/worker sidecars) | 30-min poll of `latest.json` | Hardcoded in `tauri.conf.json`, **not env-overridable** | Feed-artifact validation yes; real update needs a test build with an overridable endpoint |
+| E2B template | Build-time only; rolling `:staging`/`:production` tags affect **new** sandboxes only | `E2B_TEMPLATE_NAME` / `E2B_TEMPLATE_REF` | Yes — new-sandbox-gets-new-template + old-workspace-still-wakes |
+| SQLite/Alembic migrations | Ships inside the new binary/server | — | Yes — forward-apply on kept N−1 data |
+
+The two heartbeat-driven mechanisms are the priority: they are the ones that
+run **unattended against every live customer sandbox** on every release, and
+neither has an end-to-end test today (coverage is per-hop unit tests). The
+worker scenario must include a live session on the box surviving the
+swap-and-exec.
+
+Known non-mechanism, stated so nobody tests a ghost: the anyharness binary has
+**no in-place update path** — sandboxes only get a new anyharness via a new
+template (the worker ignores `desiredVersions.anyharness`; the supervisor
+`update/` module validates and stages artifacts handed to it but fetches and
+swaps nothing), and desktop only via the app bundle. If in-place anyharness
+update is built later, it enters this table with its own scenario.
+
+Lives in `tests/release/upgrade/`, runs under the same runner CLI.
+
+---
+
+## Deciding where a change's tests go
+
+1. Is the guarantee expressible as pure input→output? → Tier 1 pure logic.
+2. Does it only exist as a property of a state transition (dedup,
+   exactly-once, crash-resume, ordering)? → Tier 1 against real DB, fake
+   neighbors.
+3. Did it change a shared JSON shape? → Update the contract fixture; the other
+   language's test breaks until updated.
+4. Is it a user-visible flow with no real-agent dependency? → Tier 2 spec
+   (new spec file, or extend one).
+5. Does it need a real agent, sandbox, or the deploy artifact? → Tier 3
+   scenario (extend the existing smoke; do not add a new boot-the-world test).
+6. Did it touch the updater, template versioning, or migrations? → Tier 4.
+
+**PR obligation:** a PR that adds or changes a flow adds/updates tests at the
+tier where its guarantees live, and names them in the PR description. New
+end-to-end flows also add a row to `flows.md` in the same PR.
+
+**Postmortem rule:** any bug caught at tier 3/4 or in production gets an
+answer to "which lower tier should have owned this," and that test lands with
+the fix. Tier 3 growing per-feature is the smell that a seam test is missing —
+tier 3 stays O(1) per lane, not O(features).
+
+---
+
+## What gates what (current CI mapping)
+
+| Gate | Jobs |
+| --- | --- |
+| Merge (every PR) | `repo-shape`, `cargo test --workspace`, server `pytest tests/unit tests/integration`, shared-frontend-package vitest, desktop vitest, tier-2 intent suite |
+| Staging → production promotion | Tier 3 runner per lane + tier 4 upgrade scenario, against staging. Red blocks promotion and files an issue. **Flake-tolerant:** a green re-run unblocks; repeated red on the same scenario is a real failure, not a flake |
+| Nightly | Tier 3 lanes (incl. native-shell smoke) against whatever is on staging; failures file issues, never block merges |
+
+## Running tier 3/4 locally
+
+Local runs are a first-class path, not a CI afterthought — the runner is
+developed and debugged locally against staging:
+
+- `make release-e2e LANE=... DESKTOP=web AGENTS=...` runs from a laptop,
+  pointed either at **staging** (default for debugging what CI saw — same
+  publicly reachable API the sandboxes call back into) or at a local stack
+  plus tunnel.
+- Every key the runner needs (cheap-LLM key, E2B team, sandbox-mode Stripe,
+  test Slack workspace, test provider accounts) is inventoried in
+  `specs/developing/reference/env-vars.yaml` with where to obtain it; the
+  runner fails fast with a named-variable error when one is missing. No
+  scenario ever embeds a credential.
+- A red CI run must be reproducible by copying the run's lane flags into the
+  local command against the same staging deploy.
+
+Migration exceptions, named per house rule: desktop vitest (443 files) is not
+yet wired into the merge gate; the tier-2 intent suite and the tier-3/4 runner
+do not exist yet. `scripts/validate-agent-catalog.mjs` remains a hand-kept
+mirror of the Rust catalog validator until the contract-fixture pattern
+absorbs it.

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -99,8 +99,9 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Subscription edges: payment-failed hold + clear, mid-period cancel + rollover grace, billing modes off/observe/enforce, one-trial-per-GitHub-identity | 2 | — |
 | Usage surfaces truthful: seeded usage matches summary/timeseries/by-user/llm-balance APIs + UI | 2 | — |
 | Credits consumed properly: real session → LLM **and compute** meter events + credit decrement match consumption; Stripe webhook delivery live on staging | 3 | — |
-| Out of credits: sandbox paused and not accessible | 3 | — |
+| Out of credits: sandbox paused and not accessible — **including every bypass route** (direct API resume, stale session, webhook race, pre-exhaustion key, other org member, trigger-driven start) | 3 | — |
 | Out of credits: gateway LLM access gated; reactivates on refill | 3 | — |
+| Overage bills real money correctly: compute metered events + amounts match up to cap then hard-block; LLM auto top-up charges once then fail-closes on payment failure | 3 | — |
 | Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |
 
 ## Upgrade & release

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -1,0 +1,134 @@
+# Flow Registry
+
+The inventory of end-to-end flows that must never break. Owned and dictated by
+Pablo; agents keep the pointers live. Rules:
+
+- Adding or materially changing a flow adds/updates a row **in the same PR**.
+- `Test pointer` names the spec/scenario file that enforces the flow at its
+  tier. `—` means not yet implemented; an empty pointer is a to-do, not an
+  excuse.
+- A completeness audit (agent-run) checks: every row has a live pointer, and
+  every pointer's test actually runs in the gate its tier claims.
+
+Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
+**3** = live end-to-end (release train), **4** = upgrade path (release train).
+
+## Auth & identity — must work, even if basic
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Google OAuth sign-in (mocked provider per-merge) | 2 | — |
+| `/setup` instance claim → password login → logout → re-login | 2 | — |
+| Session revocation ends access | 2 | — |
+| Invitation: invite → accept in fresh browser → membership + role | 2 | — |
+| Invitation negatives: expired / reused / wrong-email token | 2 | — |
+| SSO: OIDC round-trip via mock IdP → user linked, domain policy applied | 2 | — |
+| SSO negatives: disallowed domain, unknown user, audience/issuer mismatch | 2 | — |
+| Real provider handshakes (Google/GitHub OAuth dance) | 3 | — |
+
+## Organization — must work, even if basic
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Create organization | 2 | — |
+| Invite users; promote/demote roles | 2 | — |
+| Admin-only surfaces gated: member cannot see/do admin actions | 2 | — |
+| Member visibility boundaries (sees own work, not others' private state) | 2 | — |
+| Remove user; access ends | 2 | — |
+
+## Workspaces
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Local workspace create | 3 | — |
+| Worktree workspace create — locally AND inside a cloud sandbox | 3 | — |
+| Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
+| New user cold path: first-ever sandbox provisioned from zero, within time budget | 3 | — |
+| Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | — |
+| Cloud workspace pause/resume/connect on real E2B | 3 | — |
+| Local ↔ cloud workspace migration | 3 | — |
+| Add repo from cloud | 2 | — |
+| Repo settings applied: default branch, action scripts, environment scripts/env vars take effect in sandbox | 3 | — |
+
+## Agents & sessions
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Every cataloged harness × its cheapest model via the gateway: send a message, get a real message back — local lane AND sandbox lane | 3 | — |
+| Correct harness spawned: right binary, right version per catalog pin — asserted locally AND in the sandbox, before the chat | 3 | — |
+| Install an agent; switch agents in a workspace | 3 | — |
+| Per-agent catalog version bump gate (staging smoke before pin bump) | 3 | — |
+| Config/harness option updates applied by a live agent | 3 | — |
+| Session resume after runtime restart | 3 | — |
+
+## Secrets
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Secrets CRUD in UI: org, personal, file secrets | 2 | — |
+| Org secret set → materializes in a new cloud sandbox | 3 | — |
+| Personal secret set → materializes in a new cloud sandbox | 3 | — |
+| File secret set → lands at the right path in the sandbox | 3 | — |
+
+## Integrations
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Connect integration (fake provider), toggle on/off | 2 | — |
+| Authenticate a real integration; agent in sandbox uses it through the gateway | 3 | — |
+
+## Workflows
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Create/edit/trigger workflow via UI → run created, plan resolved, delivery attempted (up to the sandbox seam) | 2 | — |
+| Workflow run reaches terminal state with a real agent | 3 | — |
+| Poll trigger against stub feed: replay-safe, invalid items surfaced | 2 | — |
+| Workflow services live: schedule + poll triggers, emit, chaining, Slack delivery | 3 | — |
+
+## Billing
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Checkout → grants → overage → cut-off → reactivation (Stripe test mode + test clocks) | 2 | — |
+| Credits consumed properly: real session → meter events + credit decrement match consumption | 3 | — |
+| Out of credits: sandbox paused and not accessible | 3 | — |
+| Out of credits: gateway LLM access gated; reactivates on refill | 3 | — |
+| Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |
+
+## Upgrade & release
+
+There is no single "upgrade path" — five distinct mechanisms, each tested at
+its own seam. Mechanism map and current-coverage audit: the tier-4 section of
+`README.md`.
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Worker self-update: sandbox worker N−1 heartbeats, downloads N from stubbed CDN base (`DESKTOP_DOWNLOADS_BASE_URL`), verifies, swaps, execs — with a live session on the box that survives | 4 | — |
+| Catalog convergence full chain (sandbox): server catalog version bump → heartbeat → worker push → runtime reconcile → agent CLI in an **existing** sandbox reinstalled at the new pin — independent of any worker binary update | 4 | — |
+| Catalog convergence on desktop local: same chain through the bundled desktop worker → local runtime → agent CLI reinstalled at the new pin | 4 | — |
+| Desktop app update replaces bundled anyharness + worker sidecars; post-update catalog reconcile installs the right agent CLIs | 4 | — |
+| Desktop feed artifact valid per release: `latest.json` shape, signature verifies against bundled pubkey, bundle sidecars report correct versions | 4 | — |
+| Desktop real N−1 → N auto-update (nightly native lane; needs a test build with overridable feed endpoint) | 4 | — |
+| SQLite migrations forward-apply on real N−1 data | 4 | — |
+| New release's sandboxes provision from the new E2B template; existing paused workspaces still wake on their old image | 4 | — |
+
+Old-template → new-template workspace movement is the managed-target
+replacement path, which is a placeholder runbook today
+(`specs/developing/runbooks/managed-target-replacement.md`) — its test enters
+this registry when the mechanism is built.
+
+**Known non-mechanisms (product decisions, not test gaps):** the anyharness
+binary has no in-place update path anywhere — sandboxes get it only via new
+template → new sandbox (worker ignores `desiredVersions.anyharness`; the
+supervisor `update/` module stages but never fetches or swaps), and desktop
+gets it only inside the app bundle. Until that is either built or declared
+immutable-by-replacement, there is nothing to test.
+
+## Deferred — add on first production break
+
+Explicitly not in scope until one breaks in production (postmortem rule then
+applies and the test lands with the fix):
+
+- OpenCode configuration correctness per harness
+- Full agent × auth-method matrix (beyond the default auth method per agent)

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -43,12 +43,12 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Local workspace create | 3 | — |
 | Worktree workspace create — locally AND inside a cloud sandbox | 3 | — |
 | Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
-| New user cold path: first-ever sandbox provisioned from zero, within time budget | 3 | — |
+| New user cold path: GitHub App authorization triggers first-ever sandbox provisioned from zero, within time budget | 3 | — |
 | Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | — |
 | Cloud workspace pause/resume/connect on real E2B | 3 | — |
 | Local ↔ cloud workspace migration | 3 | — |
 | Add repo from cloud | 2 | — |
-| Repo settings applied: default branch, action scripts, environment scripts/env vars take effect in sandbox | 3 | — |
+| Repo settings applied: default branch, action scripts, environment scripts/env vars take effect — locally AND in sandbox | 3 | — |
 
 ## Agents & sessions
 
@@ -58,7 +58,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Correct harness spawned: right binary, right version per catalog pin — asserted locally AND in the sandbox, before the chat | 3 | — |
 | Install an agent; switch agents in a workspace | 3 | — |
 | Per-agent catalog version bump gate (staging smoke before pin bump) | 3 | — |
-| Config/harness option updates applied by a live agent | 3 | — |
+| Config/harness option updates applied by a live agent: cycle every catalog-enumerated option (models, modes) in an existing session | 3 | — |
 | Session resume after runtime restart | 3 | — |
 
 ## Secrets
@@ -75,7 +75,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
 | Connect integration (fake provider), toggle on/off | 2 | — |
-| Authenticate a real integration; agent in sandbox uses it through the gateway | 3 | — |
+| Authenticate a real integration; **every cataloged harness** uses it through the gateway — local lane AND sandbox lane | 3 | — |
 
 ## Workflows
 
@@ -91,7 +91,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
 | Checkout → grants → overage → cut-off → reactivation (Stripe test mode + test clocks) | 2 | — |
-| Credits consumed properly: real session → meter events + credit decrement match consumption | 3 | — |
+| Credits consumed properly: real session → LLM **and compute** meter events + credit decrement match consumption; Stripe webhook delivery live on staging | 3 | — |
 | Out of credits: sandbox paused and not accessible | 3 | — |
 | Out of credits: gateway LLM access gated; reactivates on refill | 3 | — |
 | Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -90,7 +90,14 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Checkout → grants → overage → cut-off → reactivation (Stripe test mode + test clocks) | 2 | — |
+| Checkout → grants → consumption → cut-off → reactivation (Stripe test mode + test clocks); grant drain order | 2 | — |
+| Seat-based billing on Pro orgs: invite/remove/re-invite reconciles Stripe quantity + proration grants, no double-grant | 2 | — |
+| Team checkout: new-org-via-checkout activation + failure/expiry terminal states | 2 | — |
+| Compute overage: bills metered usage up to cap, writes off past it, then hard-blocks; disabled → immediate cutoff | 2 | — |
+| LLM credits: exhaustion disables key, admin caps independent of credit refill, auto top-up incl. declined-card fail-closed | 2 | — |
+| Stripe webhook robustness: duplicate/replay idempotent, concurrent 409, failure retried once-only, out-of-order safe | 2 | — |
+| Subscription edges: payment-failed hold + clear, mid-period cancel + rollover grace, billing modes off/observe/enforce, one-trial-per-GitHub-identity | 2 | — |
+| Usage surfaces truthful: seeded usage matches summary/timeseries/by-user/llm-balance APIs + UI | 2 | — |
 | Credits consumed properly: real session → LLM **and compute** meter events + credit decrement match consumption; Stripe webhook delivery live on staging | 3 | — |
 | Out of credits: sandbox paused and not accessible | 3 | — |
 | Out of credits: gateway LLM access gated; reactivates on refill | 3 | — |

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -74,17 +74,17 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Connect integration (fake provider), toggle on/off | 2 | — |
+| Connect integration (real api_key definition, placeholder key, no outbound), toggle on/off | 2 | — |
 | Authenticate a real integration; **every cataloged harness** uses it through the gateway — local lane AND sandbox lane | 3 | — |
 
-## Workflows
+## Workflows — PARKED (surface being reworked; tests land with the rework PRs)
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Create/edit/trigger workflow via UI → run created, plan resolved, delivery attempted (up to the sandbox seam) | 2 | — |
-| Workflow run reaches terminal state with a real agent | 3 | — |
-| Poll trigger against stub feed: replay-safe, invalid items surfaced | 2 | — |
-| Workflow services live: schedule + poll triggers, emit, chaining, Slack delivery | 3 | — |
+| Create/edit/trigger workflow via UI → run created, plan resolved, delivery attempted (up to the sandbox seam) | 2 | parked |
+| Workflow run reaches terminal state with a real agent | 3 | parked |
+| Poll trigger against stub feed: replay-safe, invalid items surfaced | 2 | parked |
+| Workflow services live: schedule + poll triggers, emit, chaining, Slack delivery | 3 | parked |
 
 ## Billing
 

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -480,7 +480,7 @@ compute-attribution fix has its own finding. Staging lane additionally
 asserts the Stripe webhook path is live: meter events delivered (no
 stuck/undelivered webhook backlog for the test org).
 
-### T3-BILL-2: exhaustion gates — compute and LLM independently
+### T3-BILL-2: exhaustion gates — compute and LLM independently, no bypasses
 Drive the test org's credits to exhaustion (smallest real mechanism available;
 test-clock/grant manipulation is allowed as *setup*, but the enforcement under
 test is real).
@@ -488,10 +488,38 @@ Assert, compute side: running sandbox is **paused** and inaccessible; new
 cloud sandbox/workspace creation is blocked with the enumerated
 credits-exhausted kind. Assert, LLM side: gateway rejects the test key's
 completion call with the enumerated budget error; live session surfaces it as
-an enumerated error, not a hang. Then refill → sandbox resumable, gateway
-serves again, new workspaces allowed. (Tier-2 T2-BILL-1 proves this logic
-against Stripe test clocks per-PR; this scenario proves the **deployed**
-enforcement chain end-to-end on real infrastructure.)
+an enumerated error, not a hang.
+**Bypass sweep (added 2026-07-08 — "they definitely can't access things after
+money bites, no matter what"):** while exhausted, attempt every alternate
+entry we know exists and assert each is refused, not just the front door:
+- resume the paused sandbox via direct API call (not UI);
+- reconnect via a session opened **before** exhaustion (stale handle);
+- the E2B-webhook race: force a `created`/`resumed` provider event while the
+  spend hold is active → inline re-pause fires (webhook path, not just the
+  15-min reconciler);
+- LLM via a **pre-exhaustion materialized key** still on the sandbox disk —
+  the disabled-key propagation must beat it (re-materialization path);
+- start a workspace as a **different member of the same exhausted org**;
+- trigger-driven work (workflow/automation) that would start a sandbox.
+Then refill → sandbox resumable, gateway serves again, new workspaces allowed.
+(Tier-2 T2-BILL-1 proves this logic against Stripe test clocks per-PR; this
+scenario proves the **deployed** enforcement chain end-to-end on real
+infrastructure.)
+
+### T3-BILL-3: overage bills real money correctly (staging lane)
+Added 2026-07-08 — overage is the highest-stakes billing path (it charges
+cards) and was tier-2-only. On the staging test org with `overage_enabled`
+and a small per-seat cap:
+- **compute**: exhaust grants, keep a sandbox running → metered usage events
+  arrive in Stripe (test mode) for the overage price, sandbox stays UP while
+  under cap; cross the cap → hard block flips on (`cap_exhausted`), further
+  usage written off, no more billing.
+- **LLM**: drop below the top-up threshold → exactly one auto top-up invoice
+  item charged in Stripe, `topup` grant appears, key stays live. Then disable
+  the payment method → next threshold crossing fail-closes (key disabled),
+  no silent free usage and no repeated failed charges.
+Assert amounts end-to-end: seconds consumed → cents exported → Stripe event
+totals match (the fractional-cent remainder logic is under test here too).
 
 ---
 

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -1,0 +1,310 @@
+# Scenario Definitions
+
+Status: DRAFT for Pablo's ruling. Once blessed, this is the contract the test
+agents implement against — a scenario's steps and assertions define what
+"works" means for its registry row in `flows.md`. Grounded in a code survey
+2026-07-07; endpoints/tables cited are as-built, not aspirational.
+
+Conventions:
+- Every tier-2 scenario runs against the stack-boot fixture: seeded Postgres,
+  server + desktop web build (`pnpm dev` on `PROLIFERATE_WEB_PORT`) driven by
+  Playwright. Desktop-web fallback behavior applies: auth persists to
+  localStorage; `open_external` becomes `window.open` (handle popups).
+- **Do not touch** flows routed through `lib/access/tauri/credentials.ts`
+  (env-var secret storage, `restartRuntime`) in tier 2 — no web fallback
+  exists; they throw outside Tauri.
+- Seeding uses the layer-B auth story (`SINGLE_ORG_MODE` where noted,
+  password accounts) per `specs/developing/local/feature-worktree-auth.md`.
+- IDs in brackets map to `flows.md` rows.
+
+---
+
+## Tier 2 — auth
+
+### T2-AUTH-1: setup claim + password login lifecycle
+Preconditions: fresh DB, `SINGLE_ORG_MODE=true`.
+Steps: visit `/setup` → claim instance, set password → logout → log back in
+via `POST /auth/web/password/login` through the UI.
+Assert: claim succeeds once; re-visiting `/setup` shows already-claimed;
+post-login the app shell renders with the seeded user.
+Negatives: wrong password rejected; second claim attempt rejected.
+
+### T2-AUTH-2: session revocation
+Steps: log in in context A; revoke the session (settings UI or API); context A
+performs any authenticated call.
+Assert: the call fails and the UI returns to signed-out state.
+
+### T2-AUTH-3: SSO OIDC round-trip (mock IdP)
+Preconditions: mock OIDC container (e.g. dex) running; org admin creates an
+`sso_connection` (scope `organization`, protocol `oidc`, `jit_policy:
+create_member`, `default_role: member`) via
+`POST /organizations/{id}/sso/connections` → `.../enable`.
+Note (survey): SSO config is **admin-role gated only — no plan/billing gate
+exists in code**. No Stripe precondition.
+Steps: signed-out browser → `GET /sso/discover` path via the login UI →
+`POST /web/sso/start` → mock IdP auto-approves identity
+`newuser@allowed.test` → callback.
+Assert: `sso_identity` row created; user lands signed-in; membership created
+with `default_role`; re-login with the same identity reuses the user (no dup).
+Negatives: identity with email on a non-configured domain → discover finds no
+connection; `jit_policy: disabled` + unknown user → enumerated error, not 500;
+tampered `state` on callback → rejected.
+
+### T2-AUTH-4: login-method availability seam
+Assert: with Google/GitHub client env unset, `provider_enabled()` hides those
+buttons; with env set, buttons render. (Real Google/GitHub round-trips are
+tier 3 — their endpoints are not overridable, so they cannot be mocked
+without product changes we are not making.)
+
+---
+
+## Tier 2 — organization
+
+### T2-ORG-1: roles and gating
+Preconditions: org with one `owner`, one `admin`, one `member` (seeded
+password accounts).
+Steps/Assert, per role via UI:
+- member cannot see admin settings surfaces; direct API call to an
+  admin endpoint (e.g. list invitations) → 403.
+- admin can invite `member`/`admin` but **not** `owner`
+  (`required_roles_for_invitation_role`); owner can invite owner.
+- promote member→admin via membership update; the promoted user gains admin
+  surfaces without re-login (or after refresh — assert whichever the product
+  does, then pin it).
+- remove a member → their next authenticated org-scoped call fails; membership
+  row status `removed`.
+
+### T2-INV-1: invitation happy path
+Survey fact that shapes this test: **there is no secret invite token — the
+invitation UUID is the reference, and acceptance is authorized by the
+authenticated user's email matching `invitation.email`** (normalized). Email
+delivery via Resend is skipped locally and recorded as
+`delivery_status=skipped`. So: no email capture needed; drive accept through
+the product's own path.
+Steps: admin invites `invitee@test.local` (role member) → assert invitation
+row `pending`, `delivery_status` ∈ {sent, skipped} → log in as
+`invitee@test.local` (seeded password account) → desktop-web settings shows
+the pending invitation (`GET /organizations/invitations/current`) → accept via
+the UI (`POST /organizations/invitations/current/{id}/accept`).
+Assert: membership `active` with invited role; invitation `accepted` with
+`accepted_by_user_id`; org appears in the invitee's org list.
+Negatives (each its own case):
+- expired: seed `expires_at` in the past → accept → enumerated error; list
+  endpoint lazily marks `expired`.
+- revoked: admin revokes → accept fails.
+- wrong email: login as `other@test.local` → invitation not listed; direct
+  accept call with the known UUID → rejected (email mismatch).
+- duplicate pending invite for same (org, email) → rejected by partial unique
+  index → enumerated error.
+
+### T2-INV-2: single-org register-via-invite path
+Preconditions: `SINGLE_ORG_MODE=true`.
+Steps: create invite → build `/register?token={invitation_id}&email=...`
+(the URL the email would carry) → open signed-out → complete
+`POST /password/register`.
+Assert: account created AND membership active in one flow.
+
+Deferred, named: the hosted `/join/{org_id}` deep-link page hands off to the
+OS protocol handler (`proliferate://`). Web-mode testing would use the
+dev-handoff polling fallback; this is a tier-3/nightly concern, not tier 2.
+
+---
+
+## Tier 2 — secrets (CRUD + seam)
+
+### T2-SEC-1: secrets CRUD, all three scopes
+Steps: via UI (and API assertions underneath): set/update/delete a personal
+env-var secret (`PUT /secrets/personal/env-vars/{name}`), an org env-var
+secret, a workspace env-var secret, and a personal file secret (text upload).
+Assert: values never echoed back in list responses; `version` bumps on PUT;
+`materialization.status` transitions to `pending` (the seam — actual
+materialization is tier 3); binary file upload rejected with
+`invalid_secret_file_upload`.
+Negatives: member setting org-scope secret → 403.
+
+---
+
+## Tier 2 — integrations (connect + toggle, faked provider)
+
+### T2-INT-1: api_key connect + org policy toggle
+Preconditions: a stub MCP integration definition seeded (api_key kind) —
+this reuses the tier-2 stub-server slot, not a real provider.
+Steps: user connects via `POST /integrations/authentications`
+(authKind api_key) → account created. Org admin toggles
+`PATCH /integrations/admin/organizations/{id}/definitions/{id}/enabled` off.
+Assert: `effective_enabled` reflects all three layers (org policy override >
+definition default, AND account enabled) — assert the composed value the UI
+shows, off then on again.
+Negatives: OAuth-kind connect is asserted only to the seam: flow row created,
+`authorizationUrl` returned (no real provider round-trip in tier 2).
+
+---
+
+## Tier 2 — workspaces (to the seam)
+
+### T2-WS-1: cloud workspace create request path
+Preconditions: repo environment configured (else the API correctly returns
+`cloud_repo_environment_not_found` — that's a negative case).
+Steps: drive Add-Repo flow → cloud kind → `POST /cloud/workspaces`.
+Assert (the seam, per `use-create-cloud-workspace.ts`): 200 with workspace id,
+status `pending|materializing`; UI enters `awaiting-cloud-ready` pending-entry
+state. **Stop here.** No sandbox, no readiness wait.
+Negatives: no repo environment → enumerated error surfaced in UI; billing
+block (see T2-BILL-2) → blocked message, no workspace row.
+
+### T2-WS-2: local + worktree create (desktop-web limits apply)
+Local/worktree creation drive the local AnyHarness runtime and OS file
+pickers — partially Tauri-bound. Tier 2 asserts only what web mode can reach:
+the Add-Repo flow branches (`add-repo-flow-store.ts`) render and validate
+inputs. Full local/worktree creation is asserted in tier 3's desktop lane.
+[If this proves too thin, the fallback is a runtime-API-level test against a
+locally booted anyharness — decide when building.]
+
+---
+
+## Tier 2 — billing
+
+### T2-BILL-1: checkout → grants → overage → cut-off → reactivate
+Stripe test mode (`sk_test_` key) + webhook forwarding + test clocks, per
+`specs/developing/local/stripe-local-testing.md`. Steps mirror the manual pass
+already verified on the `billing` profile (memory: 2026-07-04): checkout
+completes → plan reflects paid; simulate meter overage; drive credits to zero
+via test clock.
+Assert: `authorize_sandbox_start` blocks with
+`WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED` (assert the enumerated kind,
+via the blocked-action message in UI); refill/reactivate → authorization
+passes again.
+
+### T2-BILL-2: plan limits
+Assert: free-plan repo limit enforced (`repo_limit_for_billing_state`);
+agent-gateway policy edit gated by `agent_gateway_policy_min_plan` when set.
+Survey flag for the registry row "plan gates the model list": **no
+plan-conditioned model list exists in code today.** Row stays in `flows.md`
+only if that behavior is planned product work; otherwise it should be
+deleted. [PABLO TO RULE]
+
+---
+
+## Tier 2 — workflows (to the seam)
+
+### T2-WF-1: definition lifecycle + run-to-delivery-seam
+Steps: create workflow in editor (steps incl. one invalid ref to assert live
+validation) → save version → trigger manually with args.
+Assert: `workflow_run` row created, status `pending_delivery`,
+`resolved_plan_json` populated with interpolated args; local-lane delivery
+attempt recorded. **Stop at the seam** — no runtime execution.
+
+### T2-WF-2: poll trigger against stub feed
+The PR-B validation script (workflows-architecture §10) productionized:
+replaying stub feed with one schema-invalid item.
+Assert: exactly one `workflow_trigger_item` per unique id (`spawned`), the
+invalid item recorded `invalid` with the schema error, cursor persisted,
+`last_poll_error` null; stub killed → `last_poll_error` populated, trigger
+stays enabled.
+
+---
+
+## Tier 3 — first wave (release-critical)
+
+Conventions: the runner points a desktop at the target server by writing
+`{"apiBaseUrl": "<staging>"}` into the profile's `~/.proliferate` config file
+before launch (the supported runtime override — resolution order in
+`apps/desktop/src/lib/infra/proliferate-api.ts`; read once at boot, relaunch
+to apply). The web-port lane uses `VITE_PROLIFERATE_API_BASE_URL` instead.
+Tests never drive a server-picker UI to configure themselves, even after the
+sign-in-screen server entry (self-hosting-v1 §3.5, B4-desktop) ships.
+
+### T3-FIXTURE: shared identity + lanes (infrastructure, not a test)
+Two identities the runner mints/uses, so no scenario reimplements auth:
+- **fresh user**: created per run (registration API), used by new-user
+  scenarios, torn down after.
+- **durable user**: one seeded `e2e-tests` account/org on the target server,
+  used by existing-user scenarios; its sandbox intentionally persists between
+  runs.
+Two lanes every agent/workspace scenario runs in, unless marked otherwise:
+- **local lane**: desktop (web-port mode) + local AnyHarness runtime.
+- **sandbox lane**: cloud workspace on real E2B.
+
+### T3-PROV-1: provision — new user (cold path)
+As the **fresh user**: first-ever cloud workspace → personal sandbox created
+from zero (enrollment, worker boot, materialization).
+Assert: `ready` within [BUDGET — Pablo to set; suggest p95 ≤ 5 min fail,
+warn at 3]; connect and run one shell command.
+
+### T3-PROV-2: access — existing user (warm path)
+As the **durable user**, whose sandbox already exists: reopen the workspace;
+pause → `paused` (and inaccessible); resume → `running`; connect again.
+Assert: wake within budget; prior workspace state intact. New-user and
+existing-user paths fail differently — both must be green.
+
+### T3-WT-1: worktree workspaces, both lanes
+Create a worktree workspace locally (off a local repo) AND inside a cloud
+sandbox (off the sandbox's repo checkout). Assert: worktree created on the
+right base branch, session opens in it, edits isolated from the base tree.
+
+### T3-CHAT-1: every harness × its cheapest model, via the gateway
+For **each cataloged harness**, in **both lanes**, using the harness's
+cheapest model served through the gateway (dedicated test key; model set
+below): create session, send one message, await turn end.
+Assert (outcomes, not transcripts):
+- non-empty assistant reply arrives;
+- **installed harness CLI version == catalog pin, asserted before the chat**
+  (local runtime home and inside the sandbox — "right harness, right
+  version" is its own assertion, not implied by the chat working);
+- session persists and reopens.
+Per-harness failure = per-harness red (feeds the catalog-bump gate), not
+whole-suite red.
+
+Gateway test-model set — one cheapest model per provider family the harnesses
+need, pinned in the test key's allowlist (exact IDs resolved against the
+catalog at build time):
+- Anthropic: Haiku-class (Claude Code; also OpenCode's default lane)
+- OpenAI: the cheapest Codex-supported tier (Codex)
+- Google: Flash-class (Gemini CLI)
+- xAI: the cheap code tier (Grok, if cataloged for the release)
+- One OSS/aggregator lane if OpenCode is asserted beyond Anthropic (e.g. GLM)
+Everything flows through the gateway — no direct provider keys in scenarios.
+Same env var names locally and in CI (`env-vars.yaml`), keys in GH Actions
+secrets and the local credentials file respectively.
+
+### T3-UPDATE-1: harness convergence, both lanes (pre-verification of tier 4)
+The catalog-convergence chain (tier-4 registry rows) is asserted in both
+lanes as part of this wave, not deferred: bump the served catalog version on
+the target server → heartbeat → worker pushes catalog → runtime reconciles →
+**agent CLI reinstalled at the new pin**, verified in the sandbox AND on the
+desktop-local runtime. This is the "they update the way we described, not
+just locally but in the sandbox" requirement.
+
+### T3-SEC-MAT-1: secrets materialize
+Steps: set personal + org env-var secret and a workspace file secret → create
+a fresh cloud workspace → poll `materialization.status` to `ready`.
+Assert in-sandbox: `{PROLIFERATE_HOME}/secrets/global.env` contains both
+merged env vars (org secrets materialize into **each member's personal
+sandbox** — that's the mechanism, assert it as such);
+`{repo}/.proliferate/env/workspace.env` present; manifest sha256s match.
+Update propagation: PUT a new value → status returns to `pending` → `ready` →
+sandbox file updated.
+
+### T3-INT-1: real integration through the gateway
+Steps: connect a real low-stakes integration (test Slack workspace) → agent
+session calls a tool through the integrations gateway.
+Assert: tool call succeeds; audit row written; org-policy toggle off → same
+call returns enumerated scope/policy error.
+
+### T3-REPO-1: repo settings take effect
+Steps: configure default branch + environment vars/scripts on the repo
+environment → fresh workspace.
+Assert: checkout is on the configured branch; env script ran (marker file);
+env vars present in session shell.
+
+---
+
+## Open rulings collected
+
+1. "Plan gates the model list" — not in code; keep as planned work or delete
+   the row (T2-BILL-2).
+2. T3-PROV-1 time budget number.
+3. T2-WS-2: is seam-only coverage of local/worktree create acceptable for
+   tier 2, with full coverage in tier 3's desktop lane?
+4. Google OAuth stays tier-3-only (mock not feasible without product change)
+   — confirm.

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -128,11 +128,14 @@ Negatives: member setting org-scope secret → 403.
 
 ---
 
-## Tier 2 — integrations (connect + toggle, faked provider)
+## Tier 2 — integrations (connect + toggle, real definition, no outbound)
 
 ### T2-INT-1: api_key connect + org policy toggle
-Preconditions: a stub MCP integration definition seeded (api_key kind) —
-this reuses the tier-2 stub-server slot, not a real provider.
+Ruled 2026-07-08: **no stub/fake integration provider** — same posture as
+no-fake-sandbox/no-mock-LLM. Use a **real cataloged api_key-kind integration
+definition**; the stored key is a placeholder value (connect/CRUD paths never
+validate it against the provider). No outbound call leaves the stack in
+tier 2 — the real tool call through the gateway is T3-INT-1's job.
 Steps: user connects via `POST /integrations/authentications`
 (authKind api_key) → account created. Org admin toggles
 `PATCH /integrations/admin/organizations/{id}/definitions/{id}/enabled` off.
@@ -305,6 +308,12 @@ Usage & Limits pane render those numbers (Playwright).
 
 ## Tier 2 — workflows (to the seam)
 
+**PARKED (ruled 2026-07-08): the workflows surface is being reworked in a
+large in-flight PR arc; these scenarios are not built now. The workflows
+branches rebase on top of the test harness when they land and add their own
+tests per the PR obligation in `README.md`. Definitions below are kept as the
+starting contract for that work, not as current to-dos.**
+
 ### T2-WF-1: definition lifecycle + run-to-delivery-seam
 Steps: create workflow in editor (steps incl. one invalid ref to assert live
 validation) → save version → trigger manually with args.
@@ -448,10 +457,13 @@ Update propagation: PUT a new value → status returns to `pending` → `ready` 
 sandbox file updated.
 
 ### T3-INT-1: real integration through the gateway — every harness, both lanes
-Steps: connect one real low-stakes integration (test Slack workspace) once;
-then for **each cataloged harness, in both lanes** (piggybacking T3-CHAT-1's
-session matrix): the agent session calls a tool through the integrations
-gateway.
+Ruled 2026-07-08: the integration is **api_key-kind with a real key** (e.g.
+Slack bot token for the `proliferate-e2e` workspace stored as the api_key
+credential) — no OAuth dance in the runner, no mocked provider; the gateway
+itself is what's under test.
+Steps: connect the integration once with the real key; then for **each
+cataloged harness, in both lanes** (piggybacking T3-CHAT-1's session matrix):
+the agent session calls a tool through the integrations gateway.
 Assert: tool call succeeds per harness × lane (per-harness red, like
 T3-CHAT-1); audit row written; org-policy toggle off → same call returns
 enumerated scope/policy error (toggle asserted once, not per harness).

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -225,11 +225,35 @@ Two lanes every agent/workspace scenario runs in, unless marked otherwise:
 - **local lane**: desktop (web-port mode) + local AnyHarness runtime.
 - **sandbox lane**: cloud workspace on real E2B.
 
+Identity per target (ruled 2026-07-08): the **fresh user** is mintable only
+where a registration API exists — the local/self-hosted target. On staging
+(hosted, OAuth-only signup) there is deliberately no test-only registration
+escape hatch; fresh-user cold-path scenarios run fully on the local target
+(still a real from-zero E2B provision), and staging approximates cold with
+"fresh workspace for the durable user."
+
+GitHub fixture: a dedicated test GitHub org with the Proliferate GitHub App
+installed once, durably (dev app for local, staging app for staging).
+Scenarios use repos the installation already covers; the install/OAuth dance
+itself is not automated (real-provider-handshake posture: add on first
+production break).
+
 ### T3-PROV-1: provision — new user (cold path)
 As the **fresh user**: first-ever cloud workspace → personal sandbox created
 from zero (enrollment, worker boot, materialization).
 Assert: `ready` within [BUDGET — Pablo to set; suggest p95 ≤ 5 min fail,
 warn at 3]; connect and run one shell command.
+Trigger under test (ruled 2026-07-08): the personal sandbox is created by the
+**GitHub App authorization callback**
+(`complete_github_app_user_authorization_callback` →
+`ensure_personal_cloud_sandbox_exists` + `schedule_materialize_sandbox`), with
+`ensure_personal_cloud_sandbox_exists` also reachable via repo-add and secret
+materialization. The cold path must be exercised **through the GitHub App
+auth path, not by calling the sandbox service directly** — no mock: the test
+GitHub org has the App pre-installed, and the fresh user completes real App
+authorization against it. If driving the real GitHub authorize redirect
+headlessly proves infeasible, the fallback seam is invoking the
+post-authorization service call the callback makes — never a faked GitHub.
 
 ### T3-PROV-2: access — existing user (warm path)
 As the **durable user**, whose sandbox already exists: reopen the workspace;
@@ -241,6 +265,9 @@ existing-user paths fail differently — both must be green.
 Create a worktree workspace locally (off a local repo) AND inside a cloud
 sandbox (off the sandbox's repo checkout). Assert: worktree created on the
 right base branch, session opens in it, edits isolated from the base tree.
+Budget (ruled 2026-07-08): on an already-running sandbox, worktree creation
+completes in **≤ 1 s** measured at the runtime operation (sandbox wake time,
+if any, is T3-PROV-2's budget, not this one).
 
 ### T3-CHAT-1: every harness × its cheapest model, via the gateway
 For **each cataloged harness**, in **both lanes**, using the harness's
@@ -275,9 +302,26 @@ the target server → heartbeat → worker pushes catalog → runtime reconciles
 desktop-local runtime. This is the "they update the way we described, not
 just locally but in the sandbox" requirement.
 
+### T3-CFG-1: live config options apply in an existing session
+Added 2026-07-08 (Pablo: "occasionally this breaks"). In an **existing** chat
+session (not a fresh one), per harness: enumerate the harness's exposed
+configuration options from the catalog/harness contract and cycle each one —
+every selectable model (switch → send a message → the reply is attributed to
+the switched model), every mode/approval-policy-style enum (switch → the
+session accepts it and behaves accordingly, asserted at the harness-contract
+level, e.g. the option readback/state event — not by interpreting prose).
+Assert: each option value round-trips (set → readback matches) and the session
+survives every switch. Options are **enumerated from the catalog at build
+time, never hardcoded**, so a new option is automatically in scope.
+Per-harness × per-option red. Runs in the local lane by default (cheap);
+sandbox lane on the release train.
+
 ### T3-SEC-MAT-1: secrets materialize
 Steps: set personal + org env-var secret and a workspace file secret → create
 a fresh cloud workspace → poll `materialization.status` to `ready`.
+Budget (ruled 2026-07-08): on an already-running sandbox, a secret PUT reaches
+`ready` and the sandbox file is updated within **≤ 60 s** ("roughly
+immediate"); adjust with evidence if the mechanism is legitimately slower.
 Assert in-sandbox: `{PROLIFERATE_HOME}/secrets/global.env` contains both
 merged env vars (org secrets materialize into **each member's personal
 sandbox** — that's the mechanism, assert it as such);
@@ -285,17 +329,46 @@ sandbox** — that's the mechanism, assert it as such);
 Update propagation: PUT a new value → status returns to `pending` → `ready` →
 sandbox file updated.
 
-### T3-INT-1: real integration through the gateway
-Steps: connect a real low-stakes integration (test Slack workspace) → agent
-session calls a tool through the integrations gateway.
-Assert: tool call succeeds; audit row written; org-policy toggle off → same
-call returns enumerated scope/policy error.
+### T3-INT-1: real integration through the gateway — every harness, both lanes
+Steps: connect one real low-stakes integration (test Slack workspace) once;
+then for **each cataloged harness, in both lanes** (piggybacking T3-CHAT-1's
+session matrix): the agent session calls a tool through the integrations
+gateway.
+Assert: tool call succeeds per harness × lane (per-harness red, like
+T3-CHAT-1); audit row written; org-policy toggle off → same call returns
+enumerated scope/policy error (toggle asserted once, not per harness).
 
-### T3-REPO-1: repo settings take effect
+### T3-REPO-1: repo settings take effect — both lanes
 Steps: configure default branch + environment vars/scripts on the repo
-environment → fresh workspace.
-Assert: checkout is on the configured branch; env script ran (marker file);
-env vars present in session shell.
+environment → fresh workspace, **locally AND in a cloud sandbox** (ruled
+2026-07-08: setup scripts are a local mechanism too, not sandbox-only).
+Assert, per lane: checkout is on the configured branch; setup/env script ran
+(marker file); env vars present in session shell.
+
+### T3-BILL-1: real consumption is metered — LLM and compute
+Added 2026-07-08. As the durable user, run a real agent session (reuse a
+T3-CHAT-1 run) and keep a sandbox running for a known interval.
+Assert, against the billing surfaces (usage UI/API + underlying meter
+records): (a) **LLM consumption** — the session produced meter events whose
+tokens/cost match the gateway's recorded usage for the test key, and the
+credit balance decremented accordingly; (b) **compute consumption** — sandbox
+runtime for the interval produced compute meter events and the corresponding
+credit decrement. Both sides must attribute to the right org/user. Staging
+lane additionally asserts the Stripe webhook path is live: meter events
+delivered (no stuck/undelivered webhook backlog for the test org).
+
+### T3-BILL-2: exhaustion gates — compute and LLM independently
+Drive the test org's credits to exhaustion (smallest real mechanism available;
+test-clock/grant manipulation is allowed as *setup*, but the enforcement under
+test is real).
+Assert, compute side: running sandbox is **paused** and inaccessible; new
+cloud sandbox/workspace creation is blocked with the enumerated
+credits-exhausted kind. Assert, LLM side: gateway rejects the test key's
+completion call with the enumerated budget error; live session surfaces it as
+an enumerated error, not a hang. Then refill → sandbox resumable, gateway
+serves again, new workspaces allowed. (Tier-2 T2-BILL-1 proves this logic
+against Stripe test clocks per-PR; this scenario proves the **deployed**
+enforcement chain end-to-end on real infrastructure.)
 
 ---
 

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -94,8 +94,12 @@ Negatives (each its own case):
 - revoked: admin revokes → accept fails.
 - wrong email: login as `other@test.local` → invitation not listed; direct
   accept call with the known UUID → rejected (email mismatch).
-- duplicate pending invite for same (org, email) → rejected by partial unique
-  index → enumerated error.
+- duplicate invite for same (org, email) is NOT rejected: re-inviting rotates
+  — `create_or_rotate_organization_invitation` expires the old pending row
+  (`status=expired`) and inserts a fresh pending row (new id, new
+  `expires_at`) inside one transaction. Assert: accept with the **old**
+  invitation id → `invalid_invitation` (enumerated error, same as expired);
+  accept with the **new** id → succeeds normally with invited role.
 
 ### T2-INV-2: single-org register-via-invite path
 Preconditions: `SINGLE_ORG_MODE=true`.

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -168,24 +168,138 @@ locally booted anyharness — decide when building.]
 
 ## Tier 2 — billing
 
-### T2-BILL-1: checkout → grants → overage → cut-off → reactivate
-Stripe test mode (`sk_test_` key) + webhook forwarding + test clocks, per
-`specs/developing/local/stripe-local-testing.md`. Steps mirror the manual pass
-already verified on the `billing` profile (memory: 2026-07-04): checkout
-completes → plan reflects paid; simulate meter overage; drive credits to zero
-via test clock.
-Assert: `authorize_sandbox_start` blocks with
-`WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED` (assert the enumerated kind,
-via the blocked-action message in UI); refill/reactivate → authorization
-passes again.
+Expanded 2026-07-08 after a full billing-surface survey (Pablo: "billing is
+the thing I'm least confident in — every scenario must be tested"). All
+tier-2 billing runs on Stripe **test mode** (`sk_test_`) + webhook forwarding
++ test clocks per `specs/developing/local/stripe-local-testing.md` — real
+Stripe, not a mock. Two independent config axes define the matrix and both
+branches of each must be covered where marked: `CLOUD_BILLING_MODE`
+(`off|observe|enforce`) and `PRO_BILLING_ENABLED` (pro plans vs legacy flat).
+Survey correction baked in: `authorize_sandbox_start` is **dead code** — the
+live start gate is `assert_cloud_sandbox_resume_allowed` on the resume/connect
+path (`server/proliferate/server/billing/authorization.py:193`); assert
+against that, never the dead function.
 
-### T2-BILL-2: plan limits
-Assert: free-plan repo limit enforced (`repo_limit_for_billing_state`);
-agent-gateway policy edit gated by `agent_gateway_policy_min_plan` when set.
+### T2-BILL-1: checkout → grants → consumption → cut-off → reactivate
+The core loop, per the manual pass verified 2026-07-04 on the `billing`
+profile, now automated: checkout completes → subscription synced, plan
+reflects paid; `invoice.paid` issues the period grant (`pro_period` hours =
+seats, or `cloud_monthly` on legacy); drive credits to zero via test clock +
+seeded usage segments.
+Assert: resume/connect blocked with the enumerated decision
+(`CloudSandboxResumeBlockedError`, 402) and the UI shows the
+credits-exhausted blocked state (`WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED`
+via `start_block_reason`); refill (legacy: `refill_10h` checkout; pro: top-up
+grant) → resume allowed again. Grant consumption **order** asserted: grants
+drain earliest-expiring-first within type priority
+(`ordered_accounting_grants`).
+
+### T2-BILL-2: plan limits + policy gates
+Assert: free-plan repo limit enforced (`repo_limit_for_billing_snapshot` →
+`repo_limit_exceeded` on scheduling past the cap); agent-gateway policy edit
+gated by `agent_gateway_policy_min_plan` (`org_agent_policy_plan_required`,
+403, on a free org when min plan is `pro`).
 Survey flag for the registry row "plan gates the model list": **no
 plan-conditioned model list exists in code today.** Row stays in `flows.md`
 only if that behavior is planned product work; otherwise it should be
 deleted. [PABLO TO RULE]
+
+### T2-BILL-3: seats — invite/remove/re-invite on a Pro org
+Pro billing is seat-based; every membership change must reconcile Stripe seat
+quantity and grants (`maybe_create_organization_seat_adjustment` →
+`process_pending_seat_adjustments`).
+Steps/Assert on a Pro-subscribed org with a test clock:
+- invite + accept a member → `BillingSeatAdjustment` row created; Stripe
+  subscription-item quantity bumped; a prorated `pro_seat_proration` grant
+  issued (capped +1 seat per adjustment).
+- remove the member → quantity synced down; **no** refund/grant issued.
+- re-invite + accept the **same** member within the same billing period →
+  quantity back up, but **no second proration grant** (the same-period
+  decrease marker suppresses it — the double-grant race is the risk).
+- adjustment retry: simulate a failing Stripe call → retries up to 3 then
+  `failed_terminal`; a subsequent adjustment still converges quantity.
+- negative: same flows on a free org and with `PRO_BILLING_ENABLED=false` →
+  billing untouched (no adjustment rows).
+
+### T2-BILL-4: team checkout — the second, independent org-creation path
+`team_checkout` (create a brand-new org gated on checkout) has its own
+activation/failure state machine, separate from adding billing to an existing
+org — test it separately.
+Steps: create team checkout session → org exists as `pending_checkout` (not
+joinable); complete checkout in Stripe test mode → `checkout.session.completed`
+webhook with `purpose=team_subscription` activates the org, staged invites
+send, gateway enrollment scheduled.
+Negatives: subscription not `active|trialing` at webhook time → intent
+`failed_billing_state`, org never activates; expired (24h) intent → same
+terminal, no orphan active org; replayed activation webhook → idempotent.
+
+### T2-BILL-5: compute overage — bill up to cap, write off past it, then block
+On a subject with `overage_enabled` and a per-seat cap: exhaust grants, keep
+consuming.
+Assert: uncovered seconds convert to cents and export as Stripe metered usage
+events (`BillingUsageExport` billable rows) — sandbox **not** paused while
+under cap; fractional-cent remainder carried (`BillingOverageRemainder`);
+once `cap_used_cents` ≥ cap → further usage written off
+(`writeoff_reason='overage_cap_exhausted'`) and snapshot flips to
+`cap_exhausted` → hard-blocked. Overage settings API: cap validation
+(`invalid_overage_cap` outside 0..1,000,000).
+Negative: `overage_enabled=false` → cutoff is immediate at grant exhaustion,
+zero export rows.
+
+### T2-BILL-6: LLM credits — exhaustion, admin caps, top-ups (incl. failure)
+Three distinct gate states that must not bleed into each other:
+- **exhaustion**: drive `remaining_usd` ≤ 0 on a granted subject → virtual key
+  disabled, `budget_status='exhausted'`; top-up grant → key reactivated.
+- **admin cap** (`billing_budget_limit` kind=`llm`, org-wide and per-user
+  independently): over cap → `budget_status='limit_reached'`; credit refill
+  does **not** clear it (deliberate); raising/disabling the cap does, even
+  with zero new spend (the quiet-tick sweep).
+- **auto top-up overage**: overage-enabled subject drops below threshold →
+  one-off Stripe invoice item charged, `topup` grant issued, exactly one
+  top-up per tick. **Failure path is mandatory**: declined test card / no
+  Stripe customer / `agent_gateway_llm_topup_price_id` unset → fail-closed:
+  key disabled at zero like a capped org (the "overage promise quietly
+  evaporates" risk).
+Also assert `is_gateway_budget_available` flips correctly for launch gating.
+
+### T2-BILL-7: webhook robustness — idempotency, replay, ordering
+Against the Stripe webhook receiver (`claim_webhook_event` semantics):
+- exact duplicate delivery of a processed event → silent ack, no double grant
+  (assert grant count unchanged after replaying `invoice.paid`).
+- concurrent duplicate while first is in-flight → `409 stripe_webhook_in_progress`.
+- handler exception → receipt `failed`, retry (redelivery) succeeds and
+  processes exactly once.
+- out-of-order: deliver `invoice.paid` before `customer.subscription.updated`
+  for the same subscription → grants still issued safely, final state
+  converges.
+- Slack billing notifications fire exactly once per real transition, not on
+  replays.
+
+### T2-BILL-8: subscription edge states
+- payment failure: `invoice.payment_failed` → hold applied; resume blocked
+  with the payment-failed decision; `invoice.paid` clears the hold.
+- cancellation mid-period: `cancel_at_period_end=true` synced; access
+  continues through period end; 24h rollover grace honored after
+  `current_period_end`; then hard cutoff.
+- `customer.subscription.deleted` after a **clean voluntary cancellation**:
+  pin the CURRENT behavior (unconditional `payment_failed` hold — survey
+  2026-07-08 confirmed the reason-sensitive refinement was never shipped) as
+  an expected-fail/known-bug test until the product fix lands. [FILED AS
+  FINDING — Pablo to rule fix-now vs post-release.]
+- billing modes: `CLOUD_BILLING_MODE=off` → all enforcement inert, product
+  fully usable; `observe` → accounting/exports happen, nothing ever blocked;
+  `enforce` → gates live. One smoke per mode.
+- free trial: `free_trial_v2` granted lazily on snapshot for a GitHub-linked
+  account, exactly once per GitHub identity ever (constant period key);
+  account without GitHub identity → **no trial, no error** (pin current
+  silent behavior; UX finding noted).
+
+### T2-BILL-9: usage surfaces tell the truth
+Seed known usage (segments + LLM events with fixed amounts) → assert
+`/billing/usage/summary`, `/billing/usage/timeseries`,
+`/organizations/{id}/usage/by-user`, and `/billing/llm-balance` return exactly
+the seeded totals, attributed to the right users; sidebar consumption card and
+Usage & Limits pane render those numbers (Playwright).
 
 ---
 
@@ -353,13 +467,18 @@ Assert, per lane: checkout is on the configured branch; setup/env script ran
 Added 2026-07-08. As the durable user, run a real agent session (reuse a
 T3-CHAT-1 run) and keep a sandbox running for a known interval.
 Assert, against the billing surfaces (usage UI/API + underlying meter
-records): (a) **LLM consumption** — the session produced meter events whose
-tokens/cost match the gateway's recorded usage for the test key, and the
-credit balance decremented accordingly; (b) **compute consumption** — sandbox
-runtime for the interval produced compute meter events and the corresponding
-credit decrement. Both sides must attribute to the right org/user. Staging
-lane additionally asserts the Stripe webhook path is live: meter events
-delivered (no stuck/undelivered webhook backlog for the test org).
+records): (a) **LLM consumption** — the session produced
+`agent_llm_usage_event` rows whose tokens/cost match the gateway's recorded
+usage for the test key, and the credit balance decremented accordingly;
+(b) **compute consumption** — sandbox runtime for the interval produced a
+closed `usage_segment` (opened/closed by the E2B webhooks, not a timer) and
+the accounting pass drained the corresponding grant seconds. Both sides must
+attribute to the right org/user — note the known attribution gap: compute
+segments bill the workspace owner's **personal** subject; LLM events bill the
+**org** subject where enrolled. Assert current behavior as-built; the org
+compute-attribution fix has its own finding. Staging lane additionally
+asserts the Stripe webhook path is live: meter events delivered (no
+stuck/undelivered webhook backlog for the test org).
 
 ### T3-BILL-2: exhaustion gates — compute and LLM independently
 Drive the test org's credits to exhaustion (smallest real mechanism available;
@@ -385,3 +504,24 @@ enforcement chain end-to-end on real infrastructure.)
    tier 2, with full coverage in tier 3's desktop lane?
 4. Google OAuth stays tier-3-only (mock not feasible without product change)
    — confirm.
+
+## Product findings from the billing survey (2026-07-08) — rule before fixing
+
+Confirmed against code; each needs a Pablo ruling (fix pre-release vs pin
+current behavior as known-bug expected-fail):
+
+1. **Org/per-user compute budget limits never fire.** `usage_segment` rows
+   always bill the workspace owner's *personal* billing subject
+   (`billing_runtime_usage.py:55-63`), so both compute-limit enforcement
+   sites resolve `organization_id=None` and bail — an admin-configured
+   compute cap saves in the UI and silently does nothing. (LLM caps are
+   unaffected — correctly org-attributed.)
+2. **Clean voluntary cancellation gets a `payment_failed` hold.**
+   `customer.subscription.deleted` applies the hold unconditionally
+   (`stripe_webhooks.py:193-199`) — no reason sensitivity, so a customer who
+   cancels cleanly can be spuriously blocked when Stripe deletes the record
+   at period end.
+3. **No-GitHub account gets no free trial and no explanation.**
+   `ensure_free_trial_v2_grant` silently returns when the account has no
+   linked GitHub identity — looks broken to the user. (UX severity, not
+   correctness.)

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -309,6 +309,19 @@ Sentry lane requires them.
 
 ---
 
+### Testing
+
+**`specs/developing/testing/README.md`** — the automated-testing standard:
+four tiers (unit/contract, mocked intent, live end-to-end, upgrade path),
+placement table per language, the merge-vs-release gate rule (no real
+LLM/sandbox/third-party in the merge gate, ever), contract-fixture pattern
+under `fixtures/contracts/`, the decision procedure for where a change's
+tests go, and the postmortem rule.
+
+**`specs/developing/testing/flows.md`** — the flow registry: the inventory of
+end-to-end flows that must never break, each with its tier and a pointer to
+the enforcing test. Owned by Pablo; updated in the same PR as any flow change.
+
 ### QA
 
 **`specs/developing/qa/README.md`**
@@ -316,7 +329,8 @@ Sentry lane requires them.
 The QA root is now an authoritative release QA entrypoint. It covers operator
 requirements, release intake, baseline verification, profile-isolated
 full-stack QA, a touched-surface matrix, regression rules, failure handling,
-and final QA report shape.
+and final QA report shape. Manual QA only — automated testing is owned by
+`specs/developing/testing/`.
 
 The remaining opportunity is depth: split per-surface checklists into
 `specs/developing/qa/*.md` only when release execution needs more detail than


### PR DESCRIPTION
## Summary

Adds the automated-testing spec tree under `specs/developing/testing/` and wires it into the existing spec read maps. Spec-only change, no code.

- **`testing/README.md`** — the four-tier testing model:
  - **Tier 1 — unit/contract**: pure logic + logic against real DB state; contract fixtures under `fixtures/contracts/` for cross-language shapes. Gates **merge**.
  - **Tier 2 — mocked intent**: real server + desktop web frontend + real Postgres, everything third-party (sandbox, LLM, IdP, email, Slack) faked. Gates **merge**.
  - **Tier 3 — live end-to-end**: real E2B template, real AnyHarness binary, real agents on cheap models, nothing faked. Gates **release** (release train + nightly), never merge.
  - **Tier 4 — upgrade path**: N−1 install upgraded in place to N, real artifacts served by a stub update feed. Gates **release**.
  - Hard rule: the merge gate is tiers 1–2 only — no real LLM/sandbox/third-party ever runs in the merge gate, so a tier 3/4 failure blocks staging→prod promotion (and files into the issues service) but never blocks a merge.
  - Also documents per-language placement, the decision procedure for where a change's tests belong, and the postmortem rule (a prod incident that automated tests should have caught gets a new test in the same PR as the fix).
- **`testing/flows.md`** — the flow registry: every end-to-end flow that must never break, each tagged with its tier and a pointer to the enforcing test. Owned by Pablo; updated in the same PR as any flow change.
- **`testing/scenarios.md`** — the blessed contract for the test-infra build: the concrete scenario definitions (fixtures, identities, lanes) that `flows.md` entries and the tier 2/3 runners implement against.
- Cross-links added in `specs/README.md` (Current Read Map), `specs/spec-catalog.md` (new Testing section + QA-is-manual-only clarification), and `specs/developing/README.md` (Read Order + Developer Process Map).

## Test plan

- [x] `python3 scripts/check_max_lines.py` passes (markdown isn't in its checked roots/extensions, confirmed no-op)
- [x] Confirmed the other repo-shape scripts (migration heads, anyharness paths, worker structure, frontend/server boundaries) don't reference `specs/` at all
- [x] Diffed cross-link edits against `specs/README.md`, `specs/spec-catalog.md`, `specs/developing/README.md` to confirm semantic-only edits (no unrelated rewrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)