### PR TITLE
fix(desktop): stop show-more toggle from appearing on every user message

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { CopyMessageButton } from "./CopyMessageButton";
 import { userMessageStatusLabel } from "./CloudChatTranscriptPresentation";
@@ -16,15 +16,36 @@ export function CloudChatUserMessage({
   const hasContent = content.trim().length > 0;
   const visibleStatus = userMessageStatusLabel(status);
 
+  // `line-clamp-5` reports a 1-2px scrollHeight/clientHeight delta even when
+  // the text fits in 5 lines, due to sub-pixel line-height rounding. A small
+  // tolerance avoids treating that rounding noise as real overflow, while
+  // still catching genuine 6+-line messages (which overflow by a full line).
+  const OVERFLOW_TOLERANCE_PX = 2;
+
+  const measureOverflow = useCallback(() => {
+    const el = textRef.current;
+    if (!el) return;
+    setNeedsToggle(el.scrollHeight - el.clientHeight > OVERFLOW_TOLERANCE_PX);
+  }, []);
+
   useLayoutEffect(() => {
     if (!hasContent) {
       setNeedsToggle(false);
       return;
     }
+    measureOverflow();
+  }, [content, hasContent, measureOverflow]);
+
+  useLayoutEffect(() => {
+    if (!hasContent) return;
     const el = textRef.current;
-    if (!el) return;
-    setNeedsToggle(el.scrollHeight > el.clientHeight);
-  }, [content, hasContent]);
+    if (!el || typeof ResizeObserver === "undefined") return;
+    // Wrapping (and therefore overflow) changes with element width, e.g.
+    // when the sidebar or window is resized.
+    const observer = new ResizeObserver(() => measureOverflow());
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasContent, measureOverflow]);
 
   return (
     <article className="group/msg flex justify-end" data-chat-user-message>


### PR DESCRIPTION
## Problem

Every human message in the chat transcript showed a "Show more" toggle, even one-liners. `CloudChatUserMessage` measures overflow by comparing `el.scrollHeight` to `el.clientHeight` on a `line-clamp-5` (`-webkit-box`) element. Sub-pixel rounding from the message text's line-height makes `scrollHeight` exceed `clientHeight` by a pixel or two unconditionally, so `needsToggle` was always true.

## Fix

- Compare `scrollHeight - clientHeight` against a small tolerance (2px) instead of a strict `>`, so rounding noise no longer counts as overflow while genuine 6+-line overflow (a full extra line) still does.
- Re-run the measurement on element resize via `ResizeObserver`, so wrapping changes from sidebar/window resizing correctly recompute the toggle.

File: `apps/packages/product-ui/src/chat/transcript/CloudChatUserMessage.tsx`

## Verification

- Rebuilt `@proliferate/product-ui` (`pnpm --filter "@proliferate/product-ui" build`) — clean.
- `cd apps/desktop && pnpm exec tsc --noEmit` — no new errors; pre-existing unrelated errors come from other unbuilt sibling packages (`@proliferate/cloud-sdk-react`, etc.) not touched by this change.
- No unit test added: jsdom performs no real layout, so `scrollHeight`/`clientHeight` stay 0 regardless of CSS classes, and jsdom has no `ResizeObserver`. A test would only assert against manually stubbed properties, not the real measurement path. Verified manually in the running app instead: one-line and multi-line (under 5 lines) messages no longer show the toggle; a genuinely long 6+ line message still does; resizing the window/sidebar recomputes correctly.