### PR TITLE
feat(workflows): PR G — trigger repo pin + derived workspace + run-token status auth

### DIFF
--- a/apps/desktop/src/components/playground/workflows/WorkflowFormsFixtures.tsx
+++ b/apps/desktop/src/components/playground/workflows/WorkflowFormsFixtures.tsx
@@ -15,6 +15,7 @@ import {
   TriggerBadgeRow,
   TriggerForm,
   type TriggerDraft,
+  type WorkflowTriggerRepoOption,
   type WorkflowTriggerResponse,
 } from "@/components/workflows/editor/WorkflowTriggersCard";
 import { presetForRrule } from "@/lib/domain/automations/schedule/schedule";
@@ -28,6 +29,12 @@ const AGENTS: EditorAgent[] = [
 const CLOUD_WORKSPACES: WorkflowRunTargetOption[] = [
   { id: "ws-1", label: "proliferate · cloud" },
   { id: "ws-2", label: "web · cloud" },
+];
+
+// D16: triggers pin a repo; the server derives + owns the workspace.
+const REPO_OPTIONS: WorkflowTriggerRepoOption[] = [
+  { fullName: "acme/proliferate", label: "acme/proliferate" },
+  { fullName: "acme/web", label: "acme/web" },
 ];
 
 const ARGS: WorkflowArgSpec[] = [
@@ -45,7 +52,9 @@ function makeTrigger(overrides: Partial<WorkflowTriggerResponse>): WorkflowTrigg
     enabled: true,
     concurrencyPolicy: "skip",
     targetMode: "personal_cloud",
+    repoFullName: "acme/proliferate",
     targetWorkspaceId: "ws-1",
+    inputPresets: {},
     schedule: { rrule: DAILY_RRULE, timezone: "America/Los_Angeles", summary: "Every day at 9:00 AM" },
     nextRunAt: "2026-07-04T16:00:00Z",
     lastScheduledAt: null,
@@ -118,7 +127,7 @@ export function WorkflowFormsFixtures() {
     pollIntervalSecs: 300,
     concurrency: "skip",
     enabled: true,
-    workspaceId: "ws-1",
+    repoFullName: "acme/proliferate",
     argValues: { pr_number: "912", env: "staging" },
   });
   const patchDraft = (patch: Partial<TriggerDraft>) => setDraft((prev) => ({ ...prev, ...patch }));
@@ -136,7 +145,7 @@ export function WorkflowFormsFixtures() {
     pollIntervalSecs: 300,
     concurrency: "queue",
     enabled: true,
-    workspaceId: "ws-1",
+    repoFullName: "acme/proliferate",
     argValues: { pr_number: "", env: "staging" },
   });
   const patchPollDraft = (patch: Partial<TriggerDraft>) => setPollDraft((prev) => ({ ...prev, ...patch }));
@@ -167,7 +176,6 @@ export function WorkflowFormsFixtures() {
           <span className="text-sm font-medium text-foreground">Triggers — schedule + poll chips, poll error caption</span>
           <TriggerBadgeRow
             triggers={TRIGGERS}
-            cloudWorkspaces={CLOUD_WORKSPACES}
             activeId={undefined}
             addingKind={null}
             addDisabled={false}
@@ -178,7 +186,7 @@ export function WorkflowFormsFixtures() {
           <TriggerForm
             draft={draft}
             args={args}
-            cloudWorkspaces={CLOUD_WORKSPACES}
+            repoOptions={REPO_OPTIONS}
             error={null}
             busy={false}
             isEdit
@@ -196,7 +204,7 @@ export function WorkflowFormsFixtures() {
           <TriggerForm
             draft={pollDraft}
             args={args}
-            cloudWorkspaces={CLOUD_WORKSPACES}
+            repoOptions={REPO_OPTIONS}
             error={null}
             busy={false}
             isEdit
@@ -213,7 +221,6 @@ export function WorkflowFormsFixtures() {
           <span className="text-sm font-medium text-foreground">Triggers — no cloud workspace</span>
           <TriggerBadgeRow
             triggers={[]}
-            cloudWorkspaces={[]}
             activeId={undefined}
             addingKind={null}
             addDisabled

--- a/apps/desktop/src/components/workflows/editor/WorkflowTriggersCard.tsx
+++ b/apps/desktop/src/components/workflows/editor/WorkflowTriggersCard.tsx
@@ -19,7 +19,6 @@ import {
   type AutomationSchedulePresetOrCustom,
 } from "@/lib/domain/automations/schedule/schedule";
 import { AutomationSchedulePopover } from "@/components/automations/editor/AutomationEditorControls";
-import type { WorkflowRunTargetOption } from "@/components/workflows/home/WorkflowRunArgsModal";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { Label } from "@proliferate/ui/primitives/Label";
@@ -36,12 +35,20 @@ type ArgValue = string | number | boolean;
 type Concurrency = "skip" | "queue";
 export type TriggerKind = "schedule" | "poll";
 
+/** D16: a repo the trigger can pin ("owner/name"). The server derives + owns the
+ * cloud workspace from it; the definition never names a workspace. */
+export interface WorkflowTriggerRepoOption {
+  fullName: string;
+  label: string;
+}
+
 export interface WorkflowTriggersCardProps {
   workflowId: string;
   /** The workflow's declared args — a scheduled/poll run fires with fixed/mapped values. */
   args: readonly WorkflowInputSpec[];
-  /** The owner's ready cloud workspaces (schedule + poll runs are cloud-only in v1). */
-  cloudWorkspaces: readonly WorkflowRunTargetOption[];
+  /** D16: the repos the owner can pin (schedule + poll runs are cloud-only in v1;
+   * the server derives the warm workspace from the pin). */
+  repoOptions: readonly WorkflowTriggerRepoOption[];
   /** Deep-link a poll item's spawned run (spec 8.2 row B). Omit to hide the link. */
   onOpenRun?: (runId: string) => void;
 }
@@ -82,14 +89,14 @@ export interface TriggerDraft {
   // common
   concurrency: Concurrency;
   enabled: boolean;
-  workspaceId: string;
+  repoFullName: string;
   argValues: Record<string, ArgValue>;
 }
 
 function draftFromTrigger(
   trigger: WorkflowTriggerResponse | null,
   args: readonly WorkflowInputSpec[],
-  cloudWorkspaces: readonly WorkflowRunTargetOption[],
+  repoOptions: readonly WorkflowTriggerRepoOption[],
   fallbackKind: TriggerKind,
 ): TriggerDraft {
   const kind: TriggerKind = (trigger?.kind as TriggerKind | undefined) ?? fallbackKind;
@@ -112,7 +119,7 @@ function draftFromTrigger(
     pollIntervalSecs: trigger?.poll?.intervalSecs ?? POLL_MIN_INTERVAL_SECS,
     concurrency: (trigger?.concurrencyPolicy as Concurrency) ?? "skip",
     enabled: trigger?.enabled ?? true,
-    workspaceId: trigger?.targetWorkspaceId ?? cloudWorkspaces[0]?.id ?? "",
+    repoFullName: trigger?.repoFullName ?? repoOptions[0]?.fullName ?? "",
     argValues,
   };
 }
@@ -135,7 +142,7 @@ function coerceArg(arg: WorkflowInputSpec, value: ArgValue): ArgValue {
 export function WorkflowTriggersCard({
   workflowId,
   args,
-  cloudWorkspaces,
+  repoOptions,
   onOpenRun,
 }: WorkflowTriggersCardProps) {
   const triggersQuery = useWorkflowTriggers(workflowId);
@@ -144,7 +151,7 @@ export function WorkflowTriggersCard({
 
   const triggers = triggersQuery.data ?? [];
   const pollTriggers = triggers.filter((t) => t.kind === "poll");
-  const cloudAvailable = cloudWorkspaces.length > 0;
+  const cloudAvailable = repoOptions.length > 0;
 
   const [editing, setEditing] = useState<{ id: string | null } | null>(null);
   const [draft, setDraft] = useState<TriggerDraft | null>(null);
@@ -153,7 +160,7 @@ export function WorkflowTriggersCard({
   const openForm = (trigger: WorkflowTriggerResponse | null, kind: TriggerKind = "schedule") => {
     setError(null);
     setEditing({ id: trigger?.id ?? null });
-    setDraft(draftFromTrigger(trigger, args, cloudWorkspaces, kind));
+    setDraft(draftFromTrigger(trigger, args, repoOptions, kind));
   };
 
   const closeForm = () => {
@@ -169,8 +176,8 @@ export function WorkflowTriggersCard({
 
   const submit = () => {
     if (!draft) return;
-    if (!draft.workspaceId) {
-      setError(`Choose a cloud workspace for the ${draft.kind === "poll" ? "polled" : "scheduled"} run.`);
+    if (!draft.repoFullName) {
+      setError(`Pin a repository for the ${draft.kind === "poll" ? "polled" : "scheduled"} run.`);
       return;
     }
 
@@ -204,7 +211,7 @@ export function WorkflowTriggersCard({
         enabled: draft.enabled,
         concurrencyPolicy: draft.concurrency,
         targetMode: "personal_cloud",
-        targetWorkspaceId: draft.workspaceId,
+        repoFullName: draft.repoFullName,
         poll: {
           url,
           authHeader: authHeader || null,
@@ -225,11 +232,13 @@ export function WorkflowTriggersCard({
       return;
     }
 
+    // D16 enable-gate: an enabled schedule must preset every required input; a
+    // disabled draft may leave them blank (the server enforces the same gate).
     const missing = args.find(
       (arg) => arg.required && (draft.argValues[arg.name] === "" || draft.argValues[arg.name] === undefined),
     );
-    if (missing) {
-      setError(`Provide a value for the required argument "${missing.name}".`);
+    if (draft.enabled && missing) {
+      setError(`Preset the required input "${missing.name}" before enabling this schedule.`);
       return;
     }
     const argsBody: Record<string, ArgValue> = {};
@@ -242,7 +251,7 @@ export function WorkflowTriggersCard({
       enabled: draft.enabled,
       concurrencyPolicy: draft.concurrency,
       targetMode: "personal_cloud",
-      targetWorkspaceId: draft.workspaceId,
+      repoFullName: draft.repoFullName,
       schedule: { rrule: draft.rrule, timezone: draft.timezone },
       args: argsBody,
     };
@@ -265,7 +274,6 @@ export function WorkflowTriggersCard({
 
       <TriggerBadgeRow
         triggers={triggers}
-        cloudWorkspaces={cloudWorkspaces}
         activeId={editing?.id ?? undefined}
         addingKind={editing !== null && editing.id === null ? draft?.kind ?? null : null}
         addDisabled={!cloudAvailable}
@@ -275,8 +283,8 @@ export function WorkflowTriggersCard({
 
       {!cloudAvailable ? (
         <p className="text-xs text-faint">
-          Scheduled and poll runs execute in the cloud. Create a cloud workspace to trigger this
-          workflow that way; local triggers are coming — run it manually for now.
+          Scheduled and poll runs execute in the cloud. Configure a cloud repository to trigger
+          this workflow that way; local triggers are coming — run it manually for now.
         </p>
       ) : (
         <p className="text-xs text-faint">Runs manually from here or the runs list; schedules and polls fire in the cloud.</p>
@@ -294,7 +302,7 @@ export function WorkflowTriggersCard({
         <TriggerForm
           draft={draft}
           args={args}
-          cloudWorkspaces={cloudWorkspaces}
+          repoOptions={repoOptions}
           error={error}
           busy={busy}
           isEdit={editing.id !== null}
@@ -312,7 +320,6 @@ export function WorkflowTriggersCard({
 
 interface TriggerBadgeRowProps {
   triggers: readonly WorkflowTriggerResponse[];
-  cloudWorkspaces: readonly WorkflowRunTargetOption[];
   activeId?: string | null;
   /** The kind currently being added via the inline "+ Add" form, if any. */
   addingKind: TriggerKind | null;
@@ -324,7 +331,6 @@ interface TriggerBadgeRowProps {
 /** The Ona-style chip row: Manual + schedule/poll chips + disabled "soon" chips + add buttons. */
 export function TriggerBadgeRow({
   triggers,
-  cloudWorkspaces,
   activeId,
   addingKind,
   addDisabled,
@@ -342,9 +348,7 @@ export function TriggerBadgeRow({
         <TriggerChip
           key={trigger.id}
           trigger={trigger}
-          workspaceLabel={
-            cloudWorkspaces.find((w) => w.id === trigger.targetWorkspaceId)?.label ?? "cloud workspace"
-          }
+          repoLabel={trigger.repoFullName ?? "cloud repository"}
           active={trigger.id === activeId}
           onClick={() => onEditTrigger(trigger)}
         />
@@ -403,12 +407,12 @@ function AddTriggerButton({
 
 function TriggerChip({
   trigger,
-  workspaceLabel,
+  repoLabel,
   active,
   onClick,
 }: {
   trigger: WorkflowTriggerResponse;
-  workspaceLabel: string;
+  repoLabel: string;
   active: boolean;
   onClick: () => void;
 }) {
@@ -420,8 +424,8 @@ function TriggerChip({
     ? formatAutomationTimestamp(trigger.nextRunAt ?? null, trigger.schedule?.timezone)
     : null;
   const title = isPoll
-    ? `${workspaceLabel}${trigger.poll?.lastPollError ? ` · last error: ${trigger.poll.lastPollError}` : ""}`
-    : `${workspaceLabel}${trigger.lastSkipReason ? ` · last skipped: ${trigger.lastSkipReason}` : ""}`;
+    ? `${repoLabel}${trigger.poll?.lastPollError ? ` · last error: ${trigger.poll.lastPollError}` : ""}`
+    : `${repoLabel}${trigger.lastSkipReason ? ` · last skipped: ${trigger.lastSkipReason}` : ""}`;
   return (
     <button
       type="button"
@@ -557,7 +561,7 @@ function TriggerItemsList({
 interface TriggerFormProps {
   draft: TriggerDraft;
   args: readonly WorkflowInputSpec[];
-  cloudWorkspaces: readonly WorkflowRunTargetOption[];
+  repoOptions: readonly WorkflowTriggerRepoOption[];
   error: string | null;
   busy: boolean;
   isEdit: boolean;
@@ -574,7 +578,7 @@ interface TriggerFormProps {
 export function TriggerForm({
   draft,
   args,
-  cloudWorkspaces,
+  repoOptions,
   error,
   busy,
   isEdit,
@@ -594,9 +598,9 @@ export function TriggerForm({
       ) : null}
 
       {draft.kind === "poll" ? (
-        <PollFields draft={draft} cloudWorkspaces={cloudWorkspaces} isEdit={isEdit} onPatch={onPatch} />
+        <PollFields draft={draft} repoOptions={repoOptions} isEdit={isEdit} onPatch={onPatch} />
       ) : (
-        <ScheduleFields draft={draft} cloudWorkspaces={cloudWorkspaces} onPatch={onPatch} />
+        <ScheduleFields draft={draft} repoOptions={repoOptions} onPatch={onPatch} />
       )}
 
       {args.length > 0 ? (
@@ -660,11 +664,11 @@ export function TriggerForm({
 
 function ScheduleFields({
   draft,
-  cloudWorkspaces,
+  repoOptions,
   onPatch,
 }: {
   draft: TriggerDraft;
-  cloudWorkspaces: readonly WorkflowRunTargetOption[];
+  repoOptions: readonly WorkflowTriggerRepoOption[];
   onPatch: (patch: Partial<TriggerDraft>) => void;
 }) {
   return (
@@ -685,12 +689,12 @@ function ScheduleFields({
         </span>
       </div>
       <div className="flex min-w-0 flex-col gap-1.5">
-        <Label>Cloud workspace</Label>
+        <Label>Repository</Label>
         <WorkflowSelect
-          ariaLabel="Cloud workspace"
-          value={draft.workspaceId}
-          options={cloudWorkspaces.map((workspace) => ({ value: workspace.id, label: workspace.label }))}
-          onChange={(value) => onPatch({ workspaceId: value })}
+          ariaLabel="Repository"
+          value={draft.repoFullName}
+          options={repoOptions.map((repo) => ({ value: repo.fullName, label: repo.label }))}
+          onChange={(value) => onPatch({ repoFullName: value })}
         />
       </div>
     </div>
@@ -699,12 +703,12 @@ function ScheduleFields({
 
 function PollFields({
   draft,
-  cloudWorkspaces,
+  repoOptions,
   isEdit,
   onPatch,
 }: {
   draft: TriggerDraft;
-  cloudWorkspaces: readonly WorkflowRunTargetOption[];
+  repoOptions: readonly WorkflowTriggerRepoOption[];
   isEdit: boolean;
   onPatch: (patch: Partial<TriggerDraft>) => void;
 }) {
@@ -722,12 +726,12 @@ function PollFields({
           />
         </div>
         <div className="flex min-w-0 flex-col gap-1.5">
-          <Label>Cloud workspace</Label>
+          <Label>Repository</Label>
           <WorkflowSelect
-            ariaLabel="Cloud workspace"
-            value={draft.workspaceId}
-            options={cloudWorkspaces.map((workspace) => ({ value: workspace.id, label: workspace.label }))}
-            onChange={(value) => onPatch({ workspaceId: value })}
+            ariaLabel="Repository"
+            value={draft.repoFullName}
+            options={repoOptions.map((repo) => ({ value: repo.fullName, label: repo.label }))}
+            onChange={(value) => onPatch({ repoFullName: value })}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
+++ b/apps/desktop/src/components/workflows/screen/WorkflowEditorScreen.tsx
@@ -38,7 +38,10 @@ import { harnessSupportsGoals } from "@/lib/domain/workflows/goal-capability";
 import { WorkflowMetaCard } from "../editor/WorkflowMetaCard";
 import { WorkflowSetupCard } from "../editor/WorkflowSetupCard";
 import { WorkflowScopeHeader } from "../editor/WorkflowScopeHeader";
-import { WorkflowTriggersCard } from "../editor/WorkflowTriggersCard";
+import {
+  WorkflowTriggersCard,
+  type WorkflowTriggerRepoOption,
+} from "../editor/WorkflowTriggersCard";
 import {
   WorkflowFunctionsCard,
   type WorkflowFunctionProviderOption,
@@ -159,6 +162,17 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
         })),
     [cloudTargetsQuery.data],
   );
+
+  // D16: triggers pin a repo (the server derives + owns the workspace). The repo
+  // options are the unique "owner/name" repos the owner's cloud workspaces cover.
+  const triggerRepoOptions = useMemo<WorkflowTriggerRepoOption[]>(() => {
+    const seen = new Map<string, WorkflowTriggerRepoOption>();
+    for (const workspace of cloudTargetsQuery.data ?? []) {
+      const fullName = `${workspace.repo.owner}/${workspace.repo.name}`;
+      if (!seen.has(fullName)) seen.set(fullName, { fullName, label: fullName });
+    }
+    return [...seen.values()];
+  }, [cloudTargetsQuery.data]);
 
   // Gateway function providers (spec 6.1/6.3, L21): the owner's visible
   // integrations, restricted client-side to the launch set (issues, slack) —
@@ -396,7 +410,7 @@ export function WorkflowEditorScreen({ workflowId }: WorkflowEditorScreenProps) 
               <WorkflowTriggersCard
                 workflowId={workflowId}
                 args={definition.args}
-                cloudWorkspaces={cloudWorkspaceOptions}
+                repoOptions={triggerRepoOptions}
                 onOpenRun={(runId) => navigate(`/workflows/${workflowId}/runs/${runId}`)}
               />
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1649,6 +1649,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/workflows/runs/{run_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Run Endpoint
+         * @description Take over / cancel a run (D15). User auth, owner-scoped (a run the caller
+         *     can't see 404s). This is the single human override; the UI's take-over action
+         *     routes here, and a blocked mutating verb's 409 ``SESSION_WORKFLOW_HELD`` sends
+         *     the user to it.
+         */
+        post: operations["cancel_run_endpoint_v1_cloud_workflows_runs__run_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/workflows/runs/{run_id}/deliver": {
         parameters: {
             query?: never;
@@ -5546,6 +5569,8 @@ export interface components {
             startedAt: string | null;
             /** Finishedat */
             finishedAt: string | null;
+            /** Stoppedbyuserid */
+            stoppedByUserId?: string | null;
         };
         /**
          * WorkflowRunTarget
@@ -5582,8 +5607,8 @@ export interface components {
              * @enum {string}
              */
             targetMode: "local" | "personal_cloud";
-            /** Targetworkspaceid */
-            targetWorkspaceId?: string | null;
+            /** Repofullname */
+            repoFullName?: string | null;
             schedule?: components["schemas"]["TriggerScheduleRequest"] | null;
             poll?: components["schemas"]["TriggerPollRequest"] | null;
             /** Args */
@@ -5631,8 +5656,14 @@ export interface components {
             concurrencyPolicy: string;
             /** Targetmode */
             targetMode: string;
+            /** Repofullname */
+            repoFullName: string | null;
             /** Targetworkspaceid */
             targetWorkspaceId: string | null;
+            /** Inputpresets */
+            inputPresets?: {
+                [key: string]: unknown;
+            } | null;
             schedule: components["schemas"]["TriggerScheduleResponse"] | null;
             poll?: components["schemas"]["TriggerPollResponse"] | null;
             /** Nextrunat */
@@ -5664,8 +5695,8 @@ export interface components {
             concurrencyPolicy?: ("skip" | "queue") | null;
             /** Targetmode */
             targetMode?: ("local" | "personal_cloud") | null;
-            /** Targetworkspaceid */
-            targetWorkspaceId?: string | null;
+            /** Repofullname */
+            repoFullName?: string | null;
             schedule?: components["schemas"]["TriggerScheduleRequest"] | null;
             poll?: components["schemas"]["TriggerPollRequest"] | null;
             /** Args */
@@ -9399,6 +9430,37 @@ export interface operations {
                 "application/json": components["schemas"]["RunStatusRequest"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowRunResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_run_endpoint_v1_cloud_workflows_runs__run_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/codex/workflows-deep-dive.md
+++ b/codex/workflows-deep-dive.md
@@ -252,10 +252,24 @@ Index("uq_workflow_run_trigger_slot", "trigger_id", "scheduled_for", unique=True
   'poll')` (widened PR B), `concurrency_policy IN ('skip','queue')`,
   `target_mode IN ('local','personal_cloud')`, a cloud⇒workspace / local⇒null
   constraint (line 225), `ck_workflow_trigger_schedule_fields` (line 237 — a
-  `schedule` must carry rrule + timezone + next_run_at), and — PR B —
+  `schedule` must carry rrule + timezone + next_run_at), — PR B —
   `ck_workflow_trigger_poll_fields` (line 242 — a `poll` must carry `poll_url` +
-  `poll_interval_secs`). Scheduler due-scan index `ix_workflow_trigger_scheduler_due`
-  (line 248). Poll columns (line 305) — endpoint, auth header *name*,
+  `poll_interval_secs`), and — **PR G (D16)** — `ck_workflow_trigger_repo_full_name`
+  (a schedule/poll trigger must pin `repo_full_name`). Scheduler due-scan index
+  `ix_workflow_trigger_scheduler_due` (line 248).
+  **D16 repo pin (PR G):** `repo_full_name` ("org/repo") is the *authored* "where";
+  `target_workspace_id` becomes **derived** — on trigger create/update the service
+  resolves the caller's cloud repo environment for the pin and ensures a dedicated
+  server-owned cloud workspace (reuse the repo's warm workspace, else provision the
+  row via `cloud_workspaces.create_cloud_workspace`), stamping its id. Worktree
+  materialization is NOT forced at save — `start_run` still raises
+  `target_workspace_not_ready` until the runtime workspace is ready, so that 409 is
+  a retry-at-fire concern, not a save error. The trigger-fire path is unchanged (it
+  passes the pinned id into `start_run`). `input_presets_json` records the schedule
+  preset input values behind the **enable-gate**: a schedule trigger cannot be
+  `enabled` until every required workflow input has a preset (`schedule_presets_incomplete`
+  400); a disabled draft may leave them blank. For schedule triggers the presets
+  mirror `args_json` (the fire-time args). Poll columns (line 305) — endpoint, auth header *name*,
   Fernet-encrypted auth header *value* (`poll_auth_ciphertext`, house crypto
   helpers, never surfaced on reads), interval, item JSON Schema *derived from the
   workflow inputs* (D17 — no `poll_args_mapping_json`, dropped in-migration),
@@ -754,15 +768,15 @@ after 3 consecutive failures.
 | POST | `/workflows` | create (enforces free-plan cap) |
 | GET | `/workflows/runs?workflowId` | run list |
 | GET | `/workflows/runs/{run_id}` | run detail — `WorkflowRunDetailResponse{run, stepActions[]}` (PR A; `step_actions` from `store.list_actions_for_run`) |
-| POST | `/workflows/runs/{run_id}/delivered` | **local** lane marks its delivery done |
-| POST | `/workflows/runs/{run_id}/status` | **local relay** reports observed state; also triggers `apply_step_actions` |
+| POST | `/workflows/runs/{run_id}/delivered` | marks delivery done. **D18 (E7):** auth is EITHER the per-run gateway token (anyharness) OR a user session (desktop local-lane relay); a valid token for another run → 403, no credential → 401 |
+| POST | `/workflows/runs/{run_id}/status` | reports observed state; also triggers `apply_step_actions`. **D18 (E7):** same dual auth as `/delivered` — the run token proves the writer IS the runtime (closes the spoofing hole where any logged-in owner could move the run), user session stays for the local relay |
 | POST | `/workflows/runs/{run_id}/deliver` | **cloud** lane retry of stuck `pending_delivery` |
 | GET | `/workflows/runs/{run_id}/refresh` | **cloud** lane pull; syncs ledger; also triggers `apply_step_actions` |
 | POST | `/workflows/runs/{run_id}/ping` | PR E (§3.4a) — completion ping; **no user session**, auth is the per-run gateway token; token↔run_id must match (else 403); cloud lane triggers `refresh_cloud_run`, local lane 202-no-ops; always 202 on valid token |
 | GET | `/workflows/slack/channels` | PR A — `{channels:[{id,name}], connected}`; `connected:false` + empty list when the actor has no ready Slack account ([integrations accounts store](../server/proliferate/db/store/integrations/accounts.py)) |
 | GET/PATCH/DELETE | `/workflows/{workflow_id}` | detail / update (append version) / archive |
 | POST | `/workflows/{workflow_id}/runs` | **StartRun**; personal_cloud also calls `deliver_cloud_run` in-request |
-| GET/POST · GET/PATCH/DELETE | `/workflows/{workflow_id}/triggers[/{trigger_id}]` | trigger CRUD — `kind:"schedule"\|"poll"`; a `poll` body carries `poll:{url, authHeader?, authValue?(write-only), intervalSecs}` (no item-schema/args-mapping authoring — D17), reads return `poll:{..., hasAuth, itemSchema(derived, read-only), lastPollAt, lastPollError}` (never the secret) |
+| GET/POST · GET/PATCH/DELETE | `/workflows/{workflow_id}/triggers[/{trigger_id}]` | trigger CRUD — `kind:"schedule"\|"poll"`; **D16 (PR G):** the body pins `repoFullName` ("org/repo", authored; `targetWorkspaceId` is gone) and the server derives + returns `targetWorkspaceId`; `args` are the schedule presets and reads return `repoFullName`, `inputPresets`; a `poll` body carries `poll:{url, authHeader?, authValue?(write-only), intervalSecs}` (no item-schema/args-mapping authoring — D17), reads return `poll:{..., hasAuth, itemSchema(derived, read-only), lastPollAt, lastPollError}` (never the secret) |
 | GET | `/workflows/{workflow_id}/triggers/{trigger_id}/items` | PR B — a poll trigger's seen-set, paginated (`limit`/`offset`), newest first: `{items:[{itemId, runId, status, errorMessage, receivedAt}]}` |
 
 **No server-side cancel/pause endpoint** — cancel is a runtime concern

--- a/server/alembic/versions/c5e7a9b1d3f0_workflow_trigger_repo_pin.py
+++ b/server/alembic/versions/c5e7a9b1d3f0_workflow_trigger_repo_pin.py
@@ -1,0 +1,72 @@
+"""workflow_trigger repo pin + input presets (D16)
+
+Revision ID: c5e7a9b1d3f0
+Revises: a7b9c1d3e5f7
+Create Date: 2026-07-09 01:00:00.000000
+
+PR G (D16): the trigger — not the definition — knows *where* an unattended run
+works. ``repo_full_name`` ("org/repo") becomes the authored concept for
+schedule/poll triggers (CHECK-required for those kinds); ``target_workspace_id``
+stays but is now DERIVED — the server ensures a dedicated cloud workspace for the
+pinned repo and stamps its id. ``input_presets_json`` records the schedule preset
+input values that back the enable-gate (a schedule trigger cannot be enabled until
+every required workflow input has a preset). Idempotent-guarded like the stack.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c5e7a9b1d3f0"
+down_revision: str | Sequence[str] | None = "a7b9c1d3e5f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def _has_check(table_name: str, constraint_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_check_constraints(table_name)
+    }
+
+
+def upgrade() -> None:
+    if not _has_column("workflow_trigger", "repo_full_name"):
+        op.add_column(
+            "workflow_trigger",
+            sa.Column("repo_full_name", sa.String(length=255), nullable=True),
+        )
+    if not _has_column("workflow_trigger", "input_presets_json"):
+        op.add_column(
+            "workflow_trigger",
+            sa.Column("input_presets_json", JSONB(), nullable=True),
+        )
+    # A schedule/poll trigger must pin a repo — it is the authored source of the
+    # derived warm workspace. (target_workspace_id stays derived, so its own CHECK
+    # is unchanged.)
+    if not _has_check("workflow_trigger", "ck_workflow_trigger_repo_full_name"):
+        op.create_check_constraint(
+            "ck_workflow_trigger_repo_full_name",
+            "workflow_trigger",
+            "kind NOT IN ('schedule', 'poll') OR repo_full_name IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    if _has_check("workflow_trigger", "ck_workflow_trigger_repo_full_name"):
+        op.drop_constraint(
+            "ck_workflow_trigger_repo_full_name", "workflow_trigger", type_="check"
+        )
+    if _has_column("workflow_trigger", "input_presets_json"):
+        op.drop_column("workflow_trigger", "input_presets_json")
+    if _has_column("workflow_trigger", "repo_full_name"):
+        op.drop_column("workflow_trigger", "repo_full_name")

--- a/server/proliferate/db/models/cloud/workflows.py
+++ b/server/proliferate/db/models/cloud/workflows.py
@@ -247,6 +247,12 @@ class WorkflowTrigger(Base):
             "kind <> 'poll' OR (poll_url IS NOT NULL AND poll_interval_secs IS NOT NULL)",
             name="ck_workflow_trigger_poll_fields",
         ),
+        # D16: unattended triggers (schedule/poll) pin a repo — it is the authored
+        # source of the derived warm workspace (target_workspace_id).
+        CheckConstraint(
+            "kind NOT IN ('schedule', 'poll') OR repo_full_name IS NOT NULL",
+            name="ck_workflow_trigger_repo_full_name",
+        ),
         Index("ix_workflow_trigger_workflow_id", "workflow_id"),
         Index("ix_workflow_trigger_target_workspace_id", "target_workspace_id"),
         # The scheduler's due scan: enabled schedule triggers whose slot has passed.
@@ -276,13 +282,24 @@ class WorkflowTrigger(Base):
     # triggers on one workflow may target different workspaces and run in parallel.
     concurrency_policy: Mapped[str] = mapped_column(String(16))
     target_mode: Mapped[str] = mapped_column(String(32))
+    # D16: the authored "where" for an unattended run — a "org/repo" pin. Required
+    # for schedule/poll by ck_workflow_trigger_repo_full_name; target_workspace_id
+    # is derived from it (the server owns the warm workspace).
+    repo_full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     # Cloud workspace the scheduled run delivers into (required for personal_cloud).
-    # CASCADE keeps the target-workspace NOT-NULL invariant true if a workspace is
-    # ever hard-deleted (they are normally archived, not deleted).
+    # D16: now DERIVED from repo_full_name — the server ensures a dedicated cloud
+    # workspace for the pinned repo and stamps its id here; it is never authored
+    # directly. CASCADE keeps the target-workspace NOT-NULL invariant true if a
+    # workspace is ever hard-deleted (they are normally archived, not deleted).
     target_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("cloud_workspace.id", ondelete="CASCADE"),
         nullable=True,
     )
+    # D16 schedule enable-gate: the preset input values (mock's ScheduleConfig
+    # presets). A schedule trigger cannot be enabled until every required workflow
+    # input has a preset here. For schedule triggers it mirrors args_json (the
+    # fire-time args); it is the queryable enable-gate record.
+    input_presets_json: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
     # Schedule cursor (reuses the automations RRULE house rules). Nullable at the
     # column level so future non-schedule kinds fit; the CHECK ties them to kind.
     schedule_rrule: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/server/proliferate/db/store/cloud_workflow_triggers.py
+++ b/server/proliferate/db/store/cloud_workflow_triggers.py
@@ -36,7 +36,9 @@ class WorkflowTriggerRecord:
     enabled: bool
     concurrency_policy: str
     target_mode: str
+    repo_full_name: str | None
     target_workspace_id: UUID | None
+    input_presets_json: dict[str, object] | None
     schedule_rrule: str | None
     schedule_timezone: str | None
     schedule_summary: str | None
@@ -116,7 +118,11 @@ def _record(row: WorkflowTrigger) -> WorkflowTriggerRecord:
         enabled=row.enabled,
         concurrency_policy=row.concurrency_policy,
         target_mode=row.target_mode,
+        repo_full_name=row.repo_full_name,
         target_workspace_id=row.target_workspace_id,
+        input_presets_json=(
+            dict(row.input_presets_json) if row.input_presets_json is not None else None
+        ),
         schedule_rrule=row.schedule_rrule,
         schedule_timezone=row.schedule_timezone,
         schedule_summary=row.schedule_summary,
@@ -162,7 +168,9 @@ async def create_trigger(
     kind: str,
     concurrency_policy: str,
     target_mode: str,
+    repo_full_name: str | None = None,
     target_workspace_id: UUID | None,
+    input_presets_json: dict[str, object] | None = None,
     schedule_rrule: str | None = None,
     schedule_timezone: str | None = None,
     schedule_summary: str | None = None,
@@ -183,7 +191,9 @@ async def create_trigger(
         enabled=enabled,
         concurrency_policy=concurrency_policy,
         target_mode=target_mode,
+        repo_full_name=repo_full_name,
         target_workspace_id=target_workspace_id,
+        input_presets_json=input_presets_json,
         schedule_rrule=schedule_rrule,
         schedule_timezone=schedule_timezone,
         schedule_summary=schedule_summary,
@@ -232,8 +242,11 @@ async def update_trigger(
     enabled: bool | None = None,
     concurrency_policy: str | None = None,
     target_mode: str | None = None,
+    repo_full_name: str | None = None,
     target_workspace_id: UUID | None = None,
     clear_target_workspace: bool = False,
+    input_presets_json: dict[str, object] | None = None,
+    write_input_presets: bool = False,
     schedule_rrule: str | None = None,
     schedule_timezone: str | None = None,
     schedule_summary: str | None = None,
@@ -269,10 +282,16 @@ async def update_trigger(
         row.concurrency_policy = concurrency_policy
     if target_mode is not None:
         row.target_mode = target_mode
+    if repo_full_name is not None:
+        row.repo_full_name = repo_full_name
     if clear_target_workspace:
         row.target_workspace_id = None
     elif target_workspace_id is not None:
         row.target_workspace_id = target_workspace_id
+    # write_input_presets lets the caller set presets to a fresh dict (incl. {})
+    # unambiguously; a bare None default means "no change".
+    if write_input_presets:
+        row.input_presets_json = input_presets_json
     if schedule_rrule is not None:
         row.schedule_rrule = schedule_rrule
     if schedule_timezone is not None:

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -86,6 +86,30 @@ async def list_active_workspace_branches_for_repo_environment(
     return {value for value in rows.scalars().all() if value}
 
 
+async def get_active_cloud_workspace_for_repo_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    repo_environment_id: UUID,
+) -> CloudWorkspaceValue | None:
+    """The most-recently-updated non-archived workspace the user owns for a repo
+    environment, or None. Backs D16 trigger derivation (reuse before create)."""
+
+    row = (
+        await db.execute(
+            select(CloudWorkspace)
+            .where(
+                CloudWorkspace.owner_user_id == user_id,
+                CloudWorkspace.repo_environment_id == repo_environment_id,
+                CloudWorkspace.archived_at.is_(None),
+            )
+            .order_by(CloudWorkspace.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return cloud_workspace_value(row) if row is not None else None
+
+
 async def get_cloud_workspace_for_user(
     db: AsyncSession,
     user_id: UUID,

--- a/server/proliferate/server/cloud/workflows/api.py
+++ b/server/proliferate/server/cloud/workflows/api.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.auth.dependencies import current_product_user
+from proliferate.auth.dependencies import current_product_user, optional_current_active_user
 from proliferate.constants.workflows import WORKFLOW_TARGET_MODE_PERSONAL_CLOUD
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
@@ -77,6 +77,59 @@ from proliferate.utils.time import utcnow
 router = APIRouter(prefix="/workflows", tags=["cloud-workflows"])
 
 
+@dataclass(frozen=True)
+class _RunTokenActor:
+    """Minimal actor for a runtime-authenticated run report (D18 / L16). The per-run
+    gateway token proves the run, so the owner id is all downstream owner-scoped
+    checks need — the executor is always the workflow owner in v1."""
+
+    id: UUID
+
+
+def _bearer_token(request: Request) -> str:
+    header = request.headers.get("authorization", "")
+    scheme, _, raw = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return raw.strip()
+
+
+async def _authorize_run_report(
+    db: AsyncSession, *, run_id: UUID, request: Request, user: User | None
+) -> _RunTokenActor | User:
+    """D18 (E7): accept EITHER the per-run gateway token (anyharness reporting on
+    its own behalf) OR a user session (the desktop local-lane relay) as the
+    credential for ``/status`` and ``/delivered``.
+
+    A valid run token that belongs to a *different* run is a spoofing attempt →
+    403 (mirrors ``/ping``). A bearer that is not a run token falls through to
+    user-session auth (e.g. a JWT-authed desktop). No credential at all → 401.
+    """
+
+    token = _bearer_token(request)
+    if token:
+        grant = await store.get_active_run_gateway_token_by_hash(
+            db,
+            token_hash=runtime_workers_store.hash_workflow_run_gateway_token(token),
+            now=utcnow(),
+        )
+        if grant is not None:
+            if grant.workflow_run_id != run_id:
+                raise CloudApiError(
+                    "workflow_run_token_mismatch",
+                    "This run token does not belong to the reported run.",
+                    status_code=403,
+                )
+            return _RunTokenActor(id=grant.owner_user_id)
+    if user is not None:
+        return user
+    raise CloudApiError(
+        "workflow_run_report_unauthorized",
+        "A user session or the per-run gateway token is required.",
+        status_code=401,
+    )
+
+
 @router.get("", response_model=WorkflowListResponse)
 async def list_workflows_endpoint(
     include_archived: Annotated[bool, Query(alias="includeArchived")] = False,
@@ -134,20 +187,26 @@ async def get_run_endpoint(
 @router.post("/runs/{run_id}/delivered", response_model=WorkflowRunResponse)
 async def mark_run_delivered_endpoint(
     run_id: UUID,
+    request: Request,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    user: User | None = Depends(optional_current_active_user),
 ) -> WorkflowRunResponse:
-    return run_payload(await mark_run_delivered(db, user, run_id))
+    # D18: run token (anyharness) OR user session (desktop local-lane relay).
+    actor = await _authorize_run_report(db, run_id=run_id, request=request, user=user)
+    return run_payload(await mark_run_delivered(db, actor, run_id))
 
 
 @router.post("/runs/{run_id}/status", response_model=WorkflowRunResponse)
 async def report_run_status_endpoint(
     run_id: UUID,
     body: RunStatusRequest,
+    request: Request,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    user: User | None = Depends(optional_current_active_user),
 ) -> WorkflowRunResponse:
-    return run_payload(await report_run_status(db, user, run_id, body))
+    # D18 (E7): run token (anyharness self-report) OR user session (local relay).
+    actor = await _authorize_run_report(db, run_id=run_id, request=request, user=user)
+    return run_payload(await report_run_status(db, actor, run_id, body))
 
 
 @router.post("/runs/{run_id}/cancel", response_model=WorkflowRunResponse)
@@ -190,14 +249,6 @@ async def refresh_run_endpoint(
 
     run = await get_run(db, user, run_id)
     return run_payload(await refresh_cloud_run(db, user, run))
-
-
-@dataclass(frozen=True)
-class _PingActor:
-    """Minimal actor for the ping-triggered refresh — the run-token proves the run,
-    so the owner id is all the cloud-sandbox gateway access needs."""
-
-    id: UUID
 
 
 @router.post("/runs/{run_id}/ping", status_code=202)
@@ -249,7 +300,7 @@ async def run_ping_endpoint(
     # observation; the ping is accepted (202) and no-ops the refresh here.
     if run is not None and run.target_mode == WORKFLOW_TARGET_MODE_PERSONAL_CLOUD:
         try:
-            await refresh_cloud_run(db, _PingActor(id=grant.owner_user_id), run)
+            await refresh_cloud_run(db, _RunTokenActor(id=grant.owner_user_id), run)
         except CloudApiError:
             # A failed refresh never changes engine state — the ping is a nudge,
             # not a transition; the scheduler phase-3 sweep remains the backstop.

--- a/server/proliferate/server/cloud/workflows/models.py
+++ b/server/proliferate/server/cloud/workflows/models.py
@@ -300,10 +300,14 @@ class WorkflowTriggerCreateRequest(WorkflowBaseModel):
     enabled: bool = True
     concurrency_policy: WorkflowTriggerConcurrency = Field(alias="concurrencyPolicy")
     target_mode: WorkflowTriggerTargetMode = Field(alias="targetMode")
-    target_workspace_id: UUID | None = Field(default=None, alias="targetWorkspaceId")
+    # D16: the authored "where" is a repo pin ("org/repo"), not a workspace id.
+    # The server derives + owns the dedicated cloud workspace. Required for
+    # schedule/poll (validated in the service, enforced by DB CHECK).
+    repo_full_name: str | None = Field(default=None, alias="repoFullName")
     # Exactly one of schedule / poll is required, matching ``kind``.
     schedule: TriggerScheduleRequest | None = None
     poll: TriggerPollRequest | None = None
+    # Schedule preset input values / poll static input defaults.
     args: dict[str, object] = Field(default_factory=dict)
 
 
@@ -316,7 +320,8 @@ class WorkflowTriggerUpdateRequest(WorkflowBaseModel):
         default=None, alias="concurrencyPolicy"
     )
     target_mode: WorkflowTriggerTargetMode | None = Field(default=None, alias="targetMode")
-    target_workspace_id: UUID | None = Field(default=None, alias="targetWorkspaceId")
+    # D16: re-pinning the repo re-derives the workspace. None = no change.
+    repo_full_name: str | None = Field(default=None, alias="repoFullName")
     schedule: TriggerScheduleRequest | None = None
     poll: TriggerPollRequest | None = None
     args: dict[str, object] | None = None
@@ -350,7 +355,11 @@ class WorkflowTriggerResponse(WorkflowBaseModel):
     enabled: bool
     concurrency_policy: str = Field(alias="concurrencyPolicy")
     target_mode: str = Field(alias="targetMode")
+    # D16: the authored repo pin + the derived (server-owned) workspace it maps to.
+    repo_full_name: str | None = Field(alias="repoFullName")
     target_workspace_id: str | None = Field(alias="targetWorkspaceId")
+    # Schedule preset input values (the enable-gate record); null for poll.
+    input_presets: dict[str, object] | None = Field(default=None, alias="inputPresets")
     schedule: TriggerScheduleResponse | None
     poll: TriggerPollResponse | None = None
     next_run_at: str | None = Field(alias="nextRunAt")
@@ -410,9 +419,11 @@ def trigger_payload(record: WorkflowTriggerRecord) -> WorkflowTriggerResponse:
         enabled=record.enabled,
         concurrency_policy=record.concurrency_policy,
         target_mode=record.target_mode,
+        repo_full_name=record.repo_full_name,
         target_workspace_id=(
             str(record.target_workspace_id) if record.target_workspace_id else None
         ),
+        input_presets=record.input_presets_json,
         schedule=schedule,
         poll=poll,
         next_run_at=_iso(record.next_run_at),

--- a/server/proliferate/server/cloud/workflows/service.py
+++ b/server/proliferate/server/cloud/workflows/service.py
@@ -43,6 +43,7 @@ from proliferate.constants.workflows import (
 from proliferate.db.store import cloud_workflow_triggers as trigger_store
 from proliferate.db.store import cloud_workflows as store
 from proliferate.db.store import cloud_workspaces as cloud_workspace_store
+from proliferate.db.store import repositories as repositories_store
 from proliferate.db.store.cloud_workflow_triggers import WorkflowTriggerRecord
 from proliferate.db.store.cloud_workflows import (
     WorkflowRecord,
@@ -70,13 +71,13 @@ from proliferate.server.cloud.workflows.domain.interpolation import (
     coerce_arguments,
     resolve_value,
 )
-from proliferate.server.cloud.workflows.domain.poll_contract import (
-    derive_item_schema,
-    validate_item_data,
-)
 from proliferate.server.cloud.workflows.domain.policy import (
     free_plan_workflow_limit,
     workflow_create_allowed,
+)
+from proliferate.server.cloud.workflows.domain.poll_contract import (
+    derive_item_schema,
+    validate_item_data,
 )
 from proliferate.server.cloud.workflows.domain.run_status import (
     RunTransitionError,
@@ -209,29 +210,68 @@ def workflow_arg_specs(version: WorkflowVersionRecord) -> list[ArgSpec]:
     return arg_specs
 
 
-async def ensure_cloud_workspace_owned(
-    db: AsyncSession, *, user: ActorIdentity, target_workspace_id: UUID | None
-) -> None:
-    """Validate the actor owns a live cloud workspace (ownership only).
+def _split_repo_full_name(repo_full_name: str | None) -> tuple[str, str]:
+    """Parse an "owner/name" repo pin. Raises 400 on a malformed value."""
 
-    Used at trigger create/update: the workspace must exist and be un-archived,
-    but need not be materialized yet — materialization is re-checked at fire time
-    by ``start_run`` (a workspace can finish provisioning after the trigger is set).
-    """
-
-    if target_workspace_id is None:
+    cleaned = (repo_full_name or "").strip()
+    owner, _, name = cleaned.partition("/")
+    if not owner or not name or "/" in name:
         raise CloudApiError(
-            "target_workspace_required",
-            "A cloud workspace is required to run this workflow in the cloud.",
+            "invalid_repo",
+            "Pin a repository as 'owner/name'.",
             status_code=400,
         )
-    workspace = await cloud_workspace_store.get_cloud_workspace_for_user(
-        db, user.id, target_workspace_id
+    return owner, name
+
+
+async def _ensure_trigger_target_workspace(
+    db: AsyncSession, *, user: ActorIdentity, repo_full_name: str | None
+) -> UUID:
+    """D16: derive the trigger's target workspace from its repo pin.
+
+    The trigger authors a repo; the server owns the workspace. This resolves the
+    caller's cloud repo environment for the pin and provisions a dedicated,
+    server-owned cloud workspace row for it (one warm workspace per trigger). The
+    anyharness worktree is NOT materialized here — that stays a retry-at-fire
+    concern (``start_run`` raises ``target_workspace_not_ready`` until the runtime
+    workspace is ready), exactly as before the repo pin existed.
+    """
+
+    owner, name = _split_repo_full_name(repo_full_name)
+    repo_environment = await repositories_store.get_cloud_repo_environment(
+        db, user_id=user.id, git_owner=owner, git_repo_name=name
     )
-    if workspace is None or workspace.archived_at is not None:
+    if repo_environment is None:
         raise CloudApiError(
-            "target_workspace_not_found", "Cloud workspace not found.", status_code=404
+            "cloud_repo_environment_not_found",
+            "Configure this repository as a cloud environment before pinning it to a trigger.",
+            status_code=404,
         )
+    # Reuse the warm workspace this repo already has, if any; otherwise create the
+    # dedicated row. Either way the trigger-fire path is unchanged — it stamps this
+    # id into start_run, which re-checks materialization (target_workspace_not_ready
+    # stays a retry-at-fire concern for a row whose worktree isn't ready yet).
+    existing = await cloud_workspace_store.get_active_cloud_workspace_for_repo_environment(
+        db, user_id=user.id, repo_environment_id=repo_environment.id
+    )
+    if existing is not None:
+        return existing.id
+    branch = f"workflow-trigger/{uuid4().hex[:12]}"
+    workspace = await cloud_workspace_store.create_cloud_workspace(
+        db,
+        user_id=user.id,
+        repo_environment_id=repo_environment.id,
+        display_name=f"{owner}/{name}",
+        git_branch=branch,
+        git_base_branch=repo_environment.default_branch or "main",
+    )
+    if workspace is None:  # pragma: no cover - the generated branch is unique
+        raise CloudApiError(
+            "cloud_workspace_create_failed",
+            "Could not provision a workspace for the pinned repository.",
+            status_code=409,
+        )
+    return workspace.id
 
 
 async def _visible_run(
@@ -802,24 +842,37 @@ def _normalize_trigger_schedule(schedule: TriggerScheduleRequest) -> ParsedAutom
         raise CloudApiError("invalid_schedule", str(exc), status_code=400) from exc
 
 
-async def _coerce_trigger_args(
-    db: AsyncSession, *, workflow_current_version_id: UUID | None, args: dict[str, object]
+def _coerce_schedule_presets(
+    arg_specs: list[ArgSpec], *, presets: dict[str, object]
 ) -> dict[str, object]:
-    if workflow_current_version_id is None:
-        raise CloudApiError(
-            "workflow_no_version",
-            "Add at least one step before scheduling this workflow.",
-            status_code=409,
-        )
-    version = await store.get_version(db, workflow_current_version_id)
-    if version is None:
-        raise CloudApiError(
-            "workflow_version_not_found", "Workflow version not found.", status_code=404
-        )
+    """Coerce a schedule trigger's preset input values (D16).
+
+    Partial (only the presets provided are coerced; unknown keys and bad types
+    still fail): a schedule with incomplete presets can be SAVED as a draft; the
+    enable-gate — not coercion — is what blocks enabling it.
+    """
+
     try:
-        return coerce_arguments(workflow_arg_specs(version), args)
+        return coerce_arguments([spec for spec in arg_specs if spec.name in presets], presets)
     except ArgumentError as exc:
         raise CloudApiError(exc.code, exc.message, status_code=400) from exc
+
+
+def _assert_schedule_enable_gate(
+    arg_specs: list[ArgSpec], *, presets: dict[str, object], enabled: bool
+) -> None:
+    """D16 enable-gate: an ENABLED schedule trigger must preset every required
+    input (a disabled draft may leave them blank)."""
+
+    if not enabled:
+        return
+    missing = sorted(spec.name for spec in arg_specs if spec.required and spec.name not in presets)
+    if missing:
+        raise CloudApiError(
+            "schedule_presets_incomplete",
+            f"Preset every required input before enabling this schedule: {missing}.",
+            status_code=400,
+        )
 
 
 async def _workflow_arg_specs_or_raise(
@@ -1004,15 +1057,23 @@ async def create_trigger(
     _validate_trigger_kind(body.kind)
     _validate_concurrency(body.concurrency_policy)
     _validate_trigger_target_mode(body.target_mode, kind=body.kind)
-    await ensure_cloud_workspace_owned(db, user=user, target_workspace_id=body.target_workspace_id)
+    # D16: the repo pin is the authored "where"; the server derives + owns the
+    # workspace it maps to.
+    target_workspace_id = await _ensure_trigger_target_workspace(
+        db, user=user, repo_full_name=body.repo_full_name
+    )
 
     if body.kind == WORKFLOW_TRIGGER_KIND_POLL:
-        return await _create_poll_trigger(db, user, workflow, body)
+        return await _create_poll_trigger(
+            db, user, workflow, body, target_workspace_id=target_workspace_id
+        )
 
     parsed = _normalize_trigger_schedule(_require_schedule(body.schedule))
-    coerced_args = await _coerce_trigger_args(
-        db, workflow_current_version_id=workflow.current_version_id, args=body.args
+    arg_specs = await _workflow_arg_specs_or_raise(
+        db, workflow_current_version_id=workflow.current_version_id
     )
+    presets = _coerce_schedule_presets(arg_specs, presets=body.args)
+    _assert_schedule_enable_gate(arg_specs, presets=presets, enabled=body.enabled)
     return await trigger_store.create_trigger(
         db,
         workflow_id=workflow_id,
@@ -1020,12 +1081,15 @@ async def create_trigger(
         kind=WORKFLOW_TRIGGER_KIND_SCHEDULE,
         concurrency_policy=body.concurrency_policy,
         target_mode=body.target_mode,
-        target_workspace_id=body.target_workspace_id,
+        repo_full_name=body.repo_full_name,
+        target_workspace_id=target_workspace_id,
+        input_presets_json=presets,
         schedule_rrule=parsed.rrule_text,
         schedule_timezone=parsed.timezone,
         schedule_summary=parsed.summary,
         next_run_at=parsed.next_run_at,
-        args_json=coerced_args,
+        # For schedule triggers the presets ARE the fire-time args.
+        args_json=presets,
         enabled=body.enabled,
     )
 
@@ -1043,6 +1107,8 @@ async def _create_poll_trigger(
     user: ActorIdentity,
     workflow: WorkflowRecord,
     body: WorkflowTriggerCreateRequest,
+    *,
+    target_workspace_id: UUID,
 ) -> WorkflowTriggerRecord:
     if body.poll is None:
         raise CloudApiError(
@@ -1064,7 +1130,8 @@ async def _create_poll_trigger(
         kind=WORKFLOW_TRIGGER_KIND_POLL,
         concurrency_policy=body.concurrency_policy,
         target_mode=body.target_mode,
-        target_workspace_id=body.target_workspace_id,
+        repo_full_name=body.repo_full_name,
+        target_workspace_id=target_workspace_id,
         poll_url=config.url,
         poll_auth_header=config.auth_header,
         poll_auth_ciphertext=config.auth_ciphertext,
@@ -1111,13 +1178,19 @@ async def update_trigger(
     _validate_concurrency(concurrency)
     _validate_trigger_target_mode(target_mode, kind=existing.kind)
 
-    # Cloud target needs an owned workspace (new one if supplied, else the pinned one).
-    target_workspace_id = (
-        body.target_workspace_id
-        if body.target_workspace_id is not None
-        else existing.target_workspace_id
+    # D16: re-pinning the repo re-derives a fresh server-owned workspace; leaving
+    # it alone keeps the existing derived workspace.
+    repo_changed = (
+        body.repo_full_name is not None
+        and body.repo_full_name.strip() != (existing.repo_full_name or "")
     )
-    await ensure_cloud_workspace_owned(db, user=user, target_workspace_id=target_workspace_id)
+    repo_full_name = body.repo_full_name if repo_changed else existing.repo_full_name
+    if repo_changed:
+        target_workspace_id: UUID | None = await _ensure_trigger_target_workspace(
+            db, user=user, repo_full_name=body.repo_full_name
+        )
+    else:
+        target_workspace_id = existing.target_workspace_id
 
     if existing.kind == WORKFLOW_TRIGGER_KIND_POLL:
         return await _update_poll_trigger(
@@ -1128,6 +1201,7 @@ async def update_trigger(
             enabled=enabled,
             concurrency=concurrency,
             target_mode=target_mode,
+            repo_full_name=repo_full_name,
             target_workspace_id=target_workspace_id,
         )
     if body.poll is not None:
@@ -1151,10 +1225,12 @@ async def update_trigger(
     recompute_cursor = schedule_changed or becoming_enabled or existing.next_run_at is None
     next_run_at = parsed.next_run_at if recompute_cursor else None
 
-    args = body.args if body.args is not None else existing.args_json
-    coerced_args = await _coerce_trigger_args(
-        db, workflow_current_version_id=workflow.current_version_id, args=args
+    presets_source = body.args if body.args is not None else existing.input_presets_json or {}
+    arg_specs = await _workflow_arg_specs_or_raise(
+        db, workflow_current_version_id=workflow.current_version_id
     )
+    presets = _coerce_schedule_presets(arg_specs, presets=presets_source)
+    _assert_schedule_enable_gate(arg_specs, presets=presets, enabled=enabled)
 
     updated = await trigger_store.update_trigger(
         db,
@@ -1162,12 +1238,15 @@ async def update_trigger(
         enabled=enabled,
         concurrency_policy=concurrency,
         target_mode=target_mode,
+        repo_full_name=repo_full_name,
         target_workspace_id=target_workspace_id,
+        input_presets_json=presets,
+        write_input_presets=True,
         schedule_rrule=parsed.rrule_text,
         schedule_timezone=parsed.timezone,
         schedule_summary=parsed.summary,
         next_run_at=next_run_at,
-        args_json=coerced_args,
+        args_json=presets,
     )
     assert updated is not None
     return updated
@@ -1182,6 +1261,7 @@ async def _update_poll_trigger(
     enabled: bool,
     concurrency: str,
     target_mode: str,
+    repo_full_name: str | None,
     target_workspace_id: UUID | None,
 ) -> WorkflowTriggerRecord:
     if body.schedule is not None:
@@ -1219,6 +1299,7 @@ async def _update_poll_trigger(
         enabled=enabled,
         concurrency_policy=concurrency,
         target_mode=target_mode,
+        repo_full_name=repo_full_name,
         target_workspace_id=target_workspace_id,
         args_json=coerced_static,
         write_poll_config=True,

--- a/server/tests/unit/test_workflow_poll.py
+++ b/server/tests/unit/test_workflow_poll.py
@@ -134,6 +134,9 @@ async def _make_poll_trigger(
         # logic is target-agnostic (cloud-only is a service-layer create/update rule).
         concurrency_policy="queue",
         target_mode="local",
+        # D16: poll triggers pin a repo (ck_workflow_trigger_repo_full_name); the
+        # poller-lane logic under test is target-agnostic.
+        repo_full_name="acme/widgets",
         target_workspace_id=None,
         poll_url="http://127.0.0.1:9911/poll",
         poll_interval_secs=interval_secs,
@@ -519,7 +522,8 @@ def _poll_body(**overrides):  # type: ignore[no-untyped-def]
         "kind": "poll",
         "concurrencyPolicy": "queue",
         "targetMode": "personal_cloud",
-        "targetWorkspaceId": uuid.uuid4(),
+        # D16: repo pin is authored; the workspace is derived server-side.
+        "repoFullName": "acme/widgets",
         "poll": TriggerPollRequest.model_validate(poll_kwargs),
         "args": {},
     }
@@ -537,7 +541,7 @@ async def test_poll_trigger_rejects_local_target(test_engine) -> None:  # type: 
         await db.commit()
         actor = _Actor(user.id)
         with pytest.raises(CloudApiError) as exc:
-            await _service_create(db, actor, wf.id, _poll_body(targetMode="local", targetWorkspaceId=None))
+            await _service_create(db, actor, wf.id, _poll_body(targetMode="local"))
     assert exc.value.code == "poll_local_unsupported"
 
 
@@ -580,23 +584,20 @@ async def test_poll_trigger_signature_mismatch_rejected(test_engine) -> None:  #
     async with factory() as db:
         user = await _make_user(db)
         wf = await _make_workflow(db, user)
+        # D16: a cloud repo env for the pin so derivation reaches the probe.
+        await _make_ready_cloud_workspace(db, user)
         await db.commit()
         actor = _Actor(user.id)
-
-        from proliferate.db.store import cloud_workspaces as cloud_workspace_store
 
         # item omits required "n" and gives "title" the wrong type -> mismatch.
         bad_page = _page([_item("probe_bad", title=42)])
         with (
             patch.object(
-                cloud_workspace_store,
-                "get_cloud_workspace_for_user",
-                new=AsyncMock(return_value=_WS()),
+                poller_module, "fetch_poll_page", new=AsyncMock(return_value=bad_page)
             ),
-            patch.object(poller_module, "fetch_poll_page", new=AsyncMock(return_value=bad_page)),
+            pytest.raises(CloudApiError) as exc,
         ):
-            with pytest.raises(CloudApiError) as exc:
-                await _service_create(db, actor, wf.id, _poll_body())
+            await _service_create(db, actor, wf.id, _poll_body())
     assert exc.value.code == "poll_signature_mismatch"
 
 
@@ -642,10 +643,10 @@ async def test_poll_trigger_created_when_signature_matches(test_engine) -> None:
         with patch.object(
             poller_module, "fetch_poll_page", new=AsyncMock(return_value=good_page)
         ):
-            record = await _service_create(
-                db, actor, wf.id, _poll_body(targetWorkspaceId=workspace.id)
-            )
+            record = await _service_create(db, actor, wf.id, _poll_body())
     assert record.kind == WORKFLOW_TRIGGER_KIND_POLL
+    # The workspace is derived from the repo pin (reuses the repo's warm workspace).
+    assert record.target_workspace_id == workspace.id
     assert record.poll_item_schema_json == _ITEM_SCHEMA
 
 

--- a/server/tests/unit/test_workflow_run_gateway.py
+++ b/server/tests/unit/test_workflow_run_gateway.py
@@ -805,3 +805,113 @@ async def test_ping_accepts_contract_request_shape(
         headers={"Authorization": f"Bearer {plaintext}"},
     )
     assert resp.status_code == 202
+
+
+# --- D18 (E7): /status + /delivered run-token OR user auth ---------------------
+
+
+class _StubRequest:
+    """Minimal stand-in for a Starlette Request — ``_bearer_token`` only reads
+    ``headers.get``."""
+
+    def __init__(self, authorization: str | None = None) -> None:
+        self.headers = {} if authorization is None else {"authorization": authorization}
+
+
+async def test_status_accepts_run_token(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The runtime self-reports /status with its per-run gateway token (no session)."""
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/status",
+        headers={"Authorization": f"Bearer {plaintext}"},
+        json={"status": "running"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+
+
+async def test_status_rejects_mismatched_run_token(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Run A's token cannot report on run B (spoofing → 403), mirroring /ping."""
+    user = await _make_user(db_session)
+    _run_a, token_a = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    run_b, _ = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_b}/status",
+        headers={"Authorization": f"Bearer {token_a}"},
+        json={"status": "running"},
+    )
+    assert resp.status_code == 403
+    # Run B stayed put — a rejected report changes no state.
+    after = await store.get_run(db_session, run_b)
+    assert after.status == "delivered"
+
+
+async def test_status_no_credential_unauthorized(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    user = await _make_user(db_session)
+    run_id, _ = await _seed_run_with_token(db_session, owner=user, integrations=[])
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/status",
+        json={"status": "running"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_authorize_run_report_accepts_user_session(db_session: AsyncSession) -> None:
+    """The desktop local-lane relay reports on a user session (no bearer) — the
+    resolver returns the user unchanged."""
+    from proliferate.server.cloud.workflows.api import _authorize_run_report
+
+    user = await _make_user(db_session)
+    run_id, _ = await _seed_run_with_token(db_session, owner=user, integrations=[])
+
+    actor = await _authorize_run_report(
+        db_session, run_id=run_id, request=_StubRequest(), user=user
+    )
+    assert actor is user
+
+
+async def test_authorize_run_report_prefers_run_token(db_session: AsyncSession) -> None:
+    """A valid run token authenticates as the runtime even when no user is present."""
+    from proliferate.server.cloud.workflows.api import _RunTokenActor, _authorize_run_report
+
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(db_session, owner=user, integrations=[])
+
+    actor = await _authorize_run_report(
+        db_session,
+        run_id=run_id,
+        request=_StubRequest(f"Bearer {plaintext}"),
+        user=None,
+    )
+    assert isinstance(actor, _RunTokenActor)
+    assert actor.id == user.id
+
+
+async def test_delivered_accepts_run_token(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    user = await _make_user(db_session)
+    run_id, plaintext = await _seed_run_with_token(
+        db_session, owner=user, integrations=[], status="pending_delivery"
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/v1/cloud/workflows/runs/{run_id}/delivered",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "delivered"

--- a/server/tests/unit/test_workflow_triggers.py
+++ b/server/tests/unit/test_workflow_triggers.py
@@ -87,11 +87,21 @@ async def _make_workflow(db: AsyncSession, user: User, *, required_arg: bool = F
     return workflow
 
 
-async def _make_ready_cloud_workspace(
-    db: AsyncSession, user: User, *, anyharness_workspace_id: str | None = "sandbox-ws-1"
-) -> CloudWorkspace:
+_REPO = "acme/widgets"
+
+
+async def _make_cloud_repo_environment(
+    db: AsyncSession,
+    user: User,
+    *,
+    git_owner: str = "acme",
+    git_repo_name: str = "widgets",
+) -> RepoEnvironment:
+    """A cloud repo environment for the derivation path (D16): the trigger pins a
+    repo, the service resolves its cloud environment and provisions a workspace."""
+
     repo_config = RepoConfig(
-        user_id=user.id, git_provider="github", git_owner="acme", git_repo_name="widgets"
+        user_id=user.id, git_provider="github", git_owner=git_owner, git_repo_name=git_repo_name
     )
     db.add(repo_config)
     await db.flush()
@@ -100,6 +110,13 @@ async def _make_ready_cloud_workspace(
     )
     db.add(repo_environment)
     await db.flush()
+    return repo_environment
+
+
+async def _make_ready_cloud_workspace(
+    db: AsyncSession, user: User, *, anyharness_workspace_id: str | None = "sandbox-ws-1"
+) -> CloudWorkspace:
+    repo_environment = await _make_cloud_repo_environment(db, user)
     workspace = CloudWorkspace(
         owner_user_id=user.id,
         repo_environment_id=repo_environment.id,
@@ -113,18 +130,20 @@ async def _make_ready_cloud_workspace(
 
 
 def _create_body(
-    workspace_id: uuid.UUID | None,
+    repo_full_name: str | None = _REPO,
     *,
     target_mode: str = "personal_cloud",
     concurrency: str = "skip",
     rrule: str = _HOURLY,
     timezone: str = "UTC",
     args: dict | None = None,
+    enabled: bool = True,
 ) -> WorkflowTriggerCreateRequest:
     return WorkflowTriggerCreateRequest(
         concurrencyPolicy=concurrency,  # type: ignore[call-arg]
         targetMode=target_mode,  # type: ignore[call-arg]
-        targetWorkspaceId=workspace_id,  # type: ignore[call-arg]
+        repoFullName=repo_full_name,  # type: ignore[call-arg]
+        enabled=enabled,
         schedule=TriggerScheduleRequest(rrule=rrule, timezone=timezone),
         args=args or {},
     )
@@ -178,12 +197,14 @@ async def test_create_schedule_trigger_cloud(db_session: AsyncSession) -> None:
     workspace = await _make_ready_cloud_workspace(db_session, user)
 
     trigger = await service.create_trigger(
-        db_session, user, workflow.id, _create_body(workspace.id, concurrency="queue")
+        db_session, user, workflow.id, _create_body(concurrency="queue")
     )
 
     assert trigger.kind == WORKFLOW_TRIGGER_KIND_SCHEDULE
     assert trigger.concurrency_policy == "queue"
     assert trigger.target_mode == "personal_cloud"
+    # D16: repo is authored; the workspace is derived (reuses the repo's workspace).
+    assert trigger.repo_full_name == _REPO
     assert trigger.target_workspace_id == workspace.id
     assert trigger.schedule_rrule == _HOURLY
     assert trigger.schedule_summary  # a human summary was computed
@@ -206,62 +227,95 @@ async def test_create_rejects_local_schedule(db_session: AsyncSession) -> None:
 async def test_create_rejects_bad_rrule(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     with pytest.raises(CloudApiError) as exc:
         await service.create_trigger(
             db_session,
             user,
             workflow.id,
-            _create_body(workspace.id, rrule="RRULE:FREQ=SECONDLY;INTERVAL=1"),
+            _create_body(rrule="RRULE:FREQ=SECONDLY;INTERVAL=1"),
         )
     assert exc.value.code == "invalid_schedule"
 
 
-async def test_create_rejects_missing_required_arg(db_session: AsyncSession) -> None:
+async def test_create_enabled_rejects_missing_required_preset(db_session: AsyncSession) -> None:
+    """D16 enable-gate: an enabled schedule can't ship a required input unpresetted."""
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user, required_arg=True)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     with pytest.raises(CloudApiError) as exc:
         await service.create_trigger(
-            db_session, user, workflow.id, _create_body(workspace.id, args={})
+            db_session, user, workflow.id, _create_body(args={}, enabled=True)
         )
-    assert exc.value.code == "missing_argument"
+    assert exc.value.code == "schedule_presets_incomplete"
+
+
+async def test_create_disabled_allows_missing_required_preset(db_session: AsyncSession) -> None:
+    """A disabled draft may leave required presets blank; only enabling is gated."""
+    user = await _make_user(db_session)
+    workflow = await _make_workflow(db_session, user, required_arg=True)
+    await _make_ready_cloud_workspace(db_session, user)
+    trigger = await service.create_trigger(
+        db_session, user, workflow.id, _create_body(args={}, enabled=False)
+    )
+    assert trigger.enabled is False
+    assert trigger.input_presets_json == {}
 
 
 async def test_create_covers_required_arg(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user, required_arg=True)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     trigger = await service.create_trigger(
-        db_session, user, workflow.id, _create_body(workspace.id, args={"issue": "PROJ-1"})
+        db_session, user, workflow.id, _create_body(args={"issue": "PROJ-1"})
     )
     assert trigger.args_json == {"issue": "PROJ-1"}
+    # The presets back the enable-gate and mirror the fire-time args for schedule.
+    assert trigger.input_presets_json == {"issue": "PROJ-1"}
 
 
-async def test_create_requires_cloud_workspace(db_session: AsyncSession) -> None:
+async def test_create_requires_repo(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
     with pytest.raises(CloudApiError) as exc:
         await service.create_trigger(db_session, user, workflow.id, _create_body(None))
-    assert exc.value.code == "target_workspace_required"
+    assert exc.value.code == "invalid_repo"
 
 
-async def test_create_rejects_unowned_workspace(db_session: AsyncSession) -> None:
+async def test_create_rejects_unconfigured_repo(db_session: AsyncSession) -> None:
+    """A repo the user hasn't configured as a cloud environment can't be pinned."""
     user = await _make_user(db_session)
-    other = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
-    foreign_ws = await _make_ready_cloud_workspace(db_session, other)
     with pytest.raises(CloudApiError) as exc:
-        await service.create_trigger(db_session, user, workflow.id, _create_body(foreign_ws.id))
-    assert exc.value.code == "target_workspace_not_found"
+        await service.create_trigger(
+            db_session, user, workflow.id, _create_body("someone/unconfigured")
+        )
+    assert exc.value.code == "cloud_repo_environment_not_found"
+
+
+async def test_create_derives_workspace_from_repo(db_session: AsyncSession) -> None:
+    """D16: with a cloud repo env but no existing workspace, the server provisions a
+    dedicated workspace row and stamps it as the derived target."""
+    user = await _make_user(db_session)
+    workflow = await _make_workflow(db_session, user)
+    repo_env = await _make_cloud_repo_environment(db_session, user)
+    trigger = await service.create_trigger(db_session, user, workflow.id, _create_body())
+    assert trigger.target_workspace_id is not None
+    from proliferate.db.store import cloud_workspaces as ws_store
+
+    derived = await ws_store.get_cloud_workspace_for_user(
+        db_session, user.id, trigger.target_workspace_id
+    )
+    assert derived is not None
+    assert derived.repo_environment_id == repo_env.id
 
 
 async def test_update_args_only_keeps_cursor(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     trigger = await service.create_trigger(
-        db_session, user, workflow.id, _create_body(workspace.id, concurrency="skip")
+        db_session, user, workflow.id, _create_body(concurrency="skip")
     )
     original_next = trigger.next_run_at
 
@@ -280,9 +334,9 @@ async def test_update_args_only_keeps_cursor(db_session: AsyncSession) -> None:
 async def test_update_schedule_recomputes_cursor(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     trigger = await service.create_trigger(
-        db_session, user, workflow.id, _create_body(workspace.id, rrule=_HOURLY)
+        db_session, user, workflow.id, _create_body(rrule=_HOURLY)
     )
     updated = await service.update_trigger(
         db_session,
@@ -301,9 +355,9 @@ async def test_update_schedule_recomputes_cursor(db_session: AsyncSession) -> No
 async def test_delete_trigger(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     workflow = await _make_workflow(db_session, user)
-    workspace = await _make_ready_cloud_workspace(db_session, user)
+    await _make_ready_cloud_workspace(db_session, user)
     trigger = await service.create_trigger(
-        db_session, user, workflow.id, _create_body(workspace.id)
+        db_session, user, workflow.id, _create_body()
     )
     await service.delete_trigger(db_session, user, workflow.id, trigger.id)
     assert await trigger_store.get_trigger(db_session, trigger.id) is None
@@ -313,9 +367,9 @@ async def test_trigger_visibility_isolation(db_session: AsyncSession) -> None:
     owner = await _make_user(db_session)
     other = await _make_user(db_session)
     workflow = await _make_workflow(db_session, owner)
-    workspace = await _make_ready_cloud_workspace(db_session, owner)
+    await _make_ready_cloud_workspace(db_session, owner)
     trigger = await service.create_trigger(
-        db_session, owner, workflow.id, _create_body(workspace.id)
+        db_session, owner, workflow.id, _create_body()
     )
     with pytest.raises(CloudApiError) as exc:
         await service.get_trigger(db_session, other, workflow.id, trigger.id)
@@ -330,12 +384,12 @@ async def _seed_trigger(session_factory, *, concurrency: str) -> tuple[uuid.UUID
     async with session_factory() as db, db.begin():
         user = await _make_user(db)
         workflow = await _make_workflow(db, user)
-        workspace = await _make_ready_cloud_workspace(db, user)
+        await _make_ready_cloud_workspace(db, user)
         trigger = await service.create_trigger(
             db,
             user,
             workflow.id,
-            _create_body(workspace.id, concurrency=concurrency, args={"issue": "seed"}),
+            _create_body(concurrency=concurrency, args={"issue": "seed"}),
         )
     return trigger.id, workflow.id
 


### PR DESCRIPTION
Part of the workflows core-engine amendments stack (Gate 0). Top of the stack, on PR F.

- **D16** — `workflow_trigger.repo_full_name` (CHECK-required for schedule/poll) + `input_presets_json` enable-gate; `target_workspace_id` becomes DERIVED from the pinned repo (reuse-or-create; sandbox materialization stays a retry-at-fire concern).
- **D18 (E7)** — `POST /runs/{id}/status` and `/delivered` now accept the per-run gateway token as the runtime's credential (mirrors `/ping`); user-session auth retained for the desktop local-lane relay.

Gate A: verify green; adversarial review clean for this branch. One commit; standalone-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)