### PR TITLE
tests(intent): T2-AUTH-4 login-method seam + T2-ORG-2 member visibility

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -17,7 +17,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Google OAuth sign-in (mocked provider per-merge) | 2 | — |
+| Google OAuth sign-in (mocked provider per-merge) | 2 | tests/intent/specs/login-methods.spec.ts (T2-AUTH-4; tier-2 owns the login-method availability seam — `/auth/desktop/methods` + `/auth/desktop/github/availability` report password on / GitHub off and the login screen renders the password form; the real Google/GitHub OAuth round-trip is the tier-3 "Real provider handshakes" row per scenarios.md ruling #4) |
 | `/setup` instance claim → password login → logout → re-login | 2 | — |
 | Session revocation ends access | 2 | — |
 | Invitation: invite → accept in fresh browser → membership + role | 2 | — |
@@ -33,7 +33,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Create organization | 2 | — |
 | Invite users; promote/demote roles | 2 | — |
 | Admin-only surfaces gated: member cannot see/do admin actions | 2 | — |
-| Member visibility boundaries (sees own work, not others' private state) | 2 | — |
+| Member visibility boundaries (sees own work, not others' private state) | 2 | tests/intent/specs/member-visibility.spec.ts (T2-ORG-2; member reads their org + the shared roster, but 403s on the invitations list (#1029), the join-link secret, and PATCHing another member — the read boundary being open does not open the write boundary) |
 | Remove user; access ends | 2 | — |
 
 ## Workspaces

--- a/tests/intent/package.json
+++ b/tests/intent/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "test": "playwright test",
     "test:auth": "playwright test specs/auth.spec.ts",
+    "test:login-methods": "playwright test specs/login-methods.spec.ts",
     "test:invitation": "playwright test specs/invitation.spec.ts",
+    "test:member-visibility": "playwright test specs/member-visibility.spec.ts",
     "test:organization-roles": "playwright test specs/organization-roles.spec.ts",
     "test:secrets": "playwright test specs/secrets.spec.ts",
     "test:cloud-workspace": "playwright test specs/cloud-workspace.spec.ts",

--- a/tests/intent/specs/login-methods.spec.ts
+++ b/tests/intent/specs/login-methods.spec.ts
@@ -1,0 +1,94 @@
+// T2-AUTH-4 (specs/developing/testing/scenarios.md): login-method
+// availability seam.
+//
+// Maps to the flow-registry row "Google OAuth sign-in (mocked provider
+// per-merge)". Read scenarios.md open ruling #4 first: a *real* Google/GitHub
+// OAuth round trip is tier-3-only — the provider's authorize/token endpoints
+// are not overridable, so they cannot be pointed at a mock without a product
+// change we are deliberately not making, and the actual handshake is the
+// separate tier-3 "Real provider handshakes" row. What tier 2 owns, per
+// T2-AUTH-4, is the *seam that decides which login methods the app offers*:
+// `provider_enabled()` on the server, surfaced to the unauthenticated login
+// screen. This spec pins that seam.
+//
+// Survey facts (verified against origin/main, not assumed):
+// - `GET /auth/desktop/methods` is the public probe the docstring names as
+//   the login screen's source of truth — "the email/password form becomes the
+//   default when GitHub OAuth is not configured"
+//   (server/proliferate/auth/desktop/api.py desktop_auth_methods →
+//   AuthMethodsResponse{password_login, github}).
+// - `GET /auth/desktop/github/availability` reports the GitHub-OAuth half
+//   (OAuthAvailabilityResponse{enabled, client_id}); `enabled` is
+//   `github_oauth_enabled()`, false when GITHUB_OAUTH_CLIENT_ID is unset.
+// - This suite's stack (stack/boot.ts) boots with GITHUB_OAUTH_CLIENT_ID=""
+//   on purpose (never let a leaked env point a test profile at a real OAuth
+//   app), so this deployment offers password login and hides the GitHub
+//   button. That is the availability seam in its "unset → hidden" direction.
+// - The desktop login screen (apps/desktop/src/components/auth/LoginScreen.tsx)
+//   renders the password form exactly when the server reports password on and
+//   GitHub off; there is no Google button on the login surface at all (Google
+//   is account-linking only, post-auth), which is why the tier-2-honest form
+//   of the "Google OAuth sign-in" row is this availability seam.
+//
+// The "env set → button renders" direction and the real provider handshake
+// both live in tier 3 (they need real/overridable provider endpoints); this
+// file asserts the seam that gates the desktop app's offered methods, which is
+// what per-merge coverage can honestly own.
+
+import { expect, test } from "@playwright/test";
+import { apiBaseUrl, webBaseUrl } from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+interface AuthMethodsResponse {
+  password_login: boolean;
+  github: boolean;
+}
+
+interface OAuthAvailabilityResponse {
+  enabled: boolean;
+  client_id: string | null;
+}
+
+test.describe("T2-AUTH-4: login-method availability seam", () => {
+  test("public /auth/desktop/methods probe reports password on, GitHub off for this deployment", async () => {
+    // Unauthenticated probe — the login screen calls this before any session
+    // exists, so it must answer without a token.
+    const response = await fetch(`${apiBaseUrl()}/auth/desktop/methods`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as AuthMethodsResponse;
+    // Password login is the offered method on a profile with no OAuth env.
+    expect(body.password_login).toBe(true);
+    // GitHub OAuth is not configured here → the seam hides it.
+    expect(body.github).toBe(false);
+  });
+
+  test("GET /auth/desktop/github/availability reports GitHub OAuth disabled (no client env)", async () => {
+    const response = await fetch(`${apiBaseUrl()}/auth/desktop/github/availability`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as OAuthAvailabilityResponse;
+    expect(body.enabled).toBe(false);
+    // client_id is only echoed when enabled; disabled → null (never leak an
+    // empty-string client id that the app might treat as configured).
+    expect(body.client_id).toBeNull();
+  });
+
+  test("login screen renders the password form as the offered method, not a GitHub OAuth entry", async ({ page }) => {
+    await page.goto(webBaseUrl());
+    // The availability seam's rendered consequence: LoginScreen shows the
+    // email/password form (its fields are present) because the server reports
+    // password on + GitHub off. The GitHub-OAuth branch of LoginScreen is not
+    // rendered in this state, so the offered method is unambiguously password.
+    await expect(page.getByLabel("Email")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByLabel("Password")).toBeVisible();
+    // Cross-check the seam the UI is reacting to, from the browser's own
+    // origin (same probe the app makes), so a UI regression and an API
+    // regression are told apart.
+    const methods = await page.evaluate(async (base) => {
+      const res = await fetch(`${base}/auth/desktop/methods`);
+      return (await res.json()) as { password_login: boolean; github: boolean };
+    }, apiBaseUrl());
+    expect(methods.github).toBe(false);
+    expect(methods.password_login).toBe(true);
+  });
+});

--- a/tests/intent/specs/member-visibility.spec.ts
+++ b/tests/intent/specs/member-visibility.spec.ts
@@ -1,0 +1,143 @@
+// T2-ORG-2 (specs/developing/testing/scenarios.md, flow-registry row
+// "Member visibility boundaries — sees own work, not others' private state").
+//
+// This is the visibility complement to T2-ORG-1 (organization-roles.spec.ts).
+// T2-ORG-1 pins the *mutation* boundary (a member cannot invite/promote/remove,
+// gets 403 on create-invitation). This file pins the *read* boundary: what a
+// plain member can and cannot SEE of the organization.
+//
+// Survey facts (verified against origin/main, organizations/api.py):
+// - Shared team state is member-readable: GET /organizations/{id}
+//   (get_organization_endpoint) and GET /organizations/{id}/members
+//   (list_organization_members_endpoint) both depend on current_path_org_member
+//   — a member sees the org and its roster (the team they belong to).
+// - Admin-only visibility is gated:
+//     * GET /organizations/{id}/invitations depends on current_path_org_admin
+//       as of #1029 (fix: gate org invitations list to admins) — a member can
+//       no longer read pending/accepted/revoked invitations, i.e. other
+//       people's invite state. This file is written against that admin-only
+//       contract; #1029 is merged on this branch's base, so it asserts 403
+//       directly (no expected-fail pin needed).
+//     * GET /organizations/{id}/join-link depends on current_path_org_admin —
+//       the org's join secret is admin-only.
+// - Management surfaces stay closed on the read→write edge too: PATCH
+//   /organizations/{id}/members/{membership_id} depends on current_path_org_admin,
+//   so a member cannot reach into another member's membership record.
+// All denials surface as 403 organization_permission_denied via
+// current_path_org_admin (organizations/domain/policy.py), never a 404 that
+// would leak existence differently — asserted below.
+//
+// Cloud personal secrets/workspaces would be the other "others' private state"
+// axis, but those surfaces are product-gated for password-only accounts at
+// tier 2 (see secrets.spec.ts / cloud-workspace.spec.ts) and belong to their
+// own rows; this file stays on the org-scoped visibility boundary, which is
+// cleanly reachable for password accounts.
+
+import { expect, test } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  apiRequest,
+  ensureInstanceClaimed,
+  getOwnOrganization,
+  inviteAndRegisterMember,
+  listMembers,
+  passwordLogin,
+  resetPasswordLoginRateLimits,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+// Distinct fixed email from organization-roles.spec.ts's members so the two
+// specs don't couple through shared roster state; idempotent across reruns
+// against this profile's persisted DB (inviteAndRegisterMember logs in first).
+const VIS_MEMBER_EMAIL = "t2vis-member@t2intent.example.com";
+const VIS_MEMBER_PASSWORD = "T2VisMember!Passw0rd";
+
+let ownerToken: string;
+let organizationId: string;
+let memberToken: string;
+
+test.beforeAll(async () => {
+  await ensureInstanceClaimed();
+  ownerToken = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+  organizationId = (await getOwnOrganization(ownerToken)).id;
+  memberToken = await inviteAndRegisterMember(
+    ownerToken,
+    organizationId,
+    VIS_MEMBER_EMAIL,
+    VIS_MEMBER_PASSWORD,
+    "member",
+  );
+});
+
+test.afterAll(async () => {
+  // This file's logins are all legitimate; leave the shared per-IP
+  // rate-limit bucket clean for whichever spec runs next (single worker).
+  await resetPasswordLoginRateLimits();
+});
+
+test.describe("T2-ORG-2: member visibility boundaries", () => {
+  test("member sees own work: their org appears in their org list and reads back", async () => {
+    const list = await apiRequest<{ organizations: { id: string }[] }>("/v1/organizations", {
+      token: memberToken,
+    });
+    expect(list.status).toBe(200);
+    expect(list.body.organizations.map((org) => org.id)).toContain(organizationId);
+
+    const org = await apiRequest(`/v1/organizations/${organizationId}`, { token: memberToken });
+    expect(org.status).toBe(200);
+  });
+
+  test("member sees shared team state: the member roster, including themselves and the owner", async () => {
+    // Roster is shared team state, not private state — a member is allowed to
+    // see who is on the team.
+    const roster = await listMembers(memberToken, organizationId);
+    const emails = roster.map((member) => member.email);
+    expect(emails).toContain(VIS_MEMBER_EMAIL);
+    expect(emails).toContain(ADMIN_EMAIL);
+  });
+
+  test("member cannot see others' invite state: the org invitations list is admin-only (#1029)", async () => {
+    const asMember = await apiRequest(`/v1/organizations/${organizationId}/invitations`, {
+      token: memberToken,
+    });
+    expect(asMember.status).toBe(403);
+    const detail = (asMember.body as { detail?: { code?: string } }).detail;
+    expect(detail?.code).toBe("organization_permission_denied");
+
+    // Corroborate the boundary is real (not a fixture fluke): the same
+    // endpoint returns 200 for the owner, so the 403 is the member gate, not a
+    // broken route.
+    const asOwner = await apiRequest(`/v1/organizations/${organizationId}/invitations`, {
+      token: ownerToken,
+    });
+    expect(asOwner.status).toBe(200);
+  });
+
+  test("member cannot see the org join secret: join-link is admin-only", async () => {
+    const asMember = await apiRequest(`/v1/organizations/${organizationId}/join-link`, {
+      token: memberToken,
+    });
+    expect(asMember.status).toBe(403);
+    const detail = (asMember.body as { detail?: { code?: string } }).detail;
+    expect(detail?.code).toBe("organization_permission_denied");
+  });
+
+  test("member cannot reach into another member's membership record (management stays closed)", async () => {
+    // Resolve the owner's membership id via the roster the member is allowed
+    // to read, then attempt to mutate it — the read boundary being open does
+    // not open the write boundary.
+    const roster = await listMembers(memberToken, organizationId);
+    const ownerMembership = roster.find((member) => member.email === ADMIN_EMAIL);
+    expect(ownerMembership).toBeDefined();
+
+    const attempt = await apiRequest(
+      `/v1/organizations/${organizationId}/members/${ownerMembership!.membershipId}`,
+      { method: "PATCH", token: memberToken, body: { role: "member" } },
+    );
+    expect(attempt.status).toBe(403);
+    const detail = (attempt.body as { detail?: { code?: string } }).detail;
+    expect(detail?.code).toBe("organization_permission_denied");
+  });
+});

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -263,7 +263,12 @@ function killTracked(child: ChildProcess): void {
 }
 
 export async function bootStack(options: BootOptions = {}): Promise<BootedStack> {
-  const profile = options.profile ?? PROFILE;
+  // TIER2_INTENT_PROFILE lets a local run boot the same harness on its own
+  // profile so parallel worktrees don't collide on ports/DB/run-lock (this
+  // branch was verified on `t2auth`). Callers that pass an explicit profile
+  // (the billing suite) still win; CI keeps the default, one profile per
+  // isolated container.
+  const profile = options.profile ?? process.env.TIER2_INTENT_PROFILE ?? PROFILE;
   log(`preparing profile "${profile}"...`);
   const instance = ensureProfilePorts(profile);
   ensureDatabase(instance.databaseName);


### PR DESCRIPTION
Adds the two tier-2 auth/identity and organization flow-registry rows that the
intent train (now landed on main via #1016/#1031/#1033) did not cover, and
points their flows.md rows at the new specs.

## Why this is small

The tier-2 "intent" scaffold and most of the auth/org rows landed with the
train:

| Row | Covered by (on main) |
| --- | --- |
| /setup claim -> password login -> logout -> re-login | tests/intent/specs/auth.spec.ts (T2-AUTH-1) |
| Session revocation ends access | tests/intent/specs/auth.spec.ts (T2-AUTH-2) |
| Invitation happy path + negatives | tests/intent/specs/invitation.spec.ts (T2-INV-1) |
| Create organization | claimed once in auth.spec.ts (single-org instance org) |
| Invite users; promote/demote; admin gating; remove user | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1) |
| SSO round-trip + negatives | tests/intent/specs/sso.spec.ts on #1015 (not yet merged) |

That left two rows with no coverage anywhere, which is what this PR fills.

## What this adds

T2-AUTH-4, `tests/intent/specs/login-methods.spec.ts` (flows.md row "Google
OAuth sign-in (mocked provider per-merge)"). A real Google/GitHub OAuth round
trip is tier-3 only, since the provider endpoints are not overridable and the
handshake is the separate tier-3 "Real provider handshakes" row (scenarios.md
open ruling #4). What tier 2 can honestly own is the seam that decides which
login methods the app offers: `provider_enabled()`, surfaced to the
unauthenticated login screen. The spec asserts `/auth/desktop/methods` reports
password on and GitHub off for a profile with no OAuth env,
`/auth/desktop/github/availability` reports disabled with a null client id, and
the login screen renders the password form as the offered method. Google has no
login-screen button at all today (account linking only), which is why the
availability seam is the tier-2-appropriate form of that row.

T2-ORG-2, `tests/intent/specs/member-visibility.spec.ts` (flows.md row "Member
visibility boundaries"). This is the read-boundary complement to T2-ORG-1's
mutation boundary. A member reads their own org and the shared member roster,
and gets 403 organization_permission_denied on the org invitations list
(admin-only per #1029), on the join-link secret, and on PATCHing another
member's record. The read boundary being open does not open the write boundary.

## Integration

Based on main (retargeted after the train landed; originally stacked on
tests/intent-wave2). The two specs run under the existing `intent-tests` CI
job, which executes `pnpm -C tests/intent test` over every spec in `specs/`,
so no new job is needed.

boot.ts gains a `TIER2_INTENT_PROFILE` env override so a local run can boot
the harness on its own dev profile without colliding with other worktrees on
ports/DB/run-lock. Explicit `options.profile` callers (the billing suite)
still win; CI keeps the default.

## Verification

On the wave2 base: three consecutive clean full-suite runs on a booted
`t2auth` profile (30 passed, 1 skipped each time). After the rebase onto main:
one more full-suite run on `t2auth`, 38 passed, 1 skipped — the two new specs
green alongside the landed train's specs (including the new integrations and
workspace-entry specs). The single skip is invitation.spec.ts's Account-pane
accept test, gated on #1017 (unmerged).

## Product bugs

None found in the two rows this PR covers. Both surfaces behaved to contract.

## Follow-up

One SSO negative from the flows.md row wording, audience/issuer mismatch, is
not covered by #1015's sso.spec.ts yet (it covers disallowed domain, unknown
user with JIT disabled, and tampered state). Its natural home is that spec,
since the assertion needs the mock IdP harness that lives in #1015. Org-scoped
SSO login entry points (#1048, now merged) also need their own tier-2 coverage
on top of #1015's harness.
