### PR TITLE
ci(tests): provide throwaway server secrets to the tier-3 boot step

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -173,6 +173,10 @@ jobs:
         env:
           # Local stack wiring — the runner points at these (env-manifest.ts).
           SINGLE_ORG_MODE: "true"
+          # CI-only server secrets (same throwaway values server-ci.yml uses;
+          # settings validation requires them when debug=False).
+          JWT_SECRET: release-e2e-ci-jwt-secret
+          CLOUD_SECRET_KEY: release-e2e-ci-cloud-secret
           SETUP_TOKEN_FILE: /tmp/proliferate-ci-setup-token
           DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
           REDIS_URL: redis://127.0.0.1:6379/0


### PR DESCRIPTION
Second dispatched run of release-e2e got past the build (after #1067) and died at server boot: settings validation requires jwt_secret when debug=False. Passes the same throwaway JWT_SECRET/CLOUD_SECRET_KEY pattern server-ci.yml uses. These are CI-lifetime-only values for a stack that exists for one job.