### PR TITLE
fix(desktop): make invitation-accept UI reachable for non-admin invitees

### DIFF
--- a/apps/desktop/src/components/settings/panes/AccountPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AccountPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   AccountSettingsPane,
@@ -13,11 +13,14 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import { ExternalLink, RefreshCw } from "@proliferate/ui/icons";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
+import { CurrentUserInvitationsSection } from "@/components/settings/panes/organization/CurrentUserInvitationsSection";
 import { AUTH_ACCOUNT_LABELS } from "@/copy/auth/auth-copy";
 import { CAPABILITY_COPY } from "@/copy/capabilities/capability-copy";
 import { useAuthViewer } from "@/hooks/access/cloud/auth/use-auth-viewer";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { useGitHubDesktopAuthAvailability } from "@/hooks/access/cloud/auth/use-github-auth-availability";
+import { useCurrentUserOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-current-user-organization-invitations";
+import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
 import {
   getAccountActionDescription,
   getAccountDisplayName,
@@ -28,9 +31,15 @@ import { isDevAuthBypassed } from "@/lib/domain/auth/auth-mode";
 import { useAuthActions } from "@/hooks/auth/workflows/use-auth-actions";
 import { useGitHubSignIn } from "@/hooks/auth/workflows/use-github-sign-in";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { useOrganizationJoinInvitationFlow } from "@/hooks/organizations/workflows/use-organization-join-invitation-flow";
+import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { buildGitHubOAuthAppSettingsUrl } from "@/lib/integrations/auth/proliferate-auth";
+import type { OrganizationInvitationRecord } from "@/lib/domain/organizations/organization-records";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { useToastStore } from "@/stores/toast/toast-store";
 import { buildGitHubAppUserAuthorizationServiceView } from "./account/GitHubAppUserAuthorizationService";
+
+const EMPTY_INVITATIONS: OrganizationInvitationRecord[] = [];
 
 export function AccountPane() {
   const navigate = useNavigate();
@@ -64,6 +73,15 @@ export function AccountPane() {
     isAuthenticated && !devAuthBypassed && cloudSignInAvailable,
     authViewerCacheScope,
   );
+  // Pending invitations for the signed-in user's own email. Account is the
+  // one settings page every member (admin or not) can reach — Members is
+  // admin-gated, so this is the reachable surface for a plain invitee.
+  const pendingInvitationsQuery = useCurrentUserOrganizationInvitations(isAuthenticated);
+  const pendingInvitations = pendingInvitationsQuery.data?.invitations ?? EMPTY_INVITATIONS;
+  const organizationActions = useOrganizationActions(null);
+  const joinFlow = useOrganizationJoinInvitationFlow();
+  const { activateJoinedOrganization } = useJoinedOrganizationActivation();
+  const showToast = useToastStore((state) => state.show);
   const linkedProviders = authViewer.data?.linkedProviders ?? [];
   const linkedGitHub = linkedProviders.find((provider) => (
     provider.provider === "github" && provider.connected
@@ -130,6 +148,19 @@ export function AccountPane() {
     clearGitHubAppAuthorizationRefreshTimers(githubAppAuthorizationRefreshTimersRef.current);
     githubAppAuthorizationRefreshTimersRef.current = [];
   }, [authViewerCacheScope]);
+
+  async function handleAcceptCurrentInvitation(invitationId: string) {
+    joinFlow.setStatusMessage(null);
+    try {
+      const response = await organizationActions.acceptCurrentInvitation(invitationId);
+      await activateJoinedOrganization(response.organization.id);
+      joinFlow.clearJoinTarget();
+      joinFlow.setStatusMessage(`Joined ${response.organization.name}.`);
+      showToast(`Joined ${response.organization.name}.`, "info");
+    } catch {
+      joinFlow.setStatusMessage("Could not accept invitation.");
+    }
+  }
 
   async function handleSignOut() {
     setSigningOut(true);
@@ -198,6 +229,25 @@ export function AccountPane() {
             : "Sign in to use cloud workspaces and credential sync. Local workspaces remain available without an account."
         }
       />
+
+      {joinFlow.statusMessage ? (
+        <AccountNotice>{joinFlow.statusMessage}</AccountNotice>
+      ) : null}
+
+      {joinFlow.unauthenticatedJoin ? (
+        <AccountNotice>Finish sign-in to accept this organization invitation.</AccountNotice>
+      ) : null}
+
+      {pendingInvitations.length > 0 ? (
+        <CurrentUserInvitationsSection
+          invitations={pendingInvitations}
+          accepting={organizationActions.acceptingCurrentInvitation}
+          focusedOrganizationId={joinFlow.joinOrganizationId}
+          onAccept={(invitationId) => {
+            void handleAcceptCurrentInvitation(invitationId);
+          }}
+        />
+      ) : null}
 
       <AccountSettingsPane
         displayName={displayName}
@@ -308,6 +358,14 @@ export function AccountPane() {
         error={signInError || providerLinkError}
       />
     </section>
+  );
+}
+
+function AccountNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-foreground/5 px-4 py-3 text-ui-sm text-muted-foreground">
+      {children}
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/settings/panes/AccountPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AccountPane.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import {
   AccountSettingsPane,
   type AccountPasswordCredentialSubmit,
-  type AccountProviderView,
 } from "@proliferate/product-ui/account/AccountSettingsPane";
 import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
 import { setPasswordCredential } from "@proliferate/cloud-sdk";
@@ -22,6 +21,7 @@ import { useGitHubDesktopAuthAvailability } from "@/hooks/access/cloud/auth/use-
 import { useCurrentUserOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-current-user-organization-invitations";
 import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
 import {
+  buildAccountProviderViews,
   getAccountActionDescription,
   getAccountDisplayName,
   getAccountProfileSummary,
@@ -379,75 +379,4 @@ function clearGitHubAppAuthorizationRefreshTimers(timerIds: number[]) {
   for (const timerId of timerIds) {
     window.clearTimeout(timerId);
   }
-}
-
-function buildAccountProviderViews({
-  githubAccountLabel,
-  githubConnected,
-  googleAccounts,
-  ssoAccounts,
-  googleAvailable,
-  showProviders,
-}: {
-  githubAccountLabel: string | null;
-  githubConnected: boolean;
-  googleAccounts: Array<{ accountEmail?: string | null; accountId?: string | null }>;
-  ssoAccounts: Array<{
-    accountEmail?: string | null;
-    accountId?: string | null;
-    displayName?: string | null;
-    brandLabel?: string | null;
-  }>;
-  googleAvailable: boolean;
-  showProviders: boolean;
-}): AccountProviderView[] {
-  if (!showProviders) {
-    return [
-      {
-        provider: "github",
-        label: "GitHub",
-        accountLabel: "Not signed in",
-        connected: false,
-        primary: false,
-      },
-    ];
-  }
-
-  const providers: AccountProviderView[] = ssoAccounts.map((account) => ({
-    provider: "sso" as const,
-    label: account.displayName ?? "SSO",
-    brandLabel: account.brandLabel ?? account.displayName ?? null,
-    accountLabel: account.accountEmail ?? account.accountId ?? "Connected",
-    connected: true,
-  }));
-
-  providers.push(
-    {
-      provider: "github",
-      label: "GitHub",
-      accountLabel: githubConnected ? githubAccountLabel ?? "Connected" : "Not connected",
-      connected: githubConnected,
-      primary: githubConnected,
-    },
-  );
-
-  if (googleAccounts.length > 0) {
-    providers.push(
-      ...googleAccounts.map((account) => ({
-        provider: "google" as const,
-        label: "Google",
-        accountLabel: account.accountEmail ?? account.accountId ?? "Connected",
-        connected: true,
-      })),
-    );
-  } else {
-    providers.push({
-      provider: "google",
-      label: "Google",
-      accountLabel: googleAvailable ? "Not connected" : "Not configured in this environment",
-      connected: false,
-    });
-  }
-
-  return providers;
 }

--- a/apps/desktop/src/components/settings/panes/OrganizationMembersPane.tsx
+++ b/apps/desktop/src/components/settings/panes/OrganizationMembersPane.tsx
@@ -1,12 +1,10 @@
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { CurrentUserInvitationsSection } from "@/components/settings/panes/organization/CurrentUserInvitationsSection";
 import { OrganizationInvitationsSection } from "@/components/settings/panes/organization/OrganizationInvitationsSection";
 import { OrganizationMembersSection } from "@/components/settings/panes/organization/OrganizationMembersSection";
 import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
-import { useCurrentUserOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-current-user-organization-invitations";
 import { useIsAdmin } from "@/hooks/access/cloud/organizations/use-is-admin";
 import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
 import { useOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-organization-invitations";
@@ -14,8 +12,6 @@ import { useOrganizationJoinLink } from "@/hooks/access/cloud/organizations/use-
 import { useOrganizationMembers } from "@/hooks/access/cloud/organizations/use-organization-members";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
-import { useOrganizationJoinInvitationFlow } from "@/hooks/organizations/workflows/use-organization-join-invitation-flow";
-import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION } from "@/config/settings";
 import {
   type OrganizationInvitationRecord,
@@ -44,38 +40,18 @@ export function OrganizationMembersPane() {
   const canManage = admin.isAdmin || TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION;
   const canManageOwners = admin.isOwner || TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION;
   const joinLinkQuery = useOrganizationJoinLink(activeOrganizationId, canManage);
-  const shouldLoadPendingInvitations = authStatus === "authenticated";
-  const pendingInvitationsQuery = useCurrentUserOrganizationInvitations(
-    shouldLoadPendingInvitations,
-  );
   const { copyText } = useTauriShellActions();
   const showToast = useToastStore((state) => state.show);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
-  const joinFlow = useOrganizationJoinInvitationFlow();
-  const { activateJoinedOrganization } = useJoinedOrganizationActivation();
 
   const members = membersQuery.data?.members ?? EMPTY_MEMBERS;
   const invitations = invitationsQuery.data?.invitations ?? EMPTY_INVITATIONS;
-  const pendingInvitations = pendingInvitationsQuery.data?.invitations ?? EMPTY_INVITATIONS;
 
   async function handleInvite() {
     await actions.createInvitation({ email: inviteEmail, role: inviteRole });
     setInviteEmail("");
     setInviteRole("member");
-  }
-
-  async function handleAcceptCurrentInvitation(invitationId: string) {
-    joinFlow.setStatusMessage(null);
-    try {
-      const response = await actions.acceptCurrentInvitation(invitationId);
-      await activateJoinedOrganization(response.organization.id);
-      joinFlow.clearJoinTarget();
-      joinFlow.setStatusMessage(`Joined ${response.organization.name}.`);
-      showToast(`Joined ${response.organization.name}.`, "info");
-    } catch {
-      joinFlow.setStatusMessage("Could not accept invitation.");
-    }
   }
 
   async function handleCopyJoinLink() {
@@ -101,14 +77,12 @@ export function OrganizationMembersPane() {
     });
   }
 
-  const shouldShowSignInState = authStatus !== "authenticated" && !joinFlow.unauthenticatedJoin;
+  const shouldShowSignInState = authStatus !== "authenticated";
   const shouldShowLoadingState = authStatus === "authenticated" && organizationsQuery.isLoading;
   const shouldShowErrorState = authStatus === "authenticated" && organizationsQuery.isError;
   const shouldShowEmptyState = authStatus === "authenticated"
     && organizationsQuery.isSuccess
-    && organizations.length === 0
-    && pendingInvitations.length === 0;
-  const shouldShowPendingInvitations = pendingInvitations.length > 0;
+    && organizations.length === 0;
 
   return (
     <section className="space-y-6">
@@ -116,14 +90,6 @@ export function OrganizationMembersPane() {
         title="Members"
         description="Invite teammates, copy the organization join link, and manage access."
       />
-
-      {joinFlow.statusMessage ? (
-        <OrganizationNotice>{joinFlow.statusMessage}</OrganizationNotice>
-      ) : null}
-
-      {joinFlow.unauthenticatedJoin ? (
-        <OrganizationNotice>Finish sign-in to accept this organization invitation.</OrganizationNotice>
-      ) : null}
 
       {shouldShowSignInState ? (
         <SettingsSection title="Members" description="Organization access is tied to your signed-in account.">
@@ -153,17 +119,6 @@ export function OrganizationMembersPane() {
             }
           />
         </SettingsSection>
-      ) : null}
-
-      {shouldShowPendingInvitations ? (
-        <CurrentUserInvitationsSection
-          invitations={pendingInvitations}
-          accepting={actions.acceptingCurrentInvitation}
-          focusedOrganizationId={joinFlow.joinOrganizationId}
-          onAccept={(invitationId) => {
-            void handleAcceptCurrentInvitation(invitationId);
-          }}
-        />
       ) : null}
 
       {shouldShowEmptyState ? (
@@ -211,13 +166,5 @@ export function OrganizationMembersPane() {
         </>
       ) : null}
     </section>
-  );
-}
-
-function OrganizationNotice({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-lg border border-border bg-foreground/5 px-4 py-3 text-ui-sm text-muted-foreground">
-      {children}
-    </div>
   );
 }

--- a/apps/desktop/src/hooks/app/lifecycle/use-dev-desktop-handoff.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-dev-desktop-handoff.test.tsx
@@ -63,7 +63,7 @@ describe("useDevDesktopHandoff", () => {
 
     await waitFor(() => {
       expect(result.current).toBe(
-        "/settings?section=organization-members&joinOrganizationId=org-1",
+        "/settings?section=account&joinOrganizationId=org-1",
       );
     });
     expect(handoffMocks.revealCurrentWindow).toHaveBeenCalledTimes(1);
@@ -83,7 +83,7 @@ describe("useDevDesktopHandoff", () => {
 
     await waitFor(() => {
       expect(result.current).toBe(
-        "/settings?section=organization-members&joinOrganizationId=org-1",
+        "/settings?section=account&joinOrganizationId=org-1",
       );
     });
     expect(handoffMocks.revealCurrentWindow).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.test.tsx
+++ b/apps/desktop/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.test.tsx
@@ -27,7 +27,7 @@ function renderJoinAuthLaunch() {
   function Wrapper({ children }: { children: ReactNode }) {
     return (
       <MemoryRouter
-        initialEntries={["/settings?section=organization-members&joinOrganizationId=org-1"]}
+        initialEntries={["/settings?section=account&joinOrganizationId=org-1"]}
       >
         {children}
       </MemoryRouter>

--- a/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx
+++ b/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx
@@ -27,7 +27,7 @@ function renderJoinInvitationFlow() {
   function Wrapper({ children }: { children: ReactNode }) {
     return (
       <MemoryRouter
-        initialEntries={["/settings?section=organization-members&joinOrganizationId=org-1"]}
+        initialEntries={["/settings?section=account&joinOrganizationId=org-1"]}
       >
         {children}
       </MemoryRouter>

--- a/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts
+++ b/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts
@@ -40,7 +40,9 @@ export function useOrganizationJoinInvitationFlow() {
     writePendingOrganizationJoinTarget(joinOrganizationId);
     signInStartedRef.current = false;
     setTransientJoinOrganizationId(joinOrganizationId);
-    navigate(buildSettingsHref({ section: "organization-members" }), { replace: true });
+    // Account is reachable by every signed-in user (Members is admin-only),
+    // so this is where a non-admin invitee can actually see and accept.
+    navigate(buildSettingsHref({ section: "account" }), { replace: true });
   }, [joinOrganizationId, navigate]);
 
   const clearJoinTarget = useCallback(() => {

--- a/apps/desktop/src/lib/domain/auth/account-profile-presentation.test.ts
+++ b/apps/desktop/src/lib/domain/auth/account-profile-presentation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildAccountProviderViews,
   getAccountActionDescription,
   getAccountDisplayName,
   getAccountInitials,
@@ -96,5 +97,46 @@ describe("getAccountInitials", () => {
     expect(getAccountInitials("Person Name")).toBe("PN");
     expect(getAccountInitials("octocat")).toBe("OC");
     expect(getAccountInitials("   ")).toBe("P");
+  });
+});
+
+describe("buildAccountProviderViews", () => {
+  it("shows only a disconnected GitHub row when providers aren't shown", () => {
+    const providers = buildAccountProviderViews({
+      githubAccountLabel: null,
+      githubConnected: false,
+      googleAccounts: [],
+      ssoAccounts: [],
+      googleAvailable: true,
+      showProviders: false,
+    });
+
+    expect(providers).toEqual([
+      {
+        provider: "github",
+        label: "GitHub",
+        accountLabel: "Not signed in",
+        connected: false,
+        primary: false,
+      },
+    ]);
+  });
+
+  it("lists SSO accounts first, then GitHub, then Google", () => {
+    const providers = buildAccountProviderViews({
+      githubAccountLabel: "@octocat",
+      githubConnected: true,
+      googleAccounts: [{ accountEmail: "person@example.com" }],
+      ssoAccounts: [{ accountEmail: "person@work.com", displayName: "Okta" }],
+      googleAvailable: true,
+      showProviders: true,
+    });
+
+    expect(providers.map((provider) => provider.provider)).toEqual([
+      "sso",
+      "github",
+      "google",
+    ]);
+    expect(providers[1]).toMatchObject({ accountLabel: "@octocat", connected: true });
   });
 });

--- a/apps/desktop/src/lib/domain/auth/account-profile-presentation.ts
+++ b/apps/desktop/src/lib/domain/auth/account-profile-presentation.ts
@@ -1,3 +1,4 @@
+import type { AccountProviderView } from "@proliferate/product-ui/account/AccountSettingsPane";
 import { AUTH_ACCOUNT_LABELS } from "@/copy/auth/auth-copy";
 import { CAPABILITY_COPY } from "@/copy/capabilities/capability-copy";
 
@@ -137,4 +138,77 @@ export function getAccountInitials(displayName: string): string {
     return parts[0].slice(0, 2).toUpperCase();
   }
   return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+}
+
+export interface AccountProviderViewsInput {
+  githubAccountLabel: string | null;
+  githubConnected: boolean;
+  googleAccounts: Array<{ accountEmail?: string | null; accountId?: string | null }>;
+  ssoAccounts: Array<{
+    accountEmail?: string | null;
+    accountId?: string | null;
+    displayName?: string | null;
+    brandLabel?: string | null;
+  }>;
+  googleAvailable: boolean;
+  showProviders: boolean;
+}
+
+export function buildAccountProviderViews({
+  githubAccountLabel,
+  githubConnected,
+  googleAccounts,
+  ssoAccounts,
+  googleAvailable,
+  showProviders,
+}: AccountProviderViewsInput): AccountProviderView[] {
+  if (!showProviders) {
+    return [
+      {
+        provider: "github",
+        label: "GitHub",
+        accountLabel: "Not signed in",
+        connected: false,
+        primary: false,
+      },
+    ];
+  }
+
+  const providers: AccountProviderView[] = ssoAccounts.map((account) => ({
+    provider: "sso" as const,
+    label: account.displayName ?? "SSO",
+    brandLabel: account.brandLabel ?? account.displayName ?? null,
+    accountLabel: account.accountEmail ?? account.accountId ?? "Connected",
+    connected: true,
+  }));
+
+  providers.push(
+    {
+      provider: "github",
+      label: "GitHub",
+      accountLabel: githubConnected ? githubAccountLabel ?? "Connected" : "Not connected",
+      connected: githubConnected,
+      primary: githubConnected,
+    },
+  );
+
+  if (googleAccounts.length > 0) {
+    providers.push(
+      ...googleAccounts.map((account) => ({
+        provider: "google" as const,
+        label: "Google",
+        accountLabel: account.accountEmail ?? account.accountId ?? "Connected",
+        connected: true,
+      })),
+    );
+  } else {
+    providers.push({
+      provider: "google",
+      label: "Google",
+      accountLabel: googleAvailable ? "Not connected" : "Not configured in this environment",
+      connected: false,
+    });
+  }
+
+  return providers;
 }

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
@@ -70,10 +70,10 @@ describe("desktopNavigationTarget", () => {
     );
   });
 
-  it("routes organization join links to the members settings section", () => {
+  it("routes organization join links to the account settings section (reachable by non-admins)", () => {
     expect(
       desktopNavigationTarget("proliferate://join/org-123"),
-    ).toBe("/settings?section=organization-members&joinOrganizationId=org-123");
+    ).toBe("/settings?section=account&joinOrganizationId=org-123");
   });
 
   it("routes parked Slack bot settings links to general settings", () => {

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
@@ -15,7 +15,10 @@ export function desktopNavigationTarget(url: string): string | null {
     const segments = parsed.pathname.split("/").filter(Boolean);
     if (segments.length === 1) {
       const organizationId = decodeRoutePart(segments[0]);
-      const params = new URLSearchParams({ section: "organization-members" });
+      // Lands on Account (every signed-in user can reach it), not the
+      // admin-gated Members pane — a non-admin invitee must be able to
+      // follow this link and see/accept their invitation.
+      const params = new URLSearchParams({ section: "account" });
       params.set("joinOrganizationId", organizationId);
       return `/settings?${params.toString()}`;
     }

--- a/apps/desktop/src/lib/domain/settings/navigation.test.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation.test.ts
@@ -370,13 +370,13 @@ describe("settings navigation", () => {
     });
   });
 
-  it("preserves organization join target only on the members section", () => {
+  it("preserves organization join target only on the account section (reachable by non-admins)", () => {
     expect(resolveSettingsSelection({
-      rawSection: "organization-members",
+      rawSection: "account",
       rawJoinOrganizationId: "org-1",
       repositories: [],
     })).toEqual({
-      activeSection: "organization-members",
+      activeSection: "account",
       activeRepoSourceRoot: null,
       focus: { joinOrganizationId: "org-1" },
       joinOrganizationId: "org-1",
@@ -394,14 +394,14 @@ describe("settings navigation", () => {
     });
   });
 
-  it("builds flat organization settings and members join links", () => {
+  it("builds flat organization settings and account join links", () => {
     expect(buildSettingsHref({ section: "organization" })).toBe(
       "/settings?section=organization",
     );
     expect(buildSettingsHref({
-      section: "organization-members",
+      section: "account",
       joinOrganizationId: "org-1",
-    })).toBe("/settings?section=organization-members&joinOrganizationId=org-1");
+    })).toBe("/settings?section=account&joinOrganizationId=org-1");
   });
 
   it("builds new settings links for cloud repo helpers", () => {

--- a/apps/desktop/src/lib/domain/settings/navigation.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation.ts
@@ -98,7 +98,7 @@ export function buildSettingsHref(target: SettingsNavigationTarget): string {
       params.set(name, value);
     }
   }
-  if (section === "organization-members" && target.joinOrganizationId) {
+  if (section === "account" && target.joinOrganizationId) {
     params.set("joinOrganizationId", target.joinOrganizationId);
   }
   return `/settings?${params.toString()}`;
@@ -254,7 +254,7 @@ export function resolveSettingsSelection({
     activeSection: section,
     activeRepoSourceRoot: repoSourceRoot,
     focus: sanitizeFocusForSection(section, focus),
-    joinOrganizationId: section === "organization-members" ? rawJoinOrganizationId : null,
+    joinOrganizationId: section === "account" ? rawJoinOrganizationId : null,
   };
 }
 
@@ -296,7 +296,7 @@ function sanitizeFocusForSection(
   if (section === "billing") {
     return pickFocus({ checkout: focus.checkout });
   }
-  if (section === "organization-members") {
+  if (section === "account") {
     return pickFocus({ joinOrganizationId: focus.joinOrganizationId });
   }
   if (section === "integrations") {


### PR DESCRIPTION
## Summary

Fixes #1013.

`CurrentUserInvitationsSection` (the UI for a signed-in user to see and
accept their own pending org invitations) only rendered inside
`OrganizationMembersPane`, which lives on the `organization-members`
settings section — admin-gated in `navigation-presentation.ts`.
`SettingsScreen` redirects any non-admin deep link at an admin-only
section back to the default section, so a plain invitee had **no**
working UI path, even though the backing endpoints
(`GET /organizations/invitations/current`,
`POST /organizations/invitations/current/{id}/accept`) already worked
for them.

The gap was worse than just discoverability: the actual invite-link
deep-link flow (`proliferate://join/<orgId>` native URL handler, and
the `?joinOrganizationId=` settings search param used by
`useOrganizationJoinInvitationFlow`) was **hardcoded** to land on
`organization-members` too — so following an invite link as a
non-admin bounced you straight back to General with no notice.

### Placement decision

Moved (not duplicated) the pending-invitations UI onto the **Account**
pane (`User` scope) — the one settings page every signed-in user can
reach regardless of role, since every Org-scope row in this repo's
current settings IA is `adminOnly`. Members stays admin-gated for its
actual member-management content (invite by email, role changes,
revoke).

Retargeted every place that hardcoded `organization-members` as the
join-flow landing section to `account` instead:
- `apps/desktop/src/lib/domain/auth/desktop-navigation.ts` — native
  `proliferate://join/<orgId>` URL handler
- `apps/desktop/src/lib/domain/settings/navigation.ts` — `buildSettingsHref`,
  `resolveSettingsSelection`, `sanitizeFocusForSection`
- `apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts`

`apps/desktop/src/components/settings/panes/AccountPane.tsx` now owns
the pending-invitations section + accept flow (query, accept mutation,
join-organization activation, status/unauthenticated notices) that
previously lived in `OrganizationMembersPane.tsx`.

### Verification

- `npx tsc --noEmit` clean.
- Full `apps/desktop` vitest suite: same 11 failed files / 22 failed
  tests before and after this change (pre-existing, unrelated —
  verified via `git stash` against the same `origin/main` base:
  keyboard-shortcut resolution, appearance-token timing, TurnDiffPanel
  SDK mock, playground scenarios, one support-modal timing test, one
  stale `agent-authentication` navigation fixture, one
  `orchestration-effects` OAuth-return path fixture).
- Booted the stack on a fresh `fixinvite` profile
  (`SINGLE_ORG_MODE=true`), claimed `/setup`, logged in as an org
  owner via the password API, invited `member@example.com`, registered
  that invitee through `/register` (consumes the first invite), then
  re-invited the now-active member to create a fresh pending
  invitation. Signed in as that non-admin member in the desktop web
  build and drove it with Playwright:
  - `?section=organization-members` still redirects non-admins to
    `?section=general` (Members stays properly admin-gated).
  - `?section=account` shows "Pending invitations" / "Fixinvite Org" /
    "Accept invitation" for the signed-in non-admin.
  - Clicking Accept → Join completes the accept flow; confirmed
    server-side the invitation's `status` flipped to `accepted` with
    `acceptedByUserId` set to the member's own user id.
  - `?section=account&joinOrganizationId=<id>` (the deep-link shape)
    stays on `account` instead of bouncing.

### Intent-harness follow-up

`tests/intent/specs/invitation.spec.ts` on `tests/intent-harness` has a
test that documents this exact gap and should flip when this merges:

```
T2-INV-1: invitation happy path > documents GAP: pending-invitation accept UI is unreachable for a non-admin invitee (settings admin gate)
```

That test asserts navigating to `?section=organization-members` as
the invitee redirects to General and treats that as the (gated)
end-state. With this fix, the pending invitation is reachable at
`?section=account` instead — the test should be updated to assert
against `account` and drop its "documented gap" framing once this PR
lands.

## Test plan

- [x] `npx tsc --noEmit` (apps/desktop)
- [x] `npx vitest run` (apps/desktop) — no new failures vs. `origin/main` baseline
- [x] Manual: boot `fixinvite` profile, invite + accept as non-admin via Account pane (Playwright-driven, screenshots + server-side invitation status confirmed)
- [ ] Update/flip the `tests/intent-harness` GAP test named above

🤖 Generated with [Claude Code](https://claude.com/claude-code)