### PR TITLE
test(self-hosting): tier-1 config/meta units + tier-2 claim/invite/adaptive-signin specs

### DIFF
--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -72,6 +72,35 @@ def test_meta_shape_and_types_without_env(monkeypatch) -> None:  # type: ignore[
         assert isinstance(value, str) and value
 
 
+# T1-SH-3 (specs/developing/testing/self-hosting.md): the /meta wire contract.
+#
+# `/meta` is the shape the desktop's connect-to-a-server dialog reads to render
+# its trust-confirmation screen ("Server version X"). A silent field rename or
+# reorder breaks every desktop that talks to a self-hosted server, and no other
+# test would notice. This golden test pins the exact field names AND their
+# order, both on the response model and on the live JSON, so a rename mechanically
+# fails here. Field-set membership is covered above; this is the rename guard.
+_META_GOLDEN_FIELDS = [
+    "serverVersion",
+    "desktopVersion",
+    "runtimeVersion",
+    "workerVersion",
+    "minDesktopVersion",
+]
+
+
+def test_meta_response_golden_contract(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # The declared response model is the contract of record.
+    assert list(meta_module.MetaResponse.model_fields.keys()) == _META_GOLDEN_FIELDS
+
+    _clear_pin_env(monkeypatch)
+    body = _client().get("/meta").json()
+
+    # The serialized wire order matches the model exactly (dict preserves
+    # insertion order, so this catches a reorder as well as a rename).
+    assert list(body.keys()) == _META_GOLDEN_FIELDS
+
+
 def test_meta_pins_fall_back_to_server_version(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     _clear_pin_env(monkeypatch)
     monkeypatch.setenv("SERVER_VERSION", "1.2.3")

--- a/server/tests/unit/test_sso_env_aliases.py
+++ b/server/tests/unit/test_sso_env_aliases.py
@@ -1,0 +1,112 @@
+"""T1-SH-2 (specs/developing/testing/self-hosting.md): SSO env-var alias
+equivalence sweep.
+
+Every self-hosted SSO setting accepts two env names: the bare `SSO_*` form and
+the namespaced `PROLIFERATE_SSO_*` form (config.py:107-202, via
+`AliasChoices`). The self-hosting docs standardized on the bare form as
+canonical, so an operator who copies a doc snippet with `SSO_CLIENT_ID=...`
+must land in the exact same setting as the runtime that reads
+`PROLIFERATE_SSO_CLIENT_ID=...`. This sweep guards that promise structurally
+(every SSO field carries exactly the two-form pair) and functionally (both
+forms populate the field identically), so a new SSO setting cannot ship with
+only one alias — or with a mismatched prefix — without failing here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import AliasChoices
+
+from proliferate.config import Settings
+
+# The full set of SSO settings expected to carry the two-form alias pair. Locked
+# so a new SSO var (or a dropped alias) trips this test and forces the canonical
+# bare/prefixed pair to be added deliberately.
+EXPECTED_SSO_ALIAS_FIELDS = frozenset(
+    {
+        "sso_enabled",
+        "sso_protocol",
+        "sso_display_name",
+        "sso_login_policy",
+        "sso_jit_policy",
+        "sso_default_role",
+        "sso_allowed_domains",
+        "sso_oidc_issuer_url",
+        "sso_oidc_discovery_url",
+        "sso_oidc_authorization_endpoint",
+        "sso_oidc_token_endpoint",
+        "sso_oidc_jwks_uri",
+        "sso_oidc_userinfo_endpoint",
+        "sso_oidc_client_id",
+        "sso_oidc_client_secret",
+        "sso_oidc_scopes",
+        "sso_oidc_token_endpoint_auth_method",
+        "sso_oidc_callback_base_url",
+        "sso_oidc_allow_private_provider_urls",
+    }
+)
+
+
+def _sso_alias_pairs() -> dict[str, tuple[str, str]]:
+    """Map each SSO settings field to its (bare `SSO_*`, prefixed
+    `PROLIFERATE_SSO_*`) alias pair, discovered from the model itself."""
+    pairs: dict[str, tuple[str, str]] = {}
+    for name, field in Settings.model_fields.items():
+        alias = field.validation_alias
+        if not isinstance(alias, AliasChoices):
+            continue
+        choices = [str(choice) for choice in alias.choices]
+        bare = [c for c in choices if c.startswith("SSO_")]
+        prefixed = [c for c in choices if c.startswith("PROLIFERATE_SSO_")]
+        if bare and prefixed:
+            pairs[name] = (bare[0], prefixed[0])
+    return pairs
+
+
+def _all_sso_aliases() -> list[str]:
+    aliases: list[str] = []
+    for bare, prefixed in _sso_alias_pairs().values():
+        aliases.extend((bare, prefixed))
+    return aliases
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, alias: str, value: str) -> Settings:
+    # Clear every SSO alias so a leaked ambient value can't taint the field
+    # under test, then set exactly the one form we are exercising.
+    for existing in _all_sso_aliases():
+        monkeypatch.delenv(existing, raising=False)
+    monkeypatch.setenv(alias, value)
+    return Settings(
+        _env_file=None,
+        debug=True,
+        jwt_secret="test-secret",
+        cloud_secret_key="test-cloud-secret",
+    )
+
+
+def test_every_sso_field_carries_exactly_the_two_form_alias_pair() -> None:
+    pairs = _sso_alias_pairs()
+    assert set(pairs) == EXPECTED_SSO_ALIAS_FIELDS
+    for name, (bare, prefixed) in pairs.items():
+        # The prefixed form is the bare form with the PROLIFERATE_ namespace —
+        # never a divergent spelling.
+        assert prefixed == f"PROLIFERATE_{bare}", name
+        # Exactly the two canonical forms, nothing else.
+        choices = [str(c) for c in Settings.model_fields[name].validation_alias.choices]  # type: ignore[union-attr]
+        assert set(choices) == {bare, prefixed}, name
+
+
+def test_bare_and_prefixed_forms_populate_the_field_identically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name, (bare, prefixed) in _sso_alias_pairs().items():
+        is_bool = Settings.model_fields[name].annotation is bool
+        raw_value = "true" if is_bool else f"sso-probe-{name}"
+        expected = True if is_bool else raw_value
+
+        from_bare = getattr(_build(monkeypatch, bare, raw_value), name)
+        from_prefixed = getattr(_build(monkeypatch, prefixed, raw_value), name)
+
+        assert from_bare == expected, f"{name} via {bare}"
+        assert from_prefixed == expected, f"{name} via {prefixed}"
+        assert from_bare == from_prefixed, name

--- a/server/tests/unit/test_telemetry_mode.py
+++ b/server/tests/unit/test_telemetry_mode.py
@@ -53,3 +53,91 @@ def test_invalid_mode_raises() -> None:
             get_server_telemetry_mode()
     finally:
         settings.telemetry_mode = original_mode
+
+
+# ---------------------------------------------------------------------------
+# T1-SH-1 (specs/developing/testing/self-hosting.md): single_org_mode
+# derivation.
+#
+# `single_org_mode` is the invariant every self-hosted deploy leans on (one
+# instance org, first-run `/setup` claim, invite-to-join). It is DERIVED from
+# the telemetry mode — `telemetry_mode != "hosted_product"` — so BOTH
+# `local_dev` and `self_managed` are single-org, and only hosted production is
+# multi-org (config.py:376-379). An explicit `SINGLE_ORG_MODE` /
+# `PROLIFERATE_SINGLE_ORG_MODE` override wins in both directions. This pins the
+# predicate so a refactor can't silently flip a self-hosted box into multi-org
+# (or hosted into single-org).
+# ---------------------------------------------------------------------------
+
+# Both env aliases for the override, so a leaked ambient value can't taint the
+# no-override cases (config.py:31-34).
+_OVERRIDE_ENV_ALIASES = ("SINGLE_ORG_MODE", "PROLIFERATE_SINGLE_ORG_MODE")
+
+
+def _build_settings(monkeypatch: pytest.MonkeyPatch, telemetry_mode: str) -> Settings:
+    monkeypatch.setenv("PROLIFERATE_TELEMETRY_MODE", telemetry_mode)
+    return Settings(
+        _env_file=None,
+        debug=True,
+        jwt_secret="test-secret",
+        cloud_secret_key="test-cloud-secret",
+    )
+
+
+def _clear_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for alias in _OVERRIDE_ENV_ALIASES:
+        monkeypatch.delenv(alias, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("telemetry_mode", "expected"),
+    [
+        ("self_managed", True),
+        ("local_dev", True),
+        ("hosted_product", False),
+    ],
+)
+def test_single_org_mode_derives_from_telemetry_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    telemetry_mode: str,
+    expected: bool,
+) -> None:
+    _clear_override_env(monkeypatch)
+    resolved = _build_settings(monkeypatch, telemetry_mode)
+    # No explicit override → the derived value governs.
+    assert resolved.single_org_mode_override is None
+    assert resolved.single_org_mode is expected
+
+
+def test_single_org_override_false_wins_over_self_managed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_override_env(monkeypatch)
+    monkeypatch.setenv("SINGLE_ORG_MODE", "false")
+    resolved = _build_settings(monkeypatch, "self_managed")
+    # Derivation alone would be single-org; the explicit override forces it off.
+    assert resolved.single_org_mode_override is False
+    assert resolved.single_org_mode is False
+
+
+def test_single_org_override_true_wins_over_hosted_product(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_override_env(monkeypatch)
+    monkeypatch.setenv("SINGLE_ORG_MODE", "true")
+    resolved = _build_settings(monkeypatch, "hosted_product")
+    # Derivation alone would be multi-org; the explicit override forces it on.
+    assert resolved.single_org_mode_override is True
+    assert resolved.single_org_mode is True
+
+
+def test_single_org_override_accepts_the_prefixed_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The override honors PROLIFERATE_SINGLE_ORG_MODE identically to the bare
+    # form, so operators who namespace every var still steer the mode.
+    _clear_override_env(monkeypatch)
+    monkeypatch.setenv("PROLIFERATE_SINGLE_ORG_MODE", "false")
+    resolved = _build_settings(monkeypatch, "self_managed")
+    assert resolved.single_org_mode_override is False
+    assert resolved.single_org_mode is False

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -79,6 +79,27 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Connect integration (real api_key definition, placeholder key, no outbound), toggle on/off | 2 | tests/intent/specs/integrations.spec.ts |
 | Authenticate a real integration; **every cataloged harness** uses it through the gateway — local lane AND sandbox lane | 3 | tests/release/src/scenarios/t3-int-1.ts (T3-INT-1; blocked on credential RELEASE_E2E_INTEGRATION_API_KEY + github_link_required on the gateway route. Finding: cataloged Slack is oauth2/hosted-MCP not api_key, so the contract's Slack-bot-token premise does not fit the catalog — filed; scenario uses an api_key-kind seed (exa)) |
 
+## Self-hosting
+
+Every self-hosted deploy is the production compose bundle (hand-run
+`bootstrap.sh` or the AWS one-click), single-org, claimed once via `/setup`.
+Spec of record + scenario definitions: `specs/developing/testing/self-hosting.md`.
+
+| Flow | Tier | Test pointer |
+| --- | --- | --- |
+| Single-org mode derives from telemetry mode (`!= hosted_product`), override wins both directions | 1 | server/tests/unit/test_telemetry_mode.py (T1-SH-1; self_managed AND local_dev single-org, hosted_product multi-org, `SINGLE_ORG_MODE`/`PROLIFERATE_SINGLE_ORG_MODE` override forces either way) |
+| SSO env-var canonical form: every `SSO_*` ≡ `PROLIFERATE_SSO_*` | 1 | server/tests/unit/test_sso_env_aliases.py (T1-SH-2; structural pair sweep over all 19 SSO fields + functional bare/prefixed equivalence) |
+| `/meta` version wire contract (the connect dialog's trust screen reads it) | 1 | server/tests/unit/test_meta_endpoint.py (T1-SH-3; golden field names + order on the response model and the live JSON — rename/reorder guard) |
+| Connect to a self-hosted server: dialog validation, trust screen, switch A→B | 2 | — (T2-SH-1; the connect affordance is Tauri-gated (LoginScreen.tsx:117) and never renders in the desktop-web build this suite boots, and the `set_app_config` write + relaunch + credential store throw outside Tauri — tier-3 by ruling, self-hosting.md §4. Registered not-yet-implemented rather than faked) |
+| `/setup` claim → claimer is OWNER of the single instance org; re-claim permanently closed (404) | 2 | tests/intent/specs/self-hosting.spec.ts (T2-SH-2; extends T2-AUTH-1 — owner role on the one `is_instance` org, second context gets the closed 404 API + rendered page) |
+| Invite → `/register` with the invitation token → invitee sign-in; wrong-email rejected | 2 | tests/intent/specs/self-hosting.spec.ts (T2-SH-3; token = invitation id, delivery skipped locally; real token + mismatched email → uniform 403, no account minted) |
+| Adaptive sign-in surface driven by `GET /auth/desktop/methods` + github availability | 2 | tests/intent/specs/self-hosting.spec.ts (T2-SH-4; no GitHub env → real password-only surface, no GitHub button; GitHub advertised → the button replaces the password form. With-GitHub asserted at the availability boundary — a real GitHub-configured server for the browser UI is tier-3 per §4, same ruling as T2-AUTH-4) |
+| Cold boot to second user on real infra (bootstrap → claim → invite → register → login over real TLS/DNS) | 3 | — (T3-SH-1; needs standing staging EC2 + DNS/TLS, self-hosting.md §6) |
+| Real (Tauri) desktop connect to alpha/beta: relaunch + config.json + keychain end-to-end | 3 | — (T3-SH-2; the only lane that proves the Tauri connect slice T2-SH-1 can't) |
+| Model gateway add-on: `--profile agent-gateway` + LiteLLM → real agent response | 3 | — (T3-SH-3; staging gateway test key) |
+| Operator update motion: `./update.sh` migrates + restarts, `/meta` reports N, data intact | 4 | — (T4-SH-1) |
+| Desktop artifact chain valid per release (server redirect follows, CDN manifest fresh, every platform artifact HEAD 200, tag contains the SHA) | 4 | — (T4-SH-2; the 2026-07-09 incident test — must run in the release gate, self-hosting.md §5) |
+
 ## Workflows — PARKED (surface being reworked; tests land with the rework PRs)
 
 | Flow | Tier | Test pointer |

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -356,6 +356,57 @@ stays enabled.
 
 ---
 
+## Self-hosting
+
+Full narrative + tier-3/4 definitions live in
+`specs/developing/testing/self-hosting.md` (the self-hosting spec of record);
+the tier-1/2 scenarios that the test suite implements are indexed here.
+
+### T1-SH-1: single-org derivation (unit)
+`telemetry_mode == "self_managed"` OR `"local_dev"` ⇒ `single_org_mode` true;
+`"hosted_product"` ⇒ false. `single_org_mode_override`
+(`SINGLE_ORG_MODE`/`PROLIFERATE_SINGLE_ORG_MODE`) wins in both directions.
+(config.py:376-379.)
+
+### T1-SH-2: SSO env alias equivalence (unit)
+Every SSO setting carries exactly the two-form alias pair, and the bare
+`SSO_*` form populates the field identically to `PROLIFERATE_SSO_*`. Guards the
+docs' canonical bare-form promise; a new SSO var can't ship with only one alias.
+
+### T1-SH-3: `/meta` wire contract (unit)
+Golden field names AND order on `MetaResponse` and the live JSON. `/meta` is
+what the connect dialog's trust screen renders; a rename/reorder breaks every
+desktop silently.
+
+### T2-SH-1: connect + switch (NOT tier 2)
+The connect affordance is Tauri-gated (`LoginScreen.tsx:117`) and never renders
+in the desktop-web build; the `set_app_config` write + relaunch + credential
+store throw outside Tauri. Tier-3 by ruling (self-hosting.md §4) — registered
+in `flows.md` as not-yet-implemented, not faked here.
+
+### T2-SH-2: `/setup` claim UI (extends T2-AUTH-1)
+Assert the self-hosted specifics on top of the claim/login lifecycle: the
+claimed user is **owner** of the one `is_instance` organization (single-org: the
+org list has exactly one), and a second context hitting `/setup` after the claim
+gets the permanently-closed 404 (API status AND the rendered "Not found — there
+is nothing to set up here" page).
+
+### T2-SH-3: invite → register-with-token → invitee sign-in
+Admin invites (delivery `skipped` locally, no email) → invitee opens
+`/register?token={invitation_id}&email=...` → sets a password → signs into the
+desktop-web app. Assert: active membership with the invited role in the instance
+org. Negative: a real token presented with a **mismatched email** is rejected by
+the uniform 403 (`_not_invited`) and mints no account.
+
+### T2-SH-4: adaptive sign-in
+Driven purely by `GET /auth/desktop/methods` + `/auth/desktop/github/availability`.
+No GitHub OAuth env (this stack) ⇒ real password-only surface, no GitHub button.
+GitHub availability advertised ⇒ the "Continue with GitHub" button replaces the
+password form (asserted at the availability boundary — a real GitHub-configured
+server driving the browser UI is tier-3, self-hosting.md §4, matching T2-AUTH-4).
+
+---
+
 ## Tier 3 — first wave (release-critical)
 
 Conventions: the runner points a desktop at the target server by writing

--- a/tests/intent/specs/self-hosting.spec.ts
+++ b/tests/intent/specs/self-hosting.spec.ts
@@ -1,0 +1,239 @@
+// Self-hosting tier-2 scenarios (specs/developing/testing/self-hosting.md).
+//
+// T2-SH-2: /setup claim UI — extends T2-AUTH-1 with the self-hosted specifics.
+//   The claimed user is OWNER of THE single instance organization, and a second
+//   context hitting /setup after the claim gets the permanently-closed 404
+//   surface (API and rendered page).
+// T2-SH-3: invite → /register with the invitation token → invitee sign-in.
+//   Plus the wrong-email negative: a real token presented with a mismatched
+//   email is rejected by the uniform 403 and creates no account.
+// T2-SH-4: adaptive sign-in — the surface is driven purely by
+//   GET /auth/desktop/methods + /auth/desktop/github/availability. No GitHub
+//   OAuth env (this deployment) ⇒ password form only; GitHub configured ⇒ the
+//   "Continue with GitHub" button.
+//
+// Ground truth this file leans on (verified against the code):
+// - single_org_mode is on for this stack (SINGLE_ORG_MODE=true in stack/boot.ts),
+//   so exactly one instance org exists and the claimer owns it.
+// - Invitations carry NO secret token; the invitation id IS the registration
+//   token and acceptance is authorized by email match (self_registration.py's
+//   `_not_invited` gives the same uniform 403 for a wrong/unknown/mismatched
+//   token so emails can't be enumerated).
+// - The desktop connect-to-a-server affordance is Tauri-gated
+//   (LoginScreen.tsx:117 isTauriRuntimeAvailable) and never renders in the
+//   desktop-web build this suite boots — the set_app_config write / relaunch /
+//   credential-store slice is tier-3 by ruling (self-hosting.md §4), so T2-SH-1
+//   is registered as a not-yet-implemented row rather than faked here.
+
+import { expect, test, type Page } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  apiBaseUrl,
+  apiRequest,
+  ensureInstanceClaimed,
+  getOrganizationIsInstance,
+  getOwnOrganization,
+  inviteMember,
+  listMembers,
+  passwordLogin,
+  registerInvitedAccountRaw,
+  resetPasswordLoginRateLimits,
+  revokeInvitation,
+  webBaseUrl,
+  type OrganizationSummary,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+interface AuthMethodsResponse {
+  password_login: boolean;
+  github: boolean;
+}
+
+interface OAuthAvailabilityResponse {
+  enabled: boolean;
+  client_id: string | null;
+}
+
+async function adminOrg(): Promise<{ token: string; org: OrganizationSummary }> {
+  await ensureInstanceClaimed();
+  const token = (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+  const org = await getOwnOrganization(token);
+  return { token, org };
+}
+
+test.describe("T2-SH-2: /setup claim yields a single-org OWNER; re-claim is permanently closed", () => {
+  test("the claimed user owns the single instance organization", async () => {
+    const { token, org } = await adminOrg();
+
+    // Single-org: the claimer sees exactly one organization, and it is THE
+    // instance org.
+    const orgs = await apiRequest<{ organizations: OrganizationSummary[] }>("/v1/organizations", {
+      token,
+    });
+    expect(orgs.status).toBe(200);
+    expect(orgs.body.organizations).toHaveLength(1);
+    expect(orgs.body.organizations[0].id).toBe(org.id);
+    expect(await getOrganizationIsInstance(org.id)).toBe(true);
+
+    // The claimer holds OWNER on that org (not admin, not member).
+    const members = await listMembers(token, org.id);
+    const self = members.find((member) => member.email === ADMIN_EMAIL);
+    expect(self).toBeDefined();
+    expect(self!.role).toBe("owner");
+    expect(self!.status).toBe("active");
+  });
+
+  test("a second context hitting /setup after the claim gets the closed 404 surface", async ({ page }) => {
+    await ensureInstanceClaimed();
+
+    // API: /setup is a hard 404 once claimed (uncached, poll to dodge the
+    // boot-time token-cleanup race auth.spec.ts documents).
+    await expect
+      .poll(async () => (await fetch(`${apiBaseUrl()}/setup`)).status, { timeout: 15_000 })
+      .toBe(404);
+
+    // A fresh browser (this test's own context) lands on the closed page, not a
+    // second claim form.
+    await page.goto(`${apiBaseUrl()}/setup`);
+    await expect(page.getByRole("heading", { name: "Not found" })).toBeVisible();
+    await expect(page.getByText("There is nothing to set up here.")).toBeVisible();
+    await expect(page.getByLabel("Setup token")).toHaveCount(0);
+  });
+});
+
+test.describe("T2-SH-3: invite → register-with-token → invitee sign-in", () => {
+  // The wrong-email negative fails a login on purpose; the limiter buckets by
+  // client IP (shared 127.0.0.1) so clear it between tests, per auth.spec.ts.
+  test.afterEach(async () => {
+    await resetPasswordLoginRateLimits();
+  });
+
+  test("invitee registers through the token'd /register page and signs in to the app shell", async ({ page }) => {
+    const { token: adminToken, org } = await adminOrg();
+    const inviteeEmail = `sh3-invitee-${Date.now()}@t2intent.example.com`;
+    const inviteePassword = "SelfHost3!Passw0rd";
+
+    const invitation = await inviteMember(adminToken, org.id, inviteeEmail, "member");
+    expect(invitation.status).toBe("pending");
+    // No email locally → delivery is recorded as skipped, never sent.
+    expect(invitation.deliveryStatus).toBe("skipped");
+
+    // The invitee opens the link the email would have carried: the invitation
+    // id rides as the registration token, prefilled with the invited email.
+    await page.goto(
+      `${apiBaseUrl()}/register?token=${invitation.id}&email=${encodeURIComponent(inviteeEmail)}`,
+    );
+    await expect(page.getByRole("heading", { name: "Join this Proliferate instance" })).toBeVisible();
+    await expect(page.getByLabel("Invitation token")).toHaveValue(invitation.id);
+    await expect(page.getByLabel("Email")).toHaveValue(inviteeEmail);
+    await page.getByLabel("Password").fill(inviteePassword);
+    await page.getByRole("button", { name: "Create account" }).click();
+    await expect(page.getByRole("heading", { name: "You are all set" })).toBeVisible();
+
+    // Membership is active with the invited role, in the one instance org.
+    const inviteeToken = (await passwordLogin(inviteeEmail, inviteePassword)).access_token;
+    const inviteeOrg = await getOwnOrganization(inviteeToken);
+    expect(inviteeOrg.id).toBe(org.id);
+    const members = await listMembers(adminToken, org.id);
+    const membership = members.find((member) => member.email === inviteeEmail);
+    expect(membership).toBeDefined();
+    expect(membership!.status).toBe("active");
+    expect(membership!.role).toBe("member");
+
+    // The new member signs in through the desktop-web login surface.
+    await signInThroughUi(page, inviteeEmail, inviteePassword);
+    await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+  });
+
+  test("negative: a real token presented with the wrong email is rejected and creates no account", async () => {
+    const { token: adminToken, org } = await adminOrg();
+    const invitedEmail = `sh3-owner-${Date.now()}@t2intent.example.com`;
+    const wrongEmail = `sh3-wrong-${Date.now()}@t2intent.example.com`;
+
+    const invitation = await inviteMember(adminToken, org.id, invitedEmail, "member");
+
+    // Correct token, mismatched email → the uniform 403 (_not_invited): the
+    // token/email pair is what authorizes, never the token alone.
+    const rejected = await registerInvitedAccountRaw({
+      email: wrongEmail,
+      password: "SelfHost3!Wrong0rd",
+      invitationToken: invitation.id,
+    });
+    expect(rejected.status).toBe(403);
+
+    // No account was minted for the wrong email.
+    const login = await apiRequest("/auth/desktop/password/login", {
+      method: "POST",
+      body: { email: wrongEmail, password: "SelfHost3!Wrong0rd" },
+    });
+    expect(login.status).toBe(401);
+
+    // The invitation is untouched for its rightful owner.
+    const invitations = await apiRequest<{ invitations: Array<{ id: string; status: string }> }>(
+      `/v1/organizations/${org.id}/invitations`,
+      { token: adminToken },
+    );
+    const row = invitations.body.invitations.find((item) => item.id === invitation.id);
+    expect(row?.status).toBe("pending");
+
+    // Cleanup so a rerun on this profile DB starts clean.
+    await revokeInvitation(adminToken, org.id, invitation.id);
+  });
+});
+
+test.describe("T2-SH-4: sign-in surface adapts to the server's advertised methods", () => {
+  test("no GitHub OAuth env (this deployment) → password form only, no GitHub button", async ({ page }) => {
+    // Server seam: this stack boots with GITHUB_OAUTH_CLIENT_ID unset, so the
+    // public probes advertise password-only.
+    const methods = (await (await fetch(`${apiBaseUrl()}/auth/desktop/methods`)).json()) as AuthMethodsResponse;
+    expect(methods.password_login).toBe(true);
+    expect(methods.github).toBe(false);
+    const availability = (await (
+      await fetch(`${apiBaseUrl()}/auth/desktop/github/availability`)
+    ).json()) as OAuthAvailabilityResponse;
+    expect(availability.enabled).toBe(false);
+    expect(availability.client_id).toBeNull();
+
+    // Rendered consequence: the login screen shows the email/password form and
+    // never the GitHub button.
+    await page.goto(webBaseUrl());
+    await expect(page.getByLabel("Email")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByLabel("Password")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with GitHub" })).toHaveCount(0);
+  });
+
+  test("GitHub availability advertised → the GitHub button replaces the password form", async ({ page }) => {
+    // The desktop-web build bakes its API base at build time, so a real
+    // GitHub-configured server for the UI is the tier-3 lane (self-hosting.md
+    // §4; the same ruling T2-AUTH-4 records). What tier 2 owns is the login
+    // screen's ADAPTATION to the availability contract — assert it by answering
+    // that one probe as a GitHub-configured server would, at the network
+    // boundary the app reads (github availability drives githubSignInAvailable
+    // in use-github-sign-in.ts).
+    await page.route("**/auth/desktop/github/availability", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ enabled: true, client_id: "gh-test-client" }),
+      });
+    });
+
+    await page.goto(webBaseUrl());
+    const githubButton = page.getByRole("button", { name: "Continue with GitHub" });
+    await expect(githubButton).toBeVisible({ timeout: 30_000 });
+    // Enabled (not merely rendered-but-disabled): availability resolved to
+    // enabled, so the button is actionable.
+    await expect(githubButton).toBeEnabled();
+    // The password form yields to the GitHub button when GitHub is offered.
+    await expect(page.getByLabel("Password")).toHaveCount(0);
+  });
+});
+
+async function signInThroughUi(page: Page, email: string, password: string): Promise<void> {
+  await page.goto(webBaseUrl());
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+}

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -374,13 +374,51 @@ export async function registerInvitedAccount(params: {
   password: string;
   invitationToken: string;
 }): Promise<void> {
-  const result = await postForm("/register", {
+  const result = await registerInvitedAccountRaw(params);
+  if (result.status !== 200) {
+    throw new Error(`Invited registration failed for ${params.email} (${result.status}): ${result.html.slice(0, 500)}`);
+  }
+}
+
+/**
+ * Non-throwing variant of {@link registerInvitedAccount}: POST the invited
+ * `/register` form and hand back the raw status + rendered HTML. Used for the
+ * negative cases (wrong email against a real token → the uniform 403
+ * `_not_invited` re-render) where the caller asserts on the rejection instead
+ * of treating a non-200 as an error.
+ */
+export async function registerInvitedAccountRaw(params: {
+  email: string;
+  password: string;
+  invitationToken: string;
+}): Promise<{ status: number; html: string }> {
+  return postForm("/register", {
     email: params.email,
     password: params.password,
     invitation_token: params.invitationToken,
   });
-  if (result.status !== 200) {
-    throw new Error(`Invited registration failed for ${params.email} (${result.status}): ${result.html.slice(0, 500)}`);
+}
+
+/**
+ * Read an organization's `is_instance` flag straight from Postgres. Single-org
+ * mode's claim marks THE instance organization with this column and no product
+ * API surfaces it, so this is the same "state the product exposes no API for"
+ * direct-DB read as the slug/invitation-expiry helpers above.
+ */
+export async function getOrganizationIsInstance(organizationId: string): Promise<boolean> {
+  const client = new Client({ connectionString: toPostgresDriverUrl(databaseUrl()) });
+  await client.connect();
+  try {
+    const result = await client.query<{ is_instance: boolean }>(
+      `SELECT is_instance FROM organization WHERE id = $1`,
+      [organizationId],
+    );
+    if (result.rows.length === 0) {
+      throw new Error(`Organization ${organizationId} not found`);
+    }
+    return result.rows[0].is_instance;
+  } finally {
+    await client.end();
   }
 }
 


### PR DESCRIPTION
Test-only coverage for the self-hosting surface, mapping `specs/developing/testing/self-hosting.md` (spec of record, PR #1078) onto the 4-tier testing standard. No product/application code changed.

## Tier 1 — `server/tests/unit/`
- **T1-SH-1** (`test_telemetry_mode.py`): `single_org_mode` derivation. Pins that BOTH `local_dev` and `self_managed` are single-org and only `hosted_product` is multi-org (`config.py:376-379`), and that `SINGLE_ORG_MODE`/`PROLIFERATE_SINGLE_ORG_MODE` override wins in both directions.
- **T1-SH-2** (`test_sso_env_aliases.py`, new): SSO env-var alias sweep. Structural check that all 19 SSO settings carry exactly the `SSO_*` / `PROLIFERATE_SSO_*` pair, plus functional proof that both forms populate the field identically.
- **T1-SH-3** (`test_meta_endpoint.py`): `/meta` golden wire contract — field names AND order on the response model and the live JSON, the rename/reorder guard for the connect dialog's trust screen.

## Tier 2 — `tests/intent/specs/self-hosting.spec.ts` (new)
- **T2-SH-2**: `/setup` claim yields a single-org OWNER of the one `is_instance` org; a second context after the claim gets the permanently-closed 404 (API + rendered page).
- **T2-SH-3**: invite -> `/register` with the invitation token -> invitee desktop-web sign-in; wrong-email negative (real token, mismatched email -> uniform 403, no account minted).
- **T2-SH-4**: adaptive sign-in driven by `GET /auth/desktop/methods` + github availability — real password-only surface with no GitHub button when unconfigured; the "Continue with GitHub" button when availability is advertised (asserted at the availability boundary; a real GitHub-configured server for the browser UI is tier-3, matching the T2-AUTH-4 ruling).

Shared helper additions in `stack/seed.ts`: `registerInvitedAccountRaw` (non-throwing register for the negative) and `getOrganizationIsInstance`.

## Registration
- `flows.md`: new **Self-hosting** section (tier-1/2 rows point at the specs above; tier-3/4 rows registered as to-do; **T2-SH-1** registered not-yet-implemented — the connect affordance is Tauri-gated and never renders in desktop-web, so the `set_app_config`/relaunch/credential-store slice is tier-3 by ruling).
- `scenarios.md`: **Self-hosting** section indexing T1-SH-1..3 and T2-SH-1..4.

## Local results
- Tier 1: `uv run pytest -q` on the three files — 22 passed.
- Tier 2: `self-hosting.spec.ts` — 6 passed (isolated profile `t2selfhost`, Resend unset to match CI's no-email posture).
- Regression check: `auth.spec.ts` + `invitation.spec.ts` + `login-methods.spec.ts` — 14 passed, 1 pre-existing skip (the `#1017`-gated case).

## Product findings noticed
None new. The `deliveryStatus=skipped` assertion depends on no email config (as in `invitation.spec.ts`); a dev `.env.local` with `RESEND_API_KEY` set makes the local server actually send — not a product bug, an env-posture note for anyone running locally.