### PR TITLE
test(release): implement T3-PROV-2 pause/resume and T3-SEC-MAT-1 secret materialization

### DIFF
--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -46,8 +46,8 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
 | Add-Repo flow entry: local/cloud branches render + desktop-web fallback limits (no native picker outside Tauri) | 2 | tests/intent/specs/workspace-entry.spec.ts |
 | New user cold path: GitHub App authorization triggers first-ever sandbox provisioned from zero, within time budget | 3 | tests/release/src/scenarios/t3-prov-1.ts (T3-PROV-1; REAL trigger — seeds the App-auth callback's outcome via github_app_seed.py, real user token + real installation token, then runs the real post-callback body → real E2B sandbox; asserts positive AND negative trigger contract; fallback seam when seed creds absent) |
-| Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; blocked on current_product_user — no fallback seam for this one, it's specifically the front-door path) |
-| Cloud workspace pause/resume/connect on real E2B | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; blocked, see above) |
+| Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; #1041 — real and green end-to-end on --lane local against a real E2B sandbox: front-door reconnect via the anyharness gateway proxy, direct-E2B pause/resume with ground truth verified, filesystem state proven intact across the cycle; RELEASE_E2E_E2B_API_KEY-gated, expected-fail without it; blocked, not red, when the durable org's cloud-sandbox credits are exhausted) |
+| Cloud workspace pause/resume/connect on real E2B | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; same scenario) |
 | Local ↔ cloud workspace migration | 3 | — |
 | Add repo from cloud | 2 | — |
 | Repo settings applied: default branch, action scripts, environment scripts/env vars take effect — locally AND in sandbox | 3 | tests/release/src/scenarios/t3-repo-1.ts (T3-REPO-1; #1043 authorization blocker resolved — seeds the durable user's real App auth; remaining expected-fail is environmental: t3local's App (proliferate-dev/pablonyx) isn't installed on the fixture org proliferate-e2e → github_app_installation_required) |
@@ -68,9 +68,9 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
 | Secrets CRUD in UI: org, personal, file secrets | 2 | — |
-| Org secret set → materializes in a new cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (T3-SEC-MAT-1; blocked on current_product_user — no local-lane variant exists in the contract) |
-| Personal secret set → materializes in a new cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario, blocked) |
-| File secret set → lands at the right path in the sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario, blocked) |
+| Org secret set → materializes into the owner's personal cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (T3-SEC-MAT-1; #1042 — real and green on --lane local: personal + org env-var secrets PUT, materialization polled to ready, then E2B-direct in-sandbox verification of global.env content and manifest sha256s, plus the update-propagation cycle; RELEASE_E2E_E2B_API_KEY-gated, expected-fail without it; blocked, not red, when the durable org's cloud-sandbox credits are exhausted) |
+| Personal secret set → materializes into the owner's personal cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario) |
+| Workspace file secret set → lands at the right path in a fresh cloud workspace | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario; this half needs a seeded GitHub App user authorization for the durable identity — real on --lane local when the seed is available, expected-fail citing #1043's environmental gap otherwise; never attempted on --lane staging) |
 
 ## Integrations
 

--- a/tests/release/scripts/e2b_sandbox_probe.py
+++ b/tests/release/scripts/e2b_sandbox_probe.py
@@ -1,0 +1,187 @@
+"""Direct E2B verification/action backdoor for T3-PROV-2 and T3-SEC-MAT-1.
+
+Ground truth (surveyed 2026-07-09, see specs/developing/testing/scenarios.md
+#T3-PROV-2 / #T3-SEC-MAT-1): the product API never exposes a cloud sandbox's
+provider (E2B) sandbox id -- see
+server/proliferate/server/cloud/cloud_sandboxes/models.py, which serializes
+only the internal `cloud_sandbox.id` -- and there is NO product-level pause
+endpoint at all. A sandbox only pauses via E2B's own idle-timeout lifecycle
+(`lifecycle={"on_timeout": "pause", "auto_resume": True}`, set at
+`Sandbox.create()` time in
+server/proliferate/integrations/sandbox/e2b.py:_create_sandbox) or via the
+product's own reconciler pausing an over-budget sandbox
+(server/proliferate/server/cloud/webhooks/service.py calls
+`provider.pause_sandbox`). Pablo has authorized direct use of the E2B API key
+for VERIFICATION of ground truth, and -- since no product lever exists at
+all -- for driving the pause action itself in T3-PROV-2.
+
+No database access is needed to resolve the provider sandbox id: every
+personal cloud sandbox the product creates is tagged with
+`metadata={"proliferate_cloud_sandbox_id": str(sandbox.id)}`
+(server/proliferate/server/cloud/materialization/sandbox_io/connect.py) --
+the exact same id the product API returns as `GET /v1/cloud/cloud-sandbox`'s
+`id` field. So this script finds the provider sandbox purely via E2B's own
+sandbox-list API, filtered by that metadata key -- it never touches Postgres,
+which matters most for the staging lane (its DB is VPC-only).
+
+Subcommands, one JSON object printed to stdout each:
+  find <cloud_sandbox_id>                  -> {"providerSandboxId": str|null, "state": str|null}
+  state <provider_sandbox_id>              -> {"state": str}
+  pause <provider_sandbox_id>              -> {"paused": bool}
+  exec <provider_sandbox_id> <command...>  -> {"stdout": str, "stderr": str, "exitCode": int}
+  write <provider_sandbox_id> <path>       -> {"written": bool} (content read from stdin)
+  read <provider_sandbox_id> <path>        -> {"content": str|null, "error": str|null}
+
+Requires E2B_API_KEY in the environment (the TS caller maps it from
+RELEASE_E2E_E2B_API_KEY -- see ../src/fixtures/e2b-verify.ts). This script
+never prints the key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def _api_key() -> str:
+    key = os.environ.get("E2B_API_KEY")
+    if not key:
+        print(json.dumps({"error": "E2B_API_KEY not set in this script's environment"}))
+        sys.exit(1)
+    return key
+
+
+def _state_name(value: object) -> str:
+    return str(getattr(value, "value", value))
+
+
+def cmd_find(cloud_sandbox_id: str) -> dict[str, object]:
+    from e2b import Sandbox
+    from e2b.api.client.models.sandbox_state import SandboxState
+    from e2b.sandbox.sandbox_api import SandboxQuery
+
+    api_key = _api_key()
+    paginator = Sandbox.list(
+        query=SandboxQuery(
+            metadata={"proliferate_cloud_sandbox_id": cloud_sandbox_id},
+            state=[SandboxState.RUNNING, SandboxState.PAUSED],
+        ),
+        api_key=api_key,
+    )
+    items = paginator.next_items()
+    if not items:
+        return {"providerSandboxId": None, "state": None}
+    # One cloud_sandbox row maps to at most one live provider sandbox at a time.
+    info = items[0]
+    return {"providerSandboxId": info.sandbox_id, "state": _state_name(info.state)}
+
+
+def cmd_state(provider_sandbox_id: str) -> dict[str, object]:
+    from e2b import Sandbox
+
+    api_key = _api_key()
+    info = Sandbox.get_info(provider_sandbox_id, api_key=api_key)
+    return {"state": _state_name(info.state)}
+
+
+def cmd_pause(provider_sandbox_id: str) -> dict[str, object]:
+    from e2b import Sandbox
+
+    api_key = _api_key()
+    result = Sandbox.pause(provider_sandbox_id, api_key=api_key)
+    return {"paused": bool(result)}
+
+
+def cmd_exec(provider_sandbox_id: str, command: list[str]) -> dict[str, object]:
+    from e2b import Sandbox
+
+    api_key = _api_key()
+    sbx = Sandbox.connect(provider_sandbox_id, api_key=api_key)
+    result = sbx.commands.run(" ".join(command))
+    return {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "exitCode": result.exit_code,
+    }
+
+
+def cmd_write(provider_sandbox_id: str, path: str, content: str) -> dict[str, object]:
+    from e2b import Sandbox
+
+    api_key = _api_key()
+    sbx = Sandbox.connect(provider_sandbox_id, api_key=api_key)
+    sbx.files.write(path, content)
+    return {"written": True}
+
+
+def cmd_read(provider_sandbox_id: str, path: str) -> dict[str, object]:
+    from e2b import Sandbox
+
+    api_key = _api_key()
+    sbx = Sandbox.connect(provider_sandbox_id, api_key=api_key)
+    try:
+        content = sbx.files.read(path)
+        return {"content": content, "error": None}
+    except Exception as exc:  # noqa: BLE001 - a missing file is an expected, reportable outcome, not a crash.
+        return {"content": None, "error": str(exc)[:500]}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # dest="action" (not "command") -- the exec subparser below also needs an
+    # argument literally named "command" (the argv to run), which would
+    # collide with argparse's subparsers dest of the same name.
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_find = sub.add_parser("find")
+    p_find.add_argument("cloud_sandbox_id")
+
+    p_state = sub.add_parser("state")
+    p_state.add_argument("provider_sandbox_id")
+
+    p_pause = sub.add_parser("pause")
+    p_pause.add_argument("provider_sandbox_id")
+
+    p_exec = sub.add_parser("exec")
+    p_exec.add_argument("provider_sandbox_id")
+    p_exec.add_argument("command", nargs="+")
+
+    p_write = sub.add_parser("write")
+    p_write.add_argument("provider_sandbox_id")
+    p_write.add_argument("path")
+    p_write.add_argument(
+        "--content-stdin",
+        action="store_true",
+        help="Read file content from stdin instead of an argv value (avoids leaking test values into process listings).",
+    )
+    p_write.add_argument("content", nargs="?")
+
+    p_read = sub.add_parser("read")
+    p_read.add_argument("provider_sandbox_id")
+    p_read.add_argument("path")
+
+    args = parser.parse_args()
+
+    if args.action == "find":
+        result = cmd_find(args.cloud_sandbox_id)
+    elif args.action == "state":
+        result = cmd_state(args.provider_sandbox_id)
+    elif args.action == "pause":
+        result = cmd_pause(args.provider_sandbox_id)
+    elif args.action == "exec":
+        result = cmd_exec(args.provider_sandbox_id, args.command)
+    elif args.action == "write":
+        content = sys.stdin.read() if args.content_stdin else (args.content or "")
+        result = cmd_write(args.provider_sandbox_id, args.path, content)
+    elif args.action == "read":
+        result = cmd_read(args.provider_sandbox_id, args.path)
+    else:  # pragma: no cover - argparse enforces the choice set above.
+        raise AssertionError(f"unknown action {args.action!r}")
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/release/src/fixtures/cloud-sandbox.test.ts
+++ b/tests/release/src/fixtures/cloud-sandbox.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isBillingCreditsExhaustedError } from "./cloud-sandbox.js";
+import { ApiRequestError } from "./http.js";
+
+test("isBillingCreditsExhaustedError recognizes the real 402 shape (bare code)", () => {
+  const error = new ApiRequestError("POST", "/v1/cloud/cloud-sandbox/ensure", 402, {
+    code: "billing_credits_exhausted",
+    message: "Cloud usage is paused because your included sandbox hours are exhausted.",
+    decision_type: "enforce_active_spend",
+    reason: "credits_exhausted",
+    remaining_seconds: 0,
+  });
+  assert.equal(isBillingCreditsExhaustedError(error), true);
+});
+
+test("isBillingCreditsExhaustedError recognizes the FastAPI HTTPException-wrapped shape", () => {
+  const error = new ApiRequestError("POST", "/v1/cloud/cloud-sandbox/ensure", 402, {
+    detail: { code: "billing_credits_exhausted" },
+  });
+  assert.equal(isBillingCreditsExhaustedError(error), true);
+});
+
+test("isBillingCreditsExhaustedError is false for other 402s and other statuses", () => {
+  assert.equal(
+    isBillingCreditsExhaustedError(new ApiRequestError("POST", "/x", 402, { code: "some_other_code" })),
+    false,
+  );
+  assert.equal(
+    isBillingCreditsExhaustedError(new ApiRequestError("POST", "/x", 409, { code: "billing_credits_exhausted" })),
+    false,
+  );
+  assert.equal(isBillingCreditsExhaustedError(new Error("boom")), false);
+});

--- a/tests/release/src/fixtures/cloud-sandbox.ts
+++ b/tests/release/src/fixtures/cloud-sandbox.ts
@@ -1,0 +1,151 @@
+/**
+ * Product-flow helpers shared by the sandbox-lane scenarios (T3-PROV-2,
+ * T3-SEC-MAT-1) for driving/observing a personal cloud sandbox purely
+ * through the real server API -- no DB, no E2B SDK. The E2B-direct backdoor
+ * (pause + in-sandbox ground-truth reads) lives in `e2b-verify.ts`.
+ *
+ * `GET /v1/gateway/cloud-sandbox/anyharness/{path}` is the server's real
+ * proxy into the sandbox's own AnyHarness runtime
+ * (server/proliferate/server/cloud/gateway/api.py, mounted at
+ * `{api_prefix}/v1/gateway` in server/proliferate/main.py -- NOT
+ * `/v1/cloud/cloud-sandbox/anyharness/*`, which several pre-existing doc
+ * comments elsewhere in this package assume; verified for real against
+ * t3local 2026-07-09, that path 404s) -- the same route the desktop app
+ * uses. `probeAgentsThroughGateway` calls its workspace-free
+ * `GET /v1/agents` for a real exec/connectivity proof-of-life, matching the
+ * pattern T3-PROV-1 already established (its `agentsProbe` assertion).
+ */
+
+import { ApiClient, ApiRequestError } from "./http.js";
+import { ScenarioBlockedError } from "../scenarios/types.js";
+
+export interface CloudSandboxStatus {
+  id: string;
+  status: string;
+  lastError: string | null;
+  readyAt: string | null;
+}
+
+export interface AgentSummary {
+  kind: string;
+  [key: string]: unknown;
+}
+
+export async function getCloudSandbox(client: ApiClient): Promise<CloudSandboxStatus | null> {
+  return client.get<CloudSandboxStatus | null>("/v1/cloud/cloud-sandbox");
+}
+
+export async function ensureCloudSandboxRow(client: ApiClient): Promise<CloudSandboxStatus> {
+  return client.post<CloudSandboxStatus>("/v1/cloud/cloud-sandbox/ensure", {});
+}
+
+export async function wakeCloudSandbox(client: ApiClient): Promise<CloudSandboxStatus> {
+  return client.post<CloudSandboxStatus>("/v1/cloud/cloud-sandbox/wake", {});
+}
+
+/** Real exec/connectivity proof-of-life via the server's anyharness proxy -- no sandbox workspace required. */
+export async function probeAgentsThroughGateway(client: ApiClient): Promise<AgentSummary[]> {
+  return client.get<AgentSummary[]>("/v1/gateway/cloud-sandbox/anyharness/v1/agents");
+}
+
+export async function pollCloudSandboxStatus(
+  client: ApiClient,
+  predicate: (status: CloudSandboxStatus | null) => boolean,
+  options: { timeoutMs: number; pollMs?: number } = { timeoutMs: 60_000 },
+): Promise<CloudSandboxStatus | null> {
+  const pollMs = options.pollMs ?? 2000;
+  const deadline = Date.now() + options.timeoutMs;
+  let last = await getCloudSandbox(client);
+  while (!predicate(last) && Date.now() < deadline) {
+    await sleep(pollMs);
+    last = await getCloudSandbox(client);
+  }
+  return last;
+}
+
+/**
+ * Forces the durable user's personal cloud sandbox through a REAL, full
+ * materialization pass (E2B create/resume + AnyHarness launch), for
+ * identities whose sandbox has never been touched before (e.g. a
+ * freshly-provisioned staging durable user).
+ *
+ * `POST /cloud-sandbox/ensure` and `/wake`
+ * (server/proliferate/server/cloud/cloud_sandboxes/service.py) only ensure
+ * the DB row exists -- neither calls into `connect_ready_sandbox` (the
+ * function that actually talks to E2B and launches AnyHarness; see
+ * server/proliferate/server/cloud/materialization/sandbox_io/connect.py).
+ * The real trigger for a full connect is `run_cloud_sandbox_operation`
+ * (server/proliferate/server/cloud/materialization/operation.py), which a
+ * secret PUT schedules via `materialize_secret_set`
+ * (.../materialize/secret_set.py). PUTting a harmless personal env-var
+ * secret is therefore the real, product-sanctioned lever to force a cold
+ * sandbox to fully materialize -- not a bypass, the same trigger a real user
+ * setting their first secret would hit.
+ */
+export async function warmPersonalCloudSandbox(
+  client: ApiClient,
+  options: { timeoutMs: number } = { timeoutMs: 180_000 },
+): Promise<CloudSandboxStatus> {
+  const existing = await getCloudSandbox(client);
+  if (existing === null) {
+    await ensureCloudSandboxRow(client);
+  }
+  await client.put<{ materialization: { status: string } }>(
+    `/v1/cloud/secrets/personal/env-vars/T3_WARMUP_PING`,
+    { value: String(Date.now()) },
+  );
+  const ready = await pollCloudSandboxStatus(client, (status) => status?.status === "ready", {
+    timeoutMs: options.timeoutMs,
+  });
+  if (!ready || ready.status !== "ready") {
+    throw new Error(
+      `warmPersonalCloudSandbox: sandbox did not reach status=ready within ${options.timeoutMs}ms ` +
+        `(last observed: ${JSON.stringify(ready)}).`,
+    );
+  }
+  return ready;
+}
+
+/**
+ * True for the 402 `billing_credits_exhausted` the LIVE billing gate raises
+ * (`assert_cloud_sandbox_resume_allowed_for_owner`,
+ * server/proliferate/server/billing/authorization.py) when an owner's org
+ * has zero remaining included sandbox seconds. Verified for real 2026-07-09:
+ * staging's `e2e-tests` durable org currently has `remaining_seconds: 0`,
+ * which 402s `POST /cloud-sandbox/ensure` before a sandbox can even be
+ * created for the first time. This is a fixture/ops credits-provisioning gap
+ * (the org needs a grant), not a product bug and not a scenario bug -- treat
+ * it as a known, reportable gate the same way `withProductGate` treats
+ * `github_link_required`.
+ */
+export function isBillingCreditsExhaustedError(error: unknown): boolean {
+  if (!(error instanceof ApiRequestError) || error.status !== 402) {
+    return false;
+  }
+  if (typeof error.body !== "object" || error.body === null) {
+    return false;
+  }
+  const body = error.body as { code?: unknown; detail?: { code?: unknown } };
+  return body.code === "billing_credits_exhausted" || body.detail?.code === "billing_credits_exhausted";
+}
+
+/** Wraps a scenario body that touches the cloud-sandbox billing gate; see `isBillingCreditsExhaustedError`. */
+export async function withCloudSandboxBillingGate<T>(scenarioId: string, body: () => Promise<T>): Promise<T> {
+  try {
+    return await body();
+  } catch (error) {
+    if (isBillingCreditsExhaustedError(error)) {
+      throw new ScenarioBlockedError(
+        `${scenarioId}: the durable identity's organization has zero remaining included sandbox seconds ` +
+          "(billing_credits_exhausted, remaining_seconds=0) -- a fixture/ops credits-provisioning gap on the " +
+          "target deployment, not a product or scenario bug. Grant the e2e-tests org a cloud-sandbox credit " +
+          "top-up (or enroll it on a plan with included hours) to unblock every sandbox-lane T3 scenario.",
+      );
+    }
+    throw error;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/release/src/fixtures/e2b-verify.test.ts
+++ b/tests/release/src/fixtures/e2b-verify.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { e2bVerificationAvailable } from "./e2b-verify.js";
+
+test("e2bVerificationAvailable is false when RELEASE_E2E_E2B_API_KEY is unset or blank", () => {
+  assert.equal(e2bVerificationAvailable({}), false);
+  assert.equal(e2bVerificationAvailable({ RELEASE_E2E_E2B_API_KEY: "   " }), false);
+});
+
+test("e2bVerificationAvailable is true when RELEASE_E2E_E2B_API_KEY is set", () => {
+  assert.equal(e2bVerificationAvailable({ RELEASE_E2E_E2B_API_KEY: "e2b_test_key" }), true);
+});

--- a/tests/release/src/fixtures/e2b-verify.ts
+++ b/tests/release/src/fixtures/e2b-verify.ts
@@ -1,0 +1,153 @@
+/**
+ * Direct E2B verification/action backdoor for T3-PROV-2 and T3-SEC-MAT-1
+ * (specs/developing/testing/scenarios.md). Thin spawn wrapper around
+ * `../../scripts/e2b_sandbox_probe.py` -- mirrors the shape of
+ * `github-app-seed.ts` / t3-prov-1's `runFallbackScript`.
+ *
+ * Why this exists: the product API never exposes a cloud sandbox's provider
+ * (E2B) sandbox id (`CloudSandboxResponse` in
+ * server/proliferate/server/cloud/cloud_sandboxes/models.py serializes only
+ * the internal `cloud_sandbox.id`), and there is no product-level pause
+ * endpoint at all -- pause only ever arrives via E2B's own idle-timeout
+ * lifecycle or the billing reconciler
+ * (server/proliferate/server/cloud/webhooks/service.py). Pablo has
+ * authorized direct use of the E2B API key for verification of ground truth,
+ * and -- since no product lever exists -- for driving the pause action
+ * itself in T3-PROV-2.
+ *
+ * No DB access is needed: every personal cloud sandbox is tagged at create
+ * time with `metadata={"proliferate_cloud_sandbox_id": str(sandbox.id)}`
+ * (server/proliferate/server/cloud/materialization/sandbox_io/connect.py),
+ * the exact id the product API already returns from `GET
+ * /v1/cloud/cloud-sandbox`. `findProviderSandbox` resolves the provider
+ * sandbox purely via E2B's own list API filtered on that metadata key.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+export interface E2BFindResult {
+  providerSandboxId: string | null;
+  state: "running" | "paused" | null;
+}
+
+export interface E2BStateResult {
+  state: "running" | "paused";
+}
+
+export interface E2BExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface E2BReadResult {
+  content: string | null;
+  error: string | null;
+}
+
+/** True when RELEASE_E2E_E2B_API_KEY is present -- gates every function below. */
+export function e2bVerificationAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.RELEASE_E2E_E2B_API_KEY?.trim());
+}
+
+function requireApiKey(env: NodeJS.ProcessEnv): string {
+  const key = env.RELEASE_E2E_E2B_API_KEY?.trim();
+  if (!key) {
+    throw new Error(
+      "e2b-verify: RELEASE_E2E_E2B_API_KEY is not set. This is the E2B ground-truth/pause backdoor " +
+        "authorized for T3-PROV-2/T3-SEC-MAT-1 verification -- see src/config/env-manifest.ts.",
+    );
+  }
+  return key;
+}
+
+async function runProbe<T>(args: readonly string[], env: NodeJS.ProcessEnv, stdin?: string): Promise<T> {
+  const apiKey = requireApiKey(env);
+  const scriptPath = path.resolve(import.meta.dirname, "../../scripts/e2b_sandbox_probe.py");
+  const serverDir = path.resolve(import.meta.dirname, "../../../../server");
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("uv", ["run", "python", scriptPath, ...args], {
+      cwd: serverDir,
+      // Only E2B_API_KEY crosses into the child's env for this script -- it
+      // needs nothing else (no DATABASE_URL, no product server env at all).
+      env: { ...process.env, E2B_API_KEY: apiKey },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`e2b_sandbox_probe.py ${args[0]} exited ${code}: ${stderr || stdout}`));
+        return;
+      }
+      try {
+        const lastLine = stdout.trim().split("\n").pop() ?? "{}";
+        resolve(JSON.parse(lastLine) as T);
+      } catch (error) {
+        reject(new Error(`e2b_sandbox_probe.py ${args[0]} did not print valid JSON: ${stdout}\n${error}`));
+      }
+    });
+    if (stdin !== undefined) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}
+
+/** Resolves a cloud sandbox's provider (E2B) sandbox id purely via E2B metadata -- no DB access. */
+export async function findProviderSandbox(
+  cloudSandboxId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<E2BFindResult> {
+  return runProbe<E2BFindResult>(["find", cloudSandboxId], env);
+}
+
+export async function getProviderSandboxState(
+  providerSandboxId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<E2BStateResult> {
+  return runProbe<E2BStateResult>(["state", providerSandboxId], env);
+}
+
+/** Pauses the sandbox directly via the E2B SDK -- there is no product pause endpoint. */
+export async function pauseProviderSandbox(
+  providerSandboxId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ paused: boolean }> {
+  return runProbe<{ paused: boolean }>(["pause", providerSandboxId], env);
+}
+
+export async function execInProviderSandbox(
+  providerSandboxId: string,
+  command: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<E2BExecResult> {
+  return runProbe<E2BExecResult>(["exec", providerSandboxId, ...command], env);
+}
+
+/** Writes `content` to `path` inside the sandbox via `sandbox.files.write` (content passed over stdin, never argv). */
+export async function writeProviderSandboxFile(
+  providerSandboxId: string,
+  filePath: string,
+  content: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ written: boolean }> {
+  return runProbe<{ written: boolean }>(["write", providerSandboxId, filePath, "--content-stdin"], env, content);
+}
+
+export async function readProviderSandboxFile(
+  providerSandboxId: string,
+  filePath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<E2BReadResult> {
+  return runProbe<E2BReadResult>(["read", providerSandboxId, filePath], env);
+}

--- a/tests/release/src/fixtures/lane-identity.ts
+++ b/tests/release/src/fixtures/lane-identity.ts
@@ -1,0 +1,83 @@
+/**
+ * Target-lane-aware durable-user login. `identity.ts`'s `loginDurableUser`
+ * only knows password login (the local-lane durable identity); staging's
+ * durable user (`proliferate-e2e-bot`) is a real GitHub-OAuth-only account
+ * with no password (see `staging-session.ts`'s module docstring), so
+ * `--lane staging` scenarios must authenticate through
+ * `loginDurableUserOnStaging` instead. This module is the single seam that
+ * branches on `ctx.targetLane` so scenarios don't each reimplement the
+ * branch -- kept separate from `identity.ts`/`staging-session.ts` to avoid a
+ * circular import between the two (staging-session.ts already imports the
+ * `AuthSessionResponse` type from identity.ts).
+ */
+
+import type { AuthSessionResponse } from "./identity.js";
+import { loginDurableUser } from "./identity.js";
+import { loginDurableUserOnStaging, stagingSessionAvailable } from "./staging-session.js";
+import { ScenarioBlockedError } from "../scenarios/types.js";
+import type { TargetLane } from "../config/types.js";
+
+export interface LaneIdentityContext {
+  targetLane: TargetLane;
+}
+
+/**
+ * Reports a clean `ScenarioBlockedError` (not a raw thrown error, not a red
+ * failure) when the current `ctx.targetLane`'s durable-identity credential is
+ * absent. `requiredEnv` on `ScenarioDefinition` cannot express this itself --
+ * it is keyed by `RuntimeLane` (local/sandbox), not `TargetLane`
+ * (local/staging), so a var like `RELEASE_E2E_DURABLE_USER_PASSWORD` (only
+ * needed by `--lane local`) would otherwise either wrongly block `--lane
+ * staging` runs that never use it, or (if simply omitted from `requiredEnv`)
+ * surface as an unreported raw throw instead of a blocked run. Call this
+ * before `loginDurableUserForLane`.
+ */
+export function assertDurableIdentityAvailableForLane(scenarioId: string, ctx: LaneIdentityContext): void {
+  if (ctx.targetLane === "staging") {
+    if (!stagingSessionAvailable()) {
+      throw new ScenarioBlockedError(
+        `${scenarioId}: no staging durable-user session available -- neither ` +
+          "RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN nor the rotating state file " +
+          "(~/.proliferate-local/dev/release-e2e-staging-session.json) is present. Bootstrap one per " +
+          "src/fixtures/staging-session.ts's module docstring.",
+      );
+    }
+    return;
+  }
+  const missing = ["RELEASE_E2E_DURABLE_USER_EMAIL", "RELEASE_E2E_DURABLE_USER_PASSWORD"].filter(
+    (name) => !nonEmpty(process.env[name]),
+  );
+  if (missing.length > 0) {
+    throw new ScenarioBlockedError(
+      `${scenarioId}: --lane local durable-user credential(s) absent: ${missing.join(", ")}. Either set them ` +
+        "directly or run via `make release-e2e` / the CLI's own local-lane self-seed (cli/run.ts).",
+    );
+  }
+}
+
+/**
+ * Logs the durable user in against whichever lane `ctx.targetLane` names.
+ * Staging: rotates the seeded refresh token (no password, no env creds
+ * needed beyond RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN / the state file).
+ * Local: password login via RELEASE_E2E_DURABLE_USER_EMAIL/_PASSWORD.
+ * Call `assertDurableIdentityAvailableForLane` first so a missing credential
+ * reports blocked instead of throwing a raw error.
+ */
+export async function loginDurableUserForLane(
+  ctx: LaneIdentityContext,
+  serverUrl: string,
+): Promise<AuthSessionResponse> {
+  if (ctx.targetLane === "staging") {
+    return loginDurableUserOnStaging(serverUrl);
+  }
+  return loginDurableUser({
+    serverUrl,
+    email: process.env.RELEASE_E2E_DURABLE_USER_EMAIL as string,
+    password: process.env.RELEASE_E2E_DURABLE_USER_PASSWORD as string,
+    organizationId: process.env.RELEASE_E2E_DURABLE_ORG_ID ?? "",
+  });
+}
+
+function nonEmpty(value: string | undefined): boolean {
+  return Boolean(value && value.trim().length > 0);
+}

--- a/tests/release/src/fixtures/local-runtime.ts
+++ b/tests/release/src/fixtures/local-runtime.ts
@@ -2,7 +2,10 @@
  * Thin client for the local AnyHarness runtime's own HTTP API
  * (`anyharness/crates/anyharness-lib/src/api/router.rs`) — the same API a
  * cloud sandbox exposes, just reached directly on `127.0.0.1` instead of
- * through the Python server's `/v1/cloud/cloud-sandbox/anyharness/*` proxy.
+ * through the Python server's `/v1/gateway/cloud-sandbox/anyharness/*` proxy
+ * (server/proliferate/server/cloud/gateway/api.py; verified for real
+ * 2026-07-09 -- `/v1/cloud/cloud-sandbox/anyharness/*` 404s, see
+ * `../fixtures/cloud-sandbox.ts`).
  *
  * Local-lane scenarios use this instead of the Python server for anything
  * workspace/session/agent-shaped: per the survey behind this runner (see

--- a/tests/release/src/scenarios/t3-chat-1.ts
+++ b/tests/release/src/scenarios/t3-chat-1.ts
@@ -39,8 +39,10 @@ import { LocalRuntimeClient, findErrorEvent, findLastAssistantReply, findTurnEnd
  * `single_org_mode` is true — verified 2026-07-09: the durable user gets HTTP
  * 200 from `GET /v1/cloud/cloud-sandbox` despite productReady=false). What
  * remains is a test-implementation gap: driving a full agent chat session
- * inside a real E2B sandbox through the `/v1/cloud/cloud-sandbox/anyharness/*`
- * proxy is not yet written (and needs a running sandbox + a publicly reachable
+ * inside a real E2B sandbox through the `/v1/gateway/cloud-sandbox/anyharness/*`
+ * proxy (server/proliferate/server/cloud/gateway/api.py -- NOT
+ * `/v1/cloud/cloud-sandbox/anyharness/*`, see ../fixtures/cloud-sandbox.ts)
+ * is not yet written (and needs a running sandbox + a publicly reachable
  * server URL for callbacks). Tracked TODO, not a product gate.
  */
 export const t3Chat1: ScenarioDefinition = {
@@ -73,7 +75,7 @@ export const t3Chat1: ScenarioDefinition = {
       throw new ScenarioExpectedFailError(
         "T3-CHAT-1/sandbox: the current_product_user gate is lifted in single-org mode (verified " +
           "2026-07-09), but driving a full agent chat session inside a real E2B sandbox through the " +
-          "/v1/cloud/cloud-sandbox/anyharness/* proxy is not yet implemented — it needs a running " +
+          "/v1/gateway/cloud-sandbox/anyharness/* proxy is not yet implemented — it needs a running " +
           "durable sandbox and a publicly reachable RELEASE_E2E_SERVER_URL. Tracked test TODO (#1042).",
       );
     }

--- a/tests/release/src/scenarios/t3-prov-2.ts
+++ b/tests/release/src/scenarios/t3-prov-2.ts
@@ -1,58 +1,178 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 
-import type { ScenarioDefinition } from "./types.js";
+import type { ScenarioDefinition, ScenarioRunContext } from "./types.js";
 import { ScenarioExpectedFailError } from "./types.js";
 import { withProductGate } from "../fixtures/product-gate.js";
 import { ApiClient } from "../fixtures/http.js";
-import { loginDurableUser } from "../fixtures/identity.js";
+import { assertDurableIdentityAvailableForLane, loginDurableUserForLane } from "../fixtures/lane-identity.js";
+import {
+  getCloudSandbox,
+  pollCloudSandboxStatus,
+  probeAgentsThroughGateway,
+  wakeCloudSandbox,
+  warmPersonalCloudSandbox,
+  withCloudSandboxBillingGate,
+} from "../fixtures/cloud-sandbox.js";
+import {
+  e2bVerificationAvailable,
+  execInProviderSandbox,
+  findProviderSandbox,
+  getProviderSandboxState,
+  pauseProviderSandbox,
+  readProviderSandboxFile,
+  writeProviderSandboxFile,
+} from "../fixtures/e2b-verify.js";
 
 /**
  * T3-PROV-2 — access: existing user (warm path).
  * specs/developing/testing/scenarios.md#T3-PROV-2
  *
- * Unlike T3-PROV-1 (which has a contract-sanctioned fallback seam because
- * its trigger-under-test, the GitHub App callback, is itself infeasible to
- * drive for real), T3-PROV-2 is specifically about the normal, supported
- * pause/resume/connect path a real existing user takes — `POST
- * /cloud-sandbox/wake`, the pause endpoint, `GET /cloud-sandbox` — all
- * `current_product_user`-gated. There is no sanctioned shortcut here: this
- * scenario's whole point is the front door, so it stays `blocked` (not a
- * fallback) until the gate lifts.
+ * #1041: the `current_product_user` gate lifted 2026-07-09 (PR #1023); `GET
+ * /cloud-sandbox` and `POST /cloud-sandbox/wake` succeed for real. What was
+ * left unimplemented was the pause + reconnect-state-intact half, because
+ * the product has NO pause endpoint at all -- a sandbox only pauses via
+ * E2B's own idle-timeout lifecycle or the billing reconciler
+ * (server/proliferate/server/cloud/webhooks/service.py) -- so there is no
+ * product-level lever to drive it from a test. Per Pablo's ruling this
+ * scenario drives pause directly via the E2B SDK (the sanctioned backdoor;
+ * see `../fixtures/e2b-verify.ts`'s module docstring for the full rationale
+ * and the metadata trick that avoids any DB access), while everything else
+ * (login, wake, reconnect, and the "prior state intact" proof) goes through
+ * the real product surfaces: `GET/POST /v1/cloud/cloud-sandbox*` and the
+ * real anyharness gateway proxy (`GET .../anyharness/v1/agents`, the same
+ * workspace-free exec/connectivity proof T3-PROV-1 already established).
+ *
+ * Also newly wired here: staging-lane identity. The original version of this
+ * scenario only knew password login (`loginDurableUser`), which cannot
+ * authenticate staging's durable user (a real GitHub-OAuth-only account with
+ * no password -- see `../fixtures/staging-session.ts`). `loginDurableUserForLane`
+ * (`../fixtures/lane-identity.ts`) branches on `ctx.targetLane` so this now
+ * actually runs against `--lane staging`, not just `--lane local`.
  */
 export const t3Prov2: ScenarioDefinition = {
   id: "T3-PROV-2",
   title: "access — existing user (warm path)",
   registryFlowRef: "specs/developing/testing/scenarios.md#T3-PROV-2",
   lanes: ["sandbox"],
-  requiredEnv: ["RELEASE_E2E_SERVER_URL", "RELEASE_E2E_DURABLE_USER_EMAIL", "RELEASE_E2E_DURABLE_USER_PASSWORD"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
   plan: () => [
-    { description: "log in as the durable user via T3-FIXTURE" },
-    { description: "GET /cloud-sandbox — reopen the durable user's existing sandbox" },
-    { description: "pause the workspace, assert status becomes paused and inaccessible" },
-    { description: "POST /cloud-sandbox/wake, assert status becomes running within budget" },
-    { description: "connect again and assert prior workspace state is intact" },
+    { description: "log in as the durable user (lane-aware: password locally, rotating staging session on staging)" },
+    { description: "GET /cloud-sandbox; if the sandbox has never materialized, force it via a real secret PUT" },
+    { description: "connect via the real anyharness gateway proxy (GET .../v1/agents) — pre-pause proof-of-life" },
+    { description: "[E2B-direct, no product pause endpoint exists] write a filesystem marker, then pause the sandbox" },
+    { description: "assert E2B ground truth shows paused; poll GET /cloud-sandbox for the webhook-driven status flip" },
+    { description: "POST /cloud-sandbox/wake, then reconnect via the anyharness proxy — real resume proof" },
+    { description: "assert E2B ground truth shows running again, and the filesystem marker survived the cycle" },
   ],
   run: async (ctx) => {
     if (ctx.dryRun) {
       return;
     }
-    await withProductGate("T3-PROV-2", () => runReal(ctx.env.require("RELEASE_E2E_SERVER_URL")));
+    await withProductGate("T3-PROV-2", () => withCloudSandboxBillingGate("T3-PROV-2", () => runReal(ctx)));
   },
 };
 
-async function runReal(serverUrl: string): Promise<void> {
-  const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL as string;
-  const durablePassword = process.env.RELEASE_E2E_DURABLE_USER_PASSWORD as string;
-  const session = await loginDurableUser({ serverUrl, email: durableEmail, password: durablePassword, organizationId: "" });
+async function runReal(ctx: ScenarioRunContext): Promise<void> {
+  assertDurableIdentityAvailableForLane("T3-PROV-2", ctx);
+  const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
+  const session = await loginDurableUserForLane(ctx, serverUrl);
   const client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(session.accessToken);
 
-  const existing = await client.get<{ status: string } | null>("/v1/cloud/cloud-sandbox");
-  assert.ok(existing, "T3-PROV-2: durable user must already have a personal cloud sandbox (the warm fixture)");
-  const woken = await client.post<{ status: string }>("/v1/cloud/cloud-sandbox/wake", {});
-  assert.equal(woken.status, "ready", "T3-PROV-2: waking the durable sandbox must return status=ready");
-  throw new ScenarioExpectedFailError(
-    "T3-PROV-2: GET /cloud-sandbox + POST /cloud-sandbox/wake verified against the live server on fresh " +
-      "main (single-org current_product_user bypass; wake returned status=ready). The remaining pause + " +
-      "reconnect-state-intact assertions are not yet implemented — tracked test TODO (#1041).",
+  const existing = await getCloudSandbox(client);
+  const sandbox =
+    existing?.status === "ready" ? existing : await warmPersonalCloudSandbox(client, { timeoutMs: 180_000 });
+  assert.equal(sandbox.status, "ready", "T3-PROV-2: the durable user's personal cloud sandbox must be ready");
+
+  const preAgents = await probeAgentsThroughGateway(client);
+  assert.ok(Array.isArray(preAgents) && preAgents.length > 0, "T3-PROV-2: pre-pause agents probe must be non-empty");
+  console.log(`[T3-PROV-2] pre-pause proof-of-life: ${preAgents.length} agents reported`);
+
+  if (!e2bVerificationAvailable()) {
+    throw new ScenarioExpectedFailError(
+      "T3-PROV-2: sandbox reached status=ready and the real anyharness gateway proxy answered " +
+        `(${preAgents.length} agents) — both verified for real. Pause/resume/state-intact could not be ` +
+        "verified: there is no product pause endpoint at all (pause only ever arrives via E2B's own idle " +
+        "timeout or the billing reconciler), so it can only be driven and ground-truth-verified via the E2B " +
+        "SDK directly, and RELEASE_E2E_E2B_API_KEY is absent in this run. Already wired for CI " +
+        "(release-e2e.yml maps the repo secret E2B_API_KEY to it for the staging job) — this is a local " +
+        "credential gap, not a product or scenario bug.",
+    );
+  }
+
+  const found = await findProviderSandbox(sandbox.id);
+  assert.ok(found.providerSandboxId, "T3-PROV-2: must resolve the provider sandbox via E2B metadata (no DB access)");
+  assert.equal(found.state, "running", "T3-PROV-2: E2B ground truth must show running before we pause it");
+  const providerSandboxId = found.providerSandboxId as string;
+
+  const markerPath = "/home/user/t3-prov-2-marker.txt";
+  const markerValue = `t3-prov-2-${randomUUID()}`;
+  await writeProviderSandboxFile(providerSandboxId, markerPath, markerValue);
+  const preRead = await readProviderSandboxFile(providerSandboxId, markerPath);
+  assert.equal(preRead.content?.trim(), markerValue, "T3-PROV-2: marker must be readable before pausing");
+
+  const pauseResult = await pauseProviderSandbox(providerSandboxId);
+  assert.equal(pauseResult.paused, true, "T3-PROV-2: E2B pause call must report success");
+  const pausedState = await getProviderSandboxState(providerSandboxId);
+  assert.equal(pausedState.state, "paused", "T3-PROV-2: E2B ground truth must show paused");
+
+  const productObservedPause = await pollCloudSandboxStatus(client, (status) => status?.status === "paused", {
+    timeoutMs: 60_000,
+    pollMs: 3000,
+  });
+  if (productObservedPause?.status !== "paused") {
+    console.warn(
+      "[T3-PROV-2] product's cached cloud_sandbox.status did not flip to 'paused' within 60s of a direct E2B " +
+        "pause (webhook delivery latency, or the e2b-signature secret/webhook route not reaching this target " +
+        "— not re-diagnosed here). The E2B ground-truth pause above is this scenario's authoritative assertion.",
+    );
+  }
+
+  // Named product lever (thin: only ensures the DB row today, per
+  // cloud_sandboxes/service.py — see warmPersonalCloudSandbox's docstring),
+  // called for contract fidelity with scenarios.md's plan.
+  await wakeCloudSandbox(client);
+
+  const reconnectStartedAt = Date.now();
+  const postAgents = await probeAgentsThroughGatewayWithRetries(client, { attempts: 5, delayMs: 5000 });
+  const reconnectElapsedMs = Date.now() - reconnectStartedAt;
+  assert.ok(
+    Array.isArray(postAgents) && postAgents.length > 0,
+    "T3-PROV-2: reconnecting via the real anyharness gateway proxy after pause must succeed",
   );
+  console.log(`[T3-PROV-2] reconnect after pause succeeded in ${reconnectElapsedMs}ms (${postAgents.length} agents)`);
+
+  const resumedState = await getProviderSandboxState(providerSandboxId);
+  assert.equal(resumedState.state, "running", "T3-PROV-2: E2B ground truth must show running again after reconnect");
+
+  const postRead = await readProviderSandboxFile(providerSandboxId, markerPath);
+  assert.equal(
+    postRead.content?.trim(),
+    markerValue,
+    "T3-PROV-2: filesystem state must be intact after the pause/resume cycle",
+  );
+
+  await execInProviderSandbox(providerSandboxId, ["rm", "-f", markerPath]).catch(() => undefined);
+}
+
+async function probeAgentsThroughGatewayWithRetries(
+  client: ApiClient,
+  options: { attempts: number; delayMs: number },
+): Promise<unknown[]> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+    try {
+      return await probeAgentsThroughGateway(client);
+    } catch (error) {
+      lastError = error;
+      if (attempt < options.attempts) {
+        await sleep(options.delayMs);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/release/src/scenarios/t3-sec-mat-1.ts
+++ b/tests/release/src/scenarios/t3-sec-mat-1.ts
@@ -1,81 +1,358 @@
 import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
 
-import type { ScenarioDefinition } from "./types.js";
+import type { ScenarioDefinition, ScenarioRunContext } from "./types.js";
 import { ScenarioExpectedFailError } from "./types.js";
 import { withProductGate } from "../fixtures/product-gate.js";
 import { ApiClient } from "../fixtures/http.js";
-import { loginDurableUser } from "../fixtures/identity.js";
+import { assertDurableIdentityAvailableForLane, loginDurableUserForLane } from "../fixtures/lane-identity.js";
+import { ensureCloudSandboxRow, getCloudSandbox, withCloudSandboxBillingGate } from "../fixtures/cloud-sandbox.js";
+import { e2bVerificationAvailable, findProviderSandbox, readProviderSandboxFile } from "../fixtures/e2b-verify.js";
+import { DEFAULT_GITHUB_TEST_REPO } from "../config/env-manifest.js";
+import {
+  githubAppSeedAvailable,
+  isGithubAppAuthorizationRequiredError,
+  isGithubAppInstallationRequiredError,
+  isGithubAppRefreshFailedError,
+  isGithubAppRepoNotCoveredError,
+  isGithubRepoAccessRequiredError,
+  runGithubAppSeed,
+  type SeedResult,
+} from "../fixtures/github-app-seed.js";
 
 /**
  * T3-SEC-MAT-1 — secrets materialize.
  * specs/developing/testing/scenarios.md#T3-SEC-MAT-1
  *
- * Not in the phase-1 skeleton (out of scope then; in this runner's explicit
- * scope). All secret PUT/GET routes and cloud workspace creation are
- * `current_product_user`-gated (`server/proliferate/server/cloud/secrets/api.py`,
- * `server/proliferate/server/cloud/workspaces/api.py`) — real code below,
- * reported `blocked` via `withProductGate` until
- * `fix/product-user-single-org-bypass` merges, since materialization
- * fundamentally needs a real cloud sandbox (no local-lane variant exists in
- * the contract for this scenario).
+ * #1042: the `current_product_user` gate lifted 2026-07-09 (PR #1023); the
+ * personal secret PUT already succeeded for real. This finishes the rest:
+ * the org secret, the update-propagation cycle, and — the actual point of
+ * the scenario — the in-sandbox file assertions (`{PROLIFERATE_HOME}/secrets/
+ * global.env`, its manifest, and the sha256s) rather than only trusting the
+ * materialization-status field the API reports.
+ *
+ * Filesystem paths below mirror
+ * server/proliferate/server/cloud/materialization/paths.py exactly (kept as
+ * literals here rather than re-deriving them, since this is deliberately
+ * asserting the CONTRACT the server promises, the same way a real desktop
+ * client or support engineer reading a sandbox would).
+ *
+ * In-sandbox verification uses the same E2B-direct backdoor as T3-PROV-2
+ * (`../fixtures/e2b-verify.ts`) — there is no product route that lets a
+ * client read an arbitrary file out of its own sandbox, and the ground truth
+ * for "did the write actually happen" is the sandbox filesystem, not the
+ * materialization-status field alone (that field only proves the *server*
+ * believes the write succeeded).
+ *
+ * The workspace-file-secret + fresh-cloud-workspace half additionally needs
+ * a GitHub App user authorization for the durable identity, which is the
+ * SAME pre-existing, already-tracked environmental gap T3-REPO-1 hits (see
+ * `t3-repo-1.ts` and issue #1043) — real on `--lane local` when the seed
+ * (`RELEASE_E2E_LOCAL_DATABASE_URL` + a seed token) is available, and an
+ * honestly-diagnosed `ScenarioExpectedFailError` otherwise (always on
+ * `--lane staging`: the seed writes directly to a local Postgres, which has
+ * no bearing on a staging session, so it is never attempted there).
  */
 export const t3SecMat1: ScenarioDefinition = {
   id: "T3-SEC-MAT-1",
   title: "secrets materialize",
   registryFlowRef: "specs/developing/testing/scenarios.md#T3-SEC-MAT-1",
   lanes: ["sandbox"],
-  requiredEnv: ["RELEASE_E2E_SERVER_URL", "RELEASE_E2E_DURABLE_USER_EMAIL", "RELEASE_E2E_DURABLE_USER_PASSWORD"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
   plan: () => [
-    { description: "set a personal env-var secret, an org env-var secret, and a workspace file secret" },
-    { description: "create a fresh cloud workspace" },
+    { description: "log in as the durable user (lane-aware); resolve their default organization" },
+    { description: "PUT a personal env-var secret and an org env-var secret" },
     { description: "poll materialization.status until ready (budget: <=60s on an already-running sandbox)" },
     {
       description:
-        "assert in-sandbox: {PROLIFERATE_HOME}/secrets/global.env has both merged vars; " +
-        "{repo}/.proliferate/env/workspace.env present; manifest sha256s match",
+        "[E2B-direct ground truth] assert {PROLIFERATE_HOME}/secrets/global.env contains both merged vars, " +
+        "and the manifest's per-var sha256 matches the value we set",
     },
     { description: "PUT a new value; assert status returns to pending then ready; assert sandbox file updated" },
+    {
+      description:
+        "workspace file secret + fresh cloud workspace (needs a seeded GitHub App authorization — real on " +
+        "--lane local with the seed available, expected-fail with #1043's diagnosis otherwise)",
+    },
   ],
   run: async (ctx) => {
     if (ctx.dryRun) {
       return;
     }
-    await withProductGate("T3-SEC-MAT-1", () => runReal(ctx.env.require("RELEASE_E2E_SERVER_URL")));
+    await withProductGate("T3-SEC-MAT-1", () => withCloudSandboxBillingGate("T3-SEC-MAT-1", () => runReal(ctx)));
   },
 };
 
-async function runReal(serverUrl: string): Promise<void> {
-  const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL as string;
-  const durablePassword = process.env.RELEASE_E2E_DURABLE_USER_PASSWORD as string;
-  const organizationId = process.env.RELEASE_E2E_DURABLE_ORG_ID ?? "";
+const PROLIFERATE_HOME = "/home/user/.proliferate";
+const GLOBAL_ENV_PATH = `${PROLIFERATE_HOME}/secrets/global.env`;
+const GLOBAL_MANIFEST_PATH = `${PROLIFERATE_HOME}/secrets/global.manifest.json`;
 
-  const session = await loginDurableUser({
-    serverUrl,
-    email: durableEmail,
-    password: durablePassword,
-    organizationId,
-  });
+interface SecretManifest {
+  env: Record<string, string>;
+  files: Record<string, string>;
+  versions: Record<string, number>;
+}
+
+interface CloudSecretsResponse {
+  version: number;
+  materialization: { status: "pending" | "running" | "ready" | "error"; lastError: string | null } | null;
+}
+
+async function runReal(ctx: ScenarioRunContext): Promise<void> {
+  assertDurableIdentityAvailableForLane("T3-SEC-MAT-1", ctx);
+  const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
+  const session = await loginDurableUserForLane(ctx, serverUrl);
   const client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(session.accessToken);
 
-  const secretName = `T3_SEC_MAT_1_${Date.now()}`;
-  const personal = await client.put<{ materialization: { status: string } }>(
-    `/v1/cloud/secrets/personal/env-vars/${secretName}`,
-    { value: "release-e2e-personal" },
-  );
+  const organizations = await client.get<{ organizations: Array<{ id: string }> }>("/v1/organizations");
+  const organizationId = organizations.organizations[0]?.id;
+  assert.ok(organizationId, "T3-SEC-MAT-1: the durable user must belong to at least one organization");
+
+  // Exercise the cloud-sandbox billing gate up front, the same way T3-PROV-2
+  // does, so an exhausted-credits org reports a clean, immediate
+  // `ScenarioBlockedError` (via `withCloudSandboxBillingGate` in the caller)
+  // instead of a secret PUT succeeding as "pending" and then a materialize
+  // poll timing out with a generic assertion failure below -- the secret PUT
+  // endpoint itself does not hit this gate; only sandbox
+  // ensure/wake/materialize do (server/proliferate/server/billing/
+  // authorization.py), so this must be checked independently first.
+  const existingSandbox = await getCloudSandbox(client);
+  if (existingSandbox === null) {
+    await ensureCloudSandboxRow(client);
+  }
+
+  const suffix = randomUUID().slice(0, 8);
+  const personalName = `T3_SEC_MAT_1_PERSONAL_${suffix}`;
+  const orgName = `T3_SEC_MAT_1_ORG_${suffix}`;
+  const personalValue = `personal-${suffix}`;
+  const orgValue = `org-${suffix}`;
+
+  const personalPut = await client.put<CloudSecretsResponse>(`/v1/cloud/secrets/personal/env-vars/${personalName}`, {
+    value: personalValue,
+  });
   assert.ok(
-    ["pending", "running", "ready"].includes(personal.materialization.status),
+    personalPut.materialization && ["pending", "running", "ready"].includes(personalPut.materialization.status),
     "T3-SEC-MAT-1: PUT personal secret must return a materialization status",
   );
-  // Reaching this line for real (not blocked) means the gate has lifted;
-  // the fuller flow (org secret, workspace file secret, fresh cloud
-  // workspace, in-sandbox file assertions) is intentionally not implemented
-  // beyond this first real call — write it once this scenario is actually
-  // reachable, verifying each step against the live response shape rather
-  // than guessing ahead of the gate.
-  throw new ScenarioExpectedFailError(
-    "T3-SEC-MAT-1: personal secret PUT verified against the live server on fresh main (single-org " +
-      "current_product_user bypass; returned a materialization status). The rest (org secret, workspace " +
-      "file secret, fresh cloud workspace + in-sandbox file assertions) is not yet implemented — tracked " +
-      "test TODO (#1041).",
+
+  const orgPut = await client.put<CloudSecretsResponse>(
+    `/v1/cloud/organizations/${organizationId}/secrets/env-vars/${orgName}`,
+    { value: orgValue },
   );
+  assert.ok(
+    orgPut.materialization && ["pending", "running", "ready"].includes(orgPut.materialization.status),
+    "T3-SEC-MAT-1: PUT org secret must return a materialization status",
+  );
+
+  const readyPersonal = await pollSecretsReady(client, "/v1/cloud/secrets/personal", { timeoutMs: 60_000 });
+  assert.equal(readyPersonal?.materialization?.status, "ready", "T3-SEC-MAT-1: personal secrets must reach ready");
+
+  const sandbox = await getCloudSandbox(client);
+  assert.ok(sandbox, "T3-SEC-MAT-1: the durable user must have a personal cloud sandbox after materialization");
+
+  if (!e2bVerificationAvailable()) {
+    await runWorkspaceFileSecretHalf(ctx, client, organizationId as string);
+    throw new ScenarioExpectedFailError(
+      "T3-SEC-MAT-1: personal + org secret PUT verified for real, and materialization.status reached " +
+        "'ready' (the server's own signal that it wrote the sandbox files). The in-sandbox byte-level " +
+        "assertions (global.env content, manifest sha256s) could not be verified: they require the " +
+        "E2B-direct ground-truth backdoor, and RELEASE_E2E_E2B_API_KEY is absent in this run. Already wired " +
+        "for CI (release-e2e.yml maps the repo secret E2B_API_KEY to it for the staging job) — a local " +
+        "credential gap, not a product or scenario bug.",
+    );
+  }
+
+  const found = await findProviderSandbox((sandbox as { id: string }).id);
+  assert.ok(found.providerSandboxId, "T3-SEC-MAT-1: must resolve the provider sandbox via E2B metadata");
+  const providerSandboxId = found.providerSandboxId as string;
+
+  await assertGlobalEnvContains(providerSandboxId, [
+    { name: personalName, value: personalValue },
+    { name: orgName, value: orgValue },
+  ]);
+
+  // Update propagation: PUT a new value, assert the status cycle, assert the file updates.
+  const updatedPersonalValue = `personal-updated-${suffix}`;
+  const updatedPut = await client.put<CloudSecretsResponse>(`/v1/cloud/secrets/personal/env-vars/${personalName}`, {
+    value: updatedPersonalValue,
+  });
+  assert.equal(
+    updatedPut.materialization?.status,
+    "pending",
+    "T3-SEC-MAT-1: re-PUTting a value must report pending before the sandbox catches up",
+  );
+  const readyAgain = await pollSecretsReady(client, "/v1/cloud/secrets/personal", { timeoutMs: 60_000 });
+  assert.equal(readyAgain?.materialization?.status, "ready", "T3-SEC-MAT-1: personal secrets must return to ready");
+  await assertGlobalEnvContains(providerSandboxId, [{ name: personalName, value: updatedPersonalValue }]);
+
+  await runWorkspaceFileSecretHalf(ctx, client, organizationId as string);
+}
+
+async function assertGlobalEnvContains(
+  providerSandboxId: string,
+  entries: Array<{ name: string; value: string }>,
+): Promise<void> {
+  const envRead = await readProviderSandboxFile(providerSandboxId, GLOBAL_ENV_PATH);
+  assert.ok(envRead.content, `T3-SEC-MAT-1: ${GLOBAL_ENV_PATH} must exist and be readable (error: ${envRead.error})`);
+  const content = envRead.content as string;
+
+  const manifestRead = await readProviderSandboxFile(providerSandboxId, GLOBAL_MANIFEST_PATH);
+  assert.ok(
+    manifestRead.content,
+    `T3-SEC-MAT-1: ${GLOBAL_MANIFEST_PATH} must exist and be readable (error: ${manifestRead.error})`,
+  );
+  const manifest = JSON.parse(manifestRead.content as string) as SecretManifest;
+
+  for (const entry of entries) {
+    assert.ok(content.includes(entry.name), `T3-SEC-MAT-1: global.env must contain ${entry.name}`);
+    assert.ok(
+      content.includes(entry.value),
+      `T3-SEC-MAT-1: global.env must contain ${entry.name}'s current value`,
+    );
+    const expectedSha256 = createHash("sha256").update(entry.value, "utf8").digest("hex");
+    assert.equal(
+      manifest.env[entry.name],
+      expectedSha256,
+      `T3-SEC-MAT-1: manifest sha256 for ${entry.name} must match sha256(value)`,
+    );
+  }
+}
+
+async function pollSecretsReady(
+  client: ApiClient,
+  path: string,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<CloudSecretsResponse | undefined> {
+  const pollMs = options.pollMs ?? 2000;
+  const deadline = Date.now() + options.timeoutMs;
+  let last = await client.get<CloudSecretsResponse>(path);
+  while (last.materialization?.status !== "ready" && Date.now() < deadline) {
+    await sleep(pollMs);
+    last = await client.get<CloudSecretsResponse>(path);
+  }
+  return last;
+}
+
+/**
+ * Workspace file secret + fresh cloud workspace. Needs a seeded GitHub App
+ * user authorization for the durable identity (see module docstring). Never
+ * attempted on `--lane staging` — the seed writes to a local Postgres.
+ */
+async function runWorkspaceFileSecretHalf(
+  ctx: ScenarioRunContext,
+  client: ApiClient,
+  organizationId: string,
+): Promise<void> {
+  void organizationId;
+  const [owner, repo] = (process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO).split("/");
+  const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL;
+
+  if (ctx.targetLane !== "local" || !githubAppSeedAvailable(process.env) || !durableEmail) {
+    throw new ScenarioExpectedFailError(
+      "T3-SEC-MAT-1: workspace file secret + fresh cloud workspace needs a seeded GitHub App user " +
+        "authorization for the durable identity (server/proliferate/server/cloud/repositories -- the same " +
+        "authority chain T3-REPO-1 depends on). The seed (tests/release/scripts/github_app_seed.py) writes " +
+        "directly to a local Postgres via RELEASE_E2E_LOCAL_DATABASE_URL, so it is only ever meaningful on " +
+        "--lane local, and even there needs RELEASE_E2E_DURABLE_USER_EMAIL + a seed refresh token/state " +
+        "file. Same pre-existing environmental gap tracked at #1043 -- not a new bug.",
+    );
+  }
+
+  let seed: SeedResult;
+  try {
+    seed = await runGithubAppSeed<SeedResult>(durableEmail, { command: "seed" });
+  } catch (error) {
+    // The seed script re-imports the local server's Settings, which requires
+    // the running profile's full ambient env (JWT_SECRET, DEBUG, etc. -- see
+    // specs/developing/local/feature-worktree-auth.md), not just
+    // RELEASE_E2E_LOCAL_DATABASE_URL. `githubAppSeedAvailable` only checks
+    // for a seed credential, not a fully-sourced profile shell, so a
+    // same-class environmental failure surfaces here rather than in that
+    // check -- downgrade it the same way, rather than a hard scenario red.
+    throw new ScenarioExpectedFailError(
+      `T3-SEC-MAT-1: the GitHub App seed script failed to run in this shell (likely missing the local ` +
+        `profile's ambient env beyond RELEASE_E2E_LOCAL_DATABASE_URL -- run from a shell with the t3local ` +
+        `profile's launch.env sourced): ${error instanceof Error ? error.message.split("\n")[0] : String(error)}. ` +
+        "Same pre-existing environmental gap tracked at #1043 -- not a new bug.",
+    );
+  }
+  assert.equal(seed.seeded?.status, "ready", "T3-SEC-MAT-1: durable user's GitHub App authorization must be seeded");
+
+  let environment: { defaultBranch: string };
+  try {
+    environment = await client.put<{ defaultBranch: string }>(`/v1/cloud/repositories/${owner}/${repo}/environment`, {
+      kind: "cloud",
+      gitProvider: "github",
+      defaultBranch: "develop",
+      setupScript: "",
+      runCommand: "",
+    });
+  } catch (error) {
+    if (
+      isGithubAppAuthorizationRequiredError(error) ||
+      isGithubAppInstallationRequiredError(error) ||
+      isGithubAppRepoNotCoveredError(error) ||
+      isGithubAppRefreshFailedError(error) ||
+      isGithubRepoAccessRequiredError(error)
+    ) {
+      throw new ScenarioExpectedFailError(
+        `T3-SEC-MAT-1: repo-environment PUT for ${owner}/${repo} hit the same environmental GitHub App gap ` +
+          `T3-REPO-1 tracks (#1043): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    throw error;
+  }
+  assert.equal(environment.defaultBranch, "develop", "T3-SEC-MAT-1: repo environment default branch must round-trip");
+
+  const secretPath = ".proliferate-secret/t3-sec-mat-1.txt";
+  const secretContent = `t3-sec-mat-1-workspace-secret-${randomUUID().slice(0, 8)}`;
+  await client.put(`/v1/cloud/repos/${owner}/${repo}/secrets/files`, { path: secretPath, content: secretContent });
+
+  const branchName = `t3-sec-mat-1-${randomUUID().slice(0, 8)}`;
+  const workspace = await client.post<{ id: string; status: string }>("/v1/cloud/workspaces", {
+    gitProvider: "github",
+    gitOwner: owner,
+    gitRepoName: repo,
+    baseBranch: "develop",
+    branchName,
+    source: "web",
+  });
+
+  try {
+    const ready = await pollWorkspaceReady(client, workspace.id, { timeoutMs: 180_000 });
+    assert.equal(ready?.status, "ready", "T3-SEC-MAT-1: fresh cloud workspace must reach status=ready");
+
+    const sandbox = await getCloudSandbox(client);
+    assert.ok(sandbox, "T3-SEC-MAT-1: the workspace's personal cloud sandbox must exist");
+    const found = await findProviderSandbox((sandbox as { id: string }).id);
+    assert.ok(found.providerSandboxId, "T3-SEC-MAT-1: must resolve the provider sandbox via E2B metadata");
+
+    const workspaceEnvPath = `/home/user/workspace/repos/${owner}/${repo}/.proliferate/env/workspace.env`;
+    const workspaceEnvRead = await readProviderSandboxFile(found.providerSandboxId as string, workspaceEnvPath);
+    assert.ok(
+      workspaceEnvRead.content,
+      `T3-SEC-MAT-1: ${workspaceEnvPath} must exist and be readable (error: ${workspaceEnvRead.error})`,
+    );
+  } finally {
+    await client.delete(`/v1/cloud/workspaces/${workspace.id}`).catch(() => undefined);
+  }
+}
+
+async function pollWorkspaceReady(
+  client: ApiClient,
+  workspaceId: string,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<{ id: string; status: string } | undefined> {
+  const pollMs = options.pollMs ?? 3000;
+  const deadline = Date.now() + options.timeoutMs;
+  let last = await client.get<{ id: string; status: string }>(`/v1/cloud/workspaces/${workspaceId}`);
+  while (last.status !== "ready" && last.status !== "error" && Date.now() < deadline) {
+    await sleep(pollMs);
+    last = await client.get<{ id: string; status: string }>(`/v1/cloud/workspaces/${workspaceId}`);
+  }
+  return last;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary

Finishes the sandbox-lane assertions left as test TODOs in #1041 and #1042.

- **T3-PROV-2** (pause/resume/state-intact): there is no product pause endpoint at all — pause only ever arrives via E2B's own idle timeout or the billing reconciler. This drives pause directly via the E2B SDK (resolving the provider sandbox purely from E2B's own metadata list, no DB access needed), while everything else — login, sandbox warm-up, reconnect, and the "state survived" proof — goes through the real server API and the real anyharness gateway proxy.
- **T3-SEC-MAT-1** (secrets materialize): now verifies personal + org secret materialization *in the sandbox* (global.env content, manifest sha256s) instead of trusting the API's `materialization.status` field alone, plus the update-propagation cycle (PUT new value → pending → ready → file updated). The workspace-file-secret + fresh-cloud-workspace half needs a seeded GitHub App user authorization for the durable identity — the same pre-existing gap T3-REPO-1 already tracks under #1043 — so it runs for real on `--lane local` when that seed is available and reports a diagnosed expected-fail otherwise (never attempted on `--lane staging`, since that seed writes to a local Postgres).
- Wires the staging lane's durable-user identity (`loginDurableUserOnStaging`, built earlier but never actually called by any scenario) into both scenarios via a new `lane-identity.ts` seam.
- Fixes a wrong anyharness-gateway-proxy path assumed in several existing doc comments: the real route is `/v1/gateway/cloud-sandbox/anyharness/*` (mounted at `{api_prefix}/v1/gateway` in `main.py`), not `/v1/cloud/cloud-sandbox/anyharness/*` — verified for real against a running profile (the wrong path 404s).
- Classifies the staging `e2e-tests` org's exhausted cloud-sandbox credits (`billing_credits_exhausted`, `remaining_seconds: 0` — a live, verified finding) as a blocked run rather than a red one, the same convention as the existing `github_link_required` gate.

## Verified live

- `T3-PROV-2` ran fully green against `--lane local` on a real E2B sandbox: front-door reconnect via the gateway proxy, direct-E2B pause, ground-truth state verification, reconnect, and a filesystem marker proven intact across the whole cycle.
- `T3-SEC-MAT-1` ran green through personal + org secret PUT, materialization polling, E2B-direct in-sandbox verification (content + sha256), and the update-propagation cycle; only the GitHub-App-gated workspace-file-secret half is expected-fail (pre-existing #1043 gap).
- Against `--lane staging`, both scenarios now correctly report **blocked** (not red) on the org's exhausted credits — confirmed the exit code stays 0.

## Test plan

- [x] `pnpm exec tsc --noEmit` in `tests/release/` — clean
- [x] `pnpm test` in `tests/release/` — 41/41 passing (added unit tests for `e2b-verify.ts` and `cloud-sandbox.ts`'s pure classifiers)
- [x] `pnpm exec tsx src/cli/run.ts --lane local --only T3-PROV-2,T3-SEC-MAT-1` — real, live, green/expected-fail as described above
- [x] `pnpm exec tsx src/cli/run.ts --lane staging --only T3-PROV-2,T3-SEC-MAT-1` — blocked cleanly, exit 0
- [x] `python3 scripts/check_max_lines.py` — passes