### PR TITLE
tests(intent): tier-2 harness + auth/invitation specs

### DIFF
--- a/.github/workflows/intent-tests.yml
+++ b/.github/workflows/intent-tests.yml
@@ -1,0 +1,92 @@
+name: Intent Tests
+
+# Tier-2 "mocked intent" suite (specs/developing/testing/README.md §Tier 2):
+# real server + real desktop web frontend + real Postgres, Playwright driving
+# a browser. PROVISIONAL: this job is explicitly NON-blocking while the
+# harness earns trust — do NOT add it to branch-protection required checks
+# yet. Failures are signal to read, not a merge gate. The tier-2 suite joins
+# the merge gate (per the testing standard's CI mapping) once it has a
+# demonstrated flake-free record.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  intent-tests:
+    name: intent-tests (provisional)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    # Provisional posture, enforced twice: the job name says so, and the job
+    # never fails the workflow while it is provisional.
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: proliferate
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: proliferate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proliferate -d proliferate"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install server (venv, matches local layout)
+        run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
+
+      - name: Install Playwright chromium
+        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+
+      - name: Run tier-2 intent suite
+        env:
+          # The boot fixture allocates the t2intent profile itself; on the
+          # runner the Docker services above stand in for the local stack.
+          USE_EXISTING_POSTGRES: "1"
+          USE_EXISTING_REDIS: "1"
+          LOCAL_PGHOST: 127.0.0.1
+          TIER2_INTENT_SKIP_RUNTIME: "1"
+          CI: "true"
+        run: pnpm -C tests/intent test
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-tests-traces
+          path: tests/intent/test-results/
+          retention-days: 7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.2.1(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       lucide-react:
         specifier: 0.577.0
         version: 0.577.0(react@19.2.7)
@@ -703,6 +703,25 @@ importers:
       vite:
         specifier: ^6.4.3
         version: 6.4.3(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  tests/intent:
+    dependencies:
+      pg:
+        specifier: ^8.13.1
+        version: 8.22.0
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.61.1
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
 packages:
 
@@ -2205,6 +2224,11 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@posthog/core@1.32.5':
     resolution: {integrity: sha512-Vmr6LZms7QEP1ljfTRRBVtLkeEHMrTmLECt0FXPLwUIgPwxOgvBdAYwRMWyP13WuN/XQweo1tJ9J1DxHNAF3qg==}
@@ -3728,6 +3752,9 @@ packages:
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -5760,6 +5787,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5787,8 +5848,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.61.0:
     resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5822,6 +5893,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   posthog-js@1.386.8:
     resolution: {integrity: sha512-L4cJD1sleUULE7K4mZQI5wpS24NHGtNmFw1rPHruc579unVzHuooHiVDEHp/qyNnhNxtNE6alBTiVORbYnRTSw==}
@@ -6275,6 +6362,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -6893,6 +6984,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -8618,6 +8713,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.1':
     optional: true
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@posthog/core@1.32.5':
     dependencies:
       '@posthog/types': 1.386.4
@@ -10015,6 +10114,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 24.13.2
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -11100,9 +11205,9 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  geist@1.7.2(next@16.2.1(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.2.1(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.1(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   gensync@1.0.0-beta.2: {}
 
@@ -12381,7 +12486,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@16.2.1(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.1(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
@@ -12400,6 +12505,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.1
       '@next/swc-win32-arm64-msvc': 16.2.1
       '@next/swc-win32-x64-msvc': 16.2.1
+      '@playwright/test': 1.61.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -12578,6 +12684,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -12592,9 +12733,17 @@ snapshots:
 
   playwright-core@1.61.0: {}
 
+  playwright-core@1.61.1: {}
+
   playwright@1.61.0:
     dependencies:
       playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -12633,6 +12782,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   posthog-js@1.386.8:
     dependencies:
@@ -13198,6 +13357,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  split2@4.2.0: {}
+
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -13720,6 +13881,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - "apps/packages/ui"
   - "server/artifact-runtime"
   - "apps/web"
+  - "tests/intent"
 
 allowBuilds:
   "@sentry/cli": true

--- a/tests/intent/.gitignore
+++ b/tests/intent/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/tests/intent/package.json
+++ b/tests/intent/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@proliferate/tests-intent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:auth": "playwright test specs/auth.spec.ts",
+    "test:invitation": "playwright test specs/invitation.spec.ts"
+  },
+  "dependencies": {
+    "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.51.1",
+    "@types/node": "^24.13.2",
+    "@types/pg": "^8.11.10",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/intent/playwright.config.ts
+++ b/tests/intent/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+// Tier-2 mocked-intent suite (specs/developing/testing/README.md §Tier 2).
+// One stack boot per run (globalSetup), spec files run serially within a
+// single worker: the suite shares one claimed single-org instance and one
+// Postgres DB, so parallel workers would race on org/invitation state.
+export default defineConfig({
+  testDir: "./specs",
+  globalSetup: "./stack/global-setup.ts",
+  workers: 1,
+  fullyParallel: false,
+  // Local runs and CI both get one retry: the stack is real (uvicorn + vite
+  // cold start), not mocked, so first-contact flake is possible; a green
+  // retry is meaningful, repeated red is a real failure.
+  retries: 1,
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI ? [["list"], ["github"]] : [["list"]],
+  use: {
+    baseURL: process.env.TIER2_INTENT_WEB_BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/tests/intent/specs/auth.spec.ts
+++ b/tests/intent/specs/auth.spec.ts
@@ -1,0 +1,207 @@
+// T2-AUTH-1 + T2-AUTH-2 (specs/developing/testing/scenarios.md).
+//
+// T2-AUTH-1: setup claim + password login lifecycle.
+//   Fresh DB, SINGLE_ORG_MODE=true. Visit /setup → claim instance, set
+//   password → logout → log back in via the password login through the UI.
+//   Assert: claim succeeds once; re-visiting /setup shows already-claimed;
+//   post-login the app shell renders with the seeded user.
+//   Negatives: wrong password rejected; second claim attempt rejected.
+//
+// T2-AUTH-2: session revocation.
+//   Log in in context A; revoke the session; context A performs any
+//   authenticated call. Assert: the call fails and the UI returns to
+//   signed-out state.
+//
+// Desktop-web conventions (scenarios.md): auth falls back to localStorage;
+// nothing here goes near lib/access/tauri/credentials.ts.
+
+import { expect, test, type Page } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_ORG_NAME,
+  ADMIN_PASSWORD,
+  apiBaseUrl,
+  apiRequest,
+  ensureInstanceClaimed,
+  passwordLogin,
+  readSetupToken,
+  resetPasswordLoginRateLimits,
+  webBaseUrl,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+// This file deliberately fails logins (wrong password, nonexistent account).
+// The product's limiter counts those per client IP (5 / 15 min) and every
+// context here shares 127.0.0.1, so without clearing between tests the
+// negatives would 429 later legitimate logins — limiter crosstalk, not the
+// behavior under test. (A successful login only clears the email bucket.)
+test.afterEach(async () => {
+  await resetPasswordLoginRateLimits();
+});
+
+async function signInThroughUi(page: Page, email: string, password: string): Promise<void> {
+  await page.goto(webBaseUrl());
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+}
+
+async function expectSignedInAppShell(page: Page): Promise<void> {
+  // Past the auth gate: the login form is gone and the app shell owns the page.
+  await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+  await expect
+    .poll(async () => {
+      const raw = await page.evaluate(() => window.localStorage.getItem("proliferate.auth.session"));
+      return raw ? (JSON.parse(raw) as { email?: string }).email ?? null : null;
+    }, { timeout: 30_000 })
+    .toBe(ADMIN_EMAIL);
+}
+
+test.describe("T2-AUTH-1: setup claim + password login lifecycle", () => {
+  test("claims the instance once via /setup, then re-visiting shows already-claimed", async ({ page }) => {
+    // The claim races nothing: this spec file runs first (serial, 1 worker)
+    // against a fresh profile DB, so /setup must be open unless a previous
+    // local run already claimed it (then we only assert the closed state).
+    const probe = await fetch(`${apiBaseUrl()}/setup`);
+    if (probe.status !== 404) {
+      const token = readSetupToken();
+      await page.goto(`${apiBaseUrl()}/setup`);
+      await expect(page.getByRole("heading", { name: "Set up Proliferate" })).toBeVisible();
+      await page.getByLabel("Email").fill(ADMIN_EMAIL);
+      await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+      await page.getByLabel("Organization name").fill(ADMIN_ORG_NAME);
+      await page.getByLabel("Setup token").fill(token);
+      await page.getByRole("button", { name: "Claim this instance" }).click();
+      await expect(page.getByRole("heading", { name: "You are all set" })).toBeVisible();
+      await expect(page.getByText(ADMIN_EMAIL)).toBeVisible();
+    }
+
+    // Claim closes /setup permanently: "Not found — there is nothing to set
+    // up here" IS the success state on re-visit (feature-worktree-auth.md).
+    // Poll the server first (uncached) — the page render right after the
+    // claim can race the boot-time token-cleanup task's session.
+    await expect
+      .poll(async () => (await fetch(`${apiBaseUrl()}/setup`)).status, { timeout: 15_000 })
+      .toBe(404);
+    await page.goto(`${apiBaseUrl()}/setup`);
+    await expect(page.getByRole("heading", { name: "Not found" })).toBeVisible();
+    await expect(page.getByText("There is nothing to set up here.")).toBeVisible();
+  });
+
+  test("second claim attempt is rejected (setup permanently closed)", async () => {
+    await ensureInstanceClaimed();
+    // POSTing the form again — even with a plausible token — must be a 404,
+    // never a second account.
+    const response = await fetch(`${apiBaseUrl()}/setup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        email: "second-claimer@t2intent.example.com",
+        password: "AnotherPassw0rd!",
+        setup_token: "any-token-at-all",
+        organization_name: "Should Never Exist",
+      }).toString(),
+    });
+    expect(response.status).toBe(404);
+    // And the would-be account must not authenticate.
+    const login = await apiRequest("/auth/desktop/password/login", {
+      method: "POST",
+      body: { email: "second-claimer@t2intent.example.com", password: "AnotherPassw0rd!" },
+    });
+    expect(login.status).toBe(401);
+  });
+
+  test("logs in through the desktop-web UI with the claimed password", async ({ page }) => {
+    await ensureInstanceClaimed();
+    await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expectSignedInAppShell(page);
+  });
+
+  test("negative: wrong password is rejected with the uniform error", async ({ page }) => {
+    await ensureInstanceClaimed();
+    await signInThroughUi(page, ADMIN_EMAIL, "definitely-not-the-password");
+    await expect(page.getByText("Email or password is incorrect.")).toBeVisible();
+    // Still signed out: the password form remains.
+    await expect(page.getByLabel("Password")).toBeVisible();
+  });
+
+  test("logout returns the UI to signed-out state and re-login works", async ({ page }) => {
+    await ensureInstanceClaimed();
+    await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expectSignedInAppShell(page);
+
+    // Sign out via Settings → Account.
+    await page.goto(`${webBaseUrl()}/settings?section=account`);
+    await page.getByRole("button", { name: "Sign out" }).click();
+    // Signed-out state: back to the login surface with the password form.
+    await expect(page.getByLabel("Password")).toBeVisible({ timeout: 30_000 });
+    const stored = await page.evaluate(() => window.localStorage.getItem("proliferate.auth.session"));
+    expect(stored).toBeNull();
+
+    // Log back in via POST /auth/.../password/login through the UI.
+    await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expectSignedInAppShell(page);
+  });
+});
+
+test.describe("T2-AUTH-2: session revocation", () => {
+  test("revoking the session makes context A's authenticated calls fail and the UI signs out", async ({ page }) => {
+    await ensureInstanceClaimed();
+
+    // Context A: a real signed-in browser session.
+    await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expectSignedInAppShell(page);
+
+    // Capture context A's credential (the token the app holds), then prove it
+    // authenticates right now.
+    const contextAToken = await page.evaluate(() => {
+      const raw = window.localStorage.getItem("proliferate.auth.session");
+      return raw ? (JSON.parse(raw) as { access_token: string }).access_token : null;
+    });
+    expect(contextAToken).toBeTruthy();
+    const before = await page.request.get(`${apiBaseUrl()}/users/me`, {
+      headers: { Authorization: `Bearer ${contextAToken}` },
+    });
+    expect(before.status()).toBe(200);
+
+    // Revoke from "elsewhere" (context B): a password change bumps the user's
+    // token_generation, revoking every previously issued access and refresh
+    // token on ALL surfaces — the same mechanism the product's logout and
+    // "log out everywhere" paths use (auth/identity/sessions.py). This is the
+    // all-surface revocation the product exposes to an API caller.
+    const contextB = await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD);
+    const NEW_PASSWORD = "Tier2Intent!Passw0rd2";
+    const change = await apiRequest("/auth/password", {
+      method: "PUT",
+      token: contextB.access_token,
+      body: { current_password: ADMIN_PASSWORD, new_password: NEW_PASSWORD },
+    });
+    expect(change.status).toBe(200);
+    // Restore the canonical password for the specs that follow (the change
+    // above bumped token_generation — the revocation under test — and this
+    // second change bumps it again, which only strengthens the assertion).
+    const freshTokens = await passwordLogin(ADMIN_EMAIL, NEW_PASSWORD);
+    const restore = await apiRequest("/auth/password", {
+      method: "PUT",
+      token: freshTokens.access_token,
+      body: { current_password: NEW_PASSWORD, new_password: ADMIN_PASSWORD },
+    });
+    expect(restore.status).toBe(200);
+
+    // Context A's captured token is now dead server-side.
+    const after = await page.request.get(`${apiBaseUrl()}/users/me`, {
+      headers: { Authorization: `Bearer ${contextAToken}` },
+    });
+    expect(after.status()).toBe(401);
+
+    // And the UI returns to signed-out state: reload → bootstrap validates the
+    // stored session against the server, gets the definitive 401 (refresh is
+    // revoked too), clears it, and lands on the login screen.
+    await page.reload();
+    await expect(page.getByLabel("Password")).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(async () => page.evaluate(() => window.localStorage.getItem("proliferate.auth.session")))
+      .toBeNull();
+  });
+});

--- a/tests/intent/specs/invitation.spec.ts
+++ b/tests/intent/specs/invitation.spec.ts
@@ -8,9 +8,13 @@
 //   (organization_invitations.py), never by obscurity.
 // - Email delivery via Resend is skipped locally (no RESEND_API_KEY) and
 //   recorded as delivery_status='skipped'. Assert that; never expect an email.
-// - Accept is driven through the desktop-web settings UI
-//   (CurrentUserInvitationsSection on the Members pane), which calls
-//   POST /organizations/invitations/current/{id}/accept.
+// - Accept surface: in single-org mode the invite email links to the
+//   server-rendered /register page (invitation_delivery.py) — that is the
+//   product's own accept path and the happy-path drives it. The hosted-style
+//   settings-UI accept (CurrentUserInvitationsSection →
+//   POST /organizations/invitations/current/{id}/accept) is admin-gated in
+//   settings navigation, unreachable for a plain invitee — pinned as a
+//   documented product gap in its own test below.
 // - Duplicate pending invite for the same (org, email): the partial unique
 //   index uq_organization_invitation_pending_email guarantees at most one
 //   pending row; the product's create path is upsert-on-conflict (rotate), so
@@ -21,6 +25,7 @@ import {
   ADMIN_EMAIL,
   ADMIN_PASSWORD,
   acceptCurrentInvitation,
+  apiBaseUrl,
   apiRequest,
   backdateInvitationExpiry,
   ensureInstanceClaimed,
@@ -68,47 +73,45 @@ async function ensureInviteeAccount(email: string, password: string): Promise<vo
 }
 
 test.describe("T2-INV-1: invitation happy path", () => {
-  test("admin invites → pending row with skipped delivery → invitee accepts via settings UI → active membership", async ({ page }) => {
-    // The registration path (used for seeding the account) auto-consumes the
-    // invitation, so mint the account first, remove the membership it
-    // created, then send the invitation under test.
-    await ensureInviteeAccount(INVITEE_EMAIL, INVITEE_PASSWORD);
-    const preMembers = await listMembers(adminToken, organizationId);
-    const existing = preMembers.find((member) => member.email === INVITEE_EMAIL);
-    if (existing && existing.status === "active") {
-      const removed = await apiRequest(
-        `/v1/organizations/${organizationId}/members/${existing.membership_id}`,
-        { method: "DELETE", token: adminToken },
-      );
-      expect(removed.status).toBe(200);
-    }
+  // Fresh email per run: the happy path exercises the full first-contact
+  // journey (invite → register → member), which is single-use by design.
+  const FRESH_INVITEE_EMAIL = `invitee-${Date.now()}@t2intent.example.com`;
+  const FRESH_INVITEE_PASSWORD = "FreshInvitee!Passw0rd";
 
-    const invitation = await inviteMember(adminToken, organizationId, INVITEE_EMAIL, "member");
+  test("admin invites → pending row with skipped delivery → invitee joins via the invite link → active membership", async ({ page }) => {
+    // NOTE — as-built single-org reality vs the scenario's hosted wording:
+    // in single-org mode the invite email links to the server-rendered
+    // /register page with the invitation id as the token
+    // (invitation_delivery.py chooses invitation_registration_url when
+    // settings.single_org_mode). THAT page is the invitee's accept surface;
+    // registration itself activates the membership and completes the
+    // invitation in one transaction (self_registration.py). The hosted
+    // CurrentUserInvitationsSection path is asserted (as a documented gap)
+    // in the next test.
+    const invitation = await inviteMember(adminToken, organizationId, FRESH_INVITEE_EMAIL, "member");
     expect(invitation.status).toBe("pending");
-    // Locally Resend is unconfigured → the durable delivery marks 'skipped'.
-    expect(["sent", "skipped"]).toContain(invitation.delivery_status);
-    expect(invitation.delivery_status).toBe("skipped");
+    // Locally Resend is unconfigured → the durable delivery marks 'skipped'
+    // (delivery_status ∈ {sent, skipped} per the contract; skipped here).
+    expect(["sent", "skipped"]).toContain(invitation.deliveryStatus);
+    expect(invitation.deliveryStatus).toBe("skipped");
 
-    // Invitee signs in on the desktop web app and accepts through the UI.
-    await page.goto(webBaseUrl());
-    await page.getByLabel("Email").fill(INVITEE_EMAIL);
-    await page.getByLabel("Password").fill(INVITEE_PASSWORD);
-    await page.getByRole("button", { name: "Sign in", exact: true }).click();
-    await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
-
-    // Members pane (GET /organizations/invitations/current backs this section).
-    await page.goto(`${webBaseUrl()}/settings?section=organization-members`);
-    await expect(page.getByText("Pending invitations")).toBeVisible({ timeout: 30_000 });
-    await page.getByRole("button", { name: "Accept invitation" }).first().click();
-    // Confirmation dialog → Join.
-    await page.getByRole("button", { name: "Join", exact: true }).click();
-    await expect(page.getByText(/^Joined /).first()).toBeVisible({ timeout: 30_000 });
+    // Open the invite link the email would carry and complete registration.
+    await page.goto(
+      `${apiBaseUrl()}/register?token=${invitation.id}&email=${encodeURIComponent(FRESH_INVITEE_EMAIL)}`,
+    );
+    await expect(page.getByRole("heading", { name: "Join this Proliferate instance" })).toBeVisible();
+    // Token and email arrive prefilled from the link.
+    await expect(page.getByLabel("Invitation token")).toHaveValue(invitation.id);
+    await expect(page.getByLabel("Email")).toHaveValue(FRESH_INVITEE_EMAIL);
+    await page.getByLabel("Password").fill(FRESH_INVITEE_PASSWORD);
+    await page.getByRole("button", { name: "Create account" }).click();
+    await expect(page.getByRole("heading", { name: "You are all set" })).toBeVisible();
 
     // Server-side assertions: membership active with invited role; invitation
     // accepted with accepted_by_user_id; org appears in the invitee's list.
-    const inviteeToken = (await passwordLogin(INVITEE_EMAIL, INVITEE_PASSWORD)).access_token;
+    const inviteeToken = (await passwordLogin(FRESH_INVITEE_EMAIL, FRESH_INVITEE_PASSWORD)).access_token;
     const members = await listMembers(adminToken, organizationId);
-    const membership = members.find((member) => member.email === INVITEE_EMAIL);
+    const membership = members.find((member) => member.email === FRESH_INVITEE_EMAIL);
     expect(membership).toBeDefined();
     expect(membership!.status).toBe("active");
     expect(membership!.role).toBe("member");
@@ -117,10 +120,62 @@ test.describe("T2-INV-1: invitation happy path", () => {
     const acceptedRow = adminView.find((row) => row.id === invitation.id);
     expect(acceptedRow).toBeDefined();
     expect(acceptedRow!.status).toBe("accepted");
-    expect(acceptedRow!.accepted_by_user_id).toBe(membership!.user_id);
+    expect(acceptedRow!.acceptedByUserId).toBe(membership!.userId);
 
     const inviteeOrg = await getOwnOrganization(inviteeToken);
     expect(inviteeOrg.id).toBe(organizationId);
+
+    // UI leg: the new member signs into the desktop web app and lands in the
+    // app shell (their membership is live end to end).
+    await page.goto(webBaseUrl());
+    await page.getByLabel("Email").fill(FRESH_INVITEE_EMAIL);
+    await page.getByLabel("Password").fill(FRESH_INVITEE_PASSWORD);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+    await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+  });
+
+  test("documents GAP: pending-invitation accept UI is unreachable for a non-admin invitee (settings admin gate)", async ({ page }) => {
+    // PRODUCT GAP surfaced by this harness (named in the PR body): the
+    // scenario contract says the invitee accepts via the desktop-web settings
+    // UI (CurrentUserInvitationsSection, on the organization-members pane).
+    // But `organization-members` is adminOnly in settings navigation
+    // (lib/domain/settings/navigation-presentation.ts) and SettingsScreen
+    // redirects non-admins to General — so a plain member/invitee can never
+    // see their pending invitations there in single-org mode. The endpoint
+    // the UI would call works (asserted below); only the surface is gated.
+    // This test pins the CURRENT (gated) behavior so a fix flips it loudly.
+    const invitee = (await passwordLogin(FRESH_INVITEE_EMAIL, FRESH_INVITEE_PASSWORD));
+
+    // Give the invitee a pending invitation so the section would have content
+    // if it were reachable. (Inviting an existing member is allowed; accept
+    // then simply marks the invitation accepted against the live membership.)
+    const invitation = await inviteMember(adminToken, organizationId, FRESH_INVITEE_EMAIL, "member");
+    const listed = await listInvitationsCurrent(invitee.access_token);
+    expect(listed.find((row) => row.id === invitation.id)).toBeDefined();
+
+    // Sign in as the (non-admin) invitee and try to open the Members pane.
+    await page.goto(webBaseUrl());
+    await page.getByLabel("Email").fill(FRESH_INVITEE_EMAIL);
+    await page.getByLabel("Password").fill(FRESH_INVITEE_PASSWORD);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+    await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+    await page.goto(`${webBaseUrl()}/settings?section=organization-members`);
+    // Redirected away: the URL settles on the default (general) section.
+    await expect(page).toHaveURL(/section=general/, { timeout: 30_000 });
+
+    // The accept endpoint itself works for the same user — completing the
+    // acceptance the UI could not offer.
+    const accept = await acceptCurrentInvitation(invitee.access_token, invitation.id);
+    expect(accept.status).toBe(200);
+    // Poll: the accept endpoint's transaction commits in the session
+    // dependency teardown, which can land a beat after the response is
+    // written — a fresh read too fast can still see 'pending'.
+    await expect
+      .poll(async () => {
+        const adminView = await listOrganizationInvitations(adminToken, organizationId);
+        return adminView.find((row) => row.id === invitation.id)?.status;
+      }, { timeout: 10_000 })
+      .toBe("accepted");
   });
 
   test("negative: expired invitation cannot be accepted and is lazily marked expired", async () => {
@@ -129,7 +184,7 @@ test.describe("T2-INV-1: invitation happy path", () => {
     const members = await listMembers(adminToken, organizationId);
     const otherMembership = members.find((member) => member.email === OTHER_EMAIL);
     if (otherMembership && otherMembership.status === "active") {
-      await apiRequest(`/v1/organizations/${organizationId}/members/${otherMembership.membership_id}`, {
+      await apiRequest(`/v1/organizations/${organizationId}/members/${otherMembership.membershipId}`, {
         method: "DELETE",
         token: adminToken,
       });

--- a/tests/intent/specs/invitation.spec.ts
+++ b/tests/intent/specs/invitation.spec.ts
@@ -1,0 +1,229 @@
+// T2-INV-1 (specs/developing/testing/scenarios.md): invitation happy path +
+// the four negatives (expired, revoked, wrong-email, duplicate-pending).
+//
+// Survey facts that shape this test (scenarios.md, verified against code):
+// - There is NO secret invite token. The invitation UUID is the reference and
+//   acceptance is authorized by the authenticated user's email matching
+//   invitation.email (normalized). Wrong email → rejected by the store
+//   (organization_invitations.py), never by obscurity.
+// - Email delivery via Resend is skipped locally (no RESEND_API_KEY) and
+//   recorded as delivery_status='skipped'. Assert that; never expect an email.
+// - Accept is driven through the desktop-web settings UI
+//   (CurrentUserInvitationsSection on the Members pane), which calls
+//   POST /organizations/invitations/current/{id}/accept.
+// - Duplicate pending invite for the same (org, email): the partial unique
+//   index uq_organization_invitation_pending_email guarantees at most one
+//   pending row; the product's create path is upsert-on-conflict (rotate), so
+//   the enforced behavior is "still exactly one pending row", not an error.
+
+import { expect, test } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  acceptCurrentInvitation,
+  apiRequest,
+  backdateInvitationExpiry,
+  ensureInstanceClaimed,
+  inviteMember,
+  listInvitationsCurrent,
+  listMembers,
+  listOrganizationInvitations,
+  getOwnOrganization,
+  passwordLogin,
+  registerInvitedAccount,
+  revokeInvitation,
+  webBaseUrl,
+  type InvitationSummary,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+const INVITEE_EMAIL = "invitee@t2intent.example.com";
+const INVITEE_PASSWORD = "Invitee!Passw0rd";
+const OTHER_EMAIL = "other@t2intent.example.com";
+const OTHER_PASSWORD = "Other!Passw0rd";
+
+let adminToken: string;
+let organizationId: string;
+
+test.beforeAll(async () => {
+  await ensureInstanceClaimed();
+  adminToken = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+  organizationId = (await getOwnOrganization(adminToken)).id;
+});
+
+/** Seed a password account for `email` if it does not exist yet, using the
+ * product's invite-as-allowlist registration (single-org mode's only
+ * self-serve account path). Requires a live pending invitation; creates and
+ * consumes one. Idempotent per email. */
+async function ensureInviteeAccount(email: string, password: string): Promise<void> {
+  try {
+    await passwordLogin(email, password);
+    return; // Account already exists from a previous run.
+  } catch {
+    // Fall through and register it.
+  }
+  const invitation = await inviteMember(adminToken, organizationId, email, "member");
+  await registerInvitedAccount({ email, password, invitationToken: invitation.id });
+}
+
+test.describe("T2-INV-1: invitation happy path", () => {
+  test("admin invites → pending row with skipped delivery → invitee accepts via settings UI → active membership", async ({ page }) => {
+    // The registration path (used for seeding the account) auto-consumes the
+    // invitation, so mint the account first, remove the membership it
+    // created, then send the invitation under test.
+    await ensureInviteeAccount(INVITEE_EMAIL, INVITEE_PASSWORD);
+    const preMembers = await listMembers(adminToken, organizationId);
+    const existing = preMembers.find((member) => member.email === INVITEE_EMAIL);
+    if (existing && existing.status === "active") {
+      const removed = await apiRequest(
+        `/v1/organizations/${organizationId}/members/${existing.membership_id}`,
+        { method: "DELETE", token: adminToken },
+      );
+      expect(removed.status).toBe(200);
+    }
+
+    const invitation = await inviteMember(adminToken, organizationId, INVITEE_EMAIL, "member");
+    expect(invitation.status).toBe("pending");
+    // Locally Resend is unconfigured → the durable delivery marks 'skipped'.
+    expect(["sent", "skipped"]).toContain(invitation.delivery_status);
+    expect(invitation.delivery_status).toBe("skipped");
+
+    // Invitee signs in on the desktop web app and accepts through the UI.
+    await page.goto(webBaseUrl());
+    await page.getByLabel("Email").fill(INVITEE_EMAIL);
+    await page.getByLabel("Password").fill(INVITEE_PASSWORD);
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+    await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+
+    // Members pane (GET /organizations/invitations/current backs this section).
+    await page.goto(`${webBaseUrl()}/settings?section=organization-members`);
+    await expect(page.getByText("Pending invitations")).toBeVisible({ timeout: 30_000 });
+    await page.getByRole("button", { name: "Accept invitation" }).first().click();
+    // Confirmation dialog → Join.
+    await page.getByRole("button", { name: "Join", exact: true }).click();
+    await expect(page.getByText(/^Joined /).first()).toBeVisible({ timeout: 30_000 });
+
+    // Server-side assertions: membership active with invited role; invitation
+    // accepted with accepted_by_user_id; org appears in the invitee's list.
+    const inviteeToken = (await passwordLogin(INVITEE_EMAIL, INVITEE_PASSWORD)).access_token;
+    const members = await listMembers(adminToken, organizationId);
+    const membership = members.find((member) => member.email === INVITEE_EMAIL);
+    expect(membership).toBeDefined();
+    expect(membership!.status).toBe("active");
+    expect(membership!.role).toBe("member");
+
+    const adminView = await listOrganizationInvitations(adminToken, organizationId);
+    const acceptedRow = adminView.find((row) => row.id === invitation.id);
+    expect(acceptedRow).toBeDefined();
+    expect(acceptedRow!.status).toBe("accepted");
+    expect(acceptedRow!.accepted_by_user_id).toBe(membership!.user_id);
+
+    const inviteeOrg = await getOwnOrganization(inviteeToken);
+    expect(inviteeOrg.id).toBe(organizationId);
+  });
+
+  test("negative: expired invitation cannot be accepted and is lazily marked expired", async () => {
+    await ensureInviteeAccount(OTHER_EMAIL, OTHER_PASSWORD);
+    // Make sure OTHER is not an active member (registration made them one).
+    const members = await listMembers(adminToken, organizationId);
+    const otherMembership = members.find((member) => member.email === OTHER_EMAIL);
+    if (otherMembership && otherMembership.status === "active") {
+      await apiRequest(`/v1/organizations/${organizationId}/members/${otherMembership.membership_id}`, {
+        method: "DELETE",
+        token: adminToken,
+      });
+    }
+
+    const invitation = await inviteMember(adminToken, organizationId, OTHER_EMAIL, "member");
+    await backdateInvitationExpiry(invitation.id, new Date(Date.now() - 60_000));
+
+    const otherToken = (await passwordLogin(OTHER_EMAIL, OTHER_PASSWORD)).access_token;
+
+    // The list endpoint lazily marks expired: the invitation must not be listed.
+    const listed = await listInvitationsCurrent(otherToken);
+    expect(listed.find((row) => row.id === invitation.id)).toBeUndefined();
+
+    // Direct accept → enumerated error, not a 500.
+    const accept = await acceptCurrentInvitation(otherToken, invitation.id);
+    expect(accept.status).toBe(404);
+    const detail = (accept.body as { detail?: { code?: string } }).detail;
+    expect(["invitation_expired", "invalid_invitation"]).toContain(detail?.code);
+
+    // Lazy transition persisted: the admin's list shows status=expired.
+    const adminView = await listOrganizationInvitations(adminToken, organizationId);
+    const row = adminView.find((item) => item.id === invitation.id);
+    expect(row).toBeDefined();
+    expect(row!.status).toBe("expired");
+  });
+
+  test("negative: revoked invitation cannot be accepted", async () => {
+    const invitation = await inviteMember(adminToken, organizationId, OTHER_EMAIL, "member");
+    const revoked = await revokeInvitation(adminToken, organizationId, invitation.id);
+    expect(revoked.status).toBe(200);
+    expect((revoked.body as InvitationSummary).status).toBe("revoked");
+
+    const otherToken = (await passwordLogin(OTHER_EMAIL, OTHER_PASSWORD)).access_token;
+    const listed = await listInvitationsCurrent(otherToken);
+    expect(listed.find((row) => row.id === invitation.id)).toBeUndefined();
+
+    const accept = await acceptCurrentInvitation(otherToken, invitation.id);
+    expect(accept.status).toBe(404);
+    const detail = (accept.body as { detail?: { code?: string } }).detail;
+    expect(detail?.code).toBe("invalid_invitation");
+  });
+
+  test("negative: wrong email — invitation not listed and direct accept with the known UUID rejected", async () => {
+    // Invitation addressed to INVITEE; OTHER (authenticated) tries to take it.
+    const invitation = await inviteMember(adminToken, organizationId, INVITEE_EMAIL, "member");
+
+    const otherToken = (await passwordLogin(OTHER_EMAIL, OTHER_PASSWORD)).access_token;
+    const listed = await listInvitationsCurrent(otherToken);
+    expect(listed.find((row) => row.id === invitation.id)).toBeUndefined();
+
+    // Direct accept call with the known UUID → rejected (email mismatch). The
+    // per-id accept path scopes the lookup by the caller's email, so the
+    // mismatch surfaces as invalid_invitation (404) — the caller cannot even
+    // confirm the UUID exists.
+    const accept = await acceptCurrentInvitation(otherToken, invitation.id);
+    expect([403, 404]).toContain(accept.status);
+    const detail = (accept.body as { detail?: { code?: string } }).detail;
+    expect(["invitation_email_mismatch", "invalid_invitation"]).toContain(detail?.code);
+
+    // The invitation is untouched for its rightful owner.
+    const adminView = await listOrganizationInvitations(adminToken, organizationId);
+    const row = adminView.find((item) => item.id === invitation.id);
+    expect(row!.status).toBe("pending");
+
+    // Cleanup so later runs start clean.
+    await revokeInvitation(adminToken, organizationId, invitation.id);
+  });
+
+  test("negative: duplicate pending invite for the same (org, email) — the partial unique index guarantees one pending row", async () => {
+    // SPEC DIVERGENCE (flagged for the scenario contract): scenarios.md words
+    // this negative as "rejected by partial unique index → enumerated error",
+    // but the as-built create path (db/store/organization_invitations.py
+    // create_or_rotate_organization_invitation) deliberately does NOT reject:
+    // it expires the existing pending invitation and mints a fresh one
+    // (rotate), with ON CONFLICT DO UPDATE as the concurrency backstop on the
+    // partial unique index uq_organization_invitation_pending_email. The
+    // invariant the index enforces — at most ONE live pending invitation per
+    // (org, email) — is what this test pins.
+    const first = await inviteMember(adminToken, organizationId, OTHER_EMAIL, "member");
+    const second = await inviteMember(adminToken, organizationId, OTHER_EMAIL, "admin");
+    expect(second.id).not.toBe(first.id); // Rotated: fresh row, old one expired.
+    expect(second.role).toBe("admin");
+
+    const adminView = await listOrganizationInvitations(adminToken, organizationId);
+    const pendingForEmail = adminView.filter(
+      (row) => row.email === OTHER_EMAIL && row.status === "pending",
+    );
+    expect(pendingForEmail).toHaveLength(1);
+    expect(pendingForEmail[0].id).toBe(second.id);
+    const firstRow = adminView.find((row) => row.id === first.id);
+    expect(firstRow!.status).toBe("expired");
+
+    // Cleanup.
+    await revokeInvitation(adminToken, organizationId, second.id);
+  });
+});

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -297,7 +297,12 @@ export async function bootStack(): Promise<BootedStack> {
   // Settings/auth/org/invitation surfaces (this suite's scope) don't read
   // through the runtime, but booting it keeps the app shell from showing a
   // persistent "runtime unavailable" state that could shadow assertions.
-  try {
+  // TIER2_INTENT_SKIP_RUNTIME=1 (CI) skips it entirely: building the Rust
+  // binary from scratch is far too slow for a per-PR job, and no current
+  // scenario needs it.
+  if (process.env.TIER2_INTENT_SKIP_RUNTIME === "1") {
+    log("skipping AnyHarness runtime (TIER2_INTENT_SKIP_RUNTIME=1)");
+  } else try {
     const runtimeBin = resolveAnyharnessRuntimeBin();
     spawnTracked(
       children,

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -258,9 +258,9 @@ export async function bootStack(): Promise<BootedStack> {
   rmSync(setupTokenFile, { force: true });
 
   log(`running alembic migrations against ${instance.databaseName}...`);
-  run("server/.venv/bin/alembic", ["upgrade", "head"], {
+  run(path.join(REPO_ROOT, "server", ".venv", "bin", "alembic"), ["upgrade", "head"], {
     cwd: path.join(REPO_ROOT, "server"),
-    env: { DATABASE_URL: databaseUrl },
+    env: { DATABASE_URL: databaseUrl, DEBUG: "true" },
   });
 
   mkdirSync(instance.anyharnessRuntimeHome, { recursive: true });

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -1,0 +1,360 @@
+// Tier-2 "mocked intent" stack-boot fixture.
+//
+// Boots a real server (FastAPI/uvicorn) + real desktop web frontend (Vite,
+// `apps/desktop` in web-port mode) against a seeded Postgres, on a dedicated,
+// profile-isolated port set. Nothing here fakes the sandbox provider or an
+// LLM (that's the tier-2 rule, see specs/developing/testing/README.md) — the
+// only things faked at this boundary are auth-adjacent externals (mock IdP,
+// email capture, Stripe test mode), and this suite doesn't even need those.
+//
+// Profile name is fixed to `t2intent` per
+// specs/developing/local/dev-profiles.md (one profile per worktree/purpose,
+// never `main`, kept for this suite's lifetime since it owns its own
+// Postgres DB).
+//
+// Reuses the same primitives `make run PROFILE=<name>` uses
+// (scripts/dev.mjs for port/profile allocation, alembic for migrations)
+// rather than shelling out to `make run` itself, because `make run` always
+// launches the Tauri desktop shell — tier 2 needs the desktop **web** build
+// (`pnpm dev` / vite) per specs/developing/testing/scenarios.md's stated
+// convention ("desktop web build (`pnpm dev` on PROLIFERATE_WEB_PORT)").
+
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PROFILE = "t2intent";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(here, "..", "..", "..");
+
+export interface BootedStack {
+  profile: string;
+  apiBaseUrl: string;
+  webBaseUrl: string;
+  databaseUrl: string;
+  setupTokenFile: string;
+  /** Kill every process this boot spawned. Safe to call more than once. */
+  teardown: () => Promise<void>;
+}
+
+interface ProfileInstance {
+  profile: string;
+  anyharnessRuntimeHome: string;
+  desktopHome: string;
+  databaseName: string;
+  ports: {
+    api: number;
+    desktopWeb: number;
+    hostedWeb: number;
+    mobileWeb: number;
+    hmr: number;
+    anyharness: number;
+  };
+}
+
+function log(message: string): void {
+  // eslint-disable-next-line no-console
+  console.log(`[tier2-intent/boot] ${message}`);
+}
+
+function run(command: string, args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): string {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? REPO_ROOT,
+    env: { ...process.env, ...(options.env ?? {}) },
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || "").trim();
+    throw new Error(`${command} ${args.join(" ")} failed (${result.status}): ${detail}`);
+  }
+  return result.stdout.trim();
+}
+
+function localPgHost(): string {
+  if (process.env.LOCAL_PGHOST) {
+    return process.env.LOCAL_PGHOST;
+  }
+  // Matches the Makefile's OS-conditional default: Docker Desktop's Postgres
+  // listener on macOS is reached over ::1 so it isn't confused with a
+  // Homebrew Postgres bound to 127.0.0.1.
+  return process.platform === "darwin" ? "::1" : "127.0.0.1";
+}
+
+function profileInstancePath(profile: string): string {
+  return path.join(
+    process.env.HOME ?? "",
+    ".proliferate-local",
+    "dev",
+    "profiles",
+    profile,
+    "instance.json",
+  );
+}
+
+function ensureProfilePorts(profile: string): ProfileInstance {
+  run("node", ["scripts/dev.mjs", "ensure", "--profile", profile, "--lock"]);
+  const raw = readFileSync(profileInstancePath(profile), "utf8");
+  return JSON.parse(raw) as ProfileInstance;
+}
+
+function ensureDatabase(dbName: string): void {
+  run("node", ["scripts/dev.mjs", "ensure-db", "--db-name", dbName], {
+    env: { USE_EXISTING_POSTGRES: "1" },
+  });
+}
+
+function databaseUrlFor(dbName: string): string {
+  return run("node", ["scripts/dev.mjs", "database-url", "--db-name", dbName], {
+    env: { LOCAL_PGHOST: localPgHost() },
+  });
+}
+
+function ensureRedisReachable(): void {
+  const result = spawnSync("make", ["server-redis-ready"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    log(`warning: could not confirm local Redis is ready (${(result.stderr || "").trim()}); continuing anyway`);
+  }
+}
+
+function pathHasDist(relative: string): boolean {
+  return existsSync(path.join(REPO_ROOT, relative, "dist"));
+}
+
+/** Shared frontend packages are consumed as built dist by apps/desktop; build
+ * them once (skips packages that already have a dist dir) instead of relying
+ * on HMR, matching apps/desktop's own `dev:built` script. */
+function ensureFrontendBuilt(): void {
+  const packages: Array<{ filter: string; path: string }> = [
+    { filter: "@anyharness/sdk", path: "anyharness/sdk" },
+    { filter: "@anyharness/sdk-react", path: "anyharness/sdk-react" },
+    { filter: "@proliferate/cloud-sdk", path: "cloud/sdk" },
+    { filter: "@proliferate/cloud-sdk-react", path: "cloud/sdk-react" },
+    { filter: "@proliferate/design", path: "apps/packages/design" },
+    { filter: "@proliferate/product-domain", path: "apps/packages/product-domain" },
+    { filter: "@proliferate/ui", path: "apps/packages/ui" },
+    { filter: "@proliferate/product-ui", path: "apps/packages/product-ui" },
+    { filter: "@proliferate/product-surfaces", path: "apps/packages/product-surfaces" },
+  ];
+  for (const pkg of packages) {
+    if (pathHasDist(pkg.path)) {
+      continue;
+    }
+    log(`building ${pkg.filter} (no dist found)...`);
+    run("pnpm", ["--filter", pkg.filter, "build"]);
+  }
+}
+
+function resolveAnyharnessRuntimeBin(): string {
+  if (process.env.ANYHARNESS_DEV_RUNTIME_BIN) {
+    return process.env.ANYHARNESS_DEV_RUNTIME_BIN;
+  }
+  // The shared prebuilt binary local dev keeps at this fixed path (built from
+  // main, refreshed by `pdevui`/`make build-rust`) — reusing it here mirrors
+  // the `pdevui` shortcut documented in feature-worktree-auth.md, and this
+  // suite makes no Rust changes so main's runtime is a correct stand-in.
+  const shared = path.join(
+    process.env.HOME ?? "",
+    ".proliferate-local",
+    "dev",
+    "runtime-bin",
+    "anyharness",
+  );
+  if (existsSync(shared)) {
+    return shared;
+  }
+  const targetDir = path.join(REPO_ROOT, "target", "runtime-local");
+  const built = path.join(targetDir, "debug", "anyharness");
+  if (!existsSync(built)) {
+    log("no prebuilt AnyHarness runtime binary found; building (this can take a while)...");
+    run("cargo", ["build", "--bin", "anyharness"], {
+      env: { CARGO_TARGET_DIR: targetDir },
+    });
+  }
+  return built;
+}
+
+async function waitForHttpOk(url: string, { timeoutMs = 120_000, intervalMs = 500 } = {}): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { method: "GET" });
+      if (response.ok || response.status === 404) {
+        // 404 still proves the server is up and routing (e.g. Vite root
+        // during initial cold compile can 404 briefly before serving index).
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${url} to respond${lastError ? `: ${String(lastError)}` : ""}`);
+}
+
+function spawnTracked(
+  children: ChildProcess[],
+  command: string,
+  args: string[],
+  options: { cwd?: string; env: NodeJS.ProcessEnv; name: string },
+): ChildProcess {
+  const child = spawn(command, args, {
+    cwd: options.cwd ?? REPO_ROOT,
+    env: options.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+  const prefix = `[${options.name}]`;
+  child.stdout?.on("data", (chunk: Buffer) => {
+    if (process.env.TIER2_INTENT_VERBOSE) {
+      process.stdout.write(`${prefix} ${chunk}`);
+    }
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    if (process.env.TIER2_INTENT_VERBOSE) {
+      process.stderr.write(`${prefix} ${chunk}`);
+    }
+  });
+  children.push(child);
+  return child;
+}
+
+function killTracked(child: ChildProcess): void {
+  if (child.exitCode !== null || child.killed) {
+    return;
+  }
+  try {
+    if (process.platform !== "win32" && child.pid) {
+      // Negative pid signals the whole detached process group (uvicorn/vite
+      // spawn their own children; a plain SIGTERM to the parent alone can
+      // leave orphans holding the port open across test runs).
+      process.kill(-child.pid, "SIGTERM");
+    } else {
+      child.kill("SIGTERM");
+    }
+  } catch {
+    // Already gone.
+  }
+}
+
+export async function bootStack(): Promise<BootedStack> {
+  const profile = PROFILE;
+  log(`preparing profile "${profile}"...`);
+  const instance = ensureProfilePorts(profile);
+  ensureDatabase(instance.databaseName);
+  ensureRedisReachable();
+
+  const databaseUrl = databaseUrlFor(instance.databaseName);
+  const apiBaseUrl = `http://127.0.0.1:${instance.ports.api}`;
+  const webBaseUrl = `http://127.0.0.1:${instance.ports.desktopWeb}`;
+  const setupTokenFile = `/tmp/proliferate-${profile}-setup-token`;
+  // Fresh setup token file per boot: a stale token from a prior claimed run
+  // would otherwise sit there confusing the next claim attempt.
+  rmSync(setupTokenFile, { force: true });
+
+  log(`running alembic migrations against ${instance.databaseName}...`);
+  run("server/.venv/bin/alembic", ["upgrade", "head"], {
+    cwd: path.join(REPO_ROOT, "server"),
+    env: { DATABASE_URL: databaseUrl },
+  });
+
+  mkdirSync(instance.anyharnessRuntimeHome, { recursive: true });
+
+  const children: ChildProcess[] = [];
+
+  // ── Server (FastAPI/uvicorn) ──
+  const serverEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    DEBUG: "true",
+    DATABASE_URL: databaseUrl,
+    API_BASE_URL: apiBaseUrl,
+    FRONTEND_BASE_URL: webBaseUrl,
+    SINGLE_ORG_MODE: "true",
+    SETUP_TOKEN_FILE: setupTokenFile,
+    CORS_ALLOW_ORIGINS: [
+      `http://localhost:${instance.ports.desktopWeb}`,
+      `http://127.0.0.1:${instance.ports.desktopWeb}`,
+    ].join(","),
+    // Password + first-run claim only: never let a leaked shell env accidentally
+    // point this profile at a real GitHub OAuth app (main's callback is
+    // registered against a different port; see feature-worktree-auth.md).
+    GITHUB_OAUTH_CLIENT_ID: "",
+    GITHUB_OAUTH_CLIENT_SECRET: "",
+  };
+  spawnTracked(
+    children,
+    path.join(REPO_ROOT, "server", ".venv", "bin", "uvicorn"),
+    ["proliferate.main:app", "--host", "127.0.0.1", "--port", String(instance.ports.api)],
+    { cwd: path.join(REPO_ROOT, "server"), env: serverEnv, name: "server" },
+  );
+
+  // ── AnyHarness runtime ──
+  // Settings/auth/org/invitation surfaces (this suite's scope) don't read
+  // through the runtime, but booting it keeps the app shell from showing a
+  // persistent "runtime unavailable" state that could shadow assertions.
+  try {
+    const runtimeBin = resolveAnyharnessRuntimeBin();
+    spawnTracked(
+      children,
+      runtimeBin,
+      ["serve", "--port", String(instance.ports.anyharness), "--runtime-home", instance.anyharnessRuntimeHome],
+      {
+        env: { ...process.env, RUST_LOG: "info", ANYHARNESS_DEV_CORS: "1" },
+        name: "anyharness",
+      },
+    );
+  } catch (error) {
+    log(`warning: could not start AnyHarness runtime (${String(error)}); continuing without it`);
+  }
+
+  // ── Desktop web (Vite dev server, web-port mode) ──
+  ensureFrontendBuilt();
+  const desktopEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PROLIFERATE_WEB_PORT: String(instance.ports.desktopWeb),
+    PROLIFERATE_WEB_HMR_PORT: String(instance.ports.hmr),
+    VITE_PROLIFERATE_API_BASE_URL: apiBaseUrl,
+    VITE_PROLIFERATE_ENVIRONMENT: "development",
+    VITE_PROLIFERATE_TELEMETRY_DISABLED: "true",
+    // Vite dev builds default to auth-not-required (anonymous app shell).
+    // These scenarios assert the real login/logout lifecycle, so force the
+    // auth gate on and make sure no leaked dev bypass sneaks in.
+    VITE_REQUIRE_AUTH: "true",
+  };
+  delete desktopEnv.VITE_DEV_DISABLE_AUTH;
+  spawnTracked(
+    children,
+    "pnpm",
+    ["exec", "vite", "--host", "127.0.0.1", "--port", String(instance.ports.desktopWeb), "--strictPort"],
+    { cwd: path.join(REPO_ROOT, "apps", "desktop"), env: desktopEnv, name: "desktop-web" },
+  );
+
+  log("waiting for server + desktop web to become ready...");
+  await waitForHttpOk(`${apiBaseUrl}/health`);
+  await waitForHttpOk(webBaseUrl);
+  log(`ready: api=${apiBaseUrl} web=${webBaseUrl}`);
+
+  let torndown = false;
+  const teardown = async () => {
+    if (torndown) {
+      return;
+    }
+    torndown = true;
+    log("tearing down...");
+    for (const child of children) {
+      killTracked(child);
+    }
+    // Release the profile run lock the `ensure --lock` call above took, same
+    // as `make run`'s exit trap — otherwise the next boot within the lock's
+    // 2-minute staleness window refuses to start.
+    rmSync(path.join(path.dirname(profileInstancePath(profile)), "run.lock"), { force: true });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  };
+
+  return { profile, apiBaseUrl, webBaseUrl, databaseUrl, setupTokenFile, teardown };
+}

--- a/tests/intent/stack/global-setup.ts
+++ b/tests/intent/stack/global-setup.ts
@@ -7,6 +7,7 @@
 // module closed over stay valid.
 
 import { bootStack } from "./boot.ts";
+import { resetPasswordLoginRateLimits } from "./seed.ts";
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   const stack = await bootStack();
@@ -14,5 +15,8 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.TIER2_INTENT_WEB_BASE_URL = stack.webBaseUrl;
   process.env.TIER2_INTENT_DATABASE_URL = stack.databaseUrl;
   process.env.TIER2_INTENT_SETUP_TOKEN_FILE = stack.setupTokenFile;
+  // The profile DB persists between runs; failed-login counters from a prior
+  // run's negatives must not 429 this run's logins (5 failures / 15 min / IP).
+  await resetPasswordLoginRateLimits();
   return stack.teardown;
 }

--- a/tests/intent/stack/global-setup.ts
+++ b/tests/intent/stack/global-setup.ts
@@ -1,0 +1,18 @@
+// Playwright globalSetup adapter around stack/boot.ts. Boots the stack once
+// for the whole run, publishes connection info to every test worker via
+// env vars (workers are spawned by Playwright after this resolves, so they
+// inherit process.env as set here), and returns the teardown callback —
+// Playwright calls a function returned from globalSetup as globalTeardown
+// automatically, run in the same process so the child-process handles this
+// module closed over stay valid.
+
+import { bootStack } from "./boot.ts";
+
+export default async function globalSetup(): Promise<() => Promise<void>> {
+  const stack = await bootStack();
+  process.env.TIER2_INTENT_API_BASE_URL = stack.apiBaseUrl;
+  process.env.TIER2_INTENT_WEB_BASE_URL = stack.webBaseUrl;
+  process.env.TIER2_INTENT_DATABASE_URL = stack.databaseUrl;
+  process.env.TIER2_INTENT_SETUP_TOKEN_FILE = stack.setupTokenFile;
+  return stack.teardown;
+}

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -8,7 +8,12 @@
 import { readFileSync } from "node:fs";
 import { Client } from "pg";
 
-export const ADMIN_EMAIL = "owner@t2intent.test";
+// NOTE deliberately .example.com, not .test: RFC-reserved `.test` addresses
+// expose a real product bug (first-run claim accepts them, but /users/me then
+// 500s because UserRead's EmailStr rejects special-use TLDs — validation
+// mismatch between account creation and profile serialization). Documented in
+// the PR; the suite steers around it so it tests the intended flows.
+export const ADMIN_EMAIL = "owner@t2intent.example.com";
 export const ADMIN_PASSWORD = "Tier2Intent!Passw0rd";
 export const ADMIN_ORG_NAME = "Tier2 Intent Org";
 
@@ -272,7 +277,7 @@ export async function backdateInvitationExpiry(invitationId: string, expiresAt: 
   await client.connect();
   try {
     await client.query(
-      `UPDATE organization_invitations SET expires_at = $1 WHERE id = $2`,
+      `UPDATE organization_invitation SET expires_at = $1 WHERE id = $2`,
       [expiresAt.toISOString(), invitationId],
     );
   } finally {
@@ -280,7 +285,31 @@ export async function backdateInvitationExpiry(invitationId: string, expiresAt: 
   }
 }
 
-/** The server uses asyncpg's SQLAlchemy URL scheme; node-postgres needs the plain `postgresql://` scheme. */
+/**
+ * Clear password-login rate-limit counters. The limiter buckets failures per
+ * email AND per client IP (5 failures / 15 min, constants/auth.py); every
+ * browser context in this suite shares 127.0.0.1, so the deliberate
+ * wrong-password/wrong-account negatives would trip the IP bucket for every
+ * later login in the run. Between tests that is limiter noise, not the
+ * behavior under test, so specs reset the limiter's real table after
+ * intentionally failing logins.
+ */
+export async function resetPasswordLoginRateLimits(): Promise<void> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    await client.query(`DELETE FROM password_login_attempt`);
+  } finally {
+    await client.end();
+  }
+}
+
+/** The server uses asyncpg's SQLAlchemy URL scheme; node-postgres needs the
+ * plain `postgresql://` scheme, and its resolver chokes on the bracketed
+ * `[::1]` host the macOS profile default uses — Docker's Postgres publishes
+ * on localhost for both stacks, so map it. */
 function toPostgresDriverUrl(url: string): string {
-  return url.replace(/^postgresql\+asyncpg:\/\//, "postgresql://");
+  return url
+    .replace(/^postgresql\+asyncpg:\/\//, "postgresql://")
+    .replace("@[::1]:", "@localhost:");
 }

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -131,26 +131,28 @@ export interface OrganizationSummary {
 }
 
 export async function getOwnOrganization(token: string): Promise<OrganizationSummary> {
-  const { status, body } = await apiRequest<{ organizations: Array<{ organization: OrganizationSummary }> }>(
+  const { status, body } = await apiRequest<{ organizations: OrganizationSummary[] }>(
     "/v1/organizations",
     { token },
   );
   if (status !== 200 || body.organizations.length === 0) {
     throw new Error(`Could not resolve the caller's organization (${status}): ${JSON.stringify(body)}`);
   }
-  return body.organizations[0].organization;
+  return body.organizations[0];
 }
 
+// Response field names follow the API's camelCase aliases
+// (server/proliferate/server/organizations/models.py).
 export interface InvitationSummary {
   id: string;
-  organization_id: string;
-  organization_name: string | null;
+  organizationId: string;
+  organizationName: string | null;
   email: string;
   role: string;
   status: string;
-  delivery_status: string;
-  accepted_by_user_id: string | null;
-  expires_at: string;
+  deliveryStatus: string;
+  acceptedByUserId: string | null;
+  expiresAt: string;
 }
 
 export async function inviteMember(
@@ -163,7 +165,7 @@ export async function inviteMember(
     `/v1/organizations/${organizationId}/invitations`,
     { method: "POST", token: adminToken, body: { email, role } },
   );
-  if (status !== 200) {
+  if (status !== 200 && status !== 201) {
     throw new Error(`Invite failed for ${email} (${status}): ${JSON.stringify(body)}`);
   }
   return body;
@@ -216,8 +218,8 @@ export async function acceptCurrentInvitation(
 }
 
 export interface MemberSummary {
-  membership_id: string;
-  user_id: string;
+  membershipId: string;
+  userId: string;
   email: string;
   role: string;
   status: string;

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -1,0 +1,286 @@
+// Seeding helpers: password accounts, orgs, invitations, and the one
+// legitimate direct-DB seed this suite needs (backdating an invitation's
+// `expires_at`, since there is no API to fast-forward time — the same spirit
+// as tier-2's Stripe test-clock convention, just without a clock object to
+// drive). Nothing here fakes a sandbox, an LLM, or any third party; it only
+// drives the product's own auth/org HTTP surface plus one raw SQL statement.
+
+import { readFileSync } from "node:fs";
+import { Client } from "pg";
+
+export const ADMIN_EMAIL = "owner@t2intent.test";
+export const ADMIN_PASSWORD = "Tier2Intent!Passw0rd";
+export const ADMIN_ORG_NAME = "Tier2 Intent Org";
+
+export function apiBaseUrl(): string {
+  const value = process.env.TIER2_INTENT_API_BASE_URL;
+  if (!value) {
+    throw new Error("TIER2_INTENT_API_BASE_URL is not set — did globalSetup run?");
+  }
+  return value;
+}
+
+export function webBaseUrl(): string {
+  const value = process.env.TIER2_INTENT_WEB_BASE_URL;
+  if (!value) {
+    throw new Error("TIER2_INTENT_WEB_BASE_URL is not set — did globalSetup run?");
+  }
+  return value;
+}
+
+function databaseUrl(): string {
+  const value = process.env.TIER2_INTENT_DATABASE_URL;
+  if (!value) {
+    throw new Error("TIER2_INTENT_DATABASE_URL is not set — did globalSetup run?");
+  }
+  return value;
+}
+
+export function readSetupToken(): string {
+  const path = process.env.TIER2_INTENT_SETUP_TOKEN_FILE;
+  if (!path) {
+    throw new Error("TIER2_INTENT_SETUP_TOKEN_FILE is not set — did globalSetup run?");
+  }
+  return readFileSync(path, "utf8").trim();
+}
+
+interface ApiResult<T> {
+  status: number;
+  body: T;
+}
+
+export async function apiRequest<T = unknown>(
+  path: string,
+  options: { method?: string; token?: string; body?: unknown } = {},
+): Promise<ApiResult<T>> {
+  const response = await fetch(`${apiBaseUrl()}${path}`, {
+    method: options.method ?? "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
+    },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  const body = text ? (JSON.parse(text) as T) : (undefined as T);
+  return { status: response.status, body };
+}
+
+/** POST a form-encoded body to a server-rendered page (`/setup`, `/register`). */
+async function postForm(path: string, fields: Record<string, string>): Promise<{ status: number; html: string }> {
+  const response = await fetch(`${apiBaseUrl()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields).toString(),
+    redirect: "manual",
+  });
+  return { status: response.status, html: await response.text() };
+}
+
+/**
+ * Claim the instance if it hasn't been claimed yet, using the fixed admin
+ * credentials every spec in this suite shares. Idempotent across spec files:
+ * whichever spec runs first performs the real claim (auth.spec.ts's own
+ * T2-AUTH-1 test drives this exact flow through the browser to assert it);
+ * everything after just confirms the instance is claimed and reuses the
+ * admin account. Single-org mode allows exactly one claim ever, so this must
+ * never be called with different credentials across specs.
+ */
+export async function ensureInstanceClaimed(): Promise<void> {
+  const openProbe = await fetch(`${apiBaseUrl()}/setup`);
+  if (openProbe.status === 404) {
+    return; // Already claimed (by this run or a prior one on this profile DB).
+  }
+  const token = readSetupToken();
+  const result = await postForm("/setup", {
+    email: ADMIN_EMAIL,
+    password: ADMIN_PASSWORD,
+    setup_token: token,
+    organization_name: ADMIN_ORG_NAME,
+  });
+  if (result.status !== 200) {
+    throw new Error(`Instance claim failed (${result.status}): ${result.html.slice(0, 500)}`);
+  }
+}
+
+export interface DesktopTokens {
+  access_token: string;
+  refresh_token: string;
+}
+
+export async function passwordLogin(email: string, password: string): Promise<DesktopTokens> {
+  const { status, body } = await apiRequest<DesktopTokens>("/auth/desktop/password/login", {
+    method: "POST",
+    body: { email, password },
+  });
+  if (status !== 200) {
+    throw new Error(`Password login failed for ${email} (${status}): ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+}
+
+export async function getOwnOrganization(token: string): Promise<OrganizationSummary> {
+  const { status, body } = await apiRequest<{ organizations: Array<{ organization: OrganizationSummary }> }>(
+    "/v1/organizations",
+    { token },
+  );
+  if (status !== 200 || body.organizations.length === 0) {
+    throw new Error(`Could not resolve the caller's organization (${status}): ${JSON.stringify(body)}`);
+  }
+  return body.organizations[0].organization;
+}
+
+export interface InvitationSummary {
+  id: string;
+  organization_id: string;
+  organization_name: string | null;
+  email: string;
+  role: string;
+  status: string;
+  delivery_status: string;
+  accepted_by_user_id: string | null;
+  expires_at: string;
+}
+
+export async function inviteMember(
+  adminToken: string,
+  organizationId: string,
+  email: string,
+  role: "member" | "admin" = "member",
+): Promise<InvitationSummary> {
+  const { status, body } = await apiRequest<InvitationSummary>(
+    `/v1/organizations/${organizationId}/invitations`,
+    { method: "POST", token: adminToken, body: { email, role } },
+  );
+  if (status !== 200) {
+    throw new Error(`Invite failed for ${email} (${status}): ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+export async function revokeInvitation(
+  adminToken: string,
+  organizationId: string,
+  invitationId: string,
+): Promise<ApiResult<InvitationSummary>> {
+  return apiRequest<InvitationSummary>(`/v1/organizations/${organizationId}/invitations/${invitationId}`, {
+    method: "DELETE",
+    token: adminToken,
+  });
+}
+
+export async function listInvitationsCurrent(token: string): Promise<InvitationSummary[]> {
+  const { status, body } = await apiRequest<{ invitations: InvitationSummary[] }>(
+    "/v1/organizations/invitations/current",
+    { token },
+  );
+  if (status !== 200) {
+    throw new Error(`Listing current-user invitations failed (${status}): ${JSON.stringify(body)}`);
+  }
+  return body.invitations;
+}
+
+export async function listOrganizationInvitations(
+  adminToken: string,
+  organizationId: string,
+): Promise<InvitationSummary[]> {
+  const { status, body } = await apiRequest<{ invitations: InvitationSummary[] }>(
+    `/v1/organizations/${organizationId}/invitations`,
+    { token: adminToken },
+  );
+  if (status !== 200) {
+    throw new Error(`Listing organization invitations failed (${status}): ${JSON.stringify(body)}`);
+  }
+  return body.invitations;
+}
+
+export async function acceptCurrentInvitation(
+  token: string,
+  invitationId: string,
+): Promise<ApiResult<unknown>> {
+  return apiRequest(`/v1/organizations/invitations/current/${invitationId}/accept`, {
+    method: "POST",
+    token,
+  });
+}
+
+export interface MemberSummary {
+  membership_id: string;
+  user_id: string;
+  email: string;
+  role: string;
+  status: string;
+}
+
+export async function listMembers(adminToken: string, organizationId: string): Promise<MemberSummary[]> {
+  const { status, body } = await apiRequest<{ members: MemberSummary[] }>(
+    `/v1/organizations/${organizationId}/members`,
+    { token: adminToken },
+  );
+  if (status !== 200) {
+    throw new Error(`Listing members failed (${status}): ${JSON.stringify(body)}`);
+  }
+  return body.members;
+}
+
+export async function removeMembership(
+  adminToken: string,
+  organizationId: string,
+  membershipId: string,
+): Promise<ApiResult<unknown>> {
+  return apiRequest(`/v1/organizations/${organizationId}/members/${membershipId}`, {
+    method: "DELETE",
+    token: adminToken,
+  });
+}
+
+/**
+ * Create the invitee's password account through the product's own invited
+ * self-registration surface (`POST /register`), the only account-creation
+ * path single-org mode exposes besides the one-time first-run claim. This is
+ * "seeding via the product's API", not a backdoor: it's exactly what an
+ * invited teammate's browser does when they open the invite link.
+ */
+export async function registerInvitedAccount(params: {
+  email: string;
+  password: string;
+  invitationToken: string;
+}): Promise<void> {
+  const result = await postForm("/register", {
+    email: params.email,
+    password: params.password,
+    invitation_token: params.invitationToken,
+  });
+  if (result.status !== 200) {
+    throw new Error(`Invited registration failed for ${params.email} (${result.status}): ${result.html.slice(0, 500)}`);
+  }
+}
+
+/**
+ * Backdate a pending invitation's `expires_at` directly in Postgres. There is
+ * no product API to fast-forward time, so this is the direct-DB analog of
+ * tier-2's Stripe test-clock convention (real state, just time-shifted).
+ */
+export async function backdateInvitationExpiry(invitationId: string, expiresAt: Date): Promise<void> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    await client.query(
+      `UPDATE organization_invitations SET expires_at = $1 WHERE id = $2`,
+      [expiresAt.toISOString(), invitationId],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/** The server uses asyncpg's SQLAlchemy URL scheme; node-postgres needs the plain `postgresql://` scheme. */
+function toPostgresDriverUrl(url: string): string {
+  return url.replace(/^postgresql\+asyncpg:\/\//, "postgresql://");
+}

--- a/tests/intent/tsconfig.json
+++ b/tests/intent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Tier-2 "mocked intent" test harness — phase 1, track A. Implements the stack-boot fixture plus the first three blessed scenarios from `specs/developing/testing/scenarios.md` (T2-AUTH-1, T2-AUTH-2, T2-INV-1), per the tier-2 rules in `specs/developing/testing/README.md`: real server, real desktop **web** frontend, real Postgres — no fake sandbox provider, no mock LLM.

## What the harness does

`tests/intent/` is a pnpm workspace package:

- **`stack/boot.ts`** — boots the full stack programmatically on the profile-isolated port set for profile **`t2intent`** (allocated via `scripts/dev.mjs ensure --profile t2intent --lock`, the same machinery `make run PROFILE=` uses): alembic migrations → uvicorn server (`SINGLE_ORG_MODE=true`, `SETUP_TOKEN_FILE`, GitHub OAuth blanked per `specs/developing/local/feature-worktree-auth.md` layer B) → AnyHarness runtime (shared prebuilt binary; skippable via `TIER2_INTENT_SKIP_RUNTIME=1`) → desktop web via vite on `PROLIFERATE_WEB_PORT` with `VITE_REQUIRE_AUTH=true`. Waits on `/health` + the web root, and tears down the whole process group (plus the profile run.lock) afterward.
- **`stack/seed.ts`** — seeding via the product's own surfaces: first-run `/setup` claim, password login, org/invitation/membership API helpers, invited `/register` self-registration. Exactly two direct-DB touches, both documented in-line: backdating `expires_at` (no time-travel API exists; the direct-DB analog of the Stripe test-clock convention) and clearing `password_login_attempt` (the limiter buckets per client IP — 5 fails/15 min — and every Playwright context shares 127.0.0.1, so deliberate wrong-password negatives would 429 later logins).
- **`stack/global-setup.ts`** — Playwright globalSetup: one boot per run, teardown returned as globalTeardown.
- **`playwright.config.ts`** — 1 worker, serial (the suite shares one claimed single-org instance), 1 retry, traces on failure.
- **`.github/workflows/intent-tests.yml`** — provisional CI job, named `intent-tests (provisional)`, `continue-on-error: true` — explicitly **non-blocking** until the suite earns a flake-free record. Do not add to required checks yet.

## Run locally

```bash
pnpm install
cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"   # once
pnpm -C tests/intent exec playwright install chromium                     # once
pnpm -C tests/intent test                # full suite (boots + tears down the stack itself)
pnpm -C tests/intent test:auth           # auth spec only
pnpm -C tests/intent test:invitation     # invitation spec only
```

Needs local Docker Postgres+Redis running (`server/docker-compose.yml`, same as normal dev). The suite owns the `t2intent` dev profile and its `proliferate_dev_t2intent` DB; state persists between runs and the specs are idempotent against it (a fresh claim happens on a fresh DB; later runs assert the already-claimed path). `TIER2_INTENT_VERBOSE=1` streams server/vite logs.

## Scenario → spec mapping

| Scenario (scenarios.md) | Spec | Status |
| --- | --- | --- |
| T2-AUTH-1 setup claim + password lifecycle (incl. wrong-password + second-claim negatives) | `specs/auth.spec.ts` | ✅ green |
| T2-AUTH-2 session revocation | `specs/auth.spec.ts` | ✅ green |
| T2-INV-1 happy path + expired / revoked / wrong-email / duplicate-pending negatives | `specs/invitation.spec.ts` | ✅ green (12/12 total, verified from a fully fresh DB and a persisted one) |

Two deliberate interpretation notes, marked in-line in the specs:

- **T2-AUTH-2 revocation trigger**: driven via password change from a second context (`PUT /auth/password`), which bumps `token_generation` — the product's actual all-surface revocation mechanism (same one logout uses). The UI-side assertion (context A's calls 401 and the app returns to signed-out on next bootstrap) is per the scenario.
- **T2-INV-1 happy path** drives the **single-org accept surface**: the invite email's `/register?token={invitation_id}` page (that is what `invitation_delivery.py` links in single-org mode), then asserts membership/invitation/org-list state and a UI login. The hosted-style settings accept is covered by the gap test below.

## Product bugs / gaps found (surfacing these is half the point)

1. **`.test`-TLD emails: 500 on `/users/me` after successful account creation.** The first-run claim and password login happily accept `owner@x.test`, but `UserRead`'s `EmailStr` serialization rejects RFC-reserved special-use TLDs, so every `/users/me` call for that user 500s. Validation mismatch between account creation (`server/proliferate/server/setup/accounts.py`, regex-based) and profile serialization (`server/proliferate/auth/profile_api.py`, pydantic `EmailStr`). Repro: claim with a `.test` email → login → `GET /users/me`. The suite steers around it with `.example.com` addresses (comment at `tests/intent/stack/seed.ts`).
2. **Non-admin invitee cannot reach the pending-invitation accept UI.** `CurrentUserInvitationsSection` lives on the `organization-members` settings pane, which is `adminOnly` in settings navigation and `SettingsScreen` redirects non-admins to General. So the surface scenarios.md names for accepting an invitation is unreachable for exactly the user who needs it (a plain member/invitee) — while the backing endpoints (`GET /organizations/invitations/current`, `POST .../accept`) work fine for them. Pinned as its own test (`documents GAP: ...` in `invitation.spec.ts`) that asserts the *current* gated behavior, so a fix flips it loudly.
3. **Spec-contract divergence, duplicate-pending negative.** scenarios.md says duplicate pending invite → "rejected by partial unique index → enumerated error", but the as-built path (`create_or_rotate_organization_invitation`) deliberately rotates: expires the old pending row, mints a fresh one, `ON CONFLICT DO UPDATE` as the concurrency backstop. The test pins the real invariant (at most one pending row per (org,email); old row expired). scenarios.md should be updated to match the rotate semantics.
4. **Harness-relevant quirk, not a bug**: invitation create returns **201**, and org API field names are camelCase aliases — noted here because scenarios.md's shorthand implies snake_case/200.

## Notes

- No product code was changed. Only `pnpm-workspace.yaml` (+lockfile) gained the `tests/intent` package entry.
- Verified end-to-end twice locally: once against a fully fresh DB (fresh `/setup` claim path) and once against the persisted profile DB (already-claimed path). Both 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
