### PR TITLE
fix(billing): membership changes no longer 500 when an org has two active subscriptions

### DIFF
--- a/server/proliferate/db/store/billing_seats.py
+++ b/server/proliferate/db/store/billing_seats.py
@@ -79,6 +79,12 @@ async def maybe_create_org_seat_adjustment(
     ).scalar_one_or_none()
     if subject is None:
         return False
+    # A billing subject can end up with more than one active/trialing
+    # subscription row (double checkout, re-subscribing while the old sub is
+    # still cancelling, a support-created sub). Take the newest one by the
+    # same ordering latest_healthy_cloud_subscription() uses, and cap the
+    # query at one row so this can never raise MultipleResultsFound -- a
+    # membership change must not 500 because Stripe state is messy.
     subscription = (
         await db.execute(
             select(BillingSubscription)
@@ -90,6 +96,7 @@ async def maybe_create_org_seat_adjustment(
                 BillingSubscription.current_period_end.desc().nulls_last(),
                 BillingSubscription.updated_at.desc(),
             )
+            .limit(1)
             .with_for_update()
         )
     ).scalar_one_or_none()

--- a/server/tests/integration/test_billing_seat_adjustment.py
+++ b/server/tests/integration/test_billing_seat_adjustment.py
@@ -1,0 +1,217 @@
+"""Regression coverage for maybe_create_org_seat_adjustment (issue #1044).
+
+A billing subject can end up with more than one active/trialing
+BillingSubscription row (double checkout, re-subscribing while the old sub
+is still cancelling, a support-created sub). Before the fix, the
+subscription lookup in billing_seats.maybe_create_org_seat_adjustment had no
+.limit(1), so a second active row made scalar_one_or_none() raise
+MultipleResultsFound -- and every membership change on that org (invite,
+remove, role change, SSO resolution) 500'd until the extra row was cleaned
+up by hand.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+    ORGANIZATION_STATUS_ACTIVE,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.models.billing import BillingSeatAdjustment, BillingSubscription
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import billing_seats
+from proliferate.db.store.billing_subjects import ensure_organization_billing_subject
+
+PRO_PRICE_ID = "price_pro_test"
+
+
+async def _make_user(db: AsyncSession, *, email: str) -> User:
+    user = User(
+        email=email,
+        hashed_password="unused",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        display_name=email,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_org_with_two_active_members(
+    db: AsyncSession,
+) -> tuple[Organization, OrganizationMembership]:
+    now = datetime.now(UTC)
+    organization = Organization(
+        name="Multisub Test Org",
+        status=ORGANIZATION_STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(organization)
+    await db.flush()
+
+    owner = await _make_user(db, email=f"owner-{uuid.uuid4()}@example.com")
+    member = await _make_user(db, email=f"member-{uuid.uuid4()}@example.com")
+
+    db.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role=ORGANIZATION_ROLE_OWNER,
+            status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+            joined_at=now,
+        )
+    )
+    membership = OrganizationMembership(
+        organization_id=organization.id,
+        user_id=member.id,
+        role=ORGANIZATION_ROLE_MEMBER,
+        status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+        joined_at=now,
+    )
+    db.add(membership)
+    await db.flush()
+    return organization, membership
+
+
+def _active_subscription(
+    *,
+    billing_subject_id: uuid.UUID,
+    stripe_subscription_id: str,
+    monthly_subscription_item_id: str,
+    seat_quantity: int,
+    current_period_start: datetime,
+    current_period_end: datetime,
+    updated_at: datetime,
+) -> BillingSubscription:
+    return BillingSubscription(
+        billing_subject_id=billing_subject_id,
+        stripe_subscription_id=stripe_subscription_id,
+        stripe_customer_id=f"cus_{stripe_subscription_id}",
+        status="active",
+        cancel_at_period_end=False,
+        canceled_at=None,
+        current_period_start=current_period_start,
+        current_period_end=current_period_end,
+        cloud_monthly_price_id=PRO_PRICE_ID,
+        overage_price_id=None,
+        seat_quantity=seat_quantity,
+        monthly_subscription_item_id=monthly_subscription_item_id,
+        metered_subscription_item_id=None,
+        latest_invoice_id=None,
+        latest_invoice_status=None,
+        hosted_invoice_url=None,
+        updated_at=updated_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_active_subscriptions_do_not_raise_and_pick_the_newest(
+    db_session: AsyncSession,
+) -> None:
+    organization, membership = await _make_org_with_two_active_members(db_session)
+    subject = await ensure_organization_billing_subject(db_session, organization.id)
+
+    now = datetime.now(UTC)
+    # Older active row: earlier period end, stale seat_quantity. If this one
+    # got picked by mistake, the created adjustment would carry its
+    # seat_quantity (99) and stripe ids instead of the newer sub's.
+    old_sub = _active_subscription(
+        billing_subject_id=subject.id,
+        stripe_subscription_id="sub_old_multisub",
+        monthly_subscription_item_id="si_old",
+        seat_quantity=99,
+        current_period_start=now - timedelta(days=10),
+        current_period_end=now + timedelta(days=5),
+        updated_at=now - timedelta(days=10),
+    )
+    new_sub = _active_subscription(
+        billing_subject_id=subject.id,
+        stripe_subscription_id="sub_new_multisub",
+        monthly_subscription_item_id="si_new",
+        seat_quantity=1,
+        current_period_start=now - timedelta(days=2),
+        current_period_end=now + timedelta(days=28),
+        updated_at=now,
+    )
+    db_session.add_all([old_sub, new_sub])
+    await db_session.flush()
+
+    created = await billing_seats.maybe_create_org_seat_adjustment(
+        db_session,
+        organization_id=organization.id,
+        membership_id=membership.id,
+        pro_billing_enabled=True,
+        pro_monthly_price_id=PRO_PRICE_ID,
+    )
+
+    assert created is True
+
+    adjustment = (
+        await db_session.execute(
+            select(BillingSeatAdjustment).where(
+                BillingSeatAdjustment.billing_subject_id == subject.id
+            )
+        )
+    ).scalar_one()
+    # Newest subscription by (current_period_end desc, updated_at desc) won,
+    # matching the ordering latest_healthy_cloud_subscription() uses.
+    assert adjustment.billing_subscription_id == new_sub.id
+    assert adjustment.stripe_subscription_id == "sub_new_multisub"
+    assert adjustment.previous_quantity == 1
+    assert adjustment.target_quantity == 2
+    assert adjustment.grant_quantity == 1
+
+
+@pytest.mark.asyncio
+async def test_single_active_subscription_behavior_is_unchanged(
+    db_session: AsyncSession,
+) -> None:
+    organization, membership = await _make_org_with_two_active_members(db_session)
+    subject = await ensure_organization_billing_subject(db_session, organization.id)
+
+    now = datetime.now(UTC)
+    sub = _active_subscription(
+        billing_subject_id=subject.id,
+        stripe_subscription_id="sub_only",
+        monthly_subscription_item_id="si_only",
+        seat_quantity=1,
+        current_period_start=now - timedelta(days=2),
+        current_period_end=now + timedelta(days=28),
+        updated_at=now,
+    )
+    db_session.add(sub)
+    await db_session.flush()
+
+    created = await billing_seats.maybe_create_org_seat_adjustment(
+        db_session,
+        organization_id=organization.id,
+        membership_id=membership.id,
+        pro_billing_enabled=True,
+        pro_monthly_price_id=PRO_PRICE_ID,
+    )
+
+    assert created is True
+
+    adjustment = (
+        await db_session.execute(
+            select(BillingSeatAdjustment).where(
+                BillingSeatAdjustment.billing_subject_id == subject.id
+            )
+        )
+    ).scalar_one()
+    assert adjustment.billing_subscription_id == sub.id
+    assert adjustment.previous_quantity == 1
+    assert adjustment.target_quantity == 2
+    assert adjustment.grant_quantity == 1

--- a/tests/intent/specs/billing/seats.spec.ts
+++ b/tests/intent/specs/billing/seats.spec.ts
@@ -38,7 +38,6 @@ async function subscribeOrgToPro(organizationId: string, ownerUserId: string, se
   return { subject, subscriptionId: sub.id, fullSub };
 }
 
-const ISSUE_1044 = "https://github.com/proliferate-ai/proliferate/issues/1044";
 
 test.describe("T2-BILL-3: seats — invite/remove/re-invite on a Pro org", () => {
   skipIfNoStripe(test);
@@ -178,12 +177,12 @@ test.describe("T2-BILL-3: seats — invite/remove/re-invite on a Pro org", () =>
   });
 
   test(
-    "ISSUE #1044 (pinned known-bug): two active org subscriptions break every membership change (500 MultipleResultsFound)",
+    "two active org subscriptions no longer break membership changes (issue #1044 fixed)",
     async () => {
-      test.info().annotations.push({
-        type: "known-bug",
-        description: `maybe_create_org_seat_adjustment selects the latest healthy subscription without .limit(1); a second active subscription makes scalar_one_or_none raise and every membership change 500s. ${ISSUE_1044}. When the fix lands, flip this to expect 200.`,
-      });
+      // Formerly the ISSUE #1044 known-bug pin: maybe_create_org_seat_adjustment
+      // now caps its subscription lookup at one row (newest by the
+      // latest_healthy_cloud_subscription ordering), so a second active
+      // subscription no longer raises MultipleResultsFound (issue #1044).
       const { token, organizationId } = await adminContext();
       const ownerId = await userIdFor(token);
       // Two live subscriptions on the same org subject (double-checkout /
@@ -216,16 +215,16 @@ test.describe("T2-BILL-3: seats — invite/remove/re-invite on a Pro org", () =>
       void memberToken;
       const members = await seed.listMembers(token, organizationId);
       const m = members.find((mm) => mm.email === email)!;
-      // Raw fetch: the 500 body is plain text ("Internal Server Error"),
-      // which seed.removeMembership's JSON parse would choke on.
       const removal = await fetch(
         `${process.env.TIER2_BILLING_API_BASE_URL}/v1/organizations/${organizationId}/members/${m.membershipId}`,
         { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
       );
-      expect(removal.status, "pins the current 500 (issue #1044)").toBe(500);
+      expect(
+        [200, 204],
+        "membership change succeeds despite two live subscription rows (issue #1044 fixed)",
+      ).toContain(removal.status);
 
-      // Clean up the org's membership state for later specs: retire the extra
-      // subscription rows, then the removal goes through again.
+      // Clean up the org's subscription state for later specs.
       await b.withDb((db) =>
         db.query(
           `UPDATE billing_subscription SET status = 'canceled', updated_at = now()
@@ -233,8 +232,6 @@ test.describe("T2-BILL-3: seats — invite/remove/re-invite on a Pro org", () =>
           [subject.id],
         ),
       );
-      const retry = await seed.removeMembership(token, organizationId, m.membershipId);
-      expect([200, 204]).toContain(retry.status);
     },
   );
 });


### PR DESCRIPTION
Closes #1044.

## What happened

When an org's billing subject has more than one `billing_subscription` row in status `active`/`trialing` (double checkout, re-subscribing while the old sub is still cancelling, a support-created sub), every membership change on that org 500s: member removal, invitation accept, role change, and SSO user resolution all go through `maybe_create_org_seat_adjustment`, whose subscription lookup ordered by `(current_period_end desc nulls last, updated_at desc)` but never capped the query, so `scalar_one_or_none()` raised `MultipleResultsFound` on the second row. From that point the org's member management stayed broken until someone hand-edited Stripe.

## Fix

Add `.limit(1)` to the lookup in `server/proliferate/db/store/billing_seats.py` so it deterministically picks the newest subscription. The ordering was already there and already matches what `latest_healthy_cloud_subscription()` (`server/proliferate/server/billing/domain/plans.py`) uses to pick among multiple live subscriptions, so no skip-and-warn path is needed: the choice is well defined and the seat adjustment targets the same subscription the plan logic considers current.

## Other one-row assumptions checked

I looked at the sibling `scalar_one_or_none()` queries in the seat/subscription path; none can return multiple rows, so no further hardening in this PR:

- `BillingSubject` lookup in the same function: unique partial index `uq_billing_subject_organization_id`.
- `BillingSeatAdjustment` lookup by `source_ref` in `prepare_initial_org_seat_reconcile`: `source_ref` is the upsert conflict target (unique).
- `get_billing_subscription_by_stripe_subscription_id` in `billing_subscriptions.py`: `stripe_subscription_id` is unique.
- `apply_payment_failed_hold` in `billing_subscriptions.py` queries active holds per (subject, kind, status) with no unique constraint; today there is a single writer path so it cannot double up, but it is worth an eye if hold writers multiply.

## Tests

New `server/tests/integration/test_billing_seat_adjustment.py`:

- org with two active subscriptions: `maybe_create_org_seat_adjustment` succeeds and the adjustment targets the newest subscription (asserts subscription id, stripe id, and quantities against the newer row).
- single active subscription: behavior unchanged.

Full `server` pytest suite run locally; the only failures are the two `tests/e2e/cloud/test_e2b_webhooks.py` state-update tests, which fail identically on unmodified main with the same environment (live e2b API rejects the fabricated sandbox ID), so they are pre-existing and unrelated.

The tier-2 billing suite's T2-BILL-3 known-bug pin (from #1033, now merged to main and gating this PR's CI) expected the old 500, so the flip rides here: `tests/intent/specs/billing/seats.spec.ts` now asserts the membership removal succeeds (200/204) with two live subscription rows staged.
