### PR TITLE
fix(ci): release train uniquifies same-day RELEASE_ID instead of failing mid-release

### DIFF
--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -86,7 +86,18 @@ jobs:
           set -euo pipefail
           git fetch origin main --tags --prune
           head_sha="$(git rev-parse HEAD)"
+          # Same-day reruns must not reuse an existing train tag: the collision
+          # used to surface only at the tag-creation step, AFTER the version-bump
+          # commit had already been pushed to main. Uniquify up front instead,
+          # so the second run of a day becomes release-YYYY-MM-DD-2.
           release_id="release-$(date -u +%F)"
+          if git rev-parse -q --verify "refs/tags/$release_id" >/dev/null; then
+            n=2
+            while git rev-parse -q --verify "refs/tags/$release_id-$n" >/dev/null; do
+              n=$((n+1))
+            done
+            release_id="$release_id-$n"
+          fi
           previous_train="$(git tag --list 'release-*' --sort=-creatordate | grep -v "^$release_id$" | head -n 1 || true)"
           if [[ -n "$previous_train" ]]; then
             base_sha="$(git rev-parse "$previous_train")"


### PR DESCRIPTION
## Bug

`nightly-release-train.yml` derives `release_id="release-$(date -u +%F)"` with no collision handling. A second run on the same UTC day (e.g. a rerun after a partial failure) hits the existing `release-YYYY-MM-DD` tag in `create-release-tags.mjs`, which correctly aborts the whole tag batch — but by then the **Commit version bumps** step has already pushed a version-bump commit to main. Both 2026-07-09 reruns failed exactly this way, stranding a 0.3.14 desktop version bump on main with no artifacts (part of the desktop-artifact incident; see specs/developing/testing/self-hosting.md §5 in #1078).

## Fix

Resolve the collision **before any side effects**: if `refs/tags/release-YYYY-MM-DD` exists, suffix `-2` (`-3`, ...). The `previous_train` base-sha lookup already excludes the current id by exact match, and suffixed ids sort correctly by creatordate, so diff ranges stay right. Dry-run behavior unchanged.

`create-release-tags.mjs` itself is untouched — its atomic validate-then-create behavior is correct; the bug was feeding it a guaranteed-colliding id after mutating main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)