### PR TITLE
fix(cloud): self-heal stale sandbox runtimes on reconnect + structured 502

### DIFF
--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -28,6 +28,7 @@ from proliferate.server.cloud.materialization.sandbox_io.worker_sidecar import (
 from proliferate.server.cloud.runtime.bootstrap import (
     build_runtime_env,
     build_runtime_launch_script,
+    build_supervised_runtime_stop_command,
 )
 from proliferate.server.cloud.runtime.data_key import generate_anyharness_data_key
 from proliferate.server.cloud.runtime.liveness_health import (
@@ -116,6 +117,7 @@ async def connect_ready_sandbox(
     runtime_context = await provider.resolve_runtime_context(provider_sandbox)
     runtime_token = _runtime_token(sandbox)
     data_key = _runtime_data_key(sandbox)
+    minted_new_credentials = False
 
     if runtime_token is not None and data_key is not None:
         try:
@@ -145,6 +147,7 @@ async def connect_ready_sandbox(
     else:
         runtime_token = secrets.token_urlsafe(32)
         data_key = generate_anyharness_data_key()
+        minted_new_credentials = True
         await _launch_anyharness_runtime(
             db,
             provider=provider,
@@ -157,7 +160,13 @@ async def connect_ready_sandbox(
             anyharness_data_key=data_key,
         )
 
-    if sandbox.anyharness_base_url != endpoint.runtime_url:
+    # Persist the (possibly freshly minted) runtime credentials whenever we
+    # minted them, not only when the runtime URL changed: a legacy row with a
+    # matching anyharness_base_url but a NULL token would otherwise never store
+    # the token we just minted, forcing the whole reconnect dance on every
+    # subsequent connect. _launch_anyharness_runtime already persists on its
+    # own success tail; this is the safety net for the URL-unchanged case.
+    if minted_new_credentials or sandbox.anyharness_base_url != endpoint.runtime_url:
         await cloud_sandboxes_store.mark_cloud_sandbox_ready(
             db,
             sandbox.id,
@@ -195,6 +204,24 @@ async def _launch_anyharness_runtime(
 ) -> None:
     launcher_path = runtime_launcher_path(runtime_context)
     organization_id = await _resolve_owner_organization_id(db, sandbox_record)
+    # Self-heal: a resumed sandbox can still have an OLD anyharness runtime (plus
+    # its supervisor/worker) alive and bound to the runtime port, holding a stale
+    # bearer token. Relaunching without killing it leaves the old process
+    # answering, so auth verification against the new token 401s and the whole
+    # reconnect fails. Reuse the supervisor stop mechanism, which targets only
+    # the anyharness/worker/supervisor binary paths by pgrep (never user
+    # processes) and guards against killing this shell. Best-effort: never let
+    # cleanup failures block the relaunch below.
+    await run_sandbox_command_logged(
+        provider,
+        provider_sandbox,
+        workspace_id=sandbox_record.id,
+        label="materialization_stop_stale_runtime",
+        command=build_supervised_runtime_stop_command(runtime_context),
+        runtime_context=runtime_context,
+        timeout_seconds=30,
+        log_output_on_success=True,
+    )
     await provider.write_file(
         provider_sandbox,
         launcher_path,

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -179,10 +179,23 @@ async def create_cloud_workspace_for_user(
             status_code=400,
         )
 
-    await materialization_service.materialize_repo_environment(
-        db,
-        repo_environment_id=repo_environment.id,
-    )
+    try:
+        await materialization_service.materialize_repo_environment(
+            db,
+            repo_environment_id=repo_environment.id,
+        )
+    except CloudRuntimeReconnectError as exc:
+        # Waking/relaunching the cloud sandbox runtime failed (e.g. a stale
+        # runtime rejected the bearer token). This is a transient runtime
+        # reconnect problem, not a client error — surface a structured 502 so
+        # the desktop can prompt a retry instead of showing a raw 500. Only the
+        # synchronous create path converts this; background materialization
+        # callers still see CloudRuntimeReconnectError and handle it themselves.
+        raise CloudApiError(
+            "cloud_sandbox_reconnect_failed",
+            "The cloud sandbox runtime could not be reached. Please retry in a moment.",
+            status_code=502,
+        ) from exc
 
     workspace = await _create_workspace_row_with_branch_retry(
         db,

--- a/server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py
+++ b/server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py
@@ -1,0 +1,194 @@
+"""Reconnect self-heal + token persistence for connect_ready_sandbox.
+
+Real prod incident (2026-07-09): a legacy cloud_sandbox row was
+``status=ready`` with ``provider_sandbox_id`` set but ``runtime_token_ciphertext``
+and ``anyharness_base_url`` NULL. Resuming took the fresh-mint branch and
+relaunched the runtime, but the resumed E2B sandbox still had an OLD anyharness
+process bound to the runtime port holding the OLD bearer token, so auth
+verification against the freshly minted token 401'd and the whole reconnect
+blew up.
+
+These tests pin the fix at the ``connect_ready_sandbox`` orchestration layer:
+
+1. ``_launch_anyharness_runtime`` kills any stale runtime/worker/supervisor
+   (via the supervisor stop command) BEFORE relaunching.
+2. A freshly minted runtime token is persisted even when the runtime URL is
+   unchanged, so the next connect does not repeat the dance.
+
+Providers and runtime probes are stubbed per the repo testing standard — no
+real sandboxes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import CloudSandboxStatus
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.sandboxes import CloudSandbox
+from proliferate.db.store import cloud_sandboxes as sandbox_store
+from proliferate.integrations.sandbox.base import RuntimeEndpoint, SandboxRuntimeContext
+from proliferate.server.cloud.materialization.sandbox_io import connect as connect_module
+from proliferate.server.cloud.runtime.bootstrap import build_supervised_runtime_stop_command
+from proliferate.server.cloud.runtime.sandbox_exec import build_detached_runtime_launch_command
+
+RUNTIME_URL = "https://runtime.example.invalid"
+HOME_DIR = "/home/user"
+RUNTIME_BINARY = "/home/user/.proliferate/bin/anyharness"
+
+
+class _CommandResult:
+    def __init__(self, exit_code: int = 0) -> None:
+        self.exit_code = exit_code
+        self.stdout = ""
+        self.stderr = ""
+
+
+class _FakeProvider:
+    """Records commands so tests can assert the self-heal ordering."""
+
+    template_version = "e2b-template-test"
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        self.written_files: list[str] = []
+
+    async def resume_sandbox(self, sandbox_id: str, **_kwargs: Any) -> object:
+        return object()
+
+    async def resolve_runtime_endpoint(self, sandbox: object) -> RuntimeEndpoint:
+        return RuntimeEndpoint(runtime_url=RUNTIME_URL)
+
+    async def resolve_runtime_context(self, sandbox: object) -> SandboxRuntimeContext:
+        return SandboxRuntimeContext(
+            home_dir=HOME_DIR,
+            runtime_workdir=f"{HOME_DIR}/work",
+            runtime_binary_path=RUNTIME_BINARY,
+            base_env={},
+        )
+
+    async def write_file(self, sandbox: object, path: str, content: bytes | str) -> None:
+        self.written_files.append(path)
+
+    async def run_command(self, sandbox: object, command: str, **_kwargs: Any) -> _CommandResult:
+        self.commands.append(command)
+        return _CommandResult(exit_code=0)
+
+
+def _install_stubs(monkeypatch: pytest.MonkeyPatch, provider: _FakeProvider) -> None:
+    monkeypatch.setattr(connect_module, "get_sandbox_provider", lambda _ref: provider)
+    monkeypatch.setattr(
+        connect_module, "build_runtime_launch_script", lambda *a, **k: "#!/bin/bash\ntrue\n"
+    )
+    monkeypatch.setattr(connect_module, "build_runtime_env", lambda *a, **k: {})
+
+    async def _ok_health(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _ok_auth(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _ok_sidecar(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _resume_allowed(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(connect_module, "wait_for_runtime_health", _ok_health)
+    monkeypatch.setattr(connect_module, "verify_runtime_auth_enforced", _ok_auth)
+    monkeypatch.setattr(connect_module, "launch_worker_sidecar", _ok_sidecar)
+    # Billing resume gate is out of scope for reconnect self-heal.
+    monkeypatch.setattr(connect_module, "assert_cloud_sandbox_resume_allowed", _resume_allowed)
+
+
+async def _seed_sandbox(
+    db: AsyncSession,
+    *,
+    anyharness_base_url: str | None,
+    runtime_token_ciphertext: str | None,
+) -> CloudSandbox:
+    user = User(
+        email=f"reconnect-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    sandbox = CloudSandbox(
+        owner_user_id=user.id,
+        provider_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",
+        status=CloudSandboxStatus.ready,
+        anyharness_base_url=anyharness_base_url,
+        runtime_token_ciphertext=runtime_token_ciphertext,
+        anyharness_data_key_ciphertext=None,
+    )
+    db.add(sandbox)
+    await db.commit()
+    return sandbox
+
+
+@pytest.mark.asyncio
+async def test_stale_runtime_is_killed_before_relaunch(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy NULL-token row relaunches, and the stale runtime is killed first."""
+    provider = _FakeProvider()
+    _install_stubs(monkeypatch, provider)
+    sandbox = await _seed_sandbox(
+        db_session,
+        anyharness_base_url=None,
+        runtime_token_ciphertext=None,
+    )
+    value = await sandbox_store.load_personal_cloud_sandbox(db_session, sandbox.owner_user_id)
+    assert value is not None
+
+    await connect_module.connect_ready_sandbox(db_session, sandbox=value)
+
+    runtime_context = SandboxRuntimeContext(
+        home_dir=HOME_DIR,
+        runtime_workdir=f"{HOME_DIR}/work",
+        runtime_binary_path=RUNTIME_BINARY,
+        base_env={},
+    )
+    stop_command = build_supervised_runtime_stop_command(runtime_context)
+    launch_command = build_detached_runtime_launch_command(runtime_context)
+    assert stop_command in provider.commands, provider.commands
+    assert launch_command in provider.commands, provider.commands
+    # Self-heal invariant: kill the stale runtime BEFORE relaunching it.
+    assert provider.commands.index(stop_command) < provider.commands.index(launch_command)
+
+
+@pytest.mark.asyncio
+async def test_fresh_token_persisted_when_url_unchanged(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NULL-token row whose URL already matches still persists the minted token."""
+    provider = _FakeProvider()
+    _install_stubs(monkeypatch, provider)
+    # The row already carries the URL the provider resolves to, but no token.
+    sandbox = await _seed_sandbox(
+        db_session,
+        anyharness_base_url=RUNTIME_URL,
+        runtime_token_ciphertext=None,
+    )
+    value = await sandbox_store.load_personal_cloud_sandbox(db_session, sandbox.owner_user_id)
+    assert value is not None
+    assert value.anyharness_base_url == RUNTIME_URL
+    assert value.anyharness_bearer_token_ciphertext is None
+
+    await connect_module.connect_ready_sandbox(db_session, sandbox=value)
+
+    refreshed = await sandbox_store.load_personal_cloud_sandbox(db_session, sandbox.owner_user_id)
+    assert refreshed is not None
+    # The whole point: the freshly minted token is now stored, so the next
+    # connect will take the reuse branch instead of repeating the dance.
+    assert refreshed.anyharness_bearer_token_ciphertext is not None
+    assert refreshed.anyharness_data_key_ciphertext is not None
+    assert refreshed.status == "ready"

--- a/server/tests/integration/test_cloud_workspace_reconnect_error.py
+++ b/server/tests/integration/test_cloud_workspace_reconnect_error.py
@@ -1,0 +1,99 @@
+"""create_cloud_workspace maps runtime reconnect failures to a structured 502.
+
+Real prod incident (2026-07-09): a CloudRuntimeReconnectError raised while
+waking the cloud sandbox during ``materialize_repo_environment`` escaped
+``create_cloud_workspace_for_user`` as an unhandled ASGI 500 ("Load failed" on
+desktop). The create/API boundary now converts it into a
+``cloud_sandbox_reconnect_failed`` CloudApiError (502) so the client can retry,
+matching how the sibling runtime calls (_resolve_repo_root /
+_create_anyharness_worktree) already convert.
+
+Background materialization callers still see the raw CloudRuntimeReconnectError
+— only the synchronous create path is wrapped.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workspaces import service as workspaces_service
+from proliferate.server.cloud.workspaces.models import CreateCloudWorkspaceRequest
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_reconnect_failure_maps_to_502(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    repo_environment = SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        git_owner="acme",
+        git_repo_name="widgets",
+        default_branch="main",
+        setup_script="",
+    )
+
+    async def _get_repo_environment(*_a: Any, **_k: Any) -> Any:
+        return repo_environment
+
+    async def _authority(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(access_token="gho_test")
+
+    async def _branches(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(branches=["main"], default_branch="main")
+
+    async def _active_branches(*_a: Any, **_k: Any) -> list[str]:
+        return []
+
+    async def _materialize_raises(*_a: Any, **_k: Any) -> None:
+        raise CloudRuntimeReconnectError(
+            "Runtime rejected the stored bearer token during auth verification."
+        )
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store,
+        "get_cloud_repo_environment",
+        _get_repo_environment,
+    )
+    monkeypatch.setattr(
+        workspaces_service, "require_github_cloud_repo_authority", _authority
+    )
+    monkeypatch.setattr(
+        workspaces_service, "get_repo_branches_for_credentials", _branches
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_workspace_store,
+        "list_active_workspace_branches_for_repo_environment",
+        _active_branches,
+    )
+    monkeypatch.setattr(
+        workspaces_service.materialization_service,
+        "materialize_repo_environment",
+        _materialize_raises,
+    )
+
+    body = CreateCloudWorkspaceRequest(
+        gitOwner="acme",
+        gitRepoName="widgets",
+        branchName="feature-x",
+        baseBranch="main",
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session,
+            SimpleNamespace(id=user_id),
+            body,
+        )
+
+    assert excinfo.value.status_code == 502
+    assert excinfo.value.code == "cloud_sandbox_reconnect_failed"

--- a/server/tests/integration/test_cloud_workspace_reconnect_error.py
+++ b/server/tests/integration/test_cloud_workspace_reconnect_error.py
@@ -64,12 +64,8 @@ async def test_create_workspace_reconnect_failure_maps_to_502(
         "get_cloud_repo_environment",
         _get_repo_environment,
     )
-    monkeypatch.setattr(
-        workspaces_service, "require_github_cloud_repo_authority", _authority
-    )
-    monkeypatch.setattr(
-        workspaces_service, "get_repo_branches_for_credentials", _branches
-    )
+    monkeypatch.setattr(workspaces_service, "require_github_cloud_repo_authority", _authority)
+    monkeypatch.setattr(workspaces_service, "get_repo_branches_for_credentials", _branches)
     monkeypatch.setattr(
         workspaces_service.cloud_workspace_store,
         "list_active_workspace_branches_for_repo_environment",


### PR DESCRIPTION
## Incident
A legacy cloud_sandbox row (ready, live E2B id, NULL token/base-url) hit connect: the server minted a fresh token and relaunched anyharness, but the resumed sandbox still had the OLD runtime alive on the port holding the old token. Auth verification 401'd against the new token → `CloudRuntimeReconnectError` escaped as a raw ASGI 500 → desktop showed "Load failed".

## Fix
- **Self-heal:** `_launch_anyharness_runtime` now runs the existing supervisor stop command (pgrep by absolute binary path, $$/$PPID-guarded — supervisor/runtime/worker only, never user processes) before relaunching. Covers both reconnect branches. Best-effort so cleanup can't block the relaunch.
- **Token persistence:** freshly minted credentials are now persisted even when the runtime URL is unchanged (the legacy-row case would previously re-fail on every connect).
- **Structured error:** the synchronous workspace-create path converts `CloudRuntimeReconnectError` into a 502 `cloud_sandbox_reconnect_failed` with retry guidance; background/reconciler callers still see the raw error.

## Tests
New `test_cloud_sandbox_reconnect_self_heal.py` (kill precedes relaunch; token persisted with URL unchanged) and `test_cloud_workspace_reconnect_error.py` (502 not 500). Stubbed providers, no real sandboxes. Full suite green minus pre-existing env failures.

Known tradeoff (verifier-flagged, accepted): a transient blip during the ~2s health probe now triggers kill+relaunch (same token, self-recovers) instead of a doomed port-conflicted relaunch. Follow-up: widen the retry budget before self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)