### PR TITLE
feat(server): advertise a runtime version pin and serve the anyharness binary for worker self-update

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -176,11 +176,22 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Generate SHA256SUMS
+      - name: Generate SHA256SUMS + per-asset checksums
         run: |
           cd artifacts
           sha256sum anyharness-* > SHA256SUMS
           cat SHA256SUMS
+          # Also emit a per-asset `<asset>.sha256` next to each artifact. The
+          # sandbox worker's runtime self-update derives the checksum URL from
+          # the binary's resolved CDN location (`<binary>.sha256`) rather than
+          # parsing SHA256SUMS, matching the worker binary path — so the CDN
+          # mirror needs a sibling checksum per asset.
+          for asset in anyharness-*; do
+            case "$asset" in
+              *.sha256) continue ;;
+            esac
+            sha256sum "$asset" | cut -d' ' -f1 > "${asset}.sha256"
+          done
 
       - name: Ensure runtime release tag exists
         if: github.event_name == 'workflow_call' && inputs.publish && !inputs.dry_run

--- a/server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/worker_sidecar.py
@@ -29,15 +29,25 @@ from proliferate.server.cloud.runtime_workers.service import (
     create_cloud_sandbox_enrollment,
     worker_cloud_base_url,
 )
+from proliferate.server.version import runtime_version_pin
 
 
 def _detached_worker_launch_command(runtime_context: SandboxRuntimeContext) -> str:
     binary = shlex.quote(worker_binary_path(runtime_context))
     config = shlex.quote(worker_config_path(runtime_context))
     log = shlex.quote(worker_log_path(runtime_context))
+    # Export the launched runtime version into the worker's own environment so
+    # `versions::anyharness_version()` reports what actually runs alongside it
+    # (the worker is a sibling process, not a child of the runtime launcher, so
+    # it does not otherwise inherit the runtime's env). Omitted on unstamped
+    # deployments, matching the server pin and the runtime launcher.
+    prefix = ""
+    runtime_pin = runtime_version_pin()
+    if runtime_pin:
+        prefix = f"export PROLIFERATE_ANYHARNESS_VERSION={shlex.quote(runtime_pin)}; "
     # A stale binary (e.g. an older template) simply means no worker this run.
     return "bash -lc " + shlex.quote(
-        f"test -x {binary} && nohup {binary} --config {config} > {log} 2>&1 < /dev/null &"
+        f"{prefix}test -x {binary} && nohup {binary} --config {config} > {log} 2>&1 < /dev/null &"
     )
 
 

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from proliferate.config import settings
 from proliferate.integrations.sandbox import SandboxProvider, SandboxRuntimeContext
+from proliferate.server.version import runtime_version_pin
 from proliferate.utils.telemetry_mode import is_vendor_telemetry_enabled
 
 _ANYHARNESS_DEFER_STARTUP_RETENTION_ENV = "ANYHARNESS_DEFER_STARTUP_RETENTION"
@@ -88,6 +89,16 @@ def build_runtime_env(
         env["ANYHARNESS_SENTRY_TRACES_SAMPLE_RATE"] = str(_runtime_sentry_traces_sample_rate())
     env["ANYHARNESS_BEARER_TOKEN"] = runtime_token
     env["ANYHARNESS_DATA_KEY"] = anyharness_data_key
+    # The version being launched (the binary staged into the sandbox). The
+    # launcher exports it, the runtime inherits it, and the sibling worker
+    # reads it via `versions::anyharness_version()` to report what actually
+    # runs. Absent on unstamped deployments (local dev / plain docker build):
+    # the worker then reports no anyharness version and the server pins none,
+    # so the two stay consistent. Kept in lockstep with `runtime_version_pin()`,
+    # which the heartbeat advertises as `desiredVersions.anyharness`.
+    runtime_pin = runtime_version_pin()
+    if runtime_pin:
+        env["PROLIFERATE_ANYHARNESS_VERSION"] = runtime_pin
     if target_id is not None:
         env["ANYHARNESS_RUNTIME_TARGET_ID"] = str(target_id)
     env.update(
@@ -172,6 +183,11 @@ def build_worker_config(
     runtime_context: SandboxRuntimeContext,
     runtime_bearer_token: str | None = None,
 ) -> str:
+    # Local import to avoid a module-load cycle (sandbox_exec imports nothing
+    # from bootstrap, but keeping the launcher-path helper's home here is
+    # cleaner than a top-level cross-import for a single call).
+    from proliferate.server.cloud.runtime.sandbox_exec import runtime_launcher_path
+
     worker_dir = f"{runtime_context.home_dir}/.proliferate/worker"
     values: dict[str, str | int | bool] = {
         "cloud_base_url": cloud_base_url,
@@ -183,6 +199,17 @@ def build_worker_config(
         # so it converges its own binary onto the heartbeat's desiredVersions.
         # Desktop workers must never set this: the app bundle owns updates.
         "self_update_enabled": True,
+        # The sandbox worker also owns the in-place swap of the AnyHarness
+        # runtime binary onto the heartbeat's desiredVersions.anyharness. This
+        # gate is independent of self_update_enabled so the two tracks are
+        # separately controllable; desktop leaves it off (app bundle owns it).
+        "anyharness_update_enabled": True,
+        # Paths the worker acts on for the swap (all already known here):
+        # the fixed runtime binary path, the on-disk launcher to relaunch, and
+        # the workdir to relaunch in.
+        "anyharness_binary_path": runtime_context.runtime_binary_path,
+        "anyharness_launcher_path": runtime_launcher_path(runtime_context),
+        "anyharness_workdir": runtime_context.runtime_workdir,
     }
     if runtime_bearer_token:
         values["runtime_bearer_token"] = runtime_bearer_token

--- a/server/proliferate/server/cloud/runtime_workers/api.py
+++ b/server/proliferate/server/cloud/runtime_workers/api.py
@@ -35,6 +35,7 @@ from proliferate.server.cloud.runtime_workers.service import (
     enroll_worker,
     record_heartbeat,
     revoke_desktop_worker,
+    runtime_artifact_redirect_url,
     worker_artifact_redirect_url,
 )
 
@@ -73,6 +74,18 @@ async def worker_artifact_download_endpoint(target: str, asset: str) -> Redirect
     artifacts are public.
     """
     url = await worker_artifact_redirect_url(target=target, asset=asset)
+    return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+
+
+@worker_router.get("/runtime/download/{target}/{asset}")
+async def runtime_artifact_download_endpoint(target: str, asset: str) -> RedirectResponse:
+    """302 to the pinned AnyHarness binary (or its ``.sha256``) on the downloads CDN.
+
+    Unauthenticated by design, like the worker artifact redirect: the sandbox
+    worker fetches the runtime binary over a public CDN URL behind this 302, so
+    the sandbox never needs GitHub egress or credentials.
+    """
+    url = await runtime_artifact_redirect_url(target=target, asset=asset)
     return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
 
 

--- a/server/proliferate/server/cloud/runtime_workers/models.py
+++ b/server/proliferate/server/cloud/runtime_workers/models.py
@@ -53,7 +53,11 @@ class WorkerDesiredVersions(_CamelModel):
     # self-updating workers into perpetual swap attempts, so an unstamped
     # server pins nothing.
     worker: str | None = None
-    anyharness: str
+    # None when the server image was not stamped with RUNTIME_VERSION: like the
+    # worker pin, an unstamped fallback could never match a published runtime
+    # artifact and would drive an anyharness-updating sandbox worker into
+    # perpetual swap attempts, so an unstamped server pins nothing.
+    anyharness: str | None = None
     catalog_version: str | None = None
 
 

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -37,7 +37,7 @@ from proliferate.server.cloud.runtime_workers.models import (
     WorkerEnrollResponse,
     WorkerHeartbeatResponse,
 )
-from proliferate.server.version import runtime_version as pinned_runtime_version
+from proliferate.server.version import runtime_version_pin as pinned_runtime_version
 from proliferate.server.version import worker_version_pin as pinned_worker_version
 from proliferate.utils.time import utcnow
 
@@ -54,6 +54,12 @@ _WORKER_ARTIFACT_TARGETS = frozenset(
 )
 # The binary plus its checksum, published alongside on the downloads CDN.
 _WORKER_ARTIFACT_ASSETS = frozenset({"proliferate-worker", "proliferate-worker.sha256"})
+
+# The AnyHarness runtime binary a sandbox worker converges onto, plus its
+# checksum, published alongside on the downloads CDN. Same platform targets as
+# the worker binary.
+_RUNTIME_ARTIFACT_TARGETS = _WORKER_ARTIFACT_TARGETS
+_RUNTIME_ARTIFACT_ASSETS = frozenset({"anyharness", "anyharness.sha256"})
 
 
 def worker_cloud_base_url() -> str:
@@ -285,3 +291,30 @@ async def worker_artifact_redirect_url(*, target: str, asset: str) -> str:
         if await versioned_manifest_exists(pinned):
             return pinned
     return f"{base}/worker/stable/{target}/{asset}"
+
+
+async def runtime_artifact_redirect_url(*, target: str, asset: str) -> str:
+    """Resolve the downloads-CDN URL for the pinned AnyHarness binary (or checksum).
+
+    Parallel to :func:`worker_artifact_redirect_url`: the server carries only
+    the ``RUNTIME_VERSION`` pin, never the artifact, and falls back to the
+    unpinned ``stable`` path when the pinned artifact has not been published
+    yet. A sandbox worker converging its runtime resolves the version path once
+    (fetching the binary here) and derives the ``.sha256`` URL from that
+    redirect's resolved location, so binary and checksum always share a
+    directory — and thus a version. Keeps the sandbox free of any GitHub egress
+    or credentials, exactly like the worker path.
+    """
+    if target not in _RUNTIME_ARTIFACT_TARGETS or asset not in _RUNTIME_ARTIFACT_ASSETS:
+        raise CloudApiError(
+            "cloud_runtime_artifact_unknown",
+            "Unknown runtime artifact target or asset.",
+            status_code=404,
+        )
+    base = downloads_base_url()
+    pin = pinned_runtime_version()
+    if pin is not None:
+        pinned = f"{base}/runtime/stable/{pin}/{target}/{asset}"
+        if await versioned_manifest_exists(pinned):
+            return pinned
+    return f"{base}/runtime/stable/{target}/{asset}"

--- a/server/proliferate/server/version.py
+++ b/server/proliferate/server/version.py
@@ -72,6 +72,21 @@ def worker_version() -> str:
     return _env("WORKER_VERSION") or server_version()
 
 
+def runtime_version_pin() -> str | None:
+    """The runtime version this server pins for AnyHarness self-updates, or ``None``.
+
+    Unlike :func:`runtime_version` (a display fallback), this pin actively
+    drives binary swaps: a sandbox worker downloads and relaunches whatever it
+    names when it diverges from the AnyHarness binary actually running in the
+    sandbox. When ``RUNTIME_VERSION`` was not stamped (local dev, a plain
+    ``docker build``, self-hosted images) the server-version fallback could
+    never match any published runtime artifact, so it would drive perpetual
+    update attempts against an artifact no release produced — an unstamped
+    deployment therefore pins nothing. Same rationale as :func:`worker_version_pin`.
+    """
+    return _env("RUNTIME_VERSION")
+
+
 def worker_version_pin() -> str | None:
     """The worker version this server pins for self-updates, or ``None``.
 

--- a/server/tests/integration/test_cloud_runtime_worker_versions_api.py
+++ b/server/tests/integration/test_cloud_runtime_worker_versions_api.py
@@ -85,6 +85,59 @@ class TestRuntimeWorkerVersionConvergence:
         assert "catalogVersion" in desired
 
     @pytest.mark.asyncio
+    async def test_heartbeat_omits_anyharness_pin_when_unstamped(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # No RUNTIME_VERSION stamp (local dev / plain docker build): pinning the
+        # server-version fallback would drive an anyharness-updating sandbox
+        # worker into perpetual swap attempts against an unpublished artifact,
+        # so the pin must be absent instead. A new worker seeing an absent pin
+        # treats the runtime update as a no-op — the compat contract against an
+        # unstamped/old server.
+        monkeypatch.delenv("RUNTIME_VERSION", raising=False)
+        auth = await _authed_user(client, db_session, prefix="worker-nortpin")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-nortpin")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert heartbeat.status_code == 200, heartbeat.text
+        # Absent (or explicit null): the model serializes anyharness=None.
+        assert heartbeat.json()["desiredVersions"].get("anyharness") is None
+
+    @pytest.mark.asyncio
+    async def test_old_worker_minimal_heartbeat_still_acked(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # An old worker (predating anyharness convergence) posts a bare
+        # heartbeat and ignores desiredVersions.anyharness entirely. The new
+        # server must still ack it normally — the compat contract in the other
+        # direction (old worker vs new server).
+        monkeypatch.setenv("RUNTIME_VERSION", "8.8.8")
+        auth = await _authed_user(client, db_session, prefix="worker-oldhb")
+        token = await _desktop_enrollment_token(client, auth, install_id="install-oldhb")
+        enroll = await client.post("/v1/cloud/worker/enroll", json={"enrollmentToken": token})
+        worker_token = enroll.json()["workerToken"]
+
+        heartbeat = await client.post(
+            "/v1/cloud/worker/heartbeat",
+            headers={"Authorization": f"Bearer {worker_token}"},
+            json={},
+        )
+        assert heartbeat.status_code == 200, heartbeat.text
+        assert heartbeat.json()["desiredVersions"]["anyharness"] == "8.8.8"
+
+    @pytest.mark.asyncio
     async def test_heartbeat_includes_catalog_version(
         self,
         client: AsyncClient,
@@ -276,3 +329,83 @@ class TestWorkerArtifactDownload:
             response = await client.get(path)
             assert response.status_code == 404
             assert response.json()["detail"]["code"] == "cloud_worker_artifact_unknown"
+
+
+class TestRuntimeArtifactDownload:
+    @pytest.fixture(autouse=True)
+    def _pinned_cdn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DESKTOP_DOWNLOADS_BASE_URL", raising=False)
+        monkeypatch.setenv("RUNTIME_VERSION", "3.4.5")
+
+    def _stub_probe(self, monkeypatch: pytest.MonkeyPatch, *, exists: bool) -> list[str]:
+        from proliferate.server.cloud.runtime_workers import service as service_module
+
+        probed: list[str] = []
+
+        async def probe(url: str) -> bool:
+            probed.append(url)
+            return exists
+
+        monkeypatch.setattr(service_module, "versioned_manifest_exists", probe)
+        return probed
+
+    @pytest.mark.asyncio
+    async def test_download_redirects_to_pinned_runtime_artifact(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_probe(monkeypatch, exists=True)
+        for asset in ("anyharness", "anyharness.sha256"):
+            response = await client.get(f"/v1/cloud/runtime/download/linux-x86_64/{asset}")
+            assert response.status_code == 302, response.text
+            assert response.headers["location"] == (
+                f"https://downloads.proliferate.com/runtime/stable/3.4.5/linux-x86_64/{asset}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_falls_back_when_pin_unpublished(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        probed = self._stub_probe(monkeypatch, exists=False)
+        response = await client.get("/v1/cloud/runtime/download/macos-aarch64/anyharness")
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://downloads.proliferate.com/runtime/stable/macos-aarch64/anyharness"
+        )
+        assert probed == [
+            "https://downloads.proliferate.com/runtime/stable/3.4.5/macos-aarch64/anyharness"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_download_skips_probe_when_pin_unstamped(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("RUNTIME_VERSION", raising=False)
+        probed = self._stub_probe(monkeypatch, exists=True)
+        response = await client.get("/v1/cloud/runtime/download/linux-aarch64/anyharness")
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://downloads.proliferate.com/runtime/stable/linux-aarch64/anyharness"
+        )
+        # No pin, nothing to probe: never build a ".../None/..." URL.
+        assert probed == []
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_unknown_target_or_asset(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_probe(monkeypatch, exists=True)
+        for path in (
+            "/v1/cloud/runtime/download/windows-x86_64/anyharness",
+            "/v1/cloud/runtime/download/linux-x86_64/proliferate-worker",
+        ):
+            response = await client.get(path)
+            assert response.status_code == 404
+            assert response.json()["detail"]["code"] == "cloud_runtime_artifact_unknown"

--- a/server/tests/unit/test_runtime_version_pin.py
+++ b/server/tests/unit/test_runtime_version_pin.py
@@ -1,0 +1,45 @@
+"""Unit tests for the runtime version pin and its launch-env export.
+
+The pin (`runtime_version_pin`) drives the sandbox worker's in-place AnyHarness
+binary swap: an unstamped deployment must pin nothing, and the launched runtime
+env must carry exactly what the pin advertises so heartbeats report what runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.runtime.bootstrap import build_runtime_env
+from proliferate.server.version import runtime_version_pin
+
+
+class TestRuntimeVersionPin:
+    def test_pin_is_the_stamped_runtime_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTIME_VERSION", "3.4.5")
+        assert runtime_version_pin() == "3.4.5"
+
+    def test_pin_is_none_when_unstamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No server-version display fallback: an unstamped deployment pins
+        # nothing so the worker never chases an unpublished artifact.
+        monkeypatch.delenv("RUNTIME_VERSION", raising=False)
+        monkeypatch.setenv("SERVER_VERSION", "9.9.9")
+        assert runtime_version_pin() is None
+
+    def test_pin_ignores_blank(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTIME_VERSION", "   ")
+        assert runtime_version_pin() is None
+
+
+class TestRuntimeLaunchEnvExport:
+    def test_exports_pin_when_stamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RUNTIME_VERSION", "3.4.5")
+        env = build_runtime_env("tok", anyharness_data_key="key")
+        assert env["PROLIFERATE_ANYHARNESS_VERSION"] == "3.4.5"
+
+    def test_omits_export_when_unstamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RUNTIME_VERSION", raising=False)
+        monkeypatch.setenv("SERVER_VERSION", "9.9.9")
+        env = build_runtime_env("tok", anyharness_data_key="key")
+        # No pin, no export: the worker reports no anyharness version and the
+        # server pins none, so the two stay consistent.
+        assert "PROLIFERATE_ANYHARNESS_VERSION" not in env


### PR DESCRIPTION
Server groundwork for worker-owned in-place AnyHarness binary self-update in cloud sandboxes. Spec of record: `specs/tbd/anyharness-self-update-v1.md` (#1081). This is PR 1 of 2; the worker consumes this in the follow-up. Safe to land alone — old workers ignore the new pin, the new route is unused until the worker PR.

## What

- **`runtime_version_pin()`** in `version.py`, analogous to `worker_version_pin()`: returns `RUNTIME_VERSION` or `None` (no `server_version()` display fallback). `record_heartbeat` advertises `desiredVersions.anyharness` from it, so an unstamped deployment (local dev, plain `docker build`, self-hosted) pins **nothing** instead of driving a worker to chase an artifact no release published. `WorkerDesiredVersions.anyharness` is now optional to match.
- **Runtime artifact redirect** `GET /v1/cloud/runtime/download/{target}/{asset}`, parallel to the worker one: 302 to the pinned `anyharness` binary (or its `.sha256`) on the downloads CDN, unpinned `stable` fallback, unauthenticated by design so the sandbox needs no GitHub egress or credentials.
- **`PROLIFERATE_ANYHARNESS_VERSION` export** into both the runtime launch env (`build_runtime_env`) and the worker sidecar env, so the sibling worker's `versions::anyharness_version()` reports what actually runs. Omitted when unstamped, matching the pin.
- **`build_worker_config`** writes the `anyharness_update_enabled` gate (sandbox only; desktop stays off) plus the binary / launcher / workdir paths the worker acts on.
- **`release-runtime.yml`** also emits a per-asset `.sha256` next to each asset (alongside `SHA256SUMS`) for the worker's derive-sibling checksum path.

## Compatibility (both directions asserted)

- **Old worker vs new server**: a bare heartbeat is still acked normally (`test_old_worker_minimal_heartbeat_still_acked`).
- **New worker vs unstamped/old server**: `anyharness` comes back `null`, which the worker treats as a no-op (`test_heartbeat_omits_anyharness_pin_when_unstamped`).

## Tests

`uv run pytest` — 5 new unit tests (`test_runtime_version_pin.py`: pin stamped/unstamped/blank, env-export present/absent) + 8 new integration tests (runtime download redirect: pinned / fallback / unstamped-skips-probe / unknown-target-or-asset; plus the two compat tests above). Full `test_cloud_runtime_worker_versions_api.py` suite green (16 passed).