### PR TITLE
fix: gate org invitations list to admins

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -51,3 +51,4 @@ anyharness/crates/anyharness-lib/src/api/router.rs 610 AnyHarness router (+goals
 anyharness/crates/anyharness-lib/src/app/mod.rs 608 AnyHarness app wiring (+goal/loop/activity/feed services)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 861 loops runtime — native write path + emulated Codex scheduler
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 739 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
+server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/server/proliferate/server/organizations/api.py
+++ b/server/proliferate/server/organizations/api.py
@@ -173,10 +173,10 @@ async def remove_organization_membership_endpoint(
 
 @router.get("/{organization_id}/invitations", response_model=OrganizationInvitationsResponse)
 async def list_organization_invitations_endpoint(
-    org_user: CurrentOrgUser = Depends(current_path_org_member),
+    org_admin: CurrentOrgUser = Depends(current_path_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> OrganizationInvitationsResponse:
-    invitations = await list_invitations(db, org_user)
+    invitations = await list_invitations(db, org_admin)
     return OrganizationInvitationsResponse(
         invitations=[invitation_response(invitation) for invitation in invitations],
     )

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -465,6 +465,7 @@ async def list_invitations(
     db: AsyncSession,
     org_user: CurrentOrgUser,
 ) -> list[InvitationRecord]:
+    _require_current_org_role(org_user, organization_admin_roles())
     return await invitation_store.list_organization_invitations(db, org_user.organization_id)
 
 

--- a/server/tests/integration/test_organizations_api.py
+++ b/server/tests/integration/test_organizations_api.py
@@ -560,6 +560,45 @@ async def test_invitation_accept_adds_membership_when_user_already_has_team(
 
 
 @pytest.mark.asyncio
+async def test_list_invitations_requires_admin_role(
+    client: AsyncClient,
+) -> None:
+    owner = await _create_user_and_get_tokens(client, email="owner-invites@acme.dev")
+    member = await _create_user_and_get_tokens(client, email="member-invites@acme.dev")
+
+    await _create_organization_for_user(user_id=owner["user_id"])
+    organization_id = (await _default_organization(client, owner))["id"]
+
+    response = await client.post(
+        f"/v1/organizations/{organization_id}/invitations",
+        headers=_headers(owner),
+        json={"email": "member-invites@acme.dev", "role": "member"},
+    )
+    assert response.status_code == 201
+
+    response = await client.post(
+        "/v1/organizations/invitations/accept",
+        headers=_headers(member),
+        json={"organizationId": organization_id},
+    )
+    assert response.status_code == 200
+
+    response = await client.get(
+        f"/v1/organizations/{organization_id}/invitations",
+        headers=_headers(member),
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "organization_permission_denied"
+
+    response = await client.get(
+        f"/v1/organizations/{organization_id}/invitations",
+        headers=_headers(owner),
+    )
+    assert response.status_code == 200
+    assert response.json()["invitations"][0]["email"] == "member-invites@acme.dev"
+
+
+@pytest.mark.asyncio
 async def test_invitation_accept_requires_matching_authenticated_email(
     client: AsyncClient,
 ) -> None:

--- a/specs/codebase/features/organization-invitations.md
+++ b/specs/codebase/features/organization-invitations.md
@@ -72,6 +72,16 @@ explicit accept-invitation action for the matching pending invitation. If the
 Desktop user is signed out, Desktop starts the normal sign-in path and preserves
 the join target so the same explicit accept flow resumes after authentication.
 
+## Permissions
+
+All server-side invitation management endpoints — create, resend, revoke, and
+list (`GET /organizations/{organization_id}/invitations`) — require the caller
+to hold the `admin` or `owner` role on the target organization
+(`current_path_org_admin`). Plain members can see the organization's active
+memberships (`/members`) but not pending invitation emails or roles. This
+mirrors the Desktop UI, which treats the whole `organization-members` section
+as admin-only (see `settings-admin-ia.md`).
+
 ## Admin UX
 
 Organization settings is split into:


### PR DESCRIPTION
## What was wrong

GET /organizations/{id}/invitations was gated with `current_path_org_member`
while every other invitation endpoint on this router (create/resend/revoke,
join-link) uses `current_path_org_admin`. Any org member could hit it and
see pending invite emails and roles, not just active/admin org members.

## Fix

- Switch the route to `current_path_org_admin`.
- Add the same `_require_current_org_role(... organization_admin_roles())`
  defense-in-depth check inside `list_invitations` in service.py, matching
  the pattern already used by `create_invitation`/`resend_invitation`/
  `revoke_invitation`/`update_membership`.
- Noted the permission model explicitly in
  specs/codebase/features/organization-invitations.md (it was only implied
  before).

## Frontend check

Desktop only calls this endpoint from `OrganizationMembersPane`, and the
`organization-members` settings section is already marked `adminOnly: true`
in the sidebar nav config, with the UI-iteration bypass flag
(`TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION`) set to `false`. So a
plain member can't reach this page through normal navigation today. Nothing
to change there; this closes the gap on the server side.

## Tests

Added `test_list_invitations_requires_admin_role` to
server/tests/integration/test_organizations_api.py: member gets 403
(`organization_permission_denied`), owner still gets 200. Bumped
scripts/max_lines_allowlist.txt for the file (600 -> 624 lines).

Full server suite passes locally (`cd server && uv run pytest -q`).