### PR TITLE
fix(desktop): sync right panel tab height with glass workspace header

### DIFF
--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -6,6 +6,7 @@ import { RightPanelHeaderActions } from "@/components/workspace/shell/right-pane
 import { RightPanelHeaderEntryList } from "@/components/workspace/shell/right-panel/RightPanelHeaderEntryList";
 import { RightPanelNewTabMenu } from "@/components/workspace/shell/right-panel/RightPanelNewTabMenu";
 import { useRightPanelHeaderDrag } from "@/hooks/workspaces/ui/use-right-panel-header-drag";
+import { useTransparentChromeEnabled } from "@/hooks/theme/derived/use-transparent-chrome";
 import {
   type RightPanelHeaderEntryKey,
 } from "@/lib/domain/workspaces/shell/right-panel-model";
@@ -65,6 +66,7 @@ export function RightPanelHeaderTabs({
     onReorderHeaderEntry,
   });
   const shortcutRevealVisible = useShortcutRevealVisible();
+  const transparentChromeEnabled = useTransparentChromeEnabled();
 
   useEffect(() => {
     if (newTabMenuRequestToken > 0) {
@@ -73,7 +75,10 @@ export function RightPanelHeaderTabs({
   }, [newTabMenuRequestToken]);
 
   return (
-    <div className="right-panel-tab-system ui-tab-system editor-panel-tab-root editor-panel-tab-root--simple-tabs">
+    <div
+      className="right-panel-tab-system ui-tab-system editor-panel-tab-root editor-panel-tab-root--simple-tabs"
+      data-chrome={transparentChromeEnabled ? "glass" : "solid"}
+    >
       <div className="ui-tab-system-bar">
         <div className="editor-panel-tab-bar-tab-cluster">
           <output

--- a/apps/desktop/src/lib/domain/preferences/workspace-chrome.ts
+++ b/apps/desktop/src/lib/domain/preferences/workspace-chrome.ts
@@ -1,11 +1,17 @@
 // Glass tints anchor to --color-background (the content surface), not card:
 // card is a step lighter, which rendered the header as a visibly lighter haze
 // band against the opaque chat surface on every theme.
+//
+// h-16 (64px) must stay in sync with the right panel's tab-system height:
+// .right-panel-tab-system[data-chrome="glass"] in
+// apps/packages/design/src/css/desktop.css sets --tab-system-height: 64px to
+// match, so the two headers stay aligned in glass chrome mode.
 const WORKSPACE_GLASS_HEADER_BASE_CLASS =
   "flex h-16 shrink-0 items-center bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60";
 const WORKSPACE_GLASS_HEADER_CLASS =
   `${WORKSPACE_GLASS_HEADER_BASE_CLASS} border-b border-foreground/10`;
-// 46px = codex --height-toolbar (UX_SPEC §7).
+// 46px = codex --height-toolbar (UX_SPEC §7). Must stay in sync with the
+// right panel's default --tab-system-height in desktop.css.
 const WORKSPACE_SOLID_HEADER_BASE_CLASS =
   "flex h-[46px] shrink-0 items-center bg-background";
 const WORKSPACE_SOLID_HEADER_CLASS =

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -1725,8 +1725,15 @@ body {
 }
 
 /* ---- Right panel tabs ---- */
+/*
+ * --tab-system-height mirrors the left workspace header height so the two
+ * panes line up. Solid chrome = 46px (codex --height-toolbar, UX_SPEC §7),
+ * matching WORKSPACE_SOLID_HEADER_BASE_CLASS's h-[46px]. Glass chrome bumps
+ * to 64px to match WORKSPACE_GLASS_HEADER_BASE_CLASS's h-16 (see
+ * apps/desktop/src/lib/domain/preferences/workspace-chrome.ts).
+ */
 .right-panel-tab-system {
-  --tab-system-height: 46px; /* codex --height-toolbar; aligns with the top bar. */
+  --tab-system-height: 46px;
   --tab-max-width: 156px;
   --tab-shell-max-width: 160px;
   --tab-height: 28px; /* codex tab chrome (UX_SPEC §8) */
@@ -1777,6 +1784,10 @@ body {
   color: var(--right-panel-tab-text-secondary);
   font-size: var(--right-panel-tab-font-size);
   line-height: var(--right-panel-tab-line-height);
+}
+
+.right-panel-tab-system[data-chrome="glass"] {
+  --tab-system-height: 64px; /* h-16; matches WORKSPACE_GLASS_HEADER_BASE_CLASS */
 }
 
 :root[data-mode="light"] .right-panel-tab-system {


### PR DESCRIPTION
## Problem
In glass/vibrancy chrome mode, the session-tabs header on the left is 64px (h-16) while the right pane's tab header stays pinned at 46px, causing an 18px mismatch between the two panes.

## Fix
The right panel's `.right-panel-tab-system` now reads a `data-chrome` attribute driven by the same `transparentChromeEnabled` preference the workspace shell header uses. A new `[data-chrome="glass"]` CSS rule bumps `--tab-system-height` from 46px to 64px to match `WORKSPACE_GLASS_HEADER_BASE_CLASS`'s `h-16`. Solid mode is unchanged at 46px. Comments cross-reference both sides so the two heights don't drift again.

## Verification
- `pnpm --filter "@proliferate/design" build` (rebuilt shared CSS package)
- `cd apps/desktop && pnpm exec tsc --noEmit` — no new errors introduced (pre-existing unrelated `@proliferate/cloud-sdk` module-resolution errors present on the base branch too)
- `pnpm exec vitest run src/lib/domain/preferences/workspace-chrome.test.ts` — 4 passed