### PR TITLE
test(release-e2e): assert funded billing lifecycle + Stripe test-mode swap live on staging (T3-BILL-3)

### DIFF
--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -610,19 +610,30 @@ and a small per-seat cap:
 Assert amounts end-to-end: seconds consumed → cents exported → Stripe event
 totals match (the fractional-cent remainder logic is under test here too).
 
-**Blocked on staging (2026-07-10):** cannot run against the current staging
-deployment. Staging's Stripe is in **LIVE mode** (a `cloud-checkout` returns a
-`cs_live_` session — verified), so a test-mode top-up with card 4242 is
-impossible and a real charge is out of scope; org `cloud-checkout` is
-additionally gated (`org_pro_billing_disabled` — pro billing is off on staging)
-and personal `refill-checkout` is unconfigured (`stripe_refill_price_unconfigured`).
-Compute-segment metering is independently broken: E2B delivers webhooks to
-`POST /api/v1/cloud/webhooks/e2b` but every one returns **401
-`invalid_webhook_signature`** (239 in 5 days, zero 2xx — the configured
-`E2B_WEBHOOK_SIGNATURE_SECRET` does not match what E2B signs with; E2B's
-dashboard never surfaced a signing secret), so `usage_segment` rows never open
-or close. Needs a test-mode Stripe deployment (or the durable org funded then
-drained on a test clock) and a working E2B webhook secret before it can run.
+**Status (2026-07-09): partially unblocked — the funded posture is now live,
+the metered AMOUNTS are still deferred.** Staging was swapped from `sk_live_` to
+the account's **test mode** (test price/meter ids, `PRO_BILLING_ENABLED=true`, a
+test-mode webhook endpoint at the billing webhook URL), which retires finding #4:
+`cloud-checkout` now returns test-mode Stripe URLs, the `org_pro_billing_disabled`
+gate is cleared, and the durable org was **funded through a Stripe test
+subscription** (card 4242 → the same `customer.subscription.created` /
+`invoice.paid` webhooks a real checkout fires → credits granted, verified via
+`/billing/overview`). The scenario (`tests/release/src/scenarios/t3-bill-3.ts`,
+`--lane staging`) asserts that reachable half: test-mode deployment posture +
+funded org + overage on/off round-trip. The **metered-overage AMOUNTS** stay
+deferred because finding #5 is still open — E2B webhooks to
+`POST /api/v1/cloud/webhooks/e2b` still all return **401
+`invalid_webhook_signature`** (zero 2xx), so `usage_segment` rows never open and
+no `proliferate_managed_cloud_overage_cents` meter event is emitted; and the LLM
+auto-top-up charge needs the org's own gateway key consumed (the standalone
+gateway test key has its own budget, per T3-BILL-4). Tier-2 T2-BILL-* proves the
+metered arithmetic against Stripe test clocks per-PR. Note also: with
+`PRO_BILLING_ENABLED=true`, personal `refill-checkout` returns
+`refill_checkout_disabled` (refills are a non-Pro-billing feature) — the Pro
+model uses subscription + overage + LLM auto-top-up instead. Durable-org tension:
+this scenario needs the org FUNDED while T3-BILL-4 needs it EXHAUSTED; the ruling
+gives the funded half here, so while funded T3-BILL-4 reports blocked (its own
+"funded out of band" guard), not red.
 
 ### T3-BILL-4: org billing lifecycle — out-of-credits enforcement, live
 Added 2026-07-10. The reachable half of the durable-org lifecycle ruling
@@ -756,19 +767,26 @@ current behavior as known-bug expected-fail):
 
 Surfaced building T3-BILL-4 / trying to enroll the durable staging org.
 
-4. **Staging Stripe is in LIVE mode.** `proliferate-staging-server`'s
-   `STRIPE_SECRET_KEY` is a `sk_live_` key and a `cloud-checkout` returns a
-   `cs_live_` session (verified). The tier-3 billing ruling assumes a test-mode
-   deployment (card 4242, drain/top-up teardown), so the durable org cannot be
-   enrolled or funded on staging without a real charge — NOT done, per the
-   test-mode-only rule. Ruling needed: point staging at a Stripe **test-mode**
-   key (+ test price ids for cloud-monthly / pro / refill), or fund-then-drain
-   the durable org on a live test clock. Until then T3-BILL-3 and the funded
-   half of the lifecycle stay blocked; T3-BILL-4 asserts only the reachable
-   exhaustion-enforcement contract.
-5. **Staging E2B webhooks all fail signature validation.** E2B delivers to
+4. **Staging Stripe was in LIVE mode — RESOLVED 2026-07-09 (swapped to test
+   mode).** `proliferate-staging-server` used to carry a `sk_live_`
+   `STRIPE_SECRET_KEY` and a `cloud-checkout` returned a `cs_live_` session, so
+   the durable org could not be funded without a real charge. Staging is now
+   pointed at the account's **test mode**: `STRIPE_SECRET_KEY` +
+   `STRIPE_WEBHOOK_SECRET` (Secrets Manager `proliferate/staging/server-app`)
+   are test-mode values, the `STRIPE_*_PRICE_ID` / meter-id / meter-event-name
+   task-def env vars point at the "Proliferate Cloud (Local Test)" test objects
+   (`scripts/stripe-setup-test-mode.mjs`'s catalog + a `proliferate_llm_topup_10usd_test`
+   price), `PRO_BILLING_ENABLED=true`, and a test-mode webhook endpoint is
+   registered at `…/api/v1/billing/webhooks/stripe`. Verified: `cloud-checkout`
+   returns test-mode URLs, `proBillingEnabled=true`, and the durable org was
+   funded through a Stripe test subscription (card 4242 → webhook grant → 20h /
+   pro plan). T3-BILL-3 now asserts this funded posture; T3-BILL-4's exhausted
+   contract now reports blocked while the org is funded.
+5. **Staging E2B webhooks all fail signature validation — STILL OPEN
+   (re-confirmed 2026-07-09).** E2B delivers to
    `POST /api/v1/cloud/webhooks/e2b` (source 34.177.112.204) but every request
-   returns **401 `invalid_webhook_signature`** — 239 in 5 days, zero 2xx. The
+   still returns **401 `invalid_webhook_signature`** (steady 401s in the last
+   few hours, zero 2xx). The
    server computes `base64(sha256(secret + body))` (`e2b_webhooks.py`) against
    `E2B_WEBHOOK_SIGNATURE_SECRET`; the configured secret does not match what E2B
    signs with (E2B's dashboard never surfaced a signing secret). Consequence:

--- a/tests/release/src/fixtures/billing-http.ts
+++ b/tests/release/src/fixtures/billing-http.ts
@@ -36,6 +36,8 @@ export interface OwnerSelection {
 export interface BillingOverview {
   plan: string;
   billingMode: string;
+  /** Whether the deployment has Pro (subscription) billing enabled (PRO_BILLING_ENABLED). */
+  proBillingEnabled?: boolean;
   remainingHours: number;
   includedHours: number;
   usedHours: number;
@@ -140,9 +142,20 @@ export class BillingHttpClient {
   }
 }
 
-/** True when a Stripe checkout URL is a TEST-mode session (never mutate a live one). */
+/**
+ * True when a Stripe URL was minted by a TEST-mode account. Covers both shapes
+ * staging's billing routes return: a `cs_test_` Checkout Session (an
+ * unsubscribed owner) and a `billing.stripe.com/p/session/test_…` customer
+ * portal (an already-subscribed owner — `cloud-checkout` redirects there). The
+ * test-mode swap is the whole point of this scenario, so recognise both.
+ */
 export function isStripeTestModeUrl(url: string): boolean {
-  return url.includes("cs_test_") || url.includes("/test/");
+  return url.includes("cs_test_") || url.includes("/test/") || url.includes("/session/test_");
+}
+
+/** True when a Stripe URL was minted by a LIVE-mode account (the pre-swap state finding #4 recorded). */
+export function isStripeLiveModeUrl(url: string): boolean {
+  return url.includes("cs_live_") || url.includes("/live/") || url.includes("/session/live_");
 }
 
 /** Resolves the durable org for the authenticated user: the env override, else the one owned org. */

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -10,6 +10,7 @@ import { t3Repo1 } from "./t3-repo-1.js";
 import { t3Int1 } from "./t3-int-1.js";
 import { t3Bill1 } from "./t3-bill-1.js";
 import { t3Bill2 } from "./t3-bill-2.js";
+import { t3Bill3 } from "./t3-bill-3.js";
 import { t3Bill4 } from "./t3-bill-4.js";
 import { t4Cloud1 } from "./upgrade/t4-cloud-1.js";
 import { t4Desktop1 } from "./upgrade/t4-desktop-1.js";
@@ -37,6 +38,7 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   t3Int1,
   t3Bill1,
   t3Bill2,
+  t3Bill3,
   t3Bill4,
   t3Sh1,
   t3Sh2,

--- a/tests/release/src/scenarios/t3-bill-3.ts
+++ b/tests/release/src/scenarios/t3-bill-3.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+
+import type { ScenarioDefinition } from "./types.js";
+import { ScenarioBlockedError } from "./types.js";
+import {
+  assertDurableIdentityAvailableForLane,
+  loginDurableUserForLane,
+} from "../fixtures/lane-identity.js";
+import {
+  BillingHttpClient,
+  isStripeLiveModeUrl,
+  isStripeTestModeUrl,
+  resolveDurableOrgId,
+  type OwnerSelection,
+} from "../fixtures/billing-http.js";
+
+/**
+ * T3-BILL-3 — the funded billing lifecycle against the real deployment, and
+ * the proof that staging now runs Stripe in TEST mode.
+ * specs/developing/testing/scenarios.md#T3-BILL-3
+ *
+ * Context (2026-07-09): staging was swapped from a `sk_live_` Stripe key to the
+ * account's test mode — the exact blocker finding #4 recorded (a `cloud-checkout`
+ * used to return a `cs_live_` session, so the durable org could not be funded
+ * without a real charge). With test mode wired (test price/meter ids,
+ * `PRO_BILLING_ENABLED=true`, a test-mode webhook endpoint at the billing
+ * webhook URL), the durable org was funded through a Stripe test subscription
+ * (card 4242) — the same customer.subscription.created / invoice.paid webhooks
+ * a real checkout fires — and credits landed. This scenario asserts, live
+ * against `--lane staging`, the half of the ruling that is reachable this way:
+ *
+ * VERIFIED GREEN (the ruling's "fund → credits granted" + test-mode posture):
+ *  - Pro billing is enabled on the deployment (`proBillingEnabled=true`) — the
+ *    `org_pro_billing_disabled` gate finding #4 recorded is cleared;
+ *  - a billing checkout/portal action returns a Stripe TEST-mode URL and never
+ *    a live one — the deployment's Stripe is in test mode (finding #4 retired);
+ *  - the durable org is funded: paid cloud, payment healthy, not start-blocked,
+ *    with remaining compute credit — the fund → credits-granted contract;
+ *  - overage can be turned on for the funded org via `overage-settings` and the
+ *    policy round-trips (restored afterwards).
+ *
+ * DEFERRED (documented, not a phantom pass — asserting these needs machinery
+ * that is not reachable from a nightly release run today):
+ *  - the metered-overage AMOUNTS (seconds consumed → cents exported → Stripe
+ *    event totals). Compute segments still never open on staging: E2B webhooks
+ *    to `POST /api/v1/cloud/webhooks/e2b` all 401 (`invalid_webhook_signature`,
+ *    finding #5 — unresolved as of 2026-07-09), so no `usage_segment` closes and
+ *    no `proliferate_managed_cloud_overage_cents` meter event is emitted.
+ *  - the LLM auto-top-up charge / fail-closed path. Driving the org's LLM
+ *    balance below the top-up threshold needs the org's own gateway virtual key
+ *    consumed for real; the standalone RELEASE_E2E_GATEWAY_TEST_KEY has its own
+ *    budget, not the org's (same limitation t3-bill-4 records).
+ * Tier-2 T2-BILL-* proves the metered-amount arithmetic against Stripe test
+ * clocks per-PR; this scenario proves the deployed test-mode funded posture.
+ *
+ * Note (durable-org tension): this scenario asserts the org FUNDED, while
+ * T3-BILL-4 asserts it EXHAUSTED — one durable org cannot satisfy both at once.
+ * The billing ruling gives the funded half to T3-BILL-3; while the org is
+ * funded, T3-BILL-4 reports blocked (its own "funded out of band" guard), not
+ * red.
+ */
+export const t3Bill3: ScenarioDefinition = {
+  id: "T3-BILL-3",
+  title: "funded billing lifecycle + test-mode deployment, live",
+  registryFlowRef: "specs/developing/testing/scenarios.md#T3-BILL-3",
+  lanes: ["sandbox"],
+  requiredEnv: ["RELEASE_E2E_SERVER_URL"],
+  plan: () => [
+    { description: "authenticate the durable user (lane-aware: staging rotates the seeded session)" },
+    { description: "resolve the durable org (RELEASE_E2E_DURABLE_ORG_ID, else the one owned org)" },
+    { description: "assert Pro billing is enabled on the deployment (org_pro_billing gate cleared)" },
+    { description: "assert a billing checkout/portal action returns a TEST-mode Stripe URL, never live (finding #4)" },
+    { description: "assert the org is funded: paid cloud, payment healthy, not blocked, remaining compute credit" },
+    { description: "turn overage on for the funded org via overage-settings; assert it round-trips; restore" },
+    { description: "DEFERRED: metered overage AMOUNTS (E2B webhooks 401, finding #5) + LLM auto-top-up (org key)" },
+  ],
+  run: async (ctx) => {
+    if (ctx.dryRun) {
+      return;
+    }
+    if (ctx.targetLane !== "staging") {
+      throw new ScenarioBlockedError(
+        "T3-BILL-3: staging-only. It asserts the real deployment's funded billing surface and that its Stripe " +
+          "runs in test mode (the durable staging org's test subscription); the local lane's ledger is covered by " +
+          "T3-BILL-1/2's DB probe. Run with `--lane staging`.",
+      );
+    }
+
+    const serverUrl = ctx.env.require("RELEASE_E2E_SERVER_URL");
+    assertDurableIdentityAvailableForLane("T3-BILL-3", ctx);
+    const session = await loginDurableUserForLane(ctx, serverUrl);
+    const billing = new BillingHttpClient(serverUrl, session.accessToken);
+
+    const orgs = await billing.organizations();
+    const orgId = resolveDurableOrgId(orgs, process.env.RELEASE_E2E_DURABLE_ORG_ID);
+    if (!orgId) {
+      throw new ScenarioBlockedError(
+        "T3-BILL-3: could not resolve the durable org id — set RELEASE_E2E_DURABLE_ORG_ID (the staging org the " +
+          `durable user owns), or ensure the user owns exactly one org (found ${orgs.length}).`,
+      );
+    }
+    const org: OwnerSelection = { ownerScope: "organization", organizationId: orgId };
+
+    // --- Pro billing gate cleared (finding #4's org_pro_billing_disabled). ---
+    const overview = await billing.overview(org);
+    assert.equal(
+      overview.proBillingEnabled,
+      true,
+      "T3-BILL-3: Pro billing must be enabled on the deployment (finding #4 org_pro_billing_disabled gate cleared)",
+    );
+
+    // --- The deployment's Stripe is in TEST mode (finding #4's cs_live_). A
+    //     subscribed org's cloud-checkout redirects to the customer portal, so
+    //     accept either a cs_test_ Checkout Session or a test-mode portal URL;
+    //     the load-bearing assertion is that it is never a LIVE-mode URL. ---
+    const { url } = await billing.cloudCheckout(org);
+    assert.equal(
+      isStripeLiveModeUrl(url),
+      false,
+      `T3-BILL-3: the deployment must not mint LIVE-mode Stripe URLs (finding #4: staging was cs_live_). Got ${url}`,
+    );
+    assert.equal(
+      isStripeTestModeUrl(url),
+      true,
+      `T3-BILL-3: the deployment's Stripe must be in test mode (cs_test_ / test-mode portal). Got ${url}`,
+    );
+
+    // --- Funded contract: fund → credits granted. The durable org carries a
+    //     Stripe test subscription; a fresh nightly should find it funded. If
+    //     it is not, report blocked (funding needs the out-of-band test
+    //     subscription — no self-serve checkout completion from a headless
+    //     nightly run) rather than a confusing red. ---
+    if (!overview.isPaidCloud || overview.startBlocked || overview.remainingHours <= 0) {
+      throw new ScenarioBlockedError(
+        `T3-BILL-3: the durable org (${orgId}) is not in the funded state this scenario asserts ` +
+          `(isPaidCloud=${overview.isPaidCloud}, startBlocked=${overview.startBlocked}, ` +
+          `remainingHours=${overview.remainingHours}). Its Stripe test subscription lapsed or was drained; ` +
+          "re-fund it (a test-mode cloud subscription on the org's Stripe customer) before re-running.",
+      );
+    }
+    assert.equal(overview.paymentHealthy, true, "T3-BILL-3: a funded org must report paymentHealthy");
+    assert.equal(overview.holdReason, null, "T3-BILL-3: a funded org must carry no spend hold");
+    assert.ok(
+      overview.remainingHours > 0,
+      `T3-BILL-3: a funded org must have remaining cloud hours, got ${overview.remainingHours}`,
+    );
+
+    const usage = await billing.usageSummary(org);
+    assert.ok(
+      usage.computeRemainingSeconds > 0,
+      `T3-BILL-3: a funded org must have remaining compute seconds, got ${usage.computeRemainingSeconds}`,
+    );
+
+    // --- Overage on/off round-trip for the funded org (reversible). ---
+    const before = await billing.overview(org);
+    try {
+      const enabled = await billing.setOverage(org, true);
+      assert.equal(enabled.overageEnabled, true, "T3-BILL-3: overage-settings must report overage enabled after turning it on");
+      const reread = await billing.overview(org);
+      assert.equal(reread.overageEnabled, true, "T3-BILL-3: overview must reflect the enabled overage policy");
+    } finally {
+      // Leave the org's overage posture as found (nightly re-runs, shared resource).
+      await billing.setOverage(org, before.overageEnabled);
+    }
+
+    console.log(
+      `[T3-BILL-3/staging] verified live: deployment Stripe is TEST mode (proBillingEnabled, non-live checkout URL), ` +
+        `org ${orgId} funded (paid cloud, ${overview.remainingHours}h remaining, payment healthy), overage toggle round-trips.`,
+    );
+    console.log(
+      "[T3-BILL-3/staging] DEFERRED (not verifiable on staging today): the metered-overage AMOUNTS — E2B webhooks " +
+        "still 401 (invalid_webhook_signature, finding #5) so usage_segment rows never open and no overage meter " +
+        "event is emitted — and the LLM auto-top-up charge, which needs the org's own gateway key consumed. Tier-2 " +
+        "T2-BILL-* proves the metered arithmetic against Stripe test clocks.",
+    );
+  },
+};


### PR DESCRIPTION
## What

Implements **T3-BILL-3** (`tests/release/src/scenarios/t3-bill-3.ts`) and records the staging Stripe **test-mode swap** that unblocks it.

Staging was swapped from a `sk_live_` Stripe key to the account's **test mode**: test price/meter ids (the `scripts/stripe-setup-test-mode.mjs` catalog + a new `proliferate_llm_topup_10usd_test` price), `PRO_BILLING_ENABLED=true`, and a test-mode webhook endpoint registered at the billing webhook URL. This retires staging-infra finding #4 (Stripe was in live mode): `cloud-checkout` now returns test-mode Stripe URLs, the `org_pro_billing_disabled` gate is cleared, and the durable org was funded through a Stripe test subscription (card 4242 → the same `customer.subscription.created` / `invoice.paid` webhooks a real checkout fires → credits granted, verified via `/billing/overview`).

## The scenario asserts (live, `--lane staging`, verified green)

- Pro billing enabled on the deployment (`proBillingEnabled=true`).
- A billing checkout/portal action returns a **test-mode** Stripe URL and never a live one.
- The durable org is **funded**: paid cloud, payment healthy, not start-blocked, remaining compute credit.
- Overage on/off **round-trips** for the funded org (restored afterward).

## Deferred (documented, not a phantom pass)

- The metered-overage **amounts** — staging-infra finding #5 is **still open**: E2B webhooks to `/api/v1/cloud/webhooks/e2b` still all return `401 invalid_webhook_signature`, so `usage_segment` rows never open and no overage meter event is emitted.
- The LLM auto-top-up charge — needs the org's own gateway virtual key consumed (the standalone gateway test key has its own budget).

Tier-2 `T2-BILL-*` proves the metered arithmetic against Stripe test clocks per-PR.

Durable-org tension: this scenario needs the org **funded** while T3-BILL-4 needs it **exhausted**; the billing ruling gives the funded half here, so while funded T3-BILL-4 reports blocked (its own guard), not red.

## Other changes

- `billing-http.ts`: broaden `isStripeTestModeUrl` to also recognise test-mode customer-portal URLs (a subscribed org's `cloud-checkout` redirects there), add `isStripeLiveModeUrl`, add `proBillingEnabled` to `BillingOverview`.
- `scenarios.md`: T3-BILL-3 note + findings #4 (resolved) / #5 (still open) updated to match reality.

Typecheck + harness fixture tests green; live `--lane staging` run: **1 green, 0 blocked, 0 red**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)