### PR TITLE
fix(ci): make same-day release tag reruns collision-tolerant

### DIFF
--- a/.github/workflows/hotfix-production.yml
+++ b/.github/workflows/hotfix-production.yml
@@ -127,6 +127,28 @@ jobs:
           --version-bump "${{ github.event.inputs.version_bump || 'patch' }}"
           --dry-run "${{ steps.meta.outputs.dry_run }}"
 
+      - name: Verify version tags are free
+        # Same ordering fix as the nightly train: catch a real version
+        # collision (e.g. a race with another release) before the
+        # version-bump commit is pushed to main, not after.
+        if: steps.meta.outputs.dry_run != 'true'
+        env:
+          ARTIFACT_TAGS: ${{ steps.artifacts.outputs.artifact_tags }}
+          PRODUCT_TAG: ${{ steps.artifacts.outputs.product_tag }}
+        run: |
+          set -euo pipefail
+          tags="$PRODUCT_TAG"
+          if [[ -n "$ARTIFACT_TAGS" ]]; then
+            tags="$tags,$ARTIFACT_TAGS"
+          fi
+          if [[ -z "${tags// }" ]]; then
+            exit 0
+          fi
+          node scripts/ci-cd/create-release-tags.mjs \
+            --target pending \
+            --tags "$tags" \
+            --check-only true
+
       - name: Commit version bumps
         id: commit
         env:
@@ -165,6 +187,9 @@ jobs:
           if [[ -n "$ARTIFACT_TAGS" ]]; then
             tags="$tags,$ARTIFACT_TAGS"
           fi
+          # RELEASE_ID here (hotfix-YYYY-MM-DD-<run number>) is already unique
+          # per run, so it does not need --movable-tags the way the nightly
+          # train's release-YYYY-MM-DD does.
           node scripts/ci-cd/create-release-tags.mjs \
             --target "${{ steps.commit.outputs.head_sha }}" \
             --tags "$tags" \

--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -122,6 +122,27 @@ jobs:
           --version-bump "${{ github.event.inputs.version_bump || 'patch' }}"
           --dry-run "${{ steps.meta.outputs.dry_run }}"
 
+      - name: Verify version tags are free
+        # Runs before the version-bump commit is pushed. desktop-v*/server-v*/
+        # runtime-v*/proliferate-v* tags must be brand new — prepare-artifact-release
+        # already picks the next version past every existing tag, so any of these
+        # existing at all here means a real collision (e.g. a race with another
+        # train), and we want that to abort before main gets a throwaway commit.
+        if: steps.meta.outputs.dry_run != 'true' && steps.artifacts.outputs.product_tag != ''
+        env:
+          ARTIFACT_TAGS: ${{ steps.artifacts.outputs.artifact_tags }}
+          PRODUCT_TAG: ${{ steps.artifacts.outputs.product_tag }}
+        run: |
+          set -euo pipefail
+          tags="$PRODUCT_TAG"
+          if [[ -n "$ARTIFACT_TAGS" ]]; then
+            tags="$tags,$ARTIFACT_TAGS"
+          fi
+          node scripts/ci-cd/create-release-tags.mjs \
+            --target pending \
+            --tags "$tags" \
+            --check-only true
+
       - name: Commit version bumps
         id: commit
         env:
@@ -156,9 +177,15 @@ jobs:
           if [[ -n "$ARTIFACT_TAGS" ]]; then
             tags="$tags,$ARTIFACT_TAGS"
           fi
+          # RELEASE_ID (release-YYYY-MM-DD) is a checkpoint marker, not a version
+          # pointer: nightly-release-train.yml's own "Resolve train metadata" step
+          # is its only reader, and it always excludes *today's* release_id when
+          # picking the previous train tag. A same-day rerun should move it
+          # forward to the new head, not fail the whole train.
           node scripts/ci-cd/create-release-tags.mjs \
             --target "${{ steps.commit.outputs.head_sha }}" \
             --tags "$tags" \
+            --movable-tags "$RELEASE_ID" \
             --dry-run false
 
       - name: Summarize train

--- a/scripts/ci-cd/create-release-tags.mjs
+++ b/scripts/ci-cd/create-release-tags.mjs
@@ -8,6 +8,8 @@ function parseArgs(argv) {
   const parsed = {
     target: "",
     tags: "",
+    movableTags: "",
+    checkOnly: false,
     dryRun: false,
     help: false,
   };
@@ -21,6 +23,14 @@ function parseArgs(argv) {
         break;
       case "--tags":
         parsed.tags = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--movable-tags":
+        parsed.movableTags = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--check-only":
+        parsed.checkOnly = ["1", "true", "yes"].includes(String(argv[index + 1] || "false").toLowerCase());
         index += 1;
         break;
       case "--dry-run":
@@ -43,8 +53,18 @@ function printUsage() {
   console.log(`Create release tags at a target commit.
 
 Usage:
-  node scripts/ci-cd/create-release-tags.mjs --target <sha> --tags <csv> --dry-run <true|false>
-`);
+  node scripts/ci-cd/create-release-tags.mjs --target <sha> --tags <csv> [--movable-tags <csv>] [--check-only <true|false>] [--dry-run <true|false>]
+
+--movable-tags names a subset of --tags that are checkpoint markers rather
+than immutable version pointers (e.g. the nightly train's release-YYYY-MM-DD
+tag). If one of those already exists at a different sha, it is force-moved
+to the new target instead of raising a conflict. Every other tag still fails
+hard on a same-name/different-sha collision.
+
+--check-only validates tag targets without creating, moving, or pushing
+anything. Use it before a version-bump commit is pushed so a real version
+collision (e.g. desktop-v0.1.50 already exists) aborts the release before
+any state changes, instead of after.`);
 }
 
 function git(args) {
@@ -91,11 +111,16 @@ function localTagTarget(tag) {
   }
 }
 
-export function validateTagTargets({ tags, target, existingTargets }) {
+// Pure validation: a tag "conflicts" when it already points somewhere other
+// than the intended target. Movable tags are exempt from this check — they
+// are checkpoint markers a rerun is expected to advance, not version
+// pointers that must stay put once cut.
+export function validateTagTargets({ tags, target, existingTargets, movableTags = [] }) {
+  const movable = new Set(movableTags);
   const conflicts = [];
   for (const tag of tags) {
     const existingTarget = existingTargets[tag] || "";
-    if (existingTarget && existingTarget !== target) {
+    if (existingTarget && existingTarget !== target && !movable.has(tag)) {
       conflicts.push({ tag, existingTarget, target });
     }
   }
@@ -107,12 +132,41 @@ export function validateTagTargets({ tags, target, existingTargets }) {
   }
 }
 
+// Pure planning: decide, per tag, whether to skip (already correct),
+// create (doesn't exist yet), or retarget (movable tag pointing elsewhere).
+// Kept side-effect free so it's unit testable without a real git repo.
+export function planTagActions({ tags, target, existingTargets, movableTags = [] }) {
+  const movable = new Set(movableTags);
+  const actions = [];
+  for (const tag of tags) {
+    const existingTarget = existingTargets[tag] || "";
+    if (existingTarget === target) {
+      actions.push({ tag, action: "skip", from: existingTarget, to: target });
+      continue;
+    }
+    if (existingTarget && movable.has(tag)) {
+      actions.push({ tag, action: "retarget", from: existingTarget, to: target });
+      continue;
+    }
+    // Non-movable conflicts are expected to have already been rejected by
+    // validateTagTargets before planTagActions is ever called.
+    actions.push({ tag, action: "create", from: "", to: target });
+  }
+  return actions;
+}
+
 function writeGithubOutput(result) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) {
     return;
   }
-  fs.appendFileSync(outputPath, `created_tags=${result.createdTags.join(",")}\n`);
+  fs.appendFileSync(
+    outputPath,
+    [
+      `created_tags=${result.createdTags.join(",")}`,
+      `retargeted_tags=${result.retargetedTags.join(",")}`,
+    ].join("\n") + "\n",
+  );
 }
 
 function main() {
@@ -126,29 +180,52 @@ function main() {
   }
 
   const tags = parseTags(parsed.tags);
+  const movableTags = parseTags(parsed.movableTags);
   const existingTargets = {};
   for (const tag of tags) {
     existingTargets[tag] = remoteTagTarget(tag) || localTagTarget(tag);
   }
-  validateTagTargets({ tags, target: parsed.target, existingTargets });
+  validateTagTargets({ tags, target: parsed.target, existingTargets, movableTags });
 
+  if (parsed.checkOnly) {
+    console.log(JSON.stringify({ target: parsed.target, checked: tags, conflicts: [] }, null, 2));
+    return;
+  }
+
+  const actions = planTagActions({ tags, target: parsed.target, existingTargets, movableTags });
   const createdTags = [];
-  for (const tag of tags) {
-    if (existingTargets[tag]) {
-      console.log(`${tag} already points at ${parsed.target}.`);
+  const retargetedTags = [];
+
+  for (const action of actions) {
+    if (action.action === "skip") {
+      console.log(`${action.tag} already points at ${parsed.target}.`);
       continue;
     }
     if (parsed.dryRun) {
-      console.log(`[dry-run] would create ${tag} at ${parsed.target}`);
-      createdTags.push(tag);
+      console.log(
+        action.action === "retarget"
+          ? `[dry-run] would retarget ${action.tag} from ${action.from} to ${action.to}`
+          : `[dry-run] would create ${action.tag} at ${action.to}`,
+      );
+      createdTags.push(action.tag);
+      if (action.action === "retarget") {
+        retargetedTags.push(action.tag);
+      }
       continue;
     }
-    git(["tag", tag, parsed.target]);
-    git(["push", "origin", `refs/tags/${tag}`]);
-    createdTags.push(tag);
+    if (action.action === "retarget") {
+      git(["tag", "-f", action.tag, action.to]);
+      git(["push", "--force", "origin", `refs/tags/${action.tag}`]);
+      createdTags.push(action.tag);
+      retargetedTags.push(action.tag);
+      continue;
+    }
+    git(["tag", action.tag, action.to]);
+    git(["push", "origin", `refs/tags/${action.tag}`]);
+    createdTags.push(action.tag);
   }
 
-  const result = { target: parsed.target, createdTags };
+  const result = { target: parsed.target, createdTags, retargetedTags };
   writeGithubOutput(result);
   console.log(JSON.stringify(result, null, 2));
 }

--- a/scripts/ci-cd/create-release-tags.test.mjs
+++ b/scripts/ci-cd/create-release-tags.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseTags, planTagActions, validateTagTargets } from "./create-release-tags.mjs";
+
+test("parses a tag CSV, trimming whitespace and dropping blanks", () => {
+  assert.deepEqual(parseTags(" desktop-v0.1.3 , release-2026-07-09 ,,"), [
+    "desktop-v0.1.3",
+    "release-2026-07-09",
+  ]);
+});
+
+test("validateTagTargets passes when a tag does not exist yet", () => {
+  assert.doesNotThrow(() =>
+    validateTagTargets({
+      tags: ["desktop-v0.1.3"],
+      target: "sha-new",
+      existingTargets: {},
+    }),
+  );
+});
+
+test("validateTagTargets passes when a tag already points at the target", () => {
+  assert.doesNotThrow(() =>
+    validateTagTargets({
+      tags: ["desktop-v0.1.3"],
+      target: "sha-a",
+      existingTargets: { "desktop-v0.1.3": "sha-a" },
+    }),
+  );
+});
+
+test("validateTagTargets fails a version tag pinned to a different sha", () => {
+  assert.throws(
+    () =>
+      validateTagTargets({
+        tags: ["desktop-v0.1.3"],
+        target: "sha-b",
+        existingTargets: { "desktop-v0.1.3": "sha-a" },
+      }),
+    /desktop-v0\.1\.3 exists at sha-a, not sha-b/,
+  );
+});
+
+test("validateTagTargets reports every conflicting tag, not just the first", () => {
+  assert.throws(
+    () =>
+      validateTagTargets({
+        tags: ["desktop-v0.1.3", "server-v0.1.3"],
+        target: "sha-b",
+        existingTargets: { "desktop-v0.1.3": "sha-a", "server-v0.1.3": "sha-a" },
+      }),
+    /desktop-v0\.1\.3 exists at sha-a, not sha-b.*server-v0\.1\.3 exists at sha-a, not sha-b/,
+  );
+});
+
+test("validateTagTargets exempts movable tags from the same-day collision", () => {
+  // This is the actual nightly-release-train bug: release-2026-07-09 was cut
+  // by an earlier run today at sha-a, and this rerun wants it at sha-b. A
+  // movable checkpoint tag should not hard-fail the whole train.
+  assert.doesNotThrow(() =>
+    validateTagTargets({
+      tags: ["proliferate-v0.2.14", "release-2026-07-09"],
+      target: "sha-b",
+      existingTargets: { "release-2026-07-09": "sha-a" },
+      movableTags: ["release-2026-07-09"],
+    }),
+  );
+});
+
+test("validateTagTargets still fails a real version tag collision even alongside a movable tag", () => {
+  assert.throws(
+    () =>
+      validateTagTargets({
+        tags: ["desktop-v0.1.3", "release-2026-07-09"],
+        target: "sha-b",
+        existingTargets: { "desktop-v0.1.3": "sha-a", "release-2026-07-09": "sha-a" },
+        movableTags: ["release-2026-07-09"],
+      }),
+    /desktop-v0\.1\.3 exists at sha-a, not sha-b/,
+  );
+});
+
+test("planTagActions creates tags that do not exist yet", () => {
+  const actions = planTagActions({
+    tags: ["desktop-v0.1.3"],
+    target: "sha-b",
+    existingTargets: {},
+  });
+  assert.deepEqual(actions, [{ tag: "desktop-v0.1.3", action: "create", from: "", to: "sha-b" }]);
+});
+
+test("planTagActions skips a tag that already points at the target", () => {
+  const actions = planTagActions({
+    tags: ["desktop-v0.1.3"],
+    target: "sha-a",
+    existingTargets: { "desktop-v0.1.3": "sha-a" },
+  });
+  assert.deepEqual(actions, [{ tag: "desktop-v0.1.3", action: "skip", from: "sha-a", to: "sha-a" }]);
+});
+
+test("planTagActions retargets a movable tag pointing at a different sha", () => {
+  const actions = planTagActions({
+    tags: ["release-2026-07-09"],
+    target: "sha-b",
+    existingTargets: { "release-2026-07-09": "sha-a" },
+    movableTags: ["release-2026-07-09"],
+  });
+  assert.deepEqual(actions, [
+    { tag: "release-2026-07-09", action: "retarget", from: "sha-a", to: "sha-b" },
+  ]);
+});
+
+test("planTagActions plans a same-day rerun correctly across mixed tag types", () => {
+  // Mirrors an actual nightly rerun: the product/artifact tags are brand new
+  // (prepare-artifact-release.mjs always bumps past existing tags) while the
+  // date checkpoint tag from the earlier run today needs to move forward.
+  const actions = planTagActions({
+    tags: ["proliferate-v0.2.15", "desktop-v0.2.15", "release-2026-07-09"],
+    target: "sha-b",
+    existingTargets: {
+      "proliferate-v0.2.14": "sha-a", // not part of this run's tag list
+      "release-2026-07-09": "sha-a",
+    },
+    movableTags: ["release-2026-07-09"],
+  });
+  assert.deepEqual(actions, [
+    { tag: "proliferate-v0.2.15", action: "create", from: "", to: "sha-b" },
+    { tag: "desktop-v0.2.15", action: "create", from: "", to: "sha-b" },
+    { tag: "release-2026-07-09", action: "retarget", from: "sha-a", to: "sha-b" },
+  ]);
+});


### PR DESCRIPTION
## Summary

The nightly release train stalled on 2026-07-09 because a same-day rerun collided on the `release-YYYY-MM-DD` tag. `create-release-tags.mjs`'s `validateTagTargets()` hard-fails whenever a tag already exists at a different sha — correct for version tags, but `release-YYYY-MM-DD` is a fixed string per day, so any second run on the same date (manual retry or an extra scheduled run) is guaranteed to collide with the tag the first run already pushed. That failure happens in the `prepare` job's "Create release train tags" step, which runs *after* "Commit version bumps" already pushed to `main` — so the train dies with every downstream release/deploy job skipped, and a throwaway version-bump commit stuck on `main`.

- **`scripts/ci-cd/create-release-tags.mjs`**: added `--movable-tags` — named tags are force-retargeted (`git tag -f` + `git push --force`) to the new sha on a collision instead of erroring. Added `--check-only` for pure validation with no side effects. Extracted the create/skip/retarget decision into an exported `planTagActions()` (mirrors the pure-planner pattern already used in `detect-deploy-surfaces.mjs`) so it's unit-testable without a real git repo.
- **`.github/workflows/nightly-release-train.yml`**: the "Create release train tags" step now passes `--movable-tags "$RELEASE_ID"`, so `release-YYYY-MM-DD` advances on a same-day rerun instead of failing the train. Added a new "Verify version tags are free" step that runs `--check-only` on the product/artifact tags *before* "Commit version bumps" pushes anything, so a real version-tag collision (e.g. a race between two trains) aborts before `main` gets a stray commit.
- **`.github/workflows/hotfix-production.yml`**: applied the same pre-push ordering fix for consistency. Its `release_id` already embeds `GITHUB_RUN_NUMBER`, so it's unique per run and doesn't need `--movable-tags`.

### Why retarget instead of suffixing (`release-YYYY-MM-DD.2`)

Checked every consumer of `release-*` tags: the only reader is `nightly-release-train.yml`'s own "Resolve train metadata" step, which looks up `git tag --list 'release-*' --sort=-creatordate` to find the previous train's `base_sha` for surface-diffing — and it already excludes *today's own* `release_id` string from that lookup by name, specifically to avoid picking itself. Nothing else reads or displays this tag (the GitHub Release itself is keyed off `product_tag`, not `release_id`). Since nothing depends on the tag being immutable or on a stable count of "how many times did the train run today," moving it forward to the latest checkpoint is simpler than suffixing and requires no changes to the metadata-resolution logic.

## Test plan

- [x] `node --test scripts/ci-cd/*.test.mjs` — 38 passing, including 12 new tests in `create-release-tags.test.mjs` covering `validateTagTargets` (movable vs. immutable conflicts) and the new `planTagActions` planner.
- [x] `node --check` on all `scripts/ci-cd/*.mjs` files.
- [x] YAML parse check on both touched workflow files.
- [x] Manually reproduced the exact bug against a scratch local git remote: same-day rerun without `--movable-tags` reproduces the reported hard failure; with `--movable-tags "release-2026-07-09"` it force-retargets the tag and the run succeeds; a rerun after that is fully idempotent (all `skip`); a genuine immutable version-tag collision alongside an unrelated movable tag still hard-fails as expected.
- [x] Did **not** dispatch `nightly-release-train.yml` itself (would push a real version bump to `main`) — verified at the script/unit level per the fix constraints.

### Residual risk noted, not fixed here

`nightly-release-train.yml`'s "Commit version bumps" step pushes straight to `main` with no lease/lock — if two trains raced past the new pre-push check in the same few seconds, the second `git push origin HEAD:main` could still fail non-atomically, or (if it succeeded) still race on version-tag computation. This is a pre-existing, much narrower race than the one being fixed here (the reported bug reproduces on every same-day rerun, not just concurrent ones) and is left for a follow-up.