### PR TITLE
fix(desktop): drop the glass workspace header to 46px to match the right pane

### DIFF
--- a/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -6,7 +6,6 @@ import { RightPanelHeaderActions } from "@/components/workspace/shell/right-pane
 import { RightPanelHeaderEntryList } from "@/components/workspace/shell/right-panel/RightPanelHeaderEntryList";
 import { RightPanelNewTabMenu } from "@/components/workspace/shell/right-panel/RightPanelNewTabMenu";
 import { useRightPanelHeaderDrag } from "@/hooks/workspaces/ui/use-right-panel-header-drag";
-import { useTransparentChromeEnabled } from "@/hooks/theme/derived/use-transparent-chrome";
 import {
   type RightPanelHeaderEntryKey,
 } from "@/lib/domain/workspaces/shell/right-panel-model";
@@ -66,7 +65,6 @@ export function RightPanelHeaderTabs({
     onReorderHeaderEntry,
   });
   const shortcutRevealVisible = useShortcutRevealVisible();
-  const transparentChromeEnabled = useTransparentChromeEnabled();
 
   useEffect(() => {
     if (newTabMenuRequestToken > 0) {
@@ -75,10 +73,7 @@ export function RightPanelHeaderTabs({
   }, [newTabMenuRequestToken]);
 
   return (
-    <div
-      className="right-panel-tab-system ui-tab-system editor-panel-tab-root editor-panel-tab-root--simple-tabs"
-      data-chrome={transparentChromeEnabled ? "glass" : "solid"}
-    >
+    <div className="right-panel-tab-system ui-tab-system editor-panel-tab-root editor-panel-tab-root--simple-tabs">
       <div className="ui-tab-system-bar">
         <div className="editor-panel-tab-bar-tab-cluster">
           <output

--- a/apps/desktop/src/lib/domain/preferences/workspace-chrome.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/workspace-chrome.test.ts
@@ -14,7 +14,7 @@ describe("workspace chrome classes", () => {
     })).toEqual({
       root: "bg-transparent",
       contentShell: "bg-background",
-      header: "flex h-16 shrink-0 items-center bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 border-b border-foreground/10",
+      header: "flex h-[46px] shrink-0 items-center bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 border-b border-foreground/10",
     });
 
     expect(resolveStandardWorkspaceChromeClasses({

--- a/apps/desktop/src/lib/domain/preferences/workspace-chrome.ts
+++ b/apps/desktop/src/lib/domain/preferences/workspace-chrome.ts
@@ -2,16 +2,14 @@
 // card is a step lighter, which rendered the header as a visibly lighter haze
 // band against the opaque chat surface on every theme.
 //
-// h-16 (64px) must stay in sync with the right panel's tab-system height:
-// .right-panel-tab-system[data-chrome="glass"] in
-// apps/packages/design/src/css/desktop.css sets --tab-system-height: 64px to
-// match, so the two headers stay aligned in glass chrome mode.
+// Both chrome modes use 46px (codex --height-toolbar, UX_SPEC §7) so the
+// header always lines up with the right panel's --tab-system-height in
+// apps/packages/design/src/css/desktop.css — the main header aligns down to
+// the right pane, not the other way around (owner ruling 2026-07-10).
 const WORKSPACE_GLASS_HEADER_BASE_CLASS =
-  "flex h-16 shrink-0 items-center bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60";
+  "flex h-[46px] shrink-0 items-center bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60";
 const WORKSPACE_GLASS_HEADER_CLASS =
   `${WORKSPACE_GLASS_HEADER_BASE_CLASS} border-b border-foreground/10`;
-// 46px = codex --height-toolbar (UX_SPEC §7). Must stay in sync with the
-// right panel's default --tab-system-height in desktop.css.
 const WORKSPACE_SOLID_HEADER_BASE_CLASS =
   "flex h-[46px] shrink-0 items-center bg-background";
 const WORKSPACE_SOLID_HEADER_CLASS =

--- a/apps/packages/design/src/css/desktop.css
+++ b/apps/packages/design/src/css/desktop.css
@@ -1727,10 +1727,9 @@ body {
 /* ---- Right panel tabs ---- */
 /*
  * --tab-system-height mirrors the left workspace header height so the two
- * panes line up. Solid chrome = 46px (codex --height-toolbar, UX_SPEC §7),
- * matching WORKSPACE_SOLID_HEADER_BASE_CLASS's h-[46px]. Glass chrome bumps
- * to 64px to match WORKSPACE_GLASS_HEADER_BASE_CLASS's h-16 (see
- * apps/desktop/src/lib/domain/preferences/workspace-chrome.ts).
+ * panes line up: 46px (codex --height-toolbar, UX_SPEC §7) in both chrome
+ * modes, matching the h-[46px] header classes in
+ * apps/desktop/src/lib/domain/preferences/workspace-chrome.ts.
  */
 .right-panel-tab-system {
   --tab-system-height: 46px;
@@ -1784,10 +1783,6 @@ body {
   color: var(--right-panel-tab-text-secondary);
   font-size: var(--right-panel-tab-font-size);
   line-height: var(--right-panel-tab-line-height);
-}
-
-.right-panel-tab-system[data-chrome="glass"] {
-  --tab-system-height: 64px; /* h-16; matches WORKSPACE_GLASS_HEADER_BASE_CLASS */
 }
 
 :root[data-mode="light"] .right-panel-tab-system {


### PR DESCRIPTION
## Problem
#1093 fixed the glass-mode header mismatch by raising the right panel's tab system from 46px to 64px. The intended direction was the opposite: the main workspace header should come down to the right pane's 46px.

## Fix
- `WORKSPACE_GLASS_HEADER_BASE_CLASS` goes from `h-16` to `h-[46px]`, so both chrome modes share the 46px codex toolbar height.
- The `[data-chrome="glass"] { --tab-system-height: 64px }` rule, the `data-chrome` attribute on `RightPanelHeaderTabs`, and its `useTransparentChromeEnabled` wiring are removed — the right pane stays at 46px everywhere.

## Verification
- `workspace-chrome.test.ts` updated and passing (4 tests)
- `@proliferate/design` rebuilt; `tsc --noEmit` clean in apps/desktop after `make shared-build`
- Not visually verified in a running app — worth a glass-mode glance (traffic lights sit at y=14, and the header content is vertically centered in 46px, same as solid mode today)