### PR TITLE
fix(desktop): keep workspace shell mounted across all authenticated routes

### DIFF
--- a/apps/desktop/src/pages/AuthenticatedAppHost.test.tsx
+++ b/apps/desktop/src/pages/AuthenticatedAppHost.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/hooks/organizations/lifecycle/use-organization-selection-lifecycle", 
   useOrganizationSelectionLifecycle: vi.fn(),
 }));
 
+vi.mock("@/pages/WorkflowsPage", () => ({
+  WorkflowsPage: () => <section data-testid="workflows" />,
+}));
+
 let mainMounts = 0;
 
 function TestMain({ workspaceVisible = true }: { workspaceVisible?: boolean }) {
@@ -23,6 +27,12 @@ function TestMain({ workspaceVisible = true }: { workspaceVisible?: boolean }) {
     <main data-testid="workspace" data-visible={workspaceVisible ? "true" : "false"}>
       <button type="button" onClick={() => navigate("/settings?section=general")}>
         Open settings
+      </button>
+      <button type="button" onClick={() => navigate("/workflows")}>
+        Open workflows
+      </button>
+      <button type="button" onClick={() => navigate("/")}>
+        Go home
       </button>
     </main>
   );
@@ -64,5 +74,25 @@ describe("AuthenticatedAppHost", () => {
     fireEvent.click(screen.getByText("Back"));
 
     expect(screen.getByTestId("workspace").dataset.visible).toBe("true");
+  });
+
+  it("keeps the workspace mounted while on Workflows and restores it without remounting", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AuthenticatedAppHost MainComponent={TestMain} SettingsComponent={TestSettings} />
+      </MemoryRouter>,
+    );
+
+    expect(mainMounts).toBe(1);
+
+    fireEvent.click(screen.getByText("Open workflows"));
+
+    expect(screen.getByTestId("workflows")).toBeTruthy();
+    expect(screen.getByTestId("workspace").dataset.visible).toBe("false");
+
+    fireEvent.click(screen.getByText("Go home"));
+
+    expect(screen.getByTestId("workspace").dataset.visible).toBe("true");
+    expect(mainMounts).toBe(1);
   });
 });

--- a/apps/desktop/src/pages/AuthenticatedAppHost.tsx
+++ b/apps/desktop/src/pages/AuthenticatedAppHost.tsx
@@ -33,20 +33,22 @@ export function AuthenticatedAppHost({
   }, [isSettingsRoute, location.hash, location.pathname, location.search]);
 
   const isHomeRoute = location.pathname === APP_ROUTES.home;
-  const shouldRenderWorkspace = isHomeRoute || isSettingsRoute;
+  // The workspace shell stays mounted (hidden) across every authenticated
+  // route: cold-mounting it on return from /workflows or /workspaces is
+  // seconds of synchronous hydration work.
   const workspaceHostClassName = isSettingsRoute
     ? "pointer-events-none"
-    : shouldRenderWorkspace
+    : isHomeRoute
       ? undefined
       : "hidden";
 
   return (
     <>
       <div
-        aria-hidden={isSettingsRoute ? "true" : undefined}
+        aria-hidden={isHomeRoute ? undefined : "true"}
         className={workspaceHostClassName}
       >
-        {shouldRenderWorkspace && <MainComponent workspaceVisible={!isSettingsRoute} />}
+        <MainComponent workspaceVisible={isHomeRoute} />
       </div>
 
       {isSettingsRoute ? (


### PR DESCRIPTION
## Problem
Switching between Settings and the app occasionally took seconds. AuthenticatedAppHost only rendered the workspace shell on / and /settings, so visiting /workflows or /workspaces fully unmounted MainComponent. Returning (directly or via Settings' returnTo) cold-mounted the shell synchronously: workspace selection hydration, useWorkspaces mount, hot-session ingest, git-status and activity effects.

## Fix
The workspace shell now stays mounted (hidden, aria-hidden, pointer-events off on Settings) across every authenticated route; workspaceVisible is true only on the home route. Hidden-shell quiescence was audited: useWorkspaceActivityAcknowledgement, useMainScreenShortcuts, WorkspaceShellShortcuts, and useActiveSessionActivityAcknowledgement are already gated on visible. The remaining always-on work (useWorkspaces activity-conditional refetch, hot-session ingest, git-status query) was already running on /settings under the old code and is shared cache/stream state the rest of the app uses, so keeping it live on /workflows and /workspaces adds no new timers or growth. No new intervals or subscriptions were added.

## Verification
- cd apps/desktop && pnpm exec tsc --noEmit (after make shared-build) passes
- pnpm exec vitest run src/pages/AuthenticatedAppHost.test.tsx: 2 tests pass, including a new test that the shell survives a round trip through /workflows without remounting
- Static verification only; did not boot the app under a dev profile