### PR TITLE
fix(billing): clear credits-exhausted errors end-to-end — no pager, stable 402 code, real toast message

### DIFF
--- a/apps/desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
+++ b/apps/desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
@@ -13,6 +13,7 @@ import {
   buildCloudWorkspaceAttemptFromRequest,
   type CloudWorkspaceRepoTarget,
   isCloudWorkspaceBranchConflictError,
+  resolveCloudWorkspaceCreateFailureMessage,
 } from "@/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import {
   buildSubmittingPendingWorkspaceEntry,
@@ -64,11 +65,13 @@ export type CloudWorkspaceEntryResult =
     attemptId: string;
     projectedSessionId: string | null;
   }
-  | { status: "interrupted" };
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
-}
+  | {
+    status: "interrupted";
+    // Set only when the attempt failed with a server error (vs. being
+    // superseded by a newer attempt); carries the resolved server message so
+    // callers can surface it in a toast instead of a generic string.
+    failureMessage?: string;
+  };
 
 function isAttemptCurrent(attemptId: string): boolean {
   return useSessionSelectionStore.getState().pendingWorkspaceEntry?.attemptId === attemptId;
@@ -280,14 +283,18 @@ export function useCreateCloudWorkspace() {
             retryCount,
           },
         });
+        const failureMessage = resolveCloudWorkspaceCreateFailureMessage(
+          error,
+          "Failed to create cloud workspace.",
+        );
         const currentPending = useSessionSelectionStore.getState().pendingWorkspaceEntry;
         failPendingEntry(
           currentPending?.attemptId === attemptId
             ? currentPending
             : currentEntry ?? nextEntry,
-          resolveErrorMessage(error, "Failed to create cloud workspace."),
+          failureMessage,
         );
-        return { status: "interrupted" };
+        return { status: "interrupted", failureMessage };
       }
     }
     return { status: "interrupted" };

--- a/apps/desktop/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/desktop/src/hooks/home/workflows/use-home-next-launch.ts
@@ -287,7 +287,9 @@ export function useHomeNextLaunch() {
       const result = await resultPromise;
       if (result.status === "interrupted") {
         failLatencyFlow(latencyFlowId, "cloud_workspace_create_interrupted");
-        throw new Error("Cloud workspace creation was interrupted.");
+        // Prefer the resolved server message (e.g. a billing gate 402) so the
+        // toast shows why the launch failed instead of a generic string.
+        throw new Error(result.failureMessage ?? "Cloud workspace creation was interrupted.");
       }
       if (!queuedProjectedSessionId) {
         navigate("/");

--- a/apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
@@ -6,9 +6,11 @@ import {
   buildNextCloudWorkspaceAttempt,
   collectTakenCloudWorkspaceSlugs,
   getCloudWorkspaceRepoTarget,
+  isCloudWorkspaceBillingBlockError,
   isCloudWorkspaceBranchConflictError,
   isCreateCloudWorkspaceRequest,
   resolveCloudRepoActionState,
+  resolveCloudWorkspaceCreateFailureMessage,
 } from "./cloud-workspace-creation";
 
 describe("cloud workspace creation helpers", () => {
@@ -205,6 +207,70 @@ describe("cloud workspace creation helpers", () => {
     expect(isCloudWorkspaceBranchConflictError(
       cloudError("bad", "github_branch_not_found"),
     )).toBe(false);
+  });
+
+  it("recognizes server-reported billing blocks", () => {
+    expect(isCloudWorkspaceBillingBlockError(
+      cloudError("out of hours", "billing_credits_exhausted"),
+    )).toBe(true);
+    expect(isCloudWorkspaceBillingBlockError(
+      cloudError("blocked", "billing_start_blocked"),
+    )).toBe(true);
+    expect(isCloudWorkspaceBillingBlockError(
+      cloudError("legacy", "billing_resume_blocked"),
+    )).toBe(true);
+    expect(isCloudWorkspaceBillingBlockError(
+      cloudError("nope", "github_branch_not_found"),
+    )).toBe(false);
+    expect(isCloudWorkspaceBillingBlockError(new Error("no code"))).toBe(false);
+  });
+
+  it("surfaces the server billing message with an upgrade pointer when exhausted", () => {
+    const message = resolveCloudWorkspaceCreateFailureMessage(
+      cloudError(
+        "Cloud usage is paused because your included sandbox hours are exhausted.",
+        "billing_credits_exhausted",
+      ),
+      "Failed to create cloud workspace.",
+    );
+    expect(message).toBe(
+      "Cloud usage is paused because your included sandbox hours are exhausted. "
+      + "Upgrade your plan in Settings → Billing.",
+    );
+  });
+
+  it("surfaces other billing block messages verbatim (no upgrade pointer)", () => {
+    const message = resolveCloudWorkspaceCreateFailureMessage(
+      cloudError("Cloud usage is paused because billing needs attention.", "billing_start_blocked"),
+      "Failed to create cloud workspace.",
+    );
+    expect(message).toBe("Cloud usage is paused because billing needs attention.");
+  });
+
+  it("falls back to the provided message for non-Error / message-less failures", () => {
+    expect(resolveCloudWorkspaceCreateFailureMessage("boom", "fallback")).toBe("fallback");
+    expect(resolveCloudWorkspaceCreateFailureMessage(new Error(""), "fallback")).toBe("fallback");
+  });
+
+  it("propagates an interrupted failureMessage into the home-launch toast text", () => {
+    // Mirrors use-create-cloud-workspace's interrupted result and the toast
+    // template in use-home-next-launch: an out-of-credits 402 must surface the
+    // real reason, not "Cloud workspace creation was interrupted."
+    const failureMessage = resolveCloudWorkspaceCreateFailureMessage(
+      cloudError(
+        "Cloud usage is paused because your included sandbox hours are exhausted.",
+        "billing_credits_exhausted",
+      ),
+      "Failed to create cloud workspace.",
+    );
+    const result = { status: "interrupted", failureMessage } as const;
+    const thrown = new Error(
+      result.failureMessage ?? "Cloud workspace creation was interrupted.",
+    );
+    expect(`Failed to start work: ${thrown.message}`).toBe(
+      "Failed to start work: Cloud usage is paused because your included sandbox hours "
+      + "are exhausted. Upgrade your plan in Settings → Billing.",
+    );
   });
 });
 

--- a/apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
+++ b/apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
@@ -219,3 +219,41 @@ export function isCloudWorkspaceBranchConflictError(error: unknown): boolean {
   return code === "github_branch_already_exists"
     || code === "cloud_branch_already_exists";
 }
+
+function cloudWorkspaceErrorCode(error: unknown): string | null {
+  const code = error instanceof Error ? (error as { code?: unknown }).code : null;
+  return typeof code === "string" ? code : null;
+}
+
+// Stable server-side codes for a routine billing gate on the cloud start path
+// (see server billing/authorization.py). Includes the legacy pre-split code so
+// an older server still surfaces a useful message.
+const CLOUD_WORKSPACE_BILLING_BLOCK_CODES = new Set<string>([
+  "billing_credits_exhausted",
+  "billing_start_blocked",
+  "billing_resume_blocked",
+]);
+
+export function isCloudWorkspaceBillingBlockError(error: unknown): boolean {
+  const code = cloudWorkspaceErrorCode(error);
+  return code !== null && CLOUD_WORKSPACE_BILLING_BLOCK_CODES.has(code);
+}
+
+/**
+ * Resolve the user-facing message for a failed cloud workspace creation.
+ *
+ * The server already returns a clear message on a billing gate (a 402 with a
+ * human message + stable code); we surface that verbatim instead of a generic
+ * "interrupted" string. When the block is specifically "out of included hours"
+ * we append an actionable pointer to Settings → Billing.
+ */
+export function resolveCloudWorkspaceCreateFailureMessage(
+  error: unknown,
+  fallback: string,
+): string {
+  const base = error instanceof Error && error.message ? error.message : fallback;
+  if (cloudWorkspaceErrorCode(error) === "billing_credits_exhausted") {
+    return `${base} Upgrade your plan in Settings → Billing.`;
+  }
+  return base;
+}

--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -42,7 +42,6 @@ from proliferate.server.billing.snapshots import (
 )
 from proliferate.utils.time import utcnow
 
-
 # Block reasons that mean "you are out of included/managed cloud hours" — the
 # client keys off these to show upgrade-your-plan copy. Everything else is a
 # generic start block (payment attention, admin/spend hold, compute cap).

--- a/server/proliferate/server/billing/authorization.py
+++ b/server/proliferate/server/billing/authorization.py
@@ -14,6 +14,9 @@ from proliferate.constants.billing import (
     BILLING_DECISION_ORG_LIMIT_PAUSE,
     BILLING_DECISION_USER_LIMIT_PAUSE,
     BILLING_MODE_ENFORCE,
+    WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED,
+    WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
+    WORKSPACE_ACTION_BLOCK_KIND_OVERAGE_DISABLED,
 )
 from proliferate.db import session_ops as db_session
 from proliferate.db.store import billing as billing_store
@@ -40,6 +43,31 @@ from proliferate.server.billing.snapshots import (
 from proliferate.utils.time import utcnow
 
 
+# Block reasons that mean "you are out of included/managed cloud hours" — the
+# client keys off these to show upgrade-your-plan copy. Everything else is a
+# generic start block (payment attention, admin/spend hold, compute cap).
+_CREDITS_EXHAUSTED_REASONS = frozenset(
+    {
+        WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
+        WORKSPACE_ACTION_BLOCK_KIND_OVERAGE_DISABLED,
+        WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED,
+    }
+)
+
+# Stable machine codes on the 402 detail body. These are part of the client
+# contract — the desktop maps them to actionable toast copy, so do not rename
+# without updating consumers.
+BILLING_BLOCK_CODE_CREDITS_EXHAUSTED = "billing_credits_exhausted"
+BILLING_BLOCK_CODE_START_BLOCKED = "billing_start_blocked"
+
+
+def billing_block_error_code(reason: str | None) -> str:
+    """Map a block reason to the stable 402 ``detail.code`` the client keys off."""
+    if reason in _CREDITS_EXHAUSTED_REASONS:
+        return BILLING_BLOCK_CODE_CREDITS_EXHAUSTED
+    return BILLING_BLOCK_CODE_START_BLOCKED
+
+
 class CloudSandboxResumeBlockedError(ProliferateError):
     """Raised when a cloud sandbox must not be started/resumed for billing.
 
@@ -48,9 +76,14 @@ class CloudSandboxResumeBlockedError(ProliferateError):
     start/resume gate that the orphaned ``authorize_sandbox_start`` never wired
     up (spec §4.3): a sandbox the reconciler paused for an active spend hold or
     an over-cap compute budget must not be woken by an incoming request.
+
+    This is EXPECTED business logic (a quota denial), not a page-worthy failure:
+    the ``code``/``reason``/``remaining_seconds`` on the 402 let the client show
+    an actionable message, and the ``billing_subject_id``/``owner_user_id`` let
+    the background materialization path log the denial with correlation context
+    instead of firing ``report_critical`` (see materialization/runner.py).
     """
 
-    code = "billing_resume_blocked"
     status_code = 402
 
     def __init__(
@@ -59,10 +92,28 @@ class CloudSandboxResumeBlockedError(ProliferateError):
         *,
         decision_type: str,
         reason: str | None = None,
+        billing_subject_id: UUID | None = None,
+        owner_user_id: UUID | None = None,
+        remaining_seconds: int | None = None,
     ) -> None:
-        super().__init__(message, code=self.code, status_code=self.status_code)
+        super().__init__(
+            message,
+            code=billing_block_error_code(reason),
+            status_code=self.status_code,
+        )
         self.decision_type = decision_type
         self.reason = reason
+        self.billing_subject_id = billing_subject_id
+        self.owner_user_id = owner_user_id
+        self.remaining_seconds = remaining_seconds
+        # Machine-readable fields on the 402 body (main.py copies extra_detail
+        # into detail): a stable reason code plus remaining seconds when known.
+        extra_detail: dict[str, object] = {"decision_type": decision_type}
+        if reason is not None:
+            extra_detail["reason"] = reason
+        if remaining_seconds is not None:
+            extra_detail["remaining_seconds"] = remaining_seconds
+        self.extra_detail = extra_detail
 
 
 async def authorize_sandbox_start_for_billing_subject(
@@ -290,4 +341,7 @@ async def assert_cloud_sandbox_resume_allowed_for_owner(
         or "This sandbox is paused because your billing limit was reached.",
         decision_type=decision_type,
         reason=reason,
+        billing_subject_id=decision_subject_id,
+        owner_user_id=owner_user_id,
+        remaining_seconds=snapshot.remaining_seconds,
     )

--- a/server/proliferate/server/cloud/materialization/runner.py
+++ b/server/proliferate/server/cloud/materialization/runner.py
@@ -12,8 +12,32 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.db.engine import async_session_factory
 from proliferate.db.engine import run_after_commit as db_run_after_commit
 from proliferate.integrations.sentry import report_critical
+from proliferate.server.billing.authorization import CloudSandboxResumeBlockedError
 
 logger = logging.getLogger("proliferate.cloud.materialization")
+
+
+def _log_billing_block(exc: CloudSandboxResumeBlockedError, **context: object) -> None:
+    """Log an expected billing quota denial without paging.
+
+    A materialization task hitting the live billing gate is routine business
+    logic (an out-of-credits owner), not a page-worthy failure, so we emit a
+    structured info log with correlation context instead of report_critical
+    (which is a pager duty — see CLAUDE.md logging rules).
+    """
+    logger.info(
+        "cloud_materialization_billing_block",
+        extra={
+            "reason": exc.reason,
+            "decision_type": exc.decision_type,
+            "billing_subject_id": (
+                str(exc.billing_subject_id) if exc.billing_subject_id is not None else None
+            ),
+            "user_id": str(exc.owner_user_id) if exc.owner_user_id is not None else None,
+            "remaining_seconds": exc.remaining_seconds,
+            **context,
+        },
+    )
 
 
 async def run_after_commit(
@@ -25,6 +49,8 @@ async def run_after_commit(
     async def _run() -> None:
         try:
             await task()
+        except CloudSandboxResumeBlockedError as exc:
+            _log_billing_block(exc, label=label)
         except Exception as exc:
             report_critical(
                 exc,
@@ -52,6 +78,9 @@ async def _run_with_fresh_session(
         try:
             await fn(db, **kwargs)
             await db.commit()
+        except CloudSandboxResumeBlockedError as exc:
+            await db.rollback()
+            _log_billing_block(exc, fn=getattr(fn, "__name__", repr(fn)))
         except Exception as exc:
             await db.rollback()
             report_critical(

--- a/server/tests/integration/test_billing_start_block_paging.py
+++ b/server/tests/integration/test_billing_start_block_paging.py
@@ -1,0 +1,169 @@
+"""Billing start-block: stable 402 code + no pager on routine quota denials.
+
+Prod incident (2026-07): an out-of-credits owner creating a cloud workspace hit
+the enforce-mode billing gate. That is EXPECTED business logic, but two things
+were wrong: the client only got an opaque code, and the background
+materialization path fired ``report_critical`` (a Sentry level=fatal pager) for
+the quota denial. These tests pin:
+
+* the credits-exhausted denial surfaces the stable ``billing_credits_exhausted``
+  code with a machine-readable reason + remaining_seconds on the 402 body, and
+* the materialization runner logs (does not page) on a billing block, while
+  still paging on genuinely unexpected failures.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.billing import (
+    BILLING_MODE_ENFORCE,
+    WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
+)
+from proliferate.db.models.auth import User
+from proliferate.db.store.billing_subjects import (
+    ensure_free_included_grant,
+    ensure_personal_billing_subject,
+)
+from proliferate.server.billing.authorization import CloudSandboxResumeBlockedError
+from proliferate.server.cloud.cloud_sandboxes.service import ensure_cloud_sandbox_ready
+from proliferate.server.cloud.materialization import runner as runner_module
+from tests.integration.billing_accounting_helpers import seed_usage_segment
+
+
+async def _create_user(db_session: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"start-block-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+async def _seed_credits_exhausted_user(db_session: AsyncSession) -> uuid.UUID:
+    """A free-plan owner whose included sandbox hours are fully consumed."""
+    user_id = await _create_user(db_session)
+    await ensure_personal_billing_subject(db_session, user_id)
+    await ensure_free_included_grant(db_session, user_id)
+    # Burn more than the (small) included grant so the subject is over quota
+    # with no paid overage -> credit_reason == credits_exhausted.
+    await seed_usage_segment(db_session, user_id=user_id, hours=5.0)
+    await db_session.commit()
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_credits_exhausted_uses_stable_402_code(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exhausted owner gets a 402 with the stable credits-exhausted code."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    monkeypatch.setattr(settings, "cloud_free_sandbox_hours", 1.0)
+    user_id = await _seed_credits_exhausted_user(db_session)
+
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await ensure_cloud_sandbox_ready(db_session, SimpleNamespace(id=user_id))
+
+    error = excinfo.value
+    assert error.status_code == 402
+    assert error.code == "billing_credits_exhausted"
+    assert error.reason == WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED
+    assert error.message == (
+        "Cloud usage is paused because your included sandbox hours are exhausted."
+    )
+    # Machine-readable fields the client keys off, copied into the 402 detail.
+    assert error.extra_detail["reason"] == WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED
+    assert "remaining_seconds" in error.extra_detail
+    assert error.billing_subject_id is not None
+    assert error.owner_user_id == user_id
+
+
+@contextlib.asynccontextmanager
+async def _noop_session():
+    """Minimal async session stand-in for the runner's fresh-session path."""
+
+    class _Session:
+        async def commit(self) -> None:  # pragma: no cover - trivial
+            return None
+
+        async def rollback(self) -> None:  # pragma: no cover - trivial
+            return None
+
+    yield _Session()
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_page_on_billing_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A billing block from a materialization task logs; it must not page."""
+    monkeypatch.setattr(runner_module, "async_session_factory", _noop_session)
+
+    paged: list[object] = []
+    monkeypatch.setattr(
+        runner_module,
+        "report_critical",
+        lambda exc, **_: paged.append(exc),
+    )
+    logged: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        runner_module.logger,
+        "info",
+        lambda _msg, *, extra=None: logged.append(extra or {}),
+    )
+
+    subject_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    async def _blocked(_db: object) -> None:
+        raise CloudSandboxResumeBlockedError(
+            "Cloud usage is paused because your included sandbox hours are exhausted.",
+            decision_type="enforce_active_spend",
+            reason=WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
+            billing_subject_id=subject_id,
+            owner_user_id=user_id,
+            remaining_seconds=0,
+        )
+
+    await runner_module._run_with_fresh_session(_blocked, {})
+
+    assert paged == []
+    assert len(logged) == 1
+    assert logged[0]["billing_subject_id"] == str(subject_id)
+    assert logged[0]["user_id"] == str(user_id)
+    assert logged[0]["reason"] == WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED
+
+
+@pytest.mark.asyncio
+async def test_runner_still_pages_on_unexpected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely unexpected materialization failure must still page."""
+    monkeypatch.setattr(runner_module, "async_session_factory", _noop_session)
+
+    paged: list[object] = []
+    monkeypatch.setattr(
+        runner_module,
+        "report_critical",
+        lambda exc, **_: paged.append(exc),
+    )
+
+    async def _boom(_db: object) -> None:
+        raise RuntimeError("provider exploded")
+
+    await runner_module._run_with_fresh_session(_boom, {})
+
+    assert len(paged) == 1
+    assert isinstance(paged[0], RuntimeError)

--- a/server/tests/integration/test_cloud_sandbox_wake_billing_gate.py
+++ b/server/tests/integration/test_cloud_sandbox_wake_billing_gate.py
@@ -89,7 +89,7 @@ async def test_wake_denied_when_exhausted(
         await wake_cloud_sandbox(db_session, SimpleNamespace(id=user_id))
 
     assert excinfo.value.status_code == 402
-    assert excinfo.value.code == "billing_resume_blocked"
+    assert excinfo.value.code == "billing_start_blocked"
     # The gate must run before ensure_personal_cloud_sandbox_exists stages a row.
     await db_session.rollback()
     assert await sandbox_store.load_personal_cloud_sandbox(db_session, user_id) is None
@@ -108,7 +108,7 @@ async def test_ensure_denied_when_exhausted(
         await ensure_cloud_sandbox_ready(db_session, SimpleNamespace(id=user_id))
 
     assert excinfo.value.status_code == 402
-    assert excinfo.value.code == "billing_resume_blocked"
+    assert excinfo.value.code == "billing_start_blocked"
     await db_session.rollback()
     assert await sandbox_store.load_personal_cloud_sandbox(db_session, user_id) is None
 


### PR DESCRIPTION
## Incident
A user hit the newly-enforced billing gate creating a cloud workspace. Three layers made it confusing:
1. The routine 402 fired `report_critical` (Sentry fatal + CRITICAL_FAILURE pager) with no user/org context.
2. The 402 code was a single generic `billing_resume_blocked`.
3. The desktop swallowed the server's clear message and showed "Cloud workspace creation was interrupted."

## Fix
- **Server:** materialization runner logs quota denials as structured `logger.info` with billing_subject_id/user_id/reason/remaining_seconds; `report_critical` kept for genuinely unexpected failures. 402 now carries stable codes (`billing_credits_exhausted` for credits/overage/cap, `billing_start_blocked` otherwise) + machine-readable `reason`/`decision_type`/`remaining_seconds` in the detail body. Enforcement decisions unchanged.
- **Desktop:** the interrupted result carries the resolved server message; the launch toast shows it (with "Upgrade your plan in Settings → Billing." appended only for credits-exhausted). Superseded attempts keep the generic message.

## Tests
- New `test_billing_start_block_paging.py`: 402 code/fields; runner logs-not-pages on billing block; still pages on unexpected failure.
- `cloud-workspace-creation.test.ts`: 5 cases for code detection + message resolution.
- Full server suite green (4 pre-existing env failures: E2B e2e creds, CORS preflight, invitation delivery-status drift). Desktop tsc clean, touched vitest 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)