### PR TITLE
fix(auth): extend single-org bypass to the gateway WebSocket product gate

### DIFF
--- a/server/proliferate/server/cloud/gateway/access.py
+++ b/server/proliferate/server/cloud/gateway/access.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.identity.store import get_account_readiness
 from proliferate.auth.jwt import get_jwt_strategy
 from proliferate.auth.users import UserManager
+from proliferate.config import settings
 from proliferate.db.models.auth import OAuthAccount, User
 from proliferate.integrations.sentry import set_server_sentry_user
 from proliferate.middleware.request_context import set_authenticated_user_context
@@ -84,9 +85,16 @@ async def authenticate_product_user_for_gateway_websocket(
     if user is None or not user.is_active:
         raise GatewayWebSocketAuthError("Invalid gateway access token.")
 
-    readiness = await get_account_readiness(db, user_id=user.id)
-    if not readiness.product_ready:
-        raise GatewayWebSocketAuthError("GitHub must be connected before gateway access.")
+    # This is the WebSocket sibling of the ``current_product_user`` HTTP gate,
+    # so it carries the same single-org carve-out (see #1023). Hosted keeps the
+    # GitHub product-readiness gate; single-org (self-hosted) instances admit
+    # password-only accounts, because reaching your own cloud sandbox over the
+    # gateway must work with no GitHub OAuth app configured. Endpoints that
+    # genuinely need a GitHub token still enforce that at the point of use.
+    if not settings.single_org_mode:
+        readiness = await get_account_readiness(db, user_id=user.id)
+        if not readiness.product_ready:
+            raise GatewayWebSocketAuthError("GitHub must be connected before gateway access.")
 
     set_authenticated_user_context(str(user.id))
     set_rls_actor_context(user.id)

--- a/server/tests/unit/test_cloud_sandbox_gateway_access.py
+++ b/server/tests/unit/test_cloud_sandbox_gateway_access.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import cast
+from uuid import uuid4
 
+import pytest
 from fastapi import WebSocket
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import Headers, QueryParams
 
+from proliferate.config import settings
+from proliferate.server.cloud.gateway import access
 from proliferate.server.cloud.gateway.access import (
     GATEWAY_WEBSOCKET_BEARER_PROTOCOL,
+    GatewayWebSocketAuthError,
     accepted_gateway_websocket_subprotocol,
+    authenticate_product_user_for_gateway_websocket,
     product_token_from_websocket,
 )
 
@@ -55,3 +63,81 @@ def test_product_token_from_websocket_supports_authorization_header() -> None:
     websocket = _websocket(authorization="Bearer header-token")
 
     assert product_token_from_websocket(websocket) == "header-token"
+
+
+def _patch_token_resolves_to(monkeypatch: pytest.MonkeyPatch, user: object) -> None:
+    class _FakeJwtStrategy:
+        async def read_token(self, _token: object, _user_manager: object) -> object:
+            return user
+
+    monkeypatch.setattr(access, "get_jwt_strategy", lambda: _FakeJwtStrategy())
+
+
+class TestSingleOrgGatewayWebsocketBypass:
+    """The gateway WebSocket auth mirrors current_product_user's single-org carve-out.
+
+    This is the WebSocket sibling of the HTTP ``current_product_user`` gate
+    fixed in #1023. Self-hosted single-org instances have no GitHub OAuth app
+    configured, so a password-only account must be able to reach its own cloud
+    sandbox over the gateway. Hosted keeps the GitHub product-readiness gate.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_org_bypasses_product_ready_gate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "single_org_mode_override", True)
+        user = SimpleNamespace(id=uuid4(), is_active=True)
+        _patch_token_resolves_to(monkeypatch, user)
+
+        async def _readiness(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("single-org mode must not consult product readiness")
+
+        monkeypatch.setattr(access, "get_account_readiness", _readiness)
+
+        resolved = await authenticate_product_user_for_gateway_websocket(
+            cast(AsyncSession, object()),
+            "product-token",
+        )
+        assert resolved is user
+
+    @pytest.mark.asyncio
+    async def test_hosted_mode_rejects_product_unready_user(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "single_org_mode_override", False)
+        user = SimpleNamespace(id=uuid4(), is_active=True)
+        _patch_token_resolves_to(monkeypatch, user)
+
+        async def _readiness(*_args: object, **_kwargs: object) -> object:
+            return SimpleNamespace(product_ready=False)
+
+        monkeypatch.setattr(access, "get_account_readiness", _readiness)
+
+        with pytest.raises(GatewayWebSocketAuthError):
+            await authenticate_product_user_for_gateway_websocket(
+                cast(AsyncSession, object()),
+                "product-token",
+            )
+
+    @pytest.mark.asyncio
+    async def test_hosted_mode_allows_product_ready_user(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "single_org_mode_override", False)
+        user = SimpleNamespace(id=uuid4(), is_active=True)
+        _patch_token_resolves_to(monkeypatch, user)
+
+        async def _readiness(*_args: object, **_kwargs: object) -> object:
+            return SimpleNamespace(product_ready=True)
+
+        monkeypatch.setattr(access, "get_account_readiness", _readiness)
+
+        resolved = await authenticate_product_user_for_gateway_websocket(
+            cast(AsyncSession, object()),
+            "product-token",
+        )
+        assert resolved is user

--- a/specs/codebase/features/product-auth.md
+++ b/specs/codebase/features/product-auth.md
@@ -34,6 +34,12 @@ when `settings.single_org_mode` is true, same as its sibling
 unconditionally. Endpoints that genuinely need a GitHub token (repo import,
 etc.) still enforce that at their own point of use, not through this gate.
 
+The cloud sandbox gateway WebSocket authenticates its own product user rather
+than going through `current_product_user` (it reads the bearer token off the
+WebSocket handshake). It carries the same `settings.single_org_mode` carve-out
+so reaching your own sandbox over the gateway works on self-hosted instances;
+hosted still requires GitHub readiness there.
+
 ## Web Beta Access
 
 Hosted web access is beta-gated. The server enforces the gate when issuing or


### PR DESCRIPTION
## What

`current_product_user` got the single-org carve-out in #1023, which unblocked the HTTP cloud endpoints for password-only accounts on self-hosted (single-org) instances. The cloud sandbox gateway WebSocket does not use that dependency. It authenticates its own product user in `authenticate_product_user_for_gateway_websocket` (reading the bearer token off the WebSocket handshake), and kept an inline GitHub product-readiness check that #1023 never reached.

That inline gate is the deeper sibling the tier-3 sweep found: it kept the sandbox proxy WebSocket path closed for the same password-only accounts, even though the HTTP proxy route (`current_product_user`-gated) already worked. This extends the exact same `settings.single_org_mode` carve-out to that gate.

Hosted (multi-org) behavior is unchanged: it still requires GitHub product-readiness there. Endpoints that genuinely need a GitHub token still fail cleanly at their own point of use.

## Gate catalog

Every gate that produces a GitHub-link block on the cloud sandbox proxy / connect paths, and the ruling for each:

- `auth/dependencies.py` `_require_product_ready` via `current_product_user` and `current_organization_actor`: already bypassed in single-org mode by #1023. Covers the HTTP sandbox routes (`GET /cloud-sandbox`, `POST /cloud-sandbox/wake`, workspaces, secrets, gateway HTTP proxy). No change.
- `server/cloud/gateway/access.py` `authenticate_product_user_for_gateway_websocket`: inline `product_ready` gate on the gateway WebSocket. Not reached by #1023. **Bypassed in single-org mode here.** This is product access to the user's own sandbox, so it belongs with the `current_product_user` pattern.
- `server/cloud/repos/service.py` `_require_github_access_token` (`github_link_required`, 400): genuinely needs a GitHub access token to call the GitHub API for repo listing / branches. **Left as point-of-use.**
- `server/cloud/github_app/repo_authority.py` `require_github_cloud_repo_authority` / `ensure_fresh_github_app_authorization` (`github_app_authorization_required` etc.): genuinely needs GitHub App authorization for repo-scoped operations. **Left as point-of-use.**

## Tier-3 lanes

The blocked sandbox lanes (T3-WT-1, T3-CHAT-1, T3-UPDATE-1, T3-PROV-2, T3-SEC-MAT-1) reach the sandbox either through the `current_product_user`-gated HTTP routes (unblocked by #1023) or through the gateway WebSocket proxy (this change). With both in place the front-door gate is lifted for password-only single-org users; the scenarios' own follow-up assertions (unfinished bodies) are theirs to complete.

## Tests

Added to `tests/unit/test_cloud_sandbox_gateway_access.py`, matching the `TestSingleOrgProductUserBypass` style from #1023:

- single-org password-only user passes the gateway WebSocket gate (readiness is not consulted)
- hosted user without GitHub readiness is still rejected
- hosted user with GitHub readiness is unaffected

## PR #1048 (feat/sso-entry) collision

#1048 also edits `auth/dependencies.py`, adding an org-SSO condition inside `current_product_user`'s body. This change is in a different file (`server/cloud/gateway/access.py`) and a different function, so there is no textual collision. If #1048 lands first, a follow-up may want to extend the same SSO carve-out to the gateway WebSocket for consistency, but that is out of scope here.

Pattern reference: #1023.

