### PR TITLE
fix(billing): bill org compute to the org subject, not personal

### DIFF
--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -377,6 +377,44 @@ async def compute_usage_seconds_by_user(
     return {user_id: float(seconds or 0.0) for user_id, seconds in rows}
 
 
+async def compute_usage_seconds_by_user_for_org(
+    db: AsyncSession,
+    *,
+    organization_id: UUID,
+    start: datetime,
+    end: datetime,
+    now: datetime,
+) -> dict[UUID, float]:
+    """Billable compute seconds per user over ``[start, end)`` scoped to an org.
+
+    Groups by ``UsageSegment.organization_id`` (not billing subject) so the
+    org-admin usage-by-user view aggregates every member's compute regardless of
+    which subject each segment is invoiced to — the same scope the enforcement
+    path sums (``compute_usage_seconds_in_window_for_org``). Segments opened
+    before org compute billed the org still carry ``organization_id`` (stamped at
+    open time since #1028), so they are included even where their paying subject
+    is still a personal one.
+    """
+    window_start = coerce_utc(start) or start
+    window_end = coerce_utc(end) or end
+    rows = (
+        await db.execute(
+            select(
+                UsageSegment.user_id,
+                func.coalesce(func.sum(_clipped_segment_seconds(now)), 0.0),
+            )
+            .where(
+                UsageSegment.organization_id == organization_id,
+                UsageSegment.is_billable.is_(True),
+                UsageSegment.started_at >= window_start,
+                UsageSegment.started_at < window_end,
+            )
+            .group_by(UsageSegment.user_id)
+        )
+    ).all()
+    return {user_id: float(seconds or 0.0) for user_id, seconds in rows}
+
+
 async def compute_usage_seconds_in_window(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/billing_runtime_usage.py
+++ b/server/proliferate/db/store/billing_runtime_usage.py
@@ -15,7 +15,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.constants.billing import BILLING_RECONCILER_LOCK_KEY
 from proliferate.db.models.billing import BillingDecisionEvent, UsageSegment, WebhookEventReceipt
 from proliferate.db.models.cloud.workspaces import CloudWorkspace
-from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
+from proliferate.db.store.billing_subjects import (
+    ensure_organization_billing_subject,
+    ensure_personal_billing_subject,
+)
 from proliferate.db.store.organizations import get_current_membership_for_user
 from proliferate.utils.time import utcnow
 
@@ -62,10 +65,35 @@ async def resolve_organization_id_for_user(
     Resolves the user's current (first active) membership — the same resolution
     the resume gate uses (``get_current_membership_for_user``). This is the org
     context stamped onto a usage segment so org-scoped compute budget limits can
-    be evaluated; it does not change ``billing_subject_id`` (who pays).
+    be evaluated, and it also decides who pays: a user with a current membership
+    bills the org subject (see ``resolve_billing_subject_id_for_user``).
     """
     membership = await get_current_membership_for_user(db, user_id)
     return membership.organization.id if membership is not None else None
+
+
+async def resolve_billing_subject_id_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> UUID:
+    """The subject that pays for a user's compute.
+
+    A user acting under a current org membership bills the org's billing subject
+    (org Stripe customer + org grant pool); an org-less user bills their personal
+    subject. This mirrors the LLM track exactly: an org member's gateway
+    enrollment is minted against the org billing subject
+    (``ensure_org_enrollment``), an org-less user's against their personal one
+    (``ensure_user_enrollment``), and both keyed off the same current-membership
+    test. Deriving both the paying subject and ``organization_id`` from the one
+    membership lookup keeps compute attribution and enforcement scope from ever
+    disagreeing.
+    """
+    organization_id = await resolve_organization_id_for_user(db, user_id)
+    if organization_id is not None:
+        subject = await ensure_organization_billing_subject(db, organization_id)
+        return subject.id
+    subject = await ensure_personal_billing_subject(db, user_id)
+    return subject.id
 
 
 async def _get_workspace_billing_subject(
@@ -410,11 +438,16 @@ async def ensure_sandbox_usage_started(
         owner_user_id = actor_user_id
     else:
         raise RuntimeError("Usage segment requires a runtime environment, workspace, or user.")
-    # Stamp the org the segment belongs to (owner's current membership) so
-    # org-scoped compute budget limits can be enforced. The paying subject
-    # (``billing_subject_id``) is unchanged — invoicing stays on the personal
-    # subject.
+    # Resolve the org the segment belongs to from the owner's current
+    # membership. This is both the enforcement/attribution scope and, when set,
+    # who pays: an owner acting under an org bills the org billing subject (org
+    # Stripe customer + org grants), matching the LLM track; an org-less owner
+    # keeps the personal subject resolved above. Both derive from one membership
+    # lookup so ``organization_id`` and ``billing_subject_id`` can never disagree.
     organization_id = await resolve_organization_id_for_user(db, owner_user_id)
+    if organization_id is not None:
+        org_subject = await ensure_organization_billing_subject(db, organization_id)
+        billing_subject_id = org_subject.id
     return await create_usage_segment(
         db,
         user_id=actor_user_id or owner_user_id,

--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -20,9 +20,9 @@ from proliferate.db.store import billing as billing_store
 from proliferate.db.store import organizations as organizations_store
 from proliferate.db.store.billing_runtime_usage import (
     record_billing_decision_event,
+    resolve_billing_subject_id_for_user,
     resolve_billing_subject_id_for_workspace,
 )
-from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
 from proliferate.errors import ProliferateError
 from proliferate.server.billing import snapshot_state
@@ -221,17 +221,21 @@ async def assert_cloud_sandbox_resume_allowed_for_owner(
         return
     if owner_user_id is None:
         return
-    subject = await ensure_personal_billing_subject(db, owner_user_id)
-    snapshot = await get_billing_snapshot_for_subject_in_session(db, subject.id)
+    # Resolve the subject that pays the same way segment-open does: an org member
+    # bills the org subject, an org-less owner bills personal. This must match
+    # segment attribution — org compute now drains the org grant pool, so the
+    # active-spend-hold snapshot has to read the org subject or a hold on the org
+    # pool would never block an org member's resume.
+    billing_subject_id = await resolve_billing_subject_id_for_user(db, owner_user_id)
+    snapshot = await get_billing_snapshot_for_subject_in_session(db, billing_subject_id)
     now = utcnow()
 
     decision_type: str | None = None
     reason: str | None = None
-    # The recorded decision event stays on the owner's personal subject — the
-    # subject that pays (invoicing unchanged). Compute limits are org-scoped, so
-    # the compute-cap check resolves the owner's org and sums usage by
-    # ``organization_id`` (matching the reconciler's ``_resolve_compute_limit_pause``).
-    decision_subject_id = subject.id
+    # The recorded decision event stays on the paying subject. Compute limits are
+    # org-scoped, so the compute-cap check resolves the owner's org and sums usage
+    # by ``organization_id`` (matching the reconciler's ``_resolve_compute_limit_pause``).
+    decision_subject_id = billing_subject_id
     if snapshot.active_spend_hold:
         decision_type = BILLING_DECISION_ENFORCE_ACTIVE_SPEND
         reason = snapshot.hold_reason or "active_spend_hold"

--- a/server/proliferate/server/organizations/usage/service.py
+++ b/server/proliferate/server/organizations/usage/service.py
@@ -48,9 +48,14 @@ async def get_usage_by_user(
     start = now - timedelta(days=days)
     billing_subject_id = await _org_billing_subject_id(db, organization_id)
     members = await organization_store.list_organization_members(db, organization_id)
-    compute_by_user = await billing_store.compute_usage_seconds_by_user(
+    # Compute is scoped by ``organization_id``, not the org billing subject:
+    # segments carry the org they belong to (stamped at open time) regardless of
+    # which subject each is invoiced to, so this aggregates every member's
+    # compute and matches the enforcement path's org-wide sum. LLM stays on the
+    # org billing subject because org gateway enrollments are minted against it.
+    compute_by_user = await billing_store.compute_usage_seconds_by_user_for_org(
         db,
-        billing_subject_id=billing_subject_id,
+        organization_id=organization_id,
         start=start,
         end=now,
         now=now,

--- a/server/tests/integration/test_billing_compute_attribution.py
+++ b/server/tests/integration/test_billing_compute_attribution.py
@@ -1,17 +1,22 @@
-"""Org compute budget enforcement, driven through the real segment-open path.
+"""Org compute attribution + budget enforcement, via the real segment-open path.
 
-Regression coverage for the "org-subject segment attribution gap": compute
-``usage_segment`` rows opened by the E2B webhook / provision path used to be
-attributed only to the workspace owner's *personal* billing subject, so
-org-scoped compute caps never fired. The fix stamps ``organization_id`` on the
-segment (owner's current membership) while leaving ``billing_subject_id`` — who
-pays — unchanged.
+Compute ``usage_segment`` rows opened by the E2B webhook / provision path used
+to be attributed only to the workspace owner's *personal* billing subject:
+org-scoped compute caps never fired (#1028 fixed enforcement by stamping
+``organization_id``), and org compute drained the member's personal credits
+while org compute budgets watched a pool that never moved.
 
-These tests exercise the real write path
-(``open_usage_segment_for_sandbox``), then assert enforcement fires:
-* an org-wide compute cap crossed by that usage → the live resume gate denies;
-* a per-user cap the same;
-* a segment for an org-less owner is never attributed, so nothing enforces.
+Per the 2026-07-09 ruling, compute run under an org now bills the org billing
+subject (org Stripe customer, org grant pool), matching the LLM track. Both the
+paying subject and ``organization_id`` derive from the owner's current
+membership, so they can never disagree. An org-less user is unaffected — still
+billed personal.
+
+These tests exercise the real write path (``open_usage_segment_for_sandbox``),
+then assert: an org member's segment bills the org subject and drains org grants
+(personal untouched); an org-less user bills personal; the org-admin
+usage-by-user display shows org compute; and enforcement (org-wide + per-user
+caps) still fires against the now-correct pool.
 """
 
 from __future__ import annotations
@@ -30,26 +35,35 @@ from proliferate.config import settings
 from proliferate.constants.billing import (
     BILLING_DECISION_ORG_LIMIT_PAUSE,
     BILLING_DECISION_USER_LIMIT_PAUSE,
+    BILLING_MODE_OBSERVE,
     BILLING_MODE_ENFORCE,
+    FREE_INCLUDED_GRANT_TYPE,
 )
 from proliferate.constants.organizations import (
     ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
     ORGANIZATION_ROLE_OWNER,
 )
 from proliferate.db.models.auth import User
-from proliferate.db.models.billing import UsageSegment
+from proliferate.db.models.billing import BillingGrant, UsageSegment
 from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store.billing import BudgetLimitInput, replace_budget_limits
-from proliferate.db.store.billing_runtime_usage import open_usage_segment_for_sandbox
+from proliferate.db.store.billing_runtime_usage import (
+    open_usage_segment_for_sandbox,
+    resolve_organization_id_for_user,
+)
 from proliferate.db.store.billing_subjects import (
-    ensure_free_included_grant,
+    ensure_billing_grant,
+    ensure_organization_billing_subject,
     ensure_personal_billing_subject,
 )
+from proliferate.server.billing import accounting as billing_accounting_service
 from proliferate.server.billing.authorization import (
     CloudSandboxResumeBlockedError,
     assert_cloud_sandbox_resume_allowed,
 )
+from proliferate.server.organizations.usage.service import get_usage_by_user
 from proliferate.utils.time import utcnow
+from tests.integration.billing_accounting_helpers import patch_global_session_factory
 
 
 async def _create_user(db_session: AsyncSession) -> uuid.UUID:
@@ -110,14 +124,32 @@ def _compute_limit(user_id: uuid.UUID | None, cap: float) -> BudgetLimitInput:
 
 
 async def _seed_healthy_balance(db_session: AsyncSession, user_id: uuid.UUID) -> None:
-    """Give the personal subject a free grant so the gate has no spend hold.
+    """Give the paying subject a large grant so the gate has no spend hold.
 
-    With PRO_BILLING_ENABLED the snapshot only auto-grants trial hours to
-    GitHub-linked users; a subject with zero grants is (correctly)
-    credits-exhausted, which would mask the compute-cap path under test.
+    The paying subject follows segment attribution: an org member's compute bills
+    the org subject, so the grant must sit on the org subject (otherwise the
+    resume gate reads the org subject as credits-exhausted and the active-spend
+    hold masks the compute-cap path under test). A subject with zero grants is
+    (correctly) credits-exhausted.
     """
-    await ensure_personal_billing_subject(db_session, user_id)
-    await ensure_free_included_grant(db_session, user_id)
+    now = utcnow()
+    organization_id = await resolve_organization_id_for_user(db_session, user_id)
+    if organization_id is not None:
+        subject = await ensure_organization_billing_subject(db_session, organization_id)
+        grant_user_id: uuid.UUID | None = None
+    else:
+        subject = await ensure_personal_billing_subject(db_session, user_id)
+        grant_user_id = user_id
+    await ensure_billing_grant(
+        db_session,
+        user_id=grant_user_id,
+        billing_subject_id=subject.id,
+        grant_type=FREE_INCLUDED_GRANT_TYPE,
+        hours_granted=1000.0,
+        effective_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=30),
+        source_ref=f"test:healthy-balance:{uuid.uuid4()}",
+    )
 
 
 @pytest.mark.asyncio
@@ -125,13 +157,16 @@ async def test_open_segment_stamps_owner_organization(
     db_session: AsyncSession,
     test_engine: Any,
 ) -> None:
-    """The real segment-open path records the owner's org (attribution fix)."""
+    """The real segment-open path records the owner's org and bills the org."""
     user_id, org_id = await _create_org_member(db_session)
     segment = await _open_segment_for(db_session, user_id, seconds=120.0)
     assert segment.organization_id == org_id
-    # Who pays is unchanged: still the owner's personal billing subject.
+    # Who pays is now the org billing subject (2026-07-09 ruling), derived from
+    # the same membership lookup as ``organization_id``.
+    org_subject = await ensure_organization_billing_subject(db_session, org_id)
+    assert segment.billing_subject_id == org_subject.id
     personal = await ensure_personal_billing_subject(db_session, user_id)
-    assert segment.billing_subject_id == personal.id
+    assert segment.billing_subject_id != personal.id
 
 
 @pytest.mark.asyncio
@@ -245,10 +280,10 @@ async def test_org_wide_cap_sums_across_members(
     test_engine: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Org-wide usage aggregates across members regardless of who pays.
+    """Org-wide usage aggregates across every member's segments.
 
-    Two members of the same org each run a sandbox billed to their own personal
-    subject; the org-wide cap sums both segments' seconds by ``organization_id``.
+    Two members of the same org each run a sandbox; both segments bill the org
+    subject and the org-wide cap sums their seconds by ``organization_id``.
     """
     monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
     monkeypatch.setattr(settings, "pro_billing_enabled", False)
@@ -290,3 +325,103 @@ async def test_org_wide_cap_sums_across_members(
         await assert_cloud_sandbox_resume_allowed(db_session, sandbox)  # type: ignore[arg-type]
     assert excinfo.value.decision_type == BILLING_DECISION_ORG_LIMIT_PAUSE
     await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_org_member_segment_bills_org_subject_and_drains_org_grants(
+    db_session: AsyncSession,
+    test_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An org member's compute drains the org grant pool, not personal credits."""
+    patch_global_session_factory(test_engine, monkeypatch)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    user_id, org_id = await _create_org_member(db_session)
+    org_subject = await ensure_organization_billing_subject(db_session, org_id)
+    personal_subject = await ensure_personal_billing_subject(db_session, user_id)
+    now = utcnow()
+    org_grant = await ensure_billing_grant(
+        db_session,
+        user_id=None,
+        billing_subject_id=org_subject.id,
+        grant_type=FREE_INCLUDED_GRANT_TYPE,
+        hours_granted=10.0,
+        effective_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=30),
+        source_ref=f"test:org-grant:{uuid.uuid4()}",
+    )
+    personal_grant = await ensure_billing_grant(
+        db_session,
+        user_id=user_id,
+        billing_subject_id=personal_subject.id,
+        grant_type=FREE_INCLUDED_GRANT_TYPE,
+        hours_granted=10.0,
+        effective_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=30),
+        source_ref=f"test:personal-grant:{uuid.uuid4()}",
+    )
+
+    org_grant_id = org_grant.id
+    personal_grant_id = personal_grant.id
+
+    # One real hour of org compute, opened through the production write path.
+    segment = await _open_segment_for(db_session, user_id, seconds=3600.0)
+    segment.ended_at = utcnow()
+    await db_session.flush()
+    assert segment.billing_subject_id == org_subject.id
+    scan_until = segment.ended_at
+    await db_session.commit()
+
+    result = await billing_accounting_service.account_usage_for_billing_subject(
+        billing_subject_id=org_subject.id,
+        is_paid_cloud=False,
+        billing_subscription_id=None,
+        period_start=None,
+        period_end=None,
+        overage_enabled=False,
+        billing_mode=BILLING_MODE_OBSERVE,
+        scan_until=scan_until,
+    )
+    assert result.consumed_seconds == pytest.approx(3600.0, abs=5.0)
+
+    db_session.expire_all()
+    org_grant_after = await db_session.get(BillingGrant, org_grant_id)
+    personal_grant_after = await db_session.get(BillingGrant, personal_grant_id)
+    assert org_grant_after is not None and personal_grant_after is not None
+    # Org pool drained by the hour of compute; personal pool untouched.
+    assert org_grant_after.remaining_seconds == pytest.approx(10 * 3600.0 - 3600.0, abs=5.0)
+    assert personal_grant_after.remaining_seconds == pytest.approx(10 * 3600.0)
+
+
+@pytest.mark.asyncio
+async def test_org_less_owner_bills_personal_subject(
+    db_session: AsyncSession,
+    test_engine: Any,
+) -> None:
+    """A user with no membership still bills their personal subject."""
+    user_id = await _create_user(db_session)
+    segment = await _open_segment_for(db_session, user_id, seconds=120.0)
+    personal = await ensure_personal_billing_subject(db_session, user_id)
+    assert segment.organization_id is None
+    assert segment.billing_subject_id == personal.id
+
+
+@pytest.mark.asyncio
+async def test_usage_by_user_display_shows_org_compute(
+    db_session: AsyncSession,
+    test_engine: Any,
+) -> None:
+    """The org-admin usage-by-user view reports each member's org compute.
+
+    Scopes compute by ``organization_id`` (not the org billing subject), so it
+    surfaces the member's segment even though the segment predates nothing — the
+    point is the display no longer reads an empty org-subject compute pool.
+    """
+    user_id, org_id = await _create_org_member(db_session)
+    await _open_segment_for(db_session, user_id, seconds=300.0)
+    await db_session.commit()
+
+    response = await get_usage_by_user(db_session, org_id, days=30)
+    row = next(row for row in response.users if row.user_id == user_id)
+    # Open segment: seconds accrue against ``now``, so allow a little skew.
+    assert row.compute_seconds == pytest.approx(300.0, abs=5.0)

--- a/server/tests/integration/test_organization_usage_api.py
+++ b/server/tests/integration/test_organization_usage_api.py
@@ -143,6 +143,7 @@ async def test_usage_by_user_admin_includes_zero_usage_members_and_limit_caps(
             UsageSegment(
                 user_id=member_id,
                 billing_subject_id=subject.id,
+                organization_id=organization.id,
                 workspace_id=uuid.uuid4(),
                 sandbox_id=uuid.uuid4(),
                 external_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",

--- a/specs/tbd/consumption-ui-v1.md
+++ b/specs/tbd/consumption-ui-v1.md
@@ -14,8 +14,10 @@ Two fully distinct meters. Keep them distinct.
 
 **Compute (seconds).** E2B webhooks open/close `usage_segment` rows
 (`server/proliferate/db/models/billing.py`: `user_id`, `billing_subject_id`, `organization_id`,
-`sandbox_id`, `started_at`, `ended_at`, `is_billable`). `billing_subject_id` is who pays (the
-owner's personal subject); `organization_id` is the enforcement/attribution scope (§4.2). A
+`sandbox_id`, `started_at`, `ended_at`, `is_billable`). `billing_subject_id` is who pays and
+`organization_id` is the enforcement/attribution scope (§4.2); both are resolved from the owner's
+current membership at segment-open time, so an owner acting under an org bills the org subject and
+an org-less owner bills personal (see §4.2, matching the LLM track). A
 15-min accounting pass drains
 `billing_grant.remaining_seconds`; overage exports to a Stripe meter. Enforcement that is LIVE:
 the reconciler (`server/proliferate/server/billing/reconciler.py:271-365`) pauses open segments
@@ -125,7 +127,11 @@ Nested-router pattern with `current_path_org_admin` (copy the SSO router shape,
             "computeLimitCapSeconds": 36000.0 | null, "llmLimitCapUsd": 10.0 | null}, ...]}
 ```
 
-Sorted by combined consumption descending. Include members with zero usage.
+Sorted by combined consumption descending. Include members with zero usage. `computeSeconds` is
+summed by `usage_segment.organization_id` (`billing.compute_usage_seconds_by_user_for_org`), not by
+the org billing subject, so it aggregates every member's org compute regardless of which subject
+each segment is invoiced to — the same scope §4.2 enforces. `llmCostUsd` stays keyed off the org
+billing subject because org gateway enrollments are minted against it.
 
 ### 3.4 `GET /organizations/{organization_id}/usage/users/{user_id}/timeseries` — org admin
 
@@ -176,16 +182,33 @@ with the existing `USAGE_SEGMENT_CLOSED_BY_QUOTA_ENFORCEMENT` and recording a
 `BillingDecisionEvent` with a new decision type `user_limit_pause` (or `org_limit_pause`).
 Only when `CLOUD_BILLING_MODE=enforce`, same as today's behavior.
 
-**Attribution (fixed — the org-subject segment attribution gap).** `usage_segment` carries an
-`organization_id` column (owner's current membership, or `None` for an org-less owner), stamped
-at segment-open time (`billing_runtime_usage.resolve_organization_id_for_user`). Enforcement
-resolves the org directly from `segment.organization_id` and sums window usage by
-`organization_id` (`billing.compute_usage_seconds_in_window_for_org`) — so org usage aggregates
-across every member regardless of who each segment is invoiced to. This is deliberately separate
-from `billing_subject_id`, which stays the workspace owner's **personal** subject: who pays is
-unchanged (org-owned workspaces are NOT invoiced to the org). Before this fix, segments were
-attributed only to the personal subject and the enforcement path resolved `organization_id=None`,
-so admin-configured compute caps saved in the UI and silently never fired.
+**Attribution.** `usage_segment` carries an `organization_id` column (owner's current membership,
+or `None` for an org-less owner), stamped at segment-open time
+(`billing_runtime_usage.resolve_organization_id_for_user`). Enforcement resolves the org directly
+from `segment.organization_id` and sums window usage by `organization_id`
+(`billing.compute_usage_seconds_in_window_for_org`) — so org usage aggregates across every member
+regardless of which subject each segment is invoiced to. Before #1028, segments were attributed
+only to the personal subject and the enforcement path resolved `organization_id=None`, so
+admin-configured compute caps saved in the UI silently never fired.
+
+**Who pays (ruled 2026-07-09).** Compute run under an org bills the org billing subject (org
+Stripe customer, org grant pool), matching how LLM usage already attributes to the org. At
+segment-open, `billing_runtime_usage.resolve_billing_subject_id_for_user` derives the paying
+subject from the same current-membership lookup that produces `organization_id`: a user with a
+current membership bills the org subject, an org-less user bills personal. Deriving both from one
+lookup means `billing_subject_id` and `organization_id` can never disagree, and it mirrors the LLM
+track exactly (an org member's gateway enrollment is minted against the org billing subject in
+`ensure_org_enrollment`, an org-less user's against their personal one in `ensure_user_enrollment`,
+both keyed off the same membership test). The prior behavior — org compute draining the workspace
+owner's personal credits while org compute budgets watched an empty pool — was the "org-subject
+segment attribution gap" left open by #1028.
+
+Grant drawdown, overage export, and the Stripe metered events all follow `billing_subject_id`
+unchanged (the accounting layer is subject-parametrized), so no accounting code changes; they
+simply now target the org subject for org compute. Compute caps sum by `organization_id`, a
+separate scope, so there is no double-counting. In-flight segments opened before this change keep
+their stamped subject — no retroactive re-attribution — so nothing that was already invoiced to a
+personal subject moves.
 
 ### 4.3 Compute start-side (live)
 
@@ -195,7 +218,9 @@ start/resume gate is `authorization.assert_cloud_sandbox_resume_allowed`, called
 raising a structured 402 (`CloudSandboxResumeBlockedError`) the UI can surface. It resolves the
 owner's org via membership and sums usage by `organization_id`
 (`compute_usage_seconds_in_window_for_org`), mirroring the reconciler's
-`_resolve_compute_limit_pause`.
+`_resolve_compute_limit_pause`. The active-spend-hold snapshot reads the paying subject resolved
+the same way as segment-open (`resolve_billing_subject_id_for_user`) so that a hold on the org
+grant pool blocks an org member's resume, not just the personal pool.
 
 ## 5. SDK
 


### PR DESCRIPTION
## What this does

Compute run under an organization now bills the org billing subject (org Stripe customer, org grant pool), matching how LLM usage already attributes to the org. Before this, compute usage segments always billed the workspace owner's personal subject, so org compute budgets watched a pool that never moved and members' personal credits drained during org work. This is the "who pays for org compute" question #1028 left open, now ruled (2026-07-09).

## Subject resolution

At segment-open, `resolve_billing_subject_id_for_user` derives the paying subject from the same current-membership lookup that #1028 uses to stamp `usage_segment.organization_id` (`resolve_organization_id_for_user` → `get_current_membership_for_user`): a user with a current membership bills the org subject, an org-less user bills personal. Both the paying subject and `organization_id` come from that one lookup, so they can never disagree.

This mirrors the LLM track's resolution rather than inventing a third rule. An org member's gateway enrollment is minted against the org billing subject in `ensure_org_enrollment`; an org-less user's against their personal subject in `ensure_user_enrollment`; both are keyed off the same membership existence. LLM spend then attributes to `enrollment.billing_subject_id`. Compute now follows the identical org-membership test.

One place the LLM track differs, flagged rather than papered over: gateway key materialization (`materialize/agent_auth.py`) currently fetches the personal enrollment via `get_enrollment_for_user` even for org members, so which key an org member actually uses at runtime is a separate, pre-existing question. It does not change the resolution rule for who-pays (org membership → org subject), and it is out of scope here.

## Readers checked for coherence after the flip

- Reconciler active-spend-hold: keys off `segment.billing_subject_id`, so org segments now snapshot the org subject and pause on org exhaustion. Correct, no change.
- Reconciler compute caps: sum by `organization_id` (#1028), orthogonal to the paying subject, so no double-counting. No change.
- Resume gate (`assert_cloud_sandbox_resume_allowed`): changed to resolve the active-spend-hold snapshot via the same subject resolution, otherwise a hold on the org grant pool would never block an org member. See the #1036 overlap note below.
- Accounting / grant drawdown / overage export / Stripe metered events: fully subject-parametrized (`list_billing_subject_ids_for_usage_accounting`, `list_accountable_usage_ranges`, grants, cursors, exports all filter by `billing_subject_id`), so they follow the org subject automatically. No accounting code changes.
- Personal usage summary (`usage.py`): keys off `OwnerContext.billing_subject_id`, which is already the org subject for org scope, so org compute now shows up there too. No change, coherent.

## Companion display fix

The org-admin usage-by-user page (`organizations/usage/service.py`) summed compute by the org billing subject and showed zero org compute. Repointed at the segment's `organization_id` via a new `compute_usage_seconds_by_user_for_org`, matching the enforcement scope. LLM stays on the org billing subject because org gateway enrollments are minted against it. The per-user timeseries drill-down (§3.4) still keys off the org billing subject; it now reflects org compute because segments bill the org subject, though pre-flip personal-subject segments will not appear there (see deploy note).

## Deploy behavior

In-flight and open segments opened before this change keep their stamped subject. There is no retroactive re-attribution, so nothing already invoiced to a personal subject moves. Enforcement and the display read current-window usage going forward.

Free/personal users (no org) are unaffected: still billed personal.

## Migration

None. `usage_segment.organization_id` already exists from #1028.

## Stacking and merge order

Originally stacked on `fix/org-compute-budget-attribution` (PR #1028) for its `organization_id` column and enforcement rework. #1028 has since merged to main, so this PR was retargeted to `main` and rebased; the diff now contains only the org-compute change.

## Overlap with the #1036 fix

Another change is concurrently wiring `assert_cloud_sandbox_resume_allowed` into the cloud-sandbox wake/ensure service (`cloud/cloud_sandboxes/service.py` + `billing/authorization.py`). This PR does not touch that service. It does make one minimal edit to `authorization.py`'s subject resolution inside `assert_cloud_sandbox_resume_allowed`: the active-spend-hold snapshot now reads `resolve_billing_subject_id_for_user` instead of `ensure_personal_billing_subject`. That is required for coherence with the flip (org holds must block org members). Whichever lands second should keep this subject resolution; the change is confined to the two lines that resolve the snapshot subject and `decision_subject_id`.

## Tests

New and updated coverage in `test_billing_compute_attribution.py`, driving the real segment-open path: an org member's segment bills the org subject and drains org grants while the personal pool is untouched; an org-less user bills personal; the org-admin usage-by-user display reports org compute; org-wide and per-user caps still deny resume against the now-correct pool. Spec amendment in `consumption-ui-v1.md`.

