### PR TITLE
fix(desktop): invite links carry the issuing server origin; trust-confirm before switching

### DIFF
--- a/apps/desktop/src/components/auth/ConnectServerDialog.tsx
+++ b/apps/desktop/src/components/auth/ConnectServerDialog.tsx
@@ -6,6 +6,12 @@ import type { UseConnectServerResult } from "@/hooks/auth/workflows/use-connect-
 
 interface ConnectServerDialogProps {
   controller: UseConnectServerResult;
+  /**
+   * Optional context line rendered above the flow body — used when the dialog
+   * is opened from an invite link so the user understands why they're being
+   * asked to connect to a server (see the join-invitation flow).
+   */
+  context?: string;
 }
 
 /**
@@ -14,7 +20,7 @@ interface ConnectServerDialogProps {
  * (`set_app_config` + relaunch). Presentational only — all flow logic lives
  * in `useConnectServer`.
  */
-export function ConnectServerDialog({ controller }: ConnectServerDialogProps) {
+export function ConnectServerDialog({ controller, context }: ConnectServerDialogProps) {
   const {
     step,
     url,
@@ -81,6 +87,9 @@ export function ConnectServerDialog({ controller }: ConnectServerDialogProps) {
             void submitUrl();
           }}
         >
+          {context ? (
+            <p className="text-sm text-foreground">{context}</p>
+          ) : null}
           <p className="text-sm text-muted-foreground">
             {CONNECT_SERVER_LABELS.entryDescription}
           </p>
@@ -98,6 +107,9 @@ export function ConnectServerDialog({ controller }: ConnectServerDialogProps) {
         </form>
       ) : (
         <div className="grid gap-2">
+          {context ? (
+            <p className="text-sm text-muted-foreground">{context}</p>
+          ) : null}
           <p className="text-sm text-foreground">
             {pendingHost ? CONNECT_SERVER_LABELS.trustDescription(pendingHost) : null}
           </p>

--- a/apps/desktop/src/components/settings/panes/AccountPane.tsx
+++ b/apps/desktop/src/components/settings/panes/AccountPane.tsx
@@ -12,8 +12,9 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import { ExternalLink, RefreshCw } from "@proliferate/ui/icons";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
+import { ConnectServerDialog } from "@/components/auth/ConnectServerDialog";
 import { CurrentUserInvitationsSection } from "@/components/settings/panes/organization/CurrentUserInvitationsSection";
-import { AUTH_ACCOUNT_LABELS } from "@/copy/auth/auth-copy";
+import { AUTH_ACCOUNT_LABELS, CONNECT_SERVER_LABELS } from "@/copy/auth/auth-copy";
 import { CAPABILITY_COPY } from "@/copy/capabilities/capability-copy";
 import { useAuthViewer } from "@/hooks/access/cloud/auth/use-auth-viewer";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
@@ -356,6 +357,14 @@ export function AccountPane() {
             : undefined,
         }}
         error={signInError || providerLinkError}
+      />
+
+      {/* Invite links from a different server open this trust-confirm dialog
+          before the app is ever repointed (join-invitation flow's security
+          boundary). No-op when no server switch is pending. */}
+      <ConnectServerDialog
+        controller={joinFlow.connectServer}
+        context={CONNECT_SERVER_LABELS.inviteContext}
       />
     </section>
   );

--- a/apps/desktop/src/copy/auth/auth-copy.ts
+++ b/apps/desktop/src/copy/auth/auth-copy.ts
@@ -52,6 +52,9 @@ export const CONNECT_SERVER_LABELS = {
   connect: "Connect",
   connecting: "Connecting…",
   useDifferentAddress: "Use a different address",
+  // Shown when the connect flow is opened from an invite link issued by a
+  // different server than the one this desktop is pointed at.
+  inviteContext: "This invitation is hosted on a different Proliferate server.",
 } as const;
 
 export const AUTH_ACCOUNT_LABELS = {

--- a/apps/desktop/src/hooks/auth/workflows/use-connect-server.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-connect-server.ts
@@ -33,6 +33,13 @@ export interface UseConnectServerResult {
   pendingMeta: ServerMeta | null;
   pendingHost: string | null;
   open: () => void;
+  /**
+   * Open the flow already pointed at a supplied server URL — runs the same
+   * `/meta` validation as manual entry, but starting from a caller-provided
+   * address (e.g. an invite link's embedded origin) instead of typed input.
+   * The trust-confirm step is still mandatory; nothing switches silently.
+   */
+  openForUrl: (serverUrl: string) => Promise<void>;
   close: () => void;
   submitUrl: () => Promise<void>;
   confirmConnect: () => Promise<void>;
@@ -82,11 +89,12 @@ export function useConnectServer(): UseConnectServerResult {
     setError(null);
   }, []);
 
-  const submitUrl = useCallback(async () => {
+  const runCheck = useCallback(async (rawUrl: string) => {
     if (!available) return;
-    const normalized = normalizeServerUrl(url);
+    const normalized = normalizeServerUrl(rawUrl);
     if (!normalized.ok) {
       setError(normalized.error);
+      setStep("entry");
       return;
     }
 
@@ -103,7 +111,23 @@ export function useConnectServer(): UseConnectServerResult {
     setPendingHost(normalized.host);
     setPendingMeta(result.meta);
     setStep("trust-confirm");
-  }, [available, url]);
+  }, [available]);
+
+  const submitUrl = useCallback(async () => {
+    await runCheck(url);
+  }, [runCheck, url]);
+
+  const openForUrl = useCallback(async (serverUrl: string) => {
+    if (!available) return;
+    setUrl(serverUrl);
+    setError(null);
+    setPendingMeta(null);
+    setPendingHost(null);
+    setPendingUrl(null);
+    // Falls into "entry" on any validation/reachability failure, so the user
+    // can retype the address rather than being stranded on a blank dialog.
+    await runCheck(serverUrl);
+  }, [available, runCheck]);
 
   const confirmConnect = useCallback(async () => {
     if (!available || !pendingUrl) return;
@@ -141,6 +165,7 @@ export function useConnectServer(): UseConnectServerResult {
     pendingMeta,
     pendingHost,
     open,
+    openForUrl,
     close,
     submitUrl,
     confirmConnect,

--- a/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx
+++ b/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx
@@ -2,14 +2,29 @@
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useOrganizationJoinInvitationFlow } from "./use-organization-join-invitation-flow";
 
 const authActionMocks = vi.hoisted(() => ({
   signInWithGitHub: vi.fn<() => Promise<unknown>>(),
   signInWithSso: vi.fn<(_options?: unknown) => Promise<unknown>>(),
+}));
+
+const connectServerMocks = vi.hoisted(() => ({
+  available: true,
+  step: "closed" as string,
+  openForUrl: vi.fn<(_url: string) => Promise<void>>(),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getRuntimeDesktopAppConfig: vi.fn<() => { apiBaseUrl: string | null }>(),
+  isOfficialHostedApiBaseUrl: vi.fn<(_url: string) => boolean>(),
+}));
+
+const authMethodsMocks = vi.hoisted(() => ({
+  getDesktopAuthMethods: vi.fn<() => Promise<{ passwordLogin: boolean; github: boolean }>>(),
 }));
 
 vi.mock("@/hooks/auth/workflows/use-auth-actions", () => ({
@@ -19,23 +34,36 @@ vi.mock("@/hooks/auth/workflows/use-auth-actions", () => ({
   }),
 }));
 
+vi.mock("@/hooks/auth/workflows/use-connect-server", () => ({
+  useConnectServer: () => ({
+    available: connectServerMocks.available,
+    step: connectServerMocks.step,
+    openForUrl: connectServerMocks.openForUrl,
+  }),
+}));
+
+vi.mock("@/lib/infra/proliferate-api", () => ({
+  getRuntimeDesktopAppConfig: apiMocks.getRuntimeDesktopAppConfig,
+  isOfficialHostedApiBaseUrl: apiMocks.isOfficialHostedApiBaseUrl,
+}));
+
+vi.mock("@/lib/integrations/auth/proliferate-auth-password", () => ({
+  getDesktopAuthMethods: authMethodsMocks.getDesktopAuthMethods,
+}));
+
 function clearTestStorage() {
   window.localStorage?.clear();
 }
 
-function renderJoinInvitationFlow() {
+function renderJoinInvitationFlow(initialEntry: string) {
   function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <MemoryRouter
-        initialEntries={["/settings?section=account&joinOrganizationId=org-1"]}
-      >
-        {children}
-      </MemoryRouter>
-    );
+    return <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>;
   }
 
   return renderHook(() => useOrganizationJoinInvitationFlow(), { wrapper: Wrapper });
 }
+
+const ORIGIN_LESS = "/settings?section=account&joinOrganizationId=org-1";
 
 describe("useOrganizationJoinInvitationFlow", () => {
   beforeEach(() => {
@@ -44,27 +72,29 @@ describe("useOrganizationJoinInvitationFlow", () => {
     authActionMocks.signInWithSso.mockReset();
     authActionMocks.signInWithGitHub.mockResolvedValue({});
     authActionMocks.signInWithSso.mockResolvedValue({});
-    useAuthStore.setState({
-      status: "anonymous",
-      session: null,
-      user: null,
-      error: null,
-    });
+    connectServerMocks.available = true;
+    connectServerMocks.step = "closed";
+    connectServerMocks.openForUrl.mockReset();
+    connectServerMocks.openForUrl.mockResolvedValue(undefined);
+    // Default: current server is Cloud (no configured base URL); GitHub is
+    // advertised, so the SSO/GitHub launch path is exercised.
+    apiMocks.getRuntimeDesktopAppConfig.mockReset();
+    apiMocks.getRuntimeDesktopAppConfig.mockReturnValue({ apiBaseUrl: null });
+    apiMocks.isOfficialHostedApiBaseUrl.mockReset();
+    apiMocks.isOfficialHostedApiBaseUrl.mockImplementation((url: string) => url.includes("proliferate.com"));
+    authMethodsMocks.getDesktopAuthMethods.mockReset();
+    authMethodsMocks.getDesktopAuthMethods.mockResolvedValue({ passwordLogin: false, github: true });
+    useAuthStore.setState({ status: "anonymous", session: null, user: null, error: null });
   });
 
   afterEach(() => {
     cleanup();
     clearTestStorage();
-    useAuthStore.setState({
-      status: "bootstrapping",
-      session: null,
-      user: null,
-      error: null,
-    });
+    useAuthStore.setState({ status: "bootstrapping", session: null, user: null, error: null });
   });
 
-  it("starts organization SSO for anonymous invite links", async () => {
-    renderJoinInvitationFlow();
+  it("starts organization SSO for anonymous invite links with no origin (unchanged behavior)", async () => {
+    renderJoinInvitationFlow(ORIGIN_LESS);
 
     await waitFor(() => {
       expect(authActionMocks.signInWithSso).toHaveBeenCalledWith({
@@ -73,6 +103,7 @@ describe("useOrganizationJoinInvitationFlow", () => {
       });
     });
     expect(authActionMocks.signInWithGitHub).not.toHaveBeenCalled();
+    expect(connectServerMocks.openForUrl).not.toHaveBeenCalled();
   });
 
   it("falls back to standard sign-in when the invited organization has no SSO", async () => {
@@ -80,7 +111,7 @@ describe("useOrganizationJoinInvitationFlow", () => {
       new Error("SSO is not configured for this environment."),
     );
 
-    renderJoinInvitationFlow();
+    renderJoinInvitationFlow(ORIGIN_LESS);
 
     await waitFor(() => {
       expect(authActionMocks.signInWithGitHub).toHaveBeenCalledTimes(1);
@@ -90,13 +121,58 @@ describe("useOrganizationJoinInvitationFlow", () => {
   it("does not fall back to GitHub for a configured SSO provider failure", async () => {
     authActionMocks.signInWithSso.mockRejectedValueOnce(new Error("SSO sign-in failed"));
 
-    const { result } = renderJoinInvitationFlow();
+    const { result } = renderJoinInvitationFlow(ORIGIN_LESS);
 
     await waitFor(() => {
       expect(result.current.statusMessage).toBe(
         "Sign in could not start. Use Account settings to sign in, then reopen the invite link.",
       );
     });
+    expect(authActionMocks.signInWithGitHub).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the trust-confirm dialog and starts NO auth when the invite origin differs from the current server", async () => {
+    const entry =
+      "/settings?section=account&joinOrganizationId=org-1&joinServerOrigin=https%3A%2F%2Fproliferate.corp.example";
+
+    renderJoinInvitationFlow(entry);
+
+    await waitFor(() => {
+      expect(connectServerMocks.openForUrl).toHaveBeenCalledWith("https://proliferate.corp.example");
+    });
+    expect(authActionMocks.signInWithSso).not.toHaveBeenCalled();
+    expect(authActionMocks.signInWithGitHub).not.toHaveBeenCalled();
+  });
+
+  it("treats an origin matching the currently-configured server as a normal same-server join", async () => {
+    apiMocks.getRuntimeDesktopAppConfig.mockReturnValue({
+      apiBaseUrl: "https://proliferate.corp.example",
+    });
+    const entry =
+      "/settings?section=account&joinOrganizationId=org-1&joinServerOrigin=https%3A%2F%2Fproliferate.corp.example";
+
+    renderJoinInvitationFlow(entry);
+
+    await waitFor(() => {
+      expect(authActionMocks.signInWithSso).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        prompt: "select_account",
+      });
+    });
+    expect(connectServerMocks.openForUrl).not.toHaveBeenCalled();
+  });
+
+  it("leaves the user on the sign-in surface (no auth launch) when the server is password-only", async () => {
+    authMethodsMocks.getDesktopAuthMethods.mockResolvedValue({ passwordLogin: true, github: false });
+
+    const { result } = renderJoinInvitationFlow(ORIGIN_LESS);
+
+    await waitFor(() => {
+      expect(result.current.statusMessage).toBe(
+        "Sign in to accept this invitation. Use the sign-in form below.",
+      );
+    });
+    expect(authActionMocks.signInWithSso).not.toHaveBeenCalled();
     expect(authActionMocks.signInWithGitHub).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts
+++ b/apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts
@@ -8,6 +8,10 @@ import {
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuthActions } from "@/hooks/auth/workflows/use-auth-actions";
 import {
+  useConnectServer,
+  type UseConnectServerResult,
+} from "@/hooks/auth/workflows/use-connect-server";
+import {
   canFallbackToStandardInviteSignIn,
 } from "@/lib/domain/organizations/join-auth";
 import {
@@ -16,34 +20,108 @@ import {
   writePendingOrganizationJoinTarget,
 } from "@/lib/access/browser/organization-join-target";
 import { buildSettingsHref } from "@/lib/domain/settings/navigation";
+import { getDesktopAuthMethods } from "@/lib/integrations/auth/proliferate-auth-password";
+import {
+  getRuntimeDesktopAppConfig,
+  isOfficialHostedApiBaseUrl,
+} from "@/lib/infra/proliferate-api";
 import { useAuthStore } from "@/stores/auth/auth-store";
 
-export function useOrganizationJoinInvitationFlow() {
+/**
+ * Normalize a URL to its origin (scheme + host + port, no path or trailing
+ * slash) for comparison. Returns null when the input isn't a parseable URL.
+ */
+function toOrigin(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Does the invite link's (already-parser-validated) origin resolve to the
+ * server the app is currently pointed at? An unset or official-hosted base
+ * URL means the current server is Cloud, in which case an origin that is
+ * itself an official hosted origin "matches" (Cloud invite on Cloud desktop —
+ * no switch needed).
+ */
+function joinServerOriginMatchesCurrent(joinServerOrigin: string): boolean {
+  const currentBaseUrl = getRuntimeDesktopAppConfig().apiBaseUrl;
+  if (!currentBaseUrl || isOfficialHostedApiBaseUrl(currentBaseUrl)) {
+    return isOfficialHostedApiBaseUrl(joinServerOrigin);
+  }
+  return toOrigin(currentBaseUrl) === toOrigin(joinServerOrigin);
+}
+
+export interface UseOrganizationJoinInvitationFlowResult {
+  joinOrganizationId: string | null;
+  clearJoinTarget: () => void;
+  statusMessage: string | null;
+  setStatusMessage: (value: string | null) => void;
+  unauthenticatedJoin: boolean;
+  /**
+   * Connect-server controller driving the trust-confirm dialog when the invite
+   * link is issued by a different server than the one the app is pointed at.
+   * `connectServer.step === "closed"` when no switch is pending.
+   */
+  connectServer: UseConnectServerResult;
+}
+
+export function useOrganizationJoinInvitationFlow(): UseOrganizationJoinInvitationFlowResult {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const authStatus = useAuthStore((state) => state.status);
   const { signInWithGitHub, signInWithSso } = useAuthActions();
+  const connectServer = useConnectServer();
   const signInStartedRef = useRef(false);
+  const serverSwitchStartedRef = useRef(false);
+  const serverSwitchDialogOpenedRef = useRef(false);
   const joinOrganizationId = useMemo(
     () => searchParams.get("joinOrganizationId"),
+    [searchParams],
+  );
+  const searchJoinServerOrigin = useMemo(
+    () => searchParams.get("joinServerOrigin"),
     [searchParams],
   );
   const [transientJoinOrganizationId, setTransientJoinOrganizationId] = useState(
     () => joinOrganizationId ?? readPendingOrganizationJoinTarget(),
   );
+  // The origin only ever arrives on the URL (never persisted): the relaunch
+  // that a switch triggers restarts the app pointed AT that origin, so the
+  // post-relaunch resume is a plain same-server join with no origin at all.
+  // Hold it in transient state so the arrival navigate can safely drop the
+  // param from the URL without stranding the switch.
+  const [transientJoinServerOrigin, setTransientJoinServerOrigin] = useState(
+    () => searchJoinServerOrigin,
+  );
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const requiresServerSwitch = Boolean(
+    transientJoinServerOrigin
+    && connectServer.available
+    && !joinServerOriginMatchesCurrent(transientJoinServerOrigin),
+  );
 
   useEffect(() => {
     if (!joinOrganizationId) {
       return;
     }
+    // Persist the target BEFORE any trust-confirm/relaunch: the relaunch drops
+    // the URL params, so localStorage is what lets the flow resume against the
+    // now-correct server.
     writePendingOrganizationJoinTarget(joinOrganizationId);
     signInStartedRef.current = false;
     setTransientJoinOrganizationId(joinOrganizationId);
+    setTransientJoinServerOrigin(searchJoinServerOrigin);
     // Account is reachable by every signed-in user (Members is admin-only),
     // so this is where a non-admin invitee can actually see and accept.
     navigate(buildSettingsHref({ section: "account" }), { replace: true });
-  }, [joinOrganizationId, navigate]);
+  }, [joinOrganizationId, searchJoinServerOrigin, navigate]);
 
   const clearJoinTarget = useCallback(() => {
     clearPendingOrganizationJoinTarget();
@@ -60,21 +138,83 @@ export function useOrganizationJoinInvitationFlow() {
     setStatusMessage("Review and accept the invitation below to join this organization.");
   }, [authStatus, transientJoinOrganizationId]);
 
+  // SECURITY BOUNDARY: an invite link from a different server must never switch
+  // the app silently or launch auth first. Surface the connect-server trust
+  // dialog (which itself fetches `{origin}/meta` and requires an explicit
+  // confirm) and start no authentication.
+  useEffect(() => {
+    if (
+      !transientJoinOrganizationId
+      || !requiresServerSwitch
+      || !transientJoinServerOrigin
+      || serverSwitchStartedRef.current
+    ) {
+      return;
+    }
+    serverSwitchStartedRef.current = true;
+    setStatusMessage(
+      "This invitation is hosted on a different Proliferate server. Confirm the connection to continue.",
+    );
+    void connectServer.openForUrl(transientJoinServerOrigin);
+  }, [connectServer, requiresServerSwitch, transientJoinOrganizationId, transientJoinServerOrigin]);
+
+  // Decline/cancel of the trust dialog: clear the pending join and stay put.
+  // The dialog opens asynchronously, so we only treat a return to "closed" as a
+  // decline once we've actually observed it open (never on the initial commit,
+  // when step is still "closed").
+  useEffect(() => {
+    if (!serverSwitchStartedRef.current) {
+      return;
+    }
+    if (connectServer.step !== "closed") {
+      serverSwitchDialogOpenedRef.current = true;
+      return;
+    }
+    // "connecting" leads into relaunch; only a return to "closed" is a decline.
+    if (serverSwitchDialogOpenedRef.current) {
+      serverSwitchDialogOpenedRef.current = false;
+      serverSwitchStartedRef.current = false;
+      clearJoinTarget();
+      setStatusMessage(null);
+    }
+  }, [clearJoinTarget, connectServer.step]);
+
   useEffect(() => {
     if (
       !transientJoinOrganizationId
       || authStatus !== "anonymous"
+      || requiresServerSwitch
       || signInStartedRef.current
     ) {
       return;
     }
     signInStartedRef.current = true;
-    setStatusMessage("Opening organization sign-in to accept this invitation.");
-    void signInWithSso({
-      organizationId: transientJoinOrganizationId,
-      prompt: "select_account",
-    })
-      .catch(async (error: unknown) => {
+
+    void (async () => {
+      // Methods-aware sign-in: a password-only server (self-hosted with no
+      // GitHub OAuth app) has no SSO/GitHub browser flow to launch, so leave
+      // the user on the normal sign-in surface with guidance instead of firing
+      // a dead redirect. Cloud advertises github, so it keeps today's behavior;
+      // a fetch failure also falls through to the SSO/GitHub path.
+      try {
+        const methods = await getDesktopAuthMethods();
+        if (methods.passwordLogin && !methods.github) {
+          setStatusMessage(
+            "Sign in to accept this invitation. Use the sign-in form below.",
+          );
+          return;
+        }
+      } catch {
+        // Ignore — fall through to the SSO/GitHub launch (today's behavior).
+      }
+
+      setStatusMessage("Opening organization sign-in to accept this invitation.");
+      try {
+        await signInWithSso({
+          organizationId: transientJoinOrganizationId,
+          prompt: "select_account",
+        });
+      } catch (error: unknown) {
         if (!canFallbackToStandardInviteSignIn(error)) {
           setStatusMessage(
             "Sign in could not start. Use Account settings to sign in, then reopen the invite link.",
@@ -90,8 +230,15 @@ export function useOrganizationJoinInvitationFlow() {
             "Sign in could not start. Use Account settings to sign in, then reopen the invite link.",
           );
         }
-      });
-  }, [authStatus, signInWithGitHub, signInWithSso, transientJoinOrganizationId]);
+      }
+    })();
+  }, [
+    authStatus,
+    requiresServerSwitch,
+    signInWithGitHub,
+    signInWithSso,
+    transientJoinOrganizationId,
+  ]);
 
   return {
     joinOrganizationId: transientJoinOrganizationId,
@@ -99,5 +246,6 @@ export function useOrganizationJoinInvitationFlow() {
     statusMessage,
     setStatusMessage,
     unauthenticatedJoin: Boolean(transientJoinOrganizationId && authStatus !== "authenticated"),
+    connectServer,
   };
 }

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
@@ -76,6 +76,50 @@ describe("desktopNavigationTarget", () => {
     ).toBe("/settings?section=account&joinOrganizationId=org-123");
   });
 
+  it("forwards a valid https issuing-server origin as joinServerOrigin", () => {
+    expect(
+      desktopNavigationTarget(
+        "proliferate://join/org-123?origin=https%3A%2F%2Fproliferate.corp.example",
+      ),
+    ).toBe(
+      "/settings?section=account&joinOrganizationId=org-123&joinServerOrigin=https%3A%2F%2Fproliferate.corp.example",
+    );
+  });
+
+  it("allows an http origin only for loopback dev servers", () => {
+    expect(
+      desktopNavigationTarget("proliferate://join/org-123?origin=http%3A%2F%2F127.0.0.1%3A8000"),
+    ).toBe(
+      "/settings?section=account&joinOrganizationId=org-123&joinServerOrigin=http%3A%2F%2F127.0.0.1%3A8000",
+    );
+  });
+
+  it("drops a non-loopback http origin (downgrade-attack guard)", () => {
+    expect(
+      desktopNavigationTarget("proliferate://join/org-123?origin=http%3A%2F%2Fproliferate.corp.example"),
+    ).toBe("/settings?section=account&joinOrganizationId=org-123");
+  });
+
+  it("drops a malformed origin", () => {
+    expect(
+      desktopNavigationTarget("proliferate://join/org-123?origin=not-a-url"),
+    ).toBe("/settings?section=account&joinOrganizationId=org-123");
+  });
+
+  it("drops an origin carrying embedded credentials (userinfo phishing guard)", () => {
+    expect(
+      desktopNavigationTarget(
+        "proliferate://join/org-123?origin=https%3A%2F%2Fuser%3Apass%40proliferate.corp.example",
+      ),
+    ).toBe("/settings?section=account&joinOrganizationId=org-123");
+  });
+
+  it("leaves the join route unchanged when no origin is supplied", () => {
+    expect(
+      desktopNavigationTarget("proliferate://join/org-123"),
+    ).toBe("/settings?section=account&joinOrganizationId=org-123");
+  });
+
   it("routes parked Slack bot settings links to general settings", () => {
     expect(desktopNavigationTarget("proliferate://settings/slack-bot")).toBe(
       "/settings?section=general",

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
@@ -20,6 +20,16 @@ export function desktopNavigationTarget(url: string): string | null {
       // follow this link and see/accept their invitation.
       const params = new URLSearchParams({ section: "account" });
       params.set("joinOrganizationId", organizationId);
+      // The issuing server stamps its own origin so a self-hosted invite can
+      // point the desktop at the right server (the org id is meaningless on
+      // Cloud). Any web page can fire this deep link with an attacker-supplied
+      // origin, so we validate hard and DROP anything untrusted — a dropped
+      // origin degrades to today's behavior (resolve against the current
+      // server), never a silent server switch.
+      const joinServerOrigin = parseJoinServerOrigin(parsed.searchParams.get("origin"));
+      if (joinServerOrigin) {
+        params.set("joinServerOrigin", joinServerOrigin);
+      }
       return `/settings?${params.toString()}`;
     }
   }
@@ -93,4 +103,49 @@ function decodeRoutePart(value: string): string {
   } catch {
     return value;
   }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+/**
+ * Validate the `origin` embedded in a `proliferate://join/<id>` deep link.
+ * This is the parser-side half of the trust boundary: the desktop must never
+ * treat an unvalidated origin as a server address. Returns the normalized
+ * origin (scheme + host, no trailing slash) only when it is:
+ * - a well-formed absolute URL,
+ * - https (http tolerated solely for loopback dev servers),
+ * - free of embedded credentials (no `user:pass@` phishing vector).
+ * Anything else returns null so the caller drops the param.
+ */
+function parseJoinServerOrigin(raw: string | null): string | null {
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (parsed.username || parsed.password) {
+    return null;
+  }
+
+  if (!parsed.hostname) {
+    return null;
+  }
+
+  if (parsed.protocol === "https:") {
+    return parsed.origin;
+  }
+
+  if (parsed.protocol === "http:" && isLoopbackHostname(parsed.hostname)) {
+    return parsed.origin;
+  }
+
+  return null;
 }

--- a/server/proliferate/server/organizations/landing.py
+++ b/server/proliferate/server/organizations/landing.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
+from urllib.parse import quote
 from uuid import UUID
 
+from proliferate.config import settings
 from proliferate.utils.redirect_callback_pages import render_redirect_callback_page
+
+
+def _issuing_server_origin() -> str:
+    """The origin invite links should point desktops back at.
+
+    Mirrors ``organization_join_url``'s base-url precedence so the deep link's
+    embedded origin matches the host that rendered the /join page. Cloud gets an
+    origin equal to its hosted URL (desktops read it as "matches current server"
+    and proceed unchanged); self-hosted gets its own origin so the desktop can
+    trust-confirm a switch instead of resolving the org id against Cloud.
+    """
+    return (settings.frontend_base_url or settings.api_base_url).rstrip("/")
 
 
 def build_join_landing_html(organization_name: str, organization_id: UUID) -> str:
     deep_link = f"proliferate://join/{organization_id}"
+    origin = _issuing_server_origin()
+    if origin:
+        deep_link = f"{deep_link}?origin={quote(origin, safe='')}"
     return render_redirect_callback_page(
         title=f"Join {organization_name}",
         status_label="Organization invite",

--- a/server/tests/integration/test_organizations_api.py
+++ b/server/tests/integration/test_organizations_api.py
@@ -435,9 +435,6 @@ async def test_invitation_accepts_join_for_matching_email_and_replays_current_me
     )
     assert response.status_code == 200
     assert f"proliferate://join/{organization_id}" in response.text
-    # The test env configures no base URL, so no issuing-server origin is
-    # embedded (see test_organization_join_landing.py for the configured cases).
-    assert "?origin=" not in response.text
 
     response = await client.post(
         "/v1/organizations/invitations/accept",

--- a/server/tests/integration/test_organizations_api.py
+++ b/server/tests/integration/test_organizations_api.py
@@ -435,6 +435,9 @@ async def test_invitation_accepts_join_for_matching_email_and_replays_current_me
     )
     assert response.status_code == 200
     assert f"proliferate://join/{organization_id}" in response.text
+    # The test env configures no base URL, so no issuing-server origin is
+    # embedded (see test_organization_join_landing.py for the configured cases).
+    assert "?origin=" not in response.text
 
     response = await client.post(
         "/v1/organizations/invitations/accept",

--- a/server/tests/unit/test_organization_join_landing.py
+++ b/server/tests/unit/test_organization_join_landing.py
@@ -1,0 +1,54 @@
+"""Unit tests for the organization invite landing page's deep link.
+
+The invite deep link must carry the issuing server's origin so a self-hosted
+invitee's desktop can trust-confirm a switch instead of resolving the org id
+against Cloud (see landing.py / self-hosting-v1 §3.5)."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+from uuid import uuid4
+
+import pytest
+
+from proliferate.config import settings
+from proliferate.server.organizations.landing import build_join_landing_html
+
+
+def test_deep_link_embeds_url_encoded_frontend_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "https://proliferate.corp.example/")
+    monkeypatch.setattr(settings, "api_base_url", "https://api.corp.example")
+
+    organization_id = uuid4()
+    html = build_join_landing_html("Acme", organization_id)
+
+    encoded = quote("https://proliferate.corp.example", safe="")
+    assert f"proliferate://join/{organization_id}?origin={encoded}" in html
+    # frontend_base_url wins over api_base_url and the trailing slash is stripped.
+    assert quote("https://api.corp.example", safe="") not in html
+
+
+def test_deep_link_falls_back_to_api_base_url_when_no_frontend_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "")
+    monkeypatch.setattr(settings, "api_base_url", "https://api.corp.example/")
+
+    organization_id = uuid4()
+    html = build_join_landing_html("Acme", organization_id)
+
+    encoded = quote("https://api.corp.example", safe="")
+    assert f"proliferate://join/{organization_id}?origin={encoded}" in html
+
+
+def test_deep_link_omits_origin_when_no_base_url_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "")
+    monkeypatch.setattr(settings, "api_base_url", "")
+
+    organization_id = uuid4()
+    html = build_join_landing_html("Acme", organization_id)
+
+    assert f"proliferate://join/{organization_id}" in html
+    assert "origin=" not in html


### PR DESCRIPTION
## Bug

Self-hosted servers issue invite links `https://<server>/join/<org-id>`. The landing page fired `proliferate://join/<org-id>` with the server origin discarded. The desktop then resolved the join against its currently-configured server (Cloud by default): the org id is unknown there, org-SSO fails, the fallback launches GitHub sign-in on Cloud, and the invitee lands in Cloud instead of the self-hosted server. Verified today on a live self-hosted box.

### Repro (before)
1. Self-hosted server invites a user; user opens the `/join/<org-id>` link.
2. Desktop (pointed at Cloud) fires `proliferate://join/<org-id>`, resolves org id against Cloud, SSO fails, GitHub sign-in opens on Cloud.
3. User ends up authenticated on Cloud, never on the self-hosted server.

## Design

- **Server stamps the origin.** `landing.py` appends `?origin=<url-encoded>` where origin is `frontend_base_url or api_base_url` (rstrip `/`), matching `organization_join_url`'s precedence. Omitted entirely when neither is set. Always appended otherwise — Cloud links get a Cloud origin, old desktops ignore the param.
- **Trust boundary.** Any web page can fire this deep link with an attacker origin, so the desktop parser validates hard (well-formed URL, https only — http tolerated solely for loopback dev, no userinfo) and DROPS anything untrusted, degrading to today's resolve-against-current-server behavior. No network call, no auth launch, no silent switch happens before the user explicitly confirms.
- **Switch = existing connect-server machinery.** When the validated origin differs from the effective current server (unset/official-hosted ⇒ Cloud), the join flow opens the connect-server trust-confirm dialog via a new `openForUrl(url)` entry that runs the same `/meta` validation as manual entry, then `set_app_config({apiBaseUrl: origin})` + `relaunch()`.
- **Resume after relaunch.** The join target is persisted (localStorage, 1h TTL) on deep-link arrival, before any relaunch. Post-relaunch the configured server equals the origin, the origin param is gone, and the flow resumes as a plain same-server join with no special-casing.
- **Methods-aware anonymous sign-in.** The anonymous auto-auth effect now checks `/auth/desktop/methods`: a password-only server (no GitHub) gets a guidance message and stays on the normal sign-in surface instead of firing a dead SSO/GitHub redirect. Cloud advertises github, so Cloud behavior is unchanged; the no-origin path takes the same branch it takes today.

## Compatibility matrix

| | Cloud link | Self-hosted link |
|---|---|---|
| **Old desktop** | unchanged (ignores `origin`) | unchanged (ignores `origin`) — still the old bug, but no regression |
| **New desktop, on Cloud** | origin matches current ⇒ normal join | origin differs ⇒ trust-confirm switch, then join |
| **New desktop, on that self-hosted server** | origin differs ⇒ trust-confirm switch | origin matches current ⇒ normal join |

## Test coverage

- **`desktop-navigation`**: origin parsed + forwarded as `joinServerOrigin`; loopback http allowed; non-loopback http dropped; malformed dropped; userinfo dropped; no origin ⇒ unchanged route.
- **`use-organization-join-invitation-flow`**: origin differs ⇒ trust step surfaced, NO `signInWithSso`/`signInWithGitHub`; origin matches ⇒ normal join; no origin ⇒ unchanged; password-only methods ⇒ no auth launch + status message.
- **Server**: `test_organization_join_landing.py` asserts url-encoded origin embedded (frontend precedence + trailing-slash strip, api fallback, omitted when unset); integration test locks the no-origin default.

### Test runs
- `server`: `uv run --extra dev pytest` on the new unit file (3 passed) and the touched integration test (1 passed).
- `desktop`: `vitest run` on the two touched files — 22 passed (16 navigation + 6 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)