### PR TITLE
test(intent): tier-2 org SSO login entry points (T2-AUTH-5)

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -24,6 +24,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Invitation negatives: expired / reused / wrong-email token | 2 | — |
 | SSO: OIDC round-trip via mock IdP → user linked, domain policy applied | 2 | — |
 | SSO negatives: disallowed domain, unknown user, audience/issuer mismatch | 2 | — |
+| SSO org entry points: slug + org-id discovery (unknown / no-SSO collapse to one non-enumerating answer; enabled connection returns start ids) and the desktop cold-login affordance | 2 | tests/intent/specs/sso-entry-points.spec.ts (T2-AUTH-5; entry-point seam only — the OIDC round-trip is the row above. The `apps/web` slug/`join` pages are not booted by this suite; their logic sits on the same discover seam asserted here) |
 | Real provider handshakes (Google/GitHub OAuth dance) | 3 | — |
 
 ## Organization — must work, even if basic

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -56,6 +56,31 @@ buttons; with env set, buttons render. (Real Google/GitHub round-trips are
 tier 3 — their endpoints are not overridable, so they cannot be mocked
 without product changes we are not making.)
 
+### T2-AUTH-5: org SSO login entry points (PR #1048)
+The user-facing ways *in* to org SSO: a slug login page (`/login`,
+`/login/<slug>`), the cold-login "Sign in with SSO" affordance, and
+`/join/<orgId>` web sign-in. All resolve an org **slug or id** to that org's
+SSO connection via `GET /auth/sso/discover`, then hand off to the existing
+start flow. This is the **entry-point seam**, distinct from the OIDC
+round-trip (T2-AUTH-3): discover reads the connection's stored state and never
+contacts the IdP, so the seam is fully assertable without one.
+Assert (server seam, driven directly): unknown slug AND an existing org with
+no SSO both return the identical generic answer (`enabled:false`,
+`reason:"not_available"`, no ids) so slugs can't be cycled to enumerate orgs;
+a slug (and an org id, the `/join` input) resolving to an ENABLED connection
+returns exactly the start ids (`organizationId`, `connectionId`, `protocol`,
+`displayName`). Setup seeds an enabled org-scope OIDC `sso_connection` row
+directly (same spirit as the invitation-expiry direct-DB seed) since discover
+never calls the IdP.
+Assert (desktop web build): the `OrgSsoLoginLink` affordance on `/login`
+expands to a slug field; submitting an unavailable slug (unknown, or an
+existing org with no SSO) surfaces the one generic error and does not start
+SSO.
+Surface note: the tier-2 stack boots the **desktop web build** (`apps/desktop`),
+so the `apps/web` pages (`LoginSsoPage`, the auth-screen link, `/join`) are not
+rendered here; their logic sits on the same discover seam these cases pin. The
+positive kickoff redirect and the full round-trip are T2-AUTH-3's.
+
 ---
 
 ## Tier 2 — organization

--- a/tests/intent/specs/sso-entry-points.spec.ts
+++ b/tests/intent/specs/sso-entry-points.spec.ts
@@ -1,0 +1,181 @@
+// T2-AUTH-5 (specs/developing/testing/scenarios.md): org-scoped SSO login
+// entry points.
+//
+// PR #1048 added the user-facing ways *in* to org SSO (the backend OIDC flow
+// already existed): a slug login page (`/login`, `/login/<slug>`), a "Sign in
+// with SSO" affordance on cold login, and `/join/<orgId>` web sign-in. Every
+// one of them resolves an org **slug or id** to that org's SSO connection
+// through `GET /auth/sso/discover`, then hands off to the existing start flow.
+//
+// This spec owns the ENTRY-POINT seam, not the OIDC round-trip. The round-trip
+// (mock IdP → callback → linked user + JIT membership) is T2-AUTH-3, landed
+// separately (PR #1015); duplicating it here would be redundant and would drag
+// a live IdP into a flow that does not need one. Discover reads the
+// connection's stored state only — it never contacts the IdP — so the
+// resolution seam is fully assertable without one:
+//   - negative: an unknown slug, and an existing org that has no SSO, must
+//     return the *same* generic answer (`enabled:false`, `reason:
+//     "not_available"`, no ids) so slugs cannot be cycled to enumerate which
+//     orgs exist or have SSO;
+//   - positive: a slug (and an org id, the `/join` path's input) that resolves
+//     to an ENABLED connection returns exactly the ids the start flow needs
+//     (`organizationId`, `connectionId`, `protocol`, `displayName`) — this is
+//     the entry point's whole job.
+//
+// Surface coverage note (honest tier boundary): the tier-2 stack serves the
+// **desktop web build** (`apps/desktop`, see stack/boot.ts), so the desktop
+// entry point (`OrgSsoLoginLink` on `/login`) is driven through a real browser
+// below. The `apps/web` pages (`LoginSsoPage`, the auth-screen link, the
+// `/join` page) are a *different* Vite app this harness does not boot; their
+// logic sits on the identical `discoverSso` seam, which the server-level cases
+// here pin directly. If a web-app browser lane is added to this suite later,
+// the rendered `apps/web` pages get their own rows on top of this same seam.
+
+import { expect, test, type Page } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  apiBaseUrl,
+  deleteOrgSsoConnections,
+  ensureInstanceClaimed,
+  getOrganizationSlug,
+  getOwnOrganization,
+  passwordLogin,
+  seedEnabledOrgSsoConnection,
+  webBaseUrl,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+interface SsoDiscoveryResponse {
+  enabled: boolean;
+  scope: "deployment" | "organization" | null;
+  connectionId: string | null;
+  organizationId: string | null;
+  protocol: "oidc" | "saml" | null;
+  displayName: string | null;
+  reason: string | null;
+}
+
+async function discover(query: Record<string, string>): Promise<{ status: number; body: SsoDiscoveryResponse }> {
+  const params = new URLSearchParams(query).toString();
+  const response = await fetch(`${apiBaseUrl()}/auth/sso/discover?${params}`);
+  return { status: response.status, body: (await response.json()) as SsoDiscoveryResponse };
+}
+
+// Every test needs the instance claimed (so the admin org — our
+// existing-but-no-SSO subject — exists) and the admin org's id/slug.
+let organizationId: string;
+let organizationSlug: string;
+
+test.beforeAll(async () => {
+  await ensureInstanceClaimed();
+  const adminToken = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+  organizationId = (await getOwnOrganization(adminToken)).id;
+  organizationSlug = await getOrganizationSlug(organizationId);
+});
+
+// The seeded connection must never outlive this file — sibling specs share
+// this profile's DB and none of them expects an org SSO connection to exist.
+test.afterAll(async () => {
+  await deleteOrgSsoConnections(organizationId);
+});
+
+test.describe("T2-AUTH-5: org SSO entry points — discover seam", () => {
+  test("unknown slug returns the generic not-available answer with no ids", async () => {
+    const { status, body } = await discover({ slug: "no-such-workspace-2f1a9c" });
+    expect(status).toBe(200);
+    expect(body.enabled).toBe(false);
+    expect(body.reason).toBe("not_available");
+    // No ids leak — the caller cannot tell this slug from a real one.
+    expect(body.organizationId).toBeNull();
+    expect(body.connectionId).toBeNull();
+    expect(body.protocol).toBeNull();
+    expect(body.displayName).toBeNull();
+  });
+
+  test("an existing org with no SSO returns the identical answer (no enumeration)", async () => {
+    // The admin org is real and its slug resolves to it, but it has no SSO —
+    // the response must be byte-for-byte the unknown-slug answer, or a caller
+    // could cycle slugs to learn which orgs exist / have SSO configured.
+    const { body } = await discover({ slug: organizationSlug });
+    expect(body.enabled).toBe(false);
+    expect(body.reason).toBe("not_available");
+    expect(body.organizationId).toBeNull();
+    expect(body.connectionId).toBeNull();
+  });
+
+  test("a slug resolving to an enabled connection returns exactly the start ids", async () => {
+    const connectionId = await seedEnabledOrgSsoConnection(organizationId, "Acme Okta");
+    try {
+      const { status, body } = await discover({ slug: organizationSlug });
+      expect(status).toBe(200);
+      expect(body.enabled).toBe(true);
+      expect(body.organizationId).toBe(organizationId);
+      expect(body.connectionId).toBe(connectionId);
+      expect(body.protocol).toBe("oidc");
+      expect(body.scope).toBe("organization");
+      expect(body.displayName).toBe("Acme Okta");
+      // reason is only set on the not-available answers.
+      expect(body.reason).toBeNull();
+    } finally {
+      await deleteOrgSsoConnections(organizationId);
+    }
+  });
+
+  test("the /join path's org-id discovery resolves the same enabled connection", async () => {
+    // `/join/<orgId>` discovers by organization id (not slug) and signs the
+    // user in on the web when SSO is enabled, else falls back to the Desktop
+    // handoff. Both branches are decided by this discover answer.
+    const connectionId = await seedEnabledOrgSsoConnection(organizationId, "Acme Okta");
+    try {
+      const enabled = await discover({ organizationId });
+      expect(enabled.body.enabled).toBe(true);
+      expect(enabled.body.connectionId).toBe(connectionId);
+    } finally {
+      await deleteOrgSsoConnections(organizationId);
+    }
+
+    // With no connection, the same org-id lookup reports SSO unavailable — the
+    // signal that makes `/join` fall back to the Desktop handoff.
+    const disabled = await discover({ organizationId });
+    expect(disabled.body.enabled).toBe(false);
+  });
+});
+
+// The desktop web build's cold-login SSO affordance (OrgSsoLoginLink on
+// `/login`). We drive the negative through a real browser: it exercises the
+// entry point end-to-end (expand → slug → discover → generic error) without
+// needing a live IdP, since an unavailable slug never reaches the start flow.
+async function openSsoAffordance(page: Page): Promise<void> {
+  await page.goto(`${webBaseUrl()}/login`);
+  const link = page.getByRole("button", { name: "Sign in with SSO" });
+  await expect(link).toBeVisible({ timeout: 30_000 });
+  await link.click();
+  await expect(page.getByPlaceholder("your-organization")).toBeVisible();
+}
+
+test.describe("T2-AUTH-5: org SSO entry points — desktop cold-login affordance", () => {
+  test("the affordance reveals a slug field and a Continue action", async ({ page }) => {
+    await openSsoAffordance(page);
+    await expect(page.getByRole("button", { name: /Continue with SSO/i })).toBeVisible();
+  });
+
+  test("an unknown slug surfaces the generic error and does not start SSO", async ({ page }) => {
+    await openSsoAffordance(page);
+    await page.getByPlaceholder("your-organization").fill("no-such-workspace-2f1a9c");
+    await page.getByRole("button", { name: /Continue with SSO/i }).click();
+    // The generic, non-enumerating message the hook shows for any unavailable
+    // slug (missing org, no SSO, or disabled all collapse to this).
+    await expect(page.getByText(/sign-in link your admin shared/i)).toBeVisible({ timeout: 15_000 });
+    // Still on the login surface — no navigation/kickoff happened.
+    await expect(page.getByPlaceholder("your-organization")).toBeVisible();
+  });
+
+  test("an existing org with no SSO shows the same generic error (no enumeration)", async ({ page }) => {
+    await openSsoAffordance(page);
+    await page.getByPlaceholder("your-organization").fill(organizationSlug);
+    await page.getByRole("button", { name: /Continue with SSO/i }).click();
+    await expect(page.getByText(/sign-in link your admin shared/i)).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -585,6 +585,76 @@ export async function resetPasswordLoginRateLimits(): Promise<void> {
   }
 }
 
+// ── Org SSO entry points (T2-AUTH-5) ──
+// The web/desktop SSO entry points resolve an org **slug** (or org id) to that
+// org's SSO connection through `GET /sso/discover`, then hand off to the
+// existing start flow. Discover reads the connection's stored state only — it
+// never contacts the IdP (that happens at `start`), so an enabled connection
+// row seeded directly in Postgres is enough to exercise the slug/org-id
+// resolution seam without a live IdP round-trip (the round-trip itself is
+// T2-AUTH-3, landed separately). Slugs are generated per org (lowercase,
+// URL-safe, unique); there is no API that returns an org's slug, so we read it
+// straight from the row the migration/creation path wrote.
+
+/** The org's generated login slug (`/login/<slug>`), read from Postgres. */
+export async function getOrganizationSlug(organizationId: string): Promise<string> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    const result = await client.query<{ slug: string | null }>(
+      `SELECT slug FROM organization WHERE id = $1`,
+      [organizationId],
+    );
+    const slug = result.rows[0]?.slug;
+    if (!slug) {
+      throw new Error(`Organization ${organizationId} has no slug (did the slug migration run?)`);
+    }
+    return slug;
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Seed an ENABLED organization-scope OIDC SSO connection directly in Postgres
+ * and return its id. Discover only reads status/scope/protocol/display_name/
+ * organization_id off this row, so the OIDC endpoint fields stay null — a
+ * `start` against it would need a real IdP, which is deliberately out of scope
+ * here (T2-AUTH-3 owns the round-trip). Columns with server defaults
+ * (login_policy, jit_policy, default_role, allowed_domains_json, oidc scopes)
+ * are left to fill themselves.
+ */
+export async function seedEnabledOrgSsoConnection(
+  organizationId: string,
+  displayName = "Acme Okta",
+): Promise<string> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO sso_connection (id, scope, organization_id, protocol, status, display_name, created_at, updated_at)
+       VALUES (gen_random_uuid(), 'organization', $1, 'oidc', 'enabled', $2, now(), now())
+       RETURNING id`,
+      [organizationId, displayName],
+    );
+    return result.rows[0].id;
+  } finally {
+    await client.end();
+  }
+}
+
+/** Remove every SSO connection for an org (test cleanup — keep the seeded
+ * connection from leaking into sibling specs that share this profile DB). */
+export async function deleteOrgSsoConnections(organizationId: string): Promise<void> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    await client.query(`DELETE FROM sso_connection WHERE organization_id = $1`, [organizationId]);
+  } finally {
+    await client.end();
+  }
+}
+
 /** The server uses asyncpg's SQLAlchemy URL scheme; node-postgres needs the
  * plain `postgresql://` scheme, and its resolver chokes on the bracketed
  * `[::1]` host the macOS profile default uses — Docker's Postgres publishes


### PR DESCRIPTION
## What

Tier-2 (mocked-intent) coverage for the org-SSO login entry points added in #1048: the slug login page / `/login/<slug>` links, the desktop cold-login "Sign in with SSO" affordance, and the `/join/<orgId>` web sign-in. New spec `tests/intent/specs/sso-entry-points.spec.ts` (T2-AUTH-5).

## Scope: the entry-point seam, not the round-trip

Every entry point resolves an org **slug or id** to that org's SSO connection through `GET /auth/sso/discover`, then hands off to the existing start flow. Discover reads the connection's stored state and never contacts the IdP, so the entry-point seam is fully assertable without a live IdP. The OIDC round-trip stays T2-AUTH-3 (landed separately, #1015); this PR does not duplicate it.

### What it asserts
- **Server discover seam (driven directly):**
  - unknown slug AND an existing org with no SSO both return the identical generic answer (`enabled:false`, `reason:"not_available"`, no ids) — slugs can't be cycled to enumerate which orgs exist or have SSO;
  - a slug (and an org id, the `/join` path's input) resolving to an ENABLED connection returns exactly the start ids (`organizationId`, `connectionId`, `protocol`, `displayName`).
- **Desktop web build (real browser):** the `OrgSsoLoginLink` affordance on `/login` expands to a slug field; submitting an unavailable slug surfaces the one generic error and does not start SSO.

Setup seeds an enabled org-scope OIDC `sso_connection` row directly (same spirit as the invitation-expiry direct-DB seed), cleaned up after the file so it never leaks into sibling specs sharing the profile DB.

## Surface note (honest tier boundary)

The tier-2 stack boots the **desktop web build** (`apps/desktop`), so the `apps/web` pages (`LoginSsoPage`, the auth-screen link, `/join`) are not rendered by this suite; their logic sits on the same `discoverSso` seam these cases pin.

## Verification

Ran locally against the tier-2 stack (`TIER2_INTENT_SKIP_RUNTIME=1`, dedicated profile): all 7 tests green.

Registered in `specs/developing/testing/flows.md` and `specs/developing/testing/scenarios.md`.