### PR TITLE
test(server): assert org billing exhaustion lifecycle live on staging (T3-BILL-4) + fix #1047 attribution

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -256,38 +256,86 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Staging lane — the README's documented tier-3 CI target (real deployment,
-  # publicly reachable, real gateway with cheap models). Commented out until the
-  # staging gateway test key is provisioned: the runner needs
-  # RELEASE_E2E_GATEWAY_TEST_KEY issued for an e2e-tests LiteLLM team on staging,
-  # plus RELEASE_E2E_SERVER_URL pointing at the staging API. Uncomment and add
-  # the secrets once that infrastructure exists.
-  #
-  # release-e2e-staging:
-  #   name: tier-3 staging lane (provisional)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   continue-on-error: true
-  #   steps:
-  #     - name: Preflight — staging gateway key
-  #       id: preflight
-  #       env:
-  #         GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
-  #         STAGING_SERVER_URL: ${{ secrets.RELEASE_E2E_SERVER_URL }}
-  #       run: |
-  #         if [ -z "$GATEWAY_TEST_KEY" ] || [ -z "$STAGING_SERVER_URL" ]; then
-  #           echo "::notice title=Staging tier-3 skipped::RELEASE_E2E_GATEWAY_TEST_KEY / RELEASE_E2E_SERVER_URL not set."
-  #           echo "enabled=false" >> "$GITHUB_OUTPUT"; exit 0
-  #         fi
-  #         echo "enabled=true" >> "$GITHUB_OUTPUT"
-  #     - uses: actions/checkout@v6
-  #       if: steps.preflight.outputs.enabled == 'true'
-  #     # ... node/pnpm setup ...
-  #     - name: Run tier-3 against staging
-  #       if: steps.preflight.outputs.enabled == 'true'
-  #       env:
-  #         RELEASE_E2E_SERVER_URL: ${{ secrets.RELEASE_E2E_SERVER_URL }}
-  #         RELEASE_E2E_GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
-  #         RELEASE_E2E_DURABLE_USER_EMAIL: ${{ secrets.RELEASE_E2E_DURABLE_USER_EMAIL }}
-  #         RELEASE_E2E_DURABLE_USER_PASSWORD: ${{ secrets.RELEASE_E2E_DURABLE_USER_PASSWORD }}
-  #         RELEASE_E2E_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-  #       run: make release-e2e LANE=staging DESKTOP=web AGENTS=all SCENARIOS=all
+  # publicly reachable, real gateway with cheap models). Runs against the
+  # `staging` GitHub environment (its vars/secrets: API_BASE_URL,
+  # RELEASE_E2E_GATEWAY_TEST_KEY, RELEASE_E2E_DURABLE_ORG_ID, …). The staging
+  # gateway + durable org id + gateway test key are now provisioned; the one
+  # remaining gate is the browser-free durable-user session:
+  # RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN (a `staging` environment secret).
+  # Refresh tokens rotate on every use, so a durable-in-CI mechanism (a
+  # non-rotating bootstrap, or persisting the rotated state between runs) is
+  # still needed before this authenticates for real — until then the preflight
+  # skips cleanly (::notice::), the same pattern the local lane uses.
+  release-e2e-staging:
+    name: tier-3 staging lane (provisional)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: true
+    environment: staging
+    steps:
+      - name: Preflight — staging credentials
+        id: preflight
+        env:
+          GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
+          STAGING_SERVER_URL: ${{ vars.API_BASE_URL }}
+          STAGING_SESSION_REFRESH_TOKEN: ${{ secrets.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN }}
+        run: |
+          enabled=true
+          if [ -z "$STAGING_SERVER_URL" ]; then
+            echo "::notice title=Staging tier-3 skipped::staging API_BASE_URL variable is not set."
+            enabled=false
+          fi
+          if [ -z "$STAGING_SESSION_REFRESH_TOKEN" ]; then
+            echo "::notice title=Staging tier-3 skipped::RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN (staging env secret) is not set — the durable staging user (proliferate-e2e-bot, GitHub-OAuth-only, no password) authenticates via a rotating session refresh token. Bootstrap one per tests/release/src/fixtures/staging-session.ts and add it (plus a rotation-durable mechanism) before this lane runs. Skipping cleanly."
+            enabled=false
+          fi
+          if [ -z "$GATEWAY_TEST_KEY" ]; then
+            echo "::notice title=Staging gateway key absent::RELEASE_E2E_GATEWAY_TEST_KEY not set — gateway-dependent scenarios report blocked. Billing-surface scenarios (T3-BILL-4) still run."
+          fi
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        if: steps.preflight.outputs.enabled == 'true'
+      - uses: actions/setup-node@v6
+        if: steps.preflight.outputs.enabled == 'true'
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        if: steps.preflight.outputs.enabled == 'true'
+        with:
+          version: 10
+      - uses: astral-sh/setup-uv@v7
+        if: steps.preflight.outputs.enabled == 'true'
+      - uses: actions/setup-python@v6
+        if: steps.preflight.outputs.enabled == 'true'
+        with:
+          python-version: "3.12"
+      - name: Install workspace dependencies
+        if: steps.preflight.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tier-3 against staging
+        if: steps.preflight.outputs.enabled == 'true'
+        env:
+          # API_BASE_URL already includes the deployment's /api prefix, which is
+          # exactly what RELEASE_E2E_SERVER_URL wants (env-manifest.ts).
+          RELEASE_E2E_SERVER_URL: ${{ vars.API_BASE_URL }}
+          RELEASE_E2E_GATEWAY_TEST_KEY: ${{ secrets.RELEASE_E2E_GATEWAY_TEST_KEY }}
+          RELEASE_E2E_GATEWAY_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL || 'https://staging-gateway.proliferate.com' }}
+          RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN: ${{ secrets.RELEASE_E2E_STAGING_SESSION_REFRESH_TOKEN }}
+          RELEASE_E2E_DURABLE_ORG_ID: ${{ vars.RELEASE_E2E_DURABLE_ORG_ID }}
+          RELEASE_E2E_E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          RELEASE_E2E_E2B_TEAM_ID: ${{ vars.E2B_TEAM_ID }}
+          LANE: staging
+          SCENARIOS: ${{ github.event.inputs.scenarios || 'all' }}
+          AGENTS: ${{ github.event.inputs.agents || 'all' }}
+        run: make release-e2e LANE="$LANE" DESKTOP=web AGENTS="$AGENTS" SCENARIOS="$SCENARIOS"
+
+      - name: Upload failure reports
+        if: always() && steps.preflight.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-e2e-reports-staging
+          path: tests/release/.output/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -610,6 +610,44 @@ and a small per-seat cap:
 Assert amounts end-to-end: seconds consumed → cents exported → Stripe event
 totals match (the fractional-cent remainder logic is under test here too).
 
+**Blocked on staging (2026-07-10):** cannot run against the current staging
+deployment. Staging's Stripe is in **LIVE mode** (a `cloud-checkout` returns a
+`cs_live_` session — verified), so a test-mode top-up with card 4242 is
+impossible and a real charge is out of scope; org `cloud-checkout` is
+additionally gated (`org_pro_billing_disabled` — pro billing is off on staging)
+and personal `refill-checkout` is unconfigured (`stripe_refill_price_unconfigured`).
+Compute-segment metering is independently broken: E2B delivers webhooks to
+`POST /api/v1/cloud/webhooks/e2b` but every one returns **401
+`invalid_webhook_signature`** (239 in 5 days, zero 2xx — the configured
+`E2B_WEBHOOK_SIGNATURE_SECRET` does not match what E2B signs with; E2B's
+dashboard never surfaced a signing secret), so `usage_segment` rows never open
+or close. Needs a test-mode Stripe deployment (or the durable org funded then
+drained on a test clock) and a working E2B webhook secret before it can run.
+
+### T3-BILL-4: org billing lifecycle — out-of-credits enforcement, live
+Added 2026-07-10. The reachable half of the durable-org lifecycle ruling
+(Pablo 2026-07-10), asserted against the real staging deployment through the
+billing HTTP surface a client uses — the T3-BILL-1/2 ledger DB seam is
+local-only (staging DB is VPC-only; the durable staging user is a real
+GitHub-OAuth account that passes `current_product_user`). Staging lane
+(`--lane staging`); the local lane reports blocked (its ledger is T3-BILL-1/2's).
+Against the durable org's exhausted subject, assert:
+- the **enumerated out-of-credits state** on `cloud-plan`/`overview`
+  (`startBlocked`, `holdReason=credits_exhausted`, 0 remaining hours) and
+  `llm-balance` (`remainingUsd=0`);
+- the **live compute start gate** (#1036, wired into the service layer):
+  `POST /cloud-sandbox/ensure` is refused with a 402 `billing_credits_exhausted`
+  and **no sandbox is created** (the gate fires before the row insert);
+- the **#1047 attribution split** as a positive contrast: the org member's
+  compute + LLM bill the ORG subject (exhausted) while the same user's PERSONAL
+  subject keeps its free grant — org work does not silently drain personal
+  credits;
+- **overage can be turned on** for the org via `overage-settings` and the policy
+  round-trips (restored afterward).
+The funded half (fund → consume → refill/reactivate → meter overage) is
+deferred to T3-BILL-3 above, blocked by the same staging Stripe live-mode /
+E2B-webhook findings. Test: `tests/release/src/scenarios/t3-bill-4.ts`.
+
 ---
 
 ## Tier 4 — upgrade path
@@ -713,3 +751,28 @@ current behavior as known-bug expected-fail):
    `ensure_free_trial_v2_grant` silently returns when the account has no
    linked GitHub identity — looks broken to the user. (UX severity, not
    correctness.)
+
+## Staging infra findings (2026-07-10) — block the tier-3 billing funded lane
+
+Surfaced building T3-BILL-4 / trying to enroll the durable staging org.
+
+4. **Staging Stripe is in LIVE mode.** `proliferate-staging-server`'s
+   `STRIPE_SECRET_KEY` is a `sk_live_` key and a `cloud-checkout` returns a
+   `cs_live_` session (verified). The tier-3 billing ruling assumes a test-mode
+   deployment (card 4242, drain/top-up teardown), so the durable org cannot be
+   enrolled or funded on staging without a real charge — NOT done, per the
+   test-mode-only rule. Ruling needed: point staging at a Stripe **test-mode**
+   key (+ test price ids for cloud-monthly / pro / refill), or fund-then-drain
+   the durable org on a live test clock. Until then T3-BILL-3 and the funded
+   half of the lifecycle stay blocked; T3-BILL-4 asserts only the reachable
+   exhaustion-enforcement contract.
+5. **Staging E2B webhooks all fail signature validation.** E2B delivers to
+   `POST /api/v1/cloud/webhooks/e2b` (source 34.177.112.204) but every request
+   returns **401 `invalid_webhook_signature`** — 239 in 5 days, zero 2xx. The
+   server computes `base64(sha256(secret + body))` (`e2b_webhooks.py`) against
+   `E2B_WEBHOOK_SIGNATURE_SECRET`; the configured secret does not match what E2B
+   signs with (E2B's dashboard never surfaced a signing secret). Consequence:
+   `usage_segment` rows are never opened/closed on staging, so compute metering
+   is dead there regardless of billing state. Fix: obtain/rotate the real E2B
+   signing secret (or confirm E2B's actual signing scheme) and reconcile with
+   `verify_e2b_webhook_signature`.

--- a/tests/release/scripts/billing_probe.py
+++ b/tests/release/scripts/billing_probe.py
@@ -51,10 +51,12 @@ from proliferate.db.models.cloud.agent_gateway import AgentLlmUsageEvent  # noqa
 async def _subjects_for_user(db, user_id) -> dict[str, str]:
     """Resolve the user's personal + (best-effort) org billing subjects.
 
-    Compute segments bill the *personal* subject and LLM events bill the *org*
-    subject where enrolled — the known attribution split
-    (scenarios.md#T3-BILL-1, findings 6/10). Returning both lets the scenario
-    assert each side against the subject the product actually used.
+    Since #1047, compute AND LLM both bill the *org* subject where the user has
+    a current membership (org Stripe customer + org grant pool), and personal
+    only for an org-less user — the paying subject is resolved from the same
+    membership lookup that stamps ``usage_segment.organization_id`` (#1028), so
+    the two never disagree. Returning both subjects lets the scenario assert an
+    org-member segment invoices the org subject, not personal.
     """
     rows = (
         await db.execute(select(BillingSubject).where(BillingSubject.user_id == user_id))
@@ -113,15 +115,17 @@ async def meter_records(email: str, since_seconds: int) -> dict:
         return {
             "userId": str(user.id),
             "subjects": subjects,
-            # usage_segment carries organization_id since #1028 (merged) —
-            # attribution/enforcement scope only, billing_subject_id on the
-            # segment stays the owner's personal subject. Surfaced so the
-            # scenario asserts the as-built personal-subject attribution.
+            # usage_segment carries organization_id since #1028; since #1047 the
+            # segment's billing_subject_id is the ORG subject for an org member
+            # (personal only when org-less). Surfaced so the scenario asserts an
+            # org segment invoices the org subject (per-segment organizationId
+            # below).
             "usageSegmentHasOrgColumn": hasattr(UsageSegment, "organization_id"),
             "usageSegments": [
                 {
                     "id": str(s.id),
                     "billingSubjectId": str(s.billing_subject_id),
+                    "organizationId": str(s.organization_id) if s.organization_id else None,
                     "sandboxId": str(s.sandbox_id),
                     "startedAt": s.started_at.isoformat() if s.started_at else None,
                     "endedAt": s.ended_at.isoformat() if s.ended_at else None,

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -28,12 +28,16 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
   {
     name: "RELEASE_E2E_SERVER_URL",
     description:
-      "Publicly reachable API base URL for the target lane. Staging satisfies this " +
-      "directly; a local --lane=local run needs a tunnel (e.g. ngrok) fronting " +
-      "the local profile's API port, since sandboxes must call back into it.",
+      "API base URL for the target lane, INCLUDING the deployment's api path prefix but not the " +
+      "route's own /auth or /v1 segment — scenarios write prefix-relative paths (/auth/…, /v1/…). " +
+      "Local has an empty api prefix, so this is the origin (http://127.0.0.1:8086). Staging's api " +
+      "prefix is /api, so this is https://staging-app.proliferate.com/api (the identity router mounts " +
+      "at {prefix}/auth and the v1 routers at {prefix}/v1, so /api is required for both to resolve). " +
+      "A local --lane=local run additionally needs a tunnel fronting the API port so sandboxes can " +
+      "call back into it.",
     whereItLives:
-      "Staging: the known staging API URL (see specs/developing/deploying/ci-cd.md). " +
-      "Local: printed by the tunnel tool when `make run PROFILE=<name>` is fronted by one.",
+      "Staging: https://staging-app.proliferate.com/api (origin + /api prefix). " +
+      "Local: the profile's API origin, printed by the tunnel tool when `make run PROFILE=<name>` is fronted by one.",
     secret: false,
   },
   {
@@ -137,10 +141,15 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
   {
     name: "RELEASE_E2E_DURABLE_ORG_ID",
     description:
-      "Organization id owning the durable user's account. Used as the inviting org when " +
-      "the fresh-user fixture mints a new account (invitation-gated registration is the " +
-      "only self-serve password-registration path in code today).",
-    whereItLives: "Read from the durable user's `GET /v1/organizations` response once, then pinned here.",
+      "Organization id owning the durable user's account. Used (a) as the inviting org when the " +
+      "fresh-user fixture mints a new account (invitation-gated registration), and (b) by T3-BILL-3 " +
+      "as the org whose billing lifecycle is asserted (it also falls back to the durable user's single " +
+      "owned org when unset). Local and staging have DIFFERENT durable orgs, so this is set per lane " +
+      "(a `staging` GitHub Actions variable, not a repo-wide one).",
+    whereItLives:
+      "Read from the durable user's `GET /v1/organizations` response once, then pinned. Staging value " +
+      "(the durable `proliferate-e2e-bot` user's owned org): recorded as the `RELEASE_E2E_DURABLE_ORG_ID` " +
+      "variable in the GitHub `staging` environment. Local: seeded per run by the CLI (cli/run.ts).",
     secret: false,
   },
   {

--- a/tests/release/src/fixtures/billing-http.ts
+++ b/tests/release/src/fixtures/billing-http.ts
@@ -1,0 +1,165 @@
+/**
+ * Billing HTTP fixture for the tier-3 billing lifecycle scenarios that run
+ * against a real deployment (T3-BILL-3, `--lane staging`).
+ *
+ * T3-BILL-1 / T3-BILL-2 read the billing ledger directly from the local
+ * profile DB (`billing_probe.py`, via `RELEASE_E2E_LOCAL_DATABASE_URL`) because
+ * the local server exposes those tables and the durable local user is
+ * password-only. That seam is unusable against staging: the staging DB is
+ * VPC-only, and staging's durable user (`proliferate-e2e-bot`) is a real
+ * GitHub-OAuth account that passes `current_product_user`, so the honest way to
+ * observe staging billing is the same billing HTTP surface a real client uses —
+ * `GET /v1/billing/{overview,cloud-plan,usage/summary,llm-balance}` and the
+ * checkout / overage-settings mutations. This module wraps those routes, owner
+ * -scoped (personal or a specific org) via the `?ownerScope=…&organizationId=…`
+ * query the server reads in `current_owner_context`.
+ *
+ * Path convention: `serverUrl` (RELEASE_E2E_SERVER_URL) already includes the
+ * deployment's api prefix, so paths are written prefix-relative (`/v1/billing/…`).
+ * Local has an empty api prefix (serverUrl `http://127.0.0.1:8086`); staging's
+ * prefix is `/api` (serverUrl `https://staging-app.proliferate.com/api`), so the
+ * same `/v1/billing/overview` resolves correctly on both — identical to how
+ * `identity.ts` writes `/auth/…` and `/v1/organizations/…`.
+ */
+
+import { ApiClient } from "./http.js";
+
+export type OwnerScope = "personal" | "organization";
+
+export interface OwnerSelection {
+  ownerScope: OwnerScope;
+  /** Required when ownerScope is "organization". */
+  organizationId?: string;
+}
+
+/** Subset of `BillingOverview` / `CloudPlanInfo` this runner asserts on. */
+export interface BillingOverview {
+  plan: string;
+  billingMode: string;
+  remainingHours: number;
+  includedHours: number;
+  usedHours: number;
+  overQuota: boolean;
+  isPaidCloud: boolean;
+  paymentHealthy: boolean;
+  overageEnabled: boolean;
+  startBlocked: boolean;
+  startBlockReason: string | null;
+  activeSpendHold: boolean;
+  holdReason: string | null;
+}
+
+export interface UsageSummary {
+  computeUsedSecondsMtd: number;
+  computeRemainingSeconds: number;
+  llmUsedUsdMtd: number;
+  llmRemainingUsd: number;
+  computeLimit: number | null;
+  llmLimit: number | null;
+  canSelfServeTopUp: boolean;
+}
+
+export interface LlmBalance {
+  grantedUsd: number;
+  usedUsd: number;
+  remainingUsd: number;
+}
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  membership?: { role: string; status: string };
+}
+
+export interface OverageSettingsResponse {
+  overageEnabled: boolean;
+  overageCapCentsPerSeat: number | null;
+}
+
+function ownerQuery(owner: OwnerSelection): string {
+  if (owner.ownerScope === "personal") {
+    return "?ownerScope=personal";
+  }
+  if (!owner.organizationId) {
+    throw new Error("ownerQuery: organizationId is required for organization scope.");
+  }
+  return `?ownerScope=organization&organizationId=${encodeURIComponent(owner.organizationId)}`;
+}
+
+/** Small typed client over the billing HTTP surface for one authenticated session. */
+export class BillingHttpClient {
+  private readonly client: ApiClient;
+
+  constructor(serverUrl: string, accessToken: string) {
+    this.client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(accessToken);
+  }
+
+  /** Orgs the authenticated user belongs to (used to resolve the durable org). */
+  async organizations(): Promise<OrganizationSummary[]> {
+    const response = await this.client.get<{ organizations: OrganizationSummary[] }>("/v1/organizations");
+    return response.organizations ?? [];
+  }
+
+  overview(owner: OwnerSelection): Promise<BillingOverview> {
+    return this.client.get<BillingOverview>(`/v1/billing/overview${ownerQuery(owner)}`);
+  }
+
+  cloudPlan(owner: OwnerSelection): Promise<BillingOverview> {
+    return this.client.get<BillingOverview>(`/v1/billing/cloud-plan${ownerQuery(owner)}`);
+  }
+
+  usageSummary(owner: OwnerSelection): Promise<UsageSummary> {
+    return this.client.get<UsageSummary>(`/v1/billing/usage/summary${ownerQuery(owner)}`);
+  }
+
+  llmBalance(owner: OwnerSelection): Promise<LlmBalance> {
+    return this.client.get<LlmBalance>(`/v1/billing/llm-balance${ownerQuery(owner)}`);
+  }
+
+  /** Sets the overage policy for the owner (reversible; scenarios restore it). */
+  setOverage(
+    owner: OwnerSelection,
+    enabled: boolean,
+    capCentsPerSeat?: number | null,
+  ): Promise<OverageSettingsResponse> {
+    return this.client.post<OverageSettingsResponse>("/v1/billing/overage-settings", {
+      enabled,
+      capCentsPerSeat: capCentsPerSeat ?? null,
+      ownerScope: owner.ownerScope,
+      organizationId: owner.ownerScope === "organization" ? owner.organizationId : null,
+    });
+  }
+
+  /** Raw cloud-checkout create — returns the Stripe URL so the caller can detect test vs live mode. */
+  cloudCheckout(owner: OwnerSelection): Promise<{ url: string }> {
+    const body =
+      owner.ownerScope === "organization"
+        ? { ownerScope: "organization", organizationId: owner.organizationId }
+        : {};
+    return this.client.post<{ url: string }>("/v1/billing/cloud-checkout", body);
+  }
+}
+
+/** True when a Stripe checkout URL is a TEST-mode session (never mutate a live one). */
+export function isStripeTestModeUrl(url: string): boolean {
+  return url.includes("cs_test_") || url.includes("/test/");
+}
+
+/** Resolves the durable org for the authenticated user: the env override, else the one owned org. */
+export function resolveDurableOrgId(
+  organizations: OrganizationSummary[],
+  envOverride: string | undefined,
+): string | undefined {
+  const override = envOverride?.trim();
+  if (override) {
+    return override;
+  }
+  const owned = organizations.filter((org) => org.membership?.role === "owner");
+  if (owned.length === 1) {
+    return owned[0].id;
+  }
+  if (organizations.length === 1) {
+    return organizations[0].id;
+  }
+  return undefined;
+}

--- a/tests/release/src/fixtures/billing.ts
+++ b/tests/release/src/fixtures/billing.ts
@@ -7,18 +7,22 @@ import path from "node:path";
  *
  * `ORG_COMPUTE_ATTRIBUTION_FIXED` is the single flag governing the compute
  * attribution assertion, mirroring `GITHUB_LINK_GATE_WORKAROUND_ACTIVE` in
- * `identity.ts`. PR #1028 (org compute attribution — nullable
- * `usage_segment.organization_id`, stamped at segment-open from the owner's
- * membership) merged 2026-07-06: `usage_segment` now carries `organization_id`
- * and org/per-user compute-budget caps enforce off it. That is attribution and
- * enforcement *scope* only — who pays did not change. `billing_subject_id` on
- * the segment stays the workspace owner's *personal* billing subject in both
- * the pre- and post-#1028 worlds; #1028's PR body explicitly defers "invoice
- * org compute to the org subject" as an open question. `true` here just means
- * the org-attribution column/enforcement exists to assert against.
+ * `identity.ts`. Two merges shaped it:
+ *  - #1028 (2026-07-06) added the nullable `usage_segment.organization_id`
+ *    column, stamped at segment-open from the owner's current membership, and
+ *    keyed org/per-user compute-budget caps off it — attribution/enforcement
+ *    *scope*. At that point who-pays had NOT changed yet.
+ *  - #1047 (2026-07-09) changed who-pays: `resolve_billing_subject_id_for_user`
+ *    now derives the paying subject from the same membership lookup, so an org
+ *    member's compute bills the ORG billing subject (org Stripe customer + org
+ *    grant pool), matching LLM. `billing_subject_id` and `organization_id` on a
+ *    segment can no longer disagree. Org-less users still bill personal.
+ * `true` here means org compute is billed to the org subject (both merges
+ * landed), so the scenario asserts org-member segments invoice the org subject
+ * — not the stale "compute always bills personal" behavior.
  *
- * LLM events are unaffected by any of this: they carry `organization_id`
- * today and are correctly org-attributed where the subject is enrolled.
+ * LLM events attribute the same way: they carry `organization_id` and bill the
+ * org subject where the member is enrolled, personal otherwise.
  */
 export const ORG_COMPUTE_ATTRIBUTION_FIXED = true;
 
@@ -31,6 +35,8 @@ export interface MeterRecords {
   usageSegments: Array<{
     id: string;
     billingSubjectId: string;
+    /** #1028 attribution column; #1047 makes billingSubjectId agree with it for org members. */
+    organizationId: string | null;
     sandboxId: string;
     startedAt: string | null;
     endedAt: string | null;

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -10,6 +10,7 @@ import { t3Repo1 } from "./t3-repo-1.js";
 import { t3Int1 } from "./t3-int-1.js";
 import { t3Bill1 } from "./t3-bill-1.js";
 import { t3Bill2 } from "./t3-bill-2.js";
+import { t3Bill4 } from "./t3-bill-4.js";
 import { t4Cloud1 } from "./upgrade/t4-cloud-1.js";
 import { t4Desktop1 } from "./upgrade/t4-desktop-1.js";
 
@@ -30,6 +31,7 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   t3Int1,
   t3Bill1,
   t3Bill2,
+  t3Bill4,
   t4Cloud1,
   t4Desktop1,
 ];

--- a/tests/release/src/scenarios/t3-bill-1.ts
+++ b/tests/release/src/scenarios/t3-bill-1.ts
@@ -14,19 +14,24 @@ import { ORG_COMPUTE_ATTRIBUTION_FIXED, runBillingProbe, type MeterRecords } fro
  * with the credit balance decremented, and (b) a closed `usage_segment`
  * (opened/closed by the E2B webhooks, not a timer) with the accounting pass
  * draining the corresponding grant seconds. Attribution must be asserted
- * as-built: compute → the workspace owner's PERSONAL subject (unchanged by
- * #1028 — invoicing org compute to the org subject is an explicitly deferred
- * open question there); LLM → the ORG subject where enrolled.
- * ORG_COMPUTE_ATTRIBUTION_FIXED tracks the org-attribution *column/enforcement*
- * capability (#1028, merged) — true on this branch.
+ * as-built. As of #1047 (merged) BOTH tracks attribute the same way: a user
+ * with a current org membership bills the ORG subject (org Stripe customer,
+ * org grant pool) for compute AND LLM; an org-less user bills personal. #1047
+ * resolves the paying subject at segment-open from the same membership lookup
+ * #1028 uses to stamp `usage_segment.organization_id`, so `billing_subject_id`
+ * and `organization_id` can never disagree — the earlier "compute always bills
+ * the workspace owner's personal subject" behavior is gone.
+ * ORG_COMPUTE_ATTRIBUTION_FIXED tracks that org compute now bills the org
+ * subject (#1028 column + #1047 who-pays) — true on this branch.
  *
  * Reachable now (real, cheap): the ledger reader
  * (`tests/release/scripts/billing_probe.py`) reads the durable user's meter
  * records and grants directly from the profile DB, and this scenario asserts
  * the branch's compute-attribution *capability* (`usage_segment` has an
  * `organization_id` column, per merged #1028) against
- * ORG_COMPUTE_ATTRIBUTION_FIXED — the "assert current behavior as-built" the
- * contract requires.
+ * ORG_COMPUTE_ATTRIBUTION_FIXED, plus that any compute segment carrying an
+ * `organization_id` invoices the org subject (not personal) per #1047 — the
+ * "assert current behavior as-built" the contract requires.
  *
  * Blocked (per lane, reported not skipped) for PRODUCING new consumption:
  * - local lane / LLM half: no `RELEASE_E2E_GATEWAY_TEST_KEY` exists, so a local
@@ -55,7 +60,7 @@ export const t3Bill1: ScenarioDefinition = {
     runtimeLane === "local"
       ? { description: "produce real LLM usage via a gateway-keyed session → assert agent_llm_usage_event rows + credit decrement (LLM half)" }
       : { description: "keep a real cloud sandbox running an interval → assert a closed usage_segment + grant drain (compute half)" },
-    { description: "assert attribution: compute → personal subject; LLM → org subject where enrolled" },
+    { description: "assert attribution (#1047): org-member compute + LLM → org subject; org-less user → personal" },
   ],
   run: async (ctx) => {
     if (ctx.dryRun) {
@@ -74,13 +79,38 @@ export const t3Bill1: ScenarioDefinition = {
       `T3-BILL-1: usage_segment.organization_id presence (${meter.usageSegmentHasOrgColumn}) must match ` +
         `ORG_COMPUTE_ATTRIBUTION_FIXED (${ORG_COMPUTE_ATTRIBUTION_FIXED}) — #1028 is merged so this must be true`,
     );
+    // #1047: org compute bills the ORG subject (org Stripe customer + org grant
+    // pool), matching LLM. Assert it as-built rather than pinning the old
+    // personal-subject behavior: any compute segment stamped with an
+    // organization_id must be invoiced to the org's billing subject, never the
+    // owner's personal subject.
+    const orgSubjectId = meter.subjects.organization;
+    const personalSubjectId = meter.subjects.personal;
+    for (const segment of meter.usageSegments) {
+      const org = segment.organizationId;
+      if (!org) {
+        continue; // org-less user's segment — stays personal, nothing to check
+      }
+      assert.notEqual(
+        segment.billingSubjectId,
+        personalSubjectId,
+        `T3-BILL-1: #1047 — compute segment ${segment.id} carries organization_id ${org} but is invoiced ` +
+          `to the owner's personal subject (${personalSubjectId}); it must bill the org subject`,
+      );
+      if (orgSubjectId) {
+        assert.equal(
+          segment.billingSubjectId,
+          orgSubjectId,
+          `T3-BILL-1: #1047 — org compute segment ${segment.id} must bill the org subject ${orgSubjectId}`,
+        );
+      }
+    }
     console.log(
       `[T3-BILL-1/${ctx.runtimeLane}] baseline: ${meter.usageSegments.length} segment(s), ` +
         `${meter.llmUsageEvents.length} llm event(s), ${meter.grants.length} grant(s); ` +
-        // #1028 added org attribution/enforcement scope only — compute still
-        // bills the personal subject (invoicing org compute to the org
-        // subject is an explicitly deferred open question in #1028).
-        `compute bills the personal subject`,
+        // #1047: org compute now bills the org subject (org grant pool),
+        // matching LLM; org-less users still bill personal.
+        `org-member compute + LLM bill the org subject`,
     );
 
     if (ctx.runtimeLane === "local") {

--- a/tests/release/src/scenarios/t3-bill-2.ts
+++ b/tests/release/src/scenarios/t3-bill-2.ts
@@ -30,12 +30,14 @@ import { runBillingProbe, type DrainGrantsResult, type MeterRecords } from "../f
  *   6. trigger-driven work (workflow/automation) that would start a sandbox.
  * Then refill → sandbox resumable, gateway serves again, new workspaces allowed.
  *
- * The live start gate is `assert_cloud_sandbox_resume_allowed` on the
- * resume/connect path (`authorize_sandbox_start` is dead code) — assert against
- * that, never the dead function. NOTE: that enforcement call site is on `main`,
- * not on this runner branch (6 commits behind); it is reached through the same
- * `current_product_user`-gated resume route, so it is not independently
- * assertable here yet.
+ * The live start gate is `assert_cloud_sandbox_resume_allowed_for_owner`, now
+ * (post-#1036, merged) wired into the service layer so BOTH `/cloud-sandbox/wake`
+ * and `/cloud-sandbox/ensure` inherit it before staging a row (`authorize_sandbox_start`
+ * remains dead code — assert against the wired gate, never the dead function).
+ * Its owner-subject resolution is #1047's (org member → org subject), so a hold
+ * on the org grant pool blocks the member's resume. T3-BILL-3 asserts this gate
+ * live against staging (`--lane staging`); this local-lane scenario still needs
+ * a funded-then-drained org to exercise it end to end.
  *
  * Reachable now (real): the exhaustion SETUP — `billing_probe.py drain-grants`
  * zeroes the durable user's grant seconds directly, and this scenario asserts

--- a/tests/release/src/scenarios/t3-bill-4.ts
+++ b/tests/release/src/scenarios/t3-bill-4.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "./types.js";
+import { ScenarioBlockedError } from "./types.js";
+import { ApiClient, ApiRequestError } from "../fixtures/http.js";
+import {
+  assertDurableIdentityAvailableForLane,
+  loginDurableUserForLane,
+} from "../fixtures/lane-identity.js";
+import {
+  BillingHttpClient,
+  resolveDurableOrgId,
+  type OwnerSelection,
+} from "../fixtures/billing-http.js";
+
+/**
+ * T3-BILL-4 — org billing lifecycle against the real deployment: the
+ * out-of-credits enforcement contract, asserted live.
+ * specs/developing/testing/scenarios.md#T3-BILL-4
+ *
+ * The billing ruling (Pablo 2026-07-10) is a hand-rolled durable org walking
+ * the full lifecycle: sign up as an org → upgrade → credits granted → consume
+ * (LLM + compute) → exhaustion behavior → refill/top-up reactivates → overage
+ * on → overage bills. This scenario owns the parts that are reachable for real
+ * against staging today through the billing HTTP surface a client uses (the
+ * ledger DB seam T3-BILL-1/2 use is local-only — the staging DB is VPC-only,
+ * and the durable staging user `proliferate-e2e-bot` is a GitHub-OAuth account
+ * that passes `current_product_user`).
+ *
+ * VERIFIED GREEN here (the ruling's "exhaustion behavior" + "no access after
+ * money bites" clause), against the durable staging org's exhausted subject:
+ *  - the enumerated out-of-credits state on the billing surfaces: cloud-plan /
+ *    overview report `startBlocked=true`, `holdReason=credits_exhausted`,
+ *    remaining hours 0; `llm-balance.remainingUsd=0`;
+ *  - the LIVE compute start gate (#1036, wired into the service layer):
+ *    `POST /cloud-sandbox/ensure` is refused with a 402
+ *    `billing_credits_exhausted` and no sandbox is created (the gate fires
+ *    before the row insert);
+ *  - the #1047 attribution split as a positive contrast: the org member's
+ *    compute + LLM bill the ORG subject (exhausted), while the same user's
+ *    PERSONAL subject still carries its free grant — proving org work does not
+ *    silently drain personal credits;
+ *  - overage can be turned on for the org via `overage-settings` and the policy
+ *    round-trips (restored afterward).
+ *
+ * DEFERRED (documented, not a phantom blocked-run — the enforcement half above
+ * is a complete positive contract and passes):
+ *  - funding the org → consuming → refill/reactivate → metering overage usage
+ *    cannot run against staging today. Staging's Stripe is in LIVE mode (a
+ *    `cloud-checkout` returns a `cs_live_` session), so a test-mode top-up with
+ *    card 4242 is impossible and a real charge is out of scope; org
+ *    `cloud-checkout` is additionally gated (`org_pro_billing_disabled`, pro
+ *    billing off on staging) and personal `refill-checkout` is unconfigured
+ *    (`stripe_refill_price_unconfigured`). Compute-segment metering is also
+ *    broken on staging independently: E2B delivers webhooks but every one 401s
+ *    (`invalid_webhook_signature`), so `usage_segment` rows never open/close.
+ *  - the LLM-side gateway key-withheld path (`agent_gateway_credits_exhausted`,
+ *    #1103): the standalone RELEASE_E2E_GATEWAY_TEST_KEY has its own budget, not
+ *    the org's, so it cannot demonstrate the org's virtual-key withholding.
+ * These need a test-mode Stripe deployment (or the durable org funded then
+ * drained on a test clock) and a working E2B webhook secret.
+ */
+export const t3Bill4: ScenarioDefinition = {
+  id: "T3-BILL-4",
+  title: "org billing lifecycle — out-of-credits enforcement, live",
+  registryFlowRef: "specs/developing/testing/scenarios.md#T3-BILL-4",
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user (lane-aware: staging rotates the seeded session)" },
+    { description: "resolve the durable org (RELEASE_E2E_DURABLE_ORG_ID, else the one owned org)" },
+    { description: "assert the org subject is in the enumerated credits-exhausted state (cloud-plan/overview/llm-balance)" },
+    { description: "assert the personal subject still carries its free grant (#1047 org work does not drain personal)" },
+    { description: "LIVE compute gate: POST /cloud-sandbox/ensure → 402 billing_credits_exhausted, no sandbox created (#1036)" },
+    { description: "turn overage on for the org via overage-settings; assert it round-trips; restore" },
+    { description: "DEFERRED: fund → consume → refill → meter overage (staging Stripe is LIVE mode; see docstring)" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    if (ctx.targetLane !== "staging") {
+      throw new ScenarioBlockedError(
+        "T3-BILL-4: staging-only. It asserts a real deployment's billing HTTP surface (the durable staging " +
+          "org's exhausted subject); the local lane's ledger is covered by T3-BILL-1/2's DB probe. Run with " +
+          "`--lane staging`.",
+      );
+    }
+
+    const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
+    assertDurableIdentityAvailableForLane("T3-BILL-4", ctx);
+    const session = await loginDurableUserForLane(ctx, serverUrl);
+    const billing = new BillingHttpClient(serverUrl, session.accessToken);
+
+    const orgs = await billing.organizations();
+    const orgId = resolveDurableOrgId(orgs, process.env.RELEASE_E2E_DURABLE_ORG_ID);
+    if (!orgId) {
+      throw new ScenarioBlockedError(
+        "T3-BILL-4: could not resolve the durable org id — set RELEASE_E2E_DURABLE_ORG_ID (the staging org the " +
+          `durable user owns), or ensure the user owns exactly one org (found ${orgs.length}).`,
+      );
+    }
+    const org: OwnerSelection = { ownerScope: "organization", organizationId: orgId };
+    const personal: OwnerSelection = { ownerScope: "personal" };
+
+    // --- Enumerated out-of-credits state on the org subject (the ruling's
+    //     "exhaustion behavior" / "no access after money bites"). ---
+    const orgOverview = await billing.overview(org);
+    if (!orgOverview.startBlocked) {
+      // The durable org's steady state is exhausted (it gets no free grant and
+      // cannot be test-funded on staging). A non-blocked org means someone
+      // funded it out of band; report rather than assert a confusing red.
+      throw new ScenarioBlockedError(
+        `T3-BILL-4: the durable org (${orgId}) is not in the exhausted state this scenario asserts against ` +
+          `(startBlocked=${orgOverview.startBlocked}, remainingHours=${orgOverview.remainingHours}). It was ` +
+          "funded out of band; drain it (teardown top-up model) before re-running.",
+      );
+    }
+    assert.equal(
+      orgOverview.holdReason,
+      "credits_exhausted",
+      `T3-BILL-4: exhausted org hold reason must be the enumerated credits_exhausted, got ${orgOverview.holdReason}`,
+    );
+    assert.equal(orgOverview.startBlockReason, "credits_exhausted", "T3-BILL-4: startBlockReason must be credits_exhausted");
+    assert.equal(orgOverview.remainingHours, 0, "T3-BILL-4: exhausted org must have 0 remaining hours");
+
+    const orgLlm = await billing.llmBalance(org);
+    assert.equal(orgLlm.remainingUsd, 0, "T3-BILL-4: exhausted org must have 0 remaining LLM credit");
+
+    const orgUsage = await billing.usageSummary(org);
+    assert.equal(orgUsage.computeRemainingSeconds, 0, "T3-BILL-4: exhausted org must have 0 remaining compute seconds");
+
+    // --- #1047 contrast: the same user's personal subject keeps its free
+    //     grant, proving org work bills the org pool, not personal credits. ---
+    const personalOverview = await billing.overview(personal);
+    assert.ok(
+      personalOverview.remainingHours > 0,
+      `T3-BILL-4: the durable user's personal subject should still carry its free grant (#1047 org work bills ` +
+        `the org subject, not personal); got remainingHours=${personalOverview.remainingHours}`,
+    );
+
+    // --- LIVE compute start gate (#1036): ensure/wake refused with the
+    //     enumerated 402, and NO sandbox created (gate fires before insert). ---
+    const client = new ApiClient({ baseUrl: serverUrl }).withBearerToken(session.accessToken);
+    let refusedCode: string | undefined;
+    let ensured: unknown;
+    try {
+      ensured = await client.post("/v1/cloud/cloud-sandbox/ensure", {});
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 402) {
+        refusedCode = (error.body as { detail?: { code?: string } })?.detail?.code;
+      } else {
+        throw error;
+      }
+    }
+    assert.equal(
+      refusedCode,
+      "billing_credits_exhausted",
+      `T3-BILL-4: the live compute start gate (POST /cloud-sandbox/ensure) must be refused with a 402 ` +
+        `billing_credits_exhausted while the org is exhausted — instead got ${JSON.stringify(ensured ?? refusedCode)}`,
+    );
+    const afterSandbox = await client.get<unknown>("/v1/cloud/cloud-sandbox");
+    assert.equal(
+      afterSandbox,
+      null,
+      "T3-BILL-4: the refused ensure must not create a sandbox (the gate fires before the row insert, #1036)",
+    );
+
+    // --- Overage on/off round-trip for the org (the ruling's "turn on overage
+    //     billing"), reversible: capture, enable, assert, restore. ---
+    const before = await billing.overview(org);
+    let restored = false;
+    try {
+      const enabled = await billing.setOverage(org, true);
+      assert.equal(enabled.overageEnabled, true, "T3-BILL-4: overage-settings must report overage enabled after turning it on");
+      const reread = await billing.overview(org);
+      assert.equal(reread.overageEnabled, true, "T3-BILL-4: overview must reflect the enabled overage policy");
+    } finally {
+      // Restore the org's original overage posture so the durable fixture is
+      // left as found (nightly re-runs, shared resource).
+      await billing.setOverage(org, before.overageEnabled);
+      restored = true;
+    }
+    assert.ok(restored, "T3-BILL-4: overage policy must be restored");
+
+    console.log(
+      `[T3-BILL-4/staging] verified live: org ${orgId} exhausted (credits_exhausted hold, 402 on ensure, no ` +
+        "sandbox created), personal subject still funded (#1047 split), overage toggle round-trips.",
+    );
+    console.log(
+      "[T3-BILL-4/staging] DEFERRED (not verifiable on staging today): fund→consume→refill→meter-overage — " +
+        "staging Stripe is LIVE mode (cloud-checkout returns cs_live_), org cloud-checkout is org_pro_billing_disabled, " +
+        "personal refill is stripe_refill_price_unconfigured, and E2B webhooks 401 (invalid_webhook_signature) so " +
+        "compute segments never open. Needs a test-mode Stripe deployment or a funded-then-drained org on a test clock.",
+    );
+  },
+};


### PR DESCRIPTION
## What

Tier-3 billing lifecycle work: a new staging-lane scenario that asserts the durable org's out-of-credits enforcement for real, plus the stale-assertion fixes the #1047 org-subject compute change requires.

### T3-BILL-4 — org billing lifecycle, out-of-credits enforcement (staging, green live)
Asserts the reachable half of the durable-org billing ruling against the real staging deployment, through the billing HTTP surface a client uses (the T3-BILL-1/2 ledger DB seam is local-only — staging's DB is VPC-only and its durable user is a GitHub-OAuth account that passes `current_product_user`):
- enumerated out-of-credits state on `cloud-plan`/`overview` (`startBlocked`, `holdReason=credits_exhausted`, 0 remaining hours) and `llm-balance` (`remainingUsd=0`);
- the live #1036 compute start gate: `POST /cloud-sandbox/ensure` → 402 `billing_credits_exhausted` with **no sandbox created** (gate fires before the row insert);
- the #1047 attribution split as a positive contrast: the org member's compute + LLM bill the ORG subject (exhausted) while the same user's personal subject keeps its free grant;
- overage turned on for the org via `overage-settings`, policy round-trips, then restored.

Verified **green live** against staging (`--lane staging`); the local lane reports blocked cleanly.

### #1047 fixes
Compute run under an org now bills the org subject, not the owner's personal subject. Updated the stale T3-BILL-1 attribution assertion (now asserts an org segment invoices the org subject), the `billing_probe.py` / `billing.ts` docstrings, and surfaced each segment's `organization_id` in the probe. Refreshed T3-BILL-2's note now that the #1036 resume gate is merged.

### Wiring
- Recorded the staging durable org id as the `RELEASE_E2E_DURABLE_ORG_ID` variable in the `staging` GitHub environment; the scenario also falls back to the durable user's single owned org.
- New `billing-http.ts` fixture; documented the `RELEASE_E2E_SERVER_URL` api-prefix convention (staging includes `/api`).
- Enabled the staging tier-3 CI lane (preflight-skips until the durable-user session secret is provisioned; refresh-token rotation in CI is still an open item).

## Findings (block the funded half — T3-BILL-3)
- **Staging Stripe is in LIVE mode.** A `cloud-checkout` returns a `cs_live_` session, so a test-mode top-up (card 4242) is impossible and a real charge is out of scope — the durable org was **not** enrolled. Org `cloud-checkout` is also gated (`org_pro_billing_disabled`) and personal `refill-checkout` is unconfigured. Needs a test-mode Stripe deployment or a fund-then-drain on a live test clock.
- **Staging E2B webhooks all fail signature validation.** E2B delivers to `/api/v1/cloud/webhooks/e2b` but every request 401s `invalid_webhook_signature` (239 in 5 days, zero 2xx) — the configured `E2B_WEBHOOK_SIGNATURE_SECRET` doesn't match E2B's signing, so `usage_segment` rows never open. Compute metering is dead on staging until the real signing secret is reconciled.

Both are documented in `scenarios.md` (open findings + the T3-BILL-3/4 sections).

## Test
- `pnpm typecheck` + `pnpm test` (49) green in `tests/release`.
- T3-BILL-4 run green live against staging; local lane blocked; full `--dry-run` across lanes clean.