### PR TITLE
fix(billing): only hold payment_failed on dunning-driven subscription deletion

### DIFF
--- a/server/proliferate/server/billing/stripe_webhooks.py
+++ b/server/proliferate/server/billing/stripe_webhooks.py
@@ -95,6 +95,13 @@ BILLING_SLACK_ACTIVE_STATUSES = {"active", "trialing"}
 BILLING_SLACK_CANCELLED_STATUSES = {"canceled"}
 BILLING_SLACK_PRE_START_STATUSES = {"incomplete"}
 
+# Prior subscription statuses that indicate a customer.subscription.deleted
+# event was reached via failed-payment dunning rather than a voluntary cancel.
+DUNNING_PRIOR_STATUSES = {"past_due", "unpaid"}
+# cancellation_details.reason values Stripe sets when Stripe itself (rather
+# than the customer) ended the subscription because payment collection failed.
+PAYMENT_DRIVEN_CANCELLATION_REASONS = {"payment_failed", "payment_disputed"}
+
 logger = logging.getLogger(__name__)
 
 
@@ -191,11 +198,18 @@ async def _dispatch_stripe_event(event: dict[str, Any]) -> tuple[BillingSlackNot
         )
         return result.notifications
     elif event_type == "customer.subscription.deleted":
+        subscription_id = stripe_object.get("id")
+        previous = (
+            await _load_billing_subscription_by_stripe_subscription_id(subscription_id)
+            if isinstance(subscription_id, str)
+            else None
+        )
         result = await _sync_subscription_for_billing_notifications(
             stripe_object,
             event_type=event_type,
         )
-        await _apply_payment_hold_for_subscription(stripe_object)
+        if _subscription_deletion_is_payment_driven(stripe_object, previous):
+            await _apply_payment_hold_for_subscription(stripe_object)
         return result.notifications
     elif event_type == "invoice.paid":
         return await _handle_invoice_paid(stripe_object)
@@ -528,3 +542,29 @@ async def _apply_payment_hold_for_subscription(subscription: dict[str, Any]) -> 
         source=PAYMENT_HOLD_SOURCE,
         source_ref=_id_from_expandable(subscription.get("id")),
     )
+
+
+def _subscription_deletion_is_payment_driven(
+    subscription: dict[str, Any],
+    previous: BillingSubscription | None,
+) -> bool:
+    """Decide whether a customer.subscription.deleted event is dunning-driven.
+
+    A voluntary cancellation (the customer or an admin cancels; Stripe sets
+    cancellation_details.reason to 'cancellation_requested' or leaves it
+    unset) should terminate entitlements at period end with no
+    payment_failed hold. A deletion caused by exhausted payment retries
+    keeps the hold: either Stripe reports it directly via
+    cancellation_details.reason ('payment_failed' / 'payment_disputed'), or
+    the subscription had already moved to past_due/unpaid before Stripe
+    deleted it.
+    """
+    cancellation_details = subscription.get("cancellation_details")
+    reason = cancellation_details.get("reason") if isinstance(cancellation_details, dict) else None
+    if reason in PAYMENT_DRIVEN_CANCELLATION_REASONS:
+        return True
+    if reason is not None:
+        # Any other explicit reason (e.g. 'cancellation_requested') is a
+        # voluntary cancel signal straight from Stripe; trust it.
+        return False
+    return previous is not None and previous.status in DUNNING_PRIOR_STATUSES

--- a/server/tests/integration/test_stripe_subscription_deleted_hold.py
+++ b/server/tests/integration/test_stripe_subscription_deleted_hold.py
@@ -1,0 +1,216 @@
+"""customer.subscription.deleted hold semantics (regression for #1032).
+
+A clean voluntary cancellation (cancel at period end; Stripe deletes the
+subscription with cancellation_details.reason=cancellation_requested) must not
+apply a payment_failed hold. A deletion reached through failed-payment dunning
+(explicit payment reason, or prior past_due/unpaid status with no reason) must
+keep it. Shares the signed-webhook helpers with test_stripe_webhooks.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from proliferate.config import settings
+from proliferate.db import engine as engine_module
+from proliferate.db.models.auth import User
+from proliferate.db.models.billing import BillingHold, BillingSubscription
+from proliferate.db.store.billing_subjects import ensure_personal_billing_subject
+
+from tests.integration.test_stripe_webhooks import (
+    _handle_subscription_event,
+    _subscription_payload,
+)
+
+
+def _payload_with_cancellation_reason(
+    *,
+    subject_id: str,
+    customer_id: str,
+    subscription_id: str,
+    status: str,
+    canceled_at: int | None = None,
+    cancellation_reason: str | None = None,
+) -> dict[str, object]:
+    payload = _subscription_payload(
+        subject_id=subject_id,
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        status=status,
+        canceled_at=canceled_at,
+    )
+    if cancellation_reason is not None:
+        payload["cancellation_details"] = {"reason": cancellation_reason}
+    return payload
+
+
+async def _seed_subject(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    github_login: str,
+    stripe_customer_id: str,
+) -> uuid.UUID:
+    user_id = uuid.uuid4()
+    db_session.add(
+        User(
+            id=user_id,
+            email=email,
+            hashed_password="unused",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            display_name=github_login,
+            github_login=github_login,
+        )
+    )
+    subject = await ensure_personal_billing_subject(db_session, user_id)
+    subject.stripe_customer_id = stripe_customer_id
+    subject_id = subject.id
+    await db_session.commit()
+    return subject_id
+
+
+@pytest.mark.asyncio
+async def test_subscription_deleted_voluntary_cancel_does_not_apply_payment_hold(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for #1032: a clean cancel-at-period-end deletion must
+    not be labeled payment_failed."""
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    secret = "whsec_test_secret"
+    monkeypatch.setattr(settings, "stripe_webhook_secret", secret)
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_cloud")
+
+    subject_id = await _seed_subject(
+        db_session,
+        email="voluntary-cancel@example.com",
+        github_login="voluntary-cancel",
+        stripe_customer_id="cus_voluntary_cancel",
+    )
+
+    await _handle_subscription_event(
+        secret=secret,
+        event_id="evt_voluntary_created",
+        event_type="customer.subscription.created",
+        subscription=_payload_with_cancellation_reason(
+            subject_id=str(subject_id),
+            customer_id="cus_voluntary_cancel",
+            subscription_id="sub_voluntary_cancel",
+            status="active",
+        ),
+    )
+    await _handle_subscription_event(
+        secret=secret,
+        event_id="evt_voluntary_deleted",
+        event_type="customer.subscription.deleted",
+        subscription=_payload_with_cancellation_reason(
+            subject_id=str(subject_id),
+            customer_id="cus_voluntary_cancel",
+            subscription_id="sub_voluntary_cancel",
+            status="canceled",
+            canceled_at=1_777_100_000,
+            cancellation_reason="cancellation_requested",
+        ),
+    )
+
+    db_session.expire_all()
+    holds = (
+        (
+            await db_session.execute(
+                select(BillingHold).where(BillingHold.billing_subject_id == subject_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert holds == []
+
+    subscription = (
+        await db_session.execute(
+            select(BillingSubscription).where(
+                BillingSubscription.stripe_subscription_id == "sub_voluntary_cancel"
+            )
+        )
+    ).scalar_one()
+    assert subscription.status == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_subscription_deleted_after_dunning_applies_payment_hold(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subscription that lapsed into past_due before Stripe deleted it is
+    a payment failure, not a voluntary cancel, and must keep the hold."""
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    secret = "whsec_test_secret"
+    monkeypatch.setattr(settings, "stripe_webhook_secret", secret)
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "price_cloud")
+
+    subject_id = await _seed_subject(
+        db_session,
+        email="dunning-cancel@example.com",
+        github_login="dunning-cancel",
+        stripe_customer_id="cus_dunning_cancel",
+    )
+
+    await _handle_subscription_event(
+        secret=secret,
+        event_id="evt_dunning_created",
+        event_type="customer.subscription.created",
+        subscription=_payload_with_cancellation_reason(
+            subject_id=str(subject_id),
+            customer_id="cus_dunning_cancel",
+            subscription_id="sub_dunning_cancel",
+            status="active",
+        ),
+    )
+    await _handle_subscription_event(
+        secret=secret,
+        event_id="evt_dunning_past_due",
+        event_type="customer.subscription.updated",
+        subscription=_payload_with_cancellation_reason(
+            subject_id=str(subject_id),
+            customer_id="cus_dunning_cancel",
+            subscription_id="sub_dunning_cancel",
+            status="past_due",
+        ),
+    )
+    await _handle_subscription_event(
+        secret=secret,
+        event_id="evt_dunning_deleted",
+        event_type="customer.subscription.deleted",
+        subscription=_payload_with_cancellation_reason(
+            subject_id=str(subject_id),
+            customer_id="cus_dunning_cancel",
+            subscription_id="sub_dunning_cancel",
+            status="canceled",
+            canceled_at=1_777_200_000,
+        ),
+    )
+
+    db_session.expire_all()
+    hold = (
+        await db_session.execute(
+            select(BillingHold).where(BillingHold.billing_subject_id == subject_id)
+        )
+    ).scalar_one()
+    assert hold.kind == "payment_failed"
+    assert hold.status == "active"
+    assert hold.source_ref == "sub_dunning_cancel"

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -103,7 +103,6 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Out of credits: sandbox paused and not accessible — **including every bypass route** (direct API resume, stale session, webhook race, pre-exhaustion key, other org member, trigger-driven start) | 3 | — |
 | Out of credits: gateway LLM access gated; reactivates on refill | 3 | — |
 | Overage bills real money correctly: compute metered events + amounts match up to cap then hard-block; LLM auto top-up charges once then fail-closes on payment failure | 3 | — |
-| Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |
 
 ## Upgrade & release
 

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -285,10 +285,9 @@ Against the Stripe webhook receiver (`claim_webhook_event` semantics):
   continues through period end; 24h rollover grace honored after
   `current_period_end`; then hard cutoff.
 - `customer.subscription.deleted` after a **clean voluntary cancellation**:
-  pin the CURRENT behavior (unconditional `payment_failed` hold — survey
-  2026-07-08 confirmed the reason-sensitive refinement was never shipped) as
-  an expected-fail/known-bug test until the product fix lands. [FILED AS
-  FINDING — Pablo to rule fix-now vs post-release.]
+  no `payment_failed` hold (reason-sensitive since the #1032 fix: explicit
+  payment-driven `cancellation_details.reason` or prior `past_due`/`unpaid`
+  status holds; a voluntary cancel does not).
 - billing modes: `CLOUD_BILLING_MODE=off` → all enforcement inert, product
   fully usable; `observe` → accounting/exports happen, nothing ever blocked;
   `enforce` → gates live. One smoke per mode.
@@ -556,11 +555,9 @@ current behavior as known-bug expected-fail):
    sites resolve `organization_id=None` and bail — an admin-configured
    compute cap saves in the UI and silently does nothing. (LLM caps are
    unaffected — correctly org-attributed.)
-2. **Clean voluntary cancellation gets a `payment_failed` hold.**
-   `customer.subscription.deleted` applies the hold unconditionally
-   (`stripe_webhooks.py:193-199`) — no reason sensitivity, so a customer who
-   cancels cleanly can be spuriously blocked when Stripe deletes the record
-   at period end.
+2. **Clean voluntary cancellation gets a `payment_failed` hold.** FIXED by
+   the #1032 fix: `customer.subscription.deleted` is now reason-sensitive
+   (`_subscription_deletion_is_payment_driven` in `stripe_webhooks.py`).
 3. **No-GitHub account gets no free trial and no explanation.**
    `ensure_free_trial_v2_grant` silently returns when the account has no
    linked GitHub identity — looks broken to the user. (UX severity, not

--- a/tests/intent/specs/billing/webhooks.spec.ts
+++ b/tests/intent/specs/billing/webhooks.spec.ts
@@ -15,7 +15,6 @@ import { expect } from "@playwright/test";
 import { test, adminContext, skipIfNoStripe } from "./_fixtures.ts";
 import * as b from "../../stack/billing.ts";
 
-const FINDING_7_ISSUE = "https://github.com/proliferate-ai/proliferate/issues/1032";
 
 async function subscribedPersonalSubject() {
   const { token } = await adminContext();
@@ -148,12 +147,12 @@ test.describe("T2-BILL-8: subscription edge states", () => {
   });
 
   test(
-    "FINDING 7 (pinned known-bug): subscription.deleted applies a payment_failed hold even after clean cancellation",
+    "subscription.deleted after a clean voluntary cancellation applies no payment_failed hold",
     async () => {
-      test.info().annotations.push({
-        type: "known-bug",
-        description: `customer.subscription.deleted unconditionally applies payment_failed hold — UNRULED. ${FINDING_7_ISSUE}. When the reason-sensitive fix lands, invert this assertion.`,
-      });
+      // Formerly the FINDING 7 known-bug pin (issue #1032): the hold is
+      // now reason-sensitive, so a clean cancellation must not be labeled
+      // payment_failed. Dunning-driven deletions keep the hold (covered by the
+      // server suite: test_stripe_subscription_deleted_hold.py).
       const { subject, sub, fullSub } = await subscribedPersonalSubject();
       await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
 
@@ -162,11 +161,10 @@ test.describe("T2-BILL-8: subscription edge states", () => {
       const deleted = b.deleteSubscription(sub.id);
       await b.deliverEvent({ type: "customer.subscription.deleted", object: deleted });
 
-      // CURRENT (buggy) behavior: a payment_failed hold is applied regardless.
       expect(
         (await b.listActiveHolds(subject.id)).some((h) => h.kind === "payment_failed"),
-        "pins current unconditional payment_failed hold (finding 7)",
-      ).toBe(true);
+        "no payment_failed hold after a clean voluntary cancellation (finding 7 fixed)",
+      ).toBe(false);
     },
   );
 


### PR DESCRIPTION
## What

customer.subscription.deleted applied a payment_failed hold on every deletion, no matter why the subscription ended. A clean voluntary cancellation (user cancels, subscription runs to period end and Stripe deletes it) got the same payment_failed label as a subscription that died from exhausted payment retries.

Fixes #1032.

## How

Before syncing the subscription record, load the stored subscription's status (its status right before this event mutates it). Then decide whether the deletion is payment-driven:

- `cancellation_details.reason` in `payment_failed` / `payment_disputed` -> hold (Stripe told us directly).
- `cancellation_details.reason` set to anything else (e.g. `cancellation_requested`) -> no hold, trust Stripe's explicit reason.
- No reason at all -> fall back to prior status: `past_due` or `unpaid` before deletion -> hold (dunning-driven); anything else (`active`, `trialing`, ...) -> no hold.

New helper `_subscription_deletion_is_payment_driven` in `server/proliferate/server/billing/stripe_webhooks.py`, wired into the `customer.subscription.deleted` branch of `_dispatch_stripe_event`. Nothing else about cancellation semantics changes: a voluntary cancel still loses paid access at period end, grants still expire on their own lifecycle. Only the spurious payment_failed hold goes away.

## Tests

New module `server/tests/integration/test_stripe_subscription_deleted_hold.py` (split out rather than extending `test_stripe_webhooks.py`, which is at its repo-shape line cap; reuses that file's signed-webhook helpers, same style: real handler, synthetic Stripe event payloads over the signed-webhook path):

- `test_subscription_deleted_voluntary_cancel_does_not_apply_payment_hold`: active subscription deleted with `cancellation_details.reason=cancellation_requested`; asserts no BillingHold row.
- `test_subscription_deleted_after_dunning_applies_payment_hold`: subscription goes active -> past_due -> deleted (no explicit reason); asserts the payment_failed hold is applied and active.

`cd server && uv run pytest -q` is not practical to run in full in this environment right now (a plain `pytest -q` also picks up `tests/e2e/cloud/test_provisioning.py`, which spins up real E2B sandboxes and runs for a very long time; that file is intentionally excluded from CI's own invocation in `.github/workflows/server-ci.yml`). What I did run and confirmed green:
- `tests/integration/test_stripe_webhooks.py` (18 passed, unchanged) and `tests/integration/test_stripe_subscription_deleted_hold.py` (the 2 new tests).
- `tests/unit` (full): 527 passed.
- `tests/integration -k billing` (all billing-domain integration modules): 74 passed, 342 deselected.

## Spec doc edit riding this PR

Per the same-day ruling (there is no plan-based model gating — every plan gets every model, gated only by credit limits), deleted the row "Plan gates the model list: user sees/uses exactly the models their plan allows" from the Billing section of `specs/developing/testing/flows.md`.

## Tier-2 pin flip (rides this PR)

The tier-2 billing suite (#1033, now on main and gating this PR's CI) pinned the old unconditional-hold behavior as FINDING 7 in `tests/intent/specs/billing/webhooks.spec.ts`, with an annotation saying to invert the assertion when the reason-sensitive fix lands. That inversion rides here: the spec now asserts no payment_failed hold after a clean voluntary cancel (the dunning-keeps-hold side is covered by the server suite). The matching pin text in `specs/developing/testing/scenarios.md` (T2-BILL-8 bullet + survey findings item 2) is updated to the fixed behavior.
