### PR TITLE
ci(release): let the runtime CDN publish job assume its AWS role

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -247,6 +247,11 @@ jobs:
     needs: [create-release]
     if: (github.event_name == 'push' || inputs.publish) && !inputs.dry_run
     runs-on: ubuntu-latest
+    permissions:
+      # OIDC role assumption for the downloads bucket, matching the desktop
+      # release's publish-updater job.
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem
The runtime-only hotfix (run 29065729972) got green Windows builds after #1107 but died on "Publish runtime + worker CDN trees": `configure-aws-credentials` could not load credentials. The job (added in #1091) assumes `AWS_DESKTOP_RELEASE_ROLE_ARN` via OIDC, but `release-runtime.yml` only declares `contents: write`, so the job never gets an OIDC token. It has never run before — #1091 landed after the last successful runtime release.

## Fix
Job-level `permissions: { id-token: write, contents: read }` on `publish-cdn`, matching `release-desktop.yml`'s `publish-updater`. Both callers (hotfix-production, nightly-release-train) already grant `id-token: write` at the workflow level, so the grant is within the caller's allowance.

## Verification
Config-only change; validated against the desktop workflow's working pattern. Proof is the next runtime hotfix run.