### PR TITLE
feat(workflows): PR F — session plane (binding, provenance, lockout, take-over)

### DIFF
--- a/anyharness/crates/anyharness-contract/src/v1/events.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/events.rs
@@ -231,6 +231,20 @@ pub enum PromptProvenance {
         #[serde(skip_serializing_if = "Option::is_none")]
         label: Option<String>,
     },
+    /// A workflow step injected this prompt/command into the session (contract
+    /// §5.2 / C10 / E9): the desktop renders the machine-driven bubble
+    /// ("Workflow · <label>") from this stamp, never inference. Written at send
+    /// time; rides the live stream and the persisted event payload.
+    Workflow {
+        #[serde(rename = "runId")]
+        run_id: String,
+        #[serde(rename = "stepKey")]
+        step_key: String,
+        /// The step-kind slug (`agent.prompt`, `agent.emit`, `shell.run`, …).
+        kind: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
     System {
         #[serde(skip_serializing_if = "Option::is_none")]
         label: Option<String>,

--- a/anyharness/crates/anyharness-lib/src/api/http/access.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/access.rs
@@ -145,6 +145,23 @@ pub fn assert_session_mutable(state: &AppState, session_id: &str) -> Result<(), 
         .map_err(map_access_error)
 }
 
+/// L17 lockout at the HTTP layer (C13 / E8) for mutating verbs whose mutation
+/// lives in a service without the held registry (title update). Mirrors the
+/// runtime-method guard: a session held by a live workflow run returns 409
+/// `SESSION_WORKFLOW_HELD` and routes the UI to the take-over modal.
+pub fn assert_session_not_workflow_held(
+    state: &AppState,
+    session_id: &str,
+) -> Result<(), ApiError> {
+    match state.workflow_owned_sessions.held_run(session_id) {
+        Some(run_id) => Err(ApiError::conflict(
+            format!("session is driven by workflow run {run_id}; take over to regain control"),
+            "SESSION_WORKFLOW_HELD",
+        )),
+        None => Ok(()),
+    }
+}
+
 pub async fn assert_terminal_mutable(state: &AppState, terminal_id: &str) -> Result<(), ApiError> {
     state
         .workspace_access_gate

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_config.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_config.rs
@@ -7,7 +7,9 @@ use axum::{
     Extension, Json,
 };
 
-use super::access::{assert_session_auth_scope, assert_session_mutable};
+use super::access::{
+    assert_session_auth_scope, assert_session_mutable, assert_session_not_workflow_held,
+};
 use super::error::ApiError;
 use super::sessions_contract::session_to_contract;
 use super::sessions_errors::{
@@ -39,6 +41,7 @@ pub async fn update_session_title(
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
     assert_session_mutable(&state, &session_id)?;
+    assert_session_not_workflow_held(&state, &session_id)?;
     let record = state
         .session_service
         .update_session_title(&session_id, &req.title)

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -163,8 +163,20 @@ pub(super) fn map_set_session_config_option_error(error: SetSessionConfigOptionE
         SetSessionConfigOptionError::Rejected(detail) => {
             ApiError::bad_request(detail, "SESSION_CONFIG_REJECTED")
         }
+        SetSessionConfigOptionError::Access(error) => map_access_error(error),
+        SetSessionConfigOptionError::WorkflowHeld { run_id } => workflow_held_error(&run_id),
         SetSessionConfigOptionError::Internal(error) => ApiError::internal(error.to_string()),
     }
+}
+
+/// The 409 a mutating verb returns for a session held by a live workflow run
+/// (C13 / E8). The desktop routes this code to the take-over modal — the only
+/// door — never a per-verb toast.
+fn workflow_held_error(run_id: &str) -> ApiError {
+    ApiError::conflict(
+        format!("session is driven by workflow run {run_id}; take over to regain control"),
+        "SESSION_WORKFLOW_HELD",
+    )
 }
 
 pub(super) fn map_send_prompt_error(error: SendPromptError) -> ApiError {
@@ -176,6 +188,8 @@ pub(super) fn map_send_prompt_error(error: SendPromptError) -> ApiError {
         SendPromptError::SessionClosed => ApiError::conflict("session is closed", "SESSION_CLOSED"),
         SendPromptError::EmptyPrompt => ApiError::bad_request("empty prompt", "EMPTY_PROMPT"),
         SendPromptError::InvalidPrompt(error) => ApiError::bad_request(error.detail, error.code),
+        SendPromptError::Access(error) => map_access_error(error),
+        SendPromptError::WorkflowHeld { run_id } => workflow_held_error(&run_id),
         // {error:#} keeps the anyhow cause chain; to_string() would drop it.
         SendPromptError::Internal(error) => ApiError::internal(format!("{error:#}")),
     }
@@ -192,6 +206,8 @@ pub(super) fn map_fork_session_error(error: ForkSessionError) -> ApiError {
             ApiError::conflict("session must be idle before forking", "SESSION_BUSY")
         }
         ForkSessionError::Invalid(detail) => ApiError::bad_request(detail, "FORK_INVALID_SESSION"),
+        ForkSessionError::Access(error) => map_access_error(error),
+        ForkSessionError::WorkflowHeld { run_id } => workflow_held_error(&run_id),
         ForkSessionError::MissingNativeSessionId => ApiError::conflict(
             "session must have a native agent session id before forking",
             "FORK_MISSING_NATIVE_SESSION",
@@ -218,6 +234,7 @@ pub(super) fn map_pending_prompt_mutation_error(error: PendingPromptMutationErro
         PendingPromptMutationError::InvalidPrompt(error) => {
             ApiError::bad_request(error.detail, error.code)
         }
+        PendingPromptMutationError::WorkflowHeld { run_id } => workflow_held_error(&run_id),
         PendingPromptMutationError::Internal(error) => ApiError::internal(error.to_string()),
     }
 }
@@ -255,6 +272,8 @@ pub(super) fn map_session_lifecycle_error(error: SessionLifecycleError) -> ApiEr
             format!("Session not found: {session_id}"),
             "SESSION_NOT_FOUND",
         ),
+        SessionLifecycleError::Access(error) => map_access_error(error),
+        SessionLifecycleError::WorkflowHeld { run_id } => workflow_held_error(&run_id),
         SessionLifecycleError::Internal(error) => ApiError::internal(error.to_string()),
     }
 }
@@ -266,6 +285,46 @@ mod tests {
 
     use crate::domains::sessions::runtime::ResolveInteractionError;
     use crate::domains::workspaces::access_gate::WorkspaceAccessError;
+
+    #[test]
+    fn workflow_held_maps_to_409_session_workflow_held() {
+        use crate::domains::sessions::runtime::SendPromptError;
+        let response = super::map_send_prompt_error(SendPromptError::WorkflowHeld {
+            run_id: "run-1".to_string(),
+        })
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn pending_prompt_workflow_held_maps_to_409_not_500() {
+        use crate::domains::sessions::runtime::PendingPromptMutationError;
+        // C13/E8: editing or deleting a queued prompt on a held session must
+        // surface the typed 409 SESSION_WORKFLOW_HELD, never a collapsed 500.
+        let response = super::map_pending_prompt_mutation_error(
+            PendingPromptMutationError::WorkflowHeld {
+                run_id: "run-1".to_string(),
+            },
+        )
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn access_mutation_blocked_threads_through_as_409_not_500() {
+        use crate::domains::sessions::runtime::SendPromptError;
+        use crate::domains::workspaces::access_model::WorkspaceAccessMode;
+        // The included fix (C13): access-gate errors surface as their real 409,
+        // not a collapsed 500.
+        let response = super::map_send_prompt_error(SendPromptError::Access(
+            WorkspaceAccessError::MutationBlocked {
+                workspace_id: "ws-1".to_string(),
+                mode: WorkspaceAccessMode::FrozenForHandoff,
+            },
+        ))
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
 
     #[test]
     fn interaction_access_store_failures_map_to_internal_error() {

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -141,6 +141,11 @@ pub struct AppState {
     pub goal_runtime: Arc<GoalRuntime>,
     pub workflow_service: Arc<WorkflowService>,
     pub workflow_manager: WorkflowRunManager,
+    /// L17 lockout registry (C13 / E8): shared with the session runtime + the
+    /// permission advisor. Exposed on state so the title-update HTTP handler
+    /// (whose mutation lives in `SessionService`, not the runtime) can apply the
+    /// same held guard as the runtime verbs.
+    pub workflow_owned_sessions: Arc<WorkflowOwnedSessions>,
     pub acp_manager: LiveSessionManager,
     pub terminal_service: Arc<TerminalService>,
     pub agent_login_terminal_service: Arc<AgentLoginTerminalService>,
@@ -351,6 +356,7 @@ impl AppState {
             plan_service.clone(),
             plan_service.clone(),
             goal_service.clone(),
+            workflow_owned_sessions.clone(),
         ));
         // Workflow run engine (W3): the durable service + the live run manager
         // (its own actors, spawned on delivery and on startup-resume).
@@ -508,6 +514,7 @@ impl AppState {
             goal_runtime,
             workflow_service,
             workflow_manager,
+            workflow_owned_sessions,
             acp_manager,
             terminal_service,
             agent_login_terminal_service,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/provenance.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/provenance.rs
@@ -12,9 +12,17 @@ pub(crate) enum PromptProvenance {
         #[serde(skip_serializing_if = "Option::is_none")]
         label: Option<String>,
     },
+    /// A workflow step injected this prompt/command (C10 / E9). Replaces the
+    /// dead `Automation` variant; surfaces faithfully via [`to_public`] (the old
+    /// variant lossily collapsed to `System` and dropped the ids — that bug dies
+    /// here).
     #[serde(rename_all = "camelCase")]
-    Automation {
-        automation_run_id: String,
+    Workflow {
+        run_id: String,
+        step_key: String,
+        // NB: the enum's serde tag is `kind`, so the step-kind slug is stored
+        // under `step_kind` here; it surfaces as the public `kind` field.
+        step_kind: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         label: Option<String>,
     },
@@ -91,11 +99,17 @@ impl PromptProvenance {
                 feedback_job_id: feedback_job_id.clone(),
                 label: label.clone(),
             }),
-            PromptProvenance::Automation { label, .. } => {
-                label.as_ref().map(|label| PublicPromptProvenance::System {
-                    label: Some(label.clone()),
-                })
-            }
+            PromptProvenance::Workflow {
+                run_id,
+                step_key,
+                step_kind,
+                label,
+            } => Some(PublicPromptProvenance::Workflow {
+                run_id: run_id.clone(),
+                step_key: step_key.clone(),
+                kind: step_kind.clone(),
+                label: label.clone(),
+            }),
             PromptProvenance::System { label } => {
                 if label.as_deref() == Some("subagent_wake") {
                     return None;
@@ -105,6 +119,52 @@ impl PromptProvenance {
                 })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_provenance_surfaces_faithfully_to_public() {
+        let internal = PromptProvenance::Workflow {
+            run_id: "run-1".to_string(),
+            step_key: "0.-.2".to_string(),
+            step_kind: "agent.prompt".to_string(),
+            label: Some("Investigate the issue".to_string()),
+        };
+        match internal.to_public() {
+            Some(PublicPromptProvenance::Workflow {
+                run_id,
+                step_key,
+                kind,
+                label,
+            }) => {
+                assert_eq!(run_id, "run-1");
+                assert_eq!(step_key, "0.-.2");
+                // The step-kind slug surfaces as the public `kind` field.
+                assert_eq!(kind, "agent.prompt");
+                assert_eq!(label.as_deref(), Some("Investigate the issue"));
+            }
+            other => panic!("expected faithful Workflow provenance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workflow_provenance_round_trips_through_json_with_kind_tag() {
+        // The enum's serde tag is `kind`; the slug is carried under `stepKind`.
+        let internal = PromptProvenance::Workflow {
+            run_id: "run-9".to_string(),
+            step_key: "1.-.0".to_string(),
+            step_kind: "agent.emit".to_string(),
+            label: None,
+        };
+        let json = serde_json::to_string(&internal).unwrap();
+        assert!(json.contains("\"kind\":\"workflow\""), "json was {json}");
+        assert!(json.contains("\"stepKind\":\"agent.emit\""), "json was {json}");
+        let back: PromptProvenance = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, internal);
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
@@ -9,7 +9,35 @@ use super::{
 };
 
 impl SessionRuntime {
+    /// User-facing config mutation. L17 lockout (C13 / E8): a session held by a
+    /// live workflow run rejects config changes — take-over is the only door.
+    /// The workflow executor is exempt: it calls
+    /// [`set_live_session_config_option_unlocked`] directly (its `agent.config`
+    /// step must switch the model of the very session it holds).
+    ///
+    /// [`set_live_session_config_option_unlocked`]: Self::set_live_session_config_option_unlocked
     pub async fn set_live_session_config_option(
+        &self,
+        session_id: &str,
+        config_id: &str,
+        value: &str,
+    ) -> Result<
+        (
+            SessionRecord,
+            Option<SessionLiveConfigSnapshot>,
+            ConfigApplyState,
+        ),
+        SetSessionConfigOptionError,
+    > {
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(SetSessionConfigOptionError::WorkflowHeld { run_id });
+        }
+        self.set_live_session_config_option_unlocked(session_id, config_id, value)
+            .await
+    }
+
+    /// The lockout-exempt config mutation the workflow executor uses.
+    pub(crate) async fn set_live_session_config_option_unlocked(
         &self,
         session_id: &str,
         config_id: &str,
@@ -24,9 +52,7 @@ impl SessionRuntime {
     > {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| {
-                SetSessionConfigOptionError::Internal(anyhow::anyhow!(error.to_string()))
-            })?;
+            .map_err(SetSessionConfigOptionError::Access)?;
         let record = self
             .get_session_or_not_found(session_id)
             .map_err(|error| match error {
@@ -35,6 +61,14 @@ impl SessionRuntime {
                 }
                 SessionLifecycleError::Internal(error) => {
                     SetSessionConfigOptionError::Internal(error)
+                }
+                // Unreachable from get_session_or_not_found (it never gates), but
+                // keep the mapping total.
+                SessionLifecycleError::Access(error) => {
+                    SetSessionConfigOptionError::Access(error)
+                }
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    SetSessionConfigOptionError::WorkflowHeld { run_id }
                 }
             })?;
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
@@ -21,7 +21,12 @@ impl SessionRuntime {
     ) -> Result<ForkSessionOutcome, ForkSessionError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| ForkSessionError::Internal(anyhow::anyhow!(error.to_string())))?;
+            .map_err(ForkSessionError::Access)?;
+        // L17 lockout (C13 / E8): fork is a mutating verb; blocked on a held
+        // session.
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(ForkSessionError::WorkflowHeld { run_id });
+        }
         if target.is_some() {
             return Err(ForkSessionError::Unsupported(
                 "targeted fork is not enabled for this adapter".to_string(),
@@ -35,6 +40,10 @@ impl SessionRuntime {
                     ForkSessionError::SessionNotFound(session_id)
                 }
                 SessionLifecycleError::Internal(error) => ForkSessionError::Internal(error),
+                SessionLifecycleError::Access(error) => ForkSessionError::Access(error),
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    ForkSessionError::WorkflowHeld { run_id }
+                }
             })?;
 
         validate_fork_parent(&parent, &self.session_link_service)?;
@@ -50,6 +59,10 @@ impl SessionRuntime {
                     ForkSessionError::SessionNotFound(session_id)
                 }
                 SessionLifecycleError::Internal(error) => ForkSessionError::Internal(error),
+                SessionLifecycleError::Access(error) => ForkSessionError::Access(error),
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    ForkSessionError::WorkflowHeld { run_id }
+                }
             })?;
         validate_fork_parent(&parent, &self.session_link_service)?;
         let parent_native_session_id = handle

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::domains::sessions::extensions::SessionClosingContext;
 use crate::domains::sessions::links::model::SessionLinkRelation;
@@ -10,16 +10,56 @@ use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
 
-use super::{SessionLifecycleError, SessionRuntime};
+use super::{SessionLifecycleError, SessionMcpRefresh, SessionRuntime};
 
 impl SessionRuntime {
+    /// Rebind a workflow-bound session's live MCP servers (addendum item 2): the
+    /// per-run gateway credential is injected only at session LAUNCH (via the
+    /// launch extension reading `WorkflowGatewaySessions`). A taken-over EXISTING
+    /// session was launched with only the worker-token binding, so we retire its
+    /// live actor and relaunch it — the relaunch reassembles MCP servers from the
+    /// extension seam, which now includes the per-run gateway (registered at
+    /// claim). Best-effort: a rebind failure is logged; the run still proceeds.
+    pub(crate) async fn relaunch_session_for_mcp_rebind(&self, session_id: &str) {
+        if let Some(handle) = self.acp_manager.get_handle(session_id).await {
+            let _ = handle.close().await;
+        }
+        for _ in 0..40 {
+            if !self.has_live_session(session_id).await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if let Err(error) = self
+            .ensure_live_session(
+                session_id,
+                Some(SessionMcpRefresh {
+                    mcp_servers: Vec::new(),
+                    mcp_binding_summaries: None,
+                }),
+            )
+            .await
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = ?error,
+                "workflow gateway rebind relaunch failed (ignored)"
+            );
+        }
+    }
+
     pub async fn cancel_live_session(
         &self,
         session_id: &str,
     ) -> Result<SessionRecord, SessionLifecycleError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| SessionLifecycleError::Internal(anyhow::anyhow!(error.to_string())))?;
+            .map_err(SessionLifecycleError::Access)?;
+        // L17 lockout (C13 / E8): session-level cancel is a mutating verb;
+        // blocked on a held session (take-over cancels the whole run instead).
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(SessionLifecycleError::WorkflowHeld { run_id });
+        }
         let record = self.get_session_or_not_found(session_id)?;
 
         if let Some(handle) = self.acp_manager.get_handle(session_id).await {
@@ -39,7 +79,12 @@ impl SessionRuntime {
     ) -> Result<SessionRecord, SessionLifecycleError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| SessionLifecycleError::Internal(anyhow::anyhow!(error.to_string())))?;
+            .map_err(SessionLifecycleError::Access)?;
+        // L17 lockout (C13 / E8): close is a mutating verb; blocked on a held
+        // session (take-over is the only door; terminal keeps sessions alive).
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(SessionLifecycleError::WorkflowHeld { run_id });
+        }
         let _record = self.get_session_or_not_found(session_id)?;
         let mut visited = HashSet::new();
         self.close_session_tree(session_id, &mut visited).await?;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -20,6 +20,7 @@ use crate::domains::sessions::extensions::SessionExtension;
 use crate::domains::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
 use crate::live::sessions::LiveSessionManager;
+use crate::live::workflows::WorkflowOwnedSessions;
 
 mod config;
 mod creation;
@@ -49,11 +50,26 @@ pub struct SessionRuntime {
     plan_reference_resolver: Arc<dyn PlanReferenceResolver + Send + Sync>,
     plan_interaction_link_resolver: Arc<dyn PlanInteractionLinkResolver>,
     active_goal_resolver: Arc<dyn ActiveGoalResolver>,
+    /// L17 lockout (C13 / E8): a session held by a non-terminal workflow run
+    /// rejects every mutating verb with 409 `SESSION_WORKFLOW_HELD`; take-over is
+    /// the only door. This is the same in-memory registry the workflow executor
+    /// marks its sessions in (the run row is the durable lock — this is its
+    /// cache). The executor is exempt by construction: it drives sessions through
+    /// the internal provenance path, never these public methods.
+    workflow_owned_sessions: Arc<WorkflowOwnedSessions>,
 }
 
 impl SessionRuntime {
     pub(crate) fn runtime_home(&self) -> &Path {
         &self.runtime_home
+    }
+
+    /// The lockout guard shared by every public mutating verb (C13 / E8). Returns
+    /// the holding run id when the session is engine-locked, so the caller can
+    /// surface a typed `WorkflowHeld` error that maps to 409
+    /// `SESSION_WORKFLOW_HELD` and routes the UI to the take-over modal.
+    fn workflow_held_run(&self, session_id: &str) -> Option<String> {
+        self.workflow_owned_sessions.held_run(session_id)
     }
 }
 
@@ -103,6 +119,12 @@ pub struct SessionMcpRefresh {
 pub enum SetSessionConfigOptionError {
     SessionNotFound(String),
     Rejected(String),
+    /// Workspace runtime state blocks mutation (threaded typed so it surfaces as
+    /// 409 `WORKSPACE_MUTATION_BLOCKED`, not a 500 — the access-gate 500-collapse
+    /// fix, C13).
+    Access(WorkspaceAccessError),
+    /// The session is held by a non-terminal workflow run (C13 / E8).
+    WorkflowHeld { run_id: String },
     Internal(anyhow::Error),
 }
 
@@ -112,6 +134,10 @@ pub enum SendPromptError {
     SessionClosed,
     EmptyPrompt,
     InvalidPrompt(crate::domains::sessions::prompt::PromptValidationError),
+    /// See [`SetSessionConfigOptionError::Access`].
+    Access(WorkspaceAccessError),
+    /// The session is held by a non-terminal workflow run (C13 / E8).
+    WorkflowHeld { run_id: String },
     Internal(anyhow::Error),
 }
 
@@ -133,6 +159,10 @@ pub enum ForkSessionError {
     Unsupported(String),
     Busy,
     Invalid(String),
+    /// See [`SetSessionConfigOptionError::Access`].
+    Access(WorkspaceAccessError),
+    /// The session is held by a non-terminal workflow run (C13 / E8).
+    WorkflowHeld { run_id: String },
     MissingNativeSessionId,
     MissingDataKey,
     StartFailed {
@@ -155,12 +185,22 @@ pub enum PendingPromptMutationError {
     SessionNotFound(String),
     NotFound,
     InvalidPrompt(crate::domains::sessions::prompt::PromptValidationError),
+    /// The session is held by a non-terminal workflow run (C13 / E8). Editing or
+    /// deleting a queued prompt on a workflow-driven session is blocked —
+    /// take-over is the only door (E8).
+    WorkflowHeld { run_id: String },
     Internal(anyhow::Error),
 }
 
 #[derive(Debug)]
 pub enum SessionLifecycleError {
     SessionNotFound(String),
+    /// See [`SetSessionConfigOptionError::Access`].
+    Access(WorkspaceAccessError),
+    /// The session is held by a non-terminal workflow run (C13 / E8). Blocks
+    /// user-initiated cancel/close on a workflow-driven session — take-over is
+    /// the only door (E8).
+    WorkflowHeld { run_id: String },
     Internal(anyhow::Error),
 }
 
@@ -271,6 +311,7 @@ impl SessionRuntime {
         plan_reference_resolver: Arc<dyn PlanReferenceResolver + Send + Sync>,
         plan_interaction_link_resolver: Arc<dyn PlanInteractionLinkResolver>,
         active_goal_resolver: Arc<dyn ActiveGoalResolver>,
+        workflow_owned_sessions: Arc<WorkflowOwnedSessions>,
     ) -> Self {
         Self {
             session_service,
@@ -285,6 +326,7 @@ impl SessionRuntime {
             plan_reference_resolver,
             plan_interaction_link_resolver,
             active_goal_resolver,
+            workflow_owned_sessions,
         }
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs
@@ -15,6 +15,13 @@ impl SessionRuntime {
         seq: i64,
         blocks: Vec<PromptInputBlock>,
     ) -> Result<SessionRecord, PendingPromptMutationError> {
+        // L17 lockout (C13 / E8): editing a queued prompt is a mutating verb, so a
+        // session held by a live workflow run rejects it — take-over is the only
+        // door. The executor never edits pending prompts, so it is exempt by
+        // construction (this path is purely user-facing).
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(PendingPromptMutationError::WorkflowHeld { run_id });
+        }
         self.access_gate
             .assert_can_mutate_for_session(session_id)
             .map_err(|error| {
@@ -28,6 +35,12 @@ impl SessionRuntime {
                 }
                 SessionLifecycleError::Internal(error) => {
                     PendingPromptMutationError::Internal(error)
+                }
+                SessionLifecycleError::Access(error) => {
+                    PendingPromptMutationError::Internal(anyhow::anyhow!(error.to_string()))
+                }
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    PendingPromptMutationError::WorkflowHeld { run_id }
                 }
             })?;
         let handle = self
@@ -100,6 +113,13 @@ impl SessionRuntime {
         session_id: &str,
         seq: i64,
     ) -> Result<SessionRecord, PendingPromptMutationError> {
+        // L17 lockout (C13 / E8): deleting a queued prompt is a mutating verb, so a
+        // session held by a live workflow run rejects it — take-over is the only
+        // door. The executor never deletes pending prompts, so it is exempt by
+        // construction (this path is purely user-facing).
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(PendingPromptMutationError::WorkflowHeld { run_id });
+        }
         self.access_gate
             .assert_can_mutate_for_session(session_id)
             .map_err(|error| {
@@ -113,6 +133,12 @@ impl SessionRuntime {
                 }
                 SessionLifecycleError::Internal(error) => {
                     PendingPromptMutationError::Internal(error)
+                }
+                SessionLifecycleError::Access(error) => {
+                    PendingPromptMutationError::Internal(anyhow::anyhow!(error.to_string()))
+                }
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    PendingPromptMutationError::WorkflowHeld { run_id }
                 }
             })?;
         let handle = self

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -24,7 +24,12 @@ impl SessionRuntime {
     ) -> Result<SendPromptOutcome, SendPromptError> {
         self.access_gate
             .assert_can_mutate_for_session(session_id)
-            .map_err(|error| SendPromptError::Internal(anyhow::anyhow!(error.to_string())))?;
+            .map_err(SendPromptError::Access)?;
+        // L17 lockout (C13 / E8): a session held by a live workflow run rejects
+        // every mutating verb; take-over is the only door.
+        if let Some(run_id) = self.workflow_held_run(session_id) {
+            return Err(SendPromptError::WorkflowHeld { run_id });
+        }
         if blocks.is_empty() {
             return Err(SendPromptError::EmptyPrompt);
         }
@@ -179,6 +184,10 @@ fn map_lifecycle_error_to_prompt(error: SessionLifecycleError) -> SendPromptErro
     match error {
         SessionLifecycleError::SessionNotFound(session_id) => {
             SendPromptError::SessionNotFound(session_id)
+        }
+        SessionLifecycleError::Access(error) => SendPromptError::Access(error),
+        SessionLifecycleError::WorkflowHeld { run_id } => {
+            SendPromptError::WorkflowHeld { run_id }
         }
         SessionLifecycleError::Internal(error) => SendPromptError::Internal(error),
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/startup.rs
@@ -140,6 +140,14 @@ impl SessionRuntime {
                     EnsureLiveSessionError::SessionNotFound(session_id)
                 }
                 SessionLifecycleError::Internal(error) => EnsureLiveSessionError::Internal(error),
+                SessionLifecycleError::Access(error) => {
+                    EnsureLiveSessionError::Internal(anyhow::anyhow!(error.to_string()))
+                }
+                SessionLifecycleError::WorkflowHeld { run_id } => {
+                    EnsureLiveSessionError::Internal(anyhow::anyhow!(
+                        "session held by workflow run {run_id}"
+                    ))
+                }
             })?;
 
         self.ensure_live_session_handle(&record, mcp_refresh)

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
@@ -182,6 +182,32 @@ impl WorkflowService {
         })
     }
 
+    /// Stamp a workflow-injected turn into the injections index (contract §5.2 /
+    /// C10). Written by the executor at send time, in the same family as
+    /// `begin_step` (the executor owns both the step identity and the send).
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_injection(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        run_id: &str,
+        step_key: &str,
+        kind: &str,
+        label: &str,
+        injected_text: &str,
+    ) -> anyhow::Result<()> {
+        self.store.insert_injection(
+            session_id,
+            turn_id,
+            run_id,
+            step_key,
+            kind,
+            label,
+            injected_text,
+            &now(),
+        )
+    }
+
     /// Upsert a live progress snapshot onto a RUNNING step's `output_json`
     /// (spec 3.6 live goal progress). No-op unless the step is still `running`,
     /// so a terminal write from the step driver is never clobbered by a late

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
@@ -532,3 +532,35 @@ fn record_step_goal_progress_only_writes_while_running() {
     assert!(output.contains("iterations"));
     assert!(output.contains("tokens_used"));
 }
+
+// --------------------------------------------------------------------------
+// C10 injected-turn provenance index (workflow_session_injections). The
+// executor writes a row alongside begin_step; the steps checklist / audit read
+// it back. Shell steps write no row (PROPOSED option B).
+// --------------------------------------------------------------------------
+
+#[test]
+fn record_injection_round_trips_and_is_idempotent() {
+    let service = test_service();
+    service
+        .record_injection("sess-1", "turn-1", "run-1", "0.-.0", "agent.prompt", "Investigate", "do the thing")
+        .unwrap();
+    // Idempotent on (session_id, turn_id): a crash-resume re-send is a no-op.
+    service
+        .record_injection("sess-1", "turn-1", "run-1", "0.-.0", "agent.prompt", "Investigate", "changed")
+        .unwrap();
+    let row = service
+        .store()
+        .find_injection("sess-1", "turn-1")
+        .unwrap()
+        .expect("injection row present");
+    let (run_id, step_key, kind, label, text) = row;
+    assert_eq!(run_id, "run-1");
+    assert_eq!(step_key, "0.-.0");
+    assert_eq!(kind, "agent.prompt");
+    assert_eq!(label, "Investigate");
+    // INSERT OR IGNORE: the first write wins.
+    assert_eq!(text, "do the thing");
+    // An un-injected (human) turn has no row: absence = human, presence = machine.
+    assert!(service.store().find_injection("sess-1", "turn-2").unwrap().is_none());
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
@@ -188,6 +188,61 @@ impl WorkflowStore {
         Ok(())
     }
 
+    /// Record a workflow-injected turn (contract §5.2 / C10). Idempotent on the
+    /// (session_id, turn_id) PK — a crash-resume re-send under the same turn is a
+    /// no-op. Only prompt-bearing steps call this; shell steps write no row.
+    pub fn insert_injection(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        run_id: &str,
+        step_key: &str,
+        kind: &str,
+        label: &str,
+        injected_text: &str,
+        created_at: &str,
+    ) -> anyhow::Result<()> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "INSERT OR IGNORE INTO workflow_session_injections (
+                    session_id, turn_id, run_id, step_key, kind, label, injected_text, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    session_id, turn_id, run_id, step_key, kind, label, injected_text, created_at
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// The injection row for a session turn, if the turn was workflow-injected.
+    /// Tier-1 tests + the steps checklist read through this.
+    #[allow(clippy::type_complexity)]
+    pub fn find_injection(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> anyhow::Result<Option<(String, String, String, String, String)>> {
+        self.db.with_conn(|conn| {
+            conn.query_row(
+                "SELECT run_id, step_key, kind, label, injected_text
+                 FROM workflow_session_injections WHERE session_id = ?1 AND turn_id = ?2",
+                params![session_id, turn_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+    }
+
     pub fn update_step_run(
         tx: &Connection,
         step: &WorkflowStepRunRecord,

--- a/anyharness/crates/anyharness-lib/src/live/workflows/exec_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/exec_policy.rs
@@ -30,7 +30,7 @@
 //! re-park on a historical auto-approval and wait for a resolution that never
 //! comes, so the audit trail is the structured log line, not a ledger event.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use agent_client_protocol as acp;
@@ -67,17 +67,32 @@ pub fn bypass_mode_for_kind(agent_kind: &str) -> Option<&'static str> {
     }
 }
 
-/// The set of session ids the workflow executor opened. Shared behind `Arc`
-/// between the executor (which marks ids as it opens/rehydrates sessions) and
-/// the inbound permission advisor (which auto-approves for them).
+/// The registry of sessions a workflow run currently owns, keyed by session id
+/// to the owning run id. Shared behind `Arc` between the executor (which marks
+/// ids as it opens/rehydrates/binds sessions), the inbound permission advisor
+/// (which auto-approves for owned sessions — the always-bypass net), and the
+/// session runtime (which rejects mutating verbs on a held session — C13 L17
+/// lockout). The run row is the durable lock (contract §2.3); this registry is
+/// an in-memory cache of it, hydrated on boot from non-terminal runs' session
+/// maps and re-armed on crash-resume (`hydrate_from_run`).
 ///
-/// In-memory and grow-only for the runtime's lifetime. Entries are workflow
-/// session UUIDs (never reused), so a stale entry can never mis-classify a
-/// later session; the executor re-marks its sessions on crash-resume
-/// (`hydrate_from_run`), so the net survives a restart.
+/// Ownership + hold are the SAME condition (E8 "block everything"): a session
+/// appears here iff a non-terminal run owns it. **Release** is derived from the
+/// run going terminal (C13 / D15 / addendum item 3–4): [`release_run`] drops
+/// every entry for the run — which simultaneously (a) unmarks the always-bypass
+/// net (item 3: a demoted interactive session must stop being auto-approved) and
+/// (b) unlocks the session (C13: held-ness is derived, no per-session write).
+/// No session is ever closed at release (item 4: keep alive, demote).
+///
+/// A `released` set records run ids that have gone terminal so a late
+/// `hydrate_from_run` (crash-resume racing a terminal write) can never resurrect
+/// a released id (addendum item 3).
 #[derive(Default)]
 pub struct WorkflowOwnedSessions {
-    ids: RwLock<HashSet<String>>,
+    /// session_id -> owning run_id.
+    ids: RwLock<HashMap<String, String>>,
+    /// run ids that reached terminal; [`mark`] refuses to (re-)arm these.
+    released: RwLock<HashSet<String>>,
 }
 
 impl WorkflowOwnedSessions {
@@ -85,14 +100,49 @@ impl WorkflowOwnedSessions {
         Self::default()
     }
 
-    /// Mark a session as workflow-owned (idempotent).
-    pub fn mark(&self, session_id: &str) {
-        self.ids.write().unwrap().insert(session_id.to_string());
+    /// Mark a session as owned by `run_id` (idempotent). A no-op once the run has
+    /// been released (terminal) so re-hydration can never resurrect a demoted
+    /// session (addendum item 3).
+    pub fn mark(&self, session_id: &str, run_id: &str) {
+        if self.released.read().unwrap().contains(run_id) {
+            return;
+        }
+        self.ids
+            .write()
+            .unwrap()
+            .insert(session_id.to_string(), run_id.to_string());
     }
 
-    /// Is this session workflow-owned?
+    /// Is this session workflow-owned? (The always-bypass advisor's question.)
     pub fn is_owned(&self, session_id: &str) -> bool {
-        self.ids.read().unwrap().contains(session_id)
+        self.ids.read().unwrap().contains_key(session_id)
+    }
+
+    /// The run holding this session, if any — the lockout guard's question
+    /// (C13). `Some(run_id)` means every mutating verb is blocked and routes to
+    /// the take-over modal (E8).
+    pub fn held_run(&self, session_id: &str) -> Option<String> {
+        self.ids.read().unwrap().get(session_id).cloned()
+    }
+
+    /// Release every session the run owned (terminal / take-over). Derived
+    /// unlock (C13) + bypass unmark (item 3): drops the entries and records the
+    /// run as released so a racing re-hydration can't re-arm them. Returns the
+    /// released session ids so the caller can restore their worker gateway
+    /// binding (addendum item 2) and demote them (item 4). Never closes a
+    /// session.
+    pub fn release_run(&self, run_id: &str) -> Vec<String> {
+        self.released.write().unwrap().insert(run_id.to_string());
+        let mut ids = self.ids.write().unwrap();
+        let released: Vec<String> = ids
+            .iter()
+            .filter(|(_, owner)| owner.as_str() == run_id)
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        for session_id in &released {
+            ids.remove(session_id);
+        }
+        released
     }
 }
 
@@ -177,10 +227,41 @@ mod tests {
     fn owned_registry_marks_and_reports_membership() {
         let owned = WorkflowOwnedSessions::new();
         assert!(!owned.is_owned("s1"));
-        owned.mark("s1");
-        owned.mark("s1"); // idempotent
+        owned.mark("s1", "run-1");
+        owned.mark("s1", "run-1"); // idempotent
         assert!(owned.is_owned("s1"));
+        assert_eq!(owned.held_run("s1").as_deref(), Some("run-1"));
         assert!(!owned.is_owned("s2"));
+        assert!(owned.held_run("s2").is_none());
+    }
+
+    #[test]
+    fn release_run_unmarks_every_session_and_returns_them() {
+        let owned = WorkflowOwnedSessions::new();
+        owned.mark("s1", "run-1");
+        owned.mark("s2", "run-1");
+        owned.mark("s3", "run-2");
+        let mut released = owned.release_run("run-1");
+        released.sort();
+        assert_eq!(released, vec!["s1".to_string(), "s2".to_string()]);
+        // run-1's sessions are unmarked (bypass off + unlocked); run-2 untouched.
+        assert!(!owned.is_owned("s1"));
+        assert!(owned.held_run("s1").is_none());
+        assert!(!owned.is_owned("s2"));
+        assert!(owned.is_owned("s3"));
+        assert_eq!(owned.held_run("s3").as_deref(), Some("run-2"));
+    }
+
+    #[test]
+    fn mark_after_release_does_not_resurrect_a_demoted_session() {
+        // addendum item 3: a crash-resume re-hydration racing a terminal write
+        // must not re-arm a released run's sessions.
+        let owned = WorkflowOwnedSessions::new();
+        owned.mark("s1", "run-1");
+        owned.release_run("run-1");
+        owned.mark("s1", "run-1"); // late hydrate_from_run
+        assert!(!owned.is_owned("s1"));
+        assert!(owned.held_run("s1").is_none());
     }
 
     // --- auto_approve_option_id -----------------------------------------
@@ -237,7 +318,7 @@ mod tests {
     #[test]
     fn workflow_owned_session_is_auto_approved_without_consulting_inner() {
         let owned = Arc::new(WorkflowOwnedSessions::new());
-        owned.mark("wf-sess");
+        owned.mark("wf-sess", "run-1");
         let inner = Arc::new(SpyAdvisor {
             consulted: Mutex::new(false),
         });

--- a/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/executor.rs
@@ -10,8 +10,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyharness_contract::v1::{
-    ContentPart, Goal, GoalArmState, GoalSourceKind, GoalStatus, PromptInputBlock, SessionEvent,
-    SessionEventEnvelope, SetSessionGoalRequest,
+    ContentPart, Goal, GoalArmState, GoalSourceKind, GoalStatus, SessionEvent, SessionEventEnvelope,
+    SetSessionGoalRequest,
 };
 use serde_json::{json, Value};
 use tokio::sync::broadcast;
@@ -22,6 +22,7 @@ use super::gateway::{fire_run_ping, workflow_gateway_server, RunPingSink, Workfl
 use crate::domains::goals::runtime::{GoalOpError, GoalRuntime};
 use crate::domains::sessions::live_config::ACP_MODEL_COMPAT_CONFIG_ID;
 use crate::domains::sessions::model::SessionMcpBindingPolicy;
+use crate::domains::sessions::prompt::provenance::PromptProvenance;
 use crate::domains::sessions::runtime::{SendPromptOutcome, SessionRuntime};
 use crate::domains::sessions::service::SessionService;
 use crate::domains::workflows::engine::{StepExecContext, StepOutcome, WorkflowStepExecutor};
@@ -78,6 +79,25 @@ struct CurrentSession {
     session_id: String,
     #[allow(dead_code)]
     harness: String,
+}
+
+/// The step identity carried into a prompt injection so it can be stamped with
+/// `PromptProvenance::Workflow` and recorded in `workflow_session_injections`
+/// (C10 / E9).
+struct InjectionMeta {
+    step_key: String,
+    kind: String,
+    label: String,
+}
+
+impl InjectionMeta {
+    fn from_step(step: &PlanStep) -> Self {
+        Self {
+            step_key: step.key.clone(),
+            kind: step.kind_slug().to_string(),
+            label: step.label.clone(),
+        }
+    }
 }
 
 /// One executor per run. Sessions are slot-keyed (B7): `current` maps each
@@ -139,7 +159,7 @@ impl WorkflowStepExecutorImpl {
                 // Re-arm the always-bypass safety net for the resumed session
                 // (the registry is in-memory, so a restart would otherwise drop
                 // it).
-                self.deps.workflow_owned_sessions.mark(session_id);
+                self.deps.workflow_owned_sessions.mark(session_id, &self.run_id);
                 // Re-register the per-run gateway server too, so a relaunch of
                 // the resumed session (crash-resume) re-injects it (same
                 // in-memory registry, dropped on restart).
@@ -223,19 +243,47 @@ impl WorkflowStepExecutorImpl {
             .and_then(|spec| spec.bind_session_id.clone());
 
         let (session_id, session_harness) = if let Some(bind_id) = bind_session_id {
-            // Session binding (L29): load the pre-existing session. Owned by PR
-            // F; today `bind_session_id` is always absent, so this branch is a
-            // compiling path, not a live one.
+            // Session binding (L29 / B8): load the pre-existing (taken-over)
+            // session instead of creating one. It must exist and its harness must
+            // match the slot — otherwise the plan is malformed (the server
+            // validates this at StartRun, but the runtime re-checks: a plan that
+            // reached here with a mismatch is a hard error, never a silent
+            // wrong-harness launch).
             let session = self
                 .deps
                 .session_service
                 .get_session(&bind_id)
                 .map_err(|error| failed_msg("session_bind_failed", error.to_string()))?
                 .ok_or_else(|| failed_msg("session_bind_missing", bind_id.clone()))?;
-            // Register the per-run gateway MCP server for the bound session too,
-            // so a relaunch injects it (same in-memory registry as fresh).
+            // B8: harness must match the slot (hard plan error) and the session
+            // must not already be held by a DIFFERENT live run (hard bind
+            // rejection). Both are pure decisions, extracted to
+            // [`validate_bind_target`] so they are unit-testable without a live
+            // runtime.
+            let held_run = self.deps.workflow_owned_sessions.held_run(&bind_id);
+            validate_bind_target(
+                &bind_id,
+                &self.run_id,
+                &session.agent_kind,
+                &harness,
+                held_run.as_deref(),
+            )?;
+            // Mark ownership BEFORE the rebind relaunch so the always-bypass net
+            // + lockout are armed for the taken-over session immediately (C13).
+            self.deps
+                .workflow_owned_sessions
+                .mark(&bind_id, &self.run_id);
+            // Addendum item 2: rebind the bound session's gateway MCP binding.
+            // The per-run credential is injected only at LAUNCH; this session was
+            // launched with only the worker-token binding, so register the per-run
+            // gateway server and relaunch it so its integration calls run under
+            // the run's opt-in scope, not the owner's broad personal grant.
             if let Some(server) = workflow_gateway_server(self.gateway.as_ref()) {
                 self.deps.workflow_gateway_sessions.set(&bind_id, server);
+                self.deps
+                    .session_runtime
+                    .relaunch_session_for_mcp_rebind(&bind_id)
+                    .await;
             }
             (bind_id, session.agent_kind)
         } else {
@@ -268,7 +316,7 @@ impl WorkflowStepExecutorImpl {
                 .map_err(|error| failed_msg("session_start_failed", format!("{error:?}")))?;
             // Register the session as workflow-owned so the inbound permission
             // advisor auto-approves for it. Done before launch/first turn.
-            self.deps.workflow_owned_sessions.mark(&record.id);
+            self.deps.workflow_owned_sessions.mark(&record.id, &self.run_id);
             // Register the per-run gateway MCP server for this session so the
             // launch extension injects it (plan block wins over the worker
             // dotfile via the extension ordering + dedupe on
@@ -286,7 +334,7 @@ impl WorkflowStepExecutorImpl {
         };
         // Register the session as workflow-owned so the inbound permission
         // advisor auto-approves for it. Done before the first prompt/turn.
-        self.deps.workflow_owned_sessions.mark(&session_id);
+        self.deps.workflow_owned_sessions.mark(&session_id, &self.run_id);
         let _ = self
             .deps
             .workflow_service
@@ -301,17 +349,50 @@ impl WorkflowStepExecutorImpl {
         Ok(session_id)
     }
 
-    async fn send_prompt(&self, session_id: &str, text: &str) -> Result<Option<String>, StepOutcome> {
-        let blocks = vec![PromptInputBlock::Text {
-            text: text.to_string(),
-        }];
+    /// Inject a prompt into a workflow-owned session via the internal
+    /// provenance-carrying path (C10 / E9) — NOT the public `send_prompt` the
+    /// lockout guards (C13). The prompt is stamped `PromptProvenance::Workflow`
+    /// so the transcript renders the machine bubble from stored truth, and a
+    /// normalized `workflow_session_injections` row is written alongside (the
+    /// executor owns both step identity and the send).
+    async fn send_prompt(
+        &self,
+        session_id: &str,
+        text: &str,
+        meta: &InjectionMeta,
+    ) -> Result<Option<String>, StepOutcome> {
+        let label = if meta.label.trim().is_empty() {
+            None
+        } else {
+            Some(meta.label.clone())
+        };
+        let provenance = PromptProvenance::Workflow {
+            run_id: self.run_id.clone(),
+            step_key: meta.step_key.clone(),
+            step_kind: meta.kind.clone(),
+            label,
+        };
         match self
             .deps
             .session_runtime
-            .send_prompt(session_id, blocks, None)
+            .send_text_prompt_with_provenance(session_id, text.to_string(), provenance)
             .await
         {
-            Ok(SendPromptOutcome::Running { turn_id, .. }) => Ok(Some(turn_id)),
+            Ok(SendPromptOutcome::Running { turn_id, .. }) => {
+                // Stamp the injection index (contract §5.2). Best-effort: a failed
+                // index write must never fail the step (the wire provenance on the
+                // event payload is the source of truth for rendering).
+                let _ = self.deps.workflow_service.record_injection(
+                    session_id,
+                    &turn_id,
+                    &self.run_id,
+                    &meta.step_key,
+                    &meta.kind,
+                    &meta.label,
+                    text,
+                );
+                Ok(Some(turn_id))
+            }
             Ok(SendPromptOutcome::Queued { .. }) => Ok(None),
             Err(error) => Err(failed_msg("prompt_failed", format!("{error:?}"))),
         }
@@ -330,7 +411,7 @@ impl WorkflowStepExecutorImpl {
         Ok(handle.subscribe())
     }
 
-    async fn run_prompt(&self, slot: &str, agent: &AgentPromptStep) -> StepOutcome {
+    async fn run_prompt(&self, slot: &str, agent: &AgentPromptStep, meta: &InjectionMeta) -> StepOutcome {
         let session_id = match self.ensure_session(slot).await {
             Ok(id) => id,
             Err(outcome) => return outcome,
@@ -341,7 +422,7 @@ impl WorkflowStepExecutorImpl {
                 Ok(events) => events,
                 Err(outcome) => return outcome,
             };
-            let turn_id = match self.send_prompt(&session_id, &agent.prompt).await {
+            let turn_id = match self.send_prompt(&session_id, &agent.prompt, meta).await {
                 Ok(turn_id) => turn_id,
                 Err(outcome) => return outcome,
             };
@@ -366,7 +447,7 @@ impl WorkflowStepExecutorImpl {
                 let session_id = session_id.clone();
                 async move {
                 let mut events = self.subscribe(&session_id).await?;
-                let turn_id = self.send_prompt(&session_id, &prompt).await?;
+                let turn_id = self.send_prompt(&session_id, &prompt, meta).await?;
                 match await_turn_ended_collecting(&mut events, turn_id.as_deref(), TURN_BACKSTOP)
                     .await
                 {
@@ -380,7 +461,7 @@ impl WorkflowStepExecutorImpl {
         .await
     }
 
-    async fn run_goal(&self, slot: &str, agent: &AgentPromptStep, goal: &GoalSpec, step_index: usize) -> StepOutcome {
+    async fn run_goal(&self, slot: &str, agent: &AgentPromptStep, goal: &GoalSpec, step_index: usize, meta: &InjectionMeta) -> StepOutcome {
         let session_id = match self.ensure_session(slot).await {
             Ok(id) => id,
             Err(outcome) => return outcome,
@@ -413,7 +494,7 @@ impl WorkflowStepExecutorImpl {
                 Ok(events) => events,
                 Err(outcome) => return outcome,
             };
-            if let Err(outcome) = self.send_prompt(&session_id, &prompt).await {
+            if let Err(outcome) = self.send_prompt(&session_id, &prompt, meta).await {
                 return outcome;
             }
             match await_goal_terminal(&mut events, deadline, goal.on_blocked, &mut on_progress).await {
@@ -573,7 +654,11 @@ impl WorkflowStepExecutorImpl {
                 let _ = self
                     .deps
                     .session_runtime
-                    .set_live_session_config_option(&session_id, ACP_MODEL_COMPAT_CONFIG_ID, model)
+                    .set_live_session_config_option_unlocked(
+                        &session_id,
+                        ACP_MODEL_COMPAT_CONFIG_ID,
+                        model,
+                    )
                     .await;
             }
         }
@@ -593,7 +678,7 @@ impl WorkflowStepExecutorImpl {
     /// concrete errors, up to the plan's `max_attempts` (C12: sourced from the
     /// plan, no longer a hardcoded constant); the validated object becomes the
     /// step's entire output. Exhaustion fails `emit_invalid`.
-    async fn run_emit(&self, slot: &str, step: &AgentEmitStep, step_index: usize) -> StepOutcome {
+    async fn run_emit(&self, slot: &str, step: &AgentEmitStep, step_index: usize, meta: &InjectionMeta) -> StepOutcome {
         let session_id = match self.ensure_session(slot).await {
             Ok(id) => id,
             Err(outcome) => return outcome,
@@ -622,7 +707,7 @@ impl WorkflowStepExecutorImpl {
             async move {
                 // Subscribe BEFORE prompting so a fast TurnEnded is never missed.
                 let mut events = self.subscribe(&session_id).await?;
-                let turn_id = self.send_prompt(&session_id, &prompt).await?;
+                let turn_id = self.send_prompt(&session_id, &prompt, meta).await?;
                 match await_turn_ended(&mut events, turn_id.as_deref(), TURN_BACKSTOP).await {
                     TurnWait::Ended => {}
                     TurnWait::SessionClosed => return Err(failed("session_closed")),
@@ -686,13 +771,14 @@ fn evaluate_branch(step: &BranchStep) -> StepOutcome {
 impl WorkflowStepExecutor for WorkflowStepExecutorImpl {
     async fn execute_step(&self, step: &PlanStep, ctx: &StepExecContext) -> StepOutcome {
         let slot = step.slot.as_str();
+        let meta = InjectionMeta::from_step(step);
         match &step.kind {
             StepKind::AgentConfig(cfg) => self.run_agent_config(slot, cfg).await,
             StepKind::AgentPrompt(agent) => match &agent.goal {
-                None => self.run_prompt(slot, agent).await,
-                Some(goal) => self.run_goal(slot, agent, goal, ctx.step_index).await,
+                None => self.run_prompt(slot, agent, &meta).await,
+                Some(goal) => self.run_goal(slot, agent, goal, ctx.step_index, &meta).await,
             },
-            StepKind::AgentEmit(emit) => self.run_emit(slot, emit, ctx.step_index).await,
+            StepKind::AgentEmit(emit) => self.run_emit(slot, emit, ctx.step_index, &meta).await,
             StepKind::ShellRun(shell) => self.run_shell(shell).await,
             StepKind::ScmOpenPr(pr) => self.run_scm(pr).await,
             StepKind::Notify(notify) => {
@@ -1246,6 +1332,43 @@ fn failed_msg(code: &str, message: impl Into<String>) -> StepOutcome {
     }
 }
 
+/// B8 bind-target validation (pure decision, so it is unit-testable without a
+/// live runtime). A bound session must:
+/// 1. match the slot's harness — otherwise the plan is malformed (hard error);
+/// 2. not already be held by a *different* live run — otherwise binding would
+///    silently transfer ownership (`mark` overwrites the owner entry, and the
+///    previous owner's `release_run` would then no longer drop it), leaking the
+///    lockout. Re-binding a session THIS run already holds is idempotent and OK.
+fn validate_bind_target(
+    bind_id: &str,
+    run_id: &str,
+    session_harness: &str,
+    slot_harness: &str,
+    held_run: Option<&str>,
+) -> Result<(), StepOutcome> {
+    if session_harness != slot_harness {
+        return Err(failed_msg(
+            "plan_malformed",
+            format!(
+                "bound session {bind_id} harness {session_harness} does not match slot harness \
+                 {slot_harness}"
+            ),
+        ));
+    }
+    if let Some(existing_run) = held_run {
+        if existing_run != run_id {
+            return Err(failed_msg(
+                "session_bind_held",
+                format!(
+                    "bound session {bind_id} is already held by workflow run {existing_run}; it \
+                     cannot be bound to run {run_id}"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1307,6 +1430,53 @@ mod tests {
         assert!(invocation_present(&tools, &required("linear", "update_status")));
         assert!(!invocation_present(&tools, &required("slack", "post_message")));
         assert!(!invocation_present(&[], &required("linear", "update_status")));
+    }
+
+    // --- B8 bind-target validation ---
+
+    fn outcome_code(outcome: &StepOutcome) -> &str {
+        match outcome {
+            StepOutcome::Failed { code, .. } => code,
+            _ => panic!("expected Failed outcome"),
+        }
+    }
+
+    #[test]
+    fn bind_target_ok_when_harness_matches_and_not_held() {
+        assert!(validate_bind_target("sess-1", "run-a", "claude", "claude", None).is_ok());
+    }
+
+    #[test]
+    fn bind_target_rebinding_own_run_is_idempotent() {
+        // A session already held by THIS run may be re-bound (idempotent).
+        assert!(
+            validate_bind_target("sess-1", "run-a", "claude", "claude", Some("run-a")).is_ok()
+        );
+    }
+
+    #[test]
+    fn bind_target_harness_mismatch_is_hard_plan_error() {
+        let err = validate_bind_target("sess-1", "run-a", "codex", "claude", None)
+            .expect_err("harness mismatch must be a hard error");
+        assert_eq!(outcome_code(&err), "plan_malformed");
+    }
+
+    #[test]
+    fn bind_target_rejects_session_held_by_a_different_run() {
+        // The double-owner hole: without this guard, run-b would silently re-own a
+        // session run-a holds, and run-a's release would no longer drop it.
+        let err = validate_bind_target("sess-1", "run-b", "claude", "claude", Some("run-a"))
+            .expect_err("a session held by another live run cannot be bound");
+        assert_eq!(outcome_code(&err), "session_bind_held");
+    }
+
+    #[test]
+    fn bind_target_harness_mismatch_takes_precedence_over_held() {
+        // Even when also held elsewhere, a harness mismatch is the malformed-plan
+        // error (checked first).
+        let err = validate_bind_target("sess-1", "run-b", "codex", "claude", Some("run-a"))
+            .expect_err("mismatch must error");
+        assert_eq!(outcome_code(&err), "plan_malformed");
     }
 
     // --- agent.emit schema validation ---

--- a/anyharness/crates/anyharness-lib/src/live/workflows/gateway.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/gateway.rs
@@ -166,6 +166,14 @@ impl WorkflowGatewaySessions {
     pub fn get(&self, session_id: &str) -> Option<SessionMcpServer> {
         self.servers.read().unwrap().get(session_id).cloned()
     }
+
+    /// Deregister the per-run gateway server (addendum item 2 release / item 4
+    /// demotion): a subsequent relaunch of the (now interactive) session stops
+    /// injecting the run token and falls back to the worker dotfile binding.
+    /// Returns whether an entry was removed.
+    pub fn remove(&self, session_id: &str) -> bool {
+        self.servers.write().unwrap().remove(session_id).is_some()
+    }
 }
 
 /// Session-launch extension that injects the per-run gateway MCP server for a

--- a/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/manager.rs
@@ -134,6 +134,10 @@ impl WorkflowRunManager {
                 None,
             )?;
         }
+        // Release ownership + gateway bindings now (idempotent with the actor's
+        // own terminal release when one is live) so take-over frees the sessions
+        // immediately — the run row is already terminal (C13 / items 2–4).
+        self.release_on_terminal(run_id);
         self.deps
             .workflow_service
             .get_run(run_id)?
@@ -246,14 +250,44 @@ impl WorkflowRunManager {
             let progress =
                 drive_run(&deps.workflow_service, &executor, &run_id, &cancel).await;
             manager.forget(&run_id);
-            if matches!(progress, EngineProgress::SuspendedForApproval) {
-                manager.schedule_approval_timeout(&run_id);
+            match progress {
+                EngineProgress::SuspendedForApproval => {
+                    manager.schedule_approval_timeout(&run_id)
+                }
+                // Terminal (completed/failed/cancelled): release ownership +
+                // gateway bindings, keep sessions alive/demoted (C13 / items 2–4).
+                EngineProgress::Finished(_) => manager.release_on_terminal(&run_id),
+                EngineProgress::Advanced => {}
             }
         });
     }
 
     fn forget(&self, run_id: &str) {
         self.live.lock().unwrap().remove(run_id);
+    }
+
+    /// Release everything a terminal run held (C13 derived unlock + addendum
+    /// items 2–4). The run row going terminal IS the unlock; this makes the
+    /// derivation concrete on the in-memory caches:
+    ///
+    /// - **Ownership + lockout** (item 3 / C13): drop the run's sessions from
+    ///   [`WorkflowOwnedSessions`], which simultaneously un-holds them (mutating
+    ///   verbs are allowed again) and stops the always-bypass auto-approve.
+    ///   `release_run` also records the run so a racing crash-resume can't re-arm.
+    /// - **Gateway binding** (item 2 restore): deregister each session's per-run
+    ///   gateway server, so a subsequent resume reassembles the worker dotfile
+    ///   binding instead of the (now-expired) run token.
+    /// - **Session fate** (item 4, RULED): sessions are NOT closed — they stay
+    ///   open as normal interactive sessions (transcript inspectable, work
+    ///   continuable in place). Normal idle cleanup applies thereafter.
+    ///
+    /// Idempotent: safe to call from both the actor's terminal path and the
+    /// server-relayed cancel.
+    fn release_on_terminal(&self, run_id: &str) {
+        let released = self.deps.workflow_owned_sessions.release_run(run_id);
+        for session_id in &released {
+            self.deps.workflow_gateway_sessions.remove(session_id);
+        }
     }
 
     /// Arm (or re-arm) the human.approval timeout timer for a parked run, if the

--- a/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
@@ -198,6 +198,10 @@ pub(super) const MIGRATIONS: &[(&str, &str)] = &[
         "0053_workflow_runs",
         include_str!("sql/0053_workflow_runs.sql"),
     ),
+    (
+        "0054_workflow_injections",
+        include_str!("sql/0054_workflow_injections.sql"),
+    ),
 ];
 
 pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0054_workflow_injections.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0054_workflow_injections.sql
@@ -1,0 +1,25 @@
+-- Workflow injected-turn provenance (contract §5.2, C10 / E9). Every
+-- prompt/command the workflow executor injects into a session is stamped here,
+-- so the steps checklist and any queryable "which turns did run X inject" view
+-- read from stored truth, never inference. The live/wire provenance rides the
+-- session event payload (PromptProvenance::Workflow) — this table is the
+-- normalized index written alongside `begin_step`, NOT a read-path join.
+--
+-- Only prompt-bearing steps (agent.prompt / agent.emit / agent goals) write a
+-- row: they produce a session turn. Shell steps do not go through send_prompt
+-- and write no row (PROPOSED option B, ruled in the PR-F summary) — so turn_id
+-- is NOT NULL and the PK can key on it.
+CREATE TABLE workflow_session_injections (
+    session_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_key TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    label TEXT NOT NULL,
+    injected_text TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, turn_id)
+);
+
+CREATE INDEX idx_workflow_injections_run
+    ON workflow_session_injections(run_id, step_key);

--- a/apps/packages/product-domain/src/chats/subagents/provenance.ts
+++ b/apps/packages/product-domain/src/chats/subagents/provenance.ts
@@ -122,6 +122,38 @@ export function formatReviewFeedbackQueueText(args: {
   return "Review feedback ready";
 }
 
+/**
+ * Workflow-injected prompt provenance (C10 / E9). Stamped by the workflow
+ * executor when it injects a step's prompt into a session; the transcript renders
+ * the machine-driven bubble ("Workflow · <label>") from this, exactly as
+ * subagent-wake provenance drives its bubble. The shape mirrors the runtime
+ * `PromptProvenance::Workflow` contract variant (`type: "workflow"`).
+ *
+ * Typed locally rather than via `Extract<PromptProvenance, …>` so it compiles
+ * ahead of the `@anyharness/sdk` regeneration that adds the `workflow` variant;
+ * once regenerated the two shapes coincide.
+ */
+export interface WorkflowPromptProvenance {
+  type: "workflow";
+  runId: string;
+  stepKey: string;
+  kind: string;
+  label?: string | null;
+}
+
+export function isWorkflowProvenance(
+  provenance: PromptProvenance | null | undefined,
+): provenance is PromptProvenance & WorkflowPromptProvenance {
+  return (provenance as { type?: string } | null | undefined)?.type === "workflow";
+}
+
+export function formatWorkflowPromptTranscriptText(
+  provenance: WorkflowPromptProvenance,
+): string {
+  const label = provenance.label?.trim();
+  return label && label.length > 0 ? `Workflow · ${label}` : "Workflow step";
+}
+
 export function isAgentSessionProvenance(
   provenance: PromptProvenance | null | undefined,
 ): provenance is Extract<PromptProvenance, { type: "agentSession" }> {

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -1236,6 +1236,80 @@ editor/run UI of its own (drift note #7).
 
 ---
 
+## 7.6 Session plane (PR F — binding · provenance · lockout · take-over)
+
+The session plane is the one coherent PR that makes a workflow's sessions
+first-class: how a run adopts an existing session, how machine-injected turns are
+distinguished from human ones, how a driven session is protected from stray user
+edits, and how a human takes it back. B8 + C10 + C13 + D15, plus the 2026-07-09
+addendum (gateway rebind, bypass-registry unmark, keep-alive-on-terminal).
+
+**B8 session binding (L29).** `StartRun` accepts
+`session_bindings: {<slot>: session_id}` (server `StartRunRequest.session_bindings`,
+`models.py`). The server validates each bound slot names a real agent slot
+(`service.start_run`); the resolver sets `sessions[slot].bind_session_id`
+(`_resolve_plan`). At runtime, `WorkflowStepExecutorImpl::ensure_session`'s bind
+branch (`executor.rs`) LOADS the existing session instead of
+`create_durable_session`, and **hard-errors `plan_malformed` if the session's
+harness doesn't match the slot** (never a silent wrong-harness launch). The bound
+session then appears in the run's slot→session map like any fresh session.
+
+**C10 provenance (E9 — stamp at write time).** The executor injects prompts through
+the internal provenance-carrying path
+(`SessionRuntime::send_text_prompt_with_provenance`, `prompt.rs`), NOT the public
+`send_prompt` (which the lockout guards). Each injection stamps
+`PromptProvenance::Workflow { run_id, step_key, step_kind, label }` — the internal
+enum's serde tag is `kind`, so the step-kind slug rides `step_kind` and surfaces as
+the public contract's `kind` field (`prompt/provenance.rs` → contract `events.rs`).
+The dead `Automation` variant (whose `to_public` lossily collapsed to `System`) is
+gone. Desktop reads `prompt_provenance` off the `UserMessage` exactly as it reads
+subagent-wake (`product-domain/.../subagents/provenance.ts`, `isWorkflowProvenance`).
+Alongside the send, the executor writes a normalized row to the new
+`workflow_session_injections` SQLite table (migration `0054`; `WorkflowStore::
+insert_injection`) — the queryable index for the per-session steps checklist. Only
+prompt-bearing steps write a row (shell steps write none — **PROPOSED option B,
+adopted**: `turn_id` is NOT NULL, no read-path join). Absence of a row = human turn,
+presence = machine.
+
+**C13 lockout (E8 — block everything).** A session is held iff it appears in a
+non-terminal run's session map — the run row IS the lock (no new column). The
+runtime caches this in the generalized `WorkflowOwnedSessions`
+(`HashMap<session_id, run_id>` + a `released` set, `exec_policy.rs`), which is ALSO
+the always-bypass auto-approve registry — ownership and hold are the same condition.
+`SessionRuntime` holds an `Arc<WorkflowOwnedSessions>` and guards every mutating verb
+(`send_prompt`, `set_live_session_config_option`, `fork_session`, cancel/close;
+title-update at the HTTP layer via `assert_session_not_workflow_held`) with a typed
+`WorkflowHeld { run_id }` → 409 `SESSION_WORKFLOW_HELD` that routes the UI to the
+take-over modal. **Included fix:** those verbs threaded access-gate errors as typed
+`Access(WorkspaceAccessError)` (was a 500 collapse) so `WORKSPACE_MUTATION_BLOCKED`
+and the new 409 both surface correctly. The executor is exempt by construction: it
+uses the internal prompt path + `set_live_session_config_option_unlocked`.
+
+**D15 take-over / cancel.** Server `POST /workflows/runs/{run_id}/cancel`
+(`api.py` → `delivery.cancel_run`, user auth, owner-scoped 404):
+`check_transition(→cancelled)` under `lock_run`, stamp `stopped_by_user_id`
+(migration `a7b9c1d3e5f7`) + `finished_at`, run the shared terminal side effects
+(expire the per-run gateway token, `apply_step_actions`), then best-effort runtime
+cancel via `integrations/anyharness/workflow_runs.cancel_workflow_run` (cloud lane
+through the sandbox gateway; local relayed by desktop). The runtime half already
+existed (`manager.cancel`).
+
+**Release = derived from terminal (C13 / addendum items 2–4).**
+`WorkflowRunManager::release_on_terminal` fires on any terminal outcome (actor's
+`drive_run` finishing, and the take-over `cancel`): it calls
+`WorkflowOwnedSessions::release_run` (drops the run's sessions → simultaneously
+un-holds them AND stops auto-approve — item 3; the `released` set stops a racing
+crash-resume from re-arming) and deregisters each session from
+`WorkflowGatewaySessions` so a later resume reassembles the worker dotfile binding
+instead of the expired run token (item 2 restore). Sessions are **never closed** at
+terminal (item 4, RULED): they stay open as normal interactive sessions. For a bound
+(taken-over) session, the executor rebinds mid-run at claim time —
+registers the per-run gateway server and relaunches the session
+(`relaunch_session_for_mcp_rebind`) so its integration calls run under the run's
+opt-in scope, not the owner's broad personal grant (item 2 claim).
+
+---
+
 ## 8. Known gaps / drift + PR map
 
 **Drift (design doc vs. shipped code — code wins):**

--- a/server/alembic/versions/a7b9c1d3e5f7_workflow_run_stopped_by_user.py
+++ b/server/alembic/versions/a7b9c1d3e5f7_workflow_run_stopped_by_user.py
@@ -1,0 +1,52 @@
+"""workflow run stopped_by_user_id (D15 take-over / cancel)
+
+Revision ID: a7b9c1d3e5f7
+Revises: d2f4a6c8e0b1
+Create Date: 2026-07-09 00:00:00.000000
+
+PR F (session plane, D15): the audit answer to "why is this run cancelled" —
+the user who took over / cancelled it. Nullable (set only by an explicit
+take-over), FK user with ON DELETE SET NULL so an audit trail survives user
+deletion. Idempotent-guarded like the rest of the stack.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b9c1d3e5f7"
+down_revision: str | Sequence[str] | None = "d2f4a6c8e0b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if not _has_column("workflow_run", "stopped_by_user_id"):
+        op.add_column(
+            "workflow_run",
+            sa.Column("stopped_by_user_id", sa.Uuid(), nullable=True),
+        )
+        op.create_foreign_key(
+            "fk_workflow_run_stopped_by_user_id",
+            "workflow_run",
+            "user",
+            ["stopped_by_user_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    if _has_column("workflow_run", "stopped_by_user_id"):
+        op.drop_constraint(
+            "fk_workflow_run_stopped_by_user_id", "workflow_run", type_="foreignkey"
+        )
+        op.drop_column("workflow_run", "stopped_by_user_id")

--- a/server/proliferate/db/models/cloud/workflows.py
+++ b/server/proliferate/db/models/cloud/workflows.py
@@ -195,6 +195,12 @@ class WorkflowRun(Base):
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # D15 take-over/cancel: the user who stopped the run (nullable — set only by an
+    # explicit take-over/cancel). The audit answer to "why is this cancelled".
+    stopped_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
 
 class WorkflowTrigger(Base):

--- a/server/proliferate/db/store/cloud_workflows.py
+++ b/server/proliferate/db/store/cloud_workflows.py
@@ -77,6 +77,7 @@ class WorkflowRunRecord:
     delivered_at: datetime | None
     started_at: datetime | None
     finished_at: datetime | None
+    stopped_by_user_id: UUID | None = None
 
 
 def _workflow_record(row: Workflow) -> WorkflowRecord:
@@ -134,6 +135,7 @@ def _run_record(row: WorkflowRun) -> WorkflowRunRecord:
         delivered_at=row.delivered_at,
         started_at=row.started_at,
         finished_at=row.finished_at,
+        stopped_by_user_id=row.stopped_by_user_id,
     )
 
 
@@ -372,6 +374,7 @@ async def update_run(
     delivered_at: datetime | None = None,
     started_at: datetime | None = None,
     finished_at: datetime | None = None,
+    stopped_by_user_id: UUID | None = None,
     clear_error: bool = False,
 ) -> WorkflowRunRecord | None:
     """Apply a run update. Only non-None arguments are written.
@@ -412,6 +415,8 @@ async def update_run(
         row.started_at = started_at
     if finished_at is not None:
         row.finished_at = finished_at
+    if stopped_by_user_id is not None:
+        row.stopped_by_user_id = stopped_by_user_id
     row.updated_at = utcnow()
     await db.flush()
     return _run_record(row)
@@ -441,6 +446,75 @@ async def has_non_terminal_run_for_trigger(db: AsyncSession, *, trigger_id: UUID
         )
     ).scalar_one_or_none()
     return found is not None
+
+
+def _plan_bound_session_ids(resolved_plan_json: dict[str, object] | None) -> set[str]:
+    """The session ids a resolved plan binds (B8: `sessions[slot].bind_session_id`)."""
+
+    sessions = (resolved_plan_json or {}).get("sessions")
+    if not isinstance(sessions, dict):
+        return set()
+    bound: set[str] = set()
+    for slot in sessions.values():
+        if isinstance(slot, dict):
+            bind_id = slot.get("bind_session_id")
+            if isinstance(bind_id, str) and bind_id:
+                bound.add(bind_id)
+    return bound
+
+
+async def live_run_holding_session(db: AsyncSession, *, session_id: str) -> UUID | None:
+    """The non-terminal ("live") run holding `session_id`, if any (B8 / E8).
+
+    A run holds a session when its resolved plan binds it (`bind_session_id`) or
+    it created/owns it (`anyharness_session_ids`, reported by the runtime). The
+    run row is the durable lock (the runtime's owned-session registry is only its
+    cache), so this is the authoritative server-side held check. The non-terminal
+    run set is small, so an in-Python scan of nested plan slots is fine.
+    """
+
+    rows = (
+        await db.execute(
+            select(
+                WorkflowRun.id,
+                WorkflowRun.resolved_plan_json,
+                WorkflowRun.anyharness_session_ids,
+            ).where(WorkflowRun.status.notin_(tuple(WORKFLOW_RUN_TERMINAL_STATUSES)))
+        )
+    ).all()
+    for run_id, resolved_plan_json, anyharness_session_ids in rows:
+        if session_id in (anyharness_session_ids or []):
+            return run_id
+        if session_id in _plan_bound_session_ids(resolved_plan_json):
+            return run_id
+    return None
+
+
+async def session_foreign_workspace(
+    db: AsyncSession, *, session_id: str, target_workspace_id: str
+) -> str | None:
+    """A workspace `session_id` is known to belong to that is NOT `target_workspace_id`.
+
+    The control plane has no session mirror; its only record of a session's home
+    workspace is the run rows that referenced it (`anyharness_session_ids`, which
+    the runtime reports per run). B8 requires a bound session to belong to the
+    target workspace — so if history places it in a different workspace, reject.
+    A session with no run history returns `None`; the runtime bind boundary
+    (session must exist in the target sandbox) is the authoritative backstop.
+    """
+
+    rows = (
+        await db.execute(
+            select(WorkflowRun.anyharness_workspace_id).where(
+                WorkflowRun.anyharness_session_ids.contains([session_id]),
+                WorkflowRun.anyharness_workspace_id.isnot(None),
+            )
+        )
+    ).all()
+    for (workspace_id,) in rows:
+        if workspace_id and workspace_id != target_workspace_id:
+            return workspace_id
+    return None
 
 
 async def earliest_non_terminal_run_id_for_trigger(

--- a/server/proliferate/integrations/anyharness/workflow_runs.py
+++ b/server/proliferate/integrations/anyharness/workflow_runs.py
@@ -52,6 +52,35 @@ async def deliver_workflow_run(
         )
 
 
+async def cancel_workflow_run(
+    runtime_url: str,
+    access_token: str,
+    *,
+    run_id: str,
+    timeout: float,
+) -> None:
+    """POST the runtime's take-over/cancel (D15 runtime half): stop the live actor
+    at the next step boundary and best-effort tear down the in-flight turn. The
+    server has already flipped the run terminal + released ownership, so this is a
+    best-effort nudge — a 404 (runtime never saw the run, or already forgot it) is
+    benign and swallowed by the caller."""
+
+    try:
+        async with _client(runtime_url, access_token, timeout) as client:
+            response = await client.post(f"{_WORKFLOW_RUNS_PATH}/{run_id}/cancel")
+    except httpx.HTTPError as exc:
+        raise CloudRuntimeReconnectError(str(exc) or exc.__class__.__name__) from exc
+    if response.status_code not in (
+        httpx.codes.OK,
+        httpx.codes.ACCEPTED,
+        httpx.codes.NO_CONTENT,
+        httpx.codes.NOT_FOUND,
+    ):
+        raise CloudRuntimeReconnectError(
+            f"Sandbox rejected workflow cancel (status {response.status_code})."
+        )
+
+
 async def read_workflow_run(
     runtime_url: str,
     access_token: str,

--- a/server/proliferate/server/cloud/workflows/api.py
+++ b/server/proliferate/server/cloud/workflows/api.py
@@ -23,7 +23,11 @@ from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.integrations.slack import client as slack_client
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.workflows.delivery import deliver_cloud_run, refresh_cloud_run
+from proliferate.server.cloud.workflows.delivery import (
+    cancel_run,
+    deliver_cloud_run,
+    refresh_cloud_run,
+)
 from proliferate.server.cloud.workflows.models import (
     RunStatusRequest,
     SlackChannelResponse,
@@ -144,6 +148,20 @@ async def report_run_status_endpoint(
     user: User = Depends(current_product_user),
 ) -> WorkflowRunResponse:
     return run_payload(await report_run_status(db, user, run_id, body))
+
+
+@router.post("/runs/{run_id}/cancel", response_model=WorkflowRunResponse)
+async def cancel_run_endpoint(
+    run_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> WorkflowRunResponse:
+    """Take over / cancel a run (D15). User auth, owner-scoped (a run the caller
+    can't see 404s). This is the single human override; the UI's take-over action
+    routes here, and a blocked mutating verb's 409 ``SESSION_WORKFLOW_HELD`` sends
+    the user to it."""
+
+    return run_payload(await cancel_run(db, user, run_id))
 
 
 @router.post("/runs/{run_id}/deliver", response_model=WorkflowRunResponse)

--- a/server/proliferate/server/cloud/workflows/delivery.py
+++ b/server/proliferate/server/cloud/workflows/delivery.py
@@ -34,8 +34,10 @@ from proliferate.constants.workflows import (
     WORKFLOW_CLOUD_REFRESH_TIMEOUT_SECONDS,
     WORKFLOW_DELIVERY_ERROR_CODE,
     WORKFLOW_RUN_OBSERVABLE_STATUSES,
+    WORKFLOW_RUN_STATUS_CANCELLED,
     WORKFLOW_RUN_STATUS_PENDING_DELIVERY,
     WORKFLOW_RUN_STATUS_RUNNING,
+    WORKFLOW_TARGET_MODE_LOCAL,
     WORKFLOW_TARGET_MODE_PERSONAL_CLOUD,
 )
 from proliferate.db.store import cloud_workflows as store
@@ -51,8 +53,13 @@ from proliferate.server.cloud.gateway.service import ensure_cloud_sandbox_gatewa
 from proliferate.server.cloud.integration_gateway.domain.scope import (
     intersect_namespaces_with_worker,
 )
-from proliferate.server.cloud.workflows.domain.run_status import is_terminal
-from proliferate.server.cloud.workflows.service import mark_run_delivered
+from proliferate.integrations.anyharness.workflow_runs import cancel_workflow_run
+from proliferate.server.cloud.workflows.domain.run_status import (
+    RunTransitionError,
+    check_transition,
+    is_terminal,
+)
+from proliferate.server.cloud.workflows.service import _visible_run, mark_run_delivered
 from proliferate.utils.time import utcnow
 
 _ERROR_MESSAGE_MAX_CHARS = 480
@@ -318,3 +325,75 @@ async def refresh_cloud_run(
         # leave the ledger untouched.
         return run
     return await _sync_run_from_view(db, run.id, _parse_sandbox_run_view(payload))
+
+
+# --- take-over / cancel (D15) --------------------------------------------------
+
+
+async def cancel_run(
+    db: AsyncSession, user: ActorIdentity, run_id: UUID
+) -> WorkflowRunRecord:
+    """Take over / cancel a run (D15). The single human override: flip the desired
+    status to ``cancelled``, stamp ``stopped_by_user_id`` + ``finished_at``, run
+    the shared terminal side effects (expire the per-run gateway token, apply step
+    actions), then best-effort nudge the runtime to stop the live actor.
+
+    The server write going terminal IS the release (C13 / L17): the runtime derives
+    session held-ness from the run row, so every session the run held is freed to
+    normal interactive ownership even if the runtime is momentarily unreachable
+    (a later refresh reconciles). The runtime nudge is therefore best-effort — a
+    404/transport failure never fails take-over. Local runs are relayed by the
+    desktop, so the server only performs the terminal write for them.
+    """
+
+    # Owner-scoped 404 (visible_run raises not-found for a run the user can't see).
+    run = await _visible_run(db, user=user, run_id=run_id)
+    if is_terminal(run.status):
+        return run
+
+    locked = await store.lock_run(db, run_id)
+    if locked is None:
+        raise CloudApiError("workflow_run_not_found", "Workflow run not found.", status_code=404)
+    try:
+        check_transition(locked.status, WORKFLOW_RUN_STATUS_CANCELLED)
+    except RunTransitionError as exc:
+        raise CloudApiError(exc.code, exc.message, status_code=409) from exc
+
+    now = utcnow()
+    updated = await store.update_run(
+        db,
+        run_id=run_id,
+        status=WORKFLOW_RUN_STATUS_CANCELLED,
+        finished_at=now if locked.finished_at is None else None,
+        stopped_by_user_id=user.id,
+    )
+    assert updated is not None
+
+    # Shared terminal side effects (reused from report_run_status): expire the
+    # per-run token before applying step actions so a crash mid-actions still
+    # leaves the token dead.
+    await store.expire_run_gateway_tokens_for_run(db, workflow_run_id=run_id)
+    try:
+        from proliferate.server.cloud.workflows.actions import apply_step_actions
+
+        await apply_step_actions(db, run=updated)
+    except Exception:
+        logger.exception("apply_step_actions failed on cancel run_id=%s", run_id)
+
+    # Best-effort runtime nudge. Cloud lane: POST the runtime cancel through the
+    # sandbox gateway. Local lane: the desktop relays cancel to its own runtime, so
+    # the server does not reach out.
+    if updated.target_mode != WORKFLOW_TARGET_MODE_LOCAL:
+        try:
+            access = await ensure_cloud_sandbox_gateway_access(db, user)
+            await cancel_workflow_run(
+                access.upstream_base_url,
+                access.upstream_token,
+                run_id=str(run_id),
+                timeout=WORKFLOW_CLOUD_REFRESH_TIMEOUT_SECONDS,
+            )
+        except (CloudApiError, CloudRuntimeReconnectError) as exc:
+            # The run is already terminal + released; a failed nudge is benign.
+            logger.warning("runtime cancel nudge failed run_id=%s: %s", run_id, exc)
+
+    return updated

--- a/server/proliferate/server/cloud/workflows/models.py
+++ b/server/proliferate/server/cloud/workflows/models.py
@@ -157,6 +157,8 @@ class WorkflowRunResponse(WorkflowBaseModel):
     delivered_at: str | None = Field(alias="deliveredAt")
     started_at: str | None = Field(alias="startedAt")
     finished_at: str | None = Field(alias="finishedAt")
+    # D15: the user who took over / cancelled the run (audit).
+    stopped_by_user_id: str | None = Field(default=None, alias="stoppedByUserId")
 
 
 class StepActionResponse(WorkflowBaseModel):
@@ -261,6 +263,9 @@ def run_payload(record: WorkflowRunRecord) -> WorkflowRunResponse:
         delivered_at=_iso(record.delivered_at),
         started_at=_iso(record.started_at),
         finished_at=_iso(record.finished_at),
+        stopped_by_user_id=(
+            str(record.stopped_by_user_id) if record.stopped_by_user_id else None
+        ),
     )
 
 

--- a/server/proliferate/server/cloud/workflows/service.py
+++ b/server/proliferate/server/cloud/workflows/service.py
@@ -546,6 +546,49 @@ async def start_run(
         namespaces=granted_namespaces(run_scope),
     )
 
+    # B8 session binding validation. (Harness-match stays at the runtime bind
+    # boundary — a hard Malformed-plan error — since the slot->harness fact and the
+    # session's harness both live in the runtime.)
+    if session_bindings:
+        known_slots = {node["slot"] for node in resolved_agents}
+        unknown = sorted(set(session_bindings) - known_slots)
+        if unknown:
+            raise CloudApiError(
+                "unknown_session_binding_slot",
+                f"session_bindings names slots not in this workflow: {unknown}.",
+                status_code=400,
+            )
+        for slot, bound_session_id in session_bindings.items():
+            # (ii) Not already held by a live run: the run row is the durable lock
+            # (C13/E8). Silently re-owning a session another live run holds would
+            # transfer ownership and leak the lockout — reject up front.
+            holding_run_id = await store.live_run_holding_session(
+                db, session_id=bound_session_id
+            )
+            if holding_run_id is not None:
+                raise CloudApiError(
+                    "session_binding_held",
+                    f"session bound to slot '{slot}' is already held by live "
+                    f"workflow run {holding_run_id}.",
+                    status_code=409,
+                )
+            # (i) Belongs to the target workspace: if run history places the
+            # session in a different workspace, reject (the runtime bind boundary
+            # is the authoritative backstop for sessions with no history).
+            if cloud_anyharness_workspace_id is not None:
+                foreign_workspace = await store.session_foreign_workspace(
+                    db,
+                    session_id=bound_session_id,
+                    target_workspace_id=cloud_anyharness_workspace_id,
+                )
+                if foreign_workspace is not None:
+                    raise CloudApiError(
+                        "session_binding_wrong_workspace",
+                        f"session bound to slot '{slot}' belongs to a different "
+                        "workspace than this run's target.",
+                        status_code=409,
+                    )
+
     run_id = uuid4()
     resolved_plan = _resolve_plan(
         run_id=run_id,

--- a/server/tests/unit/test_workflow_service.py
+++ b/server/tests/unit/test_workflow_service.py
@@ -7,7 +7,9 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.constants.workflows import WORKFLOW_TRIGGER_MANUAL
 from proliferate.db.models.auth import User
+from proliferate.db.store import cloud_workflows as store
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.server.cloud.errors import CloudApiError
@@ -246,6 +248,126 @@ async def test_cannot_run_archived_workflow(db_session: AsyncSession) -> None:
             db_session, user, workflow.id, inputs={"issue": "x"}, target_mode="local"
         )
     assert exc.value.code == "workflow_archived"
+
+
+async def _seed_run(
+    db: AsyncSession,
+    user: User,
+    workflow,
+    *,
+    resolved_plan_json: dict,
+    anyharness_workspace_id: str | None = None,
+    anyharness_session_ids: list[str] | None = None,
+    status: str | None = None,
+):
+    run = await store.create_run(
+        db,
+        workflow_id=workflow.id,
+        workflow_version_id=workflow.current_version_id,
+        trigger_kind=WORKFLOW_TRIGGER_MANUAL,
+        executor_user_id=user.id,
+        args_json={},
+        target_mode="local",
+        resolved_plan_json=resolved_plan_json,
+        anyharness_workspace_id=anyharness_workspace_id,
+    )
+    if anyharness_session_ids is not None or status is not None:
+        await store.update_run(
+            db,
+            run_id=run.id,
+            anyharness_session_ids=anyharness_session_ids,
+            status=status,
+        )
+    return run
+
+
+async def test_start_run_rejects_binding_held_by_live_run(db_session: AsyncSession) -> None:
+    # B8/E8: a session already held by a non-terminal ("live") run cannot be bound
+    # to a new run — silently re-owning it would transfer ownership and leak the
+    # lockout. The run row is the durable lock, so this is caught server-side.
+    user = await _make_user(db_session)
+    workflow, _ = await _create_workflow(db_session, user)
+    await _seed_run(
+        db_session,
+        user,
+        workflow,
+        resolved_plan_json={"sessions": {"main": {"bind_session_id": "sess-held"}}},
+    )
+    with pytest.raises(CloudApiError) as exc:
+        await service.start_run(
+            db_session,
+            user,
+            workflow.id,
+            inputs={"issue": "x"},
+            target_mode="local",
+            session_bindings={"main": "sess-held"},
+        )
+    assert exc.value.code == "session_binding_held"
+
+
+async def test_start_run_rejects_binding_slot_not_in_workflow(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    workflow, _ = await _create_workflow(db_session, user)
+    with pytest.raises(CloudApiError) as exc:
+        await service.start_run(
+            db_session,
+            user,
+            workflow.id,
+            inputs={"issue": "x"},
+            target_mode="local",
+            session_bindings={"ghost": "sess-x"},
+        )
+    assert exc.value.code == "unknown_session_binding_slot"
+
+
+async def test_live_run_holding_session_detects_created_and_bound(
+    db_session: AsyncSession,
+) -> None:
+    user = await _make_user(db_session)
+    workflow, _ = await _create_workflow(db_session, user)
+    # A session a live run created (reported in anyharness_session_ids) is held.
+    await _seed_run(
+        db_session,
+        user,
+        workflow,
+        resolved_plan_json={"sessions": {"main": {}}},
+        anyharness_session_ids=["sess-created"],
+    )
+    assert await store.live_run_holding_session(db_session, session_id="sess-created") is not None
+    assert await store.live_run_holding_session(db_session, session_id="sess-none") is None
+
+
+async def test_session_foreign_workspace_flags_cross_workspace(db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    workflow, _ = await _create_workflow(db_session, user)
+    await _seed_run(
+        db_session,
+        user,
+        workflow,
+        resolved_plan_json={"sessions": {"main": {}}},
+        anyharness_workspace_id="ws-A",
+        anyharness_session_ids=["sess-1"],
+    )
+    # Belongs to ws-A: targeting ws-B is a conflict; targeting ws-A is fine.
+    assert (
+        await store.session_foreign_workspace(
+            db_session, session_id="sess-1", target_workspace_id="ws-B"
+        )
+        == "ws-A"
+    )
+    assert (
+        await store.session_foreign_workspace(
+            db_session, session_id="sess-1", target_workspace_id="ws-A"
+        )
+        is None
+    )
+    # A session with no run history is unknown server-side (runtime backstop).
+    assert (
+        await store.session_foreign_workspace(
+            db_session, session_id="sess-unknown", target_workspace_id="ws-B"
+        )
+        is None
+    )
 
 
 async def test_visibility_isolates_owners(db_session: AsyncSession) -> None:

--- a/specs/generated/anyharness-db-schema.sql
+++ b/specs/generated/anyharness-db-schema.sql
@@ -506,6 +506,19 @@ CREATE TABLE workflow_runs (
     updated_at TEXT NOT NULL
 );
 
+-- table: workflow_session_injections
+CREATE TABLE workflow_session_injections (
+    session_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_key TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    label TEXT NOT NULL,
+    injected_text TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, turn_id)
+);
+
 -- table: workflow_step_runs
 CREATE TABLE workflow_step_runs (
     run_id TEXT NOT NULL REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
@@ -755,6 +768,10 @@ CREATE INDEX idx_terminal_command_runs_workspace_activity
 -- index: idx_terminal_command_runs_workspace_created
 CREATE INDEX idx_terminal_command_runs_workspace_created
     ON terminal_command_runs(workspace_id, created_at DESC);
+
+-- index: idx_workflow_injections_run
+CREATE INDEX idx_workflow_injections_run
+    ON workflow_session_injections(run_id, step_key);
 
 -- index: idx_workflow_runs_status
 CREATE INDEX idx_workflow_runs_status


### PR DESCRIPTION
Part of the workflows core-engine amendments stack (Gate 0). Builds the session plane on top of PR E.

- **B8 session binding (L29)** — StartRun `session_bindings`; server validates the bound session belongs to the target workspace + harness matches + is not already held by a live run; runtime loads the existing session for a bound slot and refuses to re-own a session held by another run.
- **C10 provenance (E9, stamp-at-write-time)** — executor uses the internal provenance-carrying prompt path; new `PromptProvenance::Workflow{run_id,step_key,kind,label}` replaces the dead `Automation` variant (rides the event payload, live + persisted); `workflow_session_injections` SQLite table (migration 0054) written alongside `begin_step`. No read-path join.
- **C13 lockout (E8)** — held sessions block ALL mutating verbs (incl. edit/delete pending prompt) with typed 409 `SESSION_WORKFLOW_HELD` (not 500); reads stay open. Release is derived from terminal run status.
- **D15 take-over/cancel** — server cancel endpoint + `stopped_by_user_id`; terminal = keep-alive + demote (addendum item 4): unmark bypass registry (item 3), restore worker gateway binding (item 2), never close sessions.

Gate A: verify green (cargo 893, workflow pytest green), adversarial review passed after fixing the C13 pending-prompt lockout hole + B8 double-owner bug (both re-confirmed). One commit; standalone-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)