### PR TITLE
fix(desktop): consumption card always visible in the sidebar, not in the account popover

### DIFF
--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -120,6 +120,14 @@ export function SidebarAccountFooter() {
 
   return (
     <div className="shrink-0">
+      {usageSummary ? (
+        <ConsumptionCard
+          usageSummary={usageSummary}
+          onTopUp={() => {
+            navigate("/settings?section=billing");
+          }}
+        />
+      ) : null}
       <div aria-hidden className="h-[0.5px] bg-sidebar-border" />
       <div className="flex items-center px-2 py-2">
         <PopoverButton
@@ -322,16 +330,6 @@ export function SidebarAccountFooter() {
                   }}
                 />
               </div>
-
-              {usageSummary ? (
-                <ConsumptionCard
-                  usageSummary={usageSummary}
-                  onTopUp={() => {
-                    navigate("/settings?section=billing");
-                    close();
-                  }}
-                />
-              ) : null}
 
               <div className="border-t border-border-light py-1">
                 <PopoverMenuItem

--- a/apps/desktop/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -99,7 +99,8 @@ function ConsumptionMeterRow({
 
 /**
  * Compute + LLM usage meters, personal scope only (an admin's org-wide view
- * lives in Usage & limits settings, not the popover — spec decision).
+ * lives in Usage & limits settings — spec decision). Rendered always-visible
+ * in the sidebar directly above the account footer, not inside its popover.
  */
 export function ConsumptionCard({
   usageSummary,


### PR DESCRIPTION
The compute/LLM consumption meters were only visible after opening the account popover. Moves the ConsumptionCard out of the popover body and renders it directly in the sidebar footer block, above the account row, so usage is always visible. Top-up still routes to Settings → Billing. Desktop tsc clean.