### PR TITLE
fix(server): align email validation between account creation and read models

### DIFF
--- a/server/proliferate/auth/models.py
+++ b/server/proliferate/auth/models.py
@@ -14,6 +14,16 @@ class UserRole(StrEnum):
 
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
+    # Overrides the inherited ``email: EmailStr`` (fastapi_users.schemas.BaseUser).
+    # Account creation validates the email strictly with EmailStr rules (see
+    # proliferate.server.setup.accounts.normalize_account_email), but this is
+    # the *read* model: it must still serialize any email already stored,
+    # including rows written before that write-side validation existed or via
+    # a path (OAuth/SSO, direct fixtures) that does not go through it. #1012
+    # was exactly this — EmailStr rejects reserved TLDs like ``.test`` at
+    # serialization time, 500ing GET /users/me for an account the product
+    # itself created.
+    email: str
     display_name: str | None = None
     github_login: str | None = None
     avatar_url: str | None = None

--- a/server/proliferate/server/setup/accounts.py
+++ b/server/proliferate/server/setup/accounts.py
@@ -9,13 +9,20 @@ byte-for-byte consistent: same email normalization, same password policy, same
 Validation failures raise ``AccountValidationError`` so each transport can map
 them onto its own error shape (HTML form error for /setup, JSON error for the
 registration route).
+
+Email syntax is validated with the same ``pydantic.EmailStr`` rules the read
+model (``UserRead``, via ``fastapi_users.schemas.BaseUser``) used to enforce at
+serialization time (see #1012): reserved/special-use TLDs such as ``.test``,
+``.invalid``, ``.local``, and ``.localhost`` are rejected here, at creation,
+with a clean 400/403 instead of being written and then 500ing on
+``GET /users/me``.
 """
 
 from __future__ import annotations
 
-import re
 from datetime import UTC, datetime
 
+from pydantic import EmailStr, TypeAdapter, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.identity.store import create_auth_user
@@ -29,7 +36,7 @@ from proliferate.constants.auth import PASSWORD_EMAIL_MAX_LENGTH
 from proliferate.db.models.auth import User
 from proliferate.db.store.auth_passwords import update_user_password_hash
 
-_EMAIL_PATTERN = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+_email_syntax_adapter = TypeAdapter(EmailStr)
 
 
 class AccountValidationError(Exception):
@@ -45,13 +52,17 @@ def normalize_account_email(email: str) -> str:
 
     The length cap matches the users email column (String(320)) so an
     oversized value fails validation here instead of blowing up on the insert.
-    Shared by the first-run claim and invited self-registration.
+    Syntax is checked with ``EmailStr`` so the write path can never accept an
+    address the read model (``UserRead``) would refuse to serialize. Shared by
+    the first-run claim and invited self-registration.
     """
     normalized_email = normalize_password_email(email)
-    if len(normalized_email) > PASSWORD_EMAIL_MAX_LENGTH or not _EMAIL_PATTERN.fullmatch(
-        normalized_email
-    ):
+    if len(normalized_email) > PASSWORD_EMAIL_MAX_LENGTH:
         raise AccountValidationError("Enter a valid email address.")
+    try:
+        _email_syntax_adapter.validate_python(normalized_email)
+    except ValidationError as exc:
+        raise AccountValidationError("Enter a valid email address.") from exc
     return normalized_email
 
 

--- a/server/tests/unit/test_email_validation_parity.py
+++ b/server/tests/unit/test_email_validation_parity.py
@@ -1,0 +1,127 @@
+"""Write/read email validation parity (#1012).
+
+Account creation used to validate email syntax with a permissive regex, while
+``UserRead`` (via ``fastapi_users.schemas.BaseUser``) validates with pydantic's
+``EmailStr``, which rejects IANA special-use/reserved TLDs such as ``.test``,
+``.invalid``, and ``.localhost``. The write path accepted
+``someone@example.test``; the read path then raised a ``ValidationError`` while
+serializing the response, so ``GET /users/me`` 500ed for an account the
+product itself had just created.
+
+The fix is two-sided:
+
+- ``normalize_account_email`` (the shared write path for the first-run claim
+  and invited self-registration) now validates with the same ``EmailStr``
+  rules, so it can no longer create an account the read model would refuse to
+  serialize.
+- ``UserRead.email`` is widened from the inherited ``EmailStr`` to plain
+  ``str`` so it always serializes, regardless of how a row reached the table
+  (OAuth/SSO provider-supplied emails, or any row already in the database from
+  before this fix existed).
+
+These tests assert that agreement directly: creating an account with a
+reserved-TLD email must fail cleanly at creation (never write a row an
+authenticated user can't read back), and any email already stored -- however
+it got there -- must always serialize through ``UserRead`` without raising.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from proliferate.auth.identity.store import create_auth_user
+from proliferate.auth.models import UserRead
+from proliferate.auth.passwords import hash_password
+from proliferate.db.store.auth_passwords import update_user_password_hash
+from proliferate.server.setup.accounts import AccountValidationError, normalize_account_email
+
+PASSWORD = "a-strong-enough-password"
+LOGIN_PATH = "/auth/desktop/password/login"
+
+
+# ---------------------------------------------------------------------------
+# Write path: normalize_account_email rejects what the read model can't
+# serialize.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "someone@example.test",
+        "someone@foo.invalid",
+        "someone@foo.localhost",
+    ],
+)
+def test_normalize_account_email_rejects_reserved_tlds(email: str) -> None:
+    with pytest.raises(AccountValidationError):
+        normalize_account_email(email)
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "someone@example.com",
+        "someone@acme.example.com",
+    ],
+)
+def test_normalize_account_email_accepts_real_shaped_domains(email: str) -> None:
+    assert normalize_account_email(email) == email.lower()
+
+
+# ---------------------------------------------------------------------------
+# Read path: UserRead must serialize any row already in the table, including
+# rows that did not go through normalize_account_email (OAuth/SSO-provisioned,
+# or written before this fix existed).
+# ---------------------------------------------------------------------------
+
+
+async def test_user_read_serializes_reserved_tld_email(test_engine) -> None:
+    factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with factory() as session:
+        user = await create_auth_user(
+            session,
+            email="legacy@acme.test",
+            display_name=None,
+            avatar_url=None,
+        )
+        await session.commit()
+
+    # This is the exact call proliferate.auth.profile_api.current_user_profile
+    # makes for GET /users/me. Before the fix this raised a pydantic
+    # ValidationError (-> unhandled 500); it must now succeed.
+    user_read = UserRead.model_validate(user)
+    assert user_read.email == "legacy@acme.test"
+
+
+async def test_get_users_me_never_500s_for_reserved_tld_account(client, test_engine) -> None:
+    """End-to-end regression for the issue's exact repro.
+
+    ``normalize_account_email`` now refuses to create a ``.test`` account
+    through the product's own registration surfaces, so this simulates the
+    one remaining way such a row can exist -- provisioned directly (as an
+    OAuth/SSO arrival would be, or as a row already in the database from
+    before this fix existed) -- and asserts the read side still never 500s.
+    """
+    email = "someone@example.test"
+    factory = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with factory() as session:
+        user = await create_auth_user(session, email=email, display_name=None, avatar_url=None)
+        await update_user_password_hash(
+            session,
+            user_id=user.id,
+            hashed_password=hash_password(PASSWORD),
+            password_set_at=datetime.now(UTC),
+        )
+        await session.commit()
+
+    login = await client.post(LOGIN_PATH, json={"email": email, "password": PASSWORD})
+    assert login.status_code == 200
+    access_token = login.json()["access_token"]
+
+    me = await client.get("/users/me", headers={"Authorization": f"Bearer {access_token}"})
+    assert me.status_code == 200
+    assert me.json()["email"] == email

--- a/server/tests/unit/test_first_run_claim.py
+++ b/server/tests/unit/test_first_run_claim.py
@@ -29,7 +29,7 @@ from proliferate.server.setup.domain.tokens import (
 )
 from proliferate.server.setup.lifecycle import ensure_first_run_setup_token
 
-CLAIM_EMAIL = "owner@acme.test"
+CLAIM_EMAIL = "owner@acme.example.com"
 CLAIM_PASSWORD = "a-strong-enough-password"
 
 
@@ -183,7 +183,11 @@ async def test_setup_routes_close_after_claim(single_org_client, test_engine, tm
     assert (await single_org_client.get("/setup")).status_code == 404
     replay = await single_org_client.post(
         "/setup",
-        data={"email": "second@acme.test", "password": CLAIM_PASSWORD, "setup_token": token},
+        data={
+            "email": "second@acme.example.com",
+            "password": CLAIM_PASSWORD,
+            "setup_token": token,
+        },
     )
     assert replay.status_code == 404
 
@@ -232,7 +236,7 @@ async def test_claim_validates_password(single_org_client, test_engine, tmp_path
 async def test_claim_rejects_oversized_email(single_org_client, test_engine, tmp_path):
     """An email longer than the users column (320) is a 400, not a 500."""
     token = await _seed_setup_token(test_engine, tmp_path)
-    oversized_email = f"{'a' * 320}@acme.test"
+    oversized_email = f"{'a' * 320}@acme.example.com"
     response = await single_org_client.post(
         "/setup",
         data={"email": oversized_email, "password": CLAIM_PASSWORD, "setup_token": token},
@@ -363,11 +367,19 @@ async def test_concurrent_double_claim_yields_exactly_one_owner(
     first, second = await asyncio.gather(
         single_org_client.post(
             "/setup",
-            data={"email": "one@acme.test", "password": CLAIM_PASSWORD, "setup_token": token},
+            data={
+                "email": "one@acme.example.com",
+                "password": CLAIM_PASSWORD,
+                "setup_token": token,
+            },
         ),
         single_org_client.post(
             "/setup",
-            data={"email": "two@acme.test", "password": CLAIM_PASSWORD, "setup_token": token},
+            data={
+                "email": "two@acme.example.com",
+                "password": CLAIM_PASSWORD,
+                "setup_token": token,
+            },
         ),
     )
 


### PR DESCRIPTION
## Summary

`GET /users/me` 500ed for accounts created with reserved-TLD emails like
`someone@example.test`. Root cause: the write path (first-run claim /
invited self-registration, both funneled through
`normalize_account_email`) validated email syntax with a permissive
hand-rolled regex, while the read model `UserRead`
(`fastapi_users.schemas.BaseUser`) validates with pydantic `EmailStr` —
which rejects IANA special-use/reserved TLDs (`.test`, `.invalid`,
`.local`, `.localhost`, `.onion`, `arpa`). The write path happily created
the account; the read path then raised an unhandled `ValidationError`
while serializing the response.

## Decision: (a) + (b) combined, not either alone

- **(a) Tighten the write path** — `normalize_account_email` in
  `server/proliferate/server/setup/accounts.py` now validates with the
  exact same `pydantic.EmailStr` rules the read model enforces (reusing
  the `TypeAdapter(EmailStr)` pattern already used in
  `auth/profile_api.py`), instead of the old
  `re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")`. A `.test`/`.invalid`/etc.
  email now fails cleanly at creation (400) instead of writing a row the
  product can't read back.
- **(b) Relax the read model** — `UserRead.email` (in
  `server/proliferate/auth/models.py`) is widened from the inherited
  `EmailStr` to plain `str`. This is the safety net: (a) alone isn't
  enough, because plenty of rows reach the `user` table through paths
  that don't go through `normalize_account_email` at all — GitHub/SSO
  OAuth provisioning, and (very concretely) a large chunk of this repo's
  own existing test fixtures create users directly via `create_auth_user`
  with `.test` emails (e.g. `tests/unit/test_admin_emails.py`,
  `test_membership_policy_roles.py`). Any of those must still serialize
  through `GET /users/me` without 500ing, including rows written before
  this fix existed. Strict on write, lenient on read.

Why not read-relaxation alone: it would still let account creation quietly
accept unroutable/reserved-TLD addresses, so a real invitee could end up
with an address that email delivery and other integrations can't act on —
`normalize_account_email` is the one shared choke point for both the
first-run claim and invited self-registration, so tightening it there is
cheap and closes the actual product-visible gap (users successfully
inviting/claiming with an address that silently can never be routed to).

Why not write-tightening alone: the read-time regression exists for rows
that never went through this write path at all (OAuth/SSO, or any row
that predates this fix), so the read model has to be tolerant regardless.

## Blast-radius check

Grepped the test suite for `.test`/`.local`/`.invalid` email usage before
tightening the write path. `tests/unit/test_first_run_claim.py` exercised
the real `/setup` claim endpoint with `owner@acme.test` and would have
started failing under the new write-side validation — updated its emails
to `.example.com` (mirroring the pattern `test_self_registration.py` and
`test_desktop_password_auth.py` already use, both of which have comments
noting they intentionally use real-shaped domains because the invitation
API / read model already validates strictly). All other `.test`-email test
usage (`test_admin_emails.py`, `test_membership_policy*.py`,
`test_sso.py`) creates users directly via `create_auth_user`, bypassing
`normalize_account_email` entirely, so it's unaffected by the write-side
change and is exactly the kind of fixture the read-side relaxation exists
to keep working.

## Test evidence

New tier-1 tests in `server/tests/unit/test_email_validation_parity.py`:
- `normalize_account_email` rejects `.test`/`.invalid`/`.localhost` and
  accepts real-shaped domains.
- `UserRead.model_validate(user)` serializes a `.test`-email row without
  raising (the exact call `GET /users/me` makes).
- An end-to-end regression: create a `.test`-email account directly (as an
  OAuth/legacy row would exist), log in, `GET /users/me` → 200, not 500.

```
$ DATABASE_URL=... JWT_SECRET=... CLOUD_SECRET_KEY=... uv run pytest -q \
    tests/unit/test_email_validation_parity.py \
    tests/unit/test_first_run_claim.py \
    tests/unit/test_self_registration.py \
    tests/unit/test_desktop_password_auth.py \
    tests/unit/test_admin_emails.py \
    tests/unit/test_membership_policy.py \
    tests/unit/test_membership_policy_roles.py
87 passed, 7 warnings in 419.49s
```

`ruff check` and `ruff format --check` both pass clean on `proliferate/`
and `tests/`.

A broader `tests/unit` + `tests/integration/test_auth_flow.py` run was
also kicked off against the shared local dev Postgres, but that instance
is under heavy concurrent load from other worktrees right now and the run
is still churning; the targeted run above covers every touched code path
and every adjacent auth/org suite that exercises `UserRead` or the claim/
registration endpoints.

## Test plan

- [x] Unit: write/read validation agreement (`test_email_validation_parity.py`)
- [x] Unit: first-run claim + invited self-registration + desktop password
      login + admin-emails + membership-policy suites all still pass
- [x] `ruff check` / `ruff format --check`
- [ ] Full `tests/unit` + `tests/integration` sweep (kicked off, pending
      due to shared local Postgres contention — will confirm before
      merging out of draft)

Fixes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)