### PR TITLE
tests(intent): T2-INT-1 gap fill — health composition, disconnect lifecycle, OAuth-seam exclusion

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -42,7 +42,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | --- | --- | --- |
 | Local workspace create | 3 | — |
 | Worktree workspace create — locally AND inside a cloud sandbox | 3 | tests/release/src/scenarios/t3-wt-1.ts (T3-WT-1; local lane green, sandbox lane blocked on current_product_user) |
-| Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
+| Cloud workspace create: request path + UI state up to the provisioning seam | 2 | tests/intent/specs/cloud-workspace.spec.ts (T2-WS-1; request-path seam — happy path past the repo-environment lookup needs a GitHub App fixture, named in the spec header) |
 | Add-Repo flow entry: local/cloud branches render + desktop-web fallback limits (no native picker outside Tauri) | 2 | tests/intent/specs/workspace-entry.spec.ts |
 | New user cold path: GitHub App authorization triggers first-ever sandbox provisioned from zero, within time budget | 3 | tests/release/src/scenarios/t3-prov-1.ts (T3-PROV-1; REAL trigger — seeds the App-auth callback's outcome via github_app_seed.py, real user token + real installation token, then runs the real post-callback body → real E2B sandbox; asserts positive AND negative trigger contract; fallback seam when seed creds absent) |
 | Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; blocked on current_product_user — no fallback seam for this one, it's specifically the front-door path) |
@@ -66,7 +66,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Secrets CRUD in UI: org, personal, file secrets | 2 | — |
+| Secrets CRUD in UI: org, personal, file secrets | 2 | tests/intent/specs/secrets.spec.ts (T2-SEC-1) |
 | Org secret set → materializes in a new cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (T3-SEC-MAT-1; blocked on current_product_user — no local-lane variant exists in the contract) |
 | Personal secret set → materializes in a new cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario, blocked) |
 | File secret set → lands at the right path in the sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario, blocked) |

--- a/tests/intent/specs/integrations.spec.ts
+++ b/tests/intent/specs/integrations.spec.ts
@@ -49,9 +49,14 @@ import {
 import {
   authenticateApiKeyIntegration,
   getIntegrationCatalog,
+  getIntegrationHealth,
   getSeedIntegrationDefinitionId,
   listAdminIntegrationDefinitions,
+  readUntil,
+  removeIntegrationAccount,
   setAdminIntegrationEnabled,
+  type AdminIntegrationDefinitionResult,
+  type IntegrationHealthItemResult,
 } from "../stack/seed-integrations.ts";
 
 test.describe.configure({ mode: "serial" });
@@ -70,6 +75,37 @@ test.beforeAll(async () => {
   // read the next test performs.
   context7DefinitionId = await getSeedIntegrationDefinitionId("context7");
 });
+
+/** Read the admin definition list until context7's row satisfies `settled`
+ * (bounded; returns the last-read row either way — see readUntil). */
+async function readAdminDefinitionUntil(
+  settled: (item: AdminIntegrationDefinitionResult | undefined) => boolean,
+): Promise<AdminIntegrationDefinitionResult | undefined> {
+  const body = await readUntil(
+    async () => {
+      const result = await listAdminIntegrationDefinitions(ownerToken, organizationId);
+      expect(result.status).toBe(200);
+      return result.body;
+    },
+    (items) => settled(items.find((item) => item.definitionId === context7DefinitionId)),
+  );
+  return body.find((item) => item.definitionId === context7DefinitionId);
+}
+
+/** Same, for context7's row on the health surface. */
+async function readHealthUntil(
+  settled: (item: IntegrationHealthItemResult | undefined) => boolean,
+): Promise<IntegrationHealthItemResult | undefined> {
+  const body = await readUntil(
+    async () => {
+      const result = await getIntegrationHealth(ownerToken, organizationId);
+      expect(result.status).toBe(200);
+      return result.body;
+    },
+    (response) => settled(response.items.find((item) => item.definitionId === context7DefinitionId)),
+  );
+  return body.items.find((item) => item.definitionId === context7DefinitionId);
+}
 
 test.describe("T2-INT-1: api_key connect + org policy toggle", () => {
   test("catalog is reachable and lists the real context7 api_key definition with its connect schema", async () => {
@@ -99,26 +135,34 @@ test.describe("T2-INT-1: api_key connect + org policy toggle", () => {
   });
 
   test("org admin toggles the definition off: effective_enabled composes the policy override over the seed default", async () => {
-    // Starting state is true either way: with no policy row yet,
-    // effective_enabled falls back to the definition's own
-    // enabled_by_default (true for every seed definition); if a prior run on
-    // this profile DB already created a policy row, this spec's own
-    // toggle-back-on step below always leaves it enabled=true. Either way,
-    // policyEnabled is either null or true here — never false — going in.
+    // Normalize the starting state instead of assuming it: with no policy
+    // row yet, effective_enabled falls back to the definition's own
+    // enabled_by_default (true for every seed definition), but this profile
+    // DB persists across runs and a prior run that failed mid-file can leave
+    // the policy row off — so if it is off, turn it back on first. What the
+    // test then asserts is the transition, which is the actual contract.
     const before = await listAdminIntegrationDefinitions(ownerToken, organizationId);
     expect(before.status).toBe(200);
     const context7Before = before.body.find((item) => item.definitionId === context7DefinitionId);
-    expect(context7Before?.policyEnabled).not.toBe(false);
-    expect(context7Before?.effectiveEnabled).toBe(true);
+    if (context7Before?.policyEnabled === false) {
+      const heal = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, true);
+      expect(heal.status).toBe(200);
+      await readAdminDefinitionUntil((item) => item?.policyEnabled === true);
+    }
+    const settledBefore = await readAdminDefinitionUntil((item) => item?.effectiveEnabled === true);
+    expect(settledBefore?.effectiveEnabled).toBe(true);
 
     const off = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, false);
     expect(off.status).toBe(200);
     expect(off.body.policyEnabled).toBe(false);
     expect(off.body.effectiveEnabled).toBe(false);
 
-    // Persisted, not just echoed back on the toggle call itself.
-    const after = await listAdminIntegrationDefinitions(ownerToken, organizationId);
-    const context7After = after.body.find((item) => item.definitionId === context7DefinitionId);
+    // Persisted, not just echoed back on the toggle call itself. readUntil
+    // absorbs the endpoint's commit-in-dependency-teardown lag (see
+    // seed-integrations.ts); the assertions still run on the settled value.
+    const context7After = await readAdminDefinitionUntil(
+      (item) => item?.policyEnabled === false,
+    );
     expect(context7After?.policyEnabled).toBe(false);
     expect(context7After?.effectiveEnabled).toBe(false);
   });
@@ -129,21 +173,100 @@ test.describe("T2-INT-1: api_key connect + org policy toggle", () => {
     expect(on.body.policyEnabled).toBe(true);
     expect(on.body.effectiveEnabled).toBe(true);
 
-    const after = await listAdminIntegrationDefinitions(ownerToken, organizationId);
-    const context7After = after.body.find((item) => item.definitionId === context7DefinitionId);
+    const context7After = await readAdminDefinitionUntil(
+      (item) => item?.policyEnabled === true,
+    );
     expect(context7After?.policyEnabled).toBe(true);
     expect(context7After?.effectiveEnabled).toBe(true);
   });
+
+  // The health surface (GET /integrations/health) is the response the UI
+  // actually renders, and the only one that carries all three enablement
+  // layers side by side: policyEnabled (org override), effectiveEnabled
+  // (override > definition default), accountEnabled, plus the composed
+  // verdict. For an api_key account the health probe is DB-only —
+  // _account_health (health.py) runs its ensure_provider_access probe only
+  // for auth_kind == "oauth2" — so this read is itself outbound-free, same
+  // as the connect path.
+  test("health surface composes all three layers for the connected account: ready, effective-enabled, account enabled", async () => {
+    const item = await readHealthUntil((entry) => entry?.health === "ready");
+    expect(item).toBeDefined();
+    expect(item?.effectiveEnabled).toBe(true);
+    expect(item?.policyEnabled).toBe(true);
+    expect(item?.accountEnabled).toBe(true);
+    expect(item?.accountId).not.toBeNull();
+    expect(item?.health).toBe("ready");
+  });
+
+  test("health surface flips to disabled_by_org while the policy is off, with the account row intact underneath", async () => {
+    const off = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, false);
+    expect(off.status).toBe(200);
+
+    const item = await readHealthUntil((entry) => entry?.health === "disabled_by_org");
+    expect(item?.effectiveEnabled).toBe(false);
+    expect(item?.policyEnabled).toBe(false);
+    expect(item?.health).toBe("disabled_by_org");
+    // The org toggle disables exposure, it does not touch the user's account:
+    // the connected account row survives, still enabled at its own layer.
+    expect(item?.accountId).not.toBeNull();
+    expect(item?.accountEnabled).toBe(true);
+
+    // Restore for the tests below (and for reruns on this persisted profile DB).
+    const on = await setAdminIntegrationEnabled(ownerToken, organizationId, context7DefinitionId, true);
+    expect(on.status).toBe(200);
+
+    const restoredItem = await readHealthUntil((entry) => entry?.health === "ready");
+    expect(restoredItem?.effectiveEnabled).toBe(true);
+    expect(restoredItem?.health).toBe("ready");
+  });
+
+  test("disconnect: DELETE the account 204s, health returns to needs_auth, and re-connecting works", async () => {
+    const connected = await readHealthUntil((entry) => entry?.accountId != null);
+    expect(connected?.accountId).not.toBeNull();
+
+    const removed = await removeIntegrationAccount(ownerToken, connected!.accountId!);
+    expect(removed.status).toBe(204);
+
+    const disconnected = await readHealthUntil((entry) => entry?.accountId == null);
+    expect(disconnected?.accountId).toBeNull();
+    expect(disconnected?.accountEnabled).toBeNull();
+    expect(disconnected?.health).toBe("needs_auth");
+    // Org policy is unaffected by the account's removal.
+    expect(disconnected?.effectiveEnabled).toBe(true);
+
+    // Re-connect (still a placeholder key, still no outbound) so the suite
+    // ends in the connected steady state every earlier test assumes on rerun.
+    const reconnect = await authenticateApiKeyIntegration(
+      ownerToken,
+      context7DefinitionId,
+      "placeholder-api-key-value-reconnect",
+    );
+    expect(reconnect.status).toBe(200);
+    expect(reconnect.body.account.status).toBe("ready");
+
+    const reconnected = await readHealthUntil((entry) => entry?.accountId != null);
+    expect(reconnected?.health).toBe("ready");
+    expect(reconnected?.accountId).not.toBeNull();
+  });
 });
 
-// NOT COVERED by this wave, named so the gap is loud rather than silent:
-// - The OAuth-kind connect path (flow row created, authorizationUrl
-//   returned, no real provider round-trip) — context7 is api_key-kind;
-//   asserting the oauth2 branch needs a different seed definition (e.g.
-//   `exa` is also api_key, so this suite would need to pick an actual
-//   oauth2-kind seed to cover that branch, or an org-custom definition).
-// - IntegrationHealthResponse reflecting the toggled state (health.py) —
-//   this spec only asserts the admin-definition-list composition, not the
-//   health surface a connected account also feeds.
-// - Removing an account (`DELETE /integrations/accounts/{id}`) and
-//   re-connecting.
+// NOT COVERED, named so the gap is loud rather than silent:
+// - The OAuth-kind connect seam (scenarios.md's negative: "flow row created,
+//   authorizationUrl returned, no real provider round-trip"). Deliberately
+//   excluded, not just unpicked: as built, start_oauth_flow
+//   (server/proliferate/server/cloud/integrations/oauth/service.py) performs
+//   real provider metadata discovery against the definition's MCP URL
+//   (discover_protected_resource_metadata / discover_authorization_server_
+//   metadata) BEFORE any flow row exists or an authorizationUrl can be
+//   returned — there is no as-built way to reach that seam without an
+//   outbound network call, which tier 2's no-outbound contract forbids.
+//   The oauth2 branch is tier 3's to assert (T3-INT-1 posture) unless the
+//   discovery step grows a seam.
+//
+// No-outbound proof for the api_key path, stated once for the whole file:
+// authenticate_integration's api_key branch (integrations/service.py) is
+// upsert_account + set_account_credentials (local encrypt) only — no code
+// path touches the provider, which is why a placeholder key lands
+// status="ready" immediately with no oauthFlowId/authorizationUrl (asserted
+// above). The health reads used here are also outbound-free for api_key
+// accounts: _account_health's provider probe runs only for oauth2 accounts.

--- a/tests/intent/stack/seed-integrations.ts
+++ b/tests/intent/stack/seed-integrations.ts
@@ -126,3 +126,70 @@ export async function listAdminIntegrationDefinitions(
     { token },
   );
 }
+
+// Health surface (`GET /integrations/health`, health.py): the one response
+// that carries all three enablement layers side by side — policyEnabled (org
+// override), effectiveEnabled (override > definition default), and
+// accountEnabled — plus the composed verdict (`ready`, `needs_auth`,
+// `disabled_by_org`, ...). This is what the UI renders, so T2-INT-1's
+// "assert the composed value the UI shows" lands here.
+export interface IntegrationHealthItemResult {
+  definitionId: string;
+  accountId: string | null;
+  namespace: string;
+  displayName: string;
+  authKind: string;
+  effectiveEnabled: boolean;
+  policyEnabled: boolean | null;
+  accountEnabled: boolean | null;
+  health: string;
+  tokenExpiresAt: string | null;
+  toolCount: number | null;
+  lastErrorCode: string | null;
+}
+
+export async function getIntegrationHealth(
+  token: string,
+  organizationId: string,
+): Promise<ApiResult<{ items: IntegrationHealthItemResult[] }>> {
+  return apiRequest<{ items: IntegrationHealthItemResult[] }>(
+    `/v1/cloud/integrations/health?organizationId=${organizationId}`,
+    { token },
+  );
+}
+
+/** `DELETE /integrations/accounts/{accountId}` — disconnect. 204 on success. */
+export async function removeIntegrationAccount(
+  token: string,
+  accountId: string,
+): Promise<ApiResult<unknown>> {
+  return apiRequest(`/v1/cloud/integrations/accounts/${accountId}`, {
+    method: "DELETE",
+    token,
+  });
+}
+
+/**
+ * Retry a read until it reflects a mutation that just returned. Same
+ * class of lag `loginRightAfterMutation` (seed.ts) absorbs: the endpoint's
+ * commit happens in `get_async_session`'s dependency teardown after the
+ * response is written, so an immediate follow-up read on a fresh connection
+ * can see the pre-mutation state for a beat. Observed directly on this
+ * surface: a definitions-list read right after the enabled PATCH returned
+ * the old policy value on the first attempt. Bounded and short — this
+ * absorbs commit lag, it must never paper over a genuinely wrong state,
+ * so the last attempt's value is returned for the caller to assert on
+ * either way.
+ */
+export async function readUntil<T>(
+  read: () => Promise<T>,
+  settled: (value: T) => boolean,
+  { tries = 20, delayMs = 150 }: { tries?: number; delayMs?: number } = {},
+): Promise<T> {
+  let last = await read();
+  for (let i = 1; i < tries && !settled(last); i++) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    last = await read();
+  }
+  return last;
+}


### PR DESCRIPTION
Follow-up to #1031 as merged. The landed integrations spec flipped to real connect/toggle assertions but named three things in its own NOT-COVERED list; this fills them and pins one exclusion.

What changed in tests/intent/specs/integrations.spec.ts:

- Health surface asserted as the composition the UI renders. GET /integrations/health is the one response carrying policyEnabled, effectiveEnabled and accountEnabled side by side plus the composed verdict. Three new tests walk it through ready, disabled_by_org (account row intact underneath), and back to ready.
- Disconnect lifecycle. DELETE /integrations/accounts/{id} 204s, health returns to needs_auth with the org policy untouched, and a re-connect with a placeholder key lands ready again, leaving the suite in the connected steady state for reruns.
- OAuth-kind connect seam is now a documented exclusion rather than a to-do. As built, start_oauth_flow performs real provider metadata discovery against the MCP URL before any flow row exists or an authorizationUrl can be returned. There is no as-built way to reach that seam without an outbound call, which tier 2 forbids, so the oauth2 branch stays tier 3 (T3-INT-1 posture) unless discovery grows a seam.
- No-outbound proof stated once for the file. The api_key branch of authenticate_integration is upsert_account plus local encrypt only, which is why a placeholder key lands status=ready immediately with no oauthFlowId or authorizationUrl; health probes skip non-oauth2 accounts, so the health reads here are also outbound-free.

Harness changes (tests/intent/stack/seed-integrations.ts): health + account-removal helpers, and a bounded readUntil that absorbs the commit-in-dependency-teardown read lag seed.ts already documents for logins. Observed directly on this surface: a definitions-list read right after the enabled PATCH returned the stale policy value. The toggle test also normalizes a leftover policy-off row from a prior mid-file failure on the persisted profile DB instead of assuming a clean start.

Also fills the two flows.md pointers the train left blank for rows whose specs merged with it: T2-WS-1 (cloud-workspace.spec.ts) and T2-SEC-1 (secrets.spec.ts). The T2-INT row pointer already named integrations.spec.ts and is unchanged.

Verification: full tier-2 intent suite run three times in a row locally on the t2intent profile, 33 passed and 1 pre-existing skip (invitation.spec.ts) each time. No product code touched.