### PR TITLE
fix(desktop): stop presenting sessions as iterating once the final answer has rendered

### DIFF
--- a/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
+++ b/apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts
@@ -86,6 +86,7 @@ function buildWorkspaceSidebarActivitySignature(
       entry.hasAttemptedPrompt ? "prompted" : "",
       entry.streamConnectionState,
       entry.activity.isStreaming ? "streaming" : "idle",
+      entry.activity.endsInFinalAssistantProse ? "final-prose" : "",
       pendingInteractionSignature(entry.activity.pendingInteractions),
       includeErrorAttention ? entry.activity.errorAttentionKey ?? "" : "",
     ].join("\u001f");

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-activity.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-activity.ts
@@ -4,6 +4,7 @@ import type {
   TranscriptState,
 } from "@anyharness/sdk";
 import { resolveSessionErrorAttentionKey } from "@proliferate/product-domain/sessions/activity";
+import { transcriptEndsInFinalAssistantProse } from "@proliferate/product-domain/chats/transcript/transcript-trailing-status";
 import type {
   SessionDirectoryActivitySummary,
   SessionDirectoryEntry,
@@ -19,6 +20,7 @@ export function activityFromTranscript(
   return {
     isStreaming: transcript.isStreaming,
     pendingInteractions: transcript.pendingInteractions,
+    endsInFinalAssistantProse: transcriptEndsInFinalAssistantProse(transcript),
     transcriptTitle: transcript.sessionMeta.title ?? null,
     errorAttentionKey: resolveSessionErrorAttentionKey({
       sessionId: transcript.sessionMeta.sessionId,
@@ -43,6 +45,7 @@ export function activitySnapshotFromDirectoryEntry(
       transcript: {
         isStreaming: entry.activity.isStreaming,
         pendingInteractions: entry.activity.pendingInteractions,
+        endsInFinalAssistantProse: entry.activity.endsInFinalAssistantProse,
       },
     }
     : null;

--- a/apps/desktop/src/lib/domain/sessions/directory/directory-entry.ts
+++ b/apps/desktop/src/lib/domain/sessions/directory/directory-entry.ts
@@ -26,6 +26,11 @@ export type SessionStreamConnectionState =
 
 export interface SessionDirectoryActivitySummary {
   isStreaming: boolean;
+  /**
+   * Latest in-progress turn already ends in completed assistant prose — the
+   * settling window where sidebar/session status must not read "iterating".
+   */
+  endsInFinalAssistantProse: boolean;
   pendingInteractions: PendingInteraction[];
   transcriptTitle: string | null;
   errorAttentionKey: string | null;
@@ -98,6 +103,7 @@ export const DEFAULT_SESSION_ACTION_CAPABILITIES: SessionActionCapabilities = {
 
 export const EMPTY_DIRECTORY_ACTIVITY: SessionDirectoryActivitySummary = {
   isStreaming: false,
+  endsInFinalAssistantProse: false,
   pendingInteractions: [],
   transcriptTitle: null,
   errorAttentionKey: null,
@@ -214,6 +220,7 @@ export function activitySummaryEqual(
   b: SessionDirectoryActivitySummary,
 ): boolean {
   return a.isStreaming === b.isStreaming
+    && a.endsInFinalAssistantProse === b.endsInFinalAssistantProse
     && a.pendingInteractions === b.pendingInteractions
     && a.transcriptTitle === b.transcriptTitle
     && a.errorAttentionKey === b.errorAttentionKey;

--- a/apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts
@@ -195,6 +195,7 @@ describe("getKnownSessionViewState", () => {
         streamConnectionState: "open",
         activity: {
           isStreaming: true,
+          endsInFinalAssistantProse: false,
           pendingInteractions: [],
           transcriptTitle: null,
           errorAttentionKey: null,

--- a/apps/packages/product-domain/src/chats/transcript/transcript-trailing-status.test.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-trailing-status.test.ts
@@ -4,6 +4,7 @@ import {
   lastTopLevelItemIsAssistantProseWithText,
   latestTransientStatusText,
   shouldAllowTurnTrailingStatus,
+  transcriptEndsInFinalAssistantProse,
 } from "./transcript-trailing-status";
 
 describe("transcript trailing status", () => {
@@ -94,6 +95,57 @@ describe("transcript trailing status", () => {
     ]);
 
     expect(latestTransientStatusText(turn, transcript)).toBe("Waiting for browser auth");
+  });
+});
+
+describe("transcriptEndsInFinalAssistantProse", () => {
+  it("is true when the in-progress latest turn ends in completed prose", () => {
+    const { transcript } = transcriptWithTurn([
+      assistantItem("assistant", false),
+    ]);
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(true);
+  });
+
+  it("is false while the prose tail is still streaming", () => {
+    const { transcript } = transcriptWithTurn([
+      assistantItem("assistant", true),
+    ]);
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(false);
+  });
+
+  it("is false once the turn has completed", () => {
+    const { transcript, turn } = transcriptWithTurn([
+      assistantItem("assistant", false),
+    ]);
+    turn.completedAt = "2026-04-13T12:00:03.000Z";
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(false);
+  });
+
+  it("is false when a tool call is the tail", () => {
+    const { transcript } = transcriptWithTurn([
+      assistantItem("assistant", false),
+      toolItem("tool"),
+    ]);
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(false);
+  });
+
+  it("skips transient thoughts and nested items when finding the tail", () => {
+    const { transcript } = transcriptWithTurn([
+      assistantItem("assistant", false),
+      transientThoughtItem("status", "Checking the next action"),
+    ]);
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(true);
+  });
+
+  it("is false for an empty transcript", () => {
+    const transcript = createTranscriptState("session-1");
+
+    expect(transcriptEndsInFinalAssistantProse(transcript)).toBe(false);
   });
 });
 

--- a/apps/packages/product-domain/src/chats/transcript/transcript-trailing-status.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-trailing-status.ts
@@ -30,6 +30,27 @@ export function lastTopLevelItemIsAssistantProseWithText(
   return item?.kind === "assistant_prose" && !!item.text;
 }
 
+/**
+ * True when the transcript's latest turn is still in progress but already
+ * ends in completed assistant prose — the "settling" window between the final
+ * rendered answer and the backend's turn_ended/phase flip. Session-level
+ * status presentation uses this to stop showing "iterating" once the answer
+ * is fully on screen, mirroring how shouldAllowTurnTrailingStatus suppresses
+ * the trailing "Thinking…" indicator. A prose tail that is still streaming
+ * does NOT count: genuinely running states stay authoritative.
+ */
+export function transcriptEndsInFinalAssistantProse(
+  transcript: TranscriptState,
+): boolean {
+  const latestTurnId = transcript.turnOrder[transcript.turnOrder.length - 1];
+  const turn = latestTurnId ? transcript.turnsById[latestTurnId] : undefined;
+  if (!turn || turn.completedAt !== null) {
+    return false;
+  }
+  const item = findLastTopLevelItem(turn, transcript);
+  return item?.kind === "assistant_prose" && !!item.text && !item.isStreaming;
+}
+
 export function latestTransientStatusText(
   turn: { itemOrder: readonly string[] },
   transcript: TranscriptState,

--- a/apps/packages/product-domain/src/sessions/activity-status.ts
+++ b/apps/packages/product-domain/src/sessions/activity-status.ts
@@ -67,10 +67,45 @@ export function resolveSessionStatus(
     || effectivelyStreaming
     || hasActionablePending
   ) {
-    return reconciledStatus === "starting" ? "starting" : "running";
+    if (reconciledStatus === "starting") {
+      return "starting";
+    }
+    return !hasActionablePending && isSessionSettlingAfterFinalProse(input)
+      ? "idle"
+      : "running";
   }
 
   return reconciledStatus ?? null;
+}
+
+/**
+ * The settling window: the live transcript's latest turn already ends in
+ * completed assistant prose, but executionSummary.phase still says "running"
+ * because turn_ended / backend persistence lags the final tokens by seconds.
+ * Presenting "iterating" here reads as a dead stall under a finished answer —
+ * the same evidence shouldAllowTurnTrailingStatus uses to suppress the
+ * trailing "Thinking…" indicator says the session should present as idle.
+ *
+ * Guards keep phase authoritative everywhere else: the transcript evidence
+ * only counts when the session's stream is open (a live stream delivers the
+ * next item or turn_ended, so a genuinely-continuing agent flips us back),
+ * and never while actionable interactions are pending. Tool calls, thoughts,
+ * and streaming prose all leave a non-final tail, so genuinely running states
+ * are unaffected.
+ */
+export function isSessionSettlingAfterFinalProse(
+  slot: Pick<
+    SessionActivitySnapshot,
+    "executionSummary" | "streamConnectionState" | "transcript"
+  > | null | undefined,
+): boolean {
+  if (!slot || slot.transcript.endsInFinalAssistantProse !== true) {
+    return false;
+  }
+  if (slot.streamConnectionState !== "open") {
+    return false;
+  }
+  return !hasActionablePendingInteractions(slot);
 }
 
 export function isSessionEffectivelyStreaming(
@@ -111,6 +146,12 @@ export function resolveSessionExecutionPhase(
     ) {
       return "idle";
     }
+    if (
+      slot.executionSummary.phase === "running"
+      && isSessionSettlingAfterFinalProse(slot)
+    ) {
+      return "idle";
+    }
     return slot.executionSummary.phase;
   }
 
@@ -129,7 +170,7 @@ export function resolveSessionExecutionPhase(
       : "starting";
   }
   if (slot.status === "running" || isSessionEffectivelyStreaming(slot)) {
-    return "running";
+    return isSessionSettlingAfterFinalProse(slot) ? "idle" : "running";
   }
   return "idle";
 }

--- a/apps/packages/product-domain/src/sessions/activity-types.ts
+++ b/apps/packages/product-domain/src/sessions/activity-types.ts
@@ -32,6 +32,15 @@ export interface SessionActivitySnapshot {
   transcript: {
     isStreaming: boolean;
     pendingInteractions: PendingInteractionLike[];
+    /**
+     * True when the latest in-progress turn already ends in completed
+     * assistant prose (see transcriptEndsInFinalAssistantProse). Status
+     * derivation then presents the session as idle during the settling
+     * window between the final rendered answer and the backend phase flip,
+     * instead of a dead-looking "iterating". Undefined preserves legacy
+     * behavior (phase stays authoritative).
+     */
+    endsInFinalAssistantProse?: boolean;
   };
 }
 

--- a/apps/packages/product-domain/src/sessions/activity.test.ts
+++ b/apps/packages/product-domain/src/sessions/activity.test.ts
@@ -448,6 +448,94 @@ describe("session activity", () => {
     })).toBe("needs_input");
   });
 
+  it("presents a settling session as idle once final prose has rendered", () => {
+    // executionSummary.phase lags the final tokens by seconds; when the live
+    // transcript already ends in completed assistant prose the sidebar must
+    // not keep reading "iterating".
+    const slot = {
+      status: "running" as const,
+      executionSummary: executionSummary("running"),
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+        endsInFinalAssistantProse: true,
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("idle");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("idle");
+    expect(resolveSessionViewState(slot)).toBe("idle");
+  });
+
+  it("keeps iterating during running phases without a final prose tail", () => {
+    const slot = {
+      status: "running" as const,
+      executionSummary: executionSummary("running"),
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+        endsInFinalAssistantProse: false,
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("running");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("iterating");
+  });
+
+  it("keeps phase authoritative for settling evidence without a live stream", () => {
+    // Without an open stream nothing would flip the session back if the
+    // agent genuinely continues, so the transcript evidence is ignored.
+    const slot = {
+      status: "running" as const,
+      executionSummary: executionSummary("running"),
+      streamConnectionState: "ended" as const,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+        endsInFinalAssistantProse: true,
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("running");
+    expect(resolveSessionSidebarActivityState(slot)).toBe("iterating");
+  });
+
+  it("keeps waiting states above settling evidence", () => {
+    const slot = {
+      status: "running" as const,
+      executionSummary: {
+        ...executionSummary("running"),
+        pendingInteractions: [{ requestId: "req-1" }],
+      },
+      streamConnectionState: "open" as const,
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+        endsInFinalAssistantProse: true,
+      },
+    };
+
+    expect(resolveSessionSidebarActivityState(slot)).toBe("waiting_input");
+  });
+
+  it("does not treat starting sessions as settling", () => {
+    const slot = {
+      status: "starting" as const,
+      executionSummary: null,
+      streamConnectionState: "open" as const,
+      hasPromptActivity: true,
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+        endsInFinalAssistantProse: true,
+      },
+    };
+
+    expect(resolveSessionExecutionPhase(slot)).toBe("starting");
+  });
+
   it("presents never-prompted starting sessions as idle", () => {
     const slot = {
       status: "starting" as const,

--- a/apps/packages/product-domain/src/sessions/activity.ts
+++ b/apps/packages/product-domain/src/sessions/activity.ts
@@ -4,6 +4,7 @@ export type {
 } from "./activity-types";
 export {
   isSessionEffectivelyStreaming,
+  isSessionSettlingAfterFinalProse,
   isSessionSlotBusy,
   pendingInteractionsForActivity,
   resolveSessionErrorAttentionKey,


### PR DESCRIPTION
## Problem

After the final agent text renders, the sidebar and session status keep showing "iterating" with no thinking indicator until turn_ended arrives, a several-second dead-looking stall. Two status pipelines disagree: the transcript's shouldAllowTurnTrailingStatus correctly suppresses the trailing Thinking indicator once the turn's tail is completed assistant prose, but resolveSessionSidebarActivityState / resolveSessionExecutionPhase derive purely from executionSummary.phase, which lags the final content while the backend finishes persistence. The desktop reconciler poll (use-session-activity-reconciler) only papers over this on a 5s cadence.

## Fix

Session-level status derivation now reconciles transcript evidence with the phase:

- New transcriptEndsInFinalAssistantProse(transcript) in product-domain reuses the exact tail rule the trailing-status suppression uses, but only counts completed (non-streaming) prose on an in-progress latest turn.
- The boolean is computed at the narrowest join point where the full TranscriptState is available (activityFromTranscript in the desktop directory activity layer), stored on SessionDirectoryActivitySummary, and threaded into SessionActivitySnapshot.transcript.
- isSessionSettlingAfterFinalProse gates the override: it applies only when the session's stream is open (so a genuinely-continuing agent flips the state back via the next item or turn_ended) and no actionable interactions are pending. In that window resolveSessionExecutionPhase and resolveSessionStatus present idle instead of running/iterating.
- Phase remains authoritative everywhere else: tool calls, thoughts, and streaming prose leave a non-final tail; starting, errored, closed, awaiting_interaction, and closed-stream states are untouched. No backend/runtime phase semantics changed.

The sidebar activity selector signature now includes the new bit so settling re-derives immediately.

## PR #817

Reviewed the residual diff of #817 (conflicting). Its transcript-trailing-status change reverses the owner rule already shipped on main (it re-shows the indicator after completed prose), so it is neither a prerequisite nor complementary to this fix; the turn-stopped notice and playground fixture there are unrelated to this bug. Nothing was folded in, and with this structural fix landing #817 can be closed (prior #760 chased the same class).

## Verification

- apps/packages/product-domain: pnpm exec vitest run, 56 files / 516 tests pass, including 6 new transcriptEndsInFinalAssistantProse tests and 5 new settling-derivation tests in activity.test.ts
- product-domain rebuilt; apps/desktop pnpm exec tsc --noEmit clean
- Desktop touched test workspace-header-tabs-model-helpers.test.ts passes (fixture gained the new required field)