### PR TITLE
feat(agent-gateway): enforce org auth-method policy at select-time

### DIFF
--- a/apps/desktop/src/components/settings/panes/OrganizationModelPolicyPane.tsx
+++ b/apps/desktop/src/components/settings/panes/OrganizationModelPolicyPane.tsx
@@ -110,8 +110,12 @@ export function OrganizationModelPolicyPane() {
     <section className="space-y-6">
       <SettingsPageHeader
         title="Model policy"
-        description="Which agents, auth routes, and models organization members can use."
+        description="Which agents and auth routes organization members can use."
       />
+
+      <p className="text-sm text-muted-foreground">
+        Restricting members to specific models (per-model allowlists) is coming soon.
+      </p>
 
       {policy.isLoading ? (
         <div className="text-sm text-muted-foreground">Loading policy…</div>
@@ -179,7 +183,7 @@ export function OrganizationModelPolicyPane() {
           </div>
 
           {/* Conflicts */}
-          <SettingsSection title="Conflicts" description="Member selections outside this policy. Flagged only — nothing is blocked.">
+          <SettingsSection title="Conflicts" description="Existing member selections outside this policy. New selections are blocked; these stay flagged until each member updates them.">
             <div className="overflow-clip rounded-lg bg-foreground/5">
               {violations.isLoading ? (
                 <div className="px-3.5 py-3.5 text-sm text-muted-foreground">Checking…</div>

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -75,6 +75,7 @@ export function isMultiSourceApiKeyConfigVisible(editor: HarnessAuthEditorApi): 
 }
 
 const CURSOR_HARNESS = "cursor";
+const POLICY_TOOLTIP = "Disabled by your organization's policy";
 
 export function HarnessAuthSection({
   harnessKind,
@@ -146,6 +147,16 @@ function HarnessAuthMethods({
   const capabilities = editor.capabilitiesQuery.data;
   const enrollment = editor.enrollmentQuery.data;
 
+  // A disallowed policy only blocks MOVING to a method, never staying on one
+  // that's already selected — that's the only remediation path for a
+  // pre-existing selection on a harness/route the org has since disallowed
+  // (there is no DELETE endpoint). Native is deliberately excluded from the
+  // harness-level gate (see editor.nativeDisallowed) so clearing a selection
+  // by switching to CLI always stays reachable.
+  const gatewayCardDisallowed = editor.gatewayDisallowed && !selectedMethods.has("gateway");
+  const apiKeyCardDisallowed = editor.apiKeyDisallowed && !selectedMethods.has("api_key");
+  const nativeCardDisallowed = editor.nativeDisallowed && !selectedMethods.has("cli");
+
   function selectMethod(method: AuthMethod) {
     if (multiSource) {
       handleMultiSourceSelect(method, editor);
@@ -160,28 +171,44 @@ function HarnessAuthMethods({
       title={HARNESS_PANE_COPY.authenticationTitle}
       description={HARNESS_PANE_COPY.authenticationDescription(displayName)}
     >
+      {editor.harnessDisallowed ? (
+        <p className="pb-2 text-sm text-muted-foreground">{POLICY_TOOLTIP}.</p>
+      ) : null}
       <div className="grid grid-cols-3 gap-3">
         <MethodCard
           label={HARNESS_PANE_COPY.methodGateway}
           icon={<CloudIcon className="size-5" />}
           selected={selectedMethods.has("gateway")}
-          disabled={editor.gatewayLocked || editor.busy}
-          disabledReason={editor.gatewayLocked ? gatewaySubtitle(capabilities, enrollment) : undefined}
+          disabled={editor.gatewayLocked || editor.busy || gatewayCardDisallowed}
+          disabledReason={
+            editor.gatewayLocked
+              ? gatewaySubtitle(capabilities, enrollment)
+              : gatewayCardDisallowed
+                ? POLICY_TOOLTIP
+                : undefined
+          }
           onClick={() => selectMethod("gateway")}
         />
         <MethodCard
           label={HARNESS_PANE_COPY.methodApiKey}
           icon={<KeyRound className="size-5" />}
           selected={selectedMethods.has("api_key")}
-          disabled={editor.busy}
+          disabled={editor.busy || apiKeyCardDisallowed}
+          disabledReason={apiKeyCardDisallowed ? POLICY_TOOLTIP : undefined}
           onClick={() => selectMethod("api_key")}
         />
         <MethodCard
           label={HARNESS_PANE_COPY.methodCli}
           icon={<SquareTerminal className="size-5" />}
           selected={selectedMethods.has("cli")}
-          disabled={multiSource || editor.busy}
-          disabledReason={multiSource ? HARNESS_PANE_COPY.cliAlwaysActive : undefined}
+          disabled={multiSource || editor.busy || nativeCardDisallowed}
+          disabledReason={
+            multiSource
+              ? HARNESS_PANE_COPY.cliAlwaysActive
+              : nativeCardDisallowed
+                ? POLICY_TOOLTIP
+                : undefined
+          }
           onClick={() => selectMethod("cli")}
         />
       </div>

--- a/apps/desktop/src/hooks/agents/workflows/use-harness-auth-editor.ts
+++ b/apps/desktop/src/hooks/agents/workflows/use-harness-auth-editor.ts
@@ -5,11 +5,13 @@ import {
   useAgentGatewayCapabilities,
   useAgentGatewayEnrollment,
   useAuthSelections,
+  useOrgAgentPolicy,
   usePutAuthSelections,
 } from "@proliferate/cloud-sdk-react";
 import { getHarnessEnvVarSuggestions } from "@/config/harness-env-vars";
 import { useAgentCatalog } from "@/hooks/agents/derived/use-agent-catalog";
 import { useAgentLoginTerminalWorkflow } from "@/hooks/agents/workflows/use-agent-login-terminal-workflow";
+import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { isReadyAgent } from "@/lib/domain/agents/status";
 import {
@@ -34,6 +36,20 @@ export interface HarnessAuthEditorApi {
 
   // Derived
   gatewayLocked: boolean;
+  // Org-policy disabling (client-side hint; the server is the hard gate). null
+  // allow-lists mean "no restriction" on that org, so every field below stays
+  // false until an org's policy actively narrows it. A member may belong to
+  // several orgs; the strictest applicable org wins (mirrors the server's
+  // per-membership enforcement loop).
+  //
+  // harnessDisallowed only gates NEW enabled selections (gateway/api_key); it
+  // never blocks going native, so a member can always clear a pre-existing
+  // selection on a harness the org has since disallowed (there is no DELETE
+  // endpoint — an empty/all-disabled PUT is the only remediation).
+  harnessDisallowed: boolean;
+  gatewayDisallowed: boolean;
+  apiKeyDisallowed: boolean;
+  nativeDisallowed: boolean;
   multiSource: boolean;
   busy: boolean;
   editorState: HarnessAuthEditorState;
@@ -74,6 +90,16 @@ export function useHarnessAuthEditor(
 ): HarnessAuthEditorApi {
   const { cloudActive } = useCloudAvailabilityState();
   const showToast = useToastStore((state) => state.show);
+
+  // Org policy is the server's hard gate; here it also drives client-side
+  // disabling so members see WHY an option is unavailable. The policy read is
+  // org-admin-gated, so for plain members it simply errors and yields no hints
+  // (the server still rejects a disallowed PUT, surfaced via the commit toast).
+  const { activeOrganizationId } = useActiveOrganization();
+  const orgPolicyQuery = useOrgAgentPolicy(
+    activeOrganizationId,
+    cloudActive && activeOrganizationId !== null,
+  );
 
   const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
   const enrollmentQuery = useAgentGatewayEnrollment(cloudActive);
@@ -143,6 +169,21 @@ export function useHarnessAuthEditor(
   const busy = putSelections.isPending;
   const editorState: HarnessAuthEditorState = { gatewayEnabled, rows };
   const native = isNativeState(editorState);
+
+  // Policy-driven disabling. null lists == no restriction; a route/harness
+  // absent from a non-null list is disallowed by the org. Native is checked
+  // against allowedRoutes only — never gated by harnessDisallowed — so going
+  // native always stays reachable as the remediation path (mirrors the
+  // server's _selection_set_policy_violation ordering).
+  const allowedRoutes = orgPolicyQuery.data?.allowedRoutes ?? null;
+  const allowedHarnesses = orgPolicyQuery.data?.allowedHarnesses ?? null;
+  const harnessDisallowed =
+    allowedHarnesses !== null && !allowedHarnesses.includes(harnessKind);
+  const gatewayDisallowed =
+    harnessDisallowed || (allowedRoutes !== null && !allowedRoutes.includes("gateway"));
+  const apiKeyDisallowed =
+    harnessDisallowed || (allowedRoutes !== null && !allowedRoutes.includes("api_key"));
+  const nativeDisallowed = allowedRoutes !== null && !allowedRoutes.includes("native");
 
   function commit(next: HarnessAuthEditorState) {
     setGatewayEnabled(next.gatewayEnabled);
@@ -252,6 +293,10 @@ export function useHarnessAuthEditor(
     selectionsQuery,
     apiKeysQuery,
     gatewayLocked,
+    harnessDisallowed,
+    gatewayDisallowed,
+    apiKeyDisallowed,
+    nativeDisallowed,
     multiSource,
     busy,
     editorState,

--- a/server/alembic/versions/76c0a297415c_org_agent_policy_native_route_backfill.py
+++ b/server/alembic/versions/76c0a297415c_org_agent_policy_native_route_backfill.py
@@ -12,7 +12,7 @@ absence of "native" unambiguously means an admin intentionally disallowed it via
 the fixed pane. Rows with a null list (no restriction) are left untouched.
 
 Revision ID: 76c0a297415c
-Revises: bcc0459a6f11
+Revises: d4bbfa6e0669
 Create Date: 2026-07-07 00:00:00.000000
 
 """
@@ -27,7 +27,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "76c0a297415c"
-down_revision: Union[str, Sequence[str], None] = "bcc0459a6f11"
+down_revision: Union[str, Sequence[str], None] = "d4bbfa6e0669"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/server/alembic/versions/76c0a297415c_org_agent_policy_native_route_backfill.py
+++ b/server/alembic/versions/76c0a297415c_org_agent_policy_native_route_backfill.py
@@ -1,0 +1,110 @@
+"""backfill "native" into legacy org_agent_policy allowed_routes
+
+Before this branch, "native" was not a valid policy route value: an admin could
+never persist it in ``allowed_routes_json`` (the server 400'd on it). Enforcement
+now reads a non-null ``allowed_routes`` list as authoritative — a route absent
+from the list is DISALLOWED, and that now includes "native".
+
+To avoid retroactively locking orgs out of native CLI login (which no admin
+could have intentionally disallowed), we normalize every pre-existing non-null
+``allowed_routes_json`` to explicitly include "native". After this backfill,
+absence of "native" unambiguously means an admin intentionally disallowed it via
+the fixed pane. Rows with a null list (no restriction) are left untouched.
+
+Revision ID: 76c0a297415c
+Revises: bcc0459a6f11
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "76c0a297415c"
+down_revision: Union[str, Sequence[str], None] = "bcc0459a6f11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NATIVE = "native"
+
+
+def backfill_native(raw: str | None) -> str | None:
+    """Return ``raw`` with "native" appended if it is a list missing it.
+
+    Pure JSON→JSON transform (no DB), extracted so the migration's data rule can
+    be unit-tested. Returns ``None`` (no update) when the value is null, not a
+    JSON list, or already contains "native".
+    """
+    if raw is None:
+        return None
+    try:
+        routes = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(routes, list) or _NATIVE in routes:
+        return None
+    return json.dumps([*routes, _NATIVE])
+
+
+def upgrade() -> None:
+    """Add "native" to every non-null allowed_routes list that lacks it."""
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT organization_id, allowed_routes_json "
+            "FROM org_agent_policy "
+            "WHERE allowed_routes_json IS NOT NULL"
+        )
+    ).fetchall()
+    for organization_id, raw in rows:
+        updated = backfill_native(raw)
+        if updated is None:
+            continue
+        bind.execute(
+            sa.text(
+                "UPDATE org_agent_policy "
+                "SET allowed_routes_json = :routes "
+                "WHERE organization_id = :org_id"
+            ),
+            {"routes": updated, "org_id": organization_id},
+        )
+
+
+def downgrade() -> None:
+    """Remove the backfilled "native" from non-null allowed_routes lists.
+
+    Best-effort inverse: strips "native" from restricted lists. It cannot know
+    which rows had "native" added by this migration versus set intentionally
+    afterward, so downgrading may drop a deliberate "native" allow — acceptable
+    for a forward-only pipeline.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT organization_id, allowed_routes_json "
+            "FROM org_agent_policy "
+            "WHERE allowed_routes_json IS NOT NULL"
+        )
+    ).fetchall()
+    for organization_id, raw in rows:
+        try:
+            routes = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(routes, list) or _NATIVE not in routes:
+            continue
+        remaining = [route for route in routes if route != _NATIVE]
+        bind.execute(
+            sa.text(
+                "UPDATE org_agent_policy "
+                "SET allowed_routes_json = :routes "
+                "WHERE organization_id = :org_id"
+            ),
+            {"routes": json.dumps(remaining), "org_id": organization_id},
+        )

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -21,6 +21,14 @@ AGENT_AUTH_SOURCE_GATEWAY = "gateway"
 AGENT_AUTH_SOURCE_API_KEY = "api_key"
 AGENT_AUTH_SOURCE_KINDS = (AGENT_AUTH_SOURCE_GATEWAY, AGENT_AUTH_SOURCE_API_KEY)
 
+# "native" is NOT a selection source_kind — it is the empty-selection state (zero
+# enabled rows == the harness's own CLI login). It exists ONLY as an org-policy
+# allow-list value: listing "native" in allowed_routes permits native CLI login;
+# omitting it (when allowed_routes is otherwise set) disallows it. Never persisted
+# as a selection row, so it is absent from AGENT_AUTH_SOURCE_KINDS above.
+AGENT_AUTH_ROUTE_NATIVE = "native"
+AGENT_AUTH_POLICY_ROUTES = (*AGENT_AUTH_SOURCE_KINDS, AGENT_AUTH_ROUTE_NATIVE)
+
 # The only state.json wire schema version AnyHarness understands (contract §3);
 # mirrors ``route_auth::state::STATE_VERSION`` on the Rust render plane.
 AGENT_AUTH_STATE_VERSION = 2

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -501,16 +501,22 @@ def _selection_set_policy_violation(
 
     Mirrors the at-rest report semantics: only ENABLED sources count (disabled
     rows never launch), and an empty enabled set == native CLI login. The
-    harness check applies regardless of route — a disallowed harness is off in
-    every form, including native.
+    harness check only applies when the desired set has an enabled source —
+    an empty/all-disabled set must always be allowed so a member can clear a
+    pre-existing selection on a harness the org has since disallowed (there is
+    no other way to comply, since there is no DELETE endpoint).
     """
-    if allowed_harnesses is not None and harness_kind not in allowed_harnesses:
+    enabled = [source for source in sources if source.enabled]
+    if (
+        allowed_harnesses is not None
+        and harness_kind not in allowed_harnesses
+        and enabled
+    ):
         return (
             f"Harness '{harness_kind}' is not allowed by your organization's policy."
         )
     if allowed_routes is None:
         return None
-    enabled = [source for source in sources if source.enabled]
     if not enabled:
         # Zero enabled sources == the harness's own (native) CLI login.
         if AGENT_AUTH_ROUTE_NATIVE not in allowed_routes:

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -507,28 +507,19 @@ def _selection_set_policy_violation(
     no other way to comply, since there is no DELETE endpoint).
     """
     enabled = [source for source in sources if source.enabled]
-    if (
-        allowed_harnesses is not None
-        and harness_kind not in allowed_harnesses
-        and enabled
-    ):
-        return (
-            f"Harness '{harness_kind}' is not allowed by your organization's policy."
-        )
+    if allowed_harnesses is not None and harness_kind not in allowed_harnesses and enabled:
+        return f"Harness '{harness_kind}' is not allowed by your organization's policy."
     if allowed_routes is None:
         return None
     if not enabled:
         # Zero enabled sources == the harness's own (native) CLI login.
         if AGENT_AUTH_ROUTE_NATIVE not in allowed_routes:
-            return (
-                "Native CLI login is not allowed by your organization's policy."
-            )
+            return "Native CLI login is not allowed by your organization's policy."
         return None
     for source in enabled:
         if source.source_kind not in allowed_routes:
             return (
-                f"Auth route '{source.source_kind}' is not allowed by "
-                "your organization's policy."
+                f"Auth route '{source.source_kind}' is not allowed by your organization's policy."
             )
     return None
 

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -24,7 +24,6 @@ from proliferate.constants.agent_gateway import (
     AGENT_AUTH_ROUTE_NATIVE,
     AGENT_AUTH_SURFACE_CLOUD,
 )
-from proliferate.db.store.organizations import list_organizations_for_user
 from proliferate.db.store import agent_gateway as agent_gateway_store
 from proliferate.db.store.agent_gateway import (
     AgentApiKeyRecord,
@@ -35,6 +34,7 @@ from proliferate.db.store.agent_gateway import (
 )
 from proliferate.db.store.billing import list_entitlements
 from proliferate.db.store.billing_subscriptions import list_subscriptions
+from proliferate.db.store.organizations import list_organizations_for_user
 from proliferate.server.billing.domain.plans import (
     active_unlimited_cloud_entitlement,
     latest_healthy_cloud_subscription,

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -20,9 +20,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.constants.agent_gateway import (
-    AGENT_AUTH_SOURCE_KINDS,
+    AGENT_AUTH_POLICY_ROUTES,
+    AGENT_AUTH_ROUTE_NATIVE,
     AGENT_AUTH_SURFACE_CLOUD,
 )
+from proliferate.db.store.organizations import list_organizations_for_user
 from proliferate.db.store import agent_gateway as agent_gateway_store
 from proliferate.db.store.agent_gateway import (
     AgentApiKeyRecord,
@@ -202,6 +204,17 @@ async def put_auth_selections(
             str(error),
             status_code=400,
         ) from error
+
+    # Org policy is a HARD gate at select-time: a member may not persist a
+    # selection set that violates any org they belong to (personal/non-org
+    # users have no memberships, so this is a no-op for them). Existing rows at
+    # rest are never touched — the violations report keeps covering stale ones.
+    await _enforce_org_selection_policy(
+        db,
+        user_id=user_id,
+        harness_kind=harness_kind,
+        sources=sources,
+    )
 
     try:
         rows = await agent_gateway_store.put_auth_selections(
@@ -421,11 +434,13 @@ async def update_org_policy(
     allowed_routes: list[str] | None,
     allowed_harnesses: list[str] | None,
 ) -> OrgAgentPolicySnapshot:
-    # "routes" are the selection source kinds (gateway/api_key); native is the
-    # empty state and carries no row, so it is never an allow-list value.
+    # "routes" are the selection source kinds (gateway/api_key) PLUS "native",
+    # the empty-selection state. Native carries no selection row, but it is a
+    # valid policy allow-list value: listing it permits native CLI login,
+    # omitting it (when the list is otherwise set) disallows it.
     routes = _validate_policy_values(
         allowed_routes,
-        allowed=AGENT_AUTH_SOURCE_KINDS,
+        allowed=AGENT_AUTH_POLICY_ROUTES,
         field="routes",
     )
     harnesses = _validate_policy_harnesses(allowed_harnesses)
@@ -465,10 +480,88 @@ def selection_violates_policy(
     allowed_routes: tuple[str, ...] | None,
     allowed_harnesses: tuple[str, ...] | None,
 ) -> bool:
-    """Flag-only conflict check; nothing is ever blocked."""
+    """Flag-only conflict check for selections AT REST; nothing here is blocked.
+
+    This powers the violations report (existing enabled rows). Select-time
+    blocking of NEW writes lives in :func:`_enforce_org_selection_policy`.
+    """
     if allowed_routes is not None and selection.source_kind not in allowed_routes:
         return True
     return allowed_harnesses is not None and selection.harness_kind not in allowed_harnesses
+
+
+def _selection_set_policy_violation(
+    *,
+    harness_kind: str,
+    sources: Sequence[DesiredAuthSource],
+    allowed_routes: tuple[str, ...] | None,
+    allowed_harnesses: tuple[str, ...] | None,
+) -> str | None:
+    """Return a member-facing message if this desired set violates the policy.
+
+    Mirrors the at-rest report semantics: only ENABLED sources count (disabled
+    rows never launch), and an empty enabled set == native CLI login. The
+    harness check applies regardless of route — a disallowed harness is off in
+    every form, including native.
+    """
+    if allowed_harnesses is not None and harness_kind not in allowed_harnesses:
+        return (
+            f"Harness '{harness_kind}' is not allowed by your organization's policy."
+        )
+    if allowed_routes is None:
+        return None
+    enabled = [source for source in sources if source.enabled]
+    if not enabled:
+        # Zero enabled sources == the harness's own (native) CLI login.
+        if AGENT_AUTH_ROUTE_NATIVE not in allowed_routes:
+            return (
+                "Native CLI login is not allowed by your organization's policy."
+            )
+        return None
+    for source in enabled:
+        if source.source_kind not in allowed_routes:
+            return (
+                f"Auth route '{source.source_kind}' is not allowed by "
+                "your organization's policy."
+            )
+    return None
+
+
+async def _enforce_org_selection_policy(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    sources: Sequence[DesiredAuthSource],
+) -> None:
+    """Reject a desired selection set that violates any of the user's orgs.
+
+    A member may belong to several orgs; a route/harness disallowed by ANY of
+    them is disallowed for the member (the strictest wins). Personal users have
+    no memberships, so this returns immediately. The stored policy row is read
+    directly (raw allow-lists), independent of the plan-based edit gate: a
+    policy that exists is enforced even if the org's edit entitlement lapsed.
+    """
+    memberships = await list_organizations_for_user(db, user_id)
+    for record in memberships:
+        policy_row = await agent_gateway_store.get_org_agent_policy(
+            db,
+            organization_id=record.organization.id,
+        )
+        if policy_row is None:
+            continue
+        message = _selection_set_policy_violation(
+            harness_kind=harness_kind,
+            sources=sources,
+            allowed_routes=_decode_policy_list(policy_row.allowed_routes_json),
+            allowed_harnesses=_decode_policy_list(policy_row.allowed_harnesses_json),
+        )
+        if message is not None:
+            raise CloudApiError(
+                "policy_violation",
+                message,
+                status_code=403,
+            )
 
 
 async def list_org_policy_violations(

--- a/server/tests/integration/test_agent_gateway_policy_api.py
+++ b/server/tests/integration/test_agent_gateway_policy_api.py
@@ -299,7 +299,7 @@ class TestOrgAgentPolicyPlanGating:
 
 class TestOrgAgentPolicyViolations:
     @pytest.mark.asyncio
-    async def test_violations_computed_live_and_nothing_blocked(
+    async def test_violations_report_covers_stale_selections(
         self,
         client: AsyncClient,
         monkeypatch: pytest.MonkeyPatch,
@@ -368,46 +368,33 @@ class TestOrgAgentPolicyViolations:
         assert all(item["email"] for item in violations)
         assert outsider_id not in {item["userId"] for item in violations}
 
-        # Flag-only: a member can still select a violating source afterwards.
-        still_allowed = await _put_selections(
+        # Select-time enforcement is now HARD: once the policy is in place a
+        # member can no longer PUT a NEW violating selection. (Detailed cases
+        # live in test_agent_gateway_policy_enforcement.)
+        blocked = await _put_selections(
             client,
             member_headers,
             harness="grok",
             surface="local",
             sources=[api_key(str(member_key["id"]))],
         )
-        assert still_allowed.status_code == 200, still_allowed.text
+        assert blocked.status_code == 403, blocked.text
+        assert blocked.json()["detail"]["code"] == "policy_violation"
 
-        after = await client.get(violations_path, headers=owner_headers)
-        assert (member_id, "grok", "local", "api_key") in {
-            (item["userId"], item["harnessKind"], item["surface"], item["sourceKind"])
-            for item in after.json()["violations"]
-        }
-
-        # A member can select any REGISTERED harness kind, and the admin can
-        # allow-list that exact kind to resolve the violation.
-        opencode_selection = await _put_selections(
-            client,
-            member_headers,
-            harness="opencode",
-            surface="cloud",
-            sources=[gateway],
-        )
-        assert opencode_selection.status_code == 200, opencode_selection.text
-        flagged_opencode = await client.get(violations_path, headers=owner_headers)
-        assert (member_id, "opencode", "cloud", "gateway") in {
-            (item["userId"], item["harnessKind"], item["surface"], item["sourceKind"])
-            for item in flagged_opencode.json()["violations"]
-        }
-
-        allow_opencode = await client.put(
+        # The stale codex/gateway selection only conflicts on the harness axis
+        # (gateway IS an allowed route). Adding codex to the allow-list resolves
+        # that at-rest violation without the member touching the row.
+        allow_codex = await client.put(
             _policy_path(organization_id),
             headers=owner_headers,
-            json={"allowedRoutes": ["gateway"], "allowedHarnesses": ["claude", "opencode"]},
+            json={"allowedRoutes": ["gateway"], "allowedHarnesses": ["claude", "codex"]},
         )
-        assert allow_opencode.status_code == 200, allow_opencode.text
+        assert allow_codex.status_code == 200, allow_codex.text
         resolved = await client.get(violations_path, headers=owner_headers)
-        assert (member_id, "opencode", "cloud", "gateway") not in {
+        resolved_flagged = {
             (item["userId"], item["harnessKind"], item["surface"], item["sourceKind"])
             for item in resolved.json()["violations"]
         }
+        assert (member_id, "codex", "cloud", "gateway") not in resolved_flagged
+        # The api_key/local row still conflicts on the route axis.
+        assert (member_id, "claude", "local", "api_key") in resolved_flagged

--- a/server/tests/integration/test_agent_gateway_policy_enforcement.py
+++ b/server/tests/integration/test_agent_gateway_policy_enforcement.py
@@ -297,9 +297,7 @@ class TestSelectTimeEnforcement:
         # An org restricts everything to gateway-only. A user who is NOT a member
         # (personal scope) is unaffected and may select api_key freely.
         owner_id, owner_headers = await _authed_user(client)
-        organization_id = await _create_organization(
-            owner_user_id=owner_id, member_user_ids=[]
-        )
+        organization_id = await _create_organization(owner_user_id=owner_id, member_user_ids=[])
         await _set_policy(
             client,
             owner_headers,
@@ -328,9 +326,7 @@ class TestSelectTimeEnforcement:
 
         # A restricted legacy list lacking native gains it.
         assert backfill_native('["gateway"]') == '["gateway", "native"]'
-        assert backfill_native('["gateway", "api_key"]') == (
-            '["gateway", "api_key", "native"]'
-        )
+        assert backfill_native('["gateway", "api_key"]') == ('["gateway", "api_key", "native"]')
         # A row that already allows native, or is unrestricted (null), is untouched.
         assert backfill_native('["gateway", "native"]') is None
         assert backfill_native(None) is None

--- a/server/tests/integration/test_agent_gateway_policy_enforcement.py
+++ b/server/tests/integration/test_agent_gateway_policy_enforcement.py
@@ -126,6 +126,85 @@ class TestSelectTimeEnforcement:
         assert "codex" in rejected.json()["detail"]["message"]
 
     @pytest.mark.asyncio
+    async def test_disallowed_harness_can_be_cleared(self, client: AsyncClient) -> None:
+        # A member has a pre-existing selection on a harness the org has since
+        # disallowed. There is no DELETE endpoint, so the only remediation is
+        # PUTting an empty/all-disabled set — that must succeed even though the
+        # harness itself is disallowed.
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        # No policy yet: seed a selection on "codex" while it's still allowed.
+        seeded = await _put_selections(
+            client,
+            member_headers,
+            harness="codex",
+            surface="cloud",
+            sources=[_GATEWAY],
+        )
+        assert seeded.status_code == 200, seeded.text
+
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=None,
+            allowed_harnesses=["claude"],
+        )
+
+        cleared = await _put_selections(
+            client,
+            member_headers,
+            harness="codex",
+            surface="cloud",
+            sources=[],
+        )
+        assert cleared.status_code == 200, cleared.text
+        assert cleared.json() == []
+
+    @pytest.mark.asyncio
+    async def test_disallowed_harness_still_rejects_enabled_source(
+        self, client: AsyncClient
+    ) -> None:
+        # Same setup as the clearing case above, but this time the member tries
+        # to PUT an enabled source on the disallowed harness — that must still
+        # be rejected; only an empty/all-disabled set is exempt.
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        seeded = await _put_selections(
+            client,
+            member_headers,
+            harness="codex",
+            surface="cloud",
+            sources=[_GATEWAY],
+        )
+        assert seeded.status_code == 200, seeded.text
+
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=None,
+            allowed_harnesses=["claude"],
+        )
+
+        rejected = await _put_selections(
+            client,
+            member_headers,
+            harness="codex",
+            surface="cloud",
+            sources=[_GATEWAY],
+        )
+        assert rejected.status_code == 403, rejected.text
+        assert rejected.json()["detail"]["code"] == "policy_violation"
+        assert "codex" in rejected.json()["detail"]["message"]
+
+    @pytest.mark.asyncio
     async def test_native_disallowed_empty_set_rejected(self, client: AsyncClient) -> None:
         owner_id, owner_headers = await _authed_user(client)
         member_id, member_headers = await _authed_user(client)

--- a/server/tests/integration/test_agent_gateway_policy_enforcement.py
+++ b/server/tests/integration/test_agent_gateway_policy_enforcement.py
@@ -1,0 +1,279 @@
+"""Select-time enforcement of the org agent policy on PUT auth-selections.
+
+The flag-only report (``test_agent_gateway_policy_api``) covers selections AT
+REST. This module covers the HARD gate: a member cannot PUT a selection set that
+violates a policy of any org they belong to. Personal (non-org) users bypass it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from proliferate.config import settings
+from tests.integration.test_agent_gateway_api import _create_key, _put_selections
+from tests.integration.test_agent_gateway_policy_api import (
+    _authed_user,
+    _create_organization,
+    _policy_path,
+)
+
+
+def _api_key(key_id: str, *, enabled: bool = True) -> dict[str, object]:
+    return {
+        "sourceKind": "api_key",
+        "apiKeyId": key_id,
+        "envVarName": "ANTHROPIC_API_KEY",
+        "enabled": enabled,
+    }
+
+
+_GATEWAY: dict[str, object] = {"sourceKind": "gateway", "enabled": True}
+
+
+def _load_backfill_native():  # noqa: ANN202
+    """Load the migration's pure transform (module name starts with a digit)."""
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "alembic"
+        / "versions"
+        / "76c0a297415c_org_agent_policy_native_route_backfill.py"
+    )
+    spec = importlib.util.spec_from_file_location("_native_backfill_migration", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.backfill_native
+
+
+async def _set_policy(
+    client: AsyncClient,
+    owner_headers: dict[str, str],
+    organization_id: str,
+    *,
+    allowed_routes: list[str] | None,
+    allowed_harnesses: list[str] | None,
+) -> None:
+    response = await client.put(
+        _policy_path(organization_id),
+        headers=owner_headers,
+        json={"allowedRoutes": allowed_routes, "allowedHarnesses": allowed_harnesses},
+    )
+    assert response.status_code == 200, response.text
+
+
+@pytest.fixture(autouse=True)
+def _free_policy_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Editing the policy is plan-gated; the free plan lifts the gate for tests.
+    monkeypatch.setattr(settings, "agent_gateway_policy_min_plan", "free")
+
+
+class TestSelectTimeEnforcement:
+    @pytest.mark.asyncio
+    async def test_disallowed_route_rejected(self, client: AsyncClient) -> None:
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway", "native"],
+            allowed_harnesses=None,
+        )
+
+        member_key = await _create_key(client, member_headers)
+        rejected = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[_api_key(str(member_key["id"]))],
+        )
+        assert rejected.status_code == 403, rejected.text
+        assert rejected.json()["detail"]["code"] == "policy_violation"
+        assert "api_key" in rejected.json()["detail"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_disallowed_harness_rejected(self, client: AsyncClient) -> None:
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=None,
+            allowed_harnesses=["claude"],
+        )
+
+        rejected = await _put_selections(
+            client,
+            member_headers,
+            harness="codex",
+            surface="cloud",
+            sources=[_GATEWAY],
+        )
+        assert rejected.status_code == 403, rejected.text
+        assert rejected.json()["detail"]["code"] == "policy_violation"
+        assert "codex" in rejected.json()["detail"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_native_disallowed_empty_set_rejected(self, client: AsyncClient) -> None:
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        # native absent from a non-null route list == native disallowed.
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway"],
+            allowed_harnesses=None,
+        )
+
+        rejected = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[],
+        )
+        assert rejected.status_code == 403, rejected.text
+        assert rejected.json()["detail"]["code"] == "policy_violation"
+        assert "Native" in rejected.json()["detail"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_disabled_row_does_not_count(self, client: AsyncClient) -> None:
+        # A disabled api_key row plus enabled gateway is native-free and route-
+        # compliant: only ENABLED sources are gated, mirroring the report.
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway"],
+            allowed_harnesses=None,
+        )
+
+        member_key = await _create_key(client, member_headers)
+        allowed = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[_GATEWAY, _api_key(str(member_key["id"]), enabled=False)],
+        )
+        assert allowed.status_code == 200, allowed.text
+
+    @pytest.mark.asyncio
+    async def test_allowed_selection_passes(self, client: AsyncClient) -> None:
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway", "native"],
+            allowed_harnesses=["claude"],
+        )
+
+        gateway_ok = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[_GATEWAY],
+        )
+        assert gateway_ok.status_code == 200, gateway_ok.text
+
+        # native explicitly allowed -> empty set passes.
+        native_ok = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="local",
+            sources=[],
+        )
+        assert native_ok.status_code == 200, native_ok.text
+
+    @pytest.mark.asyncio
+    async def test_personal_scope_bypasses_policy(self, client: AsyncClient) -> None:
+        # An org restricts everything to gateway-only. A user who is NOT a member
+        # (personal scope) is unaffected and may select api_key freely.
+        owner_id, owner_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway"],
+            allowed_harnesses=["opencode"],
+        )
+
+        _, outsider_headers = await _authed_user(client)
+        outsider_key = await _create_key(client, outsider_headers)
+        allowed = await _put_selections(
+            client,
+            outsider_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[_api_key(str(outsider_key["id"]))],
+        )
+        assert allowed.status_code == 200, allowed.text
+
+    @pytest.mark.asyncio
+    async def test_legacy_row_semantics_native_backfilled(self, client: AsyncClient) -> None:
+        # Legacy rows (saved before "native" was a valid route value) are
+        # normalized by the 76c0a297415c backfill migration to explicitly
+        # include "native", so native CLI login is NOT retroactively locked out.
+        backfill_native = _load_backfill_native()
+
+        # A restricted legacy list lacking native gains it.
+        assert backfill_native('["gateway"]') == '["gateway", "native"]'
+        assert backfill_native('["gateway", "api_key"]') == (
+            '["gateway", "api_key", "native"]'
+        )
+        # A row that already allows native, or is unrestricted (null), is untouched.
+        assert backfill_native('["gateway", "native"]') is None
+        assert backfill_native(None) is None
+
+        # And the observable effect: a backfilled legacy list allows native.
+        owner_id, owner_headers = await _authed_user(client)
+        member_id, member_headers = await _authed_user(client)
+        organization_id = await _create_organization(
+            owner_user_id=owner_id, member_user_ids=[member_id]
+        )
+        await _set_policy(
+            client,
+            owner_headers,
+            organization_id,
+            allowed_routes=["gateway", "native"],
+            allowed_harnesses=None,
+        )
+        native_ok = await _put_selections(
+            client,
+            member_headers,
+            harness="claude",
+            surface="cloud",
+            sources=[],
+        )
+        assert native_ok.status_code == 200, native_ok.text


### PR DESCRIPTION
## Summary

- Org auth-method policy was flag-only by design (a "conflicts" report, nothing actually blocked). This makes it real: `PUT` auth-selections now hard-rejects (`403 policy_violation`) new selections that violate any org the member belongs to — disallowed route, disallowed harness, or native login when native is disallowed. Existing selections at rest are untouched; the violations report still covers stale ones.
- Members can still clear selections on a harness/route the org has since disallowed — turning a selection OFF (falling back to native CLI login) is never blocked, since there is no DELETE endpoint and that's the only remediation path. The desktop UI mirrors this: a method card is only disabled when it would be a *new* disallowed selection, never when it's the harness's already-active method.
- `native` is now a valid policy allow-list value (previously only `gateway`/`api_key` were). A backfill migration adds `"native"` to every pre-existing non-null `allowed_routes` list so legacy policies keep their original meaning (no org is retroactively locked out of native CLI login it never intentionally disallowed).
- Desktop `HarnessAuthSection`/`OrganizationModelPolicyPane` now reflect the policy: disabled method cards show why, the policy pane drops the "nothing is blocked" framing, and per-model allowlists are teased as coming soon.

## Test plan

- [x] `cd server && uv run pytest -q tests/integration/test_agent_gateway_policy_enforcement.py tests/integration/test_agent_gateway_policy_api.py` — 15 passed
- [x] `apps/desktop`: `tsc --noEmit` clean after rebuilding shared package dists
- [x] Alembic: single head after retargeting the backfill migration's `down_revision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)