### PR TITLE
fix(anyharness): stamp release version into runtime and worker binaries

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -72,6 +72,25 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Stamp the release semver into the binaries so `anyharness --version`
+      # and the runtime `/health` version report the pinned version instead
+      # of the crate's hardcoded Cargo.toml version. build.rs in the anyharness,
+      # anyharness-lib, and proliferate-worker crates reads this env; the
+      # self-update preflight and health-gate require an exact match to the pin.
+      # workflow_call passes the bare semver (inputs.version); a direct
+      # `runtime-v<semver>` tag push derives it by stripping the tag prefix.
+      # Anything else (e.g. a workflow_dispatch dry run) leaves it unset so the
+      # build falls back to the Cargo.toml version.
+      - name: Resolve build version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "PROLIFERATE_BUILD_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          elif [[ "${GITHUB_REF_NAME:-}" == runtime-v* ]]; then
+            echo "PROLIFERATE_BUILD_VERSION=${GITHUB_REF_NAME#runtime-v}" >> "$GITHUB_ENV"
+          fi
+
       - name: Install musl-tools (x86_64 linux)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.10"
+version = "0.3.17"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+# `cross` runs the build inside a container, so the release version stamp
+# (set by the `build-binaries` job in .github/workflows/release-runtime.yml)
+# must be forwarded into it — otherwise the aarch64-linux binaries fall back
+# to the crate's Cargo.toml version and the self-update gates never converge.
+[build.env]
+passthrough = ["PROLIFERATE_BUILD_VERSION"]

--- a/anyharness/crates/anyharness-lib/build.rs
+++ b/anyharness/crates/anyharness-lib/build.rs
@@ -1,0 +1,19 @@
+//! Stamps the release version into the binary at build time.
+//!
+//! Release builds set `PROLIFERATE_BUILD_VERSION` (see the `build-binaries`
+//! job in `.github/workflows/release-runtime.yml`, which derives it from the
+//! `runtime-v<semver>` tag). Dev and test builds leave it unset and fall back
+//! to the crate's Cargo.toml version. The resolved value is exposed to the
+//! crate as the compile-time env `PROLIFERATE_STAMPED_VERSION`, which feeds
+//! `--version` output and the runtime `/health` `version` field so the worker
+//! self-update gates can converge on the pinned semver.
+fn main() {
+    println!("cargo:rerun-if-env-changed=PROLIFERATE_BUILD_VERSION");
+    let version = std::env::var("PROLIFERATE_BUILD_VERSION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("CARGO_PKG_VERSION").ok())
+        .unwrap_or_else(|| "0.0.0".to_string());
+    println!("cargo:rustc-env=PROLIFERATE_STAMPED_VERSION={version}");
+}

--- a/anyharness/crates/anyharness-lib/src/api/http/health.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/health.rs
@@ -24,7 +24,7 @@ pub async fn get_health(
 ) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".into(),
-        version: env!("CARGO_PKG_VERSION").into(),
+        version: env!("PROLIFERATE_STAMPED_VERSION").into(),
         runtime_home: state.runtime_home.display().to_string(),
         capabilities: RuntimeCapabilities {
             replay: crate::domains::sessions::replay::replay_enabled(),
@@ -62,5 +62,19 @@ fn resource_pressure_to_contract(
         }),
         pressure_percent: pressure.pressure_percent,
         collected_at: pressure.collected_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn health_version_is_the_stamped_release_version() {
+        // `/health` reports the build-stamped version so the worker self-update
+        // health-gate can converge on a pinned semver. Dev and test builds
+        // leave PROLIFERATE_BUILD_VERSION unset, so the stamp falls back to the
+        // crate's Cargo.toml version.
+        let reported = env!("PROLIFERATE_STAMPED_VERSION");
+        assert!(!reported.is_empty());
+        assert_eq!(reported, env!("CARGO_PKG_VERSION"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
@@ -98,7 +98,7 @@ pub fn initialize_response(
             "capabilities": { "tools": {} },
             "serverInfo": {
                 "name": definition.server_info_name,
-                "version": env!("CARGO_PKG_VERSION"),
+                "version": env!("PROLIFERATE_STAMPED_VERSION"),
             },
             "instructions": definition.instructions,
         }),

--- a/anyharness/crates/anyharness/build.rs
+++ b/anyharness/crates/anyharness/build.rs
@@ -1,0 +1,19 @@
+//! Stamps the release version into the binary at build time.
+//!
+//! Release builds set `PROLIFERATE_BUILD_VERSION` (see the `build-binaries`
+//! job in `.github/workflows/release-runtime.yml`, which derives it from the
+//! `runtime-v<semver>` tag). Dev and test builds leave it unset and fall back
+//! to the crate's Cargo.toml version. The resolved value is exposed to the
+//! crate as the compile-time env `PROLIFERATE_STAMPED_VERSION`, which feeds
+//! `--version` output and the runtime `/health` `version` field so the worker
+//! self-update gates can converge on the pinned semver.
+fn main() {
+    println!("cargo:rerun-if-env-changed=PROLIFERATE_BUILD_VERSION");
+    let version = std::env::var("PROLIFERATE_BUILD_VERSION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("CARGO_PKG_VERSION").ok())
+        .unwrap_or_else(|| "0.0.0".to_string());
+    println!("cargo:rustc-env=PROLIFERATE_STAMPED_VERSION={version}");
+}

--- a/anyharness/crates/anyharness/src/cli.rs
+++ b/anyharness/crates/anyharness/src/cli.rs
@@ -7,7 +7,7 @@ use crate::commands::serve::ServeArgs;
 #[derive(Parser)]
 #[command(name = "anyharness")]
 #[command(about = "AnyHarness: a runtime for coding agents")]
-#[command(version)]
+#[command(version = env!("PROLIFERATE_STAMPED_VERSION"))]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -70,7 +70,7 @@ pub fn init(command: &Commands) -> TelemetryGuards {
                 release: Some(
                     env_or_default(
                         "ANYHARNESS_SENTRY_RELEASE",
-                        &format!("anyharness@{}", env!("CARGO_PKG_VERSION")),
+                        &format!("anyharness@{}", env!("PROLIFERATE_STAMPED_VERSION")),
                     )
                     .into(),
                 ),

--- a/anyharness/crates/proliferate-worker/build.rs
+++ b/anyharness/crates/proliferate-worker/build.rs
@@ -1,0 +1,19 @@
+//! Stamps the release version into the binary at build time.
+//!
+//! Release builds set `PROLIFERATE_BUILD_VERSION` (see the `build-binaries`
+//! job in `.github/workflows/release-runtime.yml`, which derives it from the
+//! `runtime-v<semver>` tag). Dev and test builds leave it unset and fall back
+//! to the crate's Cargo.toml version. The resolved value is exposed to the
+//! crate as the compile-time env `PROLIFERATE_STAMPED_VERSION`, which feeds
+//! `--version` output and the runtime `/health` `version` field so the worker
+//! self-update gates can converge on the pinned semver.
+fn main() {
+    println!("cargo:rerun-if-env-changed=PROLIFERATE_BUILD_VERSION");
+    let version = std::env::var("PROLIFERATE_BUILD_VERSION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("CARGO_PKG_VERSION").ok())
+        .unwrap_or_else(|| "0.0.0".to_string());
+    println!("cargo:rustc-env=PROLIFERATE_STAMPED_VERSION={version}");
+}

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -29,7 +29,7 @@ fn env_filter_from_env() -> tracing_subscriber::EnvFilter {
 }
 
 fn default_release() -> String {
-    format!("proliferate-worker@{}", env!("CARGO_PKG_VERSION"))
+    format!("proliferate-worker@{}", env!("PROLIFERATE_STAMPED_VERSION"))
 }
 
 fn scrub_text(value: &str) -> String {

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use sentry_anyhow::capture_anyhow;
 
 #[derive(Debug, Parser)]
-#[command(name = "proliferate-worker", version)]
+#[command(name = "proliferate-worker", version = env!("PROLIFERATE_STAMPED_VERSION"))]
 struct Args {
     #[arg(long)]
     config: Option<PathBuf>,

--- a/anyharness/crates/proliferate-worker/src/versions.rs
+++ b/anyharness/crates/proliferate-worker/src/versions.rs
@@ -1,5 +1,5 @@
 pub fn worker_version() -> Option<String> {
-    Some(env!("CARGO_PKG_VERSION").to_string())
+    Some(env!("PROLIFERATE_STAMPED_VERSION").to_string())
 }
 
 /// The AnyHarness runtime version co-deployed with this worker, as advertised
@@ -15,4 +15,35 @@ pub fn anyharness_version() -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::worker_version;
+    use crate::self_update::version_output_matches;
+
+    #[test]
+    fn worker_version_is_stamped_and_non_empty() {
+        let version = worker_version().expect("worker version is always reported");
+        assert!(!version.is_empty());
+    }
+
+    #[test]
+    fn worker_version_falls_back_to_crate_version_without_a_release_stamp() {
+        // Dev and test builds leave PROLIFERATE_BUILD_VERSION unset, so the
+        // build script stamps the crate's Cargo.toml version.
+        assert_eq!(
+            env!("PROLIFERATE_STAMPED_VERSION"),
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+
+    #[test]
+    fn reported_worker_version_satisfies_the_self_update_gate() {
+        // The stamped `--version` output must clear the same exact-match gate
+        // the worker self-update preflight and health-gate apply to a pin.
+        let version = worker_version().expect("worker version");
+        let clap_output = format!("proliferate-worker {version}\n");
+        assert!(version_output_matches(&clap_output, &version));
+    }
 }


### PR DESCRIPTION
## Problem

Released AnyHarness binaries reported `CARGO_PKG_VERSION`, which is hardcoded `0.1.0` in the workspace and never bumped at release. So `anyharness --version` and the runtime `/health` `version` field always said `0.1.0` regardless of the release tag (the `runtime-v0.3.12` asset prints `anyharness 0.1.0`).

The worker self-update mechanism (#1087/#1088) requires an exact match to the pinned semver in both the download preflight (`--version`) and the post-relaunch health-gate (`/health` version) — `self_update.rs::version_output_matches`. With the reported version stuck at `0.1.0`, no real pin can ever converge, so the update is always rejected or rolled back. The worker binary's own self-update has the same defect.

## Fix

- Add a `build.rs` to the `anyharness`, `anyharness-lib`, and `proliferate-worker` crates. It reads `PROLIFERATE_BUILD_VERSION` and emits the compile-time `PROLIFERATE_STAMPED_VERSION` constant, falling back to the crate's Cargo.toml version when the env is unset.
- Wire `--version` (clap), the `/health` version field, the worker heartbeat `worker_version()`, and the Sentry release tags to the stamped constant.
- `release-runtime.yml` sets `PROLIFERATE_BUILD_VERSION` in the `build-binaries` job from the reusable-call `version` input, or by stripping the `runtime-v` prefix off a direct tag push, before the cargo build.
- `Cross.toml` forwards the env into the aarch64-linux `cross` container build.

Stamped output is the bare semver (`anyharness 0.3.12`), which clears the `version_output_matches` exact-token gate. Dev and test builds leave the env unset and keep reporting the Cargo.toml version.

The `proliferate-supervisor` crate is intentionally left alone — it is not self-updated and not gated on a version match.

## Tests

- `proliferate-worker`: the stamped version is non-empty, falls back to the crate version without a release stamp, and satisfies the self-update gate.
- `anyharness-lib`: `/health` reports the stamped version.
- `cargo test` green for `anyharness`, `anyharness-lib`, `proliferate-worker` (one pre-existing `file_logging` rotation test flakes under parallelism; passes single-threaded, unrelated to this change).

A new stamped runtime release is required before T4-CLOUD-1 can pass; the next `runtime-v<semver>` release (via the nightly release train or Hotfix Production) produces the first correctly stamped binaries.

Fixes #1089