### PR TITLE
Enforce org and per-user compute budget limits

### DIFF
--- a/server/alembic/versions/d10c0a11e5ef_usage_segment_organization_id.py
+++ b/server/alembic/versions/d10c0a11e5ef_usage_segment_organization_id.py
@@ -1,0 +1,49 @@
+"""usage_segment organization_id for org compute budget enforcement
+
+Revision ID: d10c0a11e5ef
+Revises: 75e8009a52c7
+Create Date: 2026-07-08 12:00:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d10c0a11e5ef"
+down_revision: str | Sequence[str] | None = "75e8009a52c7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if _has_column("usage_segment", "organization_id"):
+        return
+    op.add_column(
+        "usage_segment",
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_usage_segment_organization_id"),
+        "usage_segment",
+        ["organization_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    if not _has_column("usage_segment", "organization_id"):
+        return
+    op.drop_index(
+        op.f("ix_usage_segment_organization_id"),
+        table_name="usage_segment",
+    )
+    op.drop_column("usage_segment", "organization_id")

--- a/server/proliferate/db/models/billing.py
+++ b/server/proliferate/db/models/billing.py
@@ -335,6 +335,12 @@ class UsageSegment(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(index=True)
     billing_subject_id: Mapped[uuid.UUID] = mapped_column(index=True)
+    # Organization context for enforcement/attribution. ``billing_subject_id``
+    # stays the personal subject that pays (invoicing unchanged); this column
+    # records which org the segment belongs to (owner's current membership, or
+    # None for a user with no org) so org-scoped compute budget limits can be
+    # evaluated against org-wide and per-user window usage.
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
     runtime_environment_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
     workspace_id: Mapped[uuid.UUID | None] = mapped_column(index=True, nullable=True)
     sandbox_id: Mapped[uuid.UUID] = mapped_column(index=True)

--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -407,6 +407,39 @@ async def compute_usage_seconds_in_window(
     return float(result or 0.0)
 
 
+async def compute_usage_seconds_in_window_for_org(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    start: datetime,
+    end: datetime,
+    now: datetime,
+    user_id: UUID | None = None,
+) -> float:
+    """Total billable compute seconds over ``[start, end)`` scoped to an org.
+
+    Sums by ``UsageSegment.organization_id`` (not by billing subject) so an
+    org's compute usage aggregates across every member's segments regardless of
+    which personal subject each one is invoiced to. ``user_id=None`` sums the
+    whole org (org-wide cap); otherwise it filters to that member (per-user cap).
+    Segment attribution uses ``started_at`` (see the timeseries note).
+    """
+    window_start = coerce_utc(start) or start
+    window_end = coerce_utc(end) or end
+    conditions = [
+        UsageSegment.organization_id == organization_id,
+        UsageSegment.is_billable.is_(True),
+        UsageSegment.started_at >= window_start,
+        UsageSegment.started_at < window_end,
+    ]
+    if user_id is not None:
+        conditions.append(UsageSegment.user_id == user_id)
+    result = await db.scalar(
+        select(func.coalesce(func.sum(_clipped_segment_seconds(now)), 0.0)).where(*conditions)
+    )
+    return float(result or 0.0)
+
+
 @dataclass(frozen=True)
 class BudgetLimitInput:
     """A single limit in a full-replace limit set."""

--- a/server/proliferate/db/store/billing_runtime_usage.py
+++ b/server/proliferate/db/store/billing_runtime_usage.py
@@ -16,6 +16,7 @@ from proliferate.constants.billing import BILLING_RECONCILER_LOCK_KEY
 from proliferate.db.models.billing import BillingDecisionEvent, UsageSegment, WebhookEventReceipt
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
 from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
+from proliferate.db.store.organizations import get_current_membership_for_user
 from proliferate.utils.time import utcnow
 
 T = TypeVar("T")
@@ -50,6 +51,21 @@ async def get_open_usage_segment(
             )
         )
     ).scalar_one_or_none()
+
+
+async def resolve_organization_id_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> UUID | None:
+    """The org a user's compute belongs to, or None if they are org-less.
+
+    Resolves the user's current (first active) membership — the same resolution
+    the resume gate uses (``get_current_membership_for_user``). This is the org
+    context stamped onto a usage segment so org-scoped compute budget limits can
+    be evaluated; it does not change ``billing_subject_id`` (who pays).
+    """
+    membership = await get_current_membership_for_user(db, user_id)
+    return membership.organization.id if membership is not None else None
 
 
 async def _get_workspace_billing_subject(
@@ -87,6 +103,7 @@ async def create_usage_segment(
     *,
     user_id: UUID,
     billing_subject_id: UUID,
+    organization_id: UUID | None,
     runtime_environment_id: UUID | None,
     workspace_id: UUID | None,
     sandbox_id: UUID,
@@ -102,6 +119,7 @@ async def create_usage_segment(
         .values(
             user_id=user_id,
             billing_subject_id=billing_subject_id,
+            organization_id=organization_id,
             runtime_environment_id=runtime_environment_id,
             workspace_id=workspace_id,
             sandbox_id=sandbox_id,
@@ -392,10 +410,16 @@ async def ensure_sandbox_usage_started(
         owner_user_id = actor_user_id
     else:
         raise RuntimeError("Usage segment requires a runtime environment, workspace, or user.")
+    # Stamp the org the segment belongs to (owner's current membership) so
+    # org-scoped compute budget limits can be enforced. The paying subject
+    # (``billing_subject_id``) is unchanged — invoicing stays on the personal
+    # subject.
+    organization_id = await resolve_organization_id_for_user(db, owner_user_id)
     return await create_usage_segment(
         db,
         user_id=actor_user_id or owner_user_id,
         billing_subject_id=billing_subject_id,
+        organization_id=organization_id,
         runtime_environment_id=runtime_environment_id,
         workspace_id=workspace_id,
         sandbox_id=sandbox_id,

--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -22,10 +22,7 @@ from proliferate.db.store.billing_runtime_usage import (
     record_billing_decision_event,
     resolve_billing_subject_id_for_workspace,
 )
-from proliferate.db.store.billing_subjects import (
-    ensure_organization_billing_subject,
-    ensure_personal_billing_subject,
-)
+from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
 from proliferate.errors import ProliferateError
 from proliferate.server.billing import snapshot_state
@@ -147,16 +144,16 @@ async def record_sandbox_start_authorization(
 async def _compute_budget_cap_breach(
     db: AsyncSession,
     *,
-    billing_subject_id: UUID,
     organization_id: UUID,
     user_id: UUID,
     now: datetime,
 ) -> str | None:
-    """Decision type if the subject breaches an enabled org compute cap, else None.
+    """Decision type if the org breaches an enabled compute cap, else None.
 
     Mirrors the reconciler's ``_resolve_compute_limit_pause`` semantics for the
-    single-sandbox resume path: a per-user cap is checked against that user's
-    window usage (and wins), otherwise the org-wide cap sums the whole subject.
+    single-sandbox resume path: usage is summed by ``organization_id`` across
+    the org's segments, a per-user cap is checked against that user's window
+    usage (and wins), otherwise the org-wide cap sums the whole org.
     """
     limits = [
         limit
@@ -168,9 +165,9 @@ async def _compute_budget_cap_breach(
 
     async def _window_seconds(window: str, scope_user_id: UUID | None) -> float:
         start, end = window_bounds(window, now)
-        return await billing_store.compute_usage_seconds_in_window(
+        return await billing_store.compute_usage_seconds_in_window_for_org(
             db,
-            billing_subject_id=billing_subject_id,
+            organization_id=organization_id,
             start=start,
             end=end,
             now=now,
@@ -212,35 +209,29 @@ async def assert_cloud_sandbox_resume_allowed(
 
     decision_type: str | None = None
     reason: str | None = None
-    # Subject for the recorded decision event / compute-cap usage window. The
-    # spend-hold path stays on the owner's personal subject; the compute-cap
-    # path re-binds to the org billing subject (below) so it mirrors the
-    # reconciler, which scopes compute limits by ``segment.billing_subject_id``.
+    # The recorded decision event stays on the owner's personal subject — the
+    # subject that pays (invoicing unchanged). Compute limits are org-scoped, so
+    # the compute-cap check resolves the owner's org and sums usage by
+    # ``organization_id`` (matching the reconciler's ``_resolve_compute_limit_pause``).
     decision_subject_id = subject.id
     if snapshot.active_spend_hold:
         decision_type = BILLING_DECISION_ENFORCE_ACTIVE_SPEND
         reason = snapshot.hold_reason or "active_spend_hold"
     else:
-        # ``ensure_personal_billing_subject`` always yields ``organization_id is
-        # None`` (DB CheckConstraint), so the sandbox's org can't come from the
-        # subject. The cloud_sandbox row has no org column either, but the owner
-        # is one membership lookup away — the same resolution connect.py uses for
-        # identity tags. Compute limits are org-scoped, so resolve the org, then
-        # its billing subject, and check caps against that org subject's usage
-        # (matching the reconciler's ``_resolve_compute_limit_pause``).
+        # The cloud_sandbox row has no org column, but the owner is one
+        # membership lookup away — the same resolution connect.py uses for
+        # identity tags and the segment open path uses to stamp
+        # ``usage_segment.organization_id``.
         membership = await organizations_store.get_current_membership_for_user(db, owner_user_id)
         if membership is not None:
             organization_id = membership.organization.id
-            org_subject = await ensure_organization_billing_subject(db, organization_id)
             decision_type = await _compute_budget_cap_breach(
                 db,
-                billing_subject_id=org_subject.id,
                 organization_id=organization_id,
                 user_id=owner_user_id,
                 now=now,
             )
             if decision_type is not None:
-                decision_subject_id = org_subject.id
                 reason = "compute budget limit reached"
 
     if decision_type is None:

--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -37,7 +37,6 @@ from proliferate.db.store.billing_runtime_usage import (
     release_billing_reconciler_lock,
     try_acquire_billing_reconciler_lock,
 )
-from proliferate.db.store.billing_subjects import get_billing_subject_by_id
 from proliferate.db.store.cloud_sandboxes import (
     load_cloud_sandbox_by_id,
     mark_cloud_sandbox_destroyed,
@@ -153,7 +152,6 @@ async def _mark_sandbox_environment_unavailable(
 async def _resolve_compute_limit_pause(
     *,
     segment: UsageSegment,
-    org_id_by_subject: dict[UUID, UUID | None],
     compute_limits_by_org: dict[UUID, list[BillingBudgetLimit]],
     spend_cache: dict[tuple[UUID, str, UUID | None], float],
     now: datetime,
@@ -161,18 +159,14 @@ async def _resolve_compute_limit_pause(
     """Decision type when the segment breaches an org compute cap, else None.
 
     Enforce-mode only, matching the ``active_spend_hold`` path. Compute limits
-    are org-scoped: personal subjects (no ``organization_id``) never bind. A
-    per-user cap is compared against the segment user's window usage and takes
-    precedence over an org-wide cap, which sums the whole subject.
+    are org-scoped: a segment with no ``organization_id`` (org-less owner) never
+    binds. Org usage is summed by ``organization_id`` across every member's
+    segments regardless of who pays for each. A per-user cap is compared against
+    the segment user's window usage and takes precedence over an org-wide cap.
     """
     if settings.cloud_billing_mode != BILLING_MODE_ENFORCE:
         return None
-    subject_id = segment.billing_subject_id
-    if subject_id not in org_id_by_subject:
-        async with db_engine.async_session_factory() as db:
-            subject = await get_billing_subject_by_id(db, subject_id)
-        org_id_by_subject[subject_id] = subject.organization_id if subject is not None else None
-    organization_id = org_id_by_subject[subject_id]
+    organization_id = segment.organization_id
     if organization_id is None:
         return None
     if organization_id not in compute_limits_by_org:
@@ -186,13 +180,13 @@ async def _resolve_compute_limit_pause(
         return None
 
     async def _window_seconds(window: str, scope_user_id: UUID | None) -> float:
-        key = (subject_id, window, scope_user_id)
+        key = (organization_id, window, scope_user_id)
         if key not in spend_cache:
             start, end = window_bounds(window, now)
             async with db_engine.async_session_factory() as db:
-                spend_cache[key] = await billing_store.compute_usage_seconds_in_window(
+                spend_cache[key] = await billing_store.compute_usage_seconds_in_window_for_org(
                     db,
-                    billing_subject_id=subject_id,
+                    organization_id=organization_id,
                     start=start,
                     end=end,
                     now=now,
@@ -304,8 +298,8 @@ async def run_billing_reconcile_pass() -> None:
         snapshots_by_subject: dict[UUID, BillingSnapshot] = {}
         recorded_hold_decision_subjects: set[UUID] = set()
         # Org budget-limit enforcement caches (spec §4.2), scoped to this pass:
-        # subject→org, org→enabled compute limits, and window usage.
-        org_id_by_subject: dict[UUID, UUID | None] = {}
+        # org→enabled compute limits, and org window usage keyed by
+        # (organization_id, window, user_id | None).
         compute_limits_by_org: dict[UUID, list[BillingBudgetLimit]] = {}
         compute_spend_cache: dict[tuple[UUID, str, UUID | None], float] = {}
         recorded_limit_decisions: set[tuple[UUID, UUID | None, str]] = set()
@@ -337,7 +331,6 @@ async def run_billing_reconcile_pass() -> None:
                 recorded_hold_decision_subjects.add(segment.billing_subject_id)
             limit_decision = await _resolve_compute_limit_pause(
                 segment=segment,
-                org_id_by_subject=org_id_by_subject,
                 compute_limits_by_org=compute_limits_by_org,
                 spend_cache=compute_spend_cache,
                 now=now,

--- a/server/tests/integration/test_billing_compute_attribution.py
+++ b/server/tests/integration/test_billing_compute_attribution.py
@@ -1,0 +1,292 @@
+"""Org compute budget enforcement, driven through the real segment-open path.
+
+Regression coverage for the "org-subject segment attribution gap": compute
+``usage_segment`` rows opened by the E2B webhook / provision path used to be
+attributed only to the workspace owner's *personal* billing subject, so
+org-scoped compute caps never fired. The fix stamps ``organization_id`` on the
+segment (owner's current membership) while leaving ``billing_subject_id`` — who
+pays — unchanged.
+
+These tests exercise the real write path
+(``open_usage_segment_for_sandbox``), then assert enforcement fires:
+* an org-wide compute cap crossed by that usage → the live resume gate denies;
+* a per-user cap the same;
+* a segment for an org-less owner is never attributed, so nothing enforces.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.billing import (
+    BILLING_DECISION_ORG_LIMIT_PAUSE,
+    BILLING_DECISION_USER_LIMIT_PAUSE,
+    BILLING_MODE_ENFORCE,
+)
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_OWNER,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.billing import UsageSegment
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store.billing import BudgetLimitInput, replace_budget_limits
+from proliferate.db.store.billing_runtime_usage import open_usage_segment_for_sandbox
+from proliferate.db.store.billing_subjects import (
+    ensure_free_included_grant,
+    ensure_personal_billing_subject,
+)
+from proliferate.server.billing.authorization import (
+    CloudSandboxResumeBlockedError,
+    assert_cloud_sandbox_resume_allowed,
+)
+from proliferate.utils.time import utcnow
+
+
+async def _create_user(db_session: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"attrib-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+async def _create_org_member(db_session: AsyncSession) -> tuple[uuid.UUID, uuid.UUID]:
+    """A user with an active membership in a fresh org. Returns (user_id, org_id)."""
+    user_id = await _create_user(db_session)
+    org = Organization(name=f"org-{uuid.uuid4().hex[:8]}", status="active")
+    db_session.add(org)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=org.id,
+            user_id=user_id,
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+        )
+    )
+    await db_session.flush()
+    return user_id, org.id
+
+
+async def _open_segment_for(
+    db_session: AsyncSession, user_id: uuid.UUID, *, seconds: float
+) -> UsageSegment:
+    """Open a real usage segment for a user's sandbox, started ``seconds`` ago."""
+    started_at = utcnow() - timedelta(seconds=seconds)
+    return await open_usage_segment_for_sandbox(
+        db_session,
+        sandbox_id=uuid.uuid4(),
+        external_sandbox_id=f"ext-{uuid.uuid4().hex[:8]}",
+        sandbox_execution_id=None,
+        started_at=started_at,
+        opened_by="provision",
+        user_id=user_id,
+    )
+
+
+def _compute_limit(user_id: uuid.UUID | None, cap: float) -> BudgetLimitInput:
+    return BudgetLimitInput(
+        user_id=user_id,
+        kind="compute",
+        window="month",
+        cap_value=Decimal(str(cap)),
+        enabled=True,
+    )
+
+
+async def _seed_healthy_balance(db_session: AsyncSession, user_id: uuid.UUID) -> None:
+    """Give the personal subject a free grant so the gate has no spend hold.
+
+    With PRO_BILLING_ENABLED the snapshot only auto-grants trial hours to
+    GitHub-linked users; a subject with zero grants is (correctly)
+    credits-exhausted, which would mask the compute-cap path under test.
+    """
+    await ensure_personal_billing_subject(db_session, user_id)
+    await ensure_free_included_grant(db_session, user_id)
+
+
+@pytest.mark.asyncio
+async def test_open_segment_stamps_owner_organization(
+    db_session: AsyncSession,
+    test_engine: Any,
+) -> None:
+    """The real segment-open path records the owner's org (attribution fix)."""
+    user_id, org_id = await _create_org_member(db_session)
+    segment = await _open_segment_for(db_session, user_id, seconds=120.0)
+    assert segment.organization_id == org_id
+    # Who pays is unchanged: still the owner's personal billing subject.
+    personal = await ensure_personal_billing_subject(db_session, user_id)
+    assert segment.billing_subject_id == personal.id
+
+
+@pytest.mark.asyncio
+async def test_org_less_owner_segment_has_no_organization(
+    db_session: AsyncSession,
+    test_engine: Any,
+) -> None:
+    """A user with no membership yields an unattributed segment."""
+    user_id = await _create_user(db_session)
+    segment = await _open_segment_for(db_session, user_id, seconds=120.0)
+    assert segment.organization_id is None
+
+
+@pytest.mark.asyncio
+async def test_org_wide_compute_cap_denies_resume(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Org-wide compute cap crossed by real usage → resume denied."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id, org_id = await _create_org_member(db_session)
+    await _seed_healthy_balance(db_session, user_id)
+    await _open_segment_for(db_session, user_id, seconds=3600.0)
+    await replace_budget_limits(
+        db_session, organization_id=org_id, limits=[_compute_limit(None, 60.0)]
+    )
+    await db_session.commit()
+
+    sandbox = SimpleNamespace(owner_user_id=user_id, organization_id=None)
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
+    assert excinfo.value.decision_type == BILLING_DECISION_ORG_LIMIT_PAUSE
+    assert excinfo.value.status_code == 402
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_per_user_compute_cap_denies_resume(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-user compute cap crossed by real usage → resume denied."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id, org_id = await _create_org_member(db_session)
+    await _seed_healthy_balance(db_session, user_id)
+    await _open_segment_for(db_session, user_id, seconds=3600.0)
+    await replace_budget_limits(
+        db_session, organization_id=org_id, limits=[_compute_limit(user_id, 60.0)]
+    )
+    await db_session.commit()
+
+    sandbox = SimpleNamespace(owner_user_id=user_id, organization_id=None)
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
+    assert excinfo.value.decision_type == BILLING_DECISION_USER_LIMIT_PAUSE
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_under_cap_resume_allowed(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Usage below the org cap does not block a wake."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id, org_id = await _create_org_member(db_session)
+    await _seed_healthy_balance(db_session, user_id)
+    await _open_segment_for(db_session, user_id, seconds=60.0)
+    await replace_budget_limits(
+        db_session, organization_id=org_id, limits=[_compute_limit(None, 100000.0)]
+    )
+    await db_session.commit()
+
+    sandbox = SimpleNamespace(owner_user_id=user_id, organization_id=None)
+    await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_personal_workspace_unaffected_by_any_org_cap(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An org-less owner is never enforced against org caps; resume allowed.
+
+    Even with heavy real usage, a segment for a user with no membership carries
+    ``organization_id=None``, so no org cap can bind — the personal path is
+    unaffected by the fix.
+    """
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id = await _create_user(db_session)
+    await _seed_healthy_balance(db_session, user_id)
+    segment = await _open_segment_for(db_session, user_id, seconds=3600.0)
+    assert segment.organization_id is None
+    await db_session.commit()
+
+    sandbox = SimpleNamespace(owner_user_id=user_id, organization_id=None)
+    await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_org_wide_cap_sums_across_members(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Org-wide usage aggregates across members regardless of who pays.
+
+    Two members of the same org each run a sandbox billed to their own personal
+    subject; the org-wide cap sums both segments' seconds by ``organization_id``.
+    """
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    owner_id, org_id = await _create_org_member(db_session)
+    await _seed_healthy_balance(db_session, owner_id)
+    second_id = await _create_user(db_session)
+    db_session.add(
+        OrganizationMembership(
+            organization_id=org_id,
+            user_id=second_id,
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+        )
+    )
+    await db_session.flush()
+    # Each member uses 40s; neither alone crosses a 60s org-wide cap, together
+    # they do.
+    await _open_segment_for(db_session, owner_id, seconds=40.0)
+    await _open_segment_for(db_session, second_id, seconds=40.0)
+    await replace_budget_limits(
+        db_session, organization_id=org_id, limits=[_compute_limit(None, 60.0)]
+    )
+    await db_session.commit()
+
+    # Both segments are attributed to the org.
+    seg_org_ids = (
+        (
+            await db_session.execute(
+                select(UsageSegment.organization_id).where(UsageSegment.organization_id == org_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(seg_org_ids) == 2
+
+    sandbox = SimpleNamespace(owner_user_id=owner_id, organization_id=None)
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
+    assert excinfo.value.decision_type == BILLING_DECISION_ORG_LIMIT_PAUSE
+    await db_session.rollback()

--- a/server/tests/integration/test_billing_limit_enforcement_compute.py
+++ b/server/tests/integration/test_billing_limit_enforcement_compute.py
@@ -42,7 +42,6 @@ from proliferate.db.models.organizations import Organization
 from proliferate.db.store.billing import BudgetLimitInput, replace_budget_limits
 from proliferate.db.store.billing_subjects import (
     ensure_free_included_grant,
-    ensure_organization_billing_subject,
     ensure_personal_billing_subject,
 )
 from proliferate.integrations.sandbox.base import ProviderSandboxState
@@ -72,11 +71,18 @@ async def _create_user(db_session: AsyncSession) -> uuid.UUID:
     return user.id
 
 
-def _segment(*, subject_id: uuid.UUID, user_id: uuid.UUID, seconds: float) -> UsageSegment:
+def _segment(
+    *,
+    subject_id: uuid.UUID,
+    user_id: uuid.UUID,
+    seconds: float,
+    organization_id: uuid.UUID | None = None,
+) -> UsageSegment:
     started = NOW - timedelta(seconds=seconds)
     return UsageSegment(
         user_id=user_id,
         billing_subject_id=subject_id,
+        organization_id=organization_id,
         workspace_id=uuid.uuid4(),
         sandbox_id=uuid.uuid4(),
         external_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",
@@ -94,12 +100,25 @@ async def _seed_org_with_usage(
     make_limits: Callable[[uuid.UUID], list[BudgetLimitInput]],
     used_seconds: float,
 ) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Seed an org, a member, and one closed segment attributed to the org.
+
+    The segment carries the member's personal ``billing_subject_id`` (who pays,
+    unchanged) and the org's ``organization_id`` (the attribution the fix adds),
+    which is what compute enforcement now sums against.
+    """
     org = Organization(name=f"org-{uuid.uuid4().hex[:8]}", status="active")
     db_session.add(org)
     await db_session.flush()
-    subject = await ensure_organization_billing_subject(db_session, org.id)
     user_id = await _create_user(db_session)
-    db_session.add(_segment(subject_id=subject.id, user_id=user_id, seconds=used_seconds))
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    db_session.add(
+        _segment(
+            subject_id=subject.id,
+            user_id=user_id,
+            seconds=used_seconds,
+            organization_id=org.id,
+        )
+    )
     await replace_budget_limits(db_session, organization_id=org.id, limits=make_limits(user_id))
     await db_session.commit()
     return org.id, subject.id, user_id
@@ -123,13 +142,12 @@ async def test_resolve_per_user_cap_breach(
 ) -> None:
     patch_global_session_factory(test_engine, monkeypatch)
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
-    _org, subject_id, user_id = await _seed_org_with_usage(
+    org_id, subject_id, user_id = await _seed_org_with_usage(
         db_session, make_limits=lambda uid: [_compute_limit(uid, 60.0)], used_seconds=3600.0
     )
-    segment = SimpleNamespace(billing_subject_id=subject_id, user_id=user_id)
+    segment = SimpleNamespace(organization_id=org_id, user_id=user_id)
     decision = await _resolve_compute_limit_pause(
         segment=segment,
-        org_id_by_subject={},
         compute_limits_by_org={},
         spend_cache={},
         now=NOW,
@@ -145,13 +163,12 @@ async def test_resolve_org_wide_cap_breach(
 ) -> None:
     patch_global_session_factory(test_engine, monkeypatch)
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
-    _org, subject_id, user_id = await _seed_org_with_usage(
+    org_id, subject_id, user_id = await _seed_org_with_usage(
         db_session, make_limits=lambda _uid: [_compute_limit(None, 60.0)], used_seconds=3600.0
     )
-    segment = SimpleNamespace(billing_subject_id=subject_id, user_id=user_id)
+    segment = SimpleNamespace(organization_id=org_id, user_id=user_id)
     decision = await _resolve_compute_limit_pause(
         segment=segment,
-        org_id_by_subject={},
         compute_limits_by_org={},
         spend_cache={},
         now=NOW,
@@ -167,13 +184,12 @@ async def test_resolve_under_cap_returns_none(
 ) -> None:
     patch_global_session_factory(test_engine, monkeypatch)
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
-    _org, subject_id, user_id = await _seed_org_with_usage(
+    org_id, subject_id, user_id = await _seed_org_with_usage(
         db_session, make_limits=lambda uid: [_compute_limit(uid, 100000.0)], used_seconds=3600.0
     )
-    segment = SimpleNamespace(billing_subject_id=subject_id, user_id=user_id)
+    segment = SimpleNamespace(organization_id=org_id, user_id=user_id)
     decision = await _resolve_compute_limit_pause(
         segment=segment,
-        org_id_by_subject={},
         compute_limits_by_org={},
         spend_cache={},
         now=NOW,
@@ -189,13 +205,12 @@ async def test_resolve_skips_observe_mode(
 ) -> None:
     patch_global_session_factory(test_engine, monkeypatch)
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_OBSERVE)
-    _org, subject_id, user_id = await _seed_org_with_usage(
+    org_id, subject_id, user_id = await _seed_org_with_usage(
         db_session, make_limits=lambda uid: [_compute_limit(uid, 60.0)], used_seconds=3600.0
     )
-    segment = SimpleNamespace(billing_subject_id=subject_id, user_id=user_id)
+    segment = SimpleNamespace(organization_id=org_id, user_id=user_id)
     decision = await _resolve_compute_limit_pause(
         segment=segment,
-        org_id_by_subject={},
         compute_limits_by_org={},
         spend_cache={},
         now=NOW,
@@ -209,19 +224,18 @@ async def test_resolve_skips_personal_subject(
     test_engine: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A subject with no organization (personal) never binds an org limit."""
+    """A segment with no organization (org-less owner) never binds an org limit."""
     patch_global_session_factory(test_engine, monkeypatch)
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
-    from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
-
     user_id = await _create_user(db_session)
     subject = await ensure_personal_billing_subject(db_session, user_id)
-    db_session.add(_segment(subject_id=subject.id, user_id=user_id, seconds=3600.0))
+    db_session.add(
+        _segment(subject_id=subject.id, user_id=user_id, seconds=3600.0, organization_id=None)
+    )
     await db_session.commit()
-    segment = SimpleNamespace(billing_subject_id=subject.id, user_id=user_id)
+    segment = SimpleNamespace(organization_id=None, user_id=user_id)
     decision = await _resolve_compute_limit_pause(
         segment=segment,
-        org_id_by_subject={},
         compute_limits_by_org={},
         spend_cache={},
         now=NOW,

--- a/specs/tbd/consumption-ui-v1.md
+++ b/specs/tbd/consumption-ui-v1.md
@@ -13,8 +13,10 @@ over time, per user, or set caps. This spec adds that without touching the engin
 Two fully distinct meters. Keep them distinct.
 
 **Compute (seconds).** E2B webhooks open/close `usage_segment` rows
-(`server/proliferate/db/models/billing.py:329-351`: `user_id`, `billing_subject_id`,
-`sandbox_id`, `started_at`, `ended_at`, `is_billable`). A 15-min accounting pass drains
+(`server/proliferate/db/models/billing.py`: `user_id`, `billing_subject_id`, `organization_id`,
+`sandbox_id`, `started_at`, `ended_at`, `is_billable`). `billing_subject_id` is who pays (the
+owner's personal subject); `organization_id` is the enforcement/attribution scope (§4.2). A
+15-min accounting pass drains
 `billing_grant.remaining_seconds`; overage exports to a Stripe meter. Enforcement that is LIVE:
 the reconciler (`server/proliferate/server/billing/reconciler.py:271-365`) pauses open segments
 when `active_spend_hold`. **`authorize_sandbox_start` in
@@ -167,21 +169,33 @@ one import interval; that matches compute's 15-min reconciler lag and is accepta
 
 ### 4.2 Compute — via the live reconciler
 
-In `_enforce_or_reconcile_segment` (`reconciler.py:271-365`), alongside the existing
+In `_enforce_or_reconcile_segment` (`reconciler.py`), alongside the existing
 `active_spend_hold` check: load the org's enabled compute limits once per pass, compute window
 usage for the segment's `user_id` (and org-wide), and pause when over cap, closing the segment
 with the existing `USAGE_SEGMENT_CLOSED_BY_QUOTA_ENFORCEMENT` and recording a
 `BillingDecisionEvent` with a new decision type `user_limit_pause` (or `org_limit_pause`).
 Only when `CLOUD_BILLING_MODE=enforce`, same as today's behavior.
 
-### 4.3 Compute start-side (best effort)
+**Attribution (fixed — the org-subject segment attribution gap).** `usage_segment` carries an
+`organization_id` column (owner's current membership, or `None` for an org-less owner), stamped
+at segment-open time (`billing_runtime_usage.resolve_organization_id_for_user`). Enforcement
+resolves the org directly from `segment.organization_id` and sums window usage by
+`organization_id` (`billing.compute_usage_seconds_in_window_for_org`) — so org usage aggregates
+across every member regardless of who each segment is invoiced to. This is deliberately separate
+from `billing_subject_id`, which stays the workspace owner's **personal** subject: who pays is
+unchanged (org-owned workspaces are NOT invoiced to the org). Before this fix, segments were
+attributed only to the personal subject and the enforcement path resolved `organization_id=None`,
+so admin-configured compute caps saved in the UI and silently never fired.
 
-`authorize_sandbox_start` is orphaned. During implementation, grep for the real cloud-sandbox
-start/resume chokepoint (start from `server/proliferate/server/cloud/cloud_sandboxes/service.py`
-and whatever the managed-sandbox stack calls before provisioning/resume). If there is a natural
-seam, add the limit check there (blocked → the same structured error the UI can surface). If no
-clean seam exists, ship reconciler-only enforcement and record the gap at the top of
-`budget_limits.py` as a TODO comment — do NOT invent a new call chain for this.
+### 4.3 Compute start-side (live)
+
+`authorize_sandbox_start` stays orphaned (dead since #823 — do not wire it up). The live
+start/resume gate is `authorization.assert_cloud_sandbox_resume_allowed`, called first in
+`connect_ready_sandbox`. It blocks a wake on an active spend hold or an over-cap compute budget,
+raising a structured 402 (`CloudSandboxResumeBlockedError`) the UI can surface. It resolves the
+owner's org via membership and sums usage by `organization_id`
+(`compute_usage_seconds_in_window_for_org`), mirroring the reconciler's
+`_resolve_compute_limit_pause`.
 
 ## 5. SDK
 


### PR DESCRIPTION
## The bug

Org-level and per-user COMPUTE budget limits set in the Usage & Limits UI never fire. An admin saves a compute cap, it persists, and it silently does nothing. (LLM caps work — they are correctly org-attributed via the LiteLLM spend import.)

Root cause: compute usage segments (`usage_segment`, opened/closed by E2B webhooks and the 15-min reconciler) were attributed only to the workspace owner's PERSONAL billing subject. Both enforcement sites read the org from that subject, got `organization_id=None` (personal subjects are org-less by DB constraint), and bailed before evaluating any org or per-user cap:

- reconciler `_resolve_compute_limit_pause` resolved org via the segment's billing subject
- resume gate `assert_cloud_sandbox_resume_allowed` summed usage against the org billing subject, which had zero segments

This is the "org-subject segment attribution gap" left over from the consumption/billing arc (#1018-#1021).

## The fix

Add `organization_id` to `usage_segment`, stamped at open time from the owner's current membership (or `None` for an org-less owner). Enforcement now keys off that column:

- reconciler resolves the org directly from `segment.organization_id`
- both the reconciler and the resume gate sum window usage with a new `compute_usage_seconds_in_window_for_org(organization_id, user_id=None, ...)`, so org usage aggregates across every member regardless of which subject each segment is invoiced to
- per-user caps filter that sum by `user_id`; org-wide caps sum the whole org

## Deliberately unchanged: who pays

`billing_subject_id` stays the workspace owner's personal subject. Invoicing, grant consumption, and overage export are untouched. `organization_id` is an enforcement/attribution scope only.

**Open question (who pays for org compute).** The LLM track bills an org member's usage to the org's billing subject, and every compute reader (enforcement + the org usage-by-user display) was written assuming org-subject-attributed segments — which suggests the original intent may have been for org-owned workspaces to bill the org. The spec does not state this explicitly, so I did NOT move invoicing to the org. If the intended behavior is that org compute bills the org, that is a follow-up (change `billing_subject_id` to the org subject) and needs an explicit ruling, because it changes which Stripe customer and which grants are drawn down.

**Related, out of scope.** The org admin usage-by-user display (`organizations/usage/service.py`) still queries compute by the org billing subject, so it shows zero org compute for the same root reason. This PR fixes enforcement only. Repointing display at `organization_id` is a small follow-up (no invoicing implications).

## Migration

Adds nullable `usage_segment.organization_id` + index (revision `d10c0a11e5ef`, forward-only). This branch owns its dev profile for its lifetime. No backfill: existing rows stay NULL and enforcement reads current-window usage going forward, so pre-existing segments do not need re-attribution pre-release.

## Test coverage

- New `test_billing_compute_attribution.py` drives the real segment-open path (`open_usage_segment_for_sandbox`) and asserts: the segment is stamped with the owner's org and still billed to the personal subject; an org-wide cap crossed by real usage denies resume (402); a per-user cap the same; an org-wide cap sums across two members each billed to their own subject; under-cap allows resume; an org-less owner is never enforced against any org cap.
- Updated `test_billing_limit_enforcement_compute.py` reconciler-decision tests to the new attribution model.

`cd server && uv run pytest -q` — targeted billing/usage suites green (enforcement, attribution, usage aggregates, usage API, org usage API); full-suite run in progress, will confirm before marking ready.