### PR TITLE
test(intent): point remove-user flow row at existing coverage

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -34,7 +34,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Invite users; promote/demote roles | 2 | — |
 | Admin-only surfaces gated: member cannot see/do admin actions | 2 | — |
 | Member visibility boundaries (sees own work, not others' private state) | 2 | — |
-| Remove user; access ends | 2 | — |
+| Remove user; access ends | 2 | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1; "remove a member -> membership status 'removed' -> their next org-scoped call fails" — 200 while active, 404 organization_not_found on the next org-scoped call post-removal, gone from the active roster, and a later relist 403s instance_access_removed rather than silently re-adding them) |
 
 ## Workspaces
 


### PR DESCRIPTION
## Summary
- The flow-registry row "Remove user; access ends" pointed at `—` even though `tests/intent/specs/organization-roles.spec.ts` (T2-ORG-1) already covers it end to end: member has access while active (200), gets removed, next org-scoped call 404s `organization_not_found`, disappears from the active roster, and a later relist 403s `instance_access_removed` instead of silently re-adding them.
- Verified the existing test locally (fresh boot, all 6 T2-ORG-1 cases green, including the remove-a-member case) — no new test was needed, just fixed the stale pointer.

## Test plan
- [x] Ran `pnpm run test:organization-roles` against a fresh `t2intent`-profile boot: 6/6 passed, including "remove a member -> membership status 'removed' -> their next org-scoped call fails"
- [ ] CI intent-tests job green on this PR