### PR TITLE
tests(intent): T2-WS-2 + T2-INT-1 — Add-Repo entry seam + integrations product-readiness gate

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -43,6 +43,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Local workspace create | 3 | — |
 | Worktree workspace create — locally AND inside a cloud sandbox | 3 | — |
 | Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
+| Add-Repo flow entry: local/cloud branches render + desktop-web fallback limits (no native picker outside Tauri) | 2 | tests/intent/specs/workspace-entry.spec.ts |
 | New user cold path: GitHub App authorization triggers first-ever sandbox provisioned from zero, within time budget | 3 | — |
 | Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | — |
 | Cloud workspace pause/resume/connect on real E2B | 3 | — |
@@ -74,7 +75,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Connect integration (real api_key definition, placeholder key, no outbound), toggle on/off | 2 | — |
+| Connect integration (real api_key definition, placeholder key, no outbound), toggle on/off | 2 | tests/intent/specs/integrations.spec.ts |
 | Authenticate a real integration; **every cataloged harness** uses it through the gateway — local lane AND sandbox lane | 3 | — |
 
 ## Workflows — PARKED (surface being reworked; tests land with the rework PRs)

--- a/tests/intent/specs/integrations.spec.ts
+++ b/tests/intent/specs/integrations.spec.ts
@@ -1,0 +1,117 @@
+// T2-INT-1 (specs/developing/testing/scenarios.md): api_key connect + org
+// policy toggle.
+//
+// Scenario, per the 2026-07-08 ruling baked into scenarios.md: "no
+// stub/fake integration provider — same posture as no-fake-sandbox/no-mock-
+// LLM. Use a real cataloged api_key-kind integration definition; the stored
+// key is a placeholder value (connect/CRUD paths never validate it against
+// the provider)." Steps: connect via `POST /integrations/authentications`
+// (authKind api_key) → account created; org admin toggles
+// `PATCH /integrations/admin/organizations/{id}/definitions/{id}/enabled`
+// off; assert `effective_enabled` composition (org policy override >
+// definition default, AND account enabled), off then on again.
+//
+// SAME SURVEY CORRECTION as secrets.spec.ts / cloud-workspace.spec.ts, and it
+// hits harder here: every route this scenario needs — including the org-
+// admin policy endpoint — sits behind `current_product_user`
+// (auth/dependencies.py), which unconditionally requires a real GitHub OAuth
+// identity + ready provider grant, no single-org-mode carve-out. Unlike
+// secrets/workspaces, this isn't even scope-limited to "cloud" surfaces in
+// spirit — org-admin definition management (list/create/enable) has no
+// intrinsic reason to need the ACTOR's own GitHub link at all (it's an
+// org-level policy toggle, not a per-user cloud resource) — but the code
+// gates it exactly the same as the user-facing connect endpoint. Verified
+// directly: a password-only owner account (owner and admin are the same
+// role in single-org mode) gets 403 `github_link_required` on the catalog
+// read, the connect call, AND the admin enable/disable toggle, before any of
+// this scenario's business logic (account creation, effective_enabled
+// composition, negatives) is ever reached.
+//
+// The connect target is real, not fabricated: `context7` is a genuine
+// `api_key`-kind entry in SEED_DEFINITIONS
+// (server/proliferate/server/cloud/integrations/seeds.py), upserted into
+// `cloud_integration_definition` on every server boot by
+// `sync_seed_definitions` (server/proliferate/main.py). This spec resolves
+// its id with one direct-DB read (same class of seed-via-product-data as
+// secrets.spec.ts/cloud-workspace.spec.ts's own direct reads) specifically to
+// prove the 403 fires even against a definition that indisputably exists —
+// not a 404 masquerading as the gate.
+//
+// Per this wave's explicit instruction not to fake GitHub auth, this spec
+// pins the AS-BUILT gate instead of the deeper connect/toggle assertions,
+// which stay unverified pending either a product decision (should org-admin
+// policy management at least be exempted, the way `current_organization_actor`
+// already exempts single-org org/invitation endpoints?) or a real GitHub App
+// test fixture.
+
+import { expect, test } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  ensureInstanceClaimed,
+  getOwnOrganization,
+  passwordLogin,
+} from "../stack/seed.ts";
+import {
+  authenticateApiKeyIntegration,
+  getIntegrationCatalog,
+  getSeedIntegrationDefinitionId,
+  listAdminIntegrationDefinitions,
+  setAdminIntegrationEnabled,
+} from "../stack/seed-integrations.ts";
+
+test.describe.configure({ mode: "serial" });
+
+let ownerToken: string;
+let organizationId: string;
+let context7DefinitionId: string;
+
+test.beforeAll(async () => {
+  await ensureInstanceClaimed();
+  ownerToken = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+  organizationId = (await getOwnOrganization(ownerToken)).id;
+  // Direct-DB, not the API: proves the definition genuinely exists
+  // (source='seed', a real cataloged connector) independent of the gate this
+  // spec is about to demonstrate blocks reading it back through the API.
+  context7DefinitionId = await getSeedIntegrationDefinitionId("context7");
+});
+
+function expectGitHubLinkRequired(result: { status: number; body: unknown }): void {
+  expect(result.status).toBe(403);
+  const detail = (result.body as { detail?: { code?: string } }).detail;
+  expect(detail?.code).toBe("github_link_required");
+}
+
+test.describe("T2-INT-1: api_key connect + org policy toggle — blocked at the product-readiness gate before reaching integrations logic", () => {
+  test("documents GAP: the integration catalog is unreachable for a password-only account, even though context7 (a real api_key definition) exists in it", async () => {
+    expectGitHubLinkRequired(await getIntegrationCatalog(ownerToken));
+  });
+
+  test("documents GAP: connecting an api_key integration 403s before the connect logic runs, against a real seeded definition id", async () => {
+    expectGitHubLinkRequired(
+      await authenticateApiKeyIntegration(ownerToken, context7DefinitionId, "placeholder-api-key-value"),
+    );
+  });
+
+  test("documents GAP: the org-admin policy surface (list + enable/disable toggle) hits the same account-level gate — it is not org-role-scoped, so the owner/admin cannot manage a real definition's policy either", async () => {
+    expectGitHubLinkRequired(await listAdminIntegrationDefinitions(ownerToken, organizationId));
+    expectGitHubLinkRequired(
+      await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, false),
+    );
+  });
+});
+
+// NOT COVERED by this wave, named so the gap is loud rather than silent:
+// - IntegrationAccountResponse shape on a successful connect (accountId,
+//   status, enabled=true) for an api_key definition;
+// - effective_enabled composition across all three layers (org policy
+//   override > definition default, AND account enabled) — the toggle
+//   off-then-on round trip the scenario names;
+// - the OAuth-kind seam-only assertion (flow row created, authorizationUrl
+//   returned, no real provider round-trip) — also unreachable via this gate,
+//   same as the api_key path;
+// - IntegrationHealthResponse reflecting the toggled state.
+// All of the above require getting a test account past current_product_user's
+// GitHub-readiness gate, which this wave does not fake. Re-scope once Pablo
+// rules on the GAP above (see also secrets.spec.ts / cloud-workspace.spec.ts,
+// which hit the identical gate on the cloud secrets/workspaces surfaces).

--- a/tests/intent/specs/integrations.spec.ts
+++ b/tests/intent/specs/integrations.spec.ts
@@ -11,21 +11,14 @@
 // off; assert `effective_enabled` composition (org policy override >
 // definition default, AND account enabled), off then on again.
 //
-// SAME SURVEY CORRECTION as secrets.spec.ts / cloud-workspace.spec.ts, and it
-// hits harder here: every route this scenario needs — including the org-
-// admin policy endpoint — sits behind `current_product_user`
-// (auth/dependencies.py), which unconditionally requires a real GitHub OAuth
-// identity + ready provider grant, no single-org-mode carve-out. Unlike
-// secrets/workspaces, this isn't even scope-limited to "cloud" surfaces in
-// spirit — org-admin definition management (list/create/enable) has no
-// intrinsic reason to need the ACTOR's own GitHub link at all (it's an
-// org-level policy toggle, not a per-user cloud resource) — but the code
-// gates it exactly the same as the user-facing connect endpoint. Verified
-// directly: a password-only owner account (owner and admin are the same
-// role in single-org mode) gets 403 `github_link_required` on the catalog
-// read, the connect call, AND the admin enable/disable toggle, before any of
-// this scenario's business logic (account creation, effective_enabled
-// composition, negatives) is ever reached.
+// UPDATE 2026-07-09: PR #1023 ("extend single-org bypass to
+// current_product_user"), merged to main, extends the exact same single-org
+// bypass `current_organization_actor` already had to `current_product_user`
+// itself — which every route in this file (auth/dependencies.py) depends on.
+// The 403 `github_link_required` this file used to pin (a password-only
+// owner account couldn't even read the integration catalog) no longer fires
+// in single-org mode, so this spec now exercises the real T2-INT-1 flow
+// instead of documenting the gate.
 //
 // The connect target is real, not fabricated: `context7` is a genuine
 // `api_key`-kind entry in SEED_DEFINITIONS
@@ -33,25 +26,17 @@
 // `cloud_integration_definition` on every server boot by
 // `sync_seed_definitions` (server/proliferate/main.py). This spec resolves
 // its id with one direct-DB read (same class of seed-via-product-data as
-// secrets.spec.ts/cloud-workspace.spec.ts's own direct reads) specifically to
-// prove the 403 fires even against a definition that indisputably exists —
-// not a 404 masquerading as the gate.
+// secrets.spec.ts/cloud-workspace.spec.ts's own direct reads) — there is
+// still no API to list seed definitions by namespace directly, only the
+// full catalog.
 //
-// Per this wave's explicit instruction not to fake GitHub auth, this spec
-// pins the AS-BUILT gate instead of the deeper connect/toggle assertions,
-// which stay unverified pending either a product decision (should org-admin
-// policy management at least be exempted, the way `current_organization_actor`
-// already exempts single-org org/invitation endpoints?) or a real GitHub App
-// test fixture.
-//
-// UPDATE: PR #1023 ("extend single-org bypass to current_product_user"),
-// merged to main 2026-07-09, answers the question above directly — it adds
-// the exact same single-org bypass to `current_product_user` itself, which
-// this file's admin-router calls also depend on. Once this branch's stack
-// (tests/intent-wave2) rebases past it, every GAP test in this file should
-// flip to real connect/toggle assertions rather than 403s. Not rebasing this
-// PR onto that fix myself — that is the wave's merge-train's job, not a
-// single stacked PR's.
+// authenticate_integration (service.py) never checks org policy before
+// creating an account — the policy toggle governs whether the org exposes
+// the definition (effective_enabled, surfaced to admins/health), not whether
+// an already-connected account can authenticate. That composition —
+// definition.enabled_by_default (true for every seed, seeds.py) overridden
+// by an org's policy row when one exists (db/store/integrations/policies.py)
+// — is exactly what this spec's toggle round trip asserts.
 
 import { expect, test } from "@playwright/test";
 import {
@@ -79,48 +64,86 @@ test.beforeAll(async () => {
   await ensureInstanceClaimed();
   ownerToken = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
   organizationId = (await getOwnOrganization(ownerToken)).id;
-  // Direct-DB, not the API: proves the definition genuinely exists
-  // (source='seed', a real cataloged connector) independent of the gate this
-  // spec is about to demonstrate blocks reading it back through the API.
+  // Direct-DB, not the API: there is still no catalog-by-namespace lookup,
+  // only the full list. This proves the definition genuinely exists
+  // (source='seed', a real cataloged connector) independent of the catalog
+  // read the next test performs.
   context7DefinitionId = await getSeedIntegrationDefinitionId("context7");
 });
 
-function expectGitHubLinkRequired(result: { status: number; body: unknown }): void {
-  expect(result.status).toBe(403);
-  const detail = (result.body as { detail?: { code?: string } }).detail;
-  expect(detail?.code).toBe("github_link_required");
-}
-
-test.describe("T2-INT-1: api_key connect + org policy toggle — blocked at the product-readiness gate before reaching integrations logic", () => {
-  test("documents GAP: the integration catalog is unreachable for a password-only account, even though context7 (a real api_key definition) exists in it", async () => {
-    expectGitHubLinkRequired(await getIntegrationCatalog(ownerToken));
+test.describe("T2-INT-1: api_key connect + org policy toggle", () => {
+  test("catalog is reachable and lists the real context7 api_key definition with its connect schema", async () => {
+    const result = await getIntegrationCatalog(ownerToken);
+    expect(result.status).toBe(200);
+    const context7 = result.body.items.find((item) => item.definitionId === context7DefinitionId);
+    expect(context7).toBeDefined();
+    expect(context7?.namespace).toBe("context7");
+    expect(context7?.authKind).toBe("api_key");
   });
 
-  test("documents GAP: connecting an api_key integration 403s before the connect logic runs, against a real seeded definition id", async () => {
-    expectGitHubLinkRequired(
-      await authenticateApiKeyIntegration(ownerToken, context7DefinitionId, "placeholder-api-key-value"),
+  test("connects context7 with a placeholder api_key: account created, ready, enabled — no outbound provider call", async () => {
+    const result = await authenticateApiKeyIntegration(
+      ownerToken,
+      context7DefinitionId,
+      "placeholder-api-key-value",
     );
+    expect(result.status).toBe(200);
+    expect(result.body.account.definitionId).toBe(context7DefinitionId);
+    expect(result.body.account.namespace).toBe("context7");
+    expect(result.body.account.authKind).toBe("api_key");
+    expect(result.body.account.status).toBe("ready");
+    expect(result.body.account.enabled).toBe(true);
+    // api_key connect never starts an OAuth flow.
+    expect(result.body.oauthFlowId).toBeNull();
+    expect(result.body.authorizationUrl).toBeNull();
   });
 
-  test("documents GAP: the org-admin policy surface (list + enable/disable toggle) hits the same account-level gate — it is not org-role-scoped, so the owner/admin cannot manage a real definition's policy either", async () => {
-    expectGitHubLinkRequired(await listAdminIntegrationDefinitions(ownerToken, organizationId));
-    expectGitHubLinkRequired(
-      await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, false),
-    );
+  test("org admin toggles the definition off: effective_enabled composes the policy override over the seed default", async () => {
+    // Starting state is true either way: with no policy row yet,
+    // effective_enabled falls back to the definition's own
+    // enabled_by_default (true for every seed definition); if a prior run on
+    // this profile DB already created a policy row, this spec's own
+    // toggle-back-on step below always leaves it enabled=true. Either way,
+    // policyEnabled is either null or true here — never false — going in.
+    const before = await listAdminIntegrationDefinitions(ownerToken, organizationId);
+    expect(before.status).toBe(200);
+    const context7Before = before.body.find((item) => item.definitionId === context7DefinitionId);
+    expect(context7Before?.policyEnabled).not.toBe(false);
+    expect(context7Before?.effectiveEnabled).toBe(true);
+
+    const off = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, false);
+    expect(off.status).toBe(200);
+    expect(off.body.policyEnabled).toBe(false);
+    expect(off.body.effectiveEnabled).toBe(false);
+
+    // Persisted, not just echoed back on the toggle call itself.
+    const after = await listAdminIntegrationDefinitions(ownerToken, organizationId);
+    const context7After = after.body.find((item) => item.definitionId === context7DefinitionId);
+    expect(context7After?.policyEnabled).toBe(false);
+    expect(context7After?.effectiveEnabled).toBe(false);
+  });
+
+  test("org admin toggles the definition back on: effective_enabled true again", async () => {
+    const on = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, true);
+    expect(on.status).toBe(200);
+    expect(on.body.policyEnabled).toBe(true);
+    expect(on.body.effectiveEnabled).toBe(true);
+
+    const after = await listAdminIntegrationDefinitions(ownerToken, organizationId);
+    const context7After = after.body.find((item) => item.definitionId === context7DefinitionId);
+    expect(context7After?.policyEnabled).toBe(true);
+    expect(context7After?.effectiveEnabled).toBe(true);
   });
 });
 
 // NOT COVERED by this wave, named so the gap is loud rather than silent:
-// - IntegrationAccountResponse shape on a successful connect (accountId,
-//   status, enabled=true) for an api_key definition;
-// - effective_enabled composition across all three layers (org policy
-//   override > definition default, AND account enabled) — the toggle
-//   off-then-on round trip the scenario names;
-// - the OAuth-kind seam-only assertion (flow row created, authorizationUrl
-//   returned, no real provider round-trip) — also unreachable via this gate,
-//   same as the api_key path;
-// - IntegrationHealthResponse reflecting the toggled state.
-// All of the above require getting a test account past current_product_user's
-// GitHub-readiness gate, which this wave does not fake. Re-scope once Pablo
-// rules on the GAP above (see also secrets.spec.ts / cloud-workspace.spec.ts,
-// which hit the identical gate on the cloud secrets/workspaces surfaces).
+// - The OAuth-kind connect path (flow row created, authorizationUrl
+//   returned, no real provider round-trip) — context7 is api_key-kind;
+//   asserting the oauth2 branch needs a different seed definition (e.g.
+//   `exa` is also api_key, so this suite would need to pick an actual
+//   oauth2-kind seed to cover that branch, or an org-custom definition).
+// - IntegrationHealthResponse reflecting the toggled state (health.py) —
+//   this spec only asserts the admin-definition-list composition, not the
+//   health surface a connected account also feeds.
+// - Removing an account (`DELETE /integrations/accounts/{id}`) and
+//   re-connecting.

--- a/tests/intent/specs/integrations.spec.ts
+++ b/tests/intent/specs/integrations.spec.ts
@@ -43,6 +43,15 @@
 // policy management at least be exempted, the way `current_organization_actor`
 // already exempts single-org org/invitation endpoints?) or a real GitHub App
 // test fixture.
+//
+// UPDATE: PR #1023 ("extend single-org bypass to current_product_user"),
+// merged to main 2026-07-09, answers the question above directly — it adds
+// the exact same single-org bypass to `current_product_user` itself, which
+// this file's admin-router calls also depend on. Once this branch's stack
+// (tests/intent-wave2) rebases past it, every GAP test in this file should
+// flip to real connect/toggle assertions rather than 403s. Not rebasing this
+// PR onto that fix myself — that is the wave's merge-train's job, not a
+// single stacked PR's.
 
 import { expect, test } from "@playwright/test";
 import {

--- a/tests/intent/specs/workspace-entry.spec.ts
+++ b/tests/intent/specs/workspace-entry.spec.ts
@@ -164,5 +164,13 @@ test.describe("T2-WS-2: local + worktree create (desktop-web limits apply)", () 
 //   surface with the same "no web equivalent" property).
 // - The cloud branch's happy path past the GitHub App blocker (repo search,
 //   validate, save) — blocked by the same product-readiness gate
-//   T2-WS-1/T2-SEC-1 already pin; re-scope alongside those once Pablo rules
-//   on the GAP.
+//   T2-WS-1/T2-SEC-1 already pin; PR #1023 (merged to main 2026-07-09) fixes
+//   that gate at the source (current_product_user), so this should become
+//   testable once tests/intent-wave2 rebases past it.
+//
+// Product finding filed while building this: the local-option no-op above
+// has zero user feedback (no toast, no message) — a desktop-web user
+// clicking "Add a local repo" sees nothing happen and no explanation that
+// this needs the native app. Filed as
+// https://github.com/proliferate-ai/proliferate/issues/1035; not fixing
+// here, this PR is test-only.

--- a/tests/intent/specs/workspace-entry.spec.ts
+++ b/tests/intent/specs/workspace-entry.spec.ts
@@ -93,12 +93,14 @@ async function expectEntryStepVisible(page: Page): Promise<void> {
 test.beforeEach(async ({ page }) => {
   await ensureInstanceClaimed();
   await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
-  // "Show sidebar" (collapsed default) or the sidebar's own always-visible
-  // "Add repository" action (already expanded) — either is the render proof
-  // that the authenticated app shell, not the login form, owns the page.
-  await expect(
-    page.getByRole("button", { name: "Show sidebar" }).or(page.getByRole("button", { name: "Add repository" })),
-  ).toBeVisible({ timeout: 30_000 });
+  // Same app-shell render proof auth.spec.ts's expectSignedInAppShell uses:
+  // past the auth gate, the login form is gone. Deliberately NOT asserting
+  // on "Add repository" here — its containing sidebar panel collapses to
+  // zero width by default (see ensureSidebarOpen below) rather than
+  // unmounting, so the button stays `visible` by Playwright's CSS-only
+  // definition even while functionally unreachable; it is not a reliable
+  // "the shell is up" signal on its own.
+  await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
 });
 
 test.describe("T2-WS-2: local + worktree create (desktop-web limits apply)", () => {

--- a/tests/intent/specs/workspace-entry.spec.ts
+++ b/tests/intent/specs/workspace-entry.spec.ts
@@ -1,0 +1,145 @@
+// T2-WS-2 (specs/developing/testing/scenarios.md): local + worktree create
+// (desktop-web limits apply).
+//
+// Scenario text: "Local/worktree creation drive the local AnyHarness runtime
+// and OS file pickers — partially Tauri-bound. Tier 2 asserts only what web
+// mode can reach: the Add-Repo flow branches (add-repo-flow-store.ts) render
+// and validate inputs. Full local/worktree creation is asserted in tier 3's
+// desktop lane."
+//
+// SPEC DIVERGENCE, flagged for the record: the scenario's title and body
+// both name "worktree create" as in-scope for the Add-Repo flow, but as
+// built the Add-Repo flow (add-repo-flow-store.ts's AddRepoFlowStoreStep,
+// AddRepoFlow.tsx's ENTRY_OPTIONS) has exactly two branches — "cloud" and
+// "local" (split into copy-only variants "link-local"/"add-local") — there
+// is no "worktree" option anywhere in this flow. Worktree creation is a
+// wholly separate action: the sidebar's per-repo "New workspace" button
+// (SidebarRepositoriesHeader / use-workspace-sidebar-actions.ts ->
+// createWorktreeWorkspace), a single click with no input form at all — name,
+// branch, and base ref are all auto-generated
+// (resolveWorktreeCreationParams, workspace-creation.ts) unless the caller
+// passes overrides, which the sidebar entry point never does. There is
+// nothing to "render and validate inputs" on for worktree creation even in
+// principle: the UI surface is one button, not a form.
+//
+// Beyond the Tauri file-picker gap this scenario names, worktree (and local)
+// creation also unconditionally drives the local AnyHarness runtime
+// (ensureRuntimeReady in add-repo-workflow.ts / use-workspace-actions.ts).
+// This suite's CI profile explicitly disables that runtime
+// (TIER2_INTENT_SKIP_RUNTIME=1, stack/boot.ts — building the Rust binary
+// from scratch per-PR is too slow) — so even a seam-only assertion of
+// "clicking New workspace starts a real worktree creation call" would be
+// flaky-by-construction in CI (no runtime to answer it) while passing
+// locally, which is worse than not testing it. Resolving scenarios.md's own
+// open ruling #3 ("is seam-only coverage of local/worktree create acceptable
+// for tier 2?") the way this spec reads it: yes for the Add-Repo entry
+// surface (below), and worktree creation specifically is out of scope for
+// tier 2 entirely, deferred to tier 3's desktop lane per the scenario's own
+// fallback framing — not a thin seam, a real gap this wave names rather than
+// silently skips.
+//
+// What IS testable in desktop-web, and is tested below: the Add-Repo flow's
+// entry step renders all three options; picking either local option has no
+// native folder picker outside Tauri (pickFolder / lib/access/tauri/shell.ts
+// catches the invoke() failure and resolves null — this is the concrete
+// "desktop-web limits apply" behavior named in the scenario title), so the
+// dialog just stays put with nothing added, no crash; and picking the cloud
+// option navigates to a real render branch that (for this suite's
+// password-only account) surfaces the identical github_link_required
+// product-readiness gate T2-WS-1/T2-SEC-1 already pin at the API layer, this
+// time observed as the "Authorize GitHub App" blocker prompt in the UI.
+
+import { expect, test, type Page } from "@playwright/test";
+import { ADMIN_EMAIL, ADMIN_PASSWORD, ensureInstanceClaimed, webBaseUrl } from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+async function signInThroughUi(page: Page, email: string, password: string): Promise<void> {
+  await page.goto(webBaseUrl());
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+}
+
+async function openAddRepoFlow(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Add repository" }).click();
+}
+
+async function expectEntryStepVisible(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Add a repository" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Link a local repo" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add a cloud repo" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add a local repo" })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await ensureInstanceClaimed();
+  await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+  // Sidebar's always-visible "Add repository" action is the render proof
+  // that the authenticated app shell (not the login form) owns the page.
+  await expect(page.getByRole("button", { name: "Add repository" })).toBeVisible({ timeout: 30_000 });
+});
+
+test.describe("T2-WS-2: local + worktree create (desktop-web limits apply)", () => {
+  test("Add-Repo entry step renders all three options", async ({ page }) => {
+    await openAddRepoFlow(page);
+    await expectEntryStepVisible(page);
+  });
+
+  for (const optionLabel of ["Link a local repo", "Add a local repo"] as const) {
+    test(`desktop-web limit: picking "${optionLabel}" has no native folder picker, so it no-ops — dialog stays on the entry step, nothing added`, async ({ page }) => {
+      await openAddRepoFlow(page);
+      await expectEntryStepVisible(page);
+
+      await page.getByRole("button", { name: optionLabel }).click();
+
+      // pickFolder() (lib/access/tauri/shell.ts) calls Tauri's invoke()
+      // outside a Tauri webview, which rejects; the catch resolves null, and
+      // AddRepoFlowHost's handler returns immediately on a null path with no
+      // state change at all — no step transition, no toast, no dialog close.
+      // Give it a beat to prove that's steady state, not a race.
+      await page.waitForTimeout(500);
+      await expectEntryStepVisible(page);
+      // No success/failure toast either: the no-op happens before
+      // useAddRepo.addRepoFromPath is ever called.
+      await expect(page.getByText(/Added |Add repository is unavailable/)).toHaveCount(0);
+    });
+  }
+
+  test("cloud branch renders and reflects the account's GitHub product-readiness gate (same as T2-WS-1/T2-SEC-1)", async ({ page }) => {
+    await openAddRepoFlow(page);
+    await expectEntryStepVisible(page);
+
+    await page.getByRole("button", { name: "Add a cloud repo" }).click();
+    await expect(page.getByRole("heading", { name: "Add a cloud repo" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+
+    // useAddCloudEnvironment's GitHub App user-authorization query settles
+    // (react-query retry: 1, apps/desktop's query-client.ts) to "not
+    // connected" for this password-only account, same underlying
+    // github_link_required gate T2-WS-1/T2-SEC-1 pin directly against the
+    // API — here it's the CloudRepoPickerBlocker's rendered heading instead
+    // of a raw 403.
+    await expect(page.getByRole("heading", { name: "Authorize GitHub App" })).toBeVisible({ timeout: 30_000 });
+
+    // Back returns to the entry step cleanly.
+    await page.getByRole("button", { name: "Back" }).click();
+    await expectEntryStepVisible(page);
+  });
+});
+
+// NOT COVERED by this wave, named so the gap is loud rather than silent:
+// - Worktree creation end to end (name/branch/base-ref resolution, the
+//   actual runtime call) — not reachable from the Add-Repo flow at all (see
+//   the SPEC DIVERGENCE note above), and requires a live local AnyHarness
+//   runtime this suite's CI profile disables. Tier 3's desktop lane owns
+//   this per the scenario's own fallback framing.
+// - Local repo creation's success path (a real native folder picker
+//   selection -> addRepoFromPath -> repo registered) — Tauri-only, no web
+//   fallback exists for the OS file dialog itself, regardless of the
+//   lib/access/tauri/credentials.ts carve-out (this is a different Tauri
+//   surface with the same "no web equivalent" property).
+// - The cloud branch's happy path past the GitHub App blocker (repo search,
+//   validate, save) — blocked by the same product-readiness gate
+//   T2-WS-1/T2-SEC-1 already pin; re-scope alongside those once Pablo rules
+//   on the GAP.

--- a/tests/intent/specs/workspace-entry.spec.ts
+++ b/tests/intent/specs/workspace-entry.spec.ts
@@ -61,7 +61,25 @@ async function signInThroughUi(page: Page, email: string, password: string): Pro
   await page.getByRole("button", { name: "Sign in", exact: true }).click();
 }
 
+/**
+ * The sidebar (which owns the "Add repository" action) defaults to
+ * collapsed on a fresh profile — StandardWorkspaceShell renders a
+ * "Show sidebar" toggle in its place (`sidebarOpen` false-by-default,
+ * apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx).
+ * Expand it once per test so "Add repository" is actually reachable, not
+ * just present-but-off-screen in a collapsed panel (verified: clicking
+ * straight at "Add repository" without this first hangs forever — the
+ * button resolves via role query but the sidebar container has zero width).
+ */
+async function ensureSidebarOpen(page: Page): Promise<void> {
+  const showSidebarButton = page.getByRole("button", { name: "Show sidebar" });
+  if (await showSidebarButton.isVisible().catch(() => false)) {
+    await showSidebarButton.click();
+  }
+}
+
 async function openAddRepoFlow(page: Page): Promise<void> {
+  await ensureSidebarOpen(page);
   await page.getByRole("button", { name: "Add repository" }).click();
 }
 
@@ -75,9 +93,12 @@ async function expectEntryStepVisible(page: Page): Promise<void> {
 test.beforeEach(async ({ page }) => {
   await ensureInstanceClaimed();
   await signInThroughUi(page, ADMIN_EMAIL, ADMIN_PASSWORD);
-  // Sidebar's always-visible "Add repository" action is the render proof
-  // that the authenticated app shell (not the login form) owns the page.
-  await expect(page.getByRole("button", { name: "Add repository" })).toBeVisible({ timeout: 30_000 });
+  // "Show sidebar" (collapsed default) or the sidebar's own always-visible
+  // "Add repository" action (already expanded) — either is the render proof
+  // that the authenticated app shell, not the login form, owns the page.
+  await expect(
+    page.getByRole("button", { name: "Show sidebar" }).or(page.getByRole("button", { name: "Add repository" })),
+  ).toBeVisible({ timeout: 30_000 });
 });
 
 test.describe("T2-WS-2: local + worktree create (desktop-web limits apply)", () => {

--- a/tests/intent/stack/seed-integrations.ts
+++ b/tests/intent/stack/seed-integrations.ts
@@ -5,18 +5,18 @@
 //
 // The one direct-DB read here (resolving a seed integration definition's id)
 // is the same kind of "seed via the product's own data, no API to read it
-// back" case `backdateInvitationExpiry` already established in seed.ts: every
-// `/v1/integrations/*` route — catalog included — requires
-// `current_product_user` (see integrations.spec.ts's header), so a
-// password-only test account cannot even list the catalog to discover a
-// definition id. `sync_seed_definitions` (server/proliferate/main.py) upserts
-// every entry in `SEED_DEFINITIONS`
+// back" case `backdateInvitationExpiry` already established in seed.ts:
+// there is still no catalog-by-namespace lookup, only the full
+// `GET /integrations/catalog` list, so resolving one real definition's id
+// directly against `cloud_integration_definition` is the more direct way to
+// bootstrap the fixture. `sync_seed_definitions` (server/proliferate/main.py)
+// upserts every entry in `SEED_DEFINITIONS`
 // (server/proliferate/server/cloud/integrations/seeds.py) into
 // `cloud_integration_definition` on every server boot, so reading the row
 // directly is reading real seeded product data, not fabricating a stub.
 
 import { Client } from "pg";
-import { apiBaseUrl, apiRequest, databaseUrl, toPostgresDriverUrl } from "./seed.ts";
+import { apiRequest, databaseUrl, toPostgresDriverUrl } from "./seed.ts";
 
 interface ApiResult<T> {
   status: number;
@@ -125,11 +125,4 @@ export async function listAdminIntegrationDefinitions(
     `/v1/cloud/integrations/admin/organizations/${organizationId}/definitions`,
     { token },
   );
-}
-
-/** Sanity probe used only to document the gate: confirms the API is up and
- * the path resolves (vs. a 404 that would make the 403 assertion vacuous). */
-export async function probeIntegrationsAlive(): Promise<boolean> {
-  const response = await fetch(`${apiBaseUrl()}/health`);
-  return response.ok;
 }

--- a/tests/intent/stack/seed-integrations.ts
+++ b/tests/intent/stack/seed-integrations.ts
@@ -1,0 +1,135 @@
+// Integrations seeding + API helpers (T2-INT-1). Split from seed.ts (already
+// near this repo's 600-line file-size convention, scripts/check_max_lines.py)
+// rather than growing it further — same spirit as the shared `apiRequest`
+// primitive, just a dedicated home for the integrations surface.
+//
+// The one direct-DB read here (resolving a seed integration definition's id)
+// is the same kind of "seed via the product's own data, no API to read it
+// back" case `backdateInvitationExpiry` already established in seed.ts: every
+// `/v1/integrations/*` route — catalog included — requires
+// `current_product_user` (see integrations.spec.ts's header), so a
+// password-only test account cannot even list the catalog to discover a
+// definition id. `sync_seed_definitions` (server/proliferate/main.py) upserts
+// every entry in `SEED_DEFINITIONS`
+// (server/proliferate/server/cloud/integrations/seeds.py) into
+// `cloud_integration_definition` on every server boot, so reading the row
+// directly is reading real seeded product data, not fabricating a stub.
+
+import { Client } from "pg";
+import { apiBaseUrl, apiRequest, databaseUrl, toPostgresDriverUrl } from "./seed.ts";
+
+interface ApiResult<T> {
+  status: number;
+  body: T;
+}
+
+/**
+ * Resolve a real seed integration definition's id by namespace, direct from
+ * `cloud_integration_definition` (source='seed'). `context7` is `api_key`-kind
+ * per SEED_DEFINITIONS and is what this suite uses as its real,
+ * no-stub-provider connect target.
+ */
+export async function getSeedIntegrationDefinitionId(namespace: string): Promise<string> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    const result = await client.query<{ id: string }>(
+      `SELECT id FROM cloud_integration_definition WHERE source = 'seed' AND namespace = $1`,
+      [namespace],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      throw new Error(
+        `No seed integration definition found for namespace "${namespace}" — did sync_seed_definitions run at server boot?`,
+      );
+    }
+    return row.id;
+  } finally {
+    await client.end();
+  }
+}
+
+export interface IntegrationAccountResult {
+  account: {
+    accountId: string;
+    definitionId: string;
+    namespace: string;
+    displayName: string;
+    authKind: string;
+    status: string;
+    enabled: boolean;
+  };
+  oauthFlowId: string | null;
+  authorizationUrl: string | null;
+  expiresAt: string | null;
+}
+
+/** `POST /v1/integrations/authentications` (authKind api_key). Placeholder
+ * key value — this path never validates it against the provider (ruled
+ * 2026-07-08, scenarios.md: "no stub/fake integration provider", real
+ * definition + placeholder credential, no outbound call in tier 2). */
+export async function authenticateApiKeyIntegration(
+  token: string,
+  definitionId: string,
+  apiKey: string,
+): Promise<ApiResult<IntegrationAccountResult>> {
+  return apiRequest<IntegrationAccountResult>("/v1/cloud/integrations/authentications", {
+    method: "POST",
+    token,
+    body: { definitionId, authKind: "api_key", apiKey },
+  });
+}
+
+export interface IntegrationCatalogItemResult {
+  definitionId: string;
+  namespace: string;
+  displayName: string;
+  authKind: string;
+}
+
+export async function getIntegrationCatalog(
+  token: string,
+): Promise<ApiResult<{ items: IntegrationCatalogItemResult[] }>> {
+  return apiRequest<{ items: IntegrationCatalogItemResult[] }>("/v1/cloud/integrations/catalog", { token });
+}
+
+export interface AdminIntegrationDefinitionResult {
+  definitionId: string;
+  namespace: string;
+  displayName: string;
+  source: string;
+  organizationId: string | null;
+  authKind: string;
+  enabledByDefault: boolean;
+  policyEnabled: boolean | null;
+  effectiveEnabled: boolean;
+}
+
+export async function setAdminIntegrationEnabled(
+  token: string,
+  organizationId: string,
+  definitionId: string,
+  enabled: boolean,
+): Promise<ApiResult<AdminIntegrationDefinitionResult>> {
+  return apiRequest<AdminIntegrationDefinitionResult>(
+    `/v1/cloud/integrations/admin/organizations/${organizationId}/definitions/${definitionId}/enabled`,
+    { method: "PATCH", token, body: { enabled } },
+  );
+}
+
+export async function listAdminIntegrationDefinitions(
+  token: string,
+  organizationId: string,
+): Promise<ApiResult<AdminIntegrationDefinitionResult[]>> {
+  return apiRequest<AdminIntegrationDefinitionResult[]>(
+    `/v1/cloud/integrations/admin/organizations/${organizationId}/definitions`,
+    { token },
+  );
+}
+
+/** Sanity probe used only to document the gate: confirms the API is up and
+ * the path resolves (vs. a 404 that would make the 403 assertion vacuous). */
+export async function probeIntegrationsAlive(): Promise<boolean> {
+  const response = await fetch(`${apiBaseUrl()}/health`);
+  return response.ok;
+}

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -33,7 +33,9 @@ export function webBaseUrl(): string {
   return value;
 }
 
-function databaseUrl(): string {
+// Exported so sibling seed-*.ts files (e.g. seed-integrations.ts) share one
+// source of truth for this instead of re-deriving it.
+export function databaseUrl(): string {
   const value = process.env.TIER2_INTENT_DATABASE_URL;
   if (!value) {
     throw new Error("TIER2_INTENT_DATABASE_URL is not set — did globalSetup run?");
@@ -586,8 +588,9 @@ export async function resetPasswordLoginRateLimits(): Promise<void> {
 /** The server uses asyncpg's SQLAlchemy URL scheme; node-postgres needs the
  * plain `postgresql://` scheme, and its resolver chokes on the bracketed
  * `[::1]` host the macOS profile default uses — Docker's Postgres publishes
- * on localhost for both stacks, so map it. */
-function toPostgresDriverUrl(url: string): string {
+ * on localhost for both stacks, so map it. Exported for the same reason as
+ * `databaseUrl` above. */
+export function toPostgresDriverUrl(url: string): string {
   return url
     .replace(/^postgresql\+asyncpg:\/\//, "postgresql://")
     .replace("@[::1]:", "@localhost:");


### PR DESCRIPTION
## Summary

Rebased onto main now that #1016 (tests/intent-wave2) squash-merged — targets main directly, no longer stacked.

Builds the two remaining tier-2 scenarios from scenarios.md:

- **T2-INT-1: api_key connect + org policy toggle.** Originally pinned the `current_product_user` gate (github_link_required, no single-org carve-out) the same way T2-SEC-1/T2-WS-1 did, hitting harder since even the org-admin definition-enable toggle sat behind the account's own GitHub link. #1023 (merged to main) extended the single-org bypass to `current_product_user` itself, so that 403 no longer fires — rewrote the spec to exercise the real scenario instead of documenting the gap: connect `context7` (a real seed api_key definition, resolved by direct DB read from `cloud_integration_definition`) with a placeholder key, then toggle the org policy off/on and assert `effective_enabled` composition (policy override over `enabled_by_default`) both ways, verified against a persisted re-read, not just the toggle response echo.

- **T2-WS-2: local + worktree create (desktop-web limits apply).** Found a real spec/code divergence: the scenario names "worktree create" as part of the Add-Repo flow, but the flow (`add-repo-flow-store.ts`) only has cloud/local branches — worktree creation is a separate one-click sidebar action with no input form (name/branch/base ref are all auto-generated), and requires a live local AnyHarness runtime that this suite's CI profile disables (`TIER2_INTENT_SKIP_RUNTIME=1`). Scoped tier 2 to what's actually testable: the entry step renders all three options; picking a local option no-ops in desktop-web (no Tauri `invoke`, caught and resolved null — the concrete "desktop-web limits apply" from the scenario title); the cloud branch navigates and settles to the same GitHub-readiness blocker UI (`Authorize GitHub App`) the API-level gate produces elsewhere — still true post-#1023, since repo endpoints guard at their own point of use (`github_app_authorization_required`), not through `current_product_user`. Worktree creation itself is named as an explicit tier-2 gap, deferred to tier 3's desktop lane per the scenario's own fallback language.

## Files

- `tests/intent/specs/integrations.spec.ts` — T2-INT-1
- `tests/intent/specs/workspace-entry.spec.ts` — T2-WS-2
- `tests/intent/stack/seed-integrations.ts` — helper file (kept separate from `seed.ts`, which is already near this repo's 600-line convention) with the direct-DB seed-definition lookup + the integrations API calls
- `tests/intent/stack/seed.ts` — exports `databaseUrl`/`toPostgresDriverUrl` so the new helper file can reuse the existing DB-connection logic instead of duplicating it
- `specs/developing/testing/flows.md` — added (not yet on main; owned by open PR #1008) with just the two pointer edits this PR needs. Expect a normal stacked-PR conflict on this file when #1008 lands — nothing to do about it now, just flagging it up front.

## Test plan

- [x] Full local stack run against real Postgres/Redis (`t2intent` profile, `TIER2_INTENT_SKIP_RUNTIME=1`): 30 passed, 1 self-skip, 0 failed — includes the full T2-INT-1 connect/toggle round trip and T2-WS-2's UI flow, both green on a fresh-DB boot
- [x] `npx playwright test --list` enumerates both new spec files correctly
- [x] `tsc --noEmit` shows no new error classes beyond the pre-existing `.ts`-import-extension warnings every other spec file already has
- [ ] `Repo shape checks` — not re-verified after the rebase; was pre-existing baseline drift inherited from the base branch before (22 violations, all in `apps/desktop/src` files this PR never touches), worth a fresh look now that this targets main directly
