### PR TITLE
fix(server): deliver signup Slack notifications inline (no Celery worker exists)

### DIFF
--- a/server/proliferate/server/notifications.py
+++ b/server/proliferate/server/notifications.py
@@ -12,7 +12,6 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.background.config import NOTIFICATIONS_QUEUE, NOTIFICATIONS_SEND_SLACK_TASK
 from proliferate.config import settings
 from proliferate.db import engine as db_engine
 from proliferate.db import session_ops as db_session
@@ -152,19 +151,25 @@ def schedule_signup_slack_notification(
     dedupe_key: str | None = None,
     db: AsyncSession | None = None,
 ) -> None:
-    payload = _signup_slack_notification_task_payload(
-        notification,
-        dedupe_key=dedupe_key,
-    )
-    task_id = f"signup-slack:{dedupe_key}" if dedupe_key else None
+    # Delivered in-process (like billing Slack notifications below) rather than
+    # via Celery: no deployment path runs a Celery worker for this queue, so an
+    # enqueue here would silently vanish.
+    name = f"signup-slack-notification-{dedupe_key}" if dedupe_key else "signup-slack-notification"
+
+    def _deliver() -> None:
+        _schedule(
+            deliver_signup_slack_notification(notification, dedupe_key=dedupe_key),
+            name=name,
+        )
+
     if db is None:
-        _enqueue_slack_notification_task(payload, task_id=task_id)
+        _deliver()
         return
 
-    async def _enqueue_after_commit() -> None:
-        _enqueue_slack_notification_task(payload, task_id=task_id)
+    async def _deliver_after_commit() -> None:
+        _deliver()
 
-    db_session.defer_after_commit(db, _enqueue_after_commit)
+    db_session.defer_after_commit(db, _deliver_after_commit)
 
 
 def schedule_billing_slack_notification(notification: BillingSlackNotification) -> None:
@@ -298,57 +303,6 @@ def _billing_slack_webhook_configured(event: BillingSlackEvent) -> bool:
         else settings.billing_negative_slack_webhook_url
     )
     return bool(webhook_url.strip())
-
-
-def _signup_slack_notification_task_payload(
-    notification: SignupSlackNotification,
-    *,
-    dedupe_key: str | None,
-) -> dict[str, object]:
-    return {
-        "kind": SIGNUP_SLACK_TASK_KIND,
-        "dedupe_key": dedupe_key,
-        "notification": {
-            "name": notification.name,
-            "email": notification.email,
-            "github": notification.github,
-            "user_created_at": (
-                notification.user_created_at.isoformat()
-                if notification.user_created_at is not None
-                else None
-            ),
-        },
-    }
-
-
-def _enqueue_slack_notification_task(
-    payload: dict[str, object],
-    *,
-    task_id: str | None,
-) -> bool:
-    try:
-        _send_slack_task_to_celery(payload, task_id=task_id)
-    except Exception:
-        logger.exception("Could not enqueue Slack notification task")
-        return False
-    return True
-
-
-def _send_slack_task_to_celery(
-    payload: dict[str, object],
-    *,
-    task_id: str | None,
-) -> None:
-    from proliferate.background.celery_app import celery_app
-    from proliferate.middleware.request_context import capture_correlation_context
-
-    celery_app.send_task(
-        NOTIFICATIONS_SEND_SLACK_TASK,
-        args=(payload,),
-        queue=NOTIFICATIONS_QUEUE,
-        task_id=task_id,
-        headers=capture_correlation_context() or None,
-    )
 
 
 def _schedule(awaitable: Coroutine[object, object, bool], *, name: str) -> bool:

--- a/server/tests/unit/test_slack_notifications.py
+++ b/server/tests/unit/test_slack_notifications.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 
 import pytest
@@ -129,23 +130,33 @@ async def test_signup_slack_notification_posts_expected_payload(
     )
 
 
-def test_schedule_signup_slack_notification_enqueues_celery_task(
+async def _drain_scheduled_signup_notifications() -> None:
+    pending = [
+        task
+        for task in asyncio.all_tasks()
+        if task is not asyncio.current_task() and task.get_name() == "signup-slack-notification"
+    ]
+    if pending:
+        await asyncio.gather(*pending)
+
+
+@pytest.mark.asyncio
+async def test_schedule_signup_slack_notification_delivers_inline_when_webhook_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[dict[str, object]] = []
 
-    def fake_send_slack_task_to_celery(
-        payload: dict[str, object],
+    async def fake_post_incoming_webhook(
         *,
-        task_id: str | None,
+        webhook_url: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
     ) -> None:
-        calls.append({"payload": payload, "task_id": task_id})
+        calls.append({"webhook_url": webhook_url, "text": text, "blocks": blocks})
 
-    monkeypatch.setattr(
-        notifications,
-        "_send_slack_task_to_celery",
-        fake_send_slack_task_to_celery,
-    )
+    monkeypatch.setattr(settings, "signups_slack_webhook_url", "https://signups")
+    monkeypatch.setattr(notifications, "post_incoming_webhook", fake_post_incoming_webhook)
+
     notifications.schedule_signup_slack_notification(
         SignupSlackNotification(
             name="Ada",
@@ -153,42 +164,38 @@ def test_schedule_signup_slack_notification_enqueues_celery_task(
             github="ada",
             user_created_at=None,
         ),
-        dedupe_key="github:ada",
+    )
+    await _drain_scheduled_signup_notifications()
+
+    assert len(calls) == 1
+    assert calls[0]["webhook_url"] == "https://signups"
+    assert calls[0]["text"] == "\n".join(
+        [
+            "signup",
+            "# Ada signed up",
+            "email: ada@example.com",
+            "github: ada",
+            "user created: unknown",
+        ]
     )
 
-    assert calls == [
-        {
-            "payload": {
-                "kind": "signup",
-                "dedupe_key": "github:ada",
-                "notification": {
-                    "name": "Ada",
-                    "email": "ada@example.com",
-                    "github": "ada",
-                    "user_created_at": None,
-                },
-            },
-            "task_id": "signup-slack:github:ada",
-        }
-    ]
 
-
-def test_schedule_signup_slack_notification_does_not_raise_when_celery_enqueue_fails(
+@pytest.mark.asyncio
+async def test_schedule_signup_slack_notification_noops_when_webhook_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def broken_send_slack_task_to_celery(
-        _payload: dict[str, object],
-        *,
-        task_id: str | None,
-    ) -> None:
-        del task_id
-        raise RuntimeError("broker unavailable")
+    calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(
-        notifications,
-        "_send_slack_task_to_celery",
-        broken_send_slack_task_to_celery,
-    )
+    async def fake_post_incoming_webhook(
+        *,
+        webhook_url: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+    ) -> None:
+        calls.append({"webhook_url": webhook_url, "text": text, "blocks": blocks})
+
+    monkeypatch.setattr(settings, "signups_slack_webhook_url", "")
+    monkeypatch.setattr(notifications, "post_incoming_webhook", fake_post_incoming_webhook)
 
     notifications.schedule_signup_slack_notification(
         SignupSlackNotification(
@@ -197,8 +204,10 @@ def test_schedule_signup_slack_notification_does_not_raise_when_celery_enqueue_f
             github="ada",
             user_created_at=None,
         ),
-        dedupe_key="github:ada",
     )
+    await _drain_scheduled_signup_notifications()
+
+    assert calls == []
 
 
 def test_send_slack_task_dispatches_signup_payload(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Signup Slack pings were enqueued to a Celery queue that no deployed worker consumes, so they were silently never delivered.
- They now use the same in-process asyncio delivery path as billing notifications, matching how billing Slack pings already work in production.
- `SIGNUPS_SLACK_WEBHOOK_URL` unset continues to be a no-op — no behavior change for orgs that haven't configured it.

## Test plan
- [x] `server/tests/unit/test_slack_notifications.py` updated and passing
- [ ] Verify a signup event in a running dev profile produces a Slack post when `SIGNUPS_SLACK_WEBHOOK_URL` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)