### PR TITLE
fix(desktop): stop gating local-surface harness settings on cloud auth

### DIFF
--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
@@ -109,8 +109,14 @@ function HarnessSettingRow({
   setting: CatalogSetting;
 }) {
   const { cloudActive } = useCloudAvailabilityState();
-  const stateQuery = useAgentAuthState(surface, cloudActive);
-  const selectionsQuery = useAuthSelections(surface, cloudActive);
+  // The "local" surface is a local CLI flag persisted through the desktop's
+  // own backend — it must not require cloud sign-in. Only the "cloud" surface
+  // depends on cloud compute being active. Mirrors HarnessAuthSection's
+  // surface === "local" handling.
+  const isLocalSurface = surface === "local";
+  const queriesEnabled = isLocalSurface || cloudActive;
+  const stateQuery = useAgentAuthState(surface, queriesEnabled);
+  const selectionsQuery = useAuthSelections(surface, queriesEnabled);
   const putSelections = usePutAuthSelections();
 
   // Read persisted value from the auth state response.
@@ -153,7 +159,7 @@ function HarnessSettingRow({
         checked={currentValue}
         onChange={handleToggle}
         aria-label={setting.label}
-        disabled={!cloudActive}
+        disabled={!isLocalSurface && !cloudActive}
       />
     </SettingsRow>
   );


### PR DESCRIPTION
## Problem
The "Use Claude Code with Chrome" toggle in harness settings does nothing when clicked. It is declared with `surfaces: ["local"]` (a local CLI flag, catalogs/agents/catalog.json), but `HarnessSettingRow` hard-wired `disabled={!cloudActive}` on the Switch and gated `stateQuery`/`selectionsQuery` on `cloudActive` regardless of surface. Without cloud sign-in the toggle stayed disabled and its persisted value never loaded.

## Fix
Scope the `cloudActive` gate to the cloud surface only in `HarnessSettingsSection.tsx`, mirroring the existing `surface === "local"` handling in `HarnessAuthSection.tsx`:
- `stateQuery`/`selectionsQuery` are enabled whenever `surface === "local"`, otherwise fall back to `cloudActive`.
- The Switch's `disabled` prop follows the same rule.

`usePutAuthSelections` (the mutation that persists the setting) was never gated on `cloudActive`, so persistence itself required no change — it goes through the desktop's own backend, not a cloud-auth-only path.

## Verification
- `cd apps/desktop && pnpm exec tsc --noEmit` — clean (required a shared-package dist rebuild via `make shared-build` first, unrelated to this diff).
- `pnpm exec vitest run src/components/settings/panes/agents/harness/HarnessPane.test.tsx` — same 25 failures present before and after this change (pre-existing "No QueryClient set" issue unrelated to this file), confirmed via `git stash` diff.