### PR TITLE
specs(testing): self-hosting test hand-off (flow rows + scenario battery)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -53,6 +53,7 @@ migration exception and state the canonical owner/rule directly.
 | Cloud provisioning, workspace creation, commands, auth, MCPs, billing, claiming | `specs/codebase/primitives/README.md`; focused primitive specs under `specs/codebase/primitives/`, including `specs/codebase/primitives/workspace-provisioning.md` for managed workspace creation read order |
 | Product workflows and surfaces | `specs/codebase/features/README.md`; focused feature specs under `specs/codebase/features/`; `specs/codebase/features/support-reporting.md` for Desktop support report uploads |
 | Local dev, CI/CD, deployment, env vars, debugging, analytics, QA | `specs/developing/README.md`; focused process docs under `specs/developing/local/`, `specs/developing/deploying/`, `specs/developing/debugging/`, `specs/developing/analytics/`, `specs/developing/qa/`, `specs/developing/runbooks/`, and `specs/developing/reference/` |
+| Automated testing standard + flow registry | `specs/developing/testing/README.md` (tiers, placement, gates), `specs/developing/testing/flows.md` (flows that must never break) |
 | Draft planning notes | `specs/tbd/README.md`; files under `specs/tbd/` are non-authoritative until promoted. |
 
 ## Spec Rules

--- a/specs/developing/README.md
+++ b/specs/developing/README.md
@@ -21,8 +21,12 @@ the area docs under `specs/codebase/structures/**`.
 - [analytics/README.md](analytics/README.md)
   - Customer.io, Metabase, PostHog, Sentry, anonymous telemetry, ownership, and
     freshness expectations
+- [testing/README.md](testing/README.md)
+  - automated testing standard: the four tiers, per-language placement,
+    merge-vs-release gates, contract fixtures, and the flow registry
+    ([testing/flows.md](testing/flows.md))
 - [qa/README.md](qa/README.md)
-  - release QA process and per-surface verification checklist
+  - manual release QA process and per-surface verification checklist
 - [runbooks/README.md](runbooks/README.md)
   - specific, repeatable operational runbooks (billing promo codes, Stripe
     webhook failures, E2B template rollback, and future cloud/worker/sandbox
@@ -40,6 +44,7 @@ the area docs under `specs/codebase/structures/**`.
 | Developing locally with profiles, Stripe, and mobile | [local/README.md](local/README.md), [local/dev-profiles.md](local/dev-profiles.md), [local/stripe-local-testing.md](local/stripe-local-testing.md), and [local/mobile.md](local/mobile.md). |
 | Debugging and support issue triage | [debugging/README.md](debugging/README.md), [debugging/support-reports.md](debugging/support-reports.md), and [debugging/performance-profiling.md](debugging/performance-profiling.md). |
 | Analytics and keeping observability fresh | [analytics/README.md](analytics/README.md) plus the Customer.io, Metabase, PostHog, Sentry, and anonymous telemetry docs in that folder. |
+| Automated testing standard and flow registry | [testing/README.md](testing/README.md) and [testing/flows.md](testing/flows.md). |
 | QA and release verification | [qa/README.md](qa/README.md), with feature-specific acceptance criteria under [../codebase/features/](../codebase/features/) and primitive smoke expectations under [../codebase/primitives/](../codebase/primitives/). |
 
 PR title, label, release-note, and checklist rules live in

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -106,6 +106,29 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Overage bills real money correctly: compute metered events + amounts match up to cap then hard-block; LLM auto top-up charges once then fail-closes on payment failure | 3 | — |
 | Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |
 
+## Self-hosting
+
+Scenario definitions, tier-2 escalations, and infra prerequisites:
+[self-hosting.md](self-hosting.md). `2*` = needs the tier-2 escalation in
+that doc's §4 (the connect UI is Tauri-gated; desktop-web never renders it —
+tests drive the LoginScreen fixture instead).
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| `single_org_mode` derivation: self_managed telemetry ⇒ single-org; override respected | 1 | — |
+| SSO env aliasing: bare `SSO_*` ≡ `PROLIFERATE_SSO_*` (AliasChoices) | 1 | — |
+| `GET /meta` response contract (fields the desktop connect dialog parses) | 1 | — |
+| Desktop connect-to-server: enter URL → `/meta` verify (host+version shown) → confirm → relaunch → connected banner | 2* | — |
+| Desktop server switch: reset to Cloud → connect to a second server | 2* | — |
+| `/setup` claim through the UI → admin lands in instance org (self-hosted framing of the claim flow) | 2 | — |
+| Invite → browser `/register` with token → invitee desktop password login | 2 | — |
+| Sign-in surface adapts to `GET /auth/desktop/methods` (password form vs GitHub button) | 2 | — |
+| Self-hosted server on real EC2 + real TLS: boot → claim → login → invite lands in DB | 3 | — |
+| Two-server connect/switch against real staging servers (alpha/beta) | 3 | — |
+| Model gateway add-on: `--profile agent-gateway` boot, agent request routes through LiteLLM | 3 | — |
+| `./update.sh`: N−1 pin → update → migrated + healthy + `/meta` reports N | 4 | — |
+| Release artifact chain intact: server desktop-pin → updater manifest → artifact URL 200 → artifact tag contains the release SHA | 4 | — |
+
 ## Upgrade & release
 
 There is no single "upgrade path" — five distinct mechanisms, each tested at

--- a/specs/developing/testing/self-hosting.md
+++ b/specs/developing/testing/self-hosting.md
@@ -1,0 +1,196 @@
+# Self-Hosting Test Hand-Off
+
+Status: hand-off from the self-hosting launch pass (2026-07-09) to the testing
+arc. Maps the self-hosting surface onto the 4-tier standard (`README.md`);
+scenario steps follow `scenarios.md` conventions. Grounded in code + a full
+local production-compose smoke run 2026-07-09, and one live incident (the
+desktop-artifact gap, §5) that this battery must be able to catch.
+
+Ruling already made by Pablo: self-hosting E2E runs against **standing staging
+servers** (real EC2), and tier-2 desktop flows **prefer desktop-web, escalate
+gaps** (gaps enumerated in §4).
+
+---
+
+## 1. The surface (mental model, validated)
+
+Every self-host deploy path is the same thing: the production Docker Compose
+bundle (`server/deploy/`) pulling public GHCR images
+(`ghcr.io/proliferate-ai/proliferate-server:stable`), whether the operator ran
+`bootstrap.sh` by hand on any Linux box or the AWS CloudFormation one-click did
+it for them on EC2. **There is no separate CFN architecture** — testing
+compose-on-EC2 covers both.
+
+Orthogonal layers, each independently on/off:
+
+- Auth: password (default) / GitHub OAuth / Google / OIDC SSO — desktop asks
+  `GET /auth/desktop/methods` and renders what's configured.
+- Add-on: cloud sandboxes (GitHub App + E2B key + self-built template).
+- Add-on: model gateway (`--profile agent-gateway`, LiteLLM).
+- Lifecycle: `./update.sh` pulls + migrates + restarts; desktops follow the
+  server's pin via `GET /desktop/updater/latest.json`.
+
+Invariants: every self-hosted server is single-org
+(`single_org_mode`, `config.py:376` — derived from non-`hosted_product`
+telemetry mode); `/setup` is claimed exactly once and 404s forever after;
+invitees register in a browser via the invitation's registration token.
+
+What already exists: `self-host-smoke.yml` (required merge check) boots the
+real compose stack http-only and walks health → `/meta` → claim → password
+login → invite → register → membership at the **API** level. Everything below
+is coverage that does not exist yet.
+
+## 2. Flow registry rows
+
+Registered in `flows.md` under the **Self-hosting** section (same PR as this
+doc), same rules as the rest of the registry: pointer per row,
+audit-checked, `—` is a to-do. `2*` = needs the tier-2 escalation in §4 (not
+reachable from plain desktop-web).
+
+## 3. Scenario definitions
+
+### Tier 1
+
+**T1-SH-1: single-org derivation.** Pure config test: `telemetry_mode=
+"self_managed"` ⇒ `single_org_mode` true; `"hosted_product"` ⇒ false;
+`single_org_mode_override` wins in both directions. (`config.py:376`.)
+
+**T1-SH-2: SSO alias equivalence.** Settings built from `SSO_CLIENT_ID=x`
+equals settings built from `PROLIFERATE_SSO_CLIENT_ID=x`, for every SSO var.
+Guards the docs' canonical-form promise (docs standardized on bare `SSO_*`).
+
+**T1-SH-3: `/meta` contract.** Golden-fixture the response shape
+(`serverVersion` et al.) — this is the wire contract the connect dialog's
+trust-confirmation renders; a field rename breaks every desktop silently.
+
+### Tier 2 (stack-boot fixture per `scenarios.md` conventions)
+
+**T2-SH-1: connect + switch (fixture-driven, see §4).**
+Preconditions: two server fixtures A and B on different ports.
+Steps: from sign-in surface → "Connect to a server" → enter A's URL →
+assert checking state → trust screen shows A's host + `Server version X` →
+Connect → assert config write + relaunch requested → assert "Connected to
+{A}" banner → Reset → connect to B.
+Negatives: non-Proliferate URL (no `/meta`) fails loudly with the entry
+retained; malformed URL rejected before any request; scheme-less input gets
+`https://` assumed.
+
+**T2-SH-2: `/setup` claim UI.** T2-AUTH-1 already covers claim + password
+lifecycle; extend its asserts with the self-hosted specifics: claimed user is
+**owner** of the single instance org; second browser hitting `/setup`
+post-claim gets the already-claimed state (404 surface).
+
+**T2-SH-3: invite → register → desktop login.**
+Steps: admin invites from the UI → read the registration token from the
+invitation (no email locally — `delivery_status=skipped`; **invitations have
+no secret token**, auth is UUID + email-match per the 2026-07-07 survey) →
+fresh browser context to `/register` with token → set password → desktop-web
+sign-in as invitee.
+Assert: invitee active member of the instance org; wrong-email registration
+rejected.
+
+**T2-SH-4: adaptive sign-in.** Server fixture without GitHub OAuth vars ⇒
+password form rendered (no GitHub button); with `GITHUB_OAUTH_CLIENT_ID/
+SECRET` set ⇒ GitHub button rendered. Driven purely by
+`GET /auth/desktop/methods`.
+
+### Tier 3 (standing staging servers)
+
+Two long-lived EC2 boxes, `alpha` and `beta`, each running the production
+compose bundle behind real DNS + Caddy-issued TLS (staging subdomains — needs
+one-time provisioning, §6). These attach to the existing
+`tests/release-runner` lanes.
+
+**T3-SH-1: cold boot to second user on real infra.** Fresh instance (reset
+motion, §6) → `bootstrap.sh` → claim → admin login → invite → register →
+invitee login. Same walk as the CI smoke but through real TLS/DNS, asserting
+rows in the instance Postgres ("shows up in the database in AWS").
+
+**T3-SH-2: real desktop against alpha/beta.** Real (Tauri) desktop build:
+connect to alpha → password login → reset → connect to beta. This is the
+only lane that proves the relaunch + config.json + keychain path end-to-end.
+
+**T3-SH-3: gateway add-on.** On alpha: set the `AGENT_GATEWAY_*`/`LITELLM_*`
+env block (per `.env.production.example`, post-#1054) → compose up with
+`--profile agent-gateway` → agent request through the gateway with the
+staging test key on the cheapest model → real response. (Consistent with the
+no-mock-LLM ruling.)
+
+### Tier 4 (upgrade path)
+
+**T4-SH-1: operator update motion.**
+Boot with `PROLIFERATE_SERVER_IMAGE_TAG=<N−1>` → run `./update.sh` → assert:
+migrations applied, health green, `/meta` reports N, existing session/user
+data intact.
+
+**T4-SH-2: artifact chain (the incident test — see §5).**
+Mechanics (confirmed by the 2026-07-09 release-pipeline investigation): the
+desktop's Tauri updater feed is hardcoded to the CDN
+(`downloads.proliferate.com`, S3 `proliferate-desktop-downloads` behind
+CloudFront); the server's `GET /desktop/updater/latest.json` 302-redirects to
+the versioned manifest for its pinned `desktopVersion`, falling back to the
+flat manifest when the versioned one is missing — so the server pin is
+display-only today and the CDN is the ground truth.
+Asserts, against the release under test:
+1. `GET <server>/desktop/updater/latest.json` follows to HTTP 200.
+2. `https://downloads.proliferate.com/desktop/stable/latest.json` →
+   `version` == the release's desktop version, `pub_date` fresh (== release
+   day; a stale pub_date with a "new" version means the manifest was
+   hand-edited, not published).
+3. `https://downloads.proliferate.com/desktop/stable/<version>/latest.json`
+   → HTTP 200 (the versioned manifest the server redirect targets).
+4. **HEAD every platform artifact URL in the manifest → HTTP 200.**
+5. The tag `desktop-v<version>` exists and contains the release SHA
+   (`git merge-base --is-ancestor <release-sha> desktop-v<version>`).
+Version-string equality is not a pass; only a fetchable artifact is. This
+must run in the release gate, not nightly-only.
+
+## 4. Tier-2 escalations (the desktop-web gaps)
+
+The connect affordance is gated on `isTauriRuntimeAvailable()`
+(`apps/desktop/src/components/auth/LoginScreen.tsx:117`) — **plain desktop-web
+never renders it**. Per the prefer-desktop-web ruling:
+
+- T2-SH-1 drives the **LoginScreen fixture** that #1027 mirrored the connect
+  UI into (used by tests/playground) — covers dialog logic, validation, trust
+  screen, copy (`copy/auth/auth-copy.ts` `CONNECT_SERVER_LABELS`).
+- The `set_app_config` write + relaunch + credential store cannot be faked
+  (`lib/access/tauri/credentials.ts` throws outside Tauri) — that slice lives
+  only in T3-SH-2 with a real build.
+
+## 5. Why the artifact-chain gate exists (incident, 2026-07-09)
+
+The connect feature (#1027) merged 2026-07-09 10:48 UTC. The nightly train had
+already cut `desktop-v0.3.13` at 09:05; both later train runs failed on a
+same-day `release-2026-07-09` tag-collision in `create-release-tags.mjs`
+(after one of them had already pushed a 0.3.14 version bump to main). Result:
+the server advanced to v0.3.16 while **no shipped desktop artifact contained
+the launch-flagship feature**, and every desktop-v* GitHub release sits in
+draft. No existing check catches this class: versions look consistent; the
+artifact is simply absent. T4-SH-2 is that check, and it must run in the
+release gate, not nightly-only.
+
+## 6. Infrastructure prerequisites (one-time)
+
+| Item | Why | Notes |
+| --- | --- | --- |
+| 2 staging EC2 boxes (alpha/beta) | T3-SH-1/2 two-server switch | small instances; production compose bundle |
+| 2 staging DNS names + real TLS | only way to test Caddy's automatic HTTPS (CI smoke is http-only) | e.g. `selfhost-a/-b.<staging domain>` |
+| Reset motion | `/setup` claims exactly once — a standing box can run the claim test once, ever | `docker compose down -v` + re-`bootstrap.sh` script; alternatively ephemeral instance per run (slower) |
+| Staging gateway test key | T3-SH-3 | same key story as the rest of tier 3 (`env-manifest.ts`) |
+| Real desktop build in the release lane | T3-SH-2, T4-SH-2 | must be a build ≥ the release under test |
+
+## 7. Sharp edges (learned the hard way; don't rediscover)
+
+- `/setup` one-shot: see reset motion above. "There is nothing to set up
+  here" means the claim already succeeded.
+- Invites: no secret token (UUID + email-match); no Resend locally ⇒ read the
+  registration token from the invitation API response, as the smoke does.
+- `update.sh` and `bootstrap.sh` **both** regenerate `.env.runtime`; the
+  operator's source of truth is `.env`.
+- Gateway boot is a two-step: env vars alone do nothing without
+  `--profile agent-gateway` on the compose command.
+- Version-equality is a lying assertion for updates — always fetch the
+  artifact (§5).
+- The AWS CFN template embeds a full copy of `.env.production.example`; any
+  env-template assertion should check both or it will pass while CFN drifts.

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -309,6 +309,19 @@ Sentry lane requires them.
 
 ---
 
+### Testing
+
+**`specs/developing/testing/README.md`** — the automated-testing standard:
+four tiers (unit/contract, mocked intent, live end-to-end, upgrade path),
+placement table per language, the merge-vs-release gate rule (no real
+LLM/sandbox/third-party in the merge gate, ever), contract-fixture pattern
+under `fixtures/contracts/`, the decision procedure for where a change's
+tests go, and the postmortem rule.
+
+**`specs/developing/testing/flows.md`** — the flow registry: the inventory of
+end-to-end flows that must never break, each with its tier and a pointer to
+the enforcing test. Owned by Pablo; updated in the same PR as any flow change.
+
 ### QA
 
 **`specs/developing/qa/README.md`**
@@ -316,7 +329,8 @@ Sentry lane requires them.
 The QA root is now an authoritative release QA entrypoint. It covers operator
 requirements, release intake, baseline verification, profile-isolated
 full-stack QA, a touched-surface matrix, regression rules, failure handling,
-and final QA report shape.
+and final QA report shape. Manual QA only — automated testing is owned by
+`specs/developing/testing/`.
 
 The remaining opportunity is depth: split per-surface checklists into
 `specs/developing/qa/*.md` only when release execution needs more detail than


### PR DESCRIPTION
## What

Hand-off from the self-hosting launch pass to the testing arc:

- **`specs/developing/testing/self-hosting.md`** (new): validated mental model of the self-hosting surface, scenario definitions T1-SH-1..T4-SH-2, tier-2 desktop-web escalations (connect UI is Tauri-gated → drive the LoginScreen fixture), one-time staging infra prerequisites (alpha/beta EC2 boxes, real TLS, reset motion), and sharp edges.
- **`flows.md`**: new **Self-hosting** section — 13 rows across tiers 1–4, all pointers `—` (to-dos for the testing agent).
- Spec index entries for the testing section (`specs/README.md`, `specs/developing/README.md`, `specs/spec-catalog.md`).

## Why the T4 artifact-chain row exists

2026-07-09 incident: #1027 (desktop connect-to-server) merged after the last successful desktop release; two same-day train reruns failed on a RELEASE_ID tag collision, so the server advanced to v0.3.16 while no shipped desktop artifact contained the flagship feature — and every version string looked consistent. T4-SH-2 asserts a *fetchable artifact*, not version equality, and must run in the release gate.

Rulings baked in (Pablo, 2026-07-09): standing staging servers for self-host E2E; prefer desktop-web + escalate gaps for tier-2 desktop flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)