### PR TITLE
feat(auth): org-scoped SSO login entry points + product-readiness carve-out

### DIFF
--- a/apps/desktop/src/components/auth/OrgSsoLoginLink.tsx
+++ b/apps/desktop/src/components/auth/OrgSsoLoginLink.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+
+import { useOrgSlugSsoSignIn } from "@/hooks/auth/workflows/use-org-slug-sso-sign-in";
+import { getRedirectTarget } from "@/lib/domain/auth/login-redirect";
+
+// Org-scoped SSO entry point on cold login: a quiet "Sign in with SSO" link that
+// reveals a workspace-slug field and drives the native SSO flow. Kept below the
+// primary sign-in actions so it never disturbs the loading -> auth transition.
+export function OrgSsoLoginLink() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { signIn, submitting, error, clearError } = useOrgSlugSsoSignIn();
+  const [expanded, setExpanded] = useState(false);
+  const [slug, setSlug] = useState("");
+
+  async function handleSubmit() {
+    if (submitting) {
+      return;
+    }
+    const signedIn = await signIn(slug);
+    if (signedIn) {
+      navigate(getRedirectTarget(location.state), { replace: true });
+    }
+  }
+
+  if (!expanded) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setExpanded(true)}
+        className="inline h-auto px-0 py-0 text-sm text-muted-foreground underline underline-offset-4 hover:bg-transparent hover:text-foreground"
+      >
+        Sign in with SSO
+      </Button>
+    );
+  }
+
+  return (
+    <form
+      className="grid w-full gap-2 text-left"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <Input
+        value={slug}
+        onChange={(event) => {
+          setSlug(event.target.value);
+          if (error) {
+            clearError();
+          }
+        }}
+        placeholder="your-organization"
+        className="text-sm"
+        disabled={submitting}
+        autoFocus
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
+      <Button
+        type="submit"
+        size="md"
+        variant="secondary"
+        className="h-11 w-full"
+        loading={submitting}
+        disabled={submitting || !slug.trim()}
+      >
+        {!submitting && <ProviderBrandIcon provider="sso" className="h-4 w-4 shrink-0" />}
+        Continue with SSO
+      </Button>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </form>
+  );
+}

--- a/apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.test.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signInWithSso: vi.fn(async () => ({ provider: "sso", source: "browser" })),
+  discoverDesktopSso: vi.fn(),
+}));
+
+vi.mock("@/hooks/auth/workflows/use-auth-actions", () => ({
+  useAuthActions: () => ({ signInWithSso: mocks.signInWithSso }),
+}));
+
+vi.mock("@/lib/integrations/auth/proliferate-sso-auth", () => ({
+  discoverDesktopSso: mocks.discoverDesktopSso,
+}));
+
+import { useOrgSlugSsoSignIn } from "./use-org-slug-sso-sign-in";
+
+afterEach(() => {
+  cleanup();
+  mocks.signInWithSso.mockClear();
+  mocks.discoverDesktopSso.mockReset();
+});
+
+describe("useOrgSlugSsoSignIn", () => {
+  it("resolves the slug and starts SSO for an enabled org connection", async () => {
+    mocks.discoverDesktopSso.mockResolvedValue({
+      enabled: true,
+      scope: "organization",
+      organizationId: "org-123",
+      connectionId: "conn-456",
+      protocol: "oidc",
+      displayName: "Okta",
+      reason: null,
+    });
+
+    const { result } = renderHook(() => useOrgSlugSsoSignIn());
+    let outcome = false;
+    await act(async () => {
+      outcome = await result.current.signIn("  acme  ");
+    });
+
+    expect(outcome).toBe(true);
+    expect(mocks.discoverDesktopSso).toHaveBeenCalledWith({ slug: "acme" });
+    expect(mocks.signInWithSso).toHaveBeenCalledWith({
+      organizationId: "org-123",
+      connectionId: "conn-456",
+      prompt: "select_account",
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a generic error and does not start SSO when the slug is unavailable", async () => {
+    mocks.discoverDesktopSso.mockResolvedValue({
+      enabled: false,
+      scope: null,
+      organizationId: null,
+      connectionId: null,
+      protocol: null,
+      displayName: null,
+      reason: "not_available",
+    });
+
+    const { result } = renderHook(() => useOrgSlugSsoSignIn());
+    let outcome = true;
+    await act(async () => {
+      outcome = await result.current.signIn("ghost-org");
+    });
+
+    expect(outcome).toBe(false);
+    expect(mocks.signInWithSso).not.toHaveBeenCalled();
+    expect(result.current.error).toContain("sign-in link your admin shared");
+  });
+
+  it("rejects an empty slug before hitting the network", async () => {
+    const { result } = renderHook(() => useOrgSlugSsoSignIn());
+    let outcome = true;
+    await act(async () => {
+      outcome = await result.current.signIn("   ");
+    });
+
+    expect(outcome).toBe(false);
+    expect(mocks.discoverDesktopSso).not.toHaveBeenCalled();
+    expect(result.current.error).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+import { useAuthActions } from "@/hooks/auth/workflows/use-auth-actions";
+import { isAbortError } from "@/lib/integrations/auth/proliferate-auth";
+import { discoverDesktopSso } from "@/lib/integrations/auth/proliferate-sso-auth";
+
+// A slug that does not resolve to enabled SSO returns the same generic answer
+// whether the org is missing, has no SSO, or has it disabled, so we surface one
+// generic message and never confirm which orgs exist.
+const SLUG_UNAVAILABLE =
+  "We could not find single sign-on for that workspace. Check the sign-in link your admin shared.";
+
+export interface UseOrgSlugSsoSignInResult {
+  signIn: (slug: string) => Promise<boolean>;
+  submitting: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+// Drives org-scoped SSO from a workspace slug on cold login: resolve the slug to
+// the org's SSO connection, then hand off to the existing native SSO machinery
+// (system browser + proliferate://auth/callback deep link).
+export function useOrgSlugSsoSignIn(): UseOrgSlugSsoSignInResult {
+  const { signInWithSso } = useAuthActions();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const signIn = useCallback(async (slug: string): Promise<boolean> => {
+    const trimmed = slug.trim();
+    if (!trimmed) {
+      setError("Enter your organization's workspace name to continue.");
+      return false;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const discovery = await discoverDesktopSso({ slug: trimmed });
+      if (!discovery.enabled || !discovery.organizationId) {
+        setError(SLUG_UNAVAILABLE);
+        return false;
+      }
+      await signInWithSso({
+        organizationId: discovery.organizationId,
+        connectionId: discovery.connectionId,
+        prompt: "select_account",
+      });
+      return true;
+    } catch (err) {
+      if (isAbortError(err)) {
+        setError(null);
+        return false;
+      }
+      setError(err instanceof Error ? err.message : "SSO sign-in failed");
+      return false;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [signInWithSso]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { signIn, submitting, error, clearError };
+}

--- a/apps/desktop/src/lib/integrations/auth/proliferate-sso-auth.ts
+++ b/apps/desktop/src/lib/integrations/auth/proliferate-sso-auth.ts
@@ -46,12 +46,14 @@ function buildUrl(path: string): string {
 }
 
 export async function discoverDesktopSso(
-  options: Pick<DesktopSsoSignInOptions, "email" | "organizationId" | "connectionId"> = {},
+  options: Pick<DesktopSsoSignInOptions, "email" | "organizationId" | "connectionId">
+    & { slug?: string | null } = {},
 ): Promise<DesktopSsoDiscovery> {
   const params = new URLSearchParams()
   if (options.email) params.set("email", options.email)
   if (options.organizationId) params.set("organizationId", options.organizationId)
   if (options.connectionId) params.set("connectionId", options.connectionId)
+  if (options.slug) params.set("slug", options.slug)
   const query = params.toString()
   const response = await fetchAuthResponse(
     buildUrl(`/auth/sso/discover${query ? `?${query}` : ""}`),

--- a/apps/desktop/src/pages/LoginPage.tsx
+++ b/apps/desktop/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useLoginPage } from "@/hooks/auth/facade/use-login-page";
 import { AuthScreenLayout } from "@/components/auth/AuthScreenLayout";
+import { OrgSsoLoginLink } from "@/components/auth/OrgSsoLoginLink";
 
 export function LoginPage() {
   const {
@@ -25,28 +26,35 @@ export function LoginPage() {
   } = useLoginPage();
 
   return (
-    <AuthScreenLayout
-      mode="auth"
-      markComplete
-      submitting={submitting}
-      busy={busy}
-      error={error}
-      githubSignInAvailable={githubSignInAvailable}
-      githubSignInChecking={githubSignInChecking}
-      githubSignInUnavailableDescription={githubSignInUnavailableDescription}
-      ssoSubmitting={ssoSubmitting}
-      ssoSignInAvailable={ssoSignInAvailable}
-      ssoSignInChecking={ssoSignInChecking}
-      ssoSignInUnavailableDescription={ssoSignInUnavailableDescription}
-      ssoDisplayName={ssoDisplayName}
-      passwordSignInAvailable={passwordSignInAvailable}
-      passwordSubmitting={passwordSubmitting}
-      onGitHubSignIn={() => void handleGitHubSignIn()}
-      onSsoSignIn={() => void handleSsoSignIn()}
-      onPasswordSignIn={(email, password) => void handlePasswordSignIn(email, password)}
-      onCancelSignIn={handleCancelSignIn}
-      canContinueLocally={canContinueLocally}
-      onContinueLocally={handleContinueLocally}
-    />
+    <>
+      <AuthScreenLayout
+        mode="auth"
+        markComplete
+        submitting={submitting}
+        busy={busy}
+        error={error}
+        githubSignInAvailable={githubSignInAvailable}
+        githubSignInChecking={githubSignInChecking}
+        githubSignInUnavailableDescription={githubSignInUnavailableDescription}
+        ssoSubmitting={ssoSubmitting}
+        ssoSignInAvailable={ssoSignInAvailable}
+        ssoSignInChecking={ssoSignInChecking}
+        ssoSignInUnavailableDescription={ssoSignInUnavailableDescription}
+        ssoDisplayName={ssoDisplayName}
+        passwordSignInAvailable={passwordSignInAvailable}
+        passwordSubmitting={passwordSubmitting}
+        onGitHubSignIn={() => void handleGitHubSignIn()}
+        onSsoSignIn={() => void handleSsoSignIn()}
+        onPasswordSignIn={(email, password) => void handlePasswordSignIn(email, password)}
+        onCancelSignIn={handleCancelSignIn}
+        canContinueLocally={canContinueLocally}
+        onContinueLocally={handleContinueLocally}
+      />
+      <div className="pointer-events-none fixed inset-x-0 bottom-10 flex justify-center px-8">
+        <div className="pointer-events-auto w-full max-w-md text-center">
+          <OrgSsoLoginLink />
+        </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { BillingReturnHandoffPage } from "./pages/BillingReturnHandoffPage";
 import { ChatPage } from "./pages/ChatPage";
 import { DesktopHandoffPage } from "./pages/DesktopHandoffPage";
 import { HomePage } from "./pages/HomePage";
+import { LoginSsoPage } from "./pages/LoginSsoPage";
 import { OrganizationJoinPage } from "./pages/OrganizationJoinPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { SettingsModalPage } from "./pages/SettingsModalPage";
@@ -29,6 +30,8 @@ export function App() {
     <>
       <InstrumentedRoutes location={backgroundLocation ?? location}>
         <Route path="auth" element={<AuthScreen />} />
+        <Route path="login" element={<LoginSsoPage />} />
+        <Route path="login/:slug" element={<LoginSsoPage />} />
         <Route path="auth/callback" element={<AuthCallbackPage />} />
         <Route path="auth/desktop/handoff" element={<DesktopHandoffPage />} />
         <Route path="auth/error" element={<AuthErrorPage />} />

--- a/apps/web/src/components/auth/screen/AuthScreen.tsx
+++ b/apps/web/src/components/auth/screen/AuthScreen.tsx
@@ -1,5 +1,6 @@
 import { KeyRound } from "lucide-react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import { type AuthProviderName } from "@proliferate/cloud-sdk";
 import {
@@ -14,6 +15,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 
 import { webEnv } from "../../../config/env";
+import { routes } from "../../../config/routes";
 import { WEB_AUTH_COPY } from "../../../copy/auth/web-auth-copy";
 import { useWebDeploymentSsoDiscovery } from "../../../hooks/auth/derived/use-web-deployment-sso-discovery";
 import {
@@ -162,6 +164,14 @@ export function AuthScreen() {
       footer={<span className="block text-faint">{AUTH_SIGN_IN_COPY.footer}</span>}
       credentialForm={credentialForm}
       providers={providerActions}
+      note={deploymentSso || deploymentSsoDiscovery.isLoading ? null : (
+        <Link
+          to={routes.ssoLogin}
+          className="underline underline-offset-4 hover:text-foreground"
+        >
+          Sign in with SSO
+        </Link>
+      )}
       error={providerError ?? (bootstrapUnreachable ? localApiUnreachableNotice() : null)}
       devAccess={webEnv.devAccessTokenLogin ? (
         <div className="mt-2 border-t border-border pt-4">

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -1,6 +1,8 @@
 export const routes = {
   home: "/",
   auth: "/auth",
+  ssoLogin: "/login",
+  ssoLoginForSlug: (slug: string) => `/login/${slug}`,
   workflows: "/workflows",
   workflow: (workflowId: string) => `/workflows/${workflowId}`,
   support: "/support",

--- a/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
+++ b/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
@@ -125,6 +125,29 @@ export async function startWebSsoFlow(input: {
   window.location.assign(response.authorizationUrl);
 }
 
+// The org-slug login page and per-org /login/<slug> links resolve a slug to an
+// organization's SSO connection, then hand off to the existing start flow. A
+// slug that does not resolve (missing org, no SSO, disabled) returns the same
+// generic answer, so we surface one generic message either way.
+const SSO_SLUG_UNAVAILABLE_MESSAGE =
+  "We could not find single sign-on for that workspace. Check the sign-in link your admin shared.";
+
+export async function startWebSsoFlowForSlug(slug: string): Promise<void> {
+  const trimmed = slug.trim();
+  if (!trimmed) {
+    throw new Error("Enter your organization's workspace name to continue.");
+  }
+  const client = createWebCloudClient(webEnv.apiBaseUrl, null);
+  const discovery = await discoverSso({ slug: trimmed }, client);
+  if (!discovery.enabled || !discovery.organizationId) {
+    throw new Error(SSO_SLUG_UNAVAILABLE_MESSAGE);
+  }
+  await startWebSsoFlow({
+    organizationId: discovery.organizationId,
+    connectionId: discovery.connectionId,
+  });
+}
+
 export async function completeWebAuthFlow(
   searchParams: URLSearchParams,
 ): Promise<AuthSessionResponse> {

--- a/apps/web/src/pages/LoginSsoPage.tsx
+++ b/apps/web/src/pages/LoginSsoPage.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { AuthLayout } from "@proliferate/product-ui/auth/AuthLayout";
+import { ProviderBrandIcon } from "@proliferate/product-ui/auth/ProviderBrandIcon";
+import { ProliferateMark } from "@proliferate/product-ui/brand/ProliferateMark";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+
+import { startWebSsoFlowForSlug } from "../lib/access/cloud/auth/web-auth-flow";
+
+// Org-scoped SSO entry point. Reached from the "Sign in with SSO" link on the
+// auth screen, or directly via /login/<slug> links an admin shares. The slug
+// resolves to the org's SSO connection server-side; a slug that does not
+// resolve returns a generic answer, so we never confirm which orgs exist.
+export function LoginSsoPage() {
+  const { slug: slugParam } = useParams();
+  const [slug, setSlug] = useState(slugParam ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit() {
+    if (submitting) {
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await startWebSsoFlowForSlug(slug);
+    } catch (ssoError) {
+      setSubmitting(false);
+      setError(ssoError instanceof Error ? ssoError.message : "SSO could not start.");
+    }
+  }
+
+  return (
+    <AuthLayout
+      mark={<ProliferateMark size={36} />}
+      title="Sign in with SSO"
+      subtitle="Enter your organization's workspace name to continue to your identity provider."
+    >
+      <form
+        className="grid gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleSubmit();
+        }}
+      >
+        <Input
+          value={slug}
+          onChange={(event) => setSlug(event.target.value)}
+          placeholder="your-organization"
+          className="text-sm"
+          disabled={submitting}
+          autoFocus
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+        <Button
+          type="submit"
+          size="md"
+          className="w-full"
+          loading={submitting}
+          disabled={submitting || !slug.trim()}
+        >
+          <ProviderBrandIcon provider="sso" className="size-[15px]" />
+          Continue
+        </Button>
+      </form>
+      {error ? (
+        <p className="text-sm leading-5 text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/pages/OrganizationJoinPage.tsx
+++ b/apps/web/src/pages/OrganizationJoinPage.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
 
+import { discoverSso } from "@proliferate/cloud-sdk";
+import { useCloudClient } from "@proliferate/cloud-sdk-react";
 import { RedirectCallbackScreen } from "@proliferate/product-ui/auth/RedirectCallbackScreen";
 import {
   canUseDevDesktopHandoff,
   getDevDesktopHandoff,
   queueDevDesktopHandoff,
 } from "../lib/access/cloud/dev-desktop-handoff";
+import { startWebSsoFlow } from "../lib/access/cloud/auth/web-auth-flow";
 
 const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"]);
 const DEV_HANDOFF_STATUS_POLL_MS = 500;
@@ -24,6 +27,12 @@ function organizationJoinDeepLink(organizationId: string): string {
 
 export function OrganizationJoinPage() {
   const { organizationId } = useParams();
+  const cloudClient = useCloudClient();
+  // Try to sign the user in on the web first: if the org has SSO enabled, the
+  // start flow redirects to the identity provider (JIT membership / invite
+  // acceptance happen in the SSO callback). Only when SSO is not available do
+  // we fall back to handing the invite off to Desktop.
+  const [joinPhase, setJoinPhase] = useState<"resolving" | "desktop">("resolving");
   const [handoffTimedOut, setHandoffTimedOut] = useState(false);
   const [devHandoffQueued, setDevHandoffQueued] = useState(false);
   const [devHandoffId, setDevHandoffId] = useState<string | null>(null);
@@ -61,11 +70,41 @@ export function OrganizationJoinPage() {
   }, [deepLinkUrl]);
 
   useEffect(() => {
-    if (!deepLinkUrl) {
+    if (!organizationId) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const discovery = await discoverSso({ organizationId }, cloudClient);
+        if (cancelled) {
+          return;
+        }
+        if (discovery.enabled && discovery.organizationId) {
+          await startWebSsoFlow({
+            organizationId: discovery.organizationId,
+            connectionId: discovery.connectionId,
+          });
+          return;
+        }
+      } catch {
+        // Fall through to the Desktop handoff when SSO cannot be resolved.
+      }
+      if (!cancelled) {
+        setJoinPhase("desktop");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, cloudClient]);
+
+  useEffect(() => {
+    if (!deepLinkUrl || joinPhase !== "desktop") {
       return;
     }
     void openInvite();
-  }, [deepLinkUrl, openInvite]);
+  }, [deepLinkUrl, joinPhase, openInvite]);
 
   useEffect(() => {
     if (!devHandoffId || devHandoffOpened) {
@@ -119,6 +158,17 @@ export function OrganizationJoinPage() {
 
   if (!deepLinkUrl) {
     return <Navigate to="/" replace />;
+  }
+
+  if (joinPhase === "resolving") {
+    return (
+      <RedirectCallbackScreen
+        title="Signing you in"
+        description="Checking your organization's sign-in options..."
+        statusLabel="Organization sign-in"
+        variant="handoff"
+      />
+    );
   }
 
   if (devHandoffOpened) {

--- a/cloud/sdk/src/client/sso.ts
+++ b/cloud/sdk/src/client/sso.ts
@@ -23,6 +23,7 @@ export interface DiscoverSsoOptions extends SsoRequestOptions {
   email?: string | null;
   organizationId?: string | null;
   connectionId?: string | null;
+  slug?: string | null;
 }
 
 export async function discoverSso(
@@ -35,6 +36,7 @@ export async function discoverSso(
       email: options.email ?? undefined,
       organizationId: options.organizationId ?? undefined,
       connectionId: options.connectionId ?? undefined,
+      slug: options.slug ?? undefined,
     },
     credentials: "include",
     signal: options.signal,

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -2739,7 +2739,9 @@ export interface components {
             /** Sources */
             sources: components["schemas"]["AgentAuthSourceInput"][];
             /** Settings */
-            settings?: Record<string, unknown> | null;
+            settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * AgentAuthSourceInput
@@ -2770,7 +2772,9 @@ export interface components {
             /** Sources */
             sources: components["schemas"]["AgentAuthStateSource"][];
             /** Settings */
-            settings?: Record<string, unknown> | null;
+            settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * AgentAuthStateResponse
@@ -6476,6 +6480,7 @@ export interface operations {
                 email?: string | null;
                 organizationId?: string | null;
                 connectionId?: string | null;
+                slug?: string | null;
             };
             header?: never;
             path?: never;

--- a/server/alembic/versions/e1f2a3b4c5d6_organization_slug.py
+++ b/server/alembic/versions/e1f2a3b4c5d6_organization_slug.py
@@ -1,0 +1,60 @@
+"""organization slug for per-org SSO login links
+
+Adds a human-friendly, URL-safe ``slug`` to organizations so admins can hand
+out ``/login/<slug>`` links that resolve to their org's SSO connection. The
+column is nullable with a partial unique index; existing rows are backfilled
+from their name.
+
+Revision ID: e1f2a3b4c5d6
+Revises: 75e8009a52c7
+Create Date: 2026-07-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from proliferate.utils.slug import slugify
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, Sequence[str], None] = "75e8009a52c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("organization", sa.Column("slug", sa.String(length=64), nullable=True))
+
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text("SELECT id, name FROM organization ORDER BY created_at ASC")
+    ).fetchall()
+
+    used: set[str] = set()
+    for row in rows:
+        base = slugify(row.name)
+        candidate = base
+        suffix = 2
+        while candidate in used:
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+        used.add(candidate)
+        connection.execute(
+            sa.text("UPDATE organization SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": row.id},
+        )
+
+    op.create_index(
+        "ux_organization_slug",
+        "organization",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("slug IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ux_organization_slug", table_name="organization")
+    op.drop_column("organization", "slug")

--- a/server/alembic/versions/e1f2a3b4c5d6_organization_slug.py
+++ b/server/alembic/versions/e1f2a3b4c5d6_organization_slug.py
@@ -6,7 +6,7 @@ column is nullable with a partial unique index; existing rows are backfilled
 from their name.
 
 Revision ID: e1f2a3b4c5d6
-Revises: 75e8009a52c7
+Revises: d10c0a11e5ef
 Create Date: 2026-07-09 00:00:00.000000
 
 """
@@ -19,7 +19,7 @@ from proliferate.utils.slug import slugify
 
 # revision identifiers, used by Alembic.
 revision: str = "e1f2a3b4c5d6"
-down_revision: Union[str, Sequence[str], None] = "75e8009a52c7"
+down_revision: Union[str, Sequence[str], None] = "d10c0a11e5ef"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/server/proliferate/auth/dependencies.py
+++ b/server/proliferate/auth/dependencies.py
@@ -12,6 +12,7 @@ from proliferate.auth.users import get_user_manager
 from proliferate.config import settings
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.db.store.auth_sso import user_has_active_organization_sso_membership
 from proliferate.errors import PermissionDenied
 from proliferate.integrations.sentry import set_server_sentry_user
 from proliferate.middleware.request_context import set_authenticated_user_context
@@ -62,8 +63,15 @@ async def current_product_user(
     password-only accounts: the product surfaces themselves must work with no
     GitHub OAuth app configured. Endpoints that genuinely need a GitHub token
     (e.g. repo import) enforce that at the point of use instead of here.
+
+    Users who arrived through an organization's SSO connection also pass: the
+    org relationship is the vetting, so a linked GitHub identity is not required
+    to reach product surfaces. GitHub stays enforced at the point of use, and
+    free-trial credits stay GitHub-gated.
     """
     if settings.single_org_mode:
+        return user
+    if await user_has_active_organization_sso_membership(db, user_id=user.id):
         return user
     return await _require_product_ready(db, user)
 

--- a/server/proliferate/auth/sso/api.py
+++ b/server/proliferate/auth/sso/api.py
@@ -35,6 +35,7 @@ async def discover_sso_endpoint(
     email: str | None = None,
     organization_id: str | None = Query(default=None, alias="organizationId"),
     connection_id: str | None = Query(default=None, alias="connectionId"),
+    slug: str | None = Query(default=None),
     db: AsyncSession = Depends(get_async_session),
 ) -> SsoDiscoveryResponse:
     discovery = await discover_sso(
@@ -42,6 +43,7 @@ async def discover_sso_endpoint(
         email=email,
         organization_id=_optional_uuid(organization_id, field="organizationId"),
         connection_id=_optional_uuid(connection_id, field="connectionId"),
+        slug=slug,
     )
     return SsoDiscoveryResponse(
         enabled=discovery.enabled,

--- a/server/proliferate/auth/sso/service.py
+++ b/server/proliferate/auth/sso/service.py
@@ -39,6 +39,7 @@ from proliferate.config import settings
 from proliferate.constants.auth import SUPPORTED_CODE_CHALLENGE_METHODS
 from proliferate.db.models.auth import User
 from proliferate.db.store import auth_sso as sso_store
+from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.auth import create_auth_code
 from proliferate.integrations.sso.errors import SsoIntegrationError
 from proliferate.integrations.sso.oidc import (
@@ -70,12 +71,63 @@ class SsoStart:
     connection: SsoConnectionSnapshot
 
 
+# Uniform "no SSO here" answer for slug-driven discovery. A nonexistent slug,
+# an org with no SSO, and an org whose SSO is disabled all return this identical
+# response so a caller cannot probe which orgs exist by cycling slugs.
+_SLUG_UNAVAILABLE = SsoDiscovery(
+    enabled=False,
+    scope=None,
+    connection_id=None,
+    organization_id=None,
+    protocol=None,
+    display_name=None,
+    reason="not_available",
+)
+
+
 async def discover_sso(
     db: AsyncSession,
     *,
     email: str | None,
     organization_id: UUID | None = None,
     connection_id: UUID | None = None,
+    slug: str | None = None,
+) -> SsoDiscovery:
+    if slug is not None:
+        resolved_organization_id = await _organization_id_for_slug(db, slug)
+        if resolved_organization_id is None:
+            return _SLUG_UNAVAILABLE
+        discovery = await _discover_for_context(
+            db,
+            email=None,
+            organization_id=resolved_organization_id,
+            connection_id=None,
+        )
+        # Only surface the ids needed to start the flow once SSO is actually
+        # usable; every other outcome collapses to the generic response.
+        return discovery if discovery.enabled else _SLUG_UNAVAILABLE
+    return await _discover_for_context(
+        db,
+        email=email,
+        organization_id=organization_id,
+        connection_id=connection_id,
+    )
+
+
+async def _organization_id_for_slug(db: AsyncSession, slug: str) -> UUID | None:
+    cleaned = slug.strip()
+    if not cleaned:
+        return None
+    organization = await organization_store.get_organization_by_slug(db, cleaned)
+    return organization.id if organization is not None else None
+
+
+async def _discover_for_context(
+    db: AsyncSession,
+    *,
+    email: str | None,
+    organization_id: UUID | None,
+    connection_id: UUID | None,
 ) -> SsoDiscovery:
     connection = await _connection_for_start(
         db,

--- a/server/proliferate/db/models/organizations.py
+++ b/server/proliferate/db/models/organizations.py
@@ -32,10 +32,20 @@ class Organization(Base):
             unique=True,
             postgresql_where=text("is_instance"),
         ),
+        Index(
+            "ux_organization_slug",
+            "slug",
+            unique=True,
+            postgresql_where=text("slug IS NOT NULL"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255))
+    # Human-friendly, URL-safe handle used for per-org SSO login links
+    # (``/login/<slug>``). Nullable so legacy rows and races never block a
+    # write; a partial unique index keeps live slugs unambiguous.
+    slug: Mapped[str | None] = mapped_column(String(64), nullable=True)
     logo_domain: Mapped[str | None] = mapped_column(String(255), nullable=True)
     logo_image: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(

--- a/server/proliferate/db/store/auth_sso.py
+++ b/server/proliferate/db/store/auth_sso.py
@@ -444,6 +444,36 @@ async def list_sso_identities_for_user(
     return [sso_identity_record(row) for row in rows]
 
 
+async def user_has_active_organization_sso_membership(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> bool:
+    """True when the user reached us through an org's SSO connection and still
+    holds an active membership in that org.
+
+    This is the "identity arrived via org SSO" signal the product-readiness gate
+    consults: an org-scoped SSO identity (``organization_id`` set) backed by a
+    live membership. The org relationship is the vetting, so it stands in for the
+    GitHub link on hosted product surfaces.
+    """
+    row = await db.execute(
+        select(SsoIdentity.id)
+        .join(
+            OrganizationMembership,
+            (OrganizationMembership.organization_id == SsoIdentity.organization_id)
+            & (OrganizationMembership.user_id == SsoIdentity.user_id),
+        )
+        .where(
+            SsoIdentity.user_id == user_id,
+            SsoIdentity.organization_id.is_not(None),
+            OrganizationMembership.status == ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+        )
+        .limit(1)
+    )
+    return row.scalar_one_or_none() is not None
+
+
 async def upsert_sso_identity_for_user(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/instance_organizations.py
+++ b/server/proliferate/db/store/instance_organizations.py
@@ -28,7 +28,10 @@ from proliferate.db.store.organization_records import (
     membership_record,
     organization_record,
 )
-from proliferate.db.store.organizations import acquire_organization_membership_lock
+from proliferate.db.store.organizations import (
+    acquire_organization_membership_lock,
+    allocate_organization_slug,
+)
 from proliferate.utils.time import utcnow
 
 
@@ -66,6 +69,7 @@ async def create_instance_organization(
     now = utcnow()
     organization = Organization(
         name=name,
+        slug=await allocate_organization_slug(db, name),
         logo_domain=logo_domain,
         logo_image=None,
         is_instance=True,

--- a/server/proliferate/db/store/organization_records.py
+++ b/server/proliferate/db/store/organization_records.py
@@ -18,6 +18,7 @@ from proliferate.db.models.organizations import (
 class OrganizationRecord:
     id: UUID
     name: str
+    slug: str | None
     logo_domain: str | None
     logo_image: str | None
     status: str
@@ -132,6 +133,7 @@ def organization_record(organization: Organization) -> OrganizationRecord:
     return OrganizationRecord(
         id=organization.id,
         name=organization.name,
+        slug=organization.slug,
         logo_domain=organization.logo_domain,
         logo_image=organization.logo_image,
         status=organization.status,

--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 from datetime import datetime
 from uuid import UUID
 
@@ -49,7 +50,50 @@ from proliferate.db.store.organization_records import (
     membership_record,
     organization_record,
 )
+from proliferate.utils.slug import slugify
 from proliferate.utils.time import utcnow
+
+# Bound the numeric-suffix search before falling back to a random token so a
+# pathological name never spins; the partial unique index is the backstop.
+_SLUG_NUMERIC_ATTEMPTS = 50
+
+
+async def _slug_taken(db: AsyncSession, slug: str) -> bool:
+    existing = await db.scalar(select(Organization.id).where(Organization.slug == slug).limit(1))
+    return existing is not None
+
+
+async def allocate_organization_slug(db: AsyncSession, name: str) -> str:
+    """Pick a unique, human-friendly slug derived from the org name.
+
+    Tries the bare slug first (so a team named "Acme" gets ``acme``), then a
+    numeric suffix, then a short random token. The partial unique index on
+    ``organization.slug`` remains the ultimate guard against the rare race.
+    """
+    base = slugify(name)
+    if not await _slug_taken(db, base):
+        return base
+    for suffix in range(2, _SLUG_NUMERIC_ATTEMPTS + 1):
+        candidate = f"{base}-{suffix}"
+        if not await _slug_taken(db, candidate):
+            return candidate
+    while True:
+        candidate = f"{base}-{secrets.token_hex(3)}"
+        if not await _slug_taken(db, candidate):
+            return candidate
+
+
+async def get_organization_by_slug(db: AsyncSession, slug: str) -> OrganizationRecord | None:
+    normalized = slugify(slug)
+    organization = (
+        await db.execute(
+            select(Organization).where(
+                Organization.slug == normalized,
+                Organization.status.in_(tuple(ORGANIZATION_CURRENT_STATUSES)),
+            )
+        )
+    ).scalar_one_or_none()
+    return organization_record(organization) if organization is not None else None
 
 
 async def acquire_membership_activation_lock(db: AsyncSession, user_id: UUID) -> None:
@@ -175,6 +219,7 @@ async def ensure_default_organization_for_user(
 
     organization = Organization(
         name=name,
+        slug=await allocate_organization_slug(db, name),
         logo_domain=logo_domain,
         logo_image=None,
         created_at=now,
@@ -271,6 +316,7 @@ async def create_pending_team_checkout_intent(
     now = utcnow()
     organization = Organization(
         name=team_name,
+        slug=await allocate_organization_slug(db, team_name),
         logo_domain=logo_domain,
         logo_image=None,
         status=ORGANIZATION_STATUS_PENDING_CHECKOUT,

--- a/server/proliferate/utils/slug.py
+++ b/server/proliferate/utils/slug.py
@@ -1,0 +1,28 @@
+"""Slug helpers for human-friendly, URL-safe organization identifiers."""
+
+from __future__ import annotations
+
+import re
+
+_SLUG_ALLOWED = re.compile(r"[^a-z0-9]+")
+_SLUG_TRIM = re.compile(r"^-+|-+$")
+
+# Keep slugs short enough to live comfortably in a login URL an admin pastes
+# into onboarding docs, but long enough to stay readable.
+SLUG_MAX_LENGTH = 48
+_SLUG_FALLBACK = "org"
+
+
+def slugify(value: str | None) -> str:
+    """Normalize a display name into a lowercase, hyphen-separated slug.
+
+    Non-alphanumeric runs collapse to a single hyphen; leading/trailing hyphens
+    are trimmed; the result is length-capped. An empty result falls back to a
+    stable placeholder so callers always get a non-empty base to build on.
+    """
+    lowered = (value or "").strip().lower()
+    hyphenated = _SLUG_ALLOWED.sub("-", lowered)
+    trimmed = _SLUG_TRIM.sub("", hyphenated)
+    capped = trimmed[:SLUG_MAX_LENGTH]
+    capped = _SLUG_TRIM.sub("", capped)
+    return capped or _SLUG_FALLBACK

--- a/server/tests/unit/auth/test_current_product_user_gate.py
+++ b/server/tests/unit/auth/test_current_product_user_gate.py
@@ -1,0 +1,100 @@
+"""Unit tests for the org-SSO carve-out in the product-readiness gate."""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth import dependencies
+from proliferate.auth.identity.types import AccountReadiness
+from proliferate.config import settings
+from proliferate.db.models.auth import User
+from proliferate.errors import PermissionDenied
+
+
+def _user() -> User:
+    return User(
+        id=uuid4(),
+        email="person@example.com",
+        hashed_password="unused-sso-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_org_mode_bypasses_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+    user = _user()
+
+    resolved = await dependencies.current_product_user(
+        user=user,
+        db=cast(AsyncSession, object()),
+    )
+
+    assert resolved is user
+
+
+@pytest.mark.asyncio
+async def test_org_sso_identity_passes_gate_without_github(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", False)
+
+    async def fake_org_sso_membership(_db: AsyncSession, *, user_id: object) -> bool:
+        return True
+
+    async def fail_readiness(*_args: object, **_kwargs: object) -> AccountReadiness:
+        raise AssertionError("GitHub readiness must not be consulted for org-SSO users.")
+
+    monkeypatch.setattr(
+        dependencies,
+        "user_has_active_organization_sso_membership",
+        fake_org_sso_membership,
+    )
+    monkeypatch.setattr(dependencies, "get_account_readiness", fail_readiness)
+
+    user = _user()
+    resolved = await dependencies.current_product_user(
+        user=user,
+        db=cast(AsyncSession, object()),
+    )
+
+    assert resolved is user
+
+
+@pytest.mark.asyncio
+async def test_plain_hosted_user_without_github_is_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "single_org_mode_override", False)
+
+    async def fake_org_sso_membership(_db: AsyncSession, *, user_id: object) -> bool:
+        return False
+
+    async def fake_readiness(*_args: object, **_kwargs: object) -> AccountReadiness:
+        return AccountReadiness(
+            product_ready=False,
+            missing_requirements=("github_identity_missing",),
+            github_identity_id=None,
+            github_grant_status=None,
+        )
+
+    monkeypatch.setattr(
+        dependencies,
+        "user_has_active_organization_sso_membership",
+        fake_org_sso_membership,
+    )
+    monkeypatch.setattr(dependencies, "get_account_readiness", fake_readiness)
+
+    with pytest.raises(PermissionDenied) as exc_info:
+        await dependencies.current_product_user(
+            user=_user(),
+            db=cast(AsyncSession, object()),
+        )
+
+    assert exc_info.value.code == "github_link_required"

--- a/server/tests/unit/auth/test_discover_sso_slug.py
+++ b/server/tests/unit/auth/test_discover_sso_slug.py
@@ -1,0 +1,173 @@
+"""Slug-driven SSO discovery: resolution and enumeration protection."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.sso import service as sso_service
+from proliferate.auth.sso.types import (
+    DEFAULT_OIDC_SCOPES,
+    SsoJitPolicy,
+    SsoLoginPolicy,
+    SsoProtocol,
+    SsoScope,
+    SsoStatus,
+)
+from proliferate.db.store.auth_sso_records import SsoConnectionRecord
+
+
+def _connection_record(
+    *,
+    connection_id: object,
+    organization_id: object,
+    status: str,
+) -> SsoConnectionRecord:
+    now = datetime.now(UTC)
+    return SsoConnectionRecord(
+        id=connection_id,
+        scope=SsoScope.ORGANIZATION.value,
+        organization_id=organization_id,
+        protocol=SsoProtocol.OIDC.value,
+        status=status,
+        display_name="Okta",
+        login_policy=SsoLoginPolicy.OPTIONAL.value,
+        jit_policy=SsoJitPolicy.CREATE_MEMBER.value,
+        default_role="member",
+        allowed_domains=(),
+        oidc_issuer_url="https://idp.example.test/",
+        oidc_discovery_url=None,
+        oidc_authorization_endpoint=None,
+        oidc_token_endpoint=None,
+        oidc_jwks_uri=None,
+        oidc_userinfo_endpoint=None,
+        oidc_client_id="client-id",
+        oidc_client_secret="client-secret",
+        oidc_client_secret_configured=True,
+        oidc_scopes=DEFAULT_OIDC_SCOPES,
+        oidc_token_endpoint_auth_method="client_secret_basic",
+        saml_idp_metadata_url=None,
+        saml_idp_metadata_xml_configured=False,
+        saml_idp_entity_id=None,
+        saml_sso_url=None,
+        saml_x509_cert_configured=False,
+        saml_email_attribute=None,
+        created_by_user_id=None,
+        updated_by_user_id=None,
+        tested_at=None,
+        last_error=None,
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_slug_resolves_to_enabled_org_sso(monkeypatch: pytest.MonkeyPatch) -> None:
+    organization_id = uuid4()
+    connection_id = uuid4()
+
+    async def fake_get_organization_by_slug(_db: AsyncSession, slug: str) -> object:
+        assert slug == "acme"
+        return SimpleNamespace(id=organization_id)
+
+    async def fake_list_connections(_db: AsyncSession, *, organization_id: object) -> list:
+        return [
+            _connection_record(
+                connection_id=connection_id,
+                organization_id=organization_id,
+                status=SsoStatus.ENABLED.value,
+            )
+        ]
+
+    monkeypatch.setattr(
+        sso_service.organization_store,
+        "get_organization_by_slug",
+        fake_get_organization_by_slug,
+    )
+    monkeypatch.setattr(
+        sso_service.sso_store,
+        "list_sso_connections_for_organization",
+        fake_list_connections,
+    )
+
+    discovery = await sso_service.discover_sso(
+        cast(AsyncSession, object()), email=None, slug="acme"
+    )
+
+    assert discovery.enabled is True
+    assert discovery.scope == SsoScope.ORGANIZATION
+    assert discovery.organization_id == organization_id
+    assert discovery.connection_id == connection_id
+    assert discovery.display_name == "Okta"
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_slug_returns_generic_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_organization_by_slug(_db: AsyncSession, _slug: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        sso_service.organization_store,
+        "get_organization_by_slug",
+        fake_get_organization_by_slug,
+    )
+
+    discovery = await sso_service.discover_sso(
+        cast(AsyncSession, object()), email=None, slug="does-not-exist"
+    )
+
+    assert discovery.enabled is False
+    assert discovery.organization_id is None
+    assert discovery.connection_id is None
+    assert discovery.display_name is None
+    assert discovery.reason == "not_available"
+
+
+@pytest.mark.asyncio
+async def test_org_without_enabled_sso_is_indistinguishable_from_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization_id = uuid4()
+    connection_id = uuid4()
+
+    async def fake_get_organization_by_slug(_db: AsyncSession, _slug: str) -> object:
+        return SimpleNamespace(id=organization_id)
+
+    async def fake_list_connections(_db: AsyncSession, *, organization_id: object) -> list:
+        # Present but disabled: must not leak that the org exists.
+        return [
+            _connection_record(
+                connection_id=connection_id,
+                organization_id=organization_id,
+                status=SsoStatus.DISABLED.value,
+            )
+        ]
+
+    monkeypatch.setattr(
+        sso_service.organization_store,
+        "get_organization_by_slug",
+        fake_get_organization_by_slug,
+    )
+    monkeypatch.setattr(
+        sso_service.sso_store,
+        "list_sso_connections_for_organization",
+        fake_list_connections,
+    )
+
+    discovery = await sso_service.discover_sso(
+        cast(AsyncSession, object()), email=None, slug="acme"
+    )
+
+    assert discovery.enabled is False
+    assert discovery.organization_id is None
+    assert discovery.connection_id is None
+    assert discovery.display_name is None
+    assert discovery.reason == "not_available"

--- a/specs/codebase/features/product-auth.md
+++ b/specs/codebase/features/product-auth.md
@@ -27,12 +27,25 @@ GitHub remains the product-readiness provider. A password-only user is signed in
 but limited until the existing GitHub readiness check succeeds. Do not add a
 hidden bypass for normal (hosted, multi-tenant) users.
 
-Single-org (self-hosted) instances are the one carve-out: there is no GitHub
-OAuth app configured, so `current_product_user` admits password-only accounts
-when `settings.single_org_mode` is true, same as its sibling
-`current_organization_actor`. Hosted keeps the GitHub readiness gate
-unconditionally. Endpoints that genuinely need a GitHub token (repo import,
-etc.) still enforce that at their own point of use, not through this gate.
+There are two carve-outs to the GitHub readiness gate in `current_product_user`:
+
+- Single-org (self-hosted) instances have no GitHub OAuth app configured, so the
+  gate admits password-only accounts when `settings.single_org_mode` is true,
+  same as its sibling `current_organization_actor`.
+- A user who arrived through an organization's SSO connection passes without a
+  linked GitHub identity. The org relationship is the vetting: the connection is
+  admin-configured and membership is enforced on every SSO login, so an
+  org-scoped SSO identity backed by an active membership stands in for the
+  GitHub link. The exact check is
+  `user_has_active_organization_sso_membership`: an `sso_identity` row with a
+  non-null `organization_id` joined to an active `organization_membership` in
+  that org. A deployment-scoped SSO identity (org id null) does not qualify.
+
+Hosted keeps the GitHub readiness gate for everyone else, unconditionally.
+Endpoints that genuinely need a GitHub token (repo import, App install, etc.)
+still enforce that at their own point of use, not through this gate, and
+free-trial credit grants stay GitHub-gated (GitHub identity is the anti-abuse
+signal for free credits). SSO passing the readiness gate does not change either.
 
 The cloud sandbox gateway WebSocket authenticates its own product user rather
 than going through `current_product_user` (it reads the bearer token off the
@@ -115,6 +128,54 @@ because login still only works for accounts with an explicit password marker.
 `x-forwarded-for` is trusted only for loopback/local calls or proxy IPs and
 CIDRs listed in `PASSWORD_AUTH_TRUSTED_PROXY_HOSTS`.
 
+## Organization SSO Sign-In
+
+The org-SSO backend (connection model, discovery/start endpoints, OIDC callback,
+JIT membership) was fully built before this slice. What was missing was a way for
+a user to reach it: web and desktop cold login only ever probed deployment-scope
+SSO, and org SSO was reachable only through the desktop invite deep link. This
+slice adds the user-facing entry points. It does not change the OIDC flow itself.
+
+Entry points, one shape across surfaces:
+
+- Web auth screen shows a quiet `Sign in with SSO` link (shown when the
+  deployment is not itself SSO-gated). It opens `/login`, a page with a single
+  field for the organization's workspace slug.
+- `/login/<slug>` prefills that field. This is the URL an admin pastes into their
+  onboarding docs (for example `app.proliferate.ai/login/acme`).
+- The slug resolves to an `organizationId`, then the page calls the existing
+  `startSsoAuth` start flow with that org (and connection) id. No new SSO
+  machinery.
+- Desktop mirrors this: a `Sign in with SSO` affordance on cold login reveals a
+  slug field and drives the existing native SSO machinery (system browser +
+  `proliferate://auth/callback` deep link).
+- Web `/join/:orgId` signs the user in on the web when the org has SSO enabled
+  (it discovers by org id and starts the SSO flow; JIT membership and invite
+  acceptance happen in the SSO callback). It only falls back to the Desktop
+  handoff when the org has no usable SSO.
+
+Slug resolution:
+
+- Organizations carry a `slug`: a lowercase, URL-safe, unique handle generated
+  from the org name at creation (partial unique index on `organization.slug`;
+  existing rows backfilled). It is derived, not user-editable in this slice.
+- `GET /auth/sso/discover?slug=<slug>` resolves the slug to its org's enabled
+  SSO connection and returns only what the start flow needs (`organizationId`,
+  `connectionId`, `protocol`, connection `displayName`). It never returns the
+  org name or other org metadata.
+- Slug lookup is explicit user input, so it does not reopen the deliberate
+  email -> org-connection enumeration protection
+  (`test_discover_sso_ignores_org_connections_without_explicit_org_context`
+  stays green; there is still no email-domain discovery of org connections).
+
+Enumeration protection on the slug channel: a nonexistent slug, an org with no
+SSO, and an org whose SSO is disabled all return the identical generic response
+(`enabled: false`, `reason: "not_available"`, no ids), so a caller cannot cycle
+slugs to learn which organizations exist or which have SSO configured. Only a
+slug that resolves to an actually-enabled connection returns the ids needed to
+start. The client surfaces one generic message ("check the sign-in link your
+admin shared") for every non-enabled outcome.
+
 ## Surface UX
 
 Web signed out:
@@ -122,6 +183,8 @@ Web signed out:
 - Shows `Continue with GitHub` as the primary provider action.
 - Shows `Continue with Google` as the secondary visible provider action.
 - Shows web beta copy before sign-in.
+- Shows a `Sign in with SSO` link to the org-slug login page (see Organization
+  SSO Sign-In), except when the deployment is itself SSO-gated.
 - Does not currently show Apple or email/password sign-in on the web auth page.
 - If readiness is missing, the existing Connect GitHub gate is shown.
 - If web beta access is denied, shows a beta-only rejection state with Desktop
@@ -137,6 +200,9 @@ Mobile signed out:
 Desktop:
 
 - Keeps GitHub as the primary sign-in path.
+- Cold login also offers a `Sign in with SSO` affordance that asks for the org
+  workspace slug and drives the existing native SSO flow (see Organization SSO
+  Sign-In).
 - Account settings expose `Set password` / `Change password` for authenticated
   users.
 - Organization join deep links may arrive before Desktop is authenticated.


### PR DESCRIPTION
## What

Org SSO was fully built on the backend (connection model, discovery/start endpoints, OIDC callback, JIT membership) but had no way in: web and desktop cold login only ever probed deployment-scope SSO, and org SSO was reachable only through the desktop invite deep link. This PR adds the user-facing entry points and lets an org-SSO identity satisfy the product-readiness gate. It does not touch the OIDC flow itself.

Ruled by Pablo 2026-07-09 (testing-open-rulings item 2).

## Entry points (one shape across surfaces)

- Web auth screen shows a quiet `Sign in with SSO` link to `/login`, a page with a single org-slug field. The slug resolves to an `organizationId` and hands off to the existing `startSsoAuth` flow.
- `/login/<slug>` prefills the field. This is the URL an admin pastes into onboarding docs (e.g. `app.proliferate.ai/login/acme`).
- Desktop cold login mirrors this with a `Sign in with SSO` affordance that asks for the slug and drives the existing native SSO machinery (system browser + `proliferate://auth/callback` deep link).
- Web `/join/:orgId` now signs the user in on the web when the org has SSO enabled (discover by org id, start SSO; JIT membership and invite acceptance happen in the callback). It falls back to the Desktop handoff only when the org has no usable SSO.

## Slug

Organizations get a generated, lowercase, URL-safe, unique `slug` (partial unique index on `organization.slug`; existing rows backfilled from name; generated at all three creation sites). Slug resolution folds into `GET /auth/sso/discover` via a `slug` query param and returns only what the start flow needs (`organizationId`, `connectionId`, `protocol`, connection `displayName`), never the org name or other metadata.

## Security

- A nonexistent slug, an org without SSO, and an org with disabled SSO all return the identical generic response (`enabled: false`, `reason: "not_available"`, no ids), so slugs cannot be cycled to enumerate which orgs exist or have SSO. Only a slug resolving to an enabled connection returns the ids needed to start.
- Slug lookup is explicit user input, so it does not reopen the deliberate email->org-connection enumeration protection. `test_discover_sso_ignores_org_connections_without_explicit_org_context` stays green; there is still no email-domain discovery of org connections.

## Gate

`current_product_user` now passes a user who arrived through an org SSO connection and still holds an active membership there (the org relationship is the vetting), alongside the existing single-org bypass. Exact check: `user_has_active_organization_sso_membership` (an `sso_identity` row with a non-null `organization_id` joined to an active `organization_membership`). GitHub stays enforced at point of use (repo import, App install), and free-trial credits stay GitHub-gated.

## Spec

Entry-point design + gate ruling landed in `specs/codebase/features/product-auth.md`.

## Migration

`e1f2a3b4c5d6_organization_slug` adds the column, backfills existing rows, then creates the partial unique index. This branch owns its dev profile for its lifetime.

## Tests

- New server unit tests: gate carve-out (org-SSO passes, plain hosted gated, single-org unchanged) and slug resolution (resolves enabled; nonexistent and no-SSO/disabled collapse to the same generic answer).
- Existing SSO suite green, including the enumeration-protection test.
- New desktop vitest for the org-slug SSO hook.
- Web + desktop typecheck clean; cloud SDK regenerated.
