### PR TITLE
feat(billing): wire the gateway LLM-credit budget gate as a second enforcement wall

### DIFF
--- a/server/proliferate/server/cloud/agent_gateway/budget.py
+++ b/server/proliferate/server/cloud/agent_gateway/budget.py
@@ -1,0 +1,57 @@
+"""Gateway budget availability (the launch-gating predicate).
+
+Second enforcement wall for LLM credit exhaustion: the first wall is the
+LiteLLM virtual-key disable applied by the usage importer
+(``usage_import._enforce_subject_exhaustion``). This predicate is consumed at
+the point where a client acquires gateway access — the agent-auth state
+render (the cloud materializer and ``GET /agent-gateway/state``, which hand
+out the decrypted virtual key) — so an exhausted subject stops receiving key
+material even if the LiteLLM-side disable lagged or failed.
+
+Lives in its own leaf module (imports only config + stores) because the state
+renderer in ``materialization/materialize/agent_auth.py`` needs it and
+``usage_import`` sits behind an import cycle
+(usage_import -> topups -> materialization.service -> materialize.agent_auth).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.store import agent_gateway as agent_gateway_store
+
+_ZERO = Decimal("0")
+
+# Stable machine code on the 402 detail body when the gate blocks — the
+# LLM-credit sibling of ``billing_credits_exhausted`` (the compute-side code
+# in ``server.billing.authorization``). Part of the client contract; do not
+# rename without updating consumers.
+AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE = "agent_gateway_credits_exhausted"
+
+
+async def is_gateway_budget_available(db: AsyncSession, user_id: UUID) -> bool:
+    """Whether a user may launch a gateway-route session.
+
+    True when the gateway is disabled (LiteLLM budgets are the only guardrail),
+    or the user has no credit grant (default-budget subjects are never blocked
+    on the ledger), or their remaining LLM credit is above zero. False only when
+    a granted subject has spent its credit. Checks the same enrollment the state
+    renderer hands out key material for (the user's personal enrollment), so the
+    gate and the key it guards always agree on the paying subject.
+    """
+    if not settings.agent_gateway_enabled:
+        return True
+    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    if enrollment is None:
+        return True
+    balance = await agent_gateway_store.get_remaining_credit_usd(
+        db,
+        enrollment.billing_subject_id,
+    )
+    if balance.granted_usd <= _ZERO:
+        return True
+    return balance.remaining_usd > _ZERO

--- a/server/proliferate/server/cloud/agent_gateway/catalog.py
+++ b/server/proliferate/server/cloud/agent_gateway/catalog.py
@@ -55,6 +55,10 @@ from proliferate.db.store.agent_gateway import (
 )
 from proliferate.integrations import litellm
 from proliferate.integrations.litellm import LiteLLMIntegrationError
+from proliferate.server.cloud.agent_gateway.budget import (
+    AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE,
+    is_gateway_budget_available,
+)
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.event_logging import log_cloud_event
 
@@ -396,6 +400,16 @@ async def mirror_catalog(
 
 
 async def _probe_gateway_models(db: AsyncSession, *, user_id: UUID) -> str:
+    # Budget gate (second wall after the LiteLLM key disable): an exhausted
+    # subject gets a clean enumerated 402 instead of exercising the gateway.
+    # Mirrors the state renderer, which withholds the virtual key for the
+    # same condition.
+    if not await is_gateway_budget_available(db, user_id):
+        raise CloudApiError(
+            AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE,
+            "Your LLM credits are exhausted; top up to keep using the gateway.",
+            status_code=402,
+        )
     enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
     virtual_key: str | None = None
     if enrollment is not None:

--- a/server/proliferate/server/cloud/agent_gateway/usage_import.py
+++ b/server/proliferate/server/cloud/agent_gateway/usage_import.py
@@ -44,6 +44,7 @@ from proliferate.db.store.billing_subjects import get_billing_subject_by_id
 from proliferate.integrations import litellm
 from proliferate.integrations.litellm import LiteLLMIntegrationError, LiteLLMSpendLogEntry
 from proliferate.server.billing.budget_limits import window_bounds
+from proliferate.server.cloud.agent_gateway.budget import is_gateway_budget_available
 from proliferate.server.cloud.agent_gateway.topups import (
     reactivate_enrollment_if_credited,
     topups_enabled,
@@ -454,24 +455,7 @@ async def _apply_llm_limit_reached(
     )
 
 
-async def is_gateway_budget_available(db: AsyncSession, user_id: UUID) -> bool:
-    """Whether a user may launch a gateway-route session (later launch-gating).
-
-    True when the gateway is disabled (LiteLLM budgets are the only guardrail),
-    or the user has no credit grant (default-budget subjects are never blocked
-    on the ledger), or their remaining LLM credit is above zero. False only when
-    a granted subject has spent its credit — the exhaustion signal PR 4's
-    capabilities endpoint will consume.
-    """
-    if not settings.agent_gateway_enabled:
-        return True
-    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
-    if enrollment is None:
-        return True
-    balance = await agent_gateway_store.get_remaining_credit_usd(
-        db,
-        enrollment.billing_subject_id,
-    )
-    if balance.granted_usd <= _ZERO:
-        return True
-    return balance.remaining_usd > _ZERO
+# Re-exported for existing importers; the predicate lives in the leaf
+# ``budget`` module so the agent-auth state renderer can consume it without
+# creating an import cycle through topups -> materialization.
+__all__ = ["UsageImportResult", "is_gateway_budget_available", "run_usage_import"]

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -80,6 +80,7 @@ from proliferate.constants.agent_gateway import (
 from proliferate.db.store import agent_gateway as agent_gateway_store
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
 from proliferate.db.store.agent_gateway import AgentAuthSelectionRecord
+from proliferate.server.cloud.agent_gateway.budget import is_gateway_budget_available
 from proliferate.server.cloud.materialization import operation, paths, sandbox_io
 
 logger = logging.getLogger("proliferate.cloud.materialization")
@@ -272,12 +273,26 @@ async def _load_state_inputs(
         if enrollment is not None:
             enrollment_sync_status = enrollment.sync_status
             if enrollment.sync_status == AGENT_GATEWAY_SYNC_STATUS_SYNCED:
-                gateway_virtual_key = (
-                    await agent_gateway_store.get_enrollment_virtual_key_decrypted(
-                        db,
-                        enrollment_id=enrollment.id,
+                # Second enforcement wall for LLM-credit exhaustion (the first
+                # is the importer disabling the LiteLLM virtual key): an
+                # exhausted subject stops being handed the key at all, so a
+                # lagging or failed key-disable cannot leak gateway access.
+                # The gateway source then renders unsatisfiable and is dropped;
+                # the runtime fails closed at launch.
+                if await is_gateway_budget_available(db, user_id):
+                    gateway_virtual_key = (
+                        await agent_gateway_store.get_enrollment_virtual_key_decrypted(
+                            db,
+                            enrollment_id=enrollment.id,
+                        )
                     )
-                )
+                else:
+                    logger.warning(
+                        "Withholding gateway virtual key: LLM credit exhausted "
+                        "(user=%s, surface=%s)",
+                        user_id,
+                        surface,
+                    )
 
     harness_settings = await agent_gateway_store.list_harness_settings_for_surface(
         db,

--- a/server/tests/integration/test_agent_gateway_usage_credits.py
+++ b/server/tests/integration/test_agent_gateway_usage_credits.py
@@ -386,3 +386,143 @@ async def test_gateway_disabled_makes_budget_always_available(
     monkeypatch.setattr(settings, "agent_gateway_enabled", False)
     user_id = await _create_user(db_session)
     assert await is_gateway_budget_available(db_session, user_id) is True
+
+
+@pytest.mark.asyncio
+async def test_exhausted_budget_withholds_gateway_key_from_state_render(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """The second enforcement wall: state.json stops carrying the virtual key.
+
+    Even if the LiteLLM key-disable (first wall) lagged or failed, an
+    exhausted subject's agent-auth state render must drop the gateway source,
+    so the runtime fails closed at launch.
+    """
+    from proliferate.db.store.agent_gateway import DesiredAuthSource
+    from proliferate.db.store.agent_gateway.selections import put_auth_selections
+    from proliferate.server.cloud.materialization.materialize.agent_auth import (
+        build_agent_auth_state,
+    )
+
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "5")
+    monkeypatch.setattr(
+        settings,
+        "agent_gateway_litellm_public_base_url",
+        "https://llm.proliferate.ai",
+    )
+    user_id = await _create_user(db_session)
+    await _link_github_identity(db_session, user_id=user_id)
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    assert enrollment.virtual_key_id is not None
+
+    await put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        sources=[DesiredAuthSource(source_kind="gateway")],
+    )
+
+    # With credit remaining, the render hands out the gateway key.
+    state, _ = await build_agent_auth_state(db_session, user_id, surface="local")
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    assert any(s["kind"] == "gateway" and s.get("key") for s in sources)
+
+    # Drain the grant; simulate the first wall failing by NOT relying on the
+    # key-disable — the render alone must now withhold the key.
+    stub_litellm.spend_rows = [
+        _spend_row(
+            request_id="req-wall2",
+            api_key=enrollment.virtual_key_id,
+            spend=6.0,
+            occurred_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+    ]
+    await run_usage_import(db_session, now=datetime(2026, 7, 1, 12, 10, tzinfo=UTC))
+    assert await is_gateway_budget_available(db_session, user_id) is False
+
+    state, _ = await build_agent_auth_state(db_session, user_id, surface="local")
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    assert not any(s["kind"] == "gateway" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_exhausted_budget_blocks_gateway_catalog_refresh_with_402(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    from proliferate.server.cloud.agent_gateway import catalog as catalog_service
+    from proliferate.server.cloud.errors import CloudApiError
+
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "5")
+    user_id = await _create_user(db_session)
+    await _link_github_identity(db_session, user_id=user_id)
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    assert enrollment.virtual_key_id is not None
+
+    stub_litellm.spend_rows = [
+        _spend_row(
+            request_id="req-catalog-drain",
+            api_key=enrollment.virtual_key_id,
+            spend=6.0,
+            occurred_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+    ]
+    await run_usage_import(db_session, now=datetime(2026, 7, 1, 12, 10, tzinfo=UTC))
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await catalog_service.refresh_catalog(
+            db_session,
+            user_id=user_id,
+            harness_kind="claude",
+            surface="local",
+            route="gateway",
+            models_json=None,
+        )
+    assert excinfo.value.code == "agent_gateway_credits_exhausted"
+    assert excinfo.value.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_available_budget_leaves_state_render_and_no_grant_unblocked(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """A no-grant subject (default-budget) is never blocked by the ledger gate."""
+    from proliferate.db.store.agent_gateway import DesiredAuthSource
+    from proliferate.db.store.agent_gateway.selections import put_auth_selections
+    from proliferate.server.cloud.materialization.materialize.agent_auth import (
+        build_agent_auth_state,
+    )
+
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    # Free credits disabled: enrollment has no grant, LiteLLM default budget
+    # is the only guardrail; the ledger gate must not block.
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "0")
+    monkeypatch.setattr(
+        settings,
+        "agent_gateway_litellm_public_base_url",
+        "https://llm.proliferate.ai",
+    )
+    user_id = await _create_user(db_session)
+    await _link_github_identity(db_session, user_id=user_id)
+    enrollment = await ensure_user_enrollment(db_session, user_id)
+    assert enrollment.virtual_key_id is not None
+
+    await put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        sources=[DesiredAuthSource(source_kind="gateway")],
+    )
+    assert await is_gateway_budget_available(db_session, user_id) is True
+    state, _ = await build_agent_auth_state(db_session, user_id, surface="local")
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    assert any(s["kind"] == "gateway" and s.get("key") for s in sources)


### PR DESCRIPTION
## What

`is_gateway_budget_available(db, user_id)` existed in `usage_import.py` but was only called from tests — the only live enforcement of LLM-credit exhaustion was the LiteLLM virtual-key disable applied by the usage importer (which can lag a tick or fail). This wires the predicate as the second wall, at the point where a client actually acquires gateway access:

- **Agent-auth state render** (the cloud materializer and `GET /agent-gateway/state`, which hand out the decrypted virtual key): when the subject's granted LLM credit is spent, the render withholds the key, the gateway source becomes unsatisfiable and is dropped (the existing fail-closed path), and the runtime refuses gateway launches. A lagging or failed LiteLLM key-disable can no longer leak access.
- **Gateway catalog refresh** (`POST /agent-gateway/catalog/{harness}/refresh` with `route=gateway`, the server-side action that exercises the caller's virtual key): returns an enumerated 402 `agent_gateway_credits_exhausted` — the LLM sibling of the compute-side `billing_credits_exhausted` from #1045's resume gate.

Mechanically, the predicate moves unchanged to a new leaf module `agent_gateway/budget.py` (`usage_import` re-exports it, so existing imports keep working) because the state renderer sits behind the `usage_import → topups → materialization.service → materialize.agent_auth` import cycle.

Billing-subject note (#1047): the gate reads the same personal enrollment the state renderer hands the key out for (`get_enrollment_for_user`), so gate and key always agree on the paying subject. Org-member keys live on the org enrollment/team and are enforced by the importer's org-cap pass + key disable.

## No migration

## Tests

Three new integration tests in `test_agent_gateway_usage_credits.py`:
- exhausted budget → state render drops the gateway source (first-wall failure simulated by not relying on the key-disable)
- exhausted budget → catalog refresh raises 402 `agent_gateway_credits_exhausted`
- no-grant (default-budget) subject stays unblocked and keeps receiving the key

Ran `test_agent_gateway_usage_credits.py` + `test_agent_gateway_api.py` + `test_agent_auth_materialization.py`: 46 passed.