### PR TITLE
fix(billing): gate cloud-sandbox wake/ensure on the resume billing gate (#1036)

### DIFF
--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -200,10 +200,30 @@ async def assert_cloud_sandbox_resume_allowed(
     billing subject, then blocks on an active spend hold or an over-cap compute
     budget — the same conditions that make the reconciler pause an open segment.
     Records a ``BillingDecisionEvent`` and raises ``CloudSandboxResumeBlockedError``.
+
+    Delegates to ``assert_cloud_sandbox_resume_allowed_for_owner``; the gate only
+    reads ``sandbox.owner_user_id``, so the owner-id variant can run at seams that
+    do not yet have a sandbox row (see the wake/ensure service layer).
+    """
+    await assert_cloud_sandbox_resume_allowed_for_owner(
+        db, owner_user_id=sandbox.owner_user_id
+    )
+
+
+async def assert_cloud_sandbox_resume_allowed_for_owner(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID | None,
+) -> None:
+    """Owner-scoped resume gate: same checks as the sandbox variant, keyed by owner.
+
+    Split out so a caller can gate before a cloud_sandbox row exists (the wake/
+    ensure path flushes a new-row INSERT inside ``ensure_personal_cloud_sandbox_exists``,
+    and this gate ``commit()``s its audit row before raising, so it must run first).
+    Enforce-mode only (``CLOUD_BILLING_MODE=enforce``).
     """
     if settings.cloud_billing_mode != BILLING_MODE_ENFORCE:
         return
-    owner_user_id = sandbox.owner_user_id
     if owner_user_id is None:
         return
     subject = await ensure_personal_billing_subject(db, owner_user_id)
@@ -262,8 +282,10 @@ async def assert_cloud_sandbox_resume_allowed(
     # Persist the decision before raising: the production caller
     # (materialization/runner._run_with_fresh_session) rolls back its session in
     # the exception handler, which would otherwise discard this un-committed
-    # audit row. Safe here — this gate is the first statement of
-    # connect_ready_sandbox, so no other writes are staged on this session yet.
+    # audit row. Safe at every call site: this gate runs first at each seam
+    # (connect_ready_sandbox's opening statement, and the wake/ensure service
+    # layer before ensure_personal_cloud_sandbox_exists stages a row INSERT), so
+    # no other writes are staged on this session yet.
     await db.commit()
     raise CloudSandboxResumeBlockedError(
         authorization_message(reason)

--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -205,9 +205,7 @@ async def assert_cloud_sandbox_resume_allowed(
     reads ``sandbox.owner_user_id``, so the owner-id variant can run at seams that
     do not yet have a sandbox row (see the wake/ensure service layer).
     """
-    await assert_cloud_sandbox_resume_allowed_for_owner(
-        db, owner_user_id=sandbox.owner_user_id
-    )
+    await assert_cloud_sandbox_resume_allowed_for_owner(db, owner_user_id=sandbox.owner_user_id)
 
 
 async def assert_cloud_sandbox_resume_allowed_for_owner(

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -17,6 +17,9 @@ from proliferate.db.store import billing_subjects
 from proliferate.db.store import cloud_sandboxes as sandbox_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+from proliferate.server.billing.authorization import (
+    assert_cloud_sandbox_resume_allowed_for_owner,
+)
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.utils.crypto import decrypt_text
 
@@ -36,6 +39,15 @@ async def ensure_cloud_sandbox_ready(
     db: AsyncSession,
     user: _UserWithId,
 ) -> CloudSandboxValue:
+    # LIVE billing gate (spec §4.3): an exhausted owner must not wake or ensure a
+    # cloud sandbox. Gate BEFORE ensure_personal_cloud_sandbox_exists stages a
+    # new-row INSERT, since the gate commits its audit row before raising. No-op
+    # unless CLOUD_BILLING_MODE=enforce. wake_cloud_sandbox delegates here, so
+    # both /cloud-sandbox/wake and /cloud-sandbox/ensure inherit this gate; the
+    # GitHub-App trigger path calls ensure_personal_cloud_sandbox_exists directly
+    # and is intentionally left ungated so a brand-new user's initial row still
+    # gets created.
+    await assert_cloud_sandbox_resume_allowed_for_owner(db, owner_user_id=user.id)
     return await ensure_personal_cloud_sandbox_exists(db, user_id=user.id)
 
 

--- a/server/tests/integration/test_cloud_sandbox_wake_billing_gate.py
+++ b/server/tests/integration/test_cloud_sandbox_wake_billing_gate.py
@@ -1,0 +1,144 @@
+"""Service-layer wake/ensure billing gate (spec §4.3, issue #1036).
+
+The resume gate used to live only in ``connect_ready_sandbox``. ``POST
+/cloud-sandbox/wake`` and ``POST /cloud-sandbox/ensure`` route through
+``wake_cloud_sandbox`` / ``ensure_cloud_sandbox_ready`` in the cloud-sandbox
+service, which only ensured the DB row, so an exhausted owner got a
+``status: ready`` sandbox back instead of a 402. These tests pin that both
+service entry points now run ``assert_cloud_sandbox_resume_allowed_for_owner``
+before any row is created, enforce-mode only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.billing import (
+    BILLING_HOLD_KIND_ADMIN_HOLD,
+    BILLING_HOLD_STATUS_ACTIVE,
+    BILLING_MODE_ENFORCE,
+    BILLING_MODE_OBSERVE,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.billing import BillingHold
+from proliferate.db.store import cloud_sandboxes as sandbox_store
+from proliferate.db.store.billing_subjects import (
+    ensure_free_included_grant,
+    ensure_personal_billing_subject,
+)
+from proliferate.server.billing.authorization import CloudSandboxResumeBlockedError
+from proliferate.server.cloud.cloud_sandboxes.service import (
+    ensure_cloud_sandbox_ready,
+    wake_cloud_sandbox,
+)
+
+
+async def _create_user(db_session: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"wake-gate-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+async def _seed_exhausted_user(db_session: AsyncSession) -> uuid.UUID:
+    """A personal subject on an active spend hold (the exhausted case)."""
+    user_id = await _create_user(db_session)
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    db_session.add(
+        BillingHold(
+            billing_subject_id=subject.id,
+            kind=BILLING_HOLD_KIND_ADMIN_HOLD,
+            status=BILLING_HOLD_STATUS_ACTIVE,
+            source="test",
+        )
+    )
+    await db_session.commit()
+    return user_id
+
+
+async def _seed_healthy_user(db_session: AsyncSession) -> uuid.UUID:
+    """A subject with trial credits and no hold (never exhausted)."""
+    user_id = await _create_user(db_session)
+    await ensure_personal_billing_subject(db_session, user_id)
+    await ensure_free_included_grant(db_session, user_id)
+    await db_session.commit()
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_wake_denied_when_exhausted(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/wake for an exhausted owner raises the structured 402 before creating a row."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    user_id = await _seed_exhausted_user(db_session)
+
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await wake_cloud_sandbox(db_session, SimpleNamespace(id=user_id))
+
+    assert excinfo.value.status_code == 402
+    assert excinfo.value.code == "billing_resume_blocked"
+    # The gate must run before ensure_personal_cloud_sandbox_exists stages a row.
+    await db_session.rollback()
+    assert await sandbox_store.load_personal_cloud_sandbox(db_session, user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_denied_when_exhausted(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/ensure is a start path too: an exhausted owner is refused with a 402."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    user_id = await _seed_exhausted_user(db_session)
+
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await ensure_cloud_sandbox_ready(db_session, SimpleNamespace(id=user_id))
+
+    assert excinfo.value.status_code == 402
+    assert excinfo.value.code == "billing_resume_blocked"
+    await db_session.rollback()
+    assert await sandbox_store.load_personal_cloud_sandbox(db_session, user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_wake_allowed_for_healthy_user(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user with fresh trial credits is not exhausted: wake creates the row."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id = await _seed_healthy_user(db_session)
+
+    sandbox = await wake_cloud_sandbox(db_session, SimpleNamespace(id=user_id))
+
+    assert sandbox is not None
+    assert sandbox.owner_user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_wake_noop_outside_enforce_mode(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Observe mode never blocks a wake, even for an exhausted owner."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_OBSERVE)
+    user_id = await _seed_exhausted_user(db_session)
+
+    sandbox = await wake_cloud_sandbox(db_session, SimpleNamespace(id=user_id))
+
+    assert sandbox is not None
+    assert sandbox.owner_user_id == user_id


### PR DESCRIPTION
## Root cause

`POST /cloud-sandbox/wake` and `POST /cloud-sandbox/ensure` route through `wake_cloud_sandbox` / `ensure_cloud_sandbox_ready` / `ensure_personal_cloud_sandbox_exists` in `cloud_sandboxes/service.py`, which only ensure the DB row and return it. The resume billing gate (`assert_cloud_sandbox_resume_allowed`) lived only in `connect_ready_sandbox`. An exhausted owner calling `/wake` directly got `status: ready` back instead of the required 402, which is what tier-3 T3-BILL-2 (bypass 1, direct-API resume) caught.

## Fix shape

Wire the gate into the service layer so any caller inherits it, reusing the existing gate function (no duplicated snapshot/hold logic):

- Gate inside `ensure_cloud_sandbox_ready`. `wake_cloud_sandbox` delegates to it, so both endpoints are covered by one call site.
- Split out `assert_cloud_sandbox_resume_allowed_for_owner(db, owner_user_id=...)`. The gate only reads `sandbox.owner_user_id`, and it `db.commit()`s its `BillingDecisionEvent` audit row before raising, so it must run before `ensure_personal_cloud_sandbox_exists` stages the new-row INSERT. Gating by owner id lets it run at that seam before a sandbox row exists. The existing sandbox-keyed `assert_cloud_sandbox_resume_allowed` now delegates to the owner-keyed variant, keeping one implementation.
- Enforce-mode only (`CLOUD_BILLING_MODE=enforce`); off/observe unchanged, matching the existing gate.

## The /ensure-402 decision

Yes, `/ensure` also 402s when exhausted. "No access after money bites, no matter what" is the requirement and `/ensure` is a start path. The brand-new-user case is unaffected: the GitHub-App user-authorization callback creates the initial row via `ensure_personal_cloud_sandbox_exists` directly (not through `ensure_cloud_sandbox_ready`), so a fresh-trial-credits user is never blocked. A test pins that a non-exhausted user still gets a row from `/wake`.

## Test coverage

`server/tests/integration/test_cloud_sandbox_wake_billing_gate.py`:
- exhausted owner (active spend hold) + enforce mode: `/wake` raises `CloudSandboxResumeBlockedError` (status 402, code `billing_resume_blocked`), and no sandbox row is created (proves the gate runs before the INSERT).
- exhausted owner + enforce mode: `/ensure` refused the same way.
- non-exhausted user (fresh trial grant) + enforce mode: `/wake` creates the row, gate is a no-op.
- exhausted owner + observe mode: `/wake` is not blocked.

Touched-module run (new file + `test_billing_limit_enforcement_compute.py`): 15 passed. Full suite: 952 passed, 2 skipped.

## Scope boundaries

The other internal callers of `ensure_personal_cloud_sandbox_exists` (`repositories/service.py`, `materialization/materialize/*.py`) only ensure the DB row and then start compute through `run_cloud_sandbox_operation` -> `connect_ready_sandbox`, which already carries the gate. They are left unchanged; no unguarded compute-start path was found there.

Note: `gateway/service.py` resolves LLM-gateway access via `ensure_cloud_sandbox_ready`, so it now also 402s for an exhausted owner in enforce mode. This is intentional (an exhausted owner should not get gateway access to a paused sandbox) and matches the requirement.

Closes #1036.
