### PR TITLE
fix(auth): extend single-org bypass to current_product_user

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -41,7 +41,7 @@ server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PU
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
 server/tests/integration/test_agent_gateway_store.py 673 P1 auth rebuild rewrote store coverage for titled-key + agent_auth_selection model
-server/tests/integration/test_auth_flow.py 2130 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test
+server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test

--- a/server/proliferate/auth/dependencies.py
+++ b/server/proliferate/auth/dependencies.py
@@ -55,6 +55,16 @@ async def current_product_user(
     user: User = Depends(current_limited_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> User:
+    """Acting user for Proliferate Cloud product surfaces (secrets, workspaces, repos).
+
+    Hosted keeps the GitHub product-readiness gate, byte-for-byte the same as
+    ``current_organization_actor``. Single-org (self-hosted) instances admit
+    password-only accounts: the product surfaces themselves must work with no
+    GitHub OAuth app configured. Endpoints that genuinely need a GitHub token
+    (e.g. repo import) enforce that at the point of use instead of here.
+    """
+    if settings.single_org_mode:
+        return user
     return await _require_product_ready(db, user)
 
 

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -531,6 +531,96 @@ class TestPasswordAuthFlow:
         assert response.status_code == 404
 
 
+class TestSingleOrgProductUserBypass:
+    """current_product_user's single-org carve-out (mirrors current_organization_actor).
+
+    Self-hosted single-org instances have no GitHub OAuth app configured, so a
+    password-only account must be able to reach product surfaces. Hosted keeps
+    the gate. Endpoints that genuinely need a GitHub token still fail cleanly
+    at their own point of use, regardless of org mode.
+    """
+
+    password = "correct horse battery"
+
+    @pytest.mark.asyncio
+    async def test_single_org_password_only_user_passes_product_gate(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "single_org_mode_override", True)
+        await _create_password_user("single-org-password@example.com", self.password)
+
+        login = await client.post(
+            "/auth/web/password/login",
+            json={"email": "single-org-password@example.com", "password": self.password},
+        )
+        assert login.status_code == 200
+        access_token = login.json()["accessToken"]
+
+        response = await client.get(
+            "/v1/cloud/workspaces",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_hosted_mode_still_enforces_product_gate_for_password_only_user(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "single_org_mode_override", False)
+        await _create_password_user("hosted-password@example.com", self.password)
+
+        login = await client.post(
+            "/auth/web/password/login",
+            json={"email": "hosted-password@example.com", "password": self.password},
+        )
+        assert login.status_code == 200
+        access_token = login.json()["accessToken"]
+
+        response = await client.get(
+            "/v1/cloud/workspaces",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "github_link_required"
+
+    @pytest.mark.asyncio
+    async def test_single_org_repo_endpoint_still_rejects_user_without_github(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The single-org bypass only lifts the blanket product gate.
+
+        A repo-import surface that genuinely needs a GitHub connection keeps
+        its own point-of-use guard (proliferate/server/cloud/repos/service.py's
+        ``_require_github_access_token`` / the GitHub App authorization check),
+        so it still fails cleanly instead of silently granting access.
+        """
+        monkeypatch.setattr(settings, "password_auth_enabled", True)
+        monkeypatch.setattr(settings, "single_org_mode_override", True)
+        await _create_password_user("single-org-no-github@example.com", self.password)
+
+        login = await client.post(
+            "/auth/web/password/login",
+            json={"email": "single-org-no-github@example.com", "password": self.password},
+        )
+        assert login.status_code == 200
+        access_token = login.json()["accessToken"]
+
+        response = await client.get(
+            "/v1/cloud/repositories/catalog",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 409
+        assert response.json()["detail"]["code"] == "github_app_authorization_required"
+
+
 class TestDesktopPKCEFlow:
     """Test the full desktop PKCE authorization code exchange."""
 

--- a/specs/codebase/features/product-auth.md
+++ b/specs/codebase/features/product-auth.md
@@ -25,7 +25,14 @@ Proliferate has two related but distinct auth concepts:
 
 GitHub remains the product-readiness provider. A password-only user is signed in
 but limited until the existing GitHub readiness check succeeds. Do not add a
-hidden bypass for normal users.
+hidden bypass for normal (hosted, multi-tenant) users.
+
+Single-org (self-hosted) instances are the one carve-out: there is no GitHub
+OAuth app configured, so `current_product_user` admits password-only accounts
+when `settings.single_org_mode` is true, same as its sibling
+`current_organization_actor`. Hosted keeps the GitHub readiness gate
+unconditionally. Endpoints that genuinely need a GitHub token (repo import,
+etc.) still enforce that at their own point of use, not through this gate.
 
 ## Web Beta Access
 

--- a/specs/codebase/structures/server/guides/auth.md
+++ b/specs/codebase/structures/server/guides/auth.md
@@ -35,7 +35,7 @@ free; nothing downstream re-checks.
 ```text
 anonymous
 └── current_active_user                    active user
-    └── current_product_user               + GitHub connected — default for product/cloud surfaces
+    └── current_product_user               + GitHub connected (hosted) / single-org bypass — default for product/cloud surfaces
         ├── require_org_membership(org_id)  org member  -> OwnerContext
         └── require_org_role(org_id, roles) org standing -> OwnerContext
 
@@ -193,7 +193,7 @@ the caller." Each is a thin `Depends()` that composes the one above it.
 | Dep | Gates |
 |---|---|
 | `current_active_user` | active user, no GitHub requirement |
-| `current_product_user` | active user **+ GitHub connected** — the default for product/cloud surfaces |
+| `current_product_user` | active user **+ GitHub connected** — the default for product/cloud surfaces. Single-org (self-hosted) instances bypass the GitHub check for password-only accounts; hosted keeps it unconditionally. |
 | `optional_current_active_user` | maybe authenticated (public route with extra behavior when signed in) |
 | `current_worker` | worker JWT, resolved to a `WorkerAuthContext` (see Worker actor) |
 


### PR DESCRIPTION
current_product_user requires GitHub product-readiness unconditionally, which makes it unsatisfiable for password-only accounts on self-hosted (single-org) instances. Every cloud secrets/workspaces/repos endpoint 403s with github_link_required for those accounts even though there's no GitHub OAuth app configured to link.

Its sibling current_organization_actor already has this exact carve-out (`if settings.single_org_mode: return user`). This extends the same bypass to current_product_user, mirroring the sibling's docstring. Hosted keeps the gate unconditionally.

Endpoints that genuinely need a GitHub token (repo import, etc.) still fail cleanly at their own point of use — this doesn't touch proliferate/server/cloud/repos/service.py's `_require_github_access_token` or the GitHub App authorization checks.

Found by the tier-2 test harness: password-only self-hosted users were locked out of cloud secrets/workspaces with no way to satisfy the gate.

## Test plan

- New `TestSingleOrgProductUserBypass` class in `server/tests/integration/test_auth_flow.py`:
  - single-org + password-only user passes `current_product_user` (GET /v1/cloud/workspaces -> 200)
  - hosted mode still enforces the gate for the same kind of user (403 github_link_required)
  - single-org + no GitHub still gets rejected cleanly by the repo endpoint's own point-of-use guard (409 github_app_authorization_required from GET /v1/cloud/repositories/catalog)
- Updated specs/codebase/structures/server/guides/auth.md and specs/codebase/features/product-auth.md to describe the carve-out
- Full server suite: `cd server && uv run pytest -q` -> 948 passed, 2 skipped (live-provider e2e tests that self-skip without RUN_CLOUD_E2E), 0 failed