### PR TITLE
fix(self-host): replace dead Bifrost gateway vars with the real LiteLLM config

### DIFF
--- a/server/deploy/.env.production.example
+++ b/server/deploy/.env.production.example
@@ -69,19 +69,27 @@ CLOUD_MCP_SLACK_CLIENT_ID=
 CLOUD_MCP_SLACK_CLIENT_SECRET=
 CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_post
 
-# Agent LLM gateway. Leave disabled unless a private Bifrost router is deployed.
+# Agent LLM gateway (optional LiteLLM add-on). Enabling it is two steps: set
+# AGENT_GATEWAY_ENABLED=true here, then start the profiled services with
+# `docker compose --env-file .env.runtime -f docker-compose.production.yml
+# --profile agent-gateway up -d`. Plain bootstrap.sh/update.sh runs never
+# start litellm/litellm-db. Docs: /docs/deployment/add-ons/model-gateway
 AGENT_GATEWAY_ENABLED=false
-AGENT_GATEWAY_BIFROST_BASE_URL=http://127.0.0.1:8080
-AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL=https://gateway.company.com
-AGENT_GATEWAY_BIFROST_ADMIN_TOKEN=
-AGENT_GATEWAY_BIFROST_ISOLATION_VERIFIED=false
-AGENT_GATEWAY_DEFAULT_MANAGED_BUDGET_USD=0
-AGENT_GATEWAY_MAX_REQUEST_BYTES=4194304
-AGENT_GATEWAY_REQUEST_TIMEOUT_SECONDS=120.0
-AGENT_GATEWAY_OPENCODE_ENABLED=false
-AGENT_GATEWAY_RECONCILER_ENABLED=false
-AGENT_GATEWAY_RECONCILER_INTERVAL_SECONDS=300.0
-AGENT_GATEWAY_RECONCILER_BATCH_SIZE=50
+AGENT_GATEWAY_LITELLM_BASE_URL=http://litellm:4000
+# Public URL agents use to reach LiteLLM, for example https://llm.company.com
+AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=
+# Generate with `openssl rand -hex 32`. AGENT_GATEWAY_LITELLM_MASTER_KEY must
+# be the exact same value as LITELLM_MASTER_KEY.
+AGENT_GATEWAY_LITELLM_MASTER_KEY=
+LITELLM_MASTER_KEY=
+LITELLM_POSTGRES_PASSWORD=
+AGENT_GATEWAY_DEFAULT_USER_BUDGET_USD=5
+AGENT_GATEWAY_DEFAULT_ORG_BUDGET_USD=0
+# Provider keys the gateway routes centrally live with the LiteLLM service;
+# ANTHROPIC_API_KEY below also serves AI session titles. Add OPENAI_API_KEY /
+# XAI_API_KEY when you route those providers.
+OPENAI_API_KEY=
+XAI_API_KEY=
 
 # Cloud workspace provider.
 E2B_API_KEY=

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -1219,19 +1219,27 @@ Resources:
                 CLOUD_MCP_SLACK_CLIENT_SECRET=
                 CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_post
 
-                # Agent LLM gateway. Leave disabled unless a private Bifrost router is deployed.
+                # Agent LLM gateway (optional LiteLLM add-on). Enabling it is two steps: set
+                # AGENT_GATEWAY_ENABLED=true here, then start the profiled services with
+                # `docker compose --env-file .env.runtime -f docker-compose.production.yml
+                # --profile agent-gateway up -d`. Plain bootstrap.sh/update.sh runs never
+                # start litellm/litellm-db. Docs: /docs/deployment/add-ons/model-gateway
                 AGENT_GATEWAY_ENABLED=false
-                AGENT_GATEWAY_BIFROST_BASE_URL=http://127.0.0.1:8080
-                AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL=https://gateway.company.com
-                AGENT_GATEWAY_BIFROST_ADMIN_TOKEN=
-                AGENT_GATEWAY_BIFROST_ISOLATION_VERIFIED=false
-                AGENT_GATEWAY_DEFAULT_MANAGED_BUDGET_USD=0
-                AGENT_GATEWAY_MAX_REQUEST_BYTES=4194304
-                AGENT_GATEWAY_REQUEST_TIMEOUT_SECONDS=120.0
-                AGENT_GATEWAY_OPENCODE_ENABLED=false
-                AGENT_GATEWAY_RECONCILER_ENABLED=false
-                AGENT_GATEWAY_RECONCILER_INTERVAL_SECONDS=300.0
-                AGENT_GATEWAY_RECONCILER_BATCH_SIZE=50
+                AGENT_GATEWAY_LITELLM_BASE_URL=http://litellm:4000
+                # Public URL agents use to reach LiteLLM, for example https://llm.company.com
+                AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=
+                # Generate with `openssl rand -hex 32`. AGENT_GATEWAY_LITELLM_MASTER_KEY must
+                # be the exact same value as LITELLM_MASTER_KEY.
+                AGENT_GATEWAY_LITELLM_MASTER_KEY=
+                LITELLM_MASTER_KEY=
+                LITELLM_POSTGRES_PASSWORD=
+                AGENT_GATEWAY_DEFAULT_USER_BUDGET_USD=5
+                AGENT_GATEWAY_DEFAULT_ORG_BUDGET_USD=0
+                # Provider keys the gateway routes centrally live with the LiteLLM service;
+                # ANTHROPIC_API_KEY below also serves AI session titles. Add OPENAI_API_KEY /
+                # XAI_API_KEY when you route those providers.
+                OPENAI_API_KEY=
+                XAI_API_KEY=
 
                 # Cloud workspace provider.
                 E2B_API_KEY=

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -125,15 +125,19 @@ overrides should go in `/opt/proliferate/server/deploy/.env.local`:
 
 ```text
 AGENT_GATEWAY_ENABLED=true
-AGENT_GATEWAY_BIFROST_BASE_URL=https://<private-or-protected-bifrost-admin>
-AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL=https://<public-bifrost-inference>
-AGENT_GATEWAY_RECONCILER_ENABLED=true
+AGENT_GATEWAY_LITELLM_BASE_URL=http://litellm:4000
+AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=https://<public-litellm-endpoint>
+AGENT_GATEWAY_LITELLM_MASTER_KEY=<same value as LITELLM_MASTER_KEY>
+LITELLM_MASTER_KEY=<openssl rand -hex 32>
+LITELLM_POSTGRES_PASSWORD=<openssl rand -hex 32>
 ```
 
-Then run `/opt/proliferate/server/deploy/update.sh`. The update script merges
-`.env.static` with `.env.local` and preserves the override across later stack
-updates. Self-hosted agent gateway deployments now point at Bifrost; the Compose
-stack no longer includes a bundled LiteLLM service.
+Then run `/opt/proliferate/server/deploy/update.sh` and start the profiled
+services: `docker compose --env-file .env.runtime -f
+docker-compose.production.yml --profile agent-gateway up -d`. The update
+script merges `.env.static` with `.env.local` and preserves the override
+across later stack updates. The gateway is the bundled LiteLLM service
+(compose profile `agent-gateway`).
 
 ## Update Flow
 

--- a/specs/developing/deploying/self-hosted-deploy.md
+++ b/specs/developing/deploying/self-hosted-deploy.md
@@ -92,16 +92,18 @@ Desktop -> https://api.company.com -> Caddy -> API
 Cloud workspace runtimes are still provider-hosted. The control plane returns a
 `runtimeUrl`, and the desktop talks to that runtime directly.
 
-The agent LLM gateway uses a Bifrost inference endpoint for sandbox model
+The agent LLM gateway is the bundled LiteLLM proxy (compose services
+`litellm` + `litellm-db`, behind `--profile agent-gateway`) for sandbox model
 traffic:
 
 ```text
-Sandbox harness -> https://llm.company.com/anthropic/... -> Bifrost -> provider API
+Sandbox harness -> https://llm.company.com/anthropic/... -> LiteLLM -> provider API
 ```
 
-The Proliferate API talks to the protected Bifrost management API through
-`AGENT_GATEWAY_BIFROST_BASE_URL`. Sandboxes receive only virtual keys and
-`AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL`.
+The Proliferate API talks to LiteLLM's management API through
+`AGENT_GATEWAY_LITELLM_BASE_URL` (authenticated with
+`AGENT_GATEWAY_LITELLM_MASTER_KEY`). Sandboxes receive only short-lived
+virtual keys and `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL`.
 
 ## First-Time Setup
 
@@ -133,13 +135,15 @@ bundle-only download. Working from a monorepo checkout instead?
    - `GITHUB_OAUTH_CLIENT_SECRET`
    - `E2B_API_KEY`
    - `E2B_TEMPLATE_NAME`
-   - optional agent gateway:
+   - optional agent gateway (also requires starting the profiled services:
+     `docker compose --profile agent-gateway up -d`):
      - `AGENT_GATEWAY_ENABLED=true`
-     - `AGENT_GATEWAY_BIFROST_BASE_URL=https://bifrost-admin.company.com`
-     - `AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL=https://llm.company.com`
-     - `AGENT_GATEWAY_RECONCILER_ENABLED=true`
-     - `AGENT_GATEWAY_DEFAULT_MANAGED_BUDGET_USD` if managed credits should be
-       available
+     - `AGENT_GATEWAY_LITELLM_BASE_URL=http://litellm:4000`
+     - `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=https://llm.company.com`
+     - `AGENT_GATEWAY_LITELLM_MASTER_KEY` = `LITELLM_MASTER_KEY`, plus
+       `LITELLM_POSTGRES_PASSWORD`
+     - `AGENT_GATEWAY_DEFAULT_USER_BUDGET_USD` /
+       `AGENT_GATEWAY_DEFAULT_ORG_BUDGET_USD` for limits
    - `CLOUD_RUNTIME_SOURCE_BINARY_PATH`,
      `CLOUD_WORKER_SOURCE_BINARY_PATH`, and
      `CLOUD_SUPERVISOR_SOURCE_BINARY_PATH` if you want cloud workspaces
@@ -211,9 +215,11 @@ docker compose -f docker-compose.production.yml run --rm migrate
 docker compose -f docker-compose.production.yml up -d
 ```
 
-When `AGENT_GATEWAY_ENABLED=true`, `bootstrap.sh` and `update.sh` start the same
-API stack and expect the configured Bifrost endpoints to be reachable. The
-Compose stack no longer creates a bundled gateway service.
+When `AGENT_GATEWAY_ENABLED=true`, `bootstrap.sh` and `update.sh` still start
+only the base API stack: the bundled `litellm`/`litellm-db` services sit
+behind the compose `agent-gateway` profile and must be started explicitly
+with `docker compose --env-file .env.runtime -f docker-compose.production.yml
+--profile agent-gateway up -d`.
 
 Recommended image strategy:
 


### PR DESCRIPTION
The deploy bundle's `.env.production.example` still shipped the removed `AGENT_GATEWAY_BIFROST_*` block — silently ignored by `Settings` (`extra="ignore"`) since the LiteLLM migration — and omitted every variable the bundled `litellm`/`litellm-db` services actually read (`LITELLM_MASTER_KEY`, `LITELLM_POSTGRES_PASSWORD`, `AGENT_GATEWAY_LITELLM_*`). An operator copying the template's gateway section verbatim configured nothing that does anything.

- Replace the dead block with the live var set (names verified against `config.py:346-352` and `docker-compose.production.yml:44-64`)
- Document the `--profile agent-gateway` two-step in the template itself (previously only a compose-file comment)
- Align `specs/developing/deploying/self-hosted-deploy.md` and `self-hosted-aws.md`, which described the same dead Bifrost flow

Docs-side counterpart lands with the landing-repo self-hosting pass. Launch-blocking per the self-hosting docs audit (finding #2/#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)