### PR TITLE
test(release-e2e): browser-free session seeding for the staging durable user

### DIFF
--- a/tests/release/scripts/staging_session_seed.py
+++ b/tests/release/scripts/staging_session_seed.py
@@ -1,0 +1,165 @@
+"""T3 staging durable-user session bootstrap (browser-free, no product change).
+
+Background (2026-07-09): the tier-3 staging lane's durable user
+(`proliferate-e2e-bot`, GitHub login, email `support@proliferate.com`) was
+created by a real one-time GitHub OAuth sign-in against the "Proliferate
+Staging" OAuth app (client `Ov23livVvkw5e0gqxlCQ`), confirmed present via a
+read-only query against the staging DB from an in-VPC one-off ECS task
+(`proliferate-staging-e2e-probe`, same network pattern as the
+`proliferate-staging-litellm-dbinit` task def): the `user` row, its
+`auth_identity` (provider=github), and a `provider_grant` row with
+status=ready and scopes ["repo","user"] all exist. Because that account is
+GitHub-OAuth-only, it has no usable password (`create_auth_user` sets
+`hashed_password` to a random unusable placeholder,
+server/proliferate/auth/identity/store.py), so the existing password-login
+durable-user fixture
+(`loginDurableUser` in tests/release/src/fixtures/identity.ts, which POSTs
+`/auth/web/password/login`) cannot authenticate it, and there is no
+self-serve way to re-run the GitHub OAuth browser dance headlessly.
+
+What this reproduces instead: product sessions in this codebase are
+stateless JWTs, not DB rows (see `mint_auth_session`,
+server/proliferate/auth/identity/sessions.py:89) — an access token
+(fastapi-users `JWTStrategy.write_token`) plus a refresh token
+(`generate_jwt` keyed on `settings.jwt_secret`), both derived purely from the
+user row (id + token_generation). So the seam here is narrower than the
+GitHub App seed script's: mint a real session for the already-existing user
+by calling the server's own `mint_auth_session` in-process — the exact
+function every real login (password, GitHub, Google, Apple) funnels through
+— once. `mint_auth_session` only *reads* state (an account-readiness lookup)
+to build the response; it writes nothing, so this is non-mutating.
+
+Why "once": the resulting refresh token is a real, working credential for
+`POST /auth/mobile/session/refresh` (server/proliferate/auth/identity/api.py),
+a public, browser-free, JSON-body endpoint that mints a *fresh* access token
++ refresh token from a valid refresh token, with no DB/VPC access needed —
+the runner rotates its own session through that endpoint before every run
+(see tests/release/src/fixtures/staging-session.ts), the same
+bootstrap-once-then-self-rotate shape as the GitHub App seed's refresh-token
+state file (tests/release/scripts/github_app_seed.py). This script only
+needs to run again if the rotating refresh token is ever lost or the user's
+`token_generation` gets bumped (logout-everywhere / password change) and
+revokes it.
+
+Why in-VPC: the staging DB is VPC-only. This script has no HTTP fallback by
+design — it must run in-process against the DB via an ECS task, e.g.:
+
+  aws ecs run-task --cluster proliferate-staging \
+    --task-definition proliferate-staging-server:<latest> \
+    --launch-type FARGATE \
+    --overrides '{"containerOverrides":[{"name":"server","command":
+      ["python","/app/scripts_bootstrap/staging_session_seed.py","mint",
+       "proliferate-e2e-bot"]}]}' \
+    --network-configuration 'awsvpcConfiguration={subnets=[...],
+      securityGroups=[...],assignPublicIp=ENABLED}'
+
+reusing the already-deployed server image (it already has every dependency
+and `settings.jwt_secret`/`DATABASE_URL` wired via the real ECS secrets) —
+this file itself is not baked into that image, so invoke it by piping this
+script's source into `python -` via the container override (no image
+rebuild, no product change):
+
+  aws ecs run-task ... --overrides "$(python3 - <<'PY'
+  import json, pathlib
+  src = pathlib.Path("tests/release/scripts/staging_session_seed.py").read_text()
+  print(json.dumps({"containerOverrides": [{"name": "server",
+      "command": ["python3", "-c", src, "mint", "proliferate-e2e-bot"]}]}))
+  PY
+  )"
+
+Usage:
+  uv run python staging_session_seed.py mint <email-or-github-login>
+  uv run python staging_session_seed.py status <email-or-github-login>
+
+Prints one JSON object to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Only meaningful when run as a file from a checkout (local/dev convenience,
+# matching github_app_seed.py and prov1_fallback.py). When this source is
+# piped into `python3 -c` instead — the real invocation shape for staging,
+# since the staging DB is VPC-only and the already-deployed server image has
+# no file path for this uncommitted-to-the-image script — `__file__` does not
+# exist; that image already sets PYTHONPATH=/app (server/Dockerfile), which
+# is sufficient on its own.
+if "__file__" in globals():
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "server"))
+
+from sqlalchemy import or_, select  # noqa: E402
+
+from proliferate.auth.identity.sessions import mint_auth_session  # noqa: E402
+from proliferate.auth.identity.store import get_account_readiness  # noqa: E402
+from proliferate.db.engine import async_session_factory  # noqa: E402
+from proliferate.db.models.auth import User  # noqa: E402
+
+
+async def _resolve_user(db, identifier: str) -> User | None:
+    result = await db.execute(
+        select(User).where(or_(User.email == identifier, User.github_login == identifier))
+    )
+    return result.scalar_one_or_none()
+
+
+async def cmd_mint(identifier: str) -> dict:
+    async with async_session_factory() as db:
+        user = await _resolve_user(db, identifier)
+        if user is None:
+            return {"error": f"no user found for identifier {identifier!r}"}
+        # mint_auth_session only reads (an account-readiness lookup) to build
+        # the response; it does not write any row, so there is nothing to
+        # commit here and no teardown needed on the DB side.
+        session = await mint_auth_session(db, user=user)
+        return {
+            "error": None,
+            "userId": str(session.user_id),
+            "email": session.email,
+            "githubLogin": session.github_login,
+            "accessToken": session.access_token,
+            "refreshToken": session.refresh_token,
+            "expiresIn": session.expires_in,
+        }
+
+
+async def cmd_status(identifier: str) -> dict:
+    """Read-only diagnostic: resolves the user and reports account readiness
+    without minting a session. Safe to run as often as needed."""
+    async with async_session_factory() as db:
+        user = await _resolve_user(db, identifier)
+        if user is None:
+            return {"error": f"no user found for identifier {identifier!r}"}
+        readiness = await get_account_readiness(db, user_id=user.id)
+        return {
+            "error": None,
+            "userId": str(user.id),
+            "email": user.email,
+            "githubLogin": user.github_login,
+            "isActive": user.is_active,
+            "isVerified": user.is_verified,
+            "createdAt": str(user.created_at),
+            "productReady": readiness.product_ready,
+            "missingRequirements": list(readiness.missing_requirements),
+            "githubGrantStatus": readiness.github_grant_status,
+        }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["mint", "status"])
+    parser.add_argument("identifier", help="Durable user's email or github_login")
+    return parser
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
+    if args.command == "mint":
+        out = asyncio.run(cmd_mint(args.identifier))
+    else:
+        out = asyncio.run(cmd_status(args.identifier))
+    print(json.dumps(out))

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -75,7 +75,10 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     name: "RELEASE_E2E_DURABLE_USER_EMAIL",
     description:
       "Login email for the durable seeded e2e-tests account used by existing-user " +
-      "scenarios (T3-PROV-2 and friends). Its sandbox intentionally persists between runs.",
+      "scenarios (T3-PROV-2 and friends). Its sandbox intentionally persists between runs. " +
+      "NOT used by --lane staging: staging's durable user (proliferate-e2e-bot, confirmed " +
+      "2026-07-09) was created by a real GitHub OAuth sign-in and has no password — see " +
+      "RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN below.",
     whereItLives:
       "Seeded once per target deployment via the same first-run/invite flow real users go " +
       "through (see server/proliferate/server/organizations/registration_api.py); " +
@@ -84,9 +87,38 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
   },
   {
     name: "RELEASE_E2E_DURABLE_USER_PASSWORD",
-    description: "Password for RELEASE_E2E_DURABLE_USER_EMAIL.",
+    description: "Password for RELEASE_E2E_DURABLE_USER_EMAIL. NOT used by --lane staging (see above).",
     whereItLives: "Team credentials vault, alongside RELEASE_E2E_DURABLE_USER_EMAIL.",
     secret: true,
+  },
+  {
+    name: "RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN",
+    description:
+      "Bootstrap-only refresh token for the staging durable user's product session " +
+      "(proliferate-e2e-bot / support@proliferate.com, a GitHub-OAuth-only account with no " +
+      "password). Used by tests/release/src/fixtures/staging-session.ts to authenticate " +
+      "--lane staging existing-user scenarios in place of RELEASE_E2E_DURABLE_USER_EMAIL/" +
+      "PASSWORD. Refresh tokens rotate on every use (POST /auth/mobile/session/refresh), so " +
+      "after the first run the live token lives in the state file below; this env var is only " +
+      "the initial bootstrap value.",
+    whereItLives:
+      "Minted once via `uv run python tests/release/scripts/staging_session_seed.py mint " +
+      "proliferate-e2e-bot`, run inside a one-off in-VPC ECS task against proliferate-staging " +
+      "(the staging DB is VPC-only — see that script's module docstring for the exact " +
+      "aws ecs run-task invocation). Local dev: ~/.proliferate-local/dev/release-e2e.env " +
+      "(or seed the state file directly). Never committed.",
+    secret: true,
+  },
+  {
+    name: "RELEASE_E2E_STAGING_SESSION_STATE",
+    description:
+      "Path to the JSON state file holding the current (rotating) staging session refresh " +
+      "token. Optional override; defaults to " +
+      "~/.proliferate-local/dev/release-e2e-staging-session.json. " +
+      "tests/release/src/fixtures/staging-session.ts rewrites it atomically after each " +
+      "rotation, so re-authenticating is possible without re-supplying the bootstrap token.",
+    whereItLives: "Written and maintained by tests/release/src/fixtures/staging-session.ts. Operator override only.",
+    secret: false,
   },
   {
     name: "RELEASE_E2E_DURABLE_ORG_ID",

--- a/tests/release/src/fixtures/identity.ts
+++ b/tests/release/src/fixtures/identity.ts
@@ -13,7 +13,12 @@
  *   org, then the fresh user redeems that invitation via
  *   `POST /auth/password/register`.
  * - durable user: one seeded `e2e-tests` account/org on the target server,
- *   logged in via `POST /auth/web/password/login`.
+ *   logged in via `POST /auth/web/password/login`. Exception: staging's
+ *   durable user (proliferate-e2e-bot, confirmed present 2026-07-09) was
+ *   created by a real GitHub OAuth sign-in and has no password, so
+ *   --lane staging existing-user scenarios authenticate via
+ *   `loginDurableUserOnStaging` in `./staging-session.ts` instead of
+ *   `loginDurableUser` below.
  *
  * Request/response shapes below mirror the real Pydantic models as of this
  * writing:

--- a/tests/release/src/fixtures/staging-session.test.ts
+++ b/tests/release/src/fixtures/staging-session.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { parseStagingSessionState, stagingSessionAvailable, stagingSessionStatePath } from "./staging-session.js";
+
+test("stagingSessionStatePath honours the override and otherwise uses the default home path", () => {
+  assert.equal(stagingSessionStatePath({ RELEASE_E2E_STAGING_SESSION_STATE: "/tmp/state.json" }), "/tmp/state.json");
+  assert.equal(
+    stagingSessionStatePath({}),
+    path.join(os.homedir(), ".proliferate-local/dev/release-e2e-staging-session.json"),
+  );
+  // whitespace-only override is treated as unset
+  assert.equal(
+    stagingSessionStatePath({ RELEASE_E2E_STAGING_SESSION_STATE: "   " }),
+    path.join(os.homedir(), ".proliferate-local/dev/release-e2e-staging-session.json"),
+  );
+});
+
+test("stagingSessionAvailable is true with a bootstrap token even if no state file exists", () => {
+  assert.equal(
+    stagingSessionAvailable({ RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN: "rt_x" }, () => false),
+    true,
+  );
+});
+
+test("stagingSessionAvailable is true with an existing state file and no bootstrap token", () => {
+  assert.equal(stagingSessionAvailable({}, () => true), true);
+});
+
+test("stagingSessionAvailable is false with neither a bootstrap token nor a state file", () => {
+  assert.equal(stagingSessionAvailable({}, () => false), false);
+});
+
+test("parseStagingSessionState trims and accepts a well-formed state file", () => {
+  const state = parseStagingSessionState(JSON.stringify({ refreshToken: "  rt_abc  ", accessToken: "at_abc" }));
+  assert.equal(state?.refreshToken, "rt_abc");
+  assert.equal(state?.accessToken, "at_abc");
+});
+
+test("parseStagingSessionState rejects a missing or blank refreshToken", () => {
+  assert.equal(parseStagingSessionState(JSON.stringify({ accessToken: "at_abc" })), undefined);
+  assert.equal(parseStagingSessionState(JSON.stringify({ refreshToken: "   " })), undefined);
+});

--- a/tests/release/src/fixtures/staging-session.ts
+++ b/tests/release/src/fixtures/staging-session.ts
@@ -1,0 +1,133 @@
+/**
+ * Browser-free session fixture for the staging lane's durable user.
+ *
+ * The staging durable user (`proliferate-e2e-bot`, email
+ * `support@proliferate.com`) exists because of a real one-time GitHub OAuth
+ * sign-in against the "Proliferate Staging" OAuth app — confirmed via a
+ * read-only staging-DB query (`user` + `auth_identity` + a `provider_grant`
+ * row with status=ready) run from an in-VPC one-off ECS task. Because that
+ * account is GitHub-OAuth-only it has no password, so `loginDurableUser` in
+ * `./identity.ts` (which POSTs `/auth/web/password/login`) cannot
+ * authenticate it, and there is no self-serve way to re-run the GitHub OAuth
+ * browser dance headlessly.
+ *
+ * Sessions in this codebase are stateless JWTs, not DB rows
+ * (`mint_auth_session`, server/proliferate/auth/identity/sessions.py). The
+ * one-time bootstrap (`tests/release/scripts/staging_session_seed.py mint`,
+ * run in-process inside a one-off in-VPC ECS task because the staging DB is
+ * VPC-only) mints a real session for the already-existing user by calling
+ * that exact function — the same one every real login funnels through — and
+ * hands back a refresh token. From then on this module rotates that refresh
+ * token itself via `POST /auth/mobile/session/refresh`
+ * (server/proliferate/auth/identity/api.py): a public, JSON-body,
+ * browser-free route that mints a fresh access + refresh token pair from a
+ * valid refresh token, with no DB/VPC access needed. Same
+ * bootstrap-once-then-self-rotate shape as the GitHub App seed fixture's
+ * refresh-token state file (./github-app-seed.ts /
+ * ../../scripts/github_app_seed.py) — this module only needs re-bootstrapping
+ * if the state file is lost or the user's `token_generation` is bumped
+ * (logout-everywhere / password change), which would revoke the refresh
+ * token.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { AuthSessionResponse } from "./identity.js";
+import { ApiClient } from "./http.js";
+
+const DEFAULT_STATE_RELATIVE = ".proliferate-local/dev/release-e2e-staging-session.json";
+
+export interface StagingSessionState {
+  refreshToken: string;
+  accessToken?: string;
+  rotatedAt?: string;
+}
+
+/** Absolute path of the rotating staging-session state file (env override or default). */
+export function stagingSessionStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.RELEASE_E2E_STAGING_SESSION_STATE?.trim();
+  return override && override.length > 0 ? override : path.join(os.homedir(), DEFAULT_STATE_RELATIVE);
+}
+
+/**
+ * Staging-session rotation is available once either the rotating state file
+ * exists or a bootstrap refresh token was supplied directly. `fileExists` is
+ * injected so this stays a pure function for unit tests.
+ */
+export function stagingSessionAvailable(
+  env: NodeJS.ProcessEnv = process.env,
+  fileExists: (p: string) => boolean = existsSync,
+): boolean {
+  const hasBootstrapToken = Boolean(env.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN?.trim());
+  return hasBootstrapToken || fileExists(stagingSessionStatePath(env));
+}
+
+/** Parses the state file's JSON, tolerating a missing/blank `refreshToken`. */
+export function parseStagingSessionState(raw: string): StagingSessionState | undefined {
+  const parsed = JSON.parse(raw) as Partial<StagingSessionState>;
+  if (typeof parsed.refreshToken !== "string" || parsed.refreshToken.trim().length === 0) {
+    return undefined;
+  }
+  return { ...parsed, refreshToken: parsed.refreshToken.trim() };
+}
+
+async function loadRefreshToken(env: NodeJS.ProcessEnv, fileExists: (p: string) => boolean): Promise<string> {
+  const statePath = stagingSessionStatePath(env);
+  if (fileExists(statePath)) {
+    const state = parseStagingSessionState(await readFile(statePath, "utf8"));
+    if (state) {
+      return state.refreshToken;
+    }
+  }
+  const bootstrap = env.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN?.trim();
+  if (bootstrap) {
+    return bootstrap;
+  }
+  throw new Error(
+    "loginDurableUserOnStaging: no staging session refresh token available: neither " +
+      `the state file (${statePath}) nor RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN is set. ` +
+      "Bootstrap one with `uv run python tests/release/scripts/staging_session_seed.py mint " +
+      "proliferate-e2e-bot`, run inside a one-off in-VPC ECS task against the proliferate-staging " +
+      "cluster (the staging DB is VPC-only) — see the script's module docstring for the exact " +
+      "`aws ecs run-task` invocation. This fixture self-rotates the token after that.",
+  );
+}
+
+/** Atomically rewrites the state file (mode 0600) so a crash mid-write never corrupts it. */
+async function persistStagingSessionState(statePath: string, state: StagingSessionState): Promise<void> {
+  await mkdir(path.dirname(statePath), { recursive: true });
+  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(state), { mode: 0o600 });
+  await rename(tmpPath, statePath);
+}
+
+/**
+ * Rotates the durable staging user's session and returns the fresh
+ * `AuthSessionResponse` (same shape `loginDurableUser` returns), so scenario
+ * code does not need to branch on which durable-login path was used.
+ */
+export async function loginDurableUserOnStaging(
+  serverUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AuthSessionResponse> {
+  const refreshToken = await loadRefreshToken(env, existsSync);
+  const client = new ApiClient({ baseUrl: serverUrl });
+  const response = await client.post<AuthSessionResponse>("/auth/mobile/session/refresh", {
+    refreshToken,
+  });
+
+  if (!response.refreshToken) {
+    throw new Error("loginDurableUserOnStaging: refresh response did not include a new refresh token.");
+  }
+
+  await persistStagingSessionState(stagingSessionStatePath(env), {
+    refreshToken: response.refreshToken,
+    accessToken: response.accessToken,
+    rotatedAt: new Date().toISOString(),
+  });
+
+  return response;
+}


### PR DESCRIPTION
## Summary

- Confirmed the staging durable user (proliferate-e2e-bot, GitHub OAuth signup against the "Proliferate Staging" OAuth app) exists via a read-only in-VPC probe of the staging DB: user row, github auth_identity, and a ready provider_grant with repo+user scopes.
- That account is GitHub-OAuth-only (no password), so the existing password-login durable-user fixture (`loginDurableUser` in `identity.ts`) can't authenticate it for `--lane staging`.
- Sessions here are stateless JWTs, not DB rows. Added `tests/release/scripts/staging_session_seed.py`, a one-time in-VPC bootstrap that mints a real session for the user via the server's own `mint_auth_session` (no product code change, same in-process seam as `github_app_seed.py`), run as an ECS task-def override on the already-deployed server image.
- Added `tests/release/src/fixtures/staging-session.ts` (+ unit tests): the runner rotates that session forever from outside the VPC via the existing public `POST /auth/mobile/session/refresh` route, atomically persisting the rotated refresh token to a local state file, same shape as the GitHub App seed fixture's rotation.
- Added two env-manifest entries (`RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN`, `RELEASE_E2E_STAGING_SESSION_STATE`) and annotated the existing durable-user password vars as not applicable to staging.

## Verification

- `tsc --noEmit` and `tsx --test src/**/*.test.ts` pass (32/32, incl. the 6 new tests).
- Ran the bootstrap for real: one-off ECS task in `proliferate-staging`, exit 0, minted a real access+refresh token pair for the confirmed user.
- Called `loginDurableUserOnStaging` from this laptop (no VPC access) and confirmed it rotated the token via the public endpoint and rewrote the state file.
- Called `GET https://staging-app.proliferate.com/api/v1/auth/viewer` with the resulting access token: 200, `user.email=support@proliferate.com`, `user.github_login=proliferate-e2e-bot`, `githubConnected=true`.
- Deregistered the temporary ECS task definitions and deleted the log group used for the probe/mint after extracting the result. No secret values were committed; the bootstrap refresh token and rotating state live only in `~/.proliferate-local/dev/release-e2e.env` and `~/.proliferate-local/dev/release-e2e-staging-session.json` (mode 600).

## Test plan

- [x] typecheck + unit tests pass
- [x] live bootstrap mint against staging (in-VPC ECS task)
- [x] live rotation from outside the VPC
- [x] live auth check against `/api/v1/auth/viewer`
