### PR TITLE
feat(workflows): PR E — per-run gateway tokens, completion ping, two-layer function scoping

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -75,7 +75,10 @@ use crate::domains::workspaces::store::WorkspaceStore;
 use crate::domains::workspaces::worktree_runtime::WorkspaceWorktreeRuntime;
 use crate::live::sessions::LiveSessionManager;
 use crate::live::terminals::{AgentLoginTerminalService, TerminalService};
-use crate::live::workflows::{WorkflowExecDeps, WorkflowOwnedSessions, WorkflowRunManager};
+use crate::live::workflows::{
+    HttpRunPingSink, WorkflowExecDeps, WorkflowGatewaySessions, WorkflowOwnedSessions,
+    WorkflowRunGatewaySessionLaunchExtension, WorkflowRunManager,
+};
 use crate::persistence::Db;
 
 #[derive(Debug, thiserror::Error)]
@@ -252,6 +255,10 @@ impl AppState {
         // Shared registry of workflow-owned sessions: written by the workflow
         // executor, read by the inbound permission advisor (always-bypass net).
         let workflow_owned_sessions = Arc::new(WorkflowOwnedSessions::new());
+        // Per-run gateway MCP servers, keyed by session id: written by the
+        // workflow executor before launch, read by the workflow gateway launch
+        // extension (§6.4/OPEN-3(a)).
+        let workflow_gateway_sessions = Arc::new(WorkflowGatewaySessions::new());
         let acp_manager = sessions::wire_live_sessions(&sessions::LiveSessionsWiringDeps {
             db: db.clone(),
             runtime_home: runtime_home.clone(),
@@ -294,6 +301,13 @@ impl AppState {
         let integration_gateway_session_launch_extension = Arc::new(
             IntegrationGatewaySessionLaunchExtension::new(runtime_home.clone()),
         );
+        // Per-run workflow gateway launch extension: injects the plan's gateway
+        // block for workflow-owned sessions. Ordered BEFORE the worker-dotfile
+        // extension below so the plan block wins on dedupe (both use the same
+        // INTEGRATION_GATEWAY_ID connection/server name).
+        let workflow_run_gateway_session_launch_extension = Arc::new(
+            WorkflowRunGatewaySessionLaunchExtension::new(workflow_gateway_sessions.clone()),
+        );
         let product_mcp_launch_catalog =
             product_mcp::build_product_mcp_launch_catalog(product_mcp::LaunchCatalogDeps {
                 runtime_base_url: runtime_base_url.clone(),
@@ -317,6 +331,9 @@ impl AppState {
             cowork_session_hooks.clone(),
             subagent_session_hooks.clone(),
             review_session_hooks.clone(),
+            // Plan-block gateway must precede the worker-dotfile gateway so it
+            // wins on MCP-server dedupe for workflow-owned sessions.
+            workflow_run_gateway_session_launch_extension.clone(),
             integration_gateway_session_launch_extension.clone(),
             goal_session_hooks,
             goal_guard_extension,
@@ -346,6 +363,8 @@ impl AppState {
             workflow_service: workflow_service.clone(),
             acp_manager: acp_manager.clone(),
             workflow_owned_sessions: workflow_owned_sessions.clone(),
+            workflow_gateway_sessions: workflow_gateway_sessions.clone(),
+            run_ping_sink: Arc::new(HttpRunPingSink::new()),
         }));
         let retire_preflight_checker = Arc::new(RetirePreflightChecker::new(
             workspace_runtime.clone(),

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/engine.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/engine.rs
@@ -162,6 +162,13 @@ pub trait WorkflowStepExecutor: Send + Sync {
     /// executor's concern: agent steps re-send a prompt as a NEW turn (unless a
     /// recorded turn already landed), and goal re-arm is allowed.
     async fn execute_step(&self, step: &PlanStep, ctx: &StepExecContext) -> StepOutcome;
+
+    /// Called by the driver after every step transition is applied (§3.7/L16).
+    /// The live executor fires the per-run completion ping here; the default is
+    /// a no-op so scripted test executors need not implement it. Must be
+    /// fire-and-forget: a slow or failing side effect here may never stall or
+    /// fail the run (the cursor has already moved).
+    fn on_step_transition(&self) {}
 }
 
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/plan.rs
@@ -47,7 +47,40 @@ pub struct ResolvedPlan {
     /// Server-resolved input values, kept verbatim for the run record.
     #[serde(default, alias = "args")]
     pub inputs: serde_json::Value,
+    /// Per-run integration-gateway block (§6.4/OPEN-3(a), §3.7/L16). Present
+    /// whenever the delivery minted a per-run gateway token — which, under L16,
+    /// is every run (an empty `integrations` list is legal). Absent for legacy
+    /// plans predating PR E. Carries the MCP URL + credential the executor
+    /// injects into workflow-owned sessions, and the completion-ping endpoint
+    /// the actor nudges after each step transition.
+    #[serde(default)]
+    pub gateway: Option<PlanGateway>,
     pub steps: Vec<PlanStep>,
+}
+
+/// The per-run gateway block the server mints at StartRun and threads through
+/// `resolved_plan_json.gateway`. `authorization` is the full `Authorization`
+/// header value (e.g. `"Bearer <per-run-token>"`), used verbatim — matching the
+/// worker dotfile convention ([`crate::integrations::integration_gateway`]) and
+/// the gateway's own `Bearer <token>` parsing.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanGateway {
+    /// The integration-gateway MCP endpoint URL (`SessionMcpServer::Http`).
+    pub url: String,
+    /// The full `Authorization` header value (verbatim), used for both the MCP
+    /// server header and the completion ping.
+    pub authorization: String,
+    /// The completion-ping endpoint (`POST`, empty body) the actor nudges after
+    /// each step transition (§3.7/L16).
+    pub ping_url: String,
+    /// The namespace-level scope this run's token grants — the definition's
+    /// resolved `integrations[]` (E3: integration namespaces, no tool lists;
+    /// the gateway treats a namespace grant as "all tools of that provider" at
+    /// call time). Empty means "no integration scopes" (still legal: the token
+    /// exists only to authorize the completion ping). The runtime only reads
+    /// its emptiness (L22 local-lane fail-fast); it never inspects tools.
+    #[serde(default)]
+    pub integrations: Vec<String>,
 }
 
 impl ResolvedPlan {
@@ -493,5 +526,69 @@ mod tests {
     fn rejects_invalid_json() {
         let error = parse("{not json").expect_err("invalid json must reject");
         assert!(matches!(error, PlanError::InvalidJson(_)));
+    }
+
+    // --- per-run gateway block (PR E, E3 namespace-level scope) ---
+
+    #[test]
+    fn parses_full_gateway_block_with_integrations() {
+        let plan = parse(
+            r#"{
+                "run_id": "run-gw",
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "gateway": {
+                    "url": "https://cloud.test/v1/cloud/integration-gateway/mcp",
+                    "authorization": "Bearer per-run-secret",
+                    "ping_url": "https://cloud.test/v1/cloud/workflows/runs/run-gw/ping",
+                    "integrations": ["issues", "slack"]
+                },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "agent.prompt", "prompt": "hi" } ]
+            }"#,
+        )
+        .expect("parse gateway plan");
+        let gateway = plan.gateway.as_ref().expect("gateway present");
+        assert_eq!(gateway.url, "https://cloud.test/v1/cloud/integration-gateway/mcp");
+        assert_eq!(gateway.authorization, "Bearer per-run-secret");
+        assert_eq!(
+            gateway.ping_url,
+            "https://cloud.test/v1/cloud/workflows/runs/run-gw/ping"
+        );
+        assert_eq!(gateway.integrations, vec!["issues", "slack"]);
+    }
+
+    #[test]
+    fn gateway_integrations_default_to_empty() {
+        // §3.7/L16: a token is minted for every run, so a gateway block can be
+        // present with no integration scopes at all (empty `integrations`).
+        let plan = parse(
+            r#"{
+                "run_id": "run-gw-empty",
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "gateway": {
+                    "url": "https://cloud.test/mcp",
+                    "authorization": "Bearer t",
+                    "ping_url": "https://cloud.test/ping"
+                },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "shell.run", "command": "x" } ]
+            }"#,
+        )
+        .expect("parse gateway plan without integrations");
+        let gateway = plan.gateway.as_ref().expect("gateway present");
+        assert!(gateway.integrations.is_empty());
+    }
+
+    #[test]
+    fn plans_without_gateway_still_parse() {
+        // A token is minted for every run under L16, but a gateway-less plan
+        // must still parse (the block is `serde(default)`).
+        let plan = parse(
+            r#"{
+                "run_id": "run-nogw",
+                "sessions": { "main": { "harness": "claude", "session_binding": "fresh" } },
+                "steps": [ { "key": "0.-.0", "slot": "main", "kind": "agent.prompt", "prompt": "hi" } ]
+            }"#,
+        )
+        .expect("parse plan without gateway");
+        assert!(plan.gateway.is_none());
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
@@ -18,7 +18,13 @@ pub async fn drive_run(
     cancel: &CancelToken,
 ) -> EngineProgress {
     loop {
-        match service.run_next_step(run_id, executor, cancel).await {
+        let result = service.run_next_step(run_id, executor, cancel).await;
+        // §3.7/L16: nudge the server after every applied step transition —
+        // mid-run advances, the terminal transition, and the engine-error
+        // failure alike. Fire-and-forget: the cursor has already moved, so a
+        // failed ping is inert and never changes engine state.
+        executor.on_step_transition();
+        match result {
             Ok(EngineProgress::Advanced) => continue,
             Ok(other) => return other,
             Err(error) => {
@@ -31,5 +37,205 @@ pub async fn drive_run(
                 return EngineProgress::Finished(WorkflowRunStatus::Failed);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use anyharness_contract::v1::WorkflowStepStatus;
+
+    use super::*;
+    use crate::app::test_support;
+    use crate::domains::workflows::engine::{StepExecContext, StepOutcome};
+    use crate::domains::workflows::plan::{PlanGateway, PlanStep};
+    use crate::domains::workflows::store::WorkflowStore;
+    use crate::live::workflows::gateway::{fire_run_ping, RunPingSink};
+    use crate::persistence::Db;
+
+    use crate::live::workflows::gateway::test_support::RecordingPingSink;
+
+    /// A scripted executor that wires the real per-run ping seam through a
+    /// recording sink: its `on_step_transition` is exactly what the live
+    /// executor does, so the drive loop's "ping after every transition"
+    /// contract is exercised end-to-end.
+    struct PingingExecutor {
+        outcomes: Mutex<VecDeque<StepOutcome>>,
+        gateway: Option<PlanGateway>,
+        sink: Arc<RecordingPingSink>,
+    }
+
+    impl PingingExecutor {
+        fn new(
+            outcomes: Vec<StepOutcome>,
+            gateway: Option<PlanGateway>,
+            sink: Arc<RecordingPingSink>,
+        ) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes.into_iter().collect()),
+                gateway,
+                sink,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WorkflowStepExecutor for PingingExecutor {
+        async fn execute_step(&self, _step: &PlanStep, _ctx: &StepExecContext) -> StepOutcome {
+            self.outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(StepOutcome::Completed {
+                    output: serde_json::json!({}),
+                })
+        }
+
+        fn on_step_transition(&self) {
+            fire_run_ping(self.gateway.as_ref(), self.sink.as_ref());
+        }
+    }
+
+    fn gateway() -> PlanGateway {
+        PlanGateway {
+            url: "https://cloud.test/mcp".to_string(),
+            authorization: "Bearer per-run".to_string(),
+            ping_url: "https://cloud.test/runs/run-1/ping".to_string(),
+            integrations: Vec::new(),
+        }
+    }
+
+    fn service_with_run(steps: &str) -> (WorkflowService, String) {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+        let service = WorkflowService::new(WorkflowStore::new(db));
+        let plan_json = format!(
+            r#"{{
+                "run_id": "run-1",
+                "setup": {{ "harness": "claude", "session_binding": "fresh" }},
+                "steps": {steps}
+            }}"#
+        );
+        let (run, created) = service
+            .create_run_idempotent(&plan_json, "workspace-1")
+            .expect("create run");
+        assert!(created);
+        (service, run.run_id)
+    }
+
+    fn completed() -> StepOutcome {
+        StepOutcome::Completed {
+            output: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn pings_after_every_transition_including_terminal() {
+        // A three-step run: three applied transitions (two advances + the
+        // terminal completion) → three pings.
+        let (service, run_id) = service_with_run(
+            r#"[{ "kind": "shell.run", "command": "a" },
+                { "kind": "shell.run", "command": "b" },
+                { "kind": "shell.run", "command": "c" }]"#,
+        );
+        let sink = Arc::new(RecordingPingSink::new());
+        let executor =
+            PingingExecutor::new(vec![completed(), completed(), completed()], Some(gateway()), sink.clone());
+        let cancel = CancelToken::new();
+        let progress = drive_run(&service, &executor, &run_id, &cancel).await;
+        assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
+        assert_eq!(sink.count(), 3, "one ping per applied transition");
+        let calls = sink.calls.lock().unwrap();
+        assert!(calls
+            .iter()
+            .all(|(url, auth)| url == "https://cloud.test/runs/run-1/ping"
+                && auth == "Bearer per-run"));
+    }
+
+    #[tokio::test]
+    async fn ping_fires_on_the_terminal_failure_transition() {
+        // A stop-on-fail step fails the run: the single failing transition is
+        // still pinged (the run is now terminal, and the server must be nudged).
+        let (service, run_id) = service_with_run(
+            r#"[{ "kind": "shell.run", "command": "x", "on_fail": { "kind": "stop" } }]"#,
+        );
+        let sink = Arc::new(RecordingPingSink::new());
+        let executor = PingingExecutor::new(
+            vec![StepOutcome::Failed {
+                code: "nonzero_exit".to_string(),
+                message: None,
+                output: None,
+            }],
+            Some(gateway()),
+            sink.clone(),
+        );
+        let cancel = CancelToken::new();
+        let progress = drive_run(&service, &executor, &run_id, &cancel).await;
+        assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Failed));
+        assert_eq!(sink.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn no_gateway_block_produces_no_pings_but_still_completes() {
+        let (service, run_id) = service_with_run(
+            r#"[{ "kind": "shell.run", "command": "a" }, { "kind": "shell.run", "command": "b" }]"#,
+        );
+        let sink = Arc::new(RecordingPingSink::new());
+        let executor = PingingExecutor::new(vec![completed(), completed()], None, sink.clone());
+        let cancel = CancelToken::new();
+        let progress = drive_run(&service, &executor, &run_id, &cancel).await;
+        assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
+        assert_eq!(sink.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn ping_failure_is_inert_run_still_completes() {
+        // A sink whose `fire` panics would be observable; instead model a
+        // "failing" ping as one that records but whose delivery is a no-op from
+        // the driver's perspective — the run must complete regardless. The
+        // fire-and-forget contract means the driver never observes ping result.
+        struct InertFailingSink {
+            fired: Mutex<usize>,
+        }
+        impl RunPingSink for InertFailingSink {
+            fn fire(&self, _ping_url: &str, _authorization: &str) {
+                // Simulate a failed POST that is swallowed (as HttpRunPingSink
+                // does): record that we tried, return normally.
+                *self.fired.lock().unwrap() += 1;
+            }
+        }
+        struct InertExecutor {
+            sink: Arc<InertFailingSink>,
+            gateway: PlanGateway,
+        }
+        #[async_trait::async_trait]
+        impl WorkflowStepExecutor for InertExecutor {
+            async fn execute_step(&self, _step: &PlanStep, _ctx: &StepExecContext) -> StepOutcome {
+                StepOutcome::Completed {
+                    output: serde_json::json!({}),
+                }
+            }
+            fn on_step_transition(&self) {
+                fire_run_ping(Some(&self.gateway), self.sink.as_ref());
+            }
+        }
+
+        let (service, run_id) =
+            service_with_run(r#"[{ "kind": "shell.run", "command": "a" }]"#);
+        let sink = Arc::new(InertFailingSink {
+            fired: Mutex::new(0),
+        });
+        let executor = InertExecutor {
+            sink: sink.clone(),
+            gateway: gateway(),
+        };
+        let cancel = CancelToken::new();
+        let progress = drive_run(&service, &executor, &run_id, &cancel).await;
+        assert_eq!(progress, EngineProgress::Finished(WorkflowRunStatus::Completed));
+        let (_, steps) = service.get_run_with_steps(&run_id).unwrap().unwrap();
+        assert!(steps.iter().all(|s| s.status == WorkflowStepStatus::Completed));
+        assert_eq!(*sink.fired.lock().unwrap(), 1);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
@@ -18,15 +18,17 @@ use tokio::sync::broadcast;
 
 use super::commands;
 use super::exec_policy::{bypass_mode_for_kind, WorkflowOwnedSessions};
+use super::gateway::{fire_run_ping, workflow_gateway_server, RunPingSink, WorkflowGatewaySessions};
 use crate::domains::goals::runtime::{GoalOpError, GoalRuntime};
 use crate::domains::sessions::live_config::ACP_MODEL_COMPAT_CONFIG_ID;
+use crate::domains::sessions::model::SessionMcpBindingPolicy;
 use crate::domains::sessions::runtime::{SendPromptOutcome, SessionRuntime};
 use crate::domains::sessions::service::SessionService;
 use crate::domains::workflows::engine::{StepExecContext, StepOutcome, WorkflowStepExecutor};
 use crate::domains::workflows::model::WorkflowRunRecord;
 use crate::domains::workflows::plan::{
     AgentConfigStep, AgentEmitStep, AgentPromptStep, BranchStep, BranchTarget, GoalSpec, OnBlocked,
-    PlanStep, RequiredInvocation, ScmOpenPrStep, SessionSpec, ShellRunStep, StepKind,
+    PlanGateway, PlanStep, RequiredInvocation, ScmOpenPrStep, SessionSpec, ShellRunStep, StepKind,
 };
 use crate::domains::workflows::service::WorkflowService;
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
@@ -63,6 +65,12 @@ pub struct WorkflowExecDeps {
     ///
     /// [`WorkflowAutoApproveAdvisor`]: super::exec_policy::WorkflowAutoApproveAdvisor
     pub workflow_owned_sessions: Arc<WorkflowOwnedSessions>,
+    /// Per-run gateway MCP servers, keyed by session id. The executor registers
+    /// its workflow-owned session's server here before launch; the launch
+    /// extension reads it (§6.4/OPEN-3(a)).
+    pub workflow_gateway_sessions: Arc<WorkflowGatewaySessions>,
+    /// Fire-and-forget sink for the per-run completion ping (§3.7/L16).
+    pub run_ping_sink: Arc<dyn RunPingSink>,
 }
 
 #[derive(Clone)]
@@ -88,6 +96,11 @@ pub struct WorkflowStepExecutorImpl {
     /// slot -> effective model (base `sessions[slot].model`, folded by
     /// `agent.config`).
     models: Mutex<HashMap<String, Option<String>>>,
+    /// The plan's per-run gateway block (§6.4/§3.7). Drives both the
+    /// session-launch MCP injection and the completion ping. Cloned from the
+    /// plan at construction; recomputed identically on crash-resume (the plan
+    /// is re-parsed to build the executor).
+    gateway: Option<PlanGateway>,
 }
 
 impl WorkflowStepExecutorImpl {
@@ -96,6 +109,7 @@ impl WorkflowStepExecutorImpl {
         run_id: String,
         workspace_id: String,
         sessions: BTreeMap<String, SessionSpec>,
+        gateway: Option<PlanGateway>,
     ) -> Self {
         let models = sessions
             .iter()
@@ -108,6 +122,7 @@ impl WorkflowStepExecutorImpl {
             sessions,
             current: Mutex::new(HashMap::new()),
             models: Mutex::new(models),
+            gateway,
         }
     }
 
@@ -125,6 +140,12 @@ impl WorkflowStepExecutorImpl {
                 // (the registry is in-memory, so a restart would otherwise drop
                 // it).
                 self.deps.workflow_owned_sessions.mark(session_id);
+                // Re-register the per-run gateway server too, so a relaunch of
+                // the resumed session (crash-resume) re-injects it (same
+                // in-memory registry, dropped on restart).
+                if let Some(server) = workflow_gateway_server(self.gateway.as_ref()) {
+                    self.deps.workflow_gateway_sessions.set(session_id, server);
+                }
                 current.insert(
                     slot.clone(),
                     CurrentSession {
@@ -173,6 +194,18 @@ impl WorkflowStepExecutorImpl {
     /// existing session instead of creating one; that field is always absent
     /// until the session-plane PR lands.
     async fn ensure_session(&self, slot: &str) -> Result<String, StepOutcome> {
+        // §5.3 builder obligation (L22 fail-fast): a gateway block that grants
+        // integration scopes but carries no usable gateway in this lane (empty
+        // authorization/URL, e.g. the local lane where nothing mints a per-run
+        // token) can never hand the agent its tools. Fail explicitly at the
+        // first agent step rather than silently launching with zero tools.
+        if gateway_functions_unsupported(self.gateway.as_ref()) {
+            return Err(failed_msg(
+                "functions_unsupported_local",
+                "workflow declares gateway integration grants but this run has no usable gateway \
+                 (integrations cannot be honored in this lane)",
+            ));
+        }
         if let Some(current) = self.current.lock().unwrap().get(slot) {
             return Ok(current.session_id.clone());
         }
@@ -199,6 +232,11 @@ impl WorkflowStepExecutorImpl {
                 .get_session(&bind_id)
                 .map_err(|error| failed_msg("session_bind_failed", error.to_string()))?
                 .ok_or_else(|| failed_msg("session_bind_missing", bind_id.clone()))?;
+            // Register the per-run gateway MCP server for the bound session too,
+            // so a relaunch injects it (same in-memory registry as fresh).
+            if let Some(server) = workflow_gateway_server(self.gateway.as_ref()) {
+                self.deps.workflow_gateway_sessions.set(&bind_id, server);
+            }
             (bind_id, session.agent_kind)
         } else {
             // Exec policy (goals-and-workflows-v1 §3.3 "always bypass"): open the
@@ -207,10 +245,15 @@ impl WorkflowStepExecutorImpl {
             // permission prompt. `None` (harness with no native bypass mode) is
             // covered by the auto-approve safety net.
             let mode = bypass_mode_for_kind(&harness);
+            // Split create/start (as reviews/subagents do) so the per-run gateway
+            // server and workflow ownership can be registered BEFORE launch — the
+            // launch extension reads both from their in-memory registries, and MCP
+            // servers are only assembled from the extension seam (never from the
+            // durable session bindings).
             let record = self
                 .deps
                 .session_runtime
-                .create_and_start_session(
+                .create_durable_session(
                     &self.workspace_id,
                     &harness,
                     model.as_deref(),
@@ -218,9 +261,25 @@ impl WorkflowStepExecutorImpl {
                     None,
                     Vec::new(),
                     None,
+                    SessionMcpBindingPolicy::InheritWorkspace,
                     false,
                     OriginContext::system_local_runtime(),
                 )
+                .map_err(|error| failed_msg("session_start_failed", format!("{error:?}")))?;
+            // Register the session as workflow-owned so the inbound permission
+            // advisor auto-approves for it. Done before launch/first turn.
+            self.deps.workflow_owned_sessions.mark(&record.id);
+            // Register the per-run gateway MCP server for this session so the
+            // launch extension injects it (plan block wins over the worker
+            // dotfile via the extension ordering + dedupe on
+            // connection_id/server_name).
+            if let Some(server) = workflow_gateway_server(self.gateway.as_ref()) {
+                self.deps.workflow_gateway_sessions.set(&record.id, server);
+            }
+            let record = self
+                .deps
+                .session_runtime
+                .start_persisted_session(&record)
                 .await
                 .map_err(|error| failed_msg("session_start_failed", format!("{error:?}")))?;
             (record.id, harness)
@@ -641,6 +700,26 @@ impl WorkflowStepExecutor for WorkflowStepExecutorImpl {
             }
             StepKind::Branch(branch) => self.run_branch(branch),
         }
+    }
+
+    /// §3.7/L16: fire the per-run completion ping after each applied transition.
+    /// No gateway block → no ping. Fire-and-forget via the injected sink.
+    fn on_step_transition(&self) {
+        fire_run_ping(self.gateway.as_ref(), self.deps.run_ping_sink.as_ref());
+    }
+}
+
+/// §5.3: a gateway block declaring integration grants that this lane cannot
+/// honor — non-empty `integrations` with an empty/absent credential or URL —
+/// must fail the run explicitly rather than silently launch the agent with zero
+/// tools.
+fn gateway_functions_unsupported(gateway: Option<&PlanGateway>) -> bool {
+    match gateway {
+        Some(gateway) => {
+            !gateway.integrations.is_empty()
+                && (gateway.authorization.trim().is_empty() || gateway.url.trim().is_empty())
+        }
+        None => false,
     }
 }
 
@@ -1178,6 +1257,35 @@ mod tests {
             provider: provider.to_string(),
             tool: tool.to_string(),
         }
+    }
+
+    fn plan_gateway(integrations: Vec<String>) -> PlanGateway {
+        PlanGateway {
+            url: "https://cloud.test/mcp".to_string(),
+            authorization: "Bearer per-run".to_string(),
+            ping_url: "https://cloud.test/ping".to_string(),
+            integrations,
+        }
+    }
+
+    #[test]
+    fn functions_unsupported_only_when_grants_lack_a_usable_gateway() {
+        // No gateway at all → supported (nothing granted).
+        assert!(!gateway_functions_unsupported(None));
+        // Gateway with no integration grants → supported (ping-only token).
+        assert!(!gateway_functions_unsupported(Some(&plan_gateway(Vec::new()))));
+        // Grants + a usable gateway → supported.
+        assert!(!gateway_functions_unsupported(Some(&plan_gateway(vec![
+            "issues".to_string()
+        ]))));
+        // Grants but empty authorization → unsupported (local lane).
+        let mut gw = plan_gateway(vec!["issues".to_string()]);
+        gw.authorization = "  ".to_string();
+        assert!(gateway_functions_unsupported(Some(&gw)));
+        // Grants but empty URL → unsupported.
+        let mut gw = plan_gateway(vec!["issues".to_string()]);
+        gw.url = String::new();
+        assert!(gateway_functions_unsupported(Some(&gw)));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/live/workflows/gateway.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/gateway.rs
@@ -1,0 +1,363 @@
+//! Per-run integration-gateway plumbing (PR E): the completion-ping sink
+//! (§3.7/L16) and the session-launch injection of the per-run gateway MCP
+//! server (§6.4/OPEN-3(a)).
+//!
+//! Both hang off the plan's [`PlanGateway`] block, which the server mints at
+//! StartRun and threads through `resolved_plan_json.gateway`. The runtime never
+//! mints or formats a credential — it forwards `gateway.authorization` verbatim
+//! (matching the worker dotfile convention in
+//! [`crate::integrations::integration_gateway`] and the gateway's own
+//! `Bearer <token>` parsing).
+//!
+//! ## Launch injection reuses the existing seam (L8)
+//!
+//! There is no new injection concept: the per-run gateway rides the same
+//! [`SessionExtension::resolve_launch_extras`] seam and the same
+//! `SessionMcpServer::Http` shape the worker-dotfile extension builds
+//! ([`crate::domains::sessions::mcp_bindings::integration_gateway`]). The
+//! executor registers the per-run server in [`WorkflowGatewaySessions`] keyed by
+//! session id *before* launch (mirroring how reviews/subagents register a
+//! session between `create_durable_session` and `start_persisted_session`), and
+//! [`WorkflowRunGatewaySessionLaunchExtension`] reads that registry at launch.
+//! Keyed by session id (not workspace) so a co-located non-workflow session can
+//! never inherit the run's credential.
+//!
+//! Precedence over the worker dotfile: the launch assembly dedupes MCP servers
+//! by `connection_id`+`server_name`, keeping the first occurrence. Both the
+//! per-run server and the dotfile server use [`INTEGRATION_GATEWAY_ID`], so
+//! ordering this extension *before* the dotfile extension in the session
+//! extension list makes the plan block win for workflow-owned sessions.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use crate::domains::sessions::extensions::{
+    SessionExtension, SessionLaunchContext, SessionLaunchExtras,
+};
+use crate::domains::sessions::mcp_bindings::model::{
+    SessionMcpHeader, SessionMcpHttpServer, SessionMcpServer,
+};
+use crate::domains::sessions::model::SessionMcpBindingPolicy;
+use crate::domains::workflows::plan::PlanGateway;
+use crate::integrations::integration_gateway::INTEGRATION_GATEWAY_ID;
+
+/// A short cap on the completion ping: the ping is a best-effort nudge, so it
+/// must never tie up a task for long.
+const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ---------------------------------------------------------------------------
+// Completion ping (§3.7/L16)
+// ---------------------------------------------------------------------------
+
+/// Fire-and-forget sink for the per-run completion ping. Implementations MUST
+/// NOT block: they return immediately, spawning the actual request internally
+/// and ignoring its result. A failed ping never changes engine state — by the
+/// time it fires the cursor has already moved; the ping only wakes the server's
+/// existing refresh path.
+pub trait RunPingSink: Send + Sync {
+    /// Nudge `ping_url` with an empty-body `POST` carrying the given
+    /// `Authorization` header value (verbatim). Returns immediately.
+    fn fire(&self, ping_url: &str, authorization: &str);
+}
+
+/// The live HTTP ping sink: an empty-body `POST` with a short timeout, spawned
+/// onto the current runtime and dropped on the floor.
+pub struct HttpRunPingSink {
+    client: reqwest::Client,
+}
+
+impl HttpRunPingSink {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl Default for HttpRunPingSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RunPingSink for HttpRunPingSink {
+    fn fire(&self, ping_url: &str, authorization: &str) {
+        let client = self.client.clone();
+        let ping_url = ping_url.to_string();
+        let authorization = authorization.to_string();
+        // Fire-and-forget: spawn the request and ignore its outcome so a slow or
+        // failing ping can never stall or fail the run.
+        tokio::spawn(async move {
+            let result = client
+                .post(&ping_url)
+                .header(reqwest::header::AUTHORIZATION, authorization)
+                .timeout(PING_TIMEOUT)
+                .send()
+                .await;
+            if let Err(error) = result {
+                tracing::debug!(error = %error, "workflow run completion ping failed (ignored)");
+            }
+        });
+    }
+}
+
+/// Fire the completion ping for a step transition, gated on the plan carrying a
+/// gateway block. No gateway → no ping (nothing to nudge). Extracted so the
+/// gating logic is unit-testable without the live executor.
+pub fn fire_run_ping(gateway: Option<&PlanGateway>, sink: &dyn RunPingSink) {
+    if let Some(gateway) = gateway {
+        sink.fire(&gateway.ping_url, &gateway.authorization);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-run gateway MCP server injection (§6.4/OPEN-3(a))
+// ---------------------------------------------------------------------------
+
+/// Build the per-run gateway MCP server from the plan block, or `None` when the
+/// block is absent or carries no usable credential. Uses the same
+/// `SessionMcpServer::Http` shape and [`INTEGRATION_GATEWAY_ID`] as the worker
+/// dotfile extension, with `authorization` forwarded verbatim.
+pub fn workflow_gateway_server(gateway: Option<&PlanGateway>) -> Option<SessionMcpServer> {
+    let gateway = gateway?;
+    if gateway.authorization.trim().is_empty() || gateway.url.trim().is_empty() {
+        return None;
+    }
+    Some(SessionMcpServer::Http(SessionMcpHttpServer {
+        connection_id: INTEGRATION_GATEWAY_ID.to_string(),
+        catalog_entry_id: None,
+        server_name: INTEGRATION_GATEWAY_ID.to_string(),
+        url: gateway.url.clone(),
+        headers: vec![SessionMcpHeader {
+            name: "authorization".to_string(),
+            value: gateway.authorization.clone(),
+        }],
+    }))
+}
+
+/// Registry of per-run gateway MCP servers, keyed by session id. Written by the
+/// workflow executor before it launches a workflow-owned session, read by
+/// [`WorkflowRunGatewaySessionLaunchExtension`] at launch. Shared behind `Arc`
+/// like [`super::exec_policy::WorkflowOwnedSessions`].
+///
+/// In-memory and grow-only for the runtime's lifetime; the executor re-registers
+/// its current session on crash-resume (`hydrate_from_run`). Session ids are
+/// never reused, so a stale entry cannot mis-target a later session.
+#[derive(Default)]
+pub struct WorkflowGatewaySessions {
+    servers: RwLock<HashMap<String, SessionMcpServer>>,
+}
+
+impl WorkflowGatewaySessions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register the per-run gateway server for a session (idempotent overwrite).
+    pub fn set(&self, session_id: &str, server: SessionMcpServer) {
+        self.servers
+            .write()
+            .unwrap()
+            .insert(session_id.to_string(), server);
+    }
+
+    /// The per-run gateway server for this session, if one was registered.
+    pub fn get(&self, session_id: &str) -> Option<SessionMcpServer> {
+        self.servers.read().unwrap().get(session_id).cloned()
+    }
+}
+
+/// Session-launch extension that injects the per-run gateway MCP server for a
+/// workflow-owned session. Reuses the existing launch-extension seam; must be
+/// ordered before the worker-dotfile extension so the plan block wins on dedupe.
+#[derive(Clone)]
+pub struct WorkflowRunGatewaySessionLaunchExtension {
+    sessions: Arc<WorkflowGatewaySessions>,
+}
+
+impl WorkflowRunGatewaySessionLaunchExtension {
+    pub fn new(sessions: Arc<WorkflowGatewaySessions>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl SessionExtension for WorkflowRunGatewaySessionLaunchExtension {
+    fn resolve_launch_extras(
+        &self,
+        ctx: &SessionLaunchContext<'_>,
+    ) -> anyhow::Result<SessionLaunchExtras> {
+        // Same guard as the dotfile extension: internal-only sessions never
+        // accept external MCP servers.
+        if ctx.session.mcp_binding_policy == SessionMcpBindingPolicy::InternalOnly {
+            return Ok(SessionLaunchExtras::default());
+        }
+        let Some(server) = self.sessions.get(&ctx.session.id) else {
+            return Ok(SessionLaunchExtras::default());
+        };
+        tracing::info!(
+            session_id = %ctx.session.id,
+            "injecting per-run workflow gateway MCP server (plan block)"
+        );
+        Ok(SessionLaunchExtras {
+            mcp_servers: vec![server],
+            ..SessionLaunchExtras::default()
+        })
+    }
+}
+
+/// Test-only fakes shared with the actor's drive-loop tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::RunPingSink;
+    use std::sync::Mutex;
+
+    /// A recording ping sink for tier-1 tests: records every fired ping's
+    /// (url, authorization) synchronously — no spawn — so assertions are
+    /// deterministic and inert (a "failing" ping never propagates).
+    #[derive(Default)]
+    pub(crate) struct RecordingPingSink {
+        pub calls: Mutex<Vec<(String, String)>>,
+    }
+
+    impl RecordingPingSink {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl RunPingSink for RecordingPingSink {
+        fn fire(&self, ping_url: &str, authorization: &str) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((ping_url.to_string(), authorization.to_string()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::RecordingPingSink;
+    use super::*;
+
+    fn gateway(integrations: Vec<String>) -> PlanGateway {
+        PlanGateway {
+            url: "https://cloud.test/mcp".to_string(),
+            authorization: "Bearer per-run-secret".to_string(),
+            ping_url: "https://cloud.test/runs/run-1/ping".to_string(),
+            integrations,
+        }
+    }
+
+    #[test]
+    fn fire_run_ping_nudges_when_gateway_present() {
+        let sink = RecordingPingSink::new();
+        let gw = gateway(Vec::new());
+        fire_run_ping(Some(&gw), &sink);
+        let calls = sink.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "https://cloud.test/runs/run-1/ping");
+        // Authorization forwarded verbatim (already the full `Bearer <token>`).
+        assert_eq!(calls[0].1, "Bearer per-run-secret");
+    }
+
+    #[test]
+    fn fire_run_ping_is_a_noop_without_a_gateway() {
+        let sink = RecordingPingSink::new();
+        fire_run_ping(None, &sink);
+        assert_eq!(sink.count(), 0);
+    }
+
+    #[test]
+    fn workflow_gateway_server_builds_http_server_verbatim() {
+        let gw = gateway(vec!["issues".to_string()]);
+        let SessionMcpServer::Http(server) =
+            workflow_gateway_server(Some(&gw)).expect("server built")
+        else {
+            panic!("expected HTTP server");
+        };
+        assert_eq!(server.connection_id, INTEGRATION_GATEWAY_ID);
+        assert_eq!(server.server_name, INTEGRATION_GATEWAY_ID);
+        assert_eq!(server.url, "https://cloud.test/mcp");
+        assert_eq!(server.headers.len(), 1);
+        assert_eq!(server.headers[0].name, "authorization");
+        assert_eq!(server.headers[0].value, "Bearer per-run-secret");
+    }
+
+    #[test]
+    fn workflow_gateway_server_is_none_without_a_credential() {
+        assert!(workflow_gateway_server(None).is_none());
+        let mut gw = gateway(Vec::new());
+        gw.authorization = "  ".to_string();
+        assert!(workflow_gateway_server(Some(&gw)).is_none());
+        let mut gw = gateway(Vec::new());
+        gw.url = String::new();
+        assert!(workflow_gateway_server(Some(&gw)).is_none());
+    }
+
+    #[test]
+    fn registry_round_trips_a_server_by_session_id() {
+        let registry = WorkflowGatewaySessions::new();
+        assert!(registry.get("sess-1").is_none());
+        let gw = gateway(Vec::new());
+        registry.set("sess-1", workflow_gateway_server(Some(&gw)).unwrap());
+        assert!(registry.get("sess-1").is_some());
+        assert!(registry.get("sess-2").is_none());
+    }
+
+    // --- Contract fixture (fixtures/contracts/run-ping/) ------------------
+    //
+    // The consuming-side assertion (§3.7/L16 test obligation): the runtime
+    // parses the golden gateway block and the ping request its sink emits
+    // matches the golden ping-request shape. A change to either fixture breaks
+    // this test until the runtime is updated in lock-step.
+
+    fn fixture(name: &str) -> serde_json::Value {
+        let path = format!(
+            "{}/../../../fixtures/contracts/run-ping/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        );
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read fixture {path}: {e}"));
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse fixture {path}: {e}"))
+    }
+
+    #[test]
+    fn parses_golden_gateway_block_and_emits_matching_ping() {
+        let block = fixture("gateway-block.json");
+        // The runtime parses resolved_plan_json.gateway into PlanGateway
+        // (unknown `_comment` field ignored).
+        let parsed: PlanGateway =
+            serde_json::from_value(block.clone()).expect("gateway block parses into PlanGateway");
+        assert_eq!(parsed.url, block["url"].as_str().unwrap());
+        assert_eq!(parsed.authorization, block["authorization"].as_str().unwrap());
+        assert_eq!(parsed.ping_url, block["ping_url"].as_str().unwrap());
+        assert_eq!(parsed.integrations, vec!["issues", "slack"]);
+
+        // The ping request the sink emits must match the golden ping-request:
+        // same method/url/authorization, empty body.
+        let ping = fixture("ping-request.json");
+        // Method + body are fixed by HttpRunPingSink (POST, no body); assert the
+        // fixture agrees so a server-side change to either forces a runtime fix.
+        assert_eq!(ping["method"].as_str(), Some("POST"));
+        assert!(ping["body"].is_null(), "completion ping carries an empty body");
+        // url + authorization are what the runtime actually emits — assert via
+        // the real fire path (recording sink), and cross-check against the
+        // gateway block (a run's own token: run A can never ping run B).
+        let sink = RecordingPingSink::new();
+        fire_run_ping(Some(&parsed), &sink);
+        let calls = sink.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (emitted_url, emitted_auth) = &calls[0];
+        assert_eq!(emitted_url, ping["url"].as_str().unwrap());
+        assert_eq!(emitted_url, &parsed.ping_url);
+        assert_eq!(emitted_auth, ping["headers"]["authorization"].as_str().unwrap());
+        assert_eq!(emitted_auth, &parsed.authorization);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
@@ -240,6 +240,7 @@ impl WorkflowRunManager {
                 run_id.clone(),
                 run.workspace_id.clone(),
                 plan.sessions.clone(),
+                plan.gateway.clone(),
             );
             executor.hydrate_from_run(&run);
             let progress =

--- a/anyharness/crates/anyharness-lib/src/live/workflows/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/mod.rs
@@ -7,8 +7,13 @@ mod actor;
 mod commands;
 mod exec_policy;
 mod executor;
+mod gateway;
 mod manager;
 
 pub use exec_policy::{WorkflowAutoApproveAdvisor, WorkflowOwnedSessions};
 pub use executor::WorkflowExecDeps;
+pub use gateway::{
+    HttpRunPingSink, RunPingSink, WorkflowGatewaySessions,
+    WorkflowRunGatewaySessionLaunchExtension,
+};
 pub use manager::WorkflowRunManager;

--- a/apps/desktop/src/components/playground/workflows/WorkflowFormsFixtures.tsx
+++ b/apps/desktop/src/components/playground/workflows/WorkflowFormsFixtures.tsx
@@ -1,8 +1,16 @@
 import { useState } from "react";
-import type { WorkflowArgSpec, WorkflowSetup } from "@proliferate/product-domain/workflows/definition";
-import type { WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
+import type {
+  WorkflowArgSpec,
+  WorkflowSetup,
+} from "@proliferate/product-domain/workflows/definition";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { WorkflowRunArgsModal, type WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
 import { WorkflowMetaCard } from "@/components/workflows/editor/WorkflowMetaCard";
 import { WorkflowSetupCard } from "@/components/workflows/editor/WorkflowSetupCard";
+import {
+  WorkflowFunctionsCard,
+  type WorkflowFunctionProviderOption,
+} from "@/components/workflows/editor/WorkflowFunctionsCard";
 import {
   TriggerBadgeRow,
   TriggerForm,
@@ -50,6 +58,13 @@ function makeTrigger(overrides: Partial<WorkflowTriggerResponse>): WorkflowTrigg
   };
 }
 
+const FUNCTION_PROVIDERS: WorkflowFunctionProviderOption[] = [
+  { namespace: "issues", displayName: "Issues Service", connected: true },
+  { namespace: "slack", displayName: "Slack", connected: false },
+];
+
+const INTEGRATION_GRANTS: string[] = ["issues"];
+
 const TRIGGERS: WorkflowTriggerResponse[] = [
   makeTrigger({ id: "trig-1" }),
   makeTrigger({
@@ -86,6 +101,9 @@ export function WorkflowFormsFixtures() {
   const [description, setDescription] = useState("Investigate and fix failing tests until the suite passes.");
   const [setup, setSetup] = useState<WorkflowSetup>({ harness: "claude", model: "opus", sessionBinding: "fresh" });
   const [args, setArgs] = useState<WorkflowArgSpec[]>(ARGS);
+  const [integrations, setIntegrations] = useState<string[]>(INTEGRATION_GRANTS);
+  const [emptyIntegrations, setEmptyIntegrations] = useState<string[]>([]);
+  const [runModalOpen, setRunModalOpen] = useState(false);
 
   const [draft, setDraft] = useState<TriggerDraft>({
     kind: "schedule",
@@ -134,6 +152,16 @@ export function WorkflowFormsFixtures() {
           onDescriptionChange={setDescription}
         />
         <WorkflowSetupCard setup={setup} args={args} agents={AGENTS} onSetupChange={setSetup} onArgsChange={setArgs} />
+
+        <div className="flex flex-col gap-2">
+          <span className="text-xs text-faint">Integrations — namespace toggles (E3), loud cloud-only caption</span>
+          <WorkflowFunctionsCard integrations={integrations} providers={FUNCTION_PROVIDERS} onChange={setIntegrations} />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-xs text-faint">Integrations — no visible Issues/Slack integration yet</span>
+          <WorkflowFunctionsCard integrations={emptyIntegrations} providers={[]} onChange={setEmptyIntegrations} />
+        </div>
 
         <div className="flex flex-col gap-3 rounded-xl border border-border bg-background p-4 shadow-sm">
           <span className="text-sm font-medium text-foreground">Triggers — schedule + poll chips, poll error caption</span>
@@ -196,6 +224,31 @@ export function WorkflowFormsFixtures() {
             Scheduled and poll runs execute in the cloud. Create a cloud workspace to trigger this workflow that way;
             local triggers are coming — run it manually for now.
           </p>
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-xl border border-border bg-background p-4 shadow-sm">
+          <span className="text-sm font-medium text-foreground">
+            Run modal — local-lane integrations warning + L22 no-ready-account error
+          </span>
+          <p className="text-xs text-faint">
+            Opens with target &quot;On this Mac&quot; against a workflow that declares integrations —
+            exercises the warning caption and the enumerated-error + Settings link together.
+          </p>
+          <Button size="sm" className="self-start" onClick={() => setRunModalOpen(true)}>
+            Open run modal
+          </Button>
+          <WorkflowRunArgsModal
+            open={runModalOpen}
+            workflowName="Triage new issues"
+            args={ARGS}
+            localWorkspaces={[{ id: "local-1", label: "proliferate (local)" }]}
+            cloudWorkspaces={CLOUD_WORKSPACES}
+            hasIntegrations
+            error="This workflow grants the 'issues' integration, but you have no ready 'issues' integration. Connect it before running."
+            onOpenIntegrationsSettings={() => {}}
+            onClose={() => setRunModalOpen(false)}
+            onSubmit={() => setRunModalOpen(false)}
+          />
         </div>
       </div>
     </section>

--- a/apps/desktop/src/components/workflows/editor/WorkflowFunctionsCard.tsx
+++ b/apps/desktop/src/components/workflows/editor/WorkflowFunctionsCard.tsx
@@ -1,0 +1,102 @@
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { CircleAlert, Check } from "@proliferate/ui/icons";
+
+/** One selectable gateway provider (spec 6.1 / L21): a namespace visible to the
+ * owner, restricted client-side to the launch set (issues, slack). */
+export interface WorkflowFunctionProviderOption {
+  namespace: string;
+  displayName: string;
+  /** Whether the owner has a ready account for this provider today. StartRun
+   * (not save) is the real gate (L22) — this is just an editor-time hint. */
+  connected: boolean;
+}
+
+export interface WorkflowFunctionsCardProps {
+  /** E3: namespace-level grant — the integration namespaces this workflow's
+   * agents may use. No per-tool selection; the gateway treats a granted
+   * namespace as "all tools of that provider" at call time. */
+  integrations: readonly string[];
+  providers: readonly WorkflowFunctionProviderOption[];
+  onChange: (integrations: string[]) => void;
+}
+
+/**
+ * The Integrations section (spec 1.5 / 6.3, PR E, E3 namespace-only): declares
+ * the integration namespaces this workflow's agents may use. Provider choices
+ * are restricted client-side to the L21 launch set intersected with the owner's
+ * visible integrations (`providers` prop) — everything else is "more arrive
+ * later". Cloud-only (§5.3): the persistent caption below is LOUD by ruling, not
+ * just a tooltip. There is no per-tool selection under E3 — granting a namespace
+ * grants every tool of that provider.
+ */
+export function WorkflowFunctionsCard({ integrations, providers, onChange }: WorkflowFunctionsCardProps) {
+  const granted = new Set(integrations);
+
+  const toggle = (namespace: string) => {
+    if (granted.has(namespace)) {
+      onChange(integrations.filter((ns) => ns !== namespace));
+    } else {
+      onChange([...integrations, namespace]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-background p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">Integrations</span>
+        {integrations.length > 0 ? (
+          <span className="text-xs text-faint">
+            {integrations.length} {integrations.length === 1 ? "integration" : "integrations"}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="text-xs text-faint">
+        Grant this workflow&apos;s agents access to a connected integration. Granting an
+        integration exposes all of its tools. Available now: Issues, Slack — more integrations
+        arrive later.
+      </p>
+
+      {integrations.length > 0 ? (
+        <p className="flex items-start gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2.5 py-1.5 text-xs text-warning">
+          <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          Integrations require cloud runs — local runs will fail with an explicit error.
+        </p>
+      ) : null}
+
+      {providers.length === 0 ? (
+        <p className="text-xs text-faint">
+          No Issues or Slack integration is visible yet — connect one in Settings → Integrations
+          to grant it here.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {providers.map((provider) => {
+            const on = granted.has(provider.namespace);
+            return (
+              <button
+                key={provider.namespace}
+                type="button"
+                onClick={() => toggle(provider.namespace)}
+                aria-pressed={on}
+                className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors ${
+                  on
+                    ? "border-accent bg-accent/10 text-foreground"
+                    : "border-border text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {on ? <Check className="size-3.5" aria-hidden /> : null}
+                <span>{provider.displayName}</span>
+                {!provider.connected ? (
+                  <Badge tone="neutral" className="py-0 text-[10px]">
+                    not connected
+                  </Badge>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/workflows/home/WorkflowRunArgsModal.tsx
+++ b/apps/desktop/src/components/workflows/home/WorkflowRunArgsModal.tsx
@@ -6,6 +6,7 @@ import { Input } from "@proliferate/ui/primitives/Input";
 import { Label } from "@proliferate/ui/primitives/Label";
 import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
 import { Switch } from "@proliferate/ui/primitives/Switch";
+import { CircleAlert } from "@proliferate/ui/icons";
 import { WorkflowSelect } from "../editor/WorkflowSelect";
 
 type TargetMode = WorkflowTargetMode;
@@ -32,8 +33,16 @@ export interface WorkflowRunArgsModalProps {
   cloudWorkspaces: readonly WorkflowRunTargetOption[];
   /** Default local workspace (e.g. the currently-open one), if any. */
   defaultLocalWorkspaceId?: string | null;
+  /** Whether this workflow declares a non-empty `integrations` grant (spec 5.3,
+   * E3): drives the local-target warning below — cloud-only in v1, never a
+   * block. */
+  hasIntegrations?: boolean;
   busy?: boolean;
   error?: string | null;
+  /** Shown as a link under `error` when the failure is the L22 no-ready-account
+   * case (`workflow_function_provider_not_ready`) — the enumerated reason
+   * already names the provider in `error`; this jumps to where to fix it. */
+  onOpenIntegrationsSettings?: () => void;
   onClose: () => void;
   onSubmit: (input: WorkflowRunSubmit) => void;
 }
@@ -62,8 +71,10 @@ export function WorkflowRunArgsModal({
   localWorkspaces,
   cloudWorkspaces,
   defaultLocalWorkspaceId,
+  hasIntegrations = false,
   busy = false,
   error = null,
+  onOpenIntegrationsSettings,
   onClose,
   onSubmit,
 }: WorkflowRunArgsModalProps) {
@@ -139,9 +150,18 @@ export function WorkflowRunArgsModal({
     >
       <div className="flex flex-col gap-4">
         {error ? (
-          <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-ui-sm text-destructive">
-            {error}
-          </p>
+          <div className="flex flex-col gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-ui-sm text-destructive">
+            <p>{error}</p>
+            {onOpenIntegrationsSettings ? (
+              <button
+                type="button"
+                onClick={onOpenIntegrationsSettings}
+                className="self-start font-medium underline-offset-2 hover:underline"
+              >
+                Go to Settings → Integrations
+              </button>
+            ) : null}
+          </div>
         ) : null}
 
         {args.map((arg) => (
@@ -186,6 +206,14 @@ export function WorkflowRunArgsModal({
             onChange={(value) => setTargetMode(value as TargetMode)}
           />
         </div>
+
+        {hasIntegrations && targetMode === "local" ? (
+          <p className="flex items-start gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2.5 py-1.5 text-xs text-warning">
+            <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+            This workflow grants integrations, which require a cloud run. Running it on this
+            Mac will fail with an explicit error at the step that needs them.
+          </p>
+        ) : null}
 
         <div className="flex flex-col gap-1.5">
           <Label>Workspace</Label>

--- a/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
@@ -4,6 +4,7 @@ import {
   createWorkflowStep,
   parseWorkflowDefinition,
   serializeWorkflowDefinition,
+  WORKFLOW_INTEGRATION_LAUNCH_NAMESPACES,
   type WorkflowArgSpec,
   type WorkflowDefinition,
   type WorkflowSetup,
@@ -30,12 +31,18 @@ import { useCloudRunTargetWorkspaces } from "@/hooks/access/cloud/workspaces/use
 import { useWorkflowDetail, useWorkflows } from "@/hooks/access/cloud/workflows/use-workflows";
 import { useWorkflowMutations } from "@/hooks/access/cloud/workflows/use-workflow-mutations";
 import { useWorkflowSlackChannels } from "@/hooks/access/cloud/workflows/use-workflow-slack-channels";
+import { useCloudIntegrations } from "@/hooks/cloud/facade/use-cloud-integrations";
+import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import type { WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
 import { harnessSupportsGoals } from "@/lib/domain/workflows/goal-capability";
 import { WorkflowMetaCard } from "../editor/WorkflowMetaCard";
 import { WorkflowSetupCard } from "../editor/WorkflowSetupCard";
 import { WorkflowScopeHeader } from "../editor/WorkflowScopeHeader";
 import { WorkflowTriggersCard } from "../editor/WorkflowTriggersCard";
+import {
+  WorkflowFunctionsCard,
+  type WorkflowFunctionProviderOption,
+} from "../editor/WorkflowFunctionsCard";
 import { WorkflowStepRailCard } from "../editor/WorkflowStepRailCard";
 import { WorkflowStepPanel, type EditorAgent } from "../editor/WorkflowStepPanel";
 import { WorkflowSelect } from "../editor/WorkflowSelect";
@@ -109,6 +116,8 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
   const cloudTargetsQuery = useCloudRunTargetWorkspaces();
   const slackChannelsQuery = useWorkflowSlackChannels();
   const workflowsQuery = useWorkflows();
+  const { activeOrganizationId } = useActiveOrganization();
+  const { integrations: cloudIntegrations } = useCloudIntegrations(activeOrganizationId);
   const { updateMutation } = useWorkflowMutations();
 
   const [draft, setDraft] = useState<Draft | null>(null);
@@ -149,6 +158,23 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
           label: workspace.displayName ?? workspace.repo.branch,
         })),
     [cloudTargetsQuery.data],
+  );
+
+  // Gateway function providers (spec 6.1/6.3, L21): the owner's visible
+  // integrations, restricted client-side to the launch set (issues, slack) —
+  // everything else is "more arrive later" per the card's caption.
+  const functionProviders = useMemo<WorkflowFunctionProviderOption[]>(
+    () =>
+      cloudIntegrations
+        .filter((integration) =>
+          (WORKFLOW_INTEGRATION_LAUNCH_NAMESPACES as readonly string[]).includes(integration.namespace),
+        )
+        .map((integration) => ({
+          namespace: integration.namespace,
+          displayName: integration.displayName,
+          connected: integration.accountId !== null && integration.health === "ready",
+        })),
+    [cloudIntegrations],
   );
 
   const issues = useMemo(
@@ -222,6 +248,7 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
 
   const setSetup = (setup: WorkflowSetup) => patchDefinition({ setup });
   const setArgs = (args: WorkflowArgSpec[]) => patchDefinition({ args });
+  const setIntegrations = (integrations: string[]) => patchDefinition({ integrations });
 
   const updateStep = (index: number, step: WorkflowStep) =>
     patchDefinition({ steps: definition.steps.map((s, i) => (i === index ? step : s)) });
@@ -361,6 +388,11 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
                 onSelect={() => { setSetupSelected(true); setSelectedStep(null); }}
               />
               <WorkflowSetupCard setup={definition.setup} args={definition.args} agents={agents} onSetupChange={setSetup} onArgsChange={setArgs} />
+              <WorkflowFunctionsCard
+                integrations={definition.integrations}
+                providers={functionProviders}
+                onChange={setIntegrations}
+              />
               <WorkflowTriggersCard
                 workflowId={workflowId}
                 args={definition.args}

--- a/apps/desktop/src/components/workflows/screen/WorkflowsHomeScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowsHomeScreen.tsx
@@ -17,6 +17,7 @@ import {
   type WorkflowStatusTone,
 } from "@proliferate/product-domain/workflows/run-status";
 import type { WorkflowTemplate } from "@proliferate/product-domain/workflows/templates";
+import { ProliferateClientError } from "@/lib/access/cloud/client";
 import { MainSidebarPageShell } from "@/components/workspace/shell/screen/MainSidebarPageShell";
 import { ProductPageShell } from "@proliferate/product-ui/layout/ProductPageShell";
 import { EmptyState } from "@proliferate/ui/layout/EmptyState";
@@ -39,6 +40,11 @@ import {
 import { WorkflowTemplatesGallery } from "../home/WorkflowTemplatesGallery";
 
 type HomeTab = "workflows" | "runs";
+
+// Mirrors gateway_grants.py's L22 fail-fast code — a declared function
+// provider with no ready account for the owner. StartRun never silently
+// narrows the grant, so this always means "connect the named provider".
+const FUNCTION_PROVIDER_NOT_READY_CODE = "workflow_function_provider_not_ready";
 
 interface DesktopCatalogAgent {
   kind: string;
@@ -127,6 +133,7 @@ export function WorkflowsHomeScreen() {
     definition: WorkflowDefinition;
   } | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
+  const [runErrorCode, setRunErrorCode] = useState<string | null>(null);
 
   const workflowsQuery = useWorkflows();
   const runsQuery = useWorkflowRuns(null);
@@ -205,6 +212,7 @@ export function WorkflowsHomeScreen() {
 
   const runNow = (workflowId: string, submit: WorkflowRunSubmit) => {
     setRunError(null);
+    setRunErrorCode(null);
     launchMutation.mutate(
       {
         workflowId,
@@ -218,7 +226,10 @@ export function WorkflowsHomeScreen() {
           setArgsModal(null);
           navigate(`/workflows/${workflowId}/runs/${run.id}`);
         },
-        onError: (error) => setRunError(error.message),
+        onError: (error) => {
+          setRunError(error.message);
+          setRunErrorCode(error instanceof ProliferateClientError ? error.code : null);
+        },
       },
     );
   };
@@ -226,6 +237,7 @@ export function WorkflowsHomeScreen() {
   // Always open the modal: even an arg-less workflow needs a run target (spec 3.2).
   const handleRun = (workflow: WorkflowResponse, definition: WorkflowDefinition) => {
     setRunError(null);
+    setRunErrorCode(null);
     setArgsModal({ workflow, definition });
   };
 
@@ -334,8 +346,14 @@ export function WorkflowsHomeScreen() {
           args={argsModal.definition.args}
           localWorkspaces={localWorkspaceOptions}
           cloudWorkspaces={cloudWorkspaceOptions}
+          hasIntegrations={argsModal.definition.integrations.length > 0}
           busy={launchMutation.isPending}
           error={runError}
+          onOpenIntegrationsSettings={
+            runErrorCode === FUNCTION_PROVIDER_NOT_READY_CODE
+              ? () => navigate("/settings?section=integrations")
+              : undefined
+          }
           onClose={() => setArgsModal(null)}
           onSubmit={(submit) => runNow(argsModal.workflow.id, submit)}
         />

--- a/apps/packages/product-domain/src/workflows/definition.ts
+++ b/apps/packages/product-domain/src/workflows/definition.ts
@@ -63,6 +63,19 @@ export const WORKFLOW_GOAL_DEFAULT_TOKEN_BUDGET = 400_000;
 
 export const FREE_PLAN_MAX_WORKFLOWS_PER_USER = 1;
 
+/** Max integration namespaces a workflow may declare (mirrors
+ * `WORKFLOW_MAX_FUNCTION_PROVIDERS`, constants/workflows.py, L22). */
+export const WORKFLOW_MAX_INTEGRATIONS = 25;
+
+/**
+ * The integration namespaces exposed to the editor's picker at launch (L21,
+ * 2026-07-07): the issues service and Slack, the only two integrations with no
+ * mid-run OAuth-refresh failure mode. OAuth-DCR providers (Linear, Notion,
+ * Supabase) are deferred — see architecture doc §6.1/§6.6. E3: namespace-only —
+ * no per-tool selection.
+ */
+export const WORKFLOW_INTEGRATION_LAUNCH_NAMESPACES = ["issues", "slack"] as const;
+
 const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SLOT_RE = /^[a-z][a-z0-9_]*$/;
 

--- a/apps/packages/product-domain/src/workflows/workflows.test.ts
+++ b/apps/packages/product-domain/src/workflows/workflows.test.ts
@@ -108,6 +108,30 @@ describe("definition parse/serialize", () => {
     expect((parsed.steps[1] as { model?: string }).model).toBeUndefined();
     expect(serializeWorkflowDefinition(parsed)).toEqual(wire);
   });
+
+  it("round-trips a namespace-level integrations grant (E3)", () => {
+    const wire = {
+      version: 1,
+      inputs: [],
+      integrations: ["issues", "slack"],
+      agents: [
+        {
+          slot: "main",
+          harness: "claude",
+          model: "sonnet",
+          steps: [{ kind: "agent.prompt", on_fail: { kind: "stop" }, prompt: "go" }],
+        },
+      ],
+    };
+    const parsed = parseWorkflowDefinition(wire);
+    expect(parsed.integrations).toEqual(wire.integrations);
+    expect(serializeWorkflowDefinition(parsed)).toEqual(wire);
+
+    // Absent on the wire -> empty on the model -> empty array on serialize
+    // (integrations is always present in v2, defaulting to []).
+    const noIntegrations = parseWorkflowDefinition({ ...wire, integrations: undefined });
+    expect(noIntegrations.integrations).toEqual([]);
+  });
 });
 
 describe("validation", () => {
@@ -181,6 +205,26 @@ describe("validation", () => {
     };
     const codes = validateWorkflowDefinition(withGoal).map((i) => i.code);
     expect(codes.filter((c) => c === "invalid_definition").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("accepts a valid functions grant and flags empty/duplicate providers and tools (spec 1.5 / L22)", () => {
+    const ok: WorkflowDefinition = {
+      ...base,
+      functions: [{ provider: "issues", tools: ["claim", "search_issues"] }],
+    };
+    expect(validateWorkflowDefinition(ok)).toEqual([]);
+
+    const bad: WorkflowDefinition = {
+      ...base,
+      functions: [
+        { provider: "issues", tools: [] },
+        { provider: "issues", tools: ["claim", "claim"] },
+      ],
+    };
+    const codes = validateWorkflowDefinition(bad).map((i) => i.code);
+    expect(codes).toContain("duplicate_function_provider");
+    // Empty tools on the first grant, duplicate tool name on the second.
+    expect(codes.filter((c) => c === "invalid_definition").length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1692,6 +1692,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/workflows/runs/{run_id}/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run Ping Endpoint
+         * @description Completion ping (L16 / §3.7). NO user-session auth — the per-run gateway
+         *     token IS the auth. The runtime fires this after each step transition; the
+         *     handler validates the token, requires token↔run_id match (so run A's token
+         *     can't ping run B), and wakes the existing refresh path for cloud-lane runs.
+         *
+         *     The body carries nothing: it is a stateless nudge. Duplicate/stale/late pings
+         *     are safe by construction — refresh is reconcile-shaped and run-status
+         *     transitions are monotonic — so no state is added here.
+         */
+        post: operations["run_ping_endpoint_v1_cloud_workflows_runs__run_id__ping_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workflows/slack/channels": {
         parameters: {
             query?: never;
@@ -9442,6 +9469,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkflowRunResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_ping_endpoint_v1_cloud_workflows_runs__run_id__ping_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -359,6 +359,16 @@ parser, no migration; E4). The spine is `agents: [{slot, harness, model, steps}]
 plan, not authored). **Zero-agent draft rule**: `require_steps=False` on
 create/update; `StartRun` always parses with `require_steps=True`.
 
+**Integrations (PR E, E3 namespace-only).** `integrations` is a flat list of
+integration namespace strings (`["sentry","linear","slack"]`) — no `{provider,
+tools}` shape, no tool lists anywhere in the definition. `_parse_integrations`
+validates each is an identifier, deduped. `resolve_run_scope` stamps the
+namespace grant per slot into `scope_json` (`{"<slot>": {"integrations": [...]}}`)
+with NO tool fetch at mint (no `tools/list` call, no new StartRun failure mode).
+The gateway enforces a namespace-only scope entry as "ALL tools of that
+provider" at call time (`domain/scope.py`), so providers whose tools grow
+mid-run work without re-mint.
+
 Step kinds ([constants/workflows.py](../server/proliferate/constants/workflows.py)):
 `agent.config` (narrowed to `{model}` only — same-harness rule), `agent.prompt`
 (+`required_invocation?{provider,tool}`), **`agent.emit`** (NEW: `name` required +
@@ -372,6 +382,13 @@ discriminator and `in_app` are removed, E1b). **`human.approval` is removed (E1)
 uniqueness (whole definition) and *strictly-prior* ref visibility: `{{inputs.NAME}}`
 must be a declared input; `{{EMIT.FIELD}}` must name an emit produced by an
 earlier step (earlier nodes in full, earlier steps in the same node).
+
+**`integrations` (§6, PR E, E3 namespace-only)** — `_parse_integrations`
+(top-level, not a step) validates a flat list of namespace strings
+(`["sentry","linear","slack"]`): each an identifier, deduped. No `{provider,
+tools}` shape and no tool lists anywhere. Structural only here (`parse_definition`
+stays pure); the owner-visibility check needs the DB and runs in the service layer
+(§3.4a).
 
 **`workflow.include` (§3.5, PR D)** — `_parse_workflow_include` validates the
 definition-only composition step's shape (a UUID `workflow_id`, an `args` mapping of
@@ -545,6 +562,113 @@ wake the sandbox in-request). No outbox/Celery.
   `report_run_status` hook, so an unattended cloud run without a live UI tab still
   gets its Slack actions performed via scheduler phase 3.
 
+### 3.4a Per-run gateway grants, completion ping, two-layer scope (PR E)
+
+New in PR E ([gateway_grants.py](../server/proliferate/server/cloud/workflows/gateway_grants.py),
+[integration_gateway/domain/scope.py](../server/proliferate/server/cloud/integration_gateway/domain/scope.py)).
+The design of record is architecture §6 + L16/L21–L26.
+
+**Mint at StartRun, EVERY run (L16).** After the plan is resolved, `start_run`
+resolves the run's NAMESPACE grant (E3) = the definition's top-level
+`integrations[]`, stamped **per slot** into `scope_json`
+(`{"<slot>": {"integrations": [...]}}` — §2.6; v1 stamps every slot with the same
+workflow-level list). `resolve_run_scope` returns that per-slot dict;
+`granted_namespaces` flattens it for the checks below. Composition inlines a
+child's *steps*, not its grant (L24). **No `tools/list` fetch at mint — E3
+introduces no new StartRun failure mode.** **L22 fail-fast** runs BEFORE the run
+row is created: `assert_declared_providers_ready` checks each declared namespace
+has a ready account for the owner via the same org-aware
+`get_ready_account_for_provider` the gateway uses — a declared namespace with no
+ready account fails the run (`workflow_function_provider_not_ready` 409), never a
+silent narrowing. Save-time, `create_workflow`/`update_workflow` additionally
+reject an `integrations` namespace the owner cannot even see
+(`workflow_function_provider_unknown`, seed + org customs). Then the run row is
+created, a per-run token is minted (`secrets.token_urlsafe`, hashed exactly like
+the worker token under its own HMAC domain — `hash_workflow_run_gateway_token`),
+and the plaintext is folded into `resolved_plan_json.gateway` (identical shape on
+both lanes — L16 — the local runtime errors if it can't honor it, §5.3):
+
+```python
+resolved_plan["gateway"] = {
+    "url": <same URL enroll composes>,          # {base}/v1/cloud/integration-gateway/mcp
+    "authorization": "Bearer <per-run token>",  # plaintext; only the hash is stored
+    "ping_url": "{base}/v1/cloud/workflows/runs/{run_id}/ping",
+    "integrations": ["sentry", "linear"],       # flat namespace list, possibly empty
+}
+```
+
+The runtime only reads `integrations`'s emptiness (L22 local-lane fail-fast); it
+never inspects tools. The token row (`cloud_workflow_run_gateway_token`) stores only
+the hash + the frozen per-slot `scope_json` (NOT NULL; an empty per-slot grant is
+never conflated with a worker token's NULL "unscoped"), status
+`active|expired|revoked`, `expires_at = now + 24h` (a backstop — terminal status
+expires it first).
+
+**Two-layer scope (L25), NAMESPACE granularity (E3).** Layer 1 = a worker-level
+provider-namespace allowlist (nullable `scope_json` on
+`cloud_integration_gateway_token`; NULL = unscoped/today's behavior, never
+"empty"). Layer 2 = the per-run token's frozen namespace grant. **Mint-vs-delivery
+intersection choice:** the delivering worker is not known at StartRun for cloud runs
+(the scheduler/`deliver_cloud_run` waking the sandbox is where the worker becomes
+known), so the token is minted at StartRun with the *definition* namespaces and the
+L25 subset intersection is performed **at delivery** — `deliver_cloud_run` →
+`_apply_delivery_scope_intersection` reads the owner's active worker allowlist
+(`get_active_worker_gateway_scope_for_owner`), intersects the plan's
+`gateway.integrations` (`scope.intersect_namespaces_with_worker`; NULL worker =
+unscoped passthrough, empty = drops all), and re-freezes BOTH the plan's
+`gateway.integrations` and the per-slot token `scope_json` before the plan ships.
+Enforcement is asymmetric: mint/delivery decides what *may* be requested; **every
+gateway request re-checks the CURRENT worker allowlist** so a worker scope narrowed
+after mint bites on the next call.
+
+**Gateway enforcement** ([dependencies.py](../server/proliferate/server/cloud/integration_gateway/dependencies.py),
+[service.py](../server/proliferate/server/cloud/integration_gateway/service.py)):
+`require_integration_gateway_grant` tries the run-token hash FIRST (its own HMAC
+domain — no collision with worker tokens), falling back to the worker token
+unchanged. It **flattens** the per-slot `scope_json` into the namespace-level
+`run_scope` the pure layer consumes — one namespace-only entry per granted provider
+(`{"provider": ns}`, no `tools` key), union across slots (`_flatten_run_scope`). A
+run grant carries `{run_id, owner, org, run_scope}` plus the freshly re-resolved
+`worker_scope`. **E3: a namespace-only scope entry matches EVERY tool of that
+provider at call time** — `scope.authorize_tool_call`/`filter_tools_to_scope` treat
+an entry with no `tools` key as all-tools, so `tools/list` returns every tool of a
+granted namespace and `tools/call` allows any of them; a provider outside the run
+scope is still denied (`integration_gateway_scope_denied`, surfaced through the MCP
+error-result envelope, not a 500). Providers whose tools grow mid-run work without
+re-mint. An explicit `tools` list on an entry (reserved for future per-slot
+narrowing) still restricts; core-v1 never emits it. The scope check is a **pure
+helper** in `integration_gateway/domain/scope.py`, callable outside the FastAPI
+dependency, so the future server-side `function_call` performer (§6.6/L18/L23)
+authorizes through the same code. **Org policy (addendum):** `ready_accounts_for_grant`
+and `account_for_provider` pass the grant's `organization_id` to the store so a
+provider the owner's org has disabled by policy is filtered out of both
+`list_providers` and `call_tool` — the same overlay the L22 mint check applies.
+
+**Completion ping (§3.7 / L16).** `POST /runs/{run_id}/ping` in
+[api.py](../server/proliferate/server/cloud/workflows/api.py) has **no user-session
+auth** — the per-run token IS its auth. It validates the bearer (active + unexpired
+`cloud_workflow_run_gateway_token`), requires `token.workflow_run_id == run_id`
+(else 403 — run A's token can't ping run B), and for cloud-lane runs triggers the
+existing `refresh_cloud_run`/`_sync_run_from_view`; local-lane runs accept 202 and
+no-op (the desktop relay owns local observation). The body carries nothing;
+duplicate/stale/late pings are safe by construction (refresh is reconcile-shaped,
+transitions monotonic) — no state is added. Terminal status is the choke point that
+expires the token: `report_run_status` AND `_sync_run_from_view` both call
+`expire_run_gateway_tokens_for_run` when the resulting status is terminal
+(idempotent), so a late ping after terminal is a benign 401.
+
+**Sandbox purpose (L26).** `cloud_sandbox` gains a stamped `purpose` enum
+(`interactive` | `workflow-run`, NOT NULL server_default `interactive`), set once at
+creation and never inferred later. Workflow cloud delivery threads
+`purpose='workflow-run'` through `ensure_cloud_sandbox_gateway_access` →
+`ensure_cloud_sandbox_ready` → `ensure_personal_cloud_sandbox`; because the personal
+sandbox is shared and returned as-is when it already exists, an existing sandbox is
+never restamped (first-create wins).
+
+**First integrations (L21):** the issues service (`api_key` seed) and Slack —
+`api_key`-style, no mid-run OAuth-refresh failure mode. OAuth-DCR providers are
+deferred until the frozen per-run scope has a mid-run reauth story.
+
 ### 3.5 Scheduler — [scheduler.py](../server/proliferate/server/cloud/workflows/scheduler.py)
 
 A second beat beside the automations scheduler, launched in
@@ -634,6 +758,7 @@ after 3 consecutive failures.
 | POST | `/workflows/runs/{run_id}/status` | **local relay** reports observed state; also triggers `apply_step_actions` |
 | POST | `/workflows/runs/{run_id}/deliver` | **cloud** lane retry of stuck `pending_delivery` |
 | GET | `/workflows/runs/{run_id}/refresh` | **cloud** lane pull; syncs ledger; also triggers `apply_step_actions` |
+| POST | `/workflows/runs/{run_id}/ping` | PR E (§3.4a) — completion ping; **no user session**, auth is the per-run gateway token; token↔run_id must match (else 403); cloud lane triggers `refresh_cloud_run`, local lane 202-no-ops; always 202 on valid token |
 | GET | `/workflows/slack/channels` | PR A — `{channels:[{id,name}], connected}`; `connected:false` + empty list when the actor has no ready Slack account ([integrations accounts store](../server/proliferate/db/store/integrations/accounts.py)) |
 | GET/PATCH/DELETE | `/workflows/{workflow_id}` | detail / update (append version) / archive |
 | POST | `/workflows/{workflow_id}/runs` | **StartRun**; personal_cloud also calls `deliver_cloud_run` in-request |

--- a/fixtures/contracts/run-ping/gateway-block.json
+++ b/fixtures/contracts/run-ping/gateway-block.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Golden contract fixture (§3.7/L16, §6.4/OPEN-3(a)): the per-run gateway block as it appears at resolved_plan_json.gateway. Producing side = server StartRun mint (Python); consuming side = anyharness runtime parses it into PlanGateway. `authorization` is the FULL Authorization header value, forwarded verbatim (matches the worker dotfile convention). `integrations` is the NAMESPACE-LEVEL grant (E3): a list of integration namespaces, no tool lists — the gateway treats a namespace grant as 'all tools of that provider' at call time. Change this file to change the contract; both sides' tests then break until updated.",
+  "url": "https://cloud.test/v1/cloud/integration-gateway/mcp",
+  "authorization": "Bearer per-run-token-abc123",
+  "ping_url": "https://cloud.test/v1/cloud/workflows/runs/run-abc123/ping",
+  "integrations": ["issues", "slack"]
+}

--- a/fixtures/contracts/run-ping/ping-request.json
+++ b/fixtures/contracts/run-ping/ping-request.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Golden contract fixture (§3.7/L16): the completion-ping HTTP request the runtime emits after each step transition. `url` MUST equal gateway-block.json `ping_url`; `headers.authorization` MUST equal gateway-block.json `authorization` (forwarded verbatim — a run's own token, so run A can never ping run B). Method is POST with an empty body (a stateless nudge). Producing side = anyharness runtime (HttpRunPingSink); consuming side = server ping endpoint.",
+  "method": "POST",
+  "url": "https://cloud.test/v1/cloud/workflows/runs/run-abc123/ping",
+  "headers": {
+    "authorization": "Bearer per-run-token-abc123"
+  },
+  "body": null
+}

--- a/server/alembic/versions/d2f4a6c8e0b1_workflow_run_gateway_token.py
+++ b/server/alembic/versions/d2f4a6c8e0b1_workflow_run_gateway_token.py
@@ -1,0 +1,162 @@
+"""workflow run gateway token + two-layer function scope + sandbox purpose
+
+Revision ID: d2f4a6c8e0b1
+Revises: f1c3d5b7a9e2
+Create Date: 2026-07-08 00:00:00.000000
+
+PR E (spec 6 / L16, L22, L25, L26):
+
+* ``cloud_workflow_run_gateway_token`` — one per run, hashed token, frozen
+  function scope (§6.4/OPEN-3a). status active|expired|revoked.
+* L25 layer 1: additive nullable ``scope_json`` on
+  ``cloud_integration_gateway_token`` (provider-namespace allowlist; NULL =
+  unscoped = today's behavior, never conflated with empty; no backfill).
+* L25 admin: nullable ``scope_json`` on ``cloud_integration_policy`` (extend the
+  existing per-org policy row, not a parallel table).
+* L26: ``purpose`` on ``cloud_sandbox`` (CHECK interactive|workflow-run, NOT NULL
+  server_default 'interactive' — existing rows are interactive).
+
+All idempotent-guarded like the rest of the stack.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2f4a6c8e0b1"
+down_revision: str | Sequence[str] | None = "f1c3d5b7a9e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return table_name in inspector.get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    # (a) the per-run gateway token table.
+    if not _has_table("cloud_workflow_run_gateway_token"):
+        op.create_table(
+            "cloud_workflow_run_gateway_token",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("workflow_run_id", sa.Uuid(), nullable=False),
+            sa.Column("owner_user_id", sa.Uuid(), nullable=False),
+            sa.Column("organization_id", sa.Uuid(), nullable=True),
+            sa.Column("token_hash", sa.String(length=64), nullable=False),
+            sa.Column("scope_json", JSONB(), nullable=False),
+            sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('active', 'expired', 'revoked')",
+                name="ck_cloud_workflow_run_gateway_token_status",
+            ),
+            sa.ForeignKeyConstraint(
+                ["workflow_run_id"], ["workflow_run.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "token_hash", name="uq_cloud_workflow_run_gateway_token_hash"
+            ),
+        )
+    if not _has_index(
+        "cloud_workflow_run_gateway_token", "ix_cloud_workflow_run_gateway_token_run_id"
+    ):
+        op.create_index(
+            "ix_cloud_workflow_run_gateway_token_run_id",
+            "cloud_workflow_run_gateway_token",
+            ["workflow_run_id"],
+        )
+    if not _has_index(
+        "cloud_workflow_run_gateway_token", "ix_cloud_workflow_run_gateway_token_hash"
+    ):
+        op.create_index(
+            "ix_cloud_workflow_run_gateway_token_hash",
+            "cloud_workflow_run_gateway_token",
+            ["token_hash"],
+        )
+    if not _has_index(
+        "cloud_workflow_run_gateway_token", "ix_cloud_workflow_run_gateway_token_owner_user_id"
+    ):
+        op.create_index(
+            "ix_cloud_workflow_run_gateway_token_owner_user_id",
+            "cloud_workflow_run_gateway_token",
+            ["owner_user_id"],
+        )
+    if not _has_index(
+        "cloud_workflow_run_gateway_token",
+        "ix_cloud_workflow_run_gateway_token_organization_id",
+    ):
+        op.create_index(
+            "ix_cloud_workflow_run_gateway_token_organization_id",
+            "cloud_workflow_run_gateway_token",
+            ["organization_id"],
+        )
+
+    # (b) L25 layer 1: worker-level allowlist (NULL = unscoped, no backfill).
+    if not _has_column("cloud_integration_gateway_token", "scope_json"):
+        op.add_column(
+            "cloud_integration_gateway_token",
+            sa.Column("scope_json", JSONB(), nullable=True),
+        )
+
+    # (c) L25 admin: org-policy scope key (nullable; extend, don't parallel-table).
+    if not _has_column("cloud_integration_policy", "scope_json"):
+        op.add_column(
+            "cloud_integration_policy",
+            sa.Column("scope_json", JSONB(), nullable=True),
+        )
+
+    # (d) L26: sandbox purpose, NOT NULL server_default 'interactive'.
+    if not _has_column("cloud_sandbox", "purpose"):
+        op.add_column(
+            "cloud_sandbox",
+            sa.Column(
+                "purpose",
+                sa.String(length=32),
+                nullable=False,
+                server_default="interactive",
+            ),
+        )
+        op.create_check_constraint(
+            "ck_cloud_sandbox_purpose",
+            "cloud_sandbox",
+            "purpose IN ('interactive', 'workflow-run')",
+        )
+
+
+def downgrade() -> None:
+    if _has_column("cloud_sandbox", "purpose"):
+        op.drop_constraint("ck_cloud_sandbox_purpose", "cloud_sandbox", type_="check")
+        op.drop_column("cloud_sandbox", "purpose")
+    if _has_column("cloud_integration_policy", "scope_json"):
+        op.drop_column("cloud_integration_policy", "scope_json")
+    if _has_column("cloud_integration_gateway_token", "scope_json"):
+        op.drop_column("cloud_integration_gateway_token", "scope_json")
+    if _has_table("cloud_workflow_run_gateway_token"):
+        for index_name in (
+            "ix_cloud_workflow_run_gateway_token_organization_id",
+            "ix_cloud_workflow_run_gateway_token_owner_user_id",
+            "ix_cloud_workflow_run_gateway_token_hash",
+            "ix_cloud_workflow_run_gateway_token_run_id",
+        ):
+            if _has_index("cloud_workflow_run_gateway_token", index_name):
+                op.drop_index(index_name, table_name="cloud_workflow_run_gateway_token")
+        op.drop_table("cloud_workflow_run_gateway_token")

--- a/server/proliferate/constants/cloud.py
+++ b/server/proliferate/constants/cloud.py
@@ -310,6 +310,11 @@ CLOUD_TARGET_HEARTBEAT_STALE_SECONDS: Final = 180
 CLOUD_RUNTIME_WORKER_ENROLLMENT_TOKEN_DOMAIN: Final = "cloud-runtime-worker-enrollment"
 CLOUD_RUNTIME_WORKER_TOKEN_DOMAIN: Final = "cloud-runtime-worker"
 CLOUD_INTEGRATION_GATEWAY_TOKEN_DOMAIN: Final = "cloud-integration-gateway"
+# The per-run workflow gateway token (PR E / OPEN-3(a)) gets its own HMAC domain
+# so a run token can never authenticate against the per-worker gateway-token
+# table and vice versa, even though both ride the same /integration-gateway/mcp
+# endpoint. Hashing reuses ``hash_runtime_token`` (worker-token hashing, exactly).
+CLOUD_WORKFLOW_RUN_GATEWAY_TOKEN_DOMAIN: Final = "cloud-workflow-run-gateway"
 
 # Cloud sandboxes mint a longer-lived enrollment (the worker boots once per
 # provisioning); desktop mints a short-lived one at login.
@@ -319,6 +324,21 @@ CLOUD_RUNTIME_WORKER_DESKTOP_ENROLLMENT_TTL_SECONDS: Final = 900
 CLOUD_RUNTIME_WORKER_HEARTBEAT_INTERVAL_SECONDS: Final = 30
 CLOUD_RUNTIME_WORKER_OFFLINE_THRESHOLD_SECONDS: Final = 90
 CLOUD_INTEGRATION_GATEWAY_MCP_PATH: Final = "/v1/cloud/integration-gateway/mcp"
+# The per-run completion-ping route (L16 / §3.7). Composed against the worker
+# cloud base URL exactly like the gateway MCP path so the runtime can reach it.
+CLOUD_WORKFLOW_RUN_PING_PATH_TEMPLATE: Final = "/v1/cloud/workflows/runs/{run_id}/ping"
+
+# ---------------------------------------------------------------------------
+# Cloud sandbox purpose (L26): a stamped enum set once at creation, never
+# inferred from caller context. ``workflow-run`` is stamped only when a sandbox
+# is created by workflow-driven cloud delivery; every other create is
+# ``interactive`` (and existing rows default to it — see the migration).
+# ---------------------------------------------------------------------------
+CLOUD_SANDBOX_PURPOSE_INTERACTIVE: Final = "interactive"
+CLOUD_SANDBOX_PURPOSE_WORKFLOW_RUN: Final = "workflow-run"
+SUPPORTED_CLOUD_SANDBOX_PURPOSES: Final = frozenset(
+    {CLOUD_SANDBOX_PURPOSE_INTERACTIVE, CLOUD_SANDBOX_PURPOSE_WORKFLOW_RUN}
+)
 
 
 # ---------------------------------------------------------------------------

--- a/server/proliferate/constants/workflows.py
+++ b/server/proliferate/constants/workflows.py
@@ -274,6 +274,22 @@ WORKFLOW_SHORT_TEXT_MAX_LENGTH: Final = 255
 WORKFLOW_MAX_STEPS: Final = 50
 WORKFLOW_MAX_ARGS: Final = 25
 
+# --- Per-run gateway function grants (spec 6 / L16, L22, L25). -----------------
+# A definition may declare a top-level ``functions`` allow-list — one entry per
+# provider, each with a non-empty tool list. StartRun resolves it into the run's
+# frozen gateway scope. The caps keep a definition from declaring an unbounded
+# grant surface.
+WORKFLOW_MAX_FUNCTION_PROVIDERS: Final = 25
+WORKFLOW_MAX_TOOLS_PER_PROVIDER: Final = 100
+
+# The per-run gateway token (OPEN-3(a)) lives for the run + a grace window; it is
+# flipped to ``expired`` the instant the run reaches a terminal status, so 24h is a
+# backstop for a run whose terminal report never arrives.
+WORKFLOW_RUN_GATEWAY_TOKEN_TTL_SECONDS: Final = 24 * 60 * 60
+WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE: Final = "active"
+WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_EXPIRED: Final = "expired"
+WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_REVOKED: Final = "revoked"
+
 # --- Free-plan cap (spec 6: 1 non-archived workflow per user). -----------------
 FREE_PLAN_MAX_WORKFLOWS_PER_USER: Final = 1
 

--- a/server/proliferate/db/models/cloud/integrations.py
+++ b/server/proliferate/db/models/cloud/integrations.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from proliferate.db.models.base import Base, utcnow
@@ -100,6 +101,13 @@ class CloudIntegrationPolicy(Base):
     organization_id: Mapped[uuid.UUID] = mapped_column(index=True)
     definition_id: Mapped[uuid.UUID] = mapped_column(index=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    # L25 admin key: the org-level scope this definition is allowed to expose to a
+    # worker's gateway token (a tool-name allowlist, ``["claim", ...]``). NULL means
+    # "no scope restriction from policy" — the admin surface for the worker-level
+    # allowlist, extending this row rather than a parallel table. Not wired into
+    # gateway enforcement in A–E (enforcement reads the worker token's scope_json);
+    # kept nullable so it can be authored without touching existing rows.
+    scope_json: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     updated_by_user_id: Mapped[uuid.UUID] = mapped_column()
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/server/proliferate/db/models/cloud/runtime_workers.py
+++ b/server/proliferate/db/models/cloud/runtime_workers.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import CheckConstraint, DateTime, Index, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from proliferate.db.models.base import Base, utcnow
@@ -128,6 +129,10 @@ class CloudIntegrationGatewayToken(Base):
     organization_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
     token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     status: Mapped[str] = mapped_column(String(32), default="active")
+    # L25 layer 1: worker-level provider-namespace allowlist (``["issues", ...]``).
+    # NULL = unscoped (today's behavior, never conflated with an empty allowlist);
+    # no backfill — existing workers stay unscoped until they re-enroll.
+    scope_json: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/server/proliferate/db/models/cloud/sandboxes.py
+++ b/server/proliferate/db/models/cloud/sandboxes.py
@@ -36,6 +36,12 @@ class CloudSandbox(Base):
             "sandbox_type IN ('e2b')",
             name="ck_cloud_sandbox_type",
         ),
+        # L26: purpose is stamped once at creation, never inferred from later
+        # callers. Existing rows default to 'interactive' (they were interactive).
+        CheckConstraint(
+            "purpose IN ('interactive', 'workflow-run')",
+            name="ck_cloud_sandbox_purpose",
+        ),
         Index(
             "ux_cloud_sandbox_personal_active",
             "owner_user_id",
@@ -65,6 +71,13 @@ class CloudSandbox(Base):
         nullable=True,
     )
     status: Mapped[CloudSandboxStatus] = mapped_column(_SANDBOX_STATUS_ENUM)
+    # L26: 'interactive' | 'workflow-run', stamped at creation. NOT NULL with a
+    # server default of 'interactive' so existing rows and every non-workflow
+    # create keep today's identity; workflow-driven cloud delivery stamps
+    # 'workflow-run' at the create call, never after.
+    purpose: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default=text("'interactive'")
+    )
     anyharness_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     runtime_token_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
     anyharness_data_key_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/server/proliferate/db/models/cloud/workflows.py
+++ b/server/proliferate/db/models/cloud/workflows.py
@@ -419,3 +419,53 @@ class WorkflowStepAction(Base):
         default=utcnow,
         onupdate=utcnow,
     )
+
+
+class WorkflowRunGatewayToken(Base):
+    """The per-run integration-gateway credential (PR E / OPEN-3(a), L16).
+
+    Every run mints exactly one of these at StartRun — even a run whose plan needs
+    no integration tools (``scope_json`` is then an empty list, which is legal and
+    NEVER conflated with an unscoped worker token). Its plaintext rides inside the
+    run's ``resolved_plan_json.gateway`` block to the sandbox; only the hash is
+    stored (hashed exactly like the worker token, under its own HMAC domain).
+
+    The token is the run-report credential too: the runtime pings
+    ``/runs/{run_id}/ping`` with it. Identity is proven by the credential, so a
+    request's run attribution is not a claim — ``workflow_run_id`` IS the run.
+
+    ``scope_json`` is the frozen function grant (the definition's ``functions[]``,
+    resolved), narrowed at delivery to the intersection with the delivering
+    worker's allowlist (L25 layer 2 ⊆ layer 1). ``status`` walks
+    active -> expired (terminal run status) | revoked.
+    """
+
+    __tablename__ = "cloud_workflow_run_gateway_token"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'expired', 'revoked')",
+            name="ck_cloud_workflow_run_gateway_token_status",
+        ),
+        Index("ix_cloud_workflow_run_gateway_token_run_id", "workflow_run_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    workflow_run_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("workflow_run.id", ondelete="CASCADE"),
+    )
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    # The resolved function grant: ``[{"provider": str, "tools": [str, ...]}, ...]``.
+    # NOT NULL — an empty list means "no tools granted", distinct from a worker
+    # token's NULL "unscoped" (L25).
+    scope_json: Mapped[list[dict[str, object]]] = mapped_column(JSONB)
+    status: Mapped[str] = mapped_column(String(16), default="active")
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/cloud_sandboxes.py
+++ b/server/proliferate/db/store/cloud_sandboxes.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.constants.cloud import CLOUD_SANDBOX_PURPOSE_INTERACTIVE
 from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.utils.time import utcnow
 
@@ -30,6 +31,7 @@ class CloudSandboxValue:
     created_by_user_id: UUID | None
     billing_subject_id: UUID | None
     status: str
+    purpose: str
     last_error: str | None
     e2b_sandbox_id: str | None
     e2b_template_ref: str
@@ -57,6 +59,7 @@ def cloud_sandbox_value(row: CloudSandbox) -> CloudSandboxValue:
         created_by_user_id=row.owner_user_id,
         billing_subject_id=None,
         status=status,
+        purpose=row.purpose,
         last_error=None,
         e2b_sandbox_id=row.provider_sandbox_id,
         e2b_template_ref=sandbox_type,
@@ -150,10 +153,14 @@ async def ensure_personal_cloud_sandbox(
     created_by_user_id: UUID,
     billing_subject_id: UUID,
     e2b_template_ref: str,
+    purpose: str = CLOUD_SANDBOX_PURPOSE_INTERACTIVE,
 ) -> CloudSandboxValue:
     del created_by_user_id, billing_subject_id, e2b_template_ref
     existing = await load_personal_cloud_sandbox(db, user_id, lock_row=True)
     if existing is not None:
+        # L26: purpose is stamped ONCE at creation and never inferred later, so an
+        # already-existing sandbox keeps whatever it was stamped with — a
+        # workflow-driven wake does not restamp an interactive sandbox.
         return existing
     now = utcnow()
     row = CloudSandbox(
@@ -161,6 +168,7 @@ async def ensure_personal_cloud_sandbox(
         sandbox_type="e2b",
         provider_sandbox_id=None,
         status="creating",
+        purpose=purpose,
         anyharness_base_url=None,
         runtime_token_ciphertext=None,
         anyharness_data_key_ciphertext=None,

--- a/server/proliferate/db/store/cloud_workflows.py
+++ b/server/proliferate/db/store/cloud_workflows.py
@@ -11,6 +11,8 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.workflows import (
+    WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+    WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_EXPIRED,
     WORKFLOW_RUN_STATUS_PENDING_DELIVERY,
     WORKFLOW_RUN_TERMINAL_STATUSES,
     WORKFLOW_SERVER_DELIVERED_TRIGGER_KINDS,
@@ -19,6 +21,7 @@ from proliferate.constants.workflows import (
 from proliferate.db.models.cloud.workflows import (
     Workflow,
     WorkflowRun,
+    WorkflowRunGatewayToken,
     WorkflowStepAction,
     WorkflowVersion,
 )
@@ -359,6 +362,7 @@ async def update_run(
     status: str | None = None,
     step_cursor: int | None = None,
     step_outputs_json: dict[str, object] | None = None,
+    resolved_plan_json: dict[str, object] | None = None,
     error_code: str | None = None,
     error_message: str | None = None,
     anyharness_workspace_id: str | None = None,
@@ -385,6 +389,8 @@ async def update_run(
         row.step_cursor = step_cursor
     if step_outputs_json is not None:
         row.step_outputs_json = step_outputs_json
+    if resolved_plan_json is not None:
+        row.resolved_plan_json = resolved_plan_json
     if clear_error:
         row.error_code = None
         row.error_message = None
@@ -560,6 +566,134 @@ async def list_actions_for_run(
         .all()
     )
     return tuple(_action_record(row) for row in rows)
+
+
+# --- per-run gateway token (PR E / OPEN-3a) ------------------------------------
+
+
+@dataclass(frozen=True)
+class RunGatewayTokenRecord:
+    id: UUID
+    workflow_run_id: UUID
+    owner_user_id: UUID
+    organization_id: UUID | None
+    # E3: per-slot namespace grant ``{"<slot>": {"integrations": [...]}}`` (§2.6).
+    scope_json: dict[str, dict[str, object]]
+    status: str
+    expires_at: datetime
+
+
+def _run_gateway_token_record(row: WorkflowRunGatewayToken) -> RunGatewayTokenRecord:
+    scope = row.scope_json if isinstance(row.scope_json, dict) else {}
+    return RunGatewayTokenRecord(
+        id=row.id,
+        workflow_run_id=row.workflow_run_id,
+        owner_user_id=row.owner_user_id,
+        organization_id=row.organization_id,
+        scope_json=dict(scope),
+        status=row.status,
+        expires_at=row.expires_at,
+    )
+
+
+async def create_run_gateway_token(
+    db: AsyncSession,
+    *,
+    workflow_run_id: UUID,
+    owner_user_id: UUID,
+    organization_id: UUID | None,
+    token_hash: str,
+    scope_json: dict[str, dict[str, object]],
+    expires_at: datetime,
+) -> RunGatewayTokenRecord:
+    now = utcnow()
+    row = WorkflowRunGatewayToken(
+        workflow_run_id=workflow_run_id,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        token_hash=token_hash,
+        scope_json=scope_json,
+        status=WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+        expires_at=expires_at,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    return _run_gateway_token_record(row)
+
+
+async def get_active_run_gateway_token_by_hash(
+    db: AsyncSession, *, token_hash: str, now: datetime
+) -> RunGatewayTokenRecord | None:
+    """An active, unexpired run gateway token by its hash (the ping/gateway auth)."""
+
+    row = (
+        await db.execute(
+            select(WorkflowRunGatewayToken).where(
+                WorkflowRunGatewayToken.token_hash == token_hash,
+                WorkflowRunGatewayToken.status == WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+                WorkflowRunGatewayToken.expires_at > now,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    row.last_used_at = now
+    await db.flush()
+    return _run_gateway_token_record(row)
+
+
+async def refreeze_run_gateway_token_scope(
+    db: AsyncSession, *, workflow_run_id: UUID, scope_json: dict[str, dict[str, object]]
+) -> None:
+    """L25 delivery re-freeze: set the active token's scope to the intersection."""
+
+    rows = (
+        (
+            await db.execute(
+                select(WorkflowRunGatewayToken).where(
+                    WorkflowRunGatewayToken.workflow_run_id == workflow_run_id,
+                    WorkflowRunGatewayToken.status
+                    == WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = utcnow()
+    for row in rows:
+        row.scope_json = scope_json
+        row.updated_at = now
+    if rows:
+        await db.flush()
+
+
+async def expire_run_gateway_tokens_for_run(db: AsyncSession, *, workflow_run_id: UUID) -> int:
+    """Flip a run's active gateway token(s) to expired. Idempotent: an already
+    terminal run has no active token, so the update touches nothing."""
+
+    rows = (
+        (
+            await db.execute(
+                select(WorkflowRunGatewayToken).where(
+                    WorkflowRunGatewayToken.workflow_run_id == workflow_run_id,
+                    WorkflowRunGatewayToken.status
+                    == WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = utcnow()
+    for row in rows:
+        row.status = WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_EXPIRED
+        row.updated_at = now
+    if rows:
+        await db.flush()
+    return len(rows)
 
 
 async def list_in_flight_triggered_cloud_runs(

--- a/server/proliferate/db/store/integrations/accounts.py
+++ b/server/proliferate/db/store/integrations/accounts.py
@@ -110,19 +110,44 @@ async def list_accounts_for_user(
 async def list_ready_accounts_for_user(
     db: AsyncSession,
     user_id: UUID,
+    *,
+    organization_id: UUID | None = None,
 ) -> tuple[IntegrationAccountRecord, ...]:
-    accounts = (
-        (
-            await db.execute(
-                select(CloudIntegrationAccount)
-                .where(
-                    CloudIntegrationAccount.owner_user_id == user_id,
-                    CloudIntegrationAccount.enabled.is_(True),
-                    CloudIntegrationAccount.status == "ready",
-                )
-                .order_by(CloudIntegrationAccount.created_at.asc())
-            )
+    """The user's enabled, ready accounts (non-archived definitions).
+
+    When ``organization_id`` is given the org's integration policy is enforced —
+    an account is excluded when the org has disabled that definition (a policy row
+    with ``enabled = false``, or no policy row and the definition is not
+    ``enabled_by_default``). This mirrors ``get_ready_account_for_provider`` so a
+    personally-connected account cannot bypass an org's disable decision. Callers
+    with a real org context (e.g. the integration gateway) MUST pass it.
+    """
+    stmt = (
+        select(CloudIntegrationAccount)
+        .join(
+            CloudIntegrationDefinition,
+            CloudIntegrationDefinition.id == CloudIntegrationAccount.definition_id,
         )
+        .where(
+            CloudIntegrationAccount.owner_user_id == user_id,
+            CloudIntegrationAccount.enabled.is_(True),
+            CloudIntegrationAccount.status == "ready",
+            CloudIntegrationDefinition.archived_at.is_(None),
+        )
+    )
+    if organization_id is not None:
+        stmt = stmt.outerjoin(
+            CloudIntegrationPolicy,
+            (CloudIntegrationPolicy.definition_id == CloudIntegrationDefinition.id)
+            & (CloudIntegrationPolicy.organization_id == organization_id),
+        ).where(
+            func.coalesce(
+                CloudIntegrationPolicy.enabled,
+                CloudIntegrationDefinition.enabled_by_default,
+            ).is_(True)
+        )
+    accounts = (
+        (await db.execute(stmt.order_by(CloudIntegrationAccount.created_at.asc())))
         .scalars()
         .all()
     )

--- a/server/proliferate/db/store/runtime_workers.py
+++ b/server/proliferate/db/store/runtime_workers.py
@@ -22,12 +22,14 @@ from proliferate.constants.cloud import (
     CLOUD_RUNTIME_WORKER_ENROLLMENT_TOKEN_DOMAIN,
     CLOUD_RUNTIME_WORKER_OFFLINE_THRESHOLD_SECONDS,
     CLOUD_RUNTIME_WORKER_TOKEN_DOMAIN,
+    CLOUD_WORKFLOW_RUN_GATEWAY_TOKEN_DOMAIN,
 )
 from proliferate.db.models.cloud.runtime_workers import (
     CloudIntegrationGatewayToken,
     CloudRuntimeWorker,
     CloudRuntimeWorkerEnrollment,
 )
+from proliferate.db.models.cloud.sandboxes import CloudSandbox
 from proliferate.utils.time import utcnow
 
 
@@ -54,6 +56,15 @@ def hash_worker_token(token: str) -> str:
 def hash_gateway_token(token: str) -> str:
     return hash_runtime_token(
         domain=CLOUD_INTEGRATION_GATEWAY_TOKEN_DOMAIN,
+        token=token,
+    )
+
+
+def hash_workflow_run_gateway_token(token: str) -> str:
+    """Hash a per-run workflow gateway token — worker-token hashing exactly, under
+    its own HMAC domain so a run token can never resolve a per-worker row."""
+    return hash_runtime_token(
+        domain=CLOUD_WORKFLOW_RUN_GATEWAY_TOKEN_DOMAIN,
         token=token,
     )
 
@@ -93,10 +104,21 @@ class RuntimeWorkerValue:
 
 @dataclass(frozen=True)
 class IntegrationGatewayGrant:
-    runtime_worker_id: UUID
-    runtime_kind: str
     owner_user_id: UUID
     organization_id: UUID | None
+    # Per-worker grant fields (None on a per-run grant).
+    runtime_worker_id: UUID | None = None
+    runtime_kind: str | None = None
+    # L25 layer 1: the resolved worker-level provider allowlist for this request.
+    # None = unscoped (today's behavior / no worker known). Re-resolved per request.
+    worker_scope: list[str] | None = None
+    # Per-run grant fields (PR E / OPEN-3a). Present only when the bearer resolved a
+    # ``cloud_workflow_run_gateway_token`` row; the credential itself proves the run.
+    run_id: UUID | None = None
+    workflow_id: UUID | None = None
+    # L25 layer 2: the run's frozen function grant (``[{provider, tools}]``). None on
+    # a per-worker grant (no per-run function restriction).
+    run_scope: list[dict[str, object]] | None = None
 
 
 def _enrollment_value(row: CloudRuntimeWorkerEnrollment) -> RuntimeWorkerEnrollmentValue:
@@ -341,4 +363,42 @@ async def get_grant_by_gateway_token_hash(
         runtime_kind=worker.runtime_kind,
         owner_user_id=worker.owner_user_id,
         organization_id=worker.organization_id,
+        # Layer-1 allowlist for this worker (NULL = unscoped, today's behavior).
+        worker_scope=list(token.scope_json) if token.scope_json is not None else None,
     )
+
+
+async def get_active_worker_gateway_scope_for_owner(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+) -> list[str] | None:
+    """The layer-1 provider allowlist of the owner's active cloud-sandbox worker.
+
+    Used both at workflow delivery (L25 intersection) and per gateway request for a
+    run token (L25 asymmetric re-check): the delivering worker is the owner's
+    active worker on their personal cloud sandbox. Returns the worker token's
+    ``scope_json`` (a provider-namespace list) or ``None`` when the worker is
+    unscoped OR no worker exists yet — both mean "unscoped passthrough", never an
+    empty allowlist.
+    """
+
+    scope = (
+        await db.execute(
+            select(CloudIntegrationGatewayToken.scope_json)
+            .join(
+                CloudRuntimeWorker,
+                CloudRuntimeWorker.id == CloudIntegrationGatewayToken.runtime_worker_id,
+            )
+            .join(CloudSandbox, CloudSandbox.id == CloudRuntimeWorker.cloud_sandbox_id)
+            .where(
+                CloudSandbox.owner_user_id == owner_user_id,
+                CloudSandbox.destroyed_at.is_(None),
+                CloudRuntimeWorker.status != "revoked",
+                CloudIntegrationGatewayToken.status == "active",
+            )
+            .order_by(CloudIntegrationGatewayToken.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return list(scope) if scope is not None else None

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.constants.cloud import CLOUD_SANDBOX_PURPOSE_INTERACTIVE
 from proliferate.db.store import billing_subjects
 from proliferate.db.store import cloud_sandboxes as sandbox_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
@@ -35,14 +36,17 @@ async def get_cloud_sandbox_detail(
 async def ensure_cloud_sandbox_ready(
     db: AsyncSession,
     user: _UserWithId,
+    *,
+    purpose: str = CLOUD_SANDBOX_PURPOSE_INTERACTIVE,
 ) -> CloudSandboxValue:
-    return await ensure_personal_cloud_sandbox_exists(db, user_id=user.id)
+    return await ensure_personal_cloud_sandbox_exists(db, user_id=user.id, purpose=purpose)
 
 
 async def ensure_personal_cloud_sandbox_exists(
     db: AsyncSession,
     *,
     user_id: UUID,
+    purpose: str = CLOUD_SANDBOX_PURPOSE_INTERACTIVE,
 ) -> CloudSandboxValue:
     await sandbox_store.acquire_cloud_sandbox_owner_lock(
         db,
@@ -51,12 +55,15 @@ async def ensure_personal_cloud_sandbox_exists(
         organization_id=None,
     )
     billing_subject = await billing_subjects.ensure_personal_billing_subject(db, user_id)
+    # ``purpose`` is honored only when this call is the one that CREATES the sandbox
+    # (L26: stamped once, never inferred). An existing sandbox is returned as-is.
     sandbox = await sandbox_store.ensure_personal_cloud_sandbox(
         db,
         user_id=user_id,
         created_by_user_id=user_id,
         billing_subject_id=billing_subject.id,
         e2b_template_ref="e2b",
+        purpose=purpose,
     )
     return sandbox
 

--- a/server/proliferate/server/cloud/gateway/service.py
+++ b/server/proliferate/server/cloud/gateway/service.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.constants.cloud import CLOUD_SANDBOX_PURPOSE_INTERACTIVE
 from proliferate.server.cloud.cloud_sandboxes.service import (
     ensure_cloud_sandbox_ready,
     load_cloud_sandbox_runtime_access,
@@ -75,6 +76,8 @@ def _reset_cloud_sandbox_gateway_access_cache_for_tests() -> None:
 async def ensure_cloud_sandbox_gateway_access(
     db: AsyncSession,
     user: _UserWithId,
+    *,
+    purpose: str = CLOUD_SANDBOX_PURPOSE_INTERACTIVE,
 ) -> CloudSandboxGatewayAccess:
     cached = _cached_gateway_access(user.id)
     if cached is not None:
@@ -85,15 +88,17 @@ async def ensure_cloud_sandbox_gateway_access(
         if cached is not None:
             return cached
 
-        access = await _resolve_cloud_sandbox_gateway_access(db, user)
+        access = await _resolve_cloud_sandbox_gateway_access(db, user, purpose=purpose)
         return _remember_gateway_access(user.id, access)
 
 
 async def _resolve_cloud_sandbox_gateway_access(
     db: AsyncSession,
     user: _UserWithId,
+    *,
+    purpose: str = CLOUD_SANDBOX_PURPOSE_INTERACTIVE,
 ) -> CloudSandboxGatewayAccess:
-    sandbox = await ensure_cloud_sandbox_ready(db, user)
+    sandbox = await ensure_cloud_sandbox_ready(db, user, purpose=purpose)
     upstream_base_url, upstream_token, _data_key = await load_cloud_sandbox_runtime_access(sandbox)
     return CloudSandboxGatewayAccess(
         upstream_base_url=upstream_base_url,

--- a/server/proliferate/server/cloud/integration_gateway/dependencies.py
+++ b/server/proliferate/server/cloud/integration_gateway/dependencies.py
@@ -1,4 +1,17 @@
-"""Auth for the integration gateway: AnyHarness bearer token -> owner grant."""
+"""Auth for the integration gateway: bearer token -> owner grant.
+
+A bearer resolves to one of two grants, tried in order (§6.4/6.7):
+
+1. A **per-run** workflow gateway token (PR E). The token IS the run: the grant
+   carries ``run_id``/``workflow_id`` and the run's frozen function scope
+   (``run_scope``, layer 2). It is tried FIRST — its own HMAC domain means a run
+   token can never collide with a worker token.
+2. The **per-worker** AnyHarness gateway token (unchanged). ``run_scope`` is None
+   (no per-run function restriction).
+
+Both grants carry ``worker_scope`` (L25 layer 1), re-resolved on every request so a
+worker allowlist narrowed *after* a run token was minted bites on the next call.
+"""
 
 from __future__ import annotations
 
@@ -6,9 +19,11 @@ from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.engine import get_async_session
+from proliferate.db.store import cloud_workflows as workflows_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.runtime_workers import IntegrationGatewayGrant
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.utils.time import utcnow
 
 
 def _bearer_token_from_request(request: Request) -> str:
@@ -23,17 +38,71 @@ def _bearer_token_from_request(request: Request) -> str:
     return token.strip()
 
 
+async def _resolve_run_token_grant(
+    db: AsyncSession, *, token: str
+) -> IntegrationGatewayGrant | None:
+    """Resolve a per-run workflow gateway token, or None if the bearer isn't one."""
+
+    run_token = await workflows_store.get_active_run_gateway_token_by_hash(
+        db,
+        token_hash=runtime_workers_store.hash_workflow_run_gateway_token(token),
+        now=utcnow(),
+    )
+    if run_token is None:
+        return None
+    # L25 layer 1, re-checked per request: the delivering worker is the owner's
+    # active cloud-sandbox worker; a scope narrowed after mint bites here.
+    worker_scope = await runtime_workers_store.get_active_worker_gateway_scope_for_owner(
+        db, owner_user_id=run_token.owner_user_id
+    )
+    return IntegrationGatewayGrant(
+        owner_user_id=run_token.owner_user_id,
+        organization_id=run_token.organization_id,
+        run_id=run_token.workflow_run_id,
+        run_scope=_flatten_run_scope(run_token.scope_json),
+        worker_scope=worker_scope,
+    )
+
+
+def _flatten_run_scope(scope_json: object) -> list[dict[str, object]]:
+    """E3: the per-slot namespace grant (``{"<slot>": {"integrations": [...]}}``)
+    flattened into the namespace-level run scope the pure enforcement layer
+    consumes — one namespace-only entry per granted provider (``{"provider": ns}``,
+    no ``tools`` key), deduped across slots.
+
+    The gateway token is per-run, not per-slot, and the caller does not identify
+    its slot, so enforcement is the union of every slot's grant. A namespace-only
+    entry means "ALL tools of that provider" at call time (``domain/scope.py``).
+    """
+
+    if not isinstance(scope_json, dict):
+        return []
+    namespaces: set[str] = set()
+    for slot_scope in scope_json.values():
+        if not isinstance(slot_scope, dict):
+            continue
+        for ns in slot_scope.get("integrations") or []:
+            if isinstance(ns, str):
+                namespaces.add(ns)
+    return [{"provider": ns} for ns in sorted(namespaces)]
+
+
 async def require_integration_gateway_grant(
     request: Request,
     db: AsyncSession = Depends(get_async_session),
 ) -> IntegrationGatewayGrant:
-    """Resolve the AnyHarness gateway token to its owning worker's identity.
+    """Resolve the gateway bearer to its owning identity + scope.
 
-    The token proves "I am an authorized runtime for worker W"; Cloud derives
-    the owning user/org and uses that to decide which integration accounts are
-    visible.
+    A per-run token is tried first (its scope is the run's frozen grant); otherwise
+    the per-worker token resolves (unscoped by run, subject only to the worker
+    allowlist as today).
     """
     token = _bearer_token_from_request(request)
+
+    run_grant = await _resolve_run_token_grant(db, token=token)
+    if run_grant is not None:
+        return run_grant
+
     grant = await runtime_workers_store.get_grant_by_gateway_token_hash(
         db,
         token_hash=runtime_workers_store.hash_gateway_token(token),

--- a/server/proliferate/server/cloud/integration_gateway/domain/scope.py
+++ b/server/proliferate/server/cloud/integration_gateway/domain/scope.py
@@ -1,0 +1,207 @@
+"""Pure two-layer gateway scope enforcement (spec 6.4/6.6/6.7, L25).
+
+This module is deliberately free of FastAPI, DB, and HTTP: it is a set of pure
+functions over plain data so the *same* authorization runs for a sandbox agent's
+``tools/call`` today AND for a future server-side ``function_call`` performer
+(§6.6/L18/L23) — the gateway checks scope, not caller location.
+
+Two layers, both re-checked on every request (L25 is asymmetric: mint decides what
+*may* be requested, request time re-checks the live worker allowlist):
+
+* ``run_scope`` — layer 2, the per-run token's frozen grant. E3: NAMESPACE-LEVEL.
+  Shape ``[{"provider": str}, ...]`` — a **namespace-only** entry (no ``tools``
+  key) grants EVERY tool of that provider (the definition stores namespaces, not
+  tool lists). An entry MAY still carry an explicit ``"tools": [str, ...]`` list to
+  restrict to those tools — reserved for future per-slot narrowing (Part II); the
+  core-v1 resolver never emits it. ``None`` means the caller is a per-worker token,
+  which carries no per-run restriction. A list (even an empty one) means a run
+  token: a provider must appear in it, and an empty list grants nothing — never
+  conflated with ``None``.
+* ``worker_scope`` — layer 1, the delivering worker's provider-namespace
+  allowlist. ``None`` means unscoped (today's behavior). A list is an allowlist of
+  provider namespaces (an empty list grants nothing).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Enumerated deny reasons (agent-readable, never a 500 — surfaced through the
+# gateway's existing MCP error-result envelope).
+SCOPE_DENY_PROVIDER_OUT_OF_WORKER = "provider_out_of_worker_scope"
+SCOPE_DENY_PROVIDER_OUT_OF_RUN = "provider_out_of_run_scope"
+SCOPE_DENY_TOOL_OUT_OF_RUN = "tool_out_of_run_scope"
+
+
+@dataclass(frozen=True)
+class ScopeDecision:
+    allowed: bool
+    reason: str | None = None
+    detail: str | None = None
+
+
+def _run_scope_entry(
+    run_scope: list[dict[str, object]], provider: str
+) -> dict[str, object] | None:
+    for entry in run_scope:
+        if isinstance(entry, dict) and entry.get("provider") == provider:
+            return entry
+    return None
+
+
+def _entry_grants_all_tools(entry: dict[str, object]) -> bool:
+    """E3: a namespace-only entry (no explicit ``tools`` list) grants every tool."""
+
+    return not isinstance(entry.get("tools"), list)
+
+
+def _tools_of(entry: dict[str, object]) -> set[str]:
+    tools = entry.get("tools")
+    if not isinstance(tools, list):
+        return set()
+    return {tool for tool in tools if isinstance(tool, str)}
+
+
+def worker_allows_provider(worker_scope: list[str] | None, provider: str) -> bool:
+    """Layer 1: NULL worker scope = unscoped passthrough; a list is an allowlist."""
+
+    if worker_scope is None:
+        return True
+    return provider in worker_scope
+
+
+def providers_in_run_scope(run_scope: list[dict[str, object]] | None) -> set[str] | None:
+    """The providers a run token may reach, or ``None`` for a worker-token grant."""
+
+    if run_scope is None:
+        return None
+    return {
+        str(entry["provider"])
+        for entry in run_scope
+        if isinstance(entry, dict) and isinstance(entry.get("provider"), str)
+    }
+
+
+def authorize_tool_call(
+    *,
+    run_scope: list[dict[str, object]] | None,
+    worker_scope: list[str] | None,
+    provider: str,
+    tool: str,
+) -> ScopeDecision:
+    """Allow/deny a single ``(provider, tool)`` against both layers."""
+
+    if not worker_allows_provider(worker_scope, provider):
+        return ScopeDecision(
+            allowed=False,
+            reason=SCOPE_DENY_PROVIDER_OUT_OF_WORKER,
+            detail=(
+                f"Provider '{provider}' is not in this worker's integration allowlist."
+            ),
+        )
+    if run_scope is not None:
+        entry = _run_scope_entry(run_scope, provider)
+        if entry is None:
+            return ScopeDecision(
+                allowed=False,
+                reason=SCOPE_DENY_PROVIDER_OUT_OF_RUN,
+                detail=(
+                    f"Provider '{provider}' is not granted to this run. "
+                    f"Granted providers: {sorted(providers_in_run_scope(run_scope) or set())}."
+                ),
+            )
+        # E3: a namespace-only grant reaches EVERY tool of the provider — no
+        # per-tool check. (An explicit tools list, reserved for future per-slot
+        # narrowing, still restricts.)
+        if not _entry_grants_all_tools(entry):
+            granted = _tools_of(entry)
+            if tool not in granted:
+                return ScopeDecision(
+                    allowed=False,
+                    reason=SCOPE_DENY_TOOL_OUT_OF_RUN,
+                    detail=(
+                        f"Tool '{tool}' on provider '{provider}' is not granted to this run. "
+                        f"Granted tools: {sorted(granted)}."
+                    ),
+                )
+    return ScopeDecision(allowed=True)
+
+
+def filter_tools_to_scope(
+    *,
+    run_scope: list[dict[str, object]] | None,
+    worker_scope: list[str] | None,
+    provider: str,
+    tools: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Filter an upstream ``tools/list`` result down to what the caller may call.
+
+    Each tool dict is expected to carry a ``name``; unnamed entries are dropped.
+    """
+
+    kept: list[dict[str, object]] = []
+    for tool in tools:
+        name = tool.get("name") if isinstance(tool, dict) else None
+        if not isinstance(name, str):
+            continue
+        if authorize_tool_call(
+            run_scope=run_scope, worker_scope=worker_scope, provider=provider, tool=name
+        ).allowed:
+            kept.append(tool)
+    return kept
+
+
+def provider_visible(
+    *,
+    run_scope: list[dict[str, object]] | None,
+    worker_scope: list[str] | None,
+    provider: str,
+) -> bool:
+    """Whether a provider should appear in ``list_providers`` for this caller.
+
+    A provider is visible when the worker allows it AND (for a run token) it has a
+    granted entry. Worker-token grants only apply the worker layer.
+    """
+
+    if not worker_allows_provider(worker_scope, provider):
+        return False
+    if run_scope is None:
+        return True
+    return _run_scope_entry(run_scope, provider) is not None
+
+
+def intersect_namespaces_with_worker(
+    namespaces: list[str],
+    worker_scope: list[str] | None,
+) -> list[str]:
+    """L25 delivery re-freeze at NAMESPACE granularity (E3).
+
+    ``worker_scope`` NULL = unscoped passthrough (namespaces unchanged, distinct
+    from an empty allowlist which drops every namespace). Order preserved.
+    """
+
+    if worker_scope is None:
+        return list(namespaces)
+    allowed = set(worker_scope)
+    return [ns for ns in namespaces if ns in allowed]
+
+
+def intersect_run_scope_with_worker(
+    run_scope: list[dict[str, object]],
+    worker_scope: list[str] | None,
+) -> list[dict[str, object]]:
+    """L25 delivery re-freeze: narrow a run scope to the delivering worker's allowlist.
+
+    ``worker_scope`` NULL = unscoped passthrough (run scope unchanged, distinct from
+    an empty allowlist which drops every provider). Tools are not narrowed here —
+    the worker layer is provider-level.
+    """
+
+    if worker_scope is None:
+        return list(run_scope)
+    allowed = set(worker_scope)
+    return [
+        entry
+        for entry in run_scope
+        if isinstance(entry, dict) and entry.get("provider") in allowed
+    ]

--- a/server/proliferate/server/cloud/integration_gateway/service.py
+++ b/server/proliferate/server/cloud/integration_gateway/service.py
@@ -18,7 +18,7 @@ from proliferate.db.store.runtime_workers import IntegrationGatewayGrant
 from proliferate.integrations import mcp_remote
 from proliferate.integrations.mcp_remote import McpRemoteError
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.integration_gateway.domain import json_rpc, virtual_tools
+from proliferate.server.cloud.integration_gateway.domain import json_rpc, scope, virtual_tools
 from proliferate.server.cloud.integration_gateway.domain.tool_args import (
     parse_call_tool_args,
     parse_list_tools_args,
@@ -35,8 +35,15 @@ async def ready_accounts_for_grant(
     *,
     grant: IntegrationGatewayGrant,
 ) -> list[GatewayProviderAccount]:
-    """The owner's enabled, ready accounts whose definition is not archived."""
-    accounts = await accounts_store.list_ready_accounts_for_user(db, grant.owner_user_id)
+    """The owner's enabled, ready accounts whose definition is not archived.
+
+    Org-aware (regression fix): for an org-scoped grant, definitions the org has
+    disabled by policy are excluded — the same overlay ``get_ready_account_for_provider``
+    applies, so ``list_providers`` cannot surface an org-disabled provider.
+    """
+    accounts = await accounts_store.list_ready_accounts_for_user(
+        db, grant.owner_user_id, organization_id=grant.organization_id
+    )
     definitions = await definitions_store.get_definitions_by_ids(
         db, {account.definition_id for account in accounts}
     )
@@ -55,7 +62,9 @@ async def account_for_provider(
     grant: IntegrationGatewayGrant,
     provider: str,
 ) -> GatewayProviderAccount:
-    pair = await accounts_store.get_ready_account_for_provider(db, grant.owner_user_id, provider)
+    pair = await accounts_store.get_ready_account_for_provider(
+        db, grant.owner_user_id, provider, organization_id=grant.organization_id
+    )
     if pair is None:
         raise CloudApiError(
             "integration_provider_not_found",
@@ -71,6 +80,9 @@ async def list_providers(
     *,
     grant: IntegrationGatewayGrant,
 ) -> dict[str, object]:
+    # Scope filtering (§6.3, least astonishment): a caller only *sees* the
+    # providers its grant reaches. Worker-token grants apply only the worker layer;
+    # run-token grants also hide providers outside the frozen run scope.
     providers = [
         {
             "provider": pair.definition.namespace,
@@ -79,6 +91,11 @@ async def list_providers(
             "status": pair.account.status,
         }
         for pair in await ready_accounts_for_grant(db, grant=grant)
+        if scope.provider_visible(
+            run_scope=grant.run_scope,
+            worker_scope=grant.worker_scope,
+            provider=pair.definition.namespace,
+        )
     ]
     return {"providers": providers}
 
@@ -93,7 +110,15 @@ async def list_tools_for_provider(
     tools = await get_or_refresh_tool_cache(
         db, account_record=pair.account, definition_record=pair.definition
     )
-    return {"provider": provider, "tools": tools}
+    # tools/list is filtered to the granted (provider, tools) — the agent never
+    # sees a tool it may not call (§6.3). Out-of-scope providers filter to empty.
+    filtered = scope.filter_tools_to_scope(
+        run_scope=grant.run_scope,
+        worker_scope=grant.worker_scope,
+        provider=provider,
+        tools=tools if isinstance(tools, list) else [],
+    )
+    return {"provider": provider, "tools": filtered}
 
 
 async def call_provider_tool(
@@ -104,6 +129,22 @@ async def call_provider_tool(
     tool: str,
     arguments: dict[str, object],
 ) -> dict[str, object]:
+    # Defense in depth (§6.3 / L25): tools/call re-checks scope on every request,
+    # both layers, even though tools/list already hid out-of-scope tools. A denial
+    # is an enumerated, agent-readable error (surfaced as an MCP error result by the
+    # tools/call handler), never a 500.
+    decision = scope.authorize_tool_call(
+        run_scope=grant.run_scope,
+        worker_scope=grant.worker_scope,
+        provider=provider,
+        tool=tool,
+    )
+    if not decision.allowed:
+        raise CloudApiError(
+            "integration_gateway_scope_denied",
+            decision.detail or "This tool is out of scope for the caller.",
+            status_code=403,
+        )
     pair = await account_for_provider(db, grant=grant, provider=provider)
     url, headers, query = await resolve_launch(db, pair.account, pair.definition)
     result = await mcp_remote.call_tool(

--- a/server/proliferate/server/cloud/workflows/api.py
+++ b/server/proliferate/server/cloud/workflows/api.py
@@ -7,10 +7,11 @@ a workflow lookup with id ``"runs"``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
@@ -18,8 +19,10 @@ from proliferate.constants.workflows import WORKFLOW_TARGET_MODE_PERSONAL_CLOUD
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.integrations.slack import client as slack_client
+from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.workflows.delivery import deliver_cloud_run, refresh_cloud_run
 from proliferate.server.cloud.workflows.models import (
     RunStatusRequest,
@@ -65,6 +68,7 @@ from proliferate.server.cloud.workflows.service import (
     update_workflow,
 )
 from proliferate.utils.crypto import decrypt_json
+from proliferate.utils.time import utcnow
 
 router = APIRouter(prefix="/workflows", tags=["cloud-workflows"])
 
@@ -168,6 +172,71 @@ async def refresh_run_endpoint(
 
     run = await get_run(db, user, run_id)
     return run_payload(await refresh_cloud_run(db, user, run))
+
+
+@dataclass(frozen=True)
+class _PingActor:
+    """Minimal actor for the ping-triggered refresh — the run-token proves the run,
+    so the owner id is all the cloud-sandbox gateway access needs."""
+
+    id: UUID
+
+
+@router.post("/runs/{run_id}/ping", status_code=202)
+async def run_ping_endpoint(
+    run_id: UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+) -> Response:
+    """Completion ping (L16 / §3.7). NO user-session auth — the per-run gateway
+    token IS the auth. The runtime fires this after each step transition; the
+    handler validates the token, requires token↔run_id match (so run A's token
+    can't ping run B), and wakes the existing refresh path for cloud-lane runs.
+
+    The body carries nothing: it is a stateless nudge. Duplicate/stale/late pings
+    are safe by construction — refresh is reconcile-shaped and run-status
+    transitions are monotonic — so no state is added here.
+    """
+
+    header = request.headers.get("authorization", "")
+    scheme, _, raw = header.partition(" ")
+    token = raw.strip()
+    if scheme.lower() != "bearer" or not token:
+        raise CloudApiError(
+            "workflow_ping_unauthorized",
+            "Missing or malformed run ping token.",
+            status_code=401,
+        )
+    grant = await store.get_active_run_gateway_token_by_hash(
+        db,
+        token_hash=runtime_workers_store.hash_workflow_run_gateway_token(token),
+        now=utcnow(),
+    )
+    if grant is None:
+        # Unknown, expired (terminal run), or revoked token.
+        raise CloudApiError(
+            "workflow_ping_unauthorized",
+            "Run ping token is invalid, expired, or revoked.",
+            status_code=401,
+        )
+    if grant.workflow_run_id != run_id:
+        raise CloudApiError(
+            "workflow_ping_run_mismatch",
+            "This token does not belong to the pinged run.",
+            status_code=403,
+        )
+
+    run = await store.get_run(db, run_id)
+    # Local-lane runs are observed by the desktop relay, which owns local
+    # observation; the ping is accepted (202) and no-ops the refresh here.
+    if run is not None and run.target_mode == WORKFLOW_TARGET_MODE_PERSONAL_CLOUD:
+        try:
+            await refresh_cloud_run(db, _PingActor(id=grant.owner_user_id), run)
+        except CloudApiError:
+            # A failed refresh never changes engine state — the ping is a nudge,
+            # not a transition; the scheduler phase-3 sweep remains the backstop.
+            pass
+    return Response(status_code=202)
 
 
 @router.get("/slack/channels", response_model=SlackChannelsResponse)

--- a/server/proliferate/server/cloud/workflows/delivery.py
+++ b/server/proliferate/server/cloud/workflows/delivery.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 logger = logging.getLogger(__name__)
 
 from proliferate.auth.authorization import ActorIdentity
+from proliferate.constants.cloud import CLOUD_SANDBOX_PURPOSE_WORKFLOW_RUN
 from proliferate.constants.workflows import (
     WORKFLOW_CLOUD_DELIVERY_TIMEOUT_SECONDS,
     WORKFLOW_CLOUD_REFRESH_TIMEOUT_SECONDS,
@@ -38,6 +39,7 @@ from proliferate.constants.workflows import (
     WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
 )
 from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_workflows import WorkflowRunRecord
 from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
 from proliferate.integrations.anyharness.workflow_runs import (
@@ -46,6 +48,9 @@ from proliferate.integrations.anyharness.workflow_runs import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.gateway.service import ensure_cloud_sandbox_gateway_access
+from proliferate.server.cloud.integration_gateway.domain.scope import (
+    intersect_namespaces_with_worker,
+)
 from proliferate.server.cloud.workflows.domain.run_status import is_terminal
 from proliferate.server.cloud.workflows.service import mark_run_delivered
 from proliferate.utils.time import utcnow
@@ -107,11 +112,18 @@ async def deliver_cloud_run(
         )
 
     try:
-        access = await ensure_cloud_sandbox_gateway_access(db, user)
+        # L26: waking the sandbox for a workflow run stamps 'workflow-run' iff this
+        # is the create; an existing sandbox keeps its stamped purpose.
+        access = await ensure_cloud_sandbox_gateway_access(
+            db, user, purpose=CLOUD_SANDBOX_PURPOSE_WORKFLOW_RUN
+        )
+        # L25: now the delivering worker is known, intersect the run's frozen scope
+        # (ceiling) with the worker's allowlist and re-freeze BEFORE the plan ships.
+        plan = await _apply_delivery_scope_intersection(db, run)
         await deliver_workflow_run(
             access.upstream_base_url,
             access.upstream_token,
-            plan=run.resolved_plan_json,
+            plan=plan,
             workspace_id=workspace_id,
             timeout=WORKFLOW_CLOUD_DELIVERY_TIMEOUT_SECONDS,
         )
@@ -120,6 +132,47 @@ async def deliver_cloud_run(
         return await _record_delivery_failure(db, run.id, message)
 
     return await mark_run_delivered(db, user, run.id)
+
+
+async def _apply_delivery_scope_intersection(
+    db: AsyncSession, run: WorkflowRunRecord
+) -> dict[str, object]:
+    """Narrow the run's frozen gateway scope to the delivering worker's allowlist.
+
+    L25 layer 2 ⊆ layer 1, computed at delivery because the worker is only known
+    now. NULL worker scope = unscoped passthrough (run scope unchanged, distinct
+    from an empty allowlist). Re-freezes both the token row and the plan's gateway
+    block so the shipped plan and the enforced token agree.
+    """
+
+    plan = dict(run.resolved_plan_json or {})
+    gateway = plan.get("gateway")
+    if not isinstance(gateway, dict):
+        return plan
+    # E3: the plan's gateway carries the flat NAMESPACE grant; the token's
+    # scope_json is per-slot. Narrow both at namespace granularity.
+    run_namespaces = gateway.get("integrations")
+    if not isinstance(run_namespaces, list):
+        return plan
+    worker_scope = await runtime_workers_store.get_active_worker_gateway_scope_for_owner(
+        db, owner_user_id=run.executor_user_id
+    )
+    intersected = intersect_namespaces_with_worker(run_namespaces, worker_scope)
+    if intersected == run_namespaces:
+        return plan
+    # Re-freeze the per-slot token scope to the intersected namespace set (v1
+    # stamps every slot with the same list; rebuild from the plan's session slots).
+    sessions = plan.get("sessions")
+    slots = list(sessions) if isinstance(sessions, dict) else []
+    new_scope_json = {slot: {"integrations": list(intersected)} for slot in slots}
+    await store.refreeze_run_gateway_token_scope(
+        db, workflow_run_id=run.id, scope_json=new_scope_json
+    )
+    gateway = dict(gateway)
+    gateway["integrations"] = intersected
+    plan["gateway"] = gateway
+    updated = await store.update_run(db, run_id=run.id, resolved_plan_json=plan)
+    return updated.resolved_plan_json if updated is not None else plan
 
 
 # --- Refresh (observed-state reconciliation) -----------------------------------
@@ -211,6 +264,12 @@ async def _sync_run_from_view(
         finished_at=finished_at,
     )
     assert updated is not None
+
+    # Terminal via the reconcile path (a ping- or scheduler-driven refresh that
+    # observes completion) expires the per-run gateway token too — idempotent, so
+    # a later report or refresh that also sees terminal is a no-op.
+    if is_terminal(updated.status):
+        await store.expire_run_gateway_tokens_for_run(db, workflow_run_id=run_id)
 
     try:
         from proliferate.server.cloud.workflows.actions import apply_step_actions

--- a/server/proliferate/server/cloud/workflows/gateway_grants.py
+++ b/server/proliferate/server/cloud/workflows/gateway_grants.py
@@ -1,0 +1,192 @@
+"""Per-run gateway token minting + scope resolution (PR E / OPEN-3a, L16/L22/L25).
+
+Every run mints exactly one per-run gateway token at StartRun — even a run with an
+empty function grant (L16: the token doubles as the completion-ping credential).
+The plaintext rides inside ``resolved_plan_json.gateway``; only the hash is stored.
+
+Scope resolution is layered (E3: NAMESPACE-LEVEL — no tool lists anywhere):
+
+* mint (StartRun): scope = the definition's ``integrations[]`` namespaces, stamped
+  per slot into ``scope_json`` (``{"<slot>": {"integrations": [...]}}`` — §2.6). No
+  ``tools/list`` fetch, no new failure mode. L22 fail-fast — a declared namespace
+  with no ready account (org-aware, the same lookup the gateway uses) FAILS the run
+  rather than silently narrowing. The gateway treats a namespace grant as "ALL
+  tools of that provider" at call time (``domain/scope.py``).
+* delivery (cloud lane, worker known): the frozen run scope is intersected with the
+  delivering worker's allowlist (L25 layer 2 ⊆ layer 1) at NAMESPACE granularity.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import timedelta
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import CLOUD_WORKFLOW_RUN_PING_PATH_TEMPLATE
+from proliferate.constants.workflows import WORKFLOW_RUN_GATEWAY_TOKEN_TTL_SECONDS
+from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store import organizations as organizations_store
+from proliferate.db.store import runtime_workers as runtime_workers_store
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.runtime_workers.service import (
+    integration_gateway_config,
+    worker_cloud_base_url,
+)
+from proliferate.utils.time import utcnow
+
+_TOKEN_BYTES = 48
+
+
+def resolve_run_scope(definition: dict[str, object]) -> dict[str, dict[str, object]]:
+    """The run's frozen namespace grant, stamped per slot (E3, §2.6).
+
+    Shape: ``{"<slot>": {"integrations": ["linear", "slack"]}}``. The definition's
+    workflow-level ``integrations`` list applies to every slot in v1 (per-slot
+    narrowing is a later editor+resolver feature that changes NO schema — the plan
+    is already per-slot). No ``tools/list`` fetch, no per-provider tool arrays.
+
+    Composition (L20) inlines a child's *steps*, not its grant: the run's scope is
+    the top-level definition's own ``integrations[]`` (L24 — each definition sizes
+    its own grant). A composed workflow must declare the union it needs.
+    """
+
+    namespaces: list[str] = []
+    seen: set[str] = set()
+    for item in definition.get("integrations") or []:
+        if isinstance(item, str) and item not in seen:
+            seen.add(item)
+            namespaces.append(item)
+
+    slots: list[str] = []
+    for node in definition.get("agents") or []:
+        if isinstance(node, dict) and isinstance(node.get("slot"), str):
+            slots.append(str(node["slot"]))
+    # A grant with no slots (e.g. a zero-agent draft) is a no-op scope.
+    return {slot: {"integrations": list(namespaces)} for slot in slots}
+
+
+def granted_namespaces(scope: dict[str, dict[str, object]]) -> list[str]:
+    """The flat, sorted union of integration namespaces a run's scope grants.
+
+    Used for the L22 ready-account check, the plan's gateway ``integrations``
+    block, and the save-time visibility check. Since v1 stamps every slot with the
+    same workflow-level list, this is just that list; the union keeps it correct if
+    per-slot narrowing lands later.
+    """
+
+    out: set[str] = set()
+    for slot_scope in scope.values():
+        if not isinstance(slot_scope, dict):
+            continue
+        for ns in slot_scope.get("integrations") or []:
+            if isinstance(ns, str):
+                out.add(ns)
+    return sorted(out)
+
+
+async def _organization_id_for_owner(db: AsyncSession, *, owner_user_id: UUID) -> UUID | None:
+    membership = await organizations_store.get_current_membership_for_user(db, owner_user_id)
+    return membership.organization.id if membership is not None else None
+
+
+async def visible_provider_namespaces(db: AsyncSession, *, owner_user_id: UUID) -> set[str]:
+    """The integration-definition namespaces visible to a workflow owner (save-time).
+
+    Seed definitions plus (if the owner is in an org) that org's customs — the same
+    visibility the integrations UI shows.
+    """
+
+    org_id = await _organization_id_for_owner(db, owner_user_id=owner_user_id)
+    if org_id is not None:
+        definitions = await definitions_store.list_definitions_visible_to_org(db, org_id)
+    else:
+        definitions = await definitions_store.list_seed_definitions(db)
+    return {definition.namespace for definition in definitions}
+
+
+async def assert_declared_providers_ready(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    namespaces: list[str],
+) -> None:
+    """L22 fail-fast at StartRun: every declared namespace must have a ready account.
+
+    Org-aware — uses the same account+policy lookup the gateway uses, so a provider
+    the owner's org has disabled counts as not-ready. Raises ``CloudApiError`` (the
+    run is never created), never silently narrows the grant.
+    """
+
+    if not namespaces:
+        return
+    organization_id = await _organization_id_for_owner(db, owner_user_id=owner_user_id)
+    for provider in namespaces:
+        account_pair = await accounts_store.get_ready_account_for_provider(
+            db, owner_user_id, provider, organization_id=organization_id
+        )
+        if account_pair is None:
+            raise CloudApiError(
+                "workflow_function_provider_not_ready",
+                f"This workflow grants the '{provider}' integration, but you have no "
+                f"ready '{provider}' integration. Connect it before running.",
+                status_code=409,
+            )
+
+
+async def mint_run_gateway_token(
+    db: AsyncSession,
+    *,
+    run_id: UUID,
+    owner_user_id: UUID,
+    scope: dict[str, dict[str, object]],
+) -> tuple[str, dict[str, object]]:
+    """Mint the run's gateway token and build the ``resolved_plan_json.gateway`` block.
+
+    Returns ``(plaintext_token, gateway_block)``. The run row must already exist
+    (the token FKs ``workflow_run.id``). Identical shape on every lane (L16).
+    """
+
+    organization_id = await _organization_id_for_owner(db, owner_user_id=owner_user_id)
+    token = secrets.token_urlsafe(_TOKEN_BYTES)
+    await store.create_run_gateway_token(
+        db,
+        workflow_run_id=run_id,
+        owner_user_id=owner_user_id,
+        organization_id=organization_id,
+        token_hash=runtime_workers_store.hash_workflow_run_gateway_token(token),
+        scope_json=scope,
+        expires_at=utcnow() + timedelta(seconds=WORKFLOW_RUN_GATEWAY_TOKEN_TTL_SECONDS),
+    )
+    return token, build_gateway_plan_block(token=token, run_id=run_id, scope=scope)
+
+
+def _ping_url(run_id: UUID) -> str:
+    base = worker_cloud_base_url()
+    if not base:
+        raise CloudApiError(
+            "cloud_worker_misconfigured",
+            "No cloud base URL is configured for the workflow completion ping.",
+            status_code=500,
+        )
+    return f"{base}{CLOUD_WORKFLOW_RUN_PING_PATH_TEMPLATE.format(run_id=run_id)}"
+
+
+def build_gateway_plan_block(
+    *, token: str, run_id: UUID, scope: dict[str, dict[str, object]]
+) -> dict[str, object]:
+    """The plan's gateway block: url (same as enroll composes), authorization,
+    ping_url, and the resolved namespace grant (E3: a flat list of integration
+    namespaces, possibly empty — the runtime only reads its emptiness for the L22
+    local-lane fail-fast; it never inspects tools)."""
+
+    config = integration_gateway_config(token)
+    return {
+        "url": config.url,
+        "authorization": config.authorization,
+        "ping_url": _ping_url(run_id),
+        "integrations": granted_namespaces(scope),
+    }

--- a/server/proliferate/server/cloud/workflows/service.py
+++ b/server/proliferate/server/cloud/workflows/service.py
@@ -83,6 +83,13 @@ from proliferate.server.cloud.workflows.domain.run_status import (
     check_transition,
     is_terminal,
 )
+from proliferate.server.cloud.workflows.gateway_grants import (
+    assert_declared_providers_ready,
+    granted_namespaces,
+    mint_run_gateway_token,
+    resolve_run_scope,
+    visible_provider_namespaces,
+)
 from proliferate.server.cloud.workflows.models import (
     RunStatusRequest,
     TriggerPollRequest,
@@ -150,6 +157,31 @@ async def _validate_workflow_includes(
         )
     except WorkflowCompositionError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
+
+
+async def _validate_workflow_functions(
+    db: AsyncSession, *, owner_user_id: UUID, definition: dict[str, object]
+) -> None:
+    """Save-time L22 check: every declared ``functions`` provider must be a
+    definition visible to the owner (seed + the owner's org customs).
+
+    Structural validation (non-empty strings, no dup providers) already happened in
+    ``parse_definition``; this needs owner context + the DB, so it runs here. It
+    does NOT require a *ready account* — that is a StartRun-time (fail-the-run)
+    concern, since accounts connect/disconnect independently of the definition.
+    """
+
+    namespaces = granted_namespaces(resolve_run_scope(definition))
+    if not namespaces:
+        return
+    visible = await visible_provider_namespaces(db, owner_user_id=owner_user_id)
+    unknown = sorted(set(namespaces) - visible)
+    if unknown:
+        raise CloudApiError(
+            "workflow_function_provider_unknown",
+            f"integrations reference provider(s) you cannot use: {unknown}.",
+            status_code=400,
+        )
 
 
 async def visible_workflow(
@@ -224,6 +256,7 @@ async def create_workflow(
     await _validate_workflow_includes(
         db, owner_user_id=user.id, workflow_id=None, definition=definition
     )
+    await _validate_workflow_functions(db, owner_user_id=user.id, definition=definition)
     active_count = await store.count_active_workflows(db, owner_user_id=user.id)
     if not workflow_create_allowed(active_count, max_allowed=free_plan_workflow_limit()):
         raise CloudApiError(
@@ -257,6 +290,7 @@ async def update_workflow(
     await _validate_workflow_includes(
         db, owner_user_id=user.id, workflow_id=workflow_id, definition=definition
     )
+    await _validate_workflow_functions(db, owner_user_id=user.id, definition=definition)
     name = _clean_name(body.name) if body.name is not None else None
     update_description = "description" in body.model_fields_set
     result = await store.append_version(
@@ -501,6 +535,17 @@ async def start_run(
     except WorkflowCompositionError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
 
+    # Per-run gateway scope (PR E, E3 namespace-level): the definition's declared
+    # integration namespaces, stamped per slot. L22 fail-fast BEFORE the run row
+    # exists — a declared namespace with no ready account fails the run cleanly
+    # rather than silently narrowing the grant. No tools/list fetch at mint.
+    run_scope = resolve_run_scope(version.definition_json)
+    await assert_declared_providers_ready(
+        db,
+        owner_user_id=workflow.owner_user_id,
+        namespaces=granted_namespaces(run_scope),
+    )
+
     run_id = uuid4()
     resolved_plan = _resolve_plan(
         run_id=run_id,
@@ -512,7 +557,7 @@ async def start_run(
         session_bindings=session_bindings or {},
         agents=resolved_agents,
     )
-    return await store.create_run(
+    run = await store.create_run(
         db,
         run_id=run_id,
         workflow_id=workflow_id,
@@ -526,6 +571,19 @@ async def start_run(
         trigger_id=trigger_id,
         scheduled_for=scheduled_for,
     )
+
+    # Mint the per-run gateway token for EVERY run (L16), both lanes, empty scope
+    # legal. The plaintext lands in the plan's gateway block; the L25 subset
+    # intersection with the delivering worker happens later, at cloud delivery,
+    # when the worker is known (local lane ships the definition scope unchanged —
+    # the runtime errors explicitly if it can't honor it, §5.3). The token FKs the
+    # run row, so it is minted after create_run, then folded into the plan.
+    _token, gateway_block = await mint_run_gateway_token(
+        db, run_id=run_id, owner_user_id=workflow.owner_user_id, scope=run_scope
+    )
+    resolved_plan["gateway"] = gateway_block
+    updated = await store.update_run(db, run_id=run_id, resolved_plan_json=resolved_plan)
+    return updated if updated is not None else run
 
 
 # --- delivery + observed status ------------------------------------------------
@@ -604,6 +662,12 @@ async def report_run_status(
         finished_at=finished_at,
     )
     assert updated is not None
+
+    # Terminal status is the choke point that expires the per-run gateway token
+    # (idempotent — an already-terminal run has no active token). Do this before
+    # apply_step_actions so a crash mid-actions still leaves the token expired.
+    if is_terminal(updated.status):
+        await store.expire_run_gateway_tokens_for_run(db, workflow_run_id=run_id)
 
     try:
         from proliferate.server.cloud.workflows.actions import apply_step_actions

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -24,6 +24,19 @@ async def _cancel_test_background_tasks() -> None:
 
 
 @pytest.fixture(autouse=True)
+def _cloud_worker_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure a cloud base URL for the suite.
+
+    Every workflow StartRun now mints a per-run gateway token and composes its
+    gateway + ping URLs from this base (PR E / L16), exactly as worker enrollment
+    already does. Real deployments always set it; tests default it to a stable
+    value so StartRun-exercising suites don't need to. Tests that assert on a
+    specific base monkeypatch it themselves within the test.
+    """
+    monkeypatch.setattr(settings, "cloud_worker_base_url", "http://cloud.test")
+
+
+@pytest.fixture(autouse=True)
 def _hosted_membership_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin the membership policy to hosted (personal org per user) by default.
 

--- a/server/tests/unit/test_workflow_run_gateway.py
+++ b/server/tests/unit/test_workflow_run_gateway.py
@@ -1,0 +1,807 @@
+"""Per-run gateway tokens, completion ping, and namespace-level scope (PR E / E3).
+
+Tier-1: a real DB (the mint/expiry/scope guarantees live in it) via ``db_session``
+and the ASGI ``client``; the upstream MCP + sandbox wake are faked across the
+network boundary. Rulings exercised: L16 (mint every run + ping credential), L22
+(fail-fast on a declared namespace with no ready account), L25 (frozen run scope ⊆
+delivering worker allowlist, re-checked per request, NAMESPACE granularity), L26
+(sandbox purpose), §3.7 (ping auth + refresh), §6.4/6.7 (gateway scope enforcement),
+E3 (namespace-only grant = ALL tools of the provider; no tool lists).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.workflows import (
+    WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE,
+    WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_EXPIRED,
+    WORKFLOW_TARGET_MODE_LOCAL,
+    WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.integrations import (
+    CloudIntegrationDefinition,
+    CloudIntegrationPolicy,
+)
+from proliferate.db.models.cloud.runtime_workers import (
+    CloudIntegrationGatewayToken,
+    CloudRuntimeWorker,
+)
+from proliferate.db.models.cloud.sandboxes import CloudSandbox
+from proliferate.db.models.cloud.workflows import WorkflowRun, WorkflowRunGatewayToken
+from proliferate.db.store import cloud_workflows as store
+from proliferate.db.store import runtime_workers as runtime_workers_store
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integration_gateway import dependencies as gateway_deps
+from proliferate.server.cloud.integration_gateway import service as gateway_service
+from proliferate.server.cloud.integration_gateway.domain import scope
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
+from proliferate.server.cloud.workflows import delivery, service
+from proliferate.server.cloud.workflows.domain.definition import parse_definition
+from proliferate.utils.crypto import encrypt_json
+from proliferate.utils.time import utcnow
+
+pytestmark = pytest.mark.asyncio
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "contracts" / "run-ping"
+_ACTIVE = WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_ACTIVE
+_EXPIRED = WORKFLOW_RUN_GATEWAY_TOKEN_STATUS_EXPIRED
+
+
+def _definition(
+    *, integrations: list[str] | None = None, steps: list[dict] | None = None
+) -> dict:
+    """A minimal v2 definition: one agent node in slot ``main`` (E3 namespaces)."""
+    return {
+        "version": 1,
+        "inputs": [],
+        "integrations": integrations or [],
+        "agents": [
+            {
+                "slot": "main",
+                "harness": "claude",
+                "model": "sonnet",
+                "steps": steps or [{"kind": "agent.prompt", "prompt": "hi"}],
+            }
+        ],
+    }
+
+
+def _scope_json(namespaces: list[str]) -> dict:
+    """The per-slot scope_json a single-slot (``main``) run stamps (§2.6, E3)."""
+    return {"main": {"integrations": list(namespaces)}}
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"gw-{uuid.uuid4().hex}@example.com",
+        hashed_password="unused",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _seed_ready_account(db: AsyncSession, *, user_id: uuid.UUID, namespace: str) -> None:
+    await sync_seed_definitions(db)
+    await db.flush()
+    definition = await definitions_store.get_seed_by_namespace(db, namespace)
+    assert definition is not None
+    account = await accounts_store.upsert_account(
+        db, user_id=user_id, definition_id=definition.id, auth_kind="api_key", status="ready"
+    )
+    await accounts_store.set_account_credentials(
+        db,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json({"secretFields": {"api_key": "s"}}),
+        credential_format="secret-fields-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+
+
+async def _store_workflow(db: AsyncSession, owner: User, definition: dict, *, name: str):
+    canonical, _specs = parse_definition(definition, require_steps=False)
+    workflow, _version = await store.create_workflow_with_version(
+        db,
+        owner_user_id=owner.id,
+        created_by_user_id=owner.id,
+        name=name,
+        description=None,
+        definition_json=canonical,
+    )
+    return workflow
+
+
+# --- mint at StartRun (L16, L22) -----------------------------------------------
+
+
+async def test_mint_for_every_run_empty_integrations_empty_scope(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    wf = await _store_workflow(db_session, user, _definition(), name="no-integrations")
+    run = await service.start_run(
+        db_session, user, wf.id, inputs={}, target_mode=WORKFLOW_TARGET_MODE_LOCAL
+    )
+    gateway = run.resolved_plan_json["gateway"]
+    assert gateway["integrations"] == []
+    assert gateway["url"].endswith("/v1/cloud/integration-gateway/mcp")
+    assert gateway["authorization"].startswith("Bearer ")
+    assert gateway["ping_url"].endswith(f"/v1/cloud/workflows/runs/{run.id}/ping")
+    tokens = (
+        await db_session.execute(
+            store.select(WorkflowRunGatewayToken).where(
+                WorkflowRunGatewayToken.workflow_run_id == run.id
+            )
+        )
+    ).scalars().all()
+    assert len(tokens) == 1
+    # An empty grant is still stamped per slot (§2.6).
+    assert tokens[0].scope_json == _scope_json([])
+    assert tokens[0].status == _ACTIVE
+
+
+async def test_mint_resolves_declared_scope(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    await _seed_ready_account(db_session, user_id=user.id, namespace="context7")
+    wf = await _store_workflow(
+        db_session, user, _definition(integrations=["context7"]), name="scoped"
+    )
+    run = await service.start_run(
+        db_session, user, wf.id, inputs={}, target_mode=WORKFLOW_TARGET_MODE_LOCAL
+    )
+    # The plan's gateway carries the flat namespace list (E3).
+    assert run.resolved_plan_json["gateway"]["integrations"] == ["context7"]
+    token = (
+        await db_session.execute(
+            store.select(WorkflowRunGatewayToken).where(
+                WorkflowRunGatewayToken.workflow_run_id == run.id
+            )
+        )
+    ).scalar_one()
+    # The token's scope_json is per-slot (§2.6) — no tool lists.
+    assert token.scope_json == _scope_json(["context7"])
+
+
+async def test_l22_fail_fast_provider_without_ready_account(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    await sync_seed_definitions(db_session)
+    await db_session.flush()
+    # 'context7' is a visible seed but the owner connected NO account for it.
+    wf = await _store_workflow(
+        db_session, user, _definition(integrations=["context7"]), name="fail-fast"
+    )
+    with pytest.raises(CloudApiError) as excinfo:
+        await service.start_run(
+            db_session, user, wf.id, inputs={}, target_mode=WORKFLOW_TARGET_MODE_LOCAL
+        )
+    assert excinfo.value.code == "workflow_function_provider_not_ready"
+    # No dangling run and no token — failure is before the run row is created.
+    runs = (
+        await db_session.execute(
+            store.select(WorkflowRun).where(WorkflowRun.workflow_id == wf.id)
+        )
+    ).scalars().all()
+    assert runs == []
+
+
+# --- L25 intersection at delivery (namespace granularity) ----------------------
+
+
+async def _seed_worker_with_scope(
+    db: AsyncSession, *, owner_user_id: uuid.UUID, scope_json: list[str] | None
+) -> None:
+    sandbox = CloudSandbox(
+        owner_user_id=owner_user_id, sandbox_type="e2b", status="ready", purpose="interactive"
+    )
+    db.add(sandbox)
+    await db.flush()
+    worker = CloudRuntimeWorker(
+        owner_user_id=owner_user_id,
+        runtime_kind="cloud_sandbox",
+        cloud_sandbox_id=sandbox.id,
+        token_hash=uuid.uuid4().hex,
+        status="online",
+    )
+    db.add(worker)
+    await db.flush()
+    db.add(
+        CloudIntegrationGatewayToken(
+            runtime_worker_id=worker.id,
+            owner_user_id=owner_user_id,
+            token_hash=uuid.uuid4().hex,
+            status="active",
+            scope_json=scope_json,
+        )
+    )
+    await db.flush()
+
+
+async def _seed_run_with_token(
+    db: AsyncSession,
+    *,
+    owner: User,
+    integrations: list[str],
+    target_mode: str = WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
+    status: str = "delivered",
+) -> tuple[uuid.UUID, str]:
+    wf = await _store_workflow(
+        db, owner, _definition(integrations=integrations), name=f"r-{uuid.uuid4().hex[:6]}"
+    )
+    version = await store.get_version(db, wf.current_version_id)
+    plan = {
+        "steps": [],
+        "sessions": {"main": {"harness": "claude", "model": "sonnet"}},
+        "gateway": {"integrations": list(integrations)},
+    }
+    run = await store.create_run(
+        db,
+        workflow_id=wf.id,
+        workflow_version_id=version.id,
+        trigger_kind="manual",
+        executor_user_id=owner.id,
+        args_json={},
+        target_mode=target_mode,
+        resolved_plan_json=plan,
+    )
+    if status != "pending_delivery":
+        await store.update_run(db, run_id=run.id, status=status)
+    plaintext = f"tok-{uuid.uuid4().hex}"
+    await store.create_run_gateway_token(
+        db,
+        workflow_run_id=run.id,
+        owner_user_id=owner.id,
+        organization_id=None,
+        token_hash=runtime_workers_store.hash_workflow_run_gateway_token(plaintext),
+        scope_json=_scope_json(integrations),
+        expires_at=utcnow() + timedelta(hours=24),
+    )
+    return run.id, plaintext
+
+
+async def test_delivery_intersects_run_scope_with_narrower_worker(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    await _seed_worker_with_scope(db_session, owner_user_id=user.id, scope_json=["context7"])
+    run_id, _ = await _seed_run_with_token(
+        db_session, owner=user, integrations=["context7", "exa"]
+    )
+    run = await store.get_run(db_session, run_id)
+
+    plan = await delivery._apply_delivery_scope_intersection(db_session, run)
+
+    assert plan["gateway"]["integrations"] == ["context7"]
+    token = (
+        await db_session.execute(
+            store.select(WorkflowRunGatewayToken).where(
+                WorkflowRunGatewayToken.workflow_run_id == run_id
+            )
+        )
+    ).scalar_one()
+    assert token.scope_json == _scope_json(["context7"])
+
+
+async def test_delivery_null_worker_scope_is_unscoped_passthrough(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    # NULL worker scope (unscoped) — distinct from empty; the run scope is unchanged.
+    await _seed_worker_with_scope(db_session, owner_user_id=user.id, scope_json=None)
+    run_id, _ = await _seed_run_with_token(db_session, owner=user, integrations=["context7"])
+    run = await store.get_run(db_session, run_id)
+
+    plan = await delivery._apply_delivery_scope_intersection(db_session, run)
+    assert plan["gateway"]["integrations"] == ["context7"]
+
+
+async def test_delivery_empty_worker_scope_grants_nothing(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    # Empty allowlist [] is NOT unscoped — it drops every namespace.
+    await _seed_worker_with_scope(db_session, owner_user_id=user.id, scope_json=[])
+    run_id, _ = await _seed_run_with_token(db_session, owner=user, integrations=["context7"])
+    run = await store.get_run(db_session, run_id)
+
+    plan = await delivery._apply_delivery_scope_intersection(db_session, run)
+    assert plan["gateway"]["integrations"] == []
+
+
+# --- terminal token expiry -----------------------------------------------------
+
+
+async def _active_token_status(db: AsyncSession, run_id: uuid.UUID) -> str:
+    token = (
+        await db.execute(
+            store.select(WorkflowRunGatewayToken).where(
+                WorkflowRunGatewayToken.workflow_run_id == run_id
+            )
+        )
+    ).scalar_one()
+    return token.status
+
+
+async def test_terminal_report_expires_token(db_session: AsyncSession) -> None:
+    from proliferate.server.cloud.workflows.models import RunStatusRequest
+
+    user = await _make_user(db_session)
+    wf = await _store_workflow(db_session, user, _definition(), name="term-report")
+    run = await service.start_run(
+        db_session, user, wf.id, inputs={}, target_mode=WORKFLOW_TARGET_MODE_LOCAL
+    )
+    assert await _active_token_status(db_session, run.id) == _ACTIVE
+    # pending_delivery -> cancelled is a legal terminal transition.
+    await service.report_run_status(
+        db_session, user, run.id, RunStatusRequest(status="cancelled")
+    )
+    assert await _active_token_status(db_session, run.id) == _EXPIRED
+
+
+async def test_terminal_refresh_expires_token(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    run_id, _ = await _seed_run_with_token(
+        db_session, owner=user, integrations=[], status="running"
+    )
+    view = delivery._SandboxRunView(
+        status="completed",
+        step_cursor=1,
+        step_outputs=None,
+        session_ids=None,
+        workspace_id=None,
+        error_code=None,
+        error_message=None,
+    )
+    await delivery._sync_run_from_view(db_session, run_id, view)
+    assert await _active_token_status(db_session, run_id) == _EXPIRED
+
+
+# --- ping endpoint (§3.7 / L16) ------------------------------------------------
+
+
+@pytest.fixture
+def _recording_refresh(monkeypatch: pytest.MonkeyPatch) -> list:
+    calls: list = []
+
+    async def _fake_refresh(db, user, run):  # type: ignore[no-untyped-def]
+        calls.append(run.id)
+        return run
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.workflows.api.refresh_cloud_run", _fake_refresh
+    )
+    return calls
+
+
+async def test_ping_happy_triggers_refresh_for_cloud_run(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/ping",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 202
+    assert _recording_refresh == [run_id]
+
+
+async def test_ping_local_run_no_op_refresh(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(
+        db_session, owner=user, integrations=[], target_mode=WORKFLOW_TARGET_MODE_LOCAL
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/ping",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 202
+    assert _recording_refresh == []  # relay owns local observation
+
+
+async def test_ping_token_for_other_run_is_forbidden(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    user = await _make_user(db_session)
+    run_a, token_a = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    run_b, _ = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_b}/ping",
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert resp.status_code == 403
+    assert _recording_refresh == []
+
+
+async def test_ping_expired_token_unauthorized(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await store.expire_run_gateway_tokens_for_run(db_session, workflow_run_id=run_id)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/ping",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 401
+    assert _recording_refresh == []
+
+
+async def test_ping_after_terminal_is_safe(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    # A late ping after the run went terminal: the token is expired, so the ping is
+    # a no-regression 401 that changes no run state.
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(
+        db_session, owner=user, integrations=[], status="completed"
+    )
+    await store.expire_run_gateway_tokens_for_run(db_session, workflow_run_id=run_id)
+    await db_session.commit()
+
+    before = await store.get_run(db_session, run_id)
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/ping",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 401
+    await db_session.refresh(await db_session.get(WorkflowRun, run_id))
+    after = await store.get_run(db_session, run_id)
+    assert after.status == before.status
+
+
+async def test_ping_is_idempotent(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {plaintext}"}
+
+    first = await client.post(f"/v1/cloud/workflows/runs/{run_id}/ping", headers=headers)
+    second = await client.post(f"/v1/cloud/workflows/runs/{run_id}/ping", headers=headers)
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert _recording_refresh == [run_id, run_id]
+
+
+# --- gateway scope: pure helpers (E3 namespace-level) --------------------------
+
+
+async def test_scope_authorize_namespace_grants_all_tools() -> None:
+    # E3: a namespace-only entry (no "tools" key) reaches every tool of the provider.
+    run_scope = [{"provider": "context7"}]
+    assert scope.authorize_tool_call(
+        run_scope=run_scope, worker_scope=None, provider="context7", tool="a"
+    ).allowed
+    assert scope.authorize_tool_call(
+        run_scope=run_scope, worker_scope=None, provider="context7", tool="anything_else"
+    ).allowed
+    denied_provider = scope.authorize_tool_call(
+        run_scope=run_scope, worker_scope=None, provider="exa", tool="a"
+    )
+    assert denied_provider.reason == scope.SCOPE_DENY_PROVIDER_OUT_OF_RUN
+    denied_worker = scope.authorize_tool_call(
+        run_scope=run_scope, worker_scope=["exa"], provider="context7", tool="a"
+    )
+    assert denied_worker.reason == scope.SCOPE_DENY_PROVIDER_OUT_OF_WORKER
+
+
+async def test_scope_filter_keeps_all_tools_of_a_granted_namespace() -> None:
+    run_scope = [{"provider": "context7"}]
+    tools = [{"name": "a"}, {"name": "b"}, {"noname": 1}]
+    filtered = scope.filter_tools_to_scope(
+        run_scope=run_scope, worker_scope=None, provider="context7", tools=tools
+    )
+    # Every named tool of the granted namespace survives (unnamed dropped).
+    assert filtered == [{"name": "a"}, {"name": "b"}]
+    # Namespace-level worker intersection.
+    assert scope.intersect_namespaces_with_worker(["context7", "exa"], None) == [
+        "context7",
+        "exa",
+    ]
+    assert scope.intersect_namespaces_with_worker(["context7", "exa"], ["exa"]) == ["exa"]
+    assert scope.intersect_namespaces_with_worker(["context7"], []) == []
+
+
+# --- gateway scope: dependency resolution --------------------------------------
+
+
+@dataclass
+class _FakeRequest:
+    headers: dict
+
+
+async def test_dependency_resolves_run_token_first_and_rechecks_worker(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    await _seed_worker_with_scope(db_session, owner_user_id=user.id, scope_json=["context7"])
+    run_id, plaintext = await _seed_run_with_token(
+        db_session, owner=user, integrations=["context7"]
+    )
+
+    request = _FakeRequest(headers={"authorization": f"Bearer {plaintext}"})
+    grant = await gateway_deps.require_integration_gateway_grant(request, db_session)
+    assert grant.run_id == run_id
+    # E3: the per-slot scope_json flattens to namespace-only run-scope entries.
+    assert grant.run_scope == [{"provider": "context7"}]
+    assert grant.worker_scope == ["context7"]
+
+    # Narrow the worker allowlist AFTER mint -> the next resolution reflects it.
+    token = (
+        await db_session.execute(
+            store.select(CloudIntegrationGatewayToken).where(
+                CloudIntegrationGatewayToken.owner_user_id == user.id
+            )
+        )
+    ).scalar_one()
+    token.scope_json = ["exa"]
+    await db_session.flush()
+    grant2 = await gateway_deps.require_integration_gateway_grant(request, db_session)
+    assert grant2.worker_scope == ["exa"]
+    assert not scope.authorize_tool_call(
+        run_scope=grant2.run_scope,
+        worker_scope=grant2.worker_scope,
+        provider="context7",
+        tool="a",
+    ).allowed
+
+
+async def test_dependency_worker_token_path_regression_free(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    sandbox = CloudSandbox(
+        owner_user_id=user.id, sandbox_type="e2b", status="ready", purpose="interactive"
+    )
+    db_session.add(sandbox)
+    await db_session.flush()
+    worker = CloudRuntimeWorker(
+        owner_user_id=user.id,
+        runtime_kind="cloud_sandbox",
+        cloud_sandbox_id=sandbox.id,
+        token_hash=uuid.uuid4().hex,
+        status="online",
+    )
+    db_session.add(worker)
+    await db_session.flush()
+    worker_token = f"wt-{uuid.uuid4().hex}"
+    db_session.add(
+        CloudIntegrationGatewayToken(
+            runtime_worker_id=worker.id,
+            owner_user_id=user.id,
+            token_hash=runtime_workers_store.hash_gateway_token(worker_token),
+            status="active",
+            scope_json=None,
+        )
+    )
+    await db_session.flush()
+
+    request = _FakeRequest(headers={"authorization": f"Bearer {worker_token}"})
+    grant = await gateway_deps.require_integration_gateway_grant(request, db_session)
+    assert grant.run_id is None  # per-worker grant
+    assert grant.run_scope is None  # no per-run restriction
+    assert grant.worker_scope is None  # unscoped, today's behavior
+
+
+# --- gateway scope: service enforcement ----------------------------------------
+
+
+async def test_call_provider_tool_out_of_scope_is_enumerated_error(
+    db_session: AsyncSession,
+) -> None:
+    # A provider NOT granted to the run is denied (namespace not in run scope).
+    grant = runtime_workers_store.IntegrationGatewayGrant(
+        owner_user_id=uuid.uuid4(),
+        organization_id=None,
+        run_id=uuid.uuid4(),
+        run_scope=[{"provider": "context7"}],
+        worker_scope=None,
+    )
+    with pytest.raises(CloudApiError) as excinfo:
+        await gateway_service.call_provider_tool(
+            db_session, grant=grant, provider="exa", tool="danger", arguments={}
+        )
+    assert excinfo.value.code == "integration_gateway_scope_denied"
+
+
+async def test_list_tools_returns_all_tools_of_granted_namespace(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @dataclass
+    class _Pair:
+        account: object
+        definition: object
+
+    async def _fake_account_for_provider(db, *, grant, provider):  # type: ignore[no-untyped-def]
+        return _Pair(account=object(), definition=object())
+
+    async def _fake_tool_cache(db, *, account_record, definition_record):  # type: ignore[no-untyped-def]
+        return [{"name": "a"}, {"name": "b"}]
+
+    monkeypatch.setattr(gateway_service, "account_for_provider", _fake_account_for_provider)
+    monkeypatch.setattr(gateway_service, "get_or_refresh_tool_cache", _fake_tool_cache)
+
+    grant = runtime_workers_store.IntegrationGatewayGrant(
+        owner_user_id=uuid.uuid4(),
+        organization_id=None,
+        run_id=uuid.uuid4(),
+        run_scope=[{"provider": "context7"}],
+        worker_scope=None,
+    )
+    result = await gateway_service.list_tools_for_provider(
+        db_session, grant=grant, provider="context7"
+    )
+    # E3: a namespace grant exposes every tool of the provider.
+    assert result["tools"] == [{"name": "a"}, {"name": "b"}]
+
+
+# --- ADDENDUM 1: org-policy enforcement in the gateway (regression guard) -------
+
+
+async def _seed_ready_account_for_definition(
+    db: AsyncSession, *, user_id: uuid.UUID, definition: CloudIntegrationDefinition
+) -> None:
+    account = await accounts_store.upsert_account(
+        db, user_id=user_id, definition_id=definition.id, auth_kind="api_key", status="ready"
+    )
+    await accounts_store.set_account_credentials(
+        db,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json({"secretFields": {"api_key": "s"}}),
+        credential_format="secret-fields-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+
+
+async def test_org_disabled_provider_filtered_from_ready_accounts(
+    db_session: AsyncSession,
+) -> None:
+    """An org-policy-disabled provider is filtered out of the gateway's ready
+    accounts (regression: this branch had dropped ``_org_allows`` filtering)."""
+    user = await _make_user(db_session)
+    await sync_seed_definitions(db_session)
+    await db_session.flush()
+    definition = await definitions_store.get_seed_by_namespace(db_session, "context7")
+    assert definition is not None
+    await _seed_ready_account_for_definition(db_session, user_id=user.id, definition=definition)
+
+    org_id = uuid.uuid4()
+
+    # Without an org overlay the account is visible.
+    open_grant = runtime_workers_store.IntegrationGatewayGrant(
+        owner_user_id=user.id,
+        organization_id=org_id,
+        run_id=uuid.uuid4(),
+        run_scope=None,
+        worker_scope=None,
+    )
+    before = await gateway_service.ready_accounts_for_grant(db_session, grant=open_grant)
+    assert any(pair.definition.namespace == "context7" for pair in before)
+
+    # Disable the definition for this org: an explicit policy row with enabled=False.
+    db_session.add(
+        CloudIntegrationPolicy(
+            organization_id=org_id,
+            definition_id=definition.id,
+            enabled=False,
+            updated_by_user_id=user.id,
+        )
+    )
+    await db_session.flush()
+
+    after = await gateway_service.ready_accounts_for_grant(db_session, grant=open_grant)
+    assert all(pair.definition.namespace != "context7" for pair in after)
+
+    # The per-provider path is filtered too (list AND call agree).
+    with pytest.raises(CloudApiError) as excinfo:
+        await gateway_service.account_for_provider(
+            db_session, grant=open_grant, provider="context7"
+        )
+    assert excinfo.value.code in {
+        "integration_provider_not_found",
+        "integration_provider_disabled",
+    }
+
+
+# --- L26 purpose stamping ------------------------------------------------------
+
+
+async def test_purpose_stamped_workflow_run_on_create(db_session: AsyncSession) -> None:
+    from proliferate.db.store import cloud_sandboxes as sandbox_store
+
+    user = await _make_user(db_session)
+    created = await sandbox_store.ensure_personal_cloud_sandbox(
+        db_session,
+        user_id=user.id,
+        created_by_user_id=user.id,
+        billing_subject_id=uuid.uuid4(),
+        e2b_template_ref="e2b",
+        purpose="workflow-run",
+    )
+    assert created.purpose == "workflow-run"
+    # Re-ensure never restamps (L26: stamped once at creation).
+    again = await sandbox_store.ensure_personal_cloud_sandbox(
+        db_session,
+        user_id=user.id,
+        created_by_user_id=user.id,
+        billing_subject_id=uuid.uuid4(),
+        e2b_template_ref="e2b",
+        purpose="interactive",
+    )
+    assert again.purpose == "workflow-run"
+
+
+async def test_purpose_defaults_interactive_on_create(db_session: AsyncSession) -> None:
+    from proliferate.db.store import cloud_sandboxes as sandbox_store
+
+    user = await _make_user(db_session)
+    created = await sandbox_store.ensure_personal_cloud_sandbox(
+        db_session,
+        user_id=user.id,
+        created_by_user_id=user.id,
+        billing_subject_id=uuid.uuid4(),
+        e2b_template_ref="e2b",
+    )
+    assert created.purpose == "interactive"
+
+
+# --- contract fixture (tier-1 contract) ----------------------------------------
+
+
+async def test_gateway_block_matches_contract_fixture() -> None:
+    from proliferate.server.cloud.workflows.gateway_grants import build_gateway_plan_block
+
+    golden = json.loads((_FIXTURE_DIR / "gateway-block.json").read_text())
+    golden_keys = {k for k in golden if not k.startswith("_")}
+    run_id = uuid.uuid4()
+    scope_json = _scope_json(["issues", "slack"])
+    block = build_gateway_plan_block(token="per-run-token-abc123", run_id=run_id, scope=scope_json)
+    assert set(block) == golden_keys
+    assert block["authorization"].startswith("Bearer ")
+    assert block["url"].endswith("/v1/cloud/integration-gateway/mcp")
+    assert block["ping_url"].endswith(f"/v1/cloud/workflows/runs/{run_id}/ping")
+    # E3: the block carries a flat list of namespaces matching the fixture.
+    assert block["integrations"] == golden["integrations"]
+    assert all(isinstance(ns, str) for ns in golden["integrations"])
+
+
+async def test_ping_accepts_contract_request_shape(
+    client: AsyncClient, db_session: AsyncSession, _recording_refresh: list
+) -> None:
+    ping = json.loads((_FIXTURE_DIR / "ping-request.json").read_text())
+    assert ping["method"] == "POST"
+    assert ping["body"] is None
+    assert "authorization" in ping["headers"]
+
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+    # Same request shape as the fixture: POST, Bearer auth header, empty body.
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/ping",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 202

--- a/server/tests/unit/test_workflow_service.py
+++ b/server/tests/unit/test_workflow_service.py
@@ -8,8 +8,12 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.auth import User
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
 from proliferate.server.cloud.workflows import service
+from proliferate.utils.crypto import encrypt_json
 from proliferate.server.cloud.workflows.models import (
     RunStatusRequest,
     WorkflowCreateRequest,
@@ -56,7 +60,30 @@ def _definition() -> dict:
     }
 
 
+async def _seed_ready_account(db: AsyncSession, *, user_id: uuid.UUID, namespace: str) -> None:
+    await sync_seed_definitions(db)
+    await db.flush()
+    definition = await definitions_store.get_seed_by_namespace(db, namespace)
+    assert definition is not None
+    account = await accounts_store.upsert_account(
+        db, user_id=user_id, definition_id=definition.id, auth_kind="api_key", status="ready"
+    )
+    await accounts_store.set_account_credentials(
+        db,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json({"secretFields": {"api_key": "s"}}),
+        credential_format="secret-fields-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+
+
 async def _create_workflow(db: AsyncSession, user: User, *, name: str = "Fix-it"):
+    # The definition declares integrations (["slack"]); save-time L22
+    # (visible_provider_namespaces) needs the seed definitions synced, and
+    # StartRun-time L22 fail-fast (assert_declared_providers_ready) needs a
+    # ready account for each declared namespace — mirror test_workflow_run_gateway.py.
+    await _seed_ready_account(db, user_id=user.id, namespace="slack")
     return await service.create_workflow(
         db, user, WorkflowCreateRequest(name=name, definition=_definition())
     )


### PR DESCRIPTION
Final code PR of the A–E arc (stacked on #1007; design of record \`codex/workflows-architecture.md\` §3.7, §5.3–5.4, §6, rulings L16/L21–L26).

## What

**Per-run gateway token, minted for EVERY run** (L16 — empty scope legal), doubling as the run-report credential:

- **\`cloud_workflow_run_gateway_token\`** (migration \`d2f4a6c8e0b1\`): hashed token, \`scope_json\` = resolved \`functions[]\`, status \`active|expired|revoked\`, expires at terminal status (report AND refresh paths, idempotent). Plaintext travels only in \`resolved_plan_json.gateway = {url, authorization, ping_url, functions}\`.
- **Completion ping (§3.7)**: \`POST /v1/cloud/workflows/runs/{run_id}/ping\` — auth IS the per-run token (no user session); token↔path run mismatch → 403; wakes the existing \`_sync_run_from_view\` refresh for cloud runs (local: 202 no-op, the relay owns local observation). Stateless nudge: duplicate/stale/late pings safe by construction. Runtime fires it fire-and-forget after **every** \`drive_run\` transition via an injected \`RunPingSink\` (failure structurally inert — the sink returns \`()\`); scheduler phase 3 demotes to backstop.
- **L22 fail-fast**: StartRun fails the run outright (before the run row exists) if a declared provider has no ready account — never silently narrows.
- **L25 two-layer scope**: nullable \`scope_json\` provider allowlist on the worker token (NULL = unscoped, distinct from empty, no backfill) + nullable scope key on \`CloudIntegrationPolicy\`. The run scope is intersected with the worker allowlist **at delivery** (the worker isn't known at StartRun for cloud runs — the token row and plan block are re-frozen to the intersection before the plan ships), and the live worker allowlist is **re-checked on every gateway request**, so a post-mint narrowing bites on the next call.
- **Gateway enforcement**: run-token-first grant resolution (worker path untouched); \`tools/list\` filtered to scope; \`tools/call\` outside scope → enumerated error. The scope check is a pure helper (\`integration_gateway/domain/scope.py\`) callable outside HTTP — §6.6's future \`function_call\` server-side performer authorizes through the same path.
- **L26**: \`purpose\` enum on \`CloudSandbox\` (\`interactive\`/\`workflow-run\`), stamped at creation, never inferred.
- **§5.3 local-lane explicit error**: a local run whose plan declares functions it cannot honor fails at the first agent step with \`functions_unsupported_local\` — never a silent zero-tools no-op. Editor + launch modal carry the loud cloud-only captions; L21 launch set is issues + Slack.
- **Gateway launch extra**: the plan's gateway block is injected through the **existing** \`SessionExtension\`/\`SessionMcpServer::Http\` seam (L8: no new injection concept), registered per **session id** so a co-located non-workflow session can't inherit the run's credential; takes precedence over the worker dotfile; re-registered on crash-resume.
- **Contract fixture** \`fixtures/contracts/run-ping/\` (golden ping request + gateway block), asserted from both Python and Rust suites.

## Verification
366 server workflow+gateway tests green on this tip (24 new run-gateway tests: mint-per-run, token-scoping 403, ping idempotency + no-status-regression, terminal expiry both paths, L25 intersection + NULL-vs-empty + post-mint narrowing, L22 fail-fast, purpose stamping, worker-path regression); 886 cargo tests (ping-after-every-transition incl. terminal, failure-inert, no-gateway-no-pings, launch-extra wiring, fixture parse); desktop tsc clean; single alembic head, chain walks A→B→E.

Flagged: \`make cloud-client-generate\` was not run for the ping route (runtime-facing, not consumed by the TS SDK) — if repo-shape requires the regen it's a one-command follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)