### PR TITLE
ci(tests): install Tauri system deps in the tier-3 workflow build step

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -153,6 +153,14 @@ jobs:
         if: steps.preflight.outputs.enabled == 'true'
         run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
 
+      - name: Install system deps (Tauri crates in the workspace build)
+        if: steps.preflight.outputs.enabled == 'true'
+        # `make build-rust` compiles the whole workspace, including the Tauri
+        # desktop crate — same package set ci.yml installs for it.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
       - name: Build the AnyHarness runtime binary
         if: steps.preflight.outputs.enabled == 'true'
         # Same target dir the Makefile's dev-artifacts check reads


### PR DESCRIPTION
First dispatched run of the new release-e2e workflow (#1064) failed at make build-rust: glib-sys needs the GTK/webkit dev packages the hosted runner lacks. Adds the same apt-get step ci.yml uses ahead of the build. Verified nothing else in the job depends on the missing packages.