### PR TITLE
fix(catalog): gate bare Claude ids on Bedrock-routed accounts (#1037, #1038)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs
@@ -508,9 +508,9 @@ fn bundled_docs_classify_oauth_discovery_contexts() {
 
 #[test]
 fn bundled_docs_bedrock_flag_beats_api_key_for_claude() {
-    // The flag deliberately forces the bedrock route in the harness, so when
-    // set (with aws creds present) it must win the slot even if an API key
-    // is also in the composed env.
+    // The flag is the bedrock routing switch: when set, the CLI routes to
+    // Bedrock and only serves us.anthropic.* ids, so it must win the slot even
+    // if an API key (or OAuth creds) is also in the composed env.
     let facts = [
         flag_fact("CLAUDE_CODE_USE_BEDROCK", "1"),
         discovery_fact("aws-credential-chain"),
@@ -518,9 +518,24 @@ fn bundled_docs_bedrock_flag_beats_api_key_for_claude() {
     ];
     assert_eq!(classify_bundled("claude", &facts), vec!["bedrock"]);
 
-    // Flag without aws credentials is not a bedrock context.
+    // The flag alone classifies as bedrock — a production Bedrock deployment
+    // on an ECS task role sets the flag but has no passively detectable creds
+    // (IMDS / task-role are the exotic tail we deliberately don't detect,
+    // decisions ledger 12). Keying bedrock on the flag is the honest signal:
+    // the CLI still routes to Bedrock, so bare ids must be gated.
     let flag_only = [flag_fact("CLAUDE_CODE_USE_BEDROCK", "1")];
-    assert_eq!(classify_bundled("claude", &flag_only), vec!["baseline"]);
+    assert_eq!(classify_bundled("claude", &flag_only), vec!["bedrock"]);
+
+    // No flag: an OAuth login is a plain anthropic-oauth account (bare ids
+    // stay usable) even when AWS creds happen to be present for other tools.
+    let oauth_with_aws = [
+        discovery_fact("claude-oauth-creds"),
+        discovery_fact("aws-credential-chain"),
+    ];
+    assert_eq!(
+        classify_bundled("claude", &oauth_with_aws),
+        vec!["anthropic-oauth"]
+    );
 }
 
 #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -61,9 +61,12 @@ fn draft_catalog_parses_with_expected_shape() {
     );
     let first = &claude.session.models[0];
     assert_eq!(first.id, "default");
+    // Bare ids are never Bedrock-servable (Bedrock takes only us.anthropic.*
+    // inference-profile ids), so `default` is api/oauth only — a Bedrock-routed
+    // account gets the us.anthropic.* rows, never this bare id.
     assert_eq!(
         first.availability.any_of,
-        vec!["anthropic-api", "anthropic-oauth", "bedrock"]
+        vec!["anthropic-api", "anthropic-oauth"]
     );
     assert!(first.default_visible);
     let effort = first.controls.get("effort").expect("effort control");

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -175,6 +175,81 @@ fn visible_models_are_the_default_visible_subset_of_available() {
 }
 
 #[test]
+fn bedrock_account_gates_bare_ids_and_shows_only_region_prefixed_models() {
+    // A Bedrock-routed account (CLAUDE_CODE_USE_BEDROCK=1) classifies as
+    // `bedrock`. Bedrock serves only us.anthropic.* inference-profile ids, so
+    // the bare current-gen ids must be gated (the account 400s on them) and
+    // the menu must be the us.anthropic.* rows.
+    let catalog = draft_catalog();
+
+    for bare in ["default", "haiku", "opus", "sonnet", "claude-opus-4-8"] {
+        let gated = catalog
+            .validate_launch("claude", &contexts(&["bedrock"]), Some(bare), None)
+            .unwrap_err();
+        assert!(
+            matches!(gated, SelectionUnsupported::ModelGated { .. }),
+            "bare id {bare:?} must be gated under bedrock, got {gated:?}"
+        );
+    }
+
+    // A us.anthropic.* id launches on the same account.
+    let ok = catalog
+        .validate_launch(
+            "claude",
+            &contexts(&["bedrock"]),
+            Some("us.anthropic.claude-opus-4-8"),
+            None,
+        )
+        .expect("region-prefixed id is available under bedrock");
+    assert_eq!(ok.model_id.as_deref(), Some("us.anthropic.claude-opus-4-8"));
+
+    // The menu carries only region-prefixed rows — never a bare id.
+    let menu = model_ids(catalog.visible_models("claude", &contexts(&["bedrock"])));
+    assert!(!menu.is_empty());
+    for id in &menu {
+        assert!(
+            id.contains(".anthropic."),
+            "bedrock menu must be region-prefixed only, saw bare id {id:?}"
+        );
+    }
+
+    // No requested model resolves to the curated bedrock default, not a bare id.
+    let default = catalog
+        .validate_launch("claude", &contexts(&["bedrock"]), None, None)
+        .expect("bedrock default resolves");
+    assert_eq!(
+        default.model_id.as_deref(),
+        Some("us.anthropic.claude-sonnet-4-6")
+    );
+}
+
+#[test]
+fn oauth_account_keeps_bare_ids_unchanged() {
+    // The #975 guarantee: a normal claude.ai OAuth login (no bedrock context)
+    // still sees and launches the bare current-gen ids — the only form it can
+    // use, since the us.anthropic.* rows are Bedrock-gated for it.
+    let catalog = draft_catalog();
+
+    for bare in ["default", "haiku", "opus", "sonnet", "claude-opus-4-8"] {
+        let ok = catalog
+            .validate_launch("claude", &contexts(&["anthropic-oauth"]), Some(bare), None)
+            .unwrap_or_else(|error| panic!("bare id {bare:?} must launch under oauth: {error:?}"));
+        assert_eq!(ok.model_id.as_deref(), Some(bare));
+    }
+
+    // A us.anthropic.* id is gated for a first-party OAuth login.
+    let gated = catalog
+        .validate_launch(
+            "claude",
+            &contexts(&["anthropic-oauth"]),
+            Some("us.anthropic.claude-opus-4-8"),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(gated, SelectionUnsupported::ModelGated { .. }));
+}
+
+#[test]
 fn controls_return_the_per_model_matrix() {
     let catalog = draft_catalog();
 

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -45,14 +45,7 @@
           "id": "bedrock",
           "authSlotId": "anthropic",
           "signals": {
-            "allOf": [
-              {
-                "envFlag": "CLAUDE_CODE_USE_BEDROCK=1"
-              },
-              {
-                "discovery": "aws-credential-chain"
-              }
-            ]
+            "envFlag": "CLAUDE_CODE_USE_BEDROCK=1"
           }
         },
         {
@@ -148,8 +141,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,
@@ -338,8 +330,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,
@@ -373,8 +364,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -51,7 +51,17 @@ const AUTH_CONTEXT_SLOTS = {
 // the registry slot's envVars/discoveryKinds (validation_pairing.rs).
 const AUTH_CONTEXT_SIGNALS = {
   claude: {
-    "bedrock": { allOf: [{ envFlag: "CLAUDE_CODE_USE_BEDROCK=1" }, { discovery: "aws-credential-chain" }] },
+    // CLAUDE_CODE_USE_BEDROCK=1 is the routing switch: when set, the CLI
+    // routes to Bedrock and only serves us.anthropic.* inference-profile ids,
+    // whichever credential source it uses. We key bedrock on the flag alone
+    // and do NOT also require aws-credential-chain — that discovery covers only
+    // the passive sources (env pair, bearer token, ~/.aws profile, SSO cache)
+    // and deliberately misses the exotic tail (IMDS / task-role / container
+    // creds, decisions ledger 12). A production Bedrock deployment on an ECS
+    // task role sets the flag but has no passively detectable creds, so an
+    // allOf would misclassify it as oauth/api and then accept bare ids the
+    // account 400s on. The flag is the honest, sufficient signal.
+    "bedrock": { envFlag: "CLAUDE_CODE_USE_BEDROCK=1" },
     "anthropic-api": { anyOf: [{ env: "ANTHROPIC_API_KEY" }, { env: "ANTHROPIC_AUTH_TOKEN" }] },
     "anthropic-oauth": { anyOf: [{ discovery: "claude-oauth-creds" }, { discovery: "claude-keychain" }] },
   },
@@ -156,6 +166,25 @@ const MODEL_VISIBILITY_OPT_OUTS = {
     "grok-imagine-video-1.5-preview",
   ],
 };
+
+// Availability stays the OBSERVED SET (menu or accepted trial per context)
+// with ONE sanctioned correction. Bedrock serves only region-prefixed
+// inference-profile ids (us.anthropic.* / global.anthropic.*). The Claude CLI
+// still lists the bare current-gen ids (default / haiku / opus) on its menu
+// during a bedrock probe run, so the raw observed set tags them
+// bedrock-available — but the CLI 400s those bare ids on use ("Try --model to
+// switch to us.anthropic.claude-opus-4-7 ..."). Menu presence is not
+// serve-ability: this is a menu-lie. Strip bedrock from any claude id that is
+// not a region-prefixed inference profile so validate_launch never accepts a
+// bare id a Bedrock-routed account cannot serve. The us.anthropic.* rows stay
+// the account's real menu; a normal oauth/api login (no bedrock context) is
+// untouched. Provenance keeps the honest observation.
+function correctAvailability(kind, modelId, contexts) {
+  if (kind === "claude" && !modelId.includes(".anthropic.")) {
+    return contexts.filter((context) => context !== "bedrock");
+  }
+  return contexts;
+}
 
 // Per-harness advanced settings: declared here (curation-owned), emitted onto
 // the agent entry, and applied at launch per the mapping kind. v1 supports
@@ -508,14 +537,15 @@ for (const [kind, runs] of byAgent) {
     const matrix = entry.mergedMatrix ?? {};
     // Observed-set semantics: exactly the contexts that saw this model.
     // 'baseline' is a first-class context; no always/anyOf inference.
-    const contexts = [...new Set(entry.observedIn.map((r) => r.split(".").slice(1).join(".")))];
+    const observedContexts = [...new Set(entry.observedIn.map((r) => r.split(".").slice(1).join(".")))];
+    const availabilityContexts = correctAvailability(kind, modelId, observedContexts);
     return {
       id: modelId,
       displayName:
         MODEL_DISPLAY_OVERRIDES[kind]?.[modelId] ??
         prettifyDisplayName(versionedDisplayName(entry.name, entry.description, modelId)),
       ...(entry.description ? { description: entry.description } : {}),
-      availability: { anyOf: contexts },
+      availability: { anyOf: availabilityContexts },
       // On a harness menu somewhere -> advertised; trial-only -> available
       // but hidden unless curation opts it in.
       defaultVisible: !(MODEL_VISIBILITY_OPT_OUTS[kind] ?? []).includes(modelId),
@@ -523,7 +553,7 @@ for (const [kind, runs] of byAgent) {
       status: "active",
       provenance: {
         observedIn: [...new Set(entry.observedIn)],
-        observedInAllContexts: contexts.length === probedContexts.length,
+        observedInAllContexts: observedContexts.length === probedContexts.length,
         viaTrialOnly: !entry.onMenu,
         ...(entry.variants ? { variantIds: entry.variants } : {}),
       },

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -45,14 +45,7 @@
           "id": "bedrock",
           "authSlotId": "anthropic",
           "signals": {
-            "allOf": [
-              {
-                "envFlag": "CLAUDE_CODE_USE_BEDROCK=1"
-              },
-              {
-                "discovery": "aws-credential-chain"
-              }
-            ]
+            "envFlag": "CLAUDE_CODE_USE_BEDROCK=1"
           }
         },
         {
@@ -147,8 +140,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,
@@ -337,8 +329,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,
@@ -372,8 +363,7 @@
             "availability": {
               "anyOf": [
                 "anthropic-api",
-                "anthropic-oauth",
-                "bedrock"
+                "anthropic-oauth"
               ]
             },
             "defaultVisible": true,

--- a/specs/tbd/agents-catalog-registry-migration.md
+++ b/specs/tbd/agents-catalog-registry-migration.md
@@ -429,3 +429,56 @@ claude thin-fork — per ~/delete/acp-protocol-and-forks-handoff.md.
   validates the standard (per the adoption backlog).
 - Worked example spec: written from the merged PR-1 diff (agents as the
   canonical annotated domain).
+
+## 9. Amendment 2026-07-09: bare Claude ids never validate on Bedrock (#1037, #1038)
+
+Ruled by Pablo. A Bedrock-routed Claude account 400s on bare model ids
+(`default`/`haiku`/`opus`/`sonnet`/`claude-opus-4-8`) with the CLI's own
+"Try --model to switch to us.anthropic.claude-opus-4-7 ..." — Bedrock serves
+only region-prefixed inference-profile ids (`us.anthropic.*` /
+`global.anthropic.*`). Validation accepted the bare id, the session was created,
+then the first prompt errored (any conn_failed → `SessionExecutionPhase::Errored`).
+The rule: validation must never accept a model the account cannot serve.
+
+Two coordinated defects, one root cause (menu presence taken as serve-ability):
+
+1. Detection (the pre-flight signal). The `bedrock` auth context keyed on
+   `allOf[CLAUDE_CODE_USE_BEDROCK=1, aws-credential-chain]`. `aws-credential-chain`
+   covers only the passive sources (ledger 12) and deliberately misses the
+   exotic tail (IMDS / task-role / container creds). A production Bedrock
+   deployment on an ECS task role sets the flag but exposes no passively
+   detectable creds, so the `allOf` failed and the account classified as
+   `anthropic-oauth`, where bare ids validate. Fix: key `bedrock` on the flag
+   alone. The flag is the routing switch — when set, the CLI routes to Bedrock
+   and only serves `us.anthropic.*`, whichever credential source it uses — so
+   the flag is the honest, sufficient signal and is the detection contract.
+   Absent the flag, an OAuth login stays `anthropic-oauth` even with AWS creds
+   present for other tools.
+
+2. Availability (the menu-lie). The Claude CLI lists the bare current-gen ids
+   on its menu during a bedrock probe run, so the observed-set availability
+   tagged `default`/`haiku`/`opus` `bedrock`-available — but the CLI 400s them
+   on use. Menu presence is not serve-ability. `build-catalog.mjs` now strips
+   `bedrock` from any Claude id that is not a region-prefixed inference profile
+   (the one sanctioned correction to observed-set availability; provenance keeps
+   the raw observation). So under the `bedrock` context the bare ids are
+   `ModelGated` and `visible_models` is the `us.anthropic.*` rows only, with the
+   no-selection default resolving via `defaults["bedrock"]` =
+   `us.anthropic.claude-sonnet-4-6`.
+
+Shape chosen: menu-level flavor gating, not transparent resolution. Transparent
+`haiku` → `us.anthropic.*` resolution is infeasible and ambiguous — the catalog
+carries no `us.anthropic.*` haiku row at all, and multiple `us.anthropic.*` opus
+generations exist. Gating is honest and keeps the one-computation invariant
+(`models` = `visible_models` = `validate_launch` = live-switch authority all run
+through `model_is_available`).
+
+This does not regress #975: a normal `claude.ai` OAuth or API login (no flag,
+so no `bedrock` context) is untouched — it still sees and launches the bare ids,
+which remain the only form it can use.
+
+Residual gap: an account that presents pure OAuth AND does not set
+`CLAUDE_CODE_USE_BEDROCK=1` yet is Anthropic-side Bedrock-enrolled has no
+pre-flight signal. Without the flag the CLI does not route to Bedrock, so this
+case is theoretical today; if it appears, the only remedies are a runtime
+error-string downgrade or a per-account model-list probe (neither is built).


### PR DESCRIPTION
## What

A Bedrock-routed Claude account 400s on the bare model ids (`default`, `haiku`, `opus`, `sonnet`, `claude-opus-4-8`) with the CLI's own "Try --model to switch to us.anthropic.claude-opus-4-7 ...". Bedrock serves only region-prefixed `us.anthropic.*` inference-profile ids. `validate_launch` accepted the bare id, so the session was created and then errored on the first prompt (any conn_failed sets `SessionExecutionPhase::Errored`). This makes validation refuse a model the account cannot serve.

## Root cause

One root cause, two coordinated defects: menu presence was taken as serve-ability.

1. Detection. The `bedrock` auth context keyed on `allOf[CLAUDE_CODE_USE_BEDROCK=1, aws-credential-chain]`. `aws-credential-chain` covers only the passive sources and deliberately misses the exotic tail (IMDS / task-role / container creds, decisions ledger 12). A production Bedrock deployment on an ECS task role sets the flag but exposes no passively detectable creds, so it classified as `anthropic-oauth`, where bare ids validate. Fix: key `bedrock` on the flag alone. The flag is the routing switch, so it is the honest and sufficient signal.

2. Availability. The Claude CLI lists the bare current-gen ids on its menu during a bedrock probe run, so observed-set availability tagged `default`/`haiku`/`opus` bedrock-available even though the CLI 400s them on use. `build-catalog.mjs` now strips `bedrock` from any Claude id that is not a region-prefixed inference profile (the one sanctioned correction to observed-set availability; provenance keeps the raw observation). Under the `bedrock` context the bare ids are now `ModelGated` and `visible_models` is the `us.anthropic.*` rows only, with the no-selection default resolving to `us.anthropic.claude-sonnet-4-6`.

## Resolution shape

Menu-level flavor gating, not transparent resolution. Transparent `haiku` → `us.anthropic.*` is infeasible and ambiguous: the catalog has no `us.anthropic.*` haiku row and multiple `us.anthropic.*` opus generations exist. Gating is honest and keeps the one-computation invariant (`models` = `visible_models` = `validate_launch` = live-switch authority all go through `model_is_available`).

## Bedrock-detection signal

The `bedrock` auth context, now keyed on `CLAUDE_CODE_USE_BEDROCK=1` alone. Gap: an account that presents pure OAuth and does not set the flag yet is Anthropic-side Bedrock-enrolled has no pre-flight signal, but without the flag the CLI does not route to Bedrock, so this case is theoretical today.

## No regression to #975

A normal `claude.ai` OAuth or API login (no flag, so no `bedrock` context) is untouched: it still sees and launches the bare ids, which remain the only form it can use.

## Tests

- `cargo test -p anyharness-lib --lib domains::agents`: 232 passed. New tests cover a Bedrock account gating every bare id and showing only region-prefixed rows, the bedrock default resolving to `us.anthropic.claude-sonnet-4-6`, and a normal OAuth account keeping the bare ids.
- JS catalog validator (`node scripts/validate-agent-catalog.mjs`): green.
- The 11 failures under `cargo test --workspace` are a pre-existing env-mutex poison cascade in `app::tests`/`router_tests` (all pass in isolation, `--test-threads=1`), unrelated to this change.

## Spec

Amendment landed in `specs/tbd/agents-catalog-registry-migration.md` section 9.

Closes #1037, #1038.