### PR TITLE
fix(ci): make server-ci GHCR publish gate input-driven (+ :stable, +litellm image)

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -141,7 +141,11 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')) || (github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run)
+    # Reusable-workflow calls inherit the caller's event name (never
+    # "workflow_call"), so this leg is driven by inputs.publish/dry_run instead.
+    # inputs.* are empty on plain push/PR events, so the comparisons stay false
+    # there and true only on a server-v tag push or an explicit publish call.
+    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
     permissions:
       contents: read
       packages: write
@@ -164,18 +168,26 @@ jobs:
         run: |
           set -euo pipefail
           GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-server"
+          LITELLM_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-litellm"
           TAGS=()
+          LITELLM_TAGS=()
 
           if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/server-v}"
           else
             VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
           fi
-          TAGS+=("${GHCR_IMAGE}:${VERSION}")
+          # Push both the immutable version tag and the rolling :stable tag that the
+          # self-host compose bundle (server/deploy/) defaults to.
+          TAGS+=("${GHCR_IMAGE}:${VERSION}" "${GHCR_IMAGE}:stable")
+          LITELLM_TAGS+=("${LITELLM_IMAGE}:${VERSION}" "${LITELLM_IMAGE}:stable")
 
           {
             echo "tags<<EOF"
             printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+            echo "litellm_tags<<EOF"
+            printf '%s\n' "${LITELLM_TAGS[@]}"
             echo "EOF"
             echo "version=${VERSION}"
           } >> "$GITHUB_OUTPUT"
@@ -214,10 +226,24 @@ jobs:
             WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
             MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
 
+      # The self-host compose bundle also defaults the LiteLLM gateway to
+      # ghcr.io/OWNER/proliferate-litellm:stable, which no workflow built before.
+      # Build it here symmetrically with the server image (same GHCR login, same
+      # version/:stable tags) so self-host operators can pull it.
+      - name: Build and push LiteLLM gateway
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: server/litellm/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.litellm_tags }}
+
   self-hosted-release-assets:
     runs-on: ubuntu-latest
     needs: [lint, test, docker]
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')) || (github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run)
+    # Same input-driven gate as the docker job (see note above): a server-v tag
+    # push, or an explicit publish call from a release train / hotfix workflow.
+    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
     permissions:
       contents: write
     steps:
@@ -296,7 +322,9 @@ jobs:
         working-directory: .
 
       - name: Ensure server release tag exists
-        if: github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run
+        # Only publish calls need to create the tag; on a real server-v tag push
+        # the tag already exists. Input-driven, not event-name-driven.
+        if: inputs.publish == true && inputs.dry_run != true
         env:
           RELEASE_TAG: ${{ format('server-v{0}', inputs.version) }}
           RELEASE_TARGET: ${{ inputs.git_sha }}


### PR DESCRIPTION
## Problem: GHCR images have never been published

The self-host launch depends on `ghcr.io/proliferate-ai/proliferate-server` (and, per the compose bundle, `proliferate-litellm`) existing in GHCR. They never have. Two independent bugs in `.github/workflows/server-ci.yml` blocked every publish path.

### Bug 1 — the `workflow_call` gate can never be true at runtime

The `docker` job, the `self-hosted-release-assets` job, and the "Ensure server release tag exists" step all gated publishing on:

```yaml
if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/server-v')) || (github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run)
```

Reusable workflows inherit the **caller's** event name — `github.event_name` is never `'workflow_call'` at runtime. Both real callers (`nightly-release-train.yml` → `release-server`, `hotfix-production.yml` → `release-server`) invoke this workflow with `publish: true, dry_run: false`, but the publish leg evaluated to false on every run, so the jobs were skipped.

**Proof** — hotfix run `29023895372`:

```
release-server / lint: success
release-server / test: success
release-server / docker: skipped
release-server / self-hosted-release-assets: skipped
```

Lint and test ran; the publish jobs were skipped even though the caller asked to publish.

### Bug 2 — the `server-v*` tag-push trigger never fires

The other leg of the gate relies on a `server-v*` tag push. Those tags are created by the Actions `GITHUB_TOKEN` inside `self-hosted-release-assets` ("Ensure server release tag exists"), and GitHub's recursion guard suppresses workflow runs triggered by the built-in token. So the tag-push path never re-triggers this workflow either. Publishing has to work from the `workflow_call` leg, which Bug 1 broke.

## Fix

Make the gate input-driven, matching what the callers actually pass, and safe on plain push/PR events (where `inputs.*` are empty):

```yaml
if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
```

Applied to the `docker` job and `self-hosted-release-assets` job. The "Ensure server release tag exists" step is now `inputs.publish == true && inputs.dry_run != true` (only publish calls create the tag; on a real tag push it already exists). `inputs.publish` defaults to `true` and `inputs.dry_run` to `false`, and both are empty on push/PR, so the comparisons stay false there — the jobs still only publish on a `server-v` tag push or an explicit publish call.

### Also: `:stable` tag + LiteLLM image

- The self-host compose bundle (`server/deploy/docker-compose.production.yml`, `.env.production.example`) defaults `PROLIFERATE_SERVER_IMAGE_TAG=stable`, but the `docker` job only pushed the immutable `:VERSION` tag. Added `:stable` to the server push.
- The same compose file defaults the gateway to `ghcr.io/proliferate-ai/proliferate-litellm:stable`. `server/litellm/Dockerfile` exists and `_deploy-litellm.yml` builds it — but only to **ECR** for the managed ECS service, never to GHCR. Self-host operators had no image to pull. Since the Dockerfile takes no build args, building it here is trivially symmetric with the server image (same GHCR login, same `:VERSION` + `:stable` tags), so I added a parallel `Build and push LiteLLM gateway` step rather than leaving it as a gap.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` → OK
- `actionlint .github/workflows/server-ci.yml` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)