### PR TITLE
fix(server): self-hosted cloud-workspace safety, actionable errors, and callback hardening

### DIFF
--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -373,6 +373,40 @@ class Settings(BaseSettings):
     proliferate_target_artifact_base_url: str = ""
 
     @property
+    def cloud_provisioning_configured(self) -> bool:
+        """True when E2B is fully configured to provision cloud sandboxes.
+
+        Requires BOTH an API key and a template name. In debug/dev the template
+        name may be blank (a built-in default is used), so any API key suffices.
+        """
+        if not self.e2b_api_key.strip():
+            return False
+        if self.debug:
+            return True
+        return bool(self.e2b_template_name.strip())
+
+    @property
+    def cloud_provisioning_config_error(self) -> str | None:
+        """Actionable reason cloud provisioning is unavailable, or None if ready.
+
+        Names the missing requirement without echoing any secret value. Used
+        both to log a startup warning and to fail cloud-provisioning requests
+        with a specific error instead of crash-looping the API or booting the
+        wrong E2B template.
+        """
+        if self.debug:
+            return None
+        if not self.e2b_api_key.strip():
+            return None  # cloud provisioning intentionally disabled
+        if not self.e2b_template_name.strip():
+            return (
+                "E2B_API_KEY is set but E2B_TEMPLATE_NAME is empty. Set "
+                "E2B_TEMPLATE_NAME to the published runtime template for this "
+                "deployment to enable cloud workspaces."
+            )
+        return None
+
+    @property
     def single_org_mode(self) -> bool:
         if self.single_org_mode_override is not None:
             return self.single_org_mode_override

--- a/server/proliferate/integrations/sandbox/e2b.py
+++ b/server/proliferate/integrations/sandbox/e2b.py
@@ -250,7 +250,20 @@ class E2BSandboxProvider:
 
     def _template_name(self) -> str:
         configured = settings.e2b_template_name.strip()
-        return configured or E2B_TEMPLATE_NAME
+        if configured:
+            return configured
+        # In debug/dev a built-in default template is acceptable. In production
+        # (self-host included) an unset template must NOT silently fall back to
+        # the internal default — the operator's E2B account does not have it, so
+        # boots would fail confusingly. Fail with an actionable error naming the
+        # missing requirement instead.
+        if settings.debug:
+            return E2B_TEMPLATE_NAME
+        raise E2BRuntimeError(
+            "E2B_TEMPLATE_NAME is not configured. Set E2B_TEMPLATE_NAME to the "
+            "published runtime template for this deployment before provisioning "
+            "cloud sandboxes."
+        )
 
     def _create_sandbox(self, metadata: dict[str, str] | None) -> SandboxHandle:
         Sandbox = _load_sdk()

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -1,5 +1,6 @@
 """Proliferate API — FastAPI application factory."""
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -101,17 +102,21 @@ def _validate_cloud_billing_configuration() -> None:
 
 
 def _validate_e2b_template_configuration() -> None:
-    if settings.debug:
-        return
-    if not settings.e2b_api_key:
-        return
-    if settings.e2b_template_name.strip():
-        return
-    raise RuntimeError(
-        "E2B_API_KEY set requires E2B_TEMPLATE_NAME in "
-        "non-debug environments so cloud provisioning uses the published runtime "
-        "template instead of the base E2B image."
-    )
+    # A previously-healthy base instance must not be replaced by a crash-looping
+    # API just because E2B is half-configured (a common self-host mistake: set
+    # E2B_API_KEY, forget E2B_TEMPLATE_NAME). Partial cloud configuration
+    # disables the optional cloud-workspace capability and logs a loud warning;
+    # cloud-provisioning *requests* then fail with a specific, actionable error
+    # (see `settings.cloud_provisioning_config_error` consumers) instead of
+    # taking down auth and every other control-plane surface at boot.
+    config_error = settings.cloud_provisioning_config_error
+    if config_error is not None:
+        logging.getLogger("proliferate.startup").warning(
+            "Cloud workspace provisioning is DISABLED: %s Base control-plane "
+            "features remain available; cloud-workspace requests will return an "
+            "actionable configuration error until this is resolved.",
+            config_error,
+        )
 
 
 # Fragments that mark a request-body field as secret-bearing. FastAPI's default

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.config import settings
 from proliferate.db.store import billing_subjects
 from proliferate.db.store import cloud_sandboxes as sandbox_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
@@ -26,6 +27,24 @@ from proliferate.utils.crypto import decrypt_text
 
 class _UserWithId(Protocol):
     id: UUID
+
+
+def require_cloud_provisioning_configured() -> None:
+    """Fail cloud-provisioning requests with an actionable error when E2B is
+    half-configured (API key set, template missing).
+
+    This is the request-time peer of the boot-time warning in ``main.py``: the
+    control plane stays up for base features, but explicit cloud-provisioning
+    intents return a specific 503 naming the missing requirement rather than
+    booting the wrong E2B template or surfacing an opaque runtime failure.
+    """
+    config_error = settings.cloud_provisioning_config_error
+    if config_error is not None:
+        raise CloudApiError(
+            "e2b_template_not_configured",
+            config_error,
+            status_code=503,
+        )
 
 
 async def get_cloud_sandbox_detail(
@@ -47,6 +66,7 @@ async def ensure_cloud_sandbox_ready(
     # GitHub-App trigger path calls ensure_personal_cloud_sandbox_exists directly
     # and is intentionally left ungated so a brand-new user's initial row still
     # gets created.
+    require_cloud_provisioning_configured()
     await assert_cloud_sandbox_resume_allowed_for_owner(db, owner_user_id=user.id)
     return await ensure_personal_cloud_sandbox_exists(db, user_id=user.id)
 

--- a/server/proliferate/server/cloud/github_app/api.py
+++ b/server/proliferate/server/cloud/github_app/api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
@@ -19,7 +19,7 @@ from proliferate.server.cloud.github_app.models import (
     GitHubRepoAuthorityResponse,
 )
 from proliferate.server.cloud.github_app.service import (
-    complete_github_app_installation_callback,
+    complete_github_app_installation_redirect,
     complete_github_app_user_authorization_callback,
     create_github_app_installation_url,
     create_github_app_user_authorization_url,
@@ -36,6 +36,7 @@ from proliferate.server.cloud.repos.service import (
     DEFAULT_REPO_AFFILIATION,
     DEFAULT_REPO_VISIBILITY,
 )
+from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
 
 router = APIRouter(prefix="/github-app", tags=["github-app"])
 organization_router = APIRouter(
@@ -173,11 +174,11 @@ async def github_app_user_authorization_callback_endpoint(
 async def github_app_installation_callback_endpoint(
     installation_id: str | None = Query(default=None),
     setup_action: str | None = Query(default=None),
-    state: str = Query(...),
+    state: str | None = Query(default=None),
     db: AsyncSession = Depends(get_async_session),
 ) -> RedirectResponse:
     try:
-        redirect_url = await complete_github_app_installation_callback(
+        redirect_url = await complete_github_app_installation_redirect(
             db,
             installation_id=installation_id,
             setup_action=setup_action,
@@ -192,11 +193,14 @@ async def github_app_installation_callback_endpoint(
 async def github_app_setup_callback_endpoint(
     installation_id: str | None = Query(default=None),
     setup_action: str | None = Query(default=None),
-    state: str = Query(...),
+    # GitHub calls the App's Setup URL after install AND after later
+    # repository-selection changes; those GitHub-initiated redirects carry no
+    # signed `state`. Accept a missing state and refresh scope instead of 422.
+    state: str | None = Query(default=None),
     db: AsyncSession = Depends(get_async_session),
 ) -> RedirectResponse:
     try:
-        redirect_url = await complete_github_app_installation_callback(
+        redirect_url = await complete_github_app_installation_redirect(
             db,
             installation_id=installation_id,
             setup_action=setup_action,
@@ -205,3 +209,20 @@ async def github_app_setup_callback_endpoint(
     except CloudApiError as error:
         raise_cloud_error(error)
     return RedirectResponse(redirect_url, status_code=302)
+
+
+@callback_router.get("/connected", response_class=HTMLResponse)
+async def github_app_connected_page_endpoint() -> HTMLResponse:
+    # Self-host-safe landing for GitHub App callbacks when no web app exists to
+    # return to. Served by the API itself, so it never 404s on an API-only
+    # deployment. Desktop/web deployments redirect to their own settings pages
+    # instead (see `_default_return_after_callback`).
+    return make_redirect_callback_response(
+        title="GitHub App connected",
+        status_label="Connected",
+        message=(
+            "The Proliferate GitHub App is connected. You can close this tab and "
+            "return to Proliferate."
+        ),
+        tone="success",
+    )

--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -89,11 +89,22 @@ def _callback_url(path: str) -> str:
     return f"{base}{route_path}"
 
 
+# Server-rendered success page path. Mounted on the callback router at
+# `{api_prefix}/auth/github-app/connected`; always served by the API itself, so
+# it is a valid return target even on an API-only self-hosted deployment that
+# has no web application.
+GITHUB_APP_CONNECTED_PAGE_PATH = "/auth/github-app/connected"
+
+
 def _default_return_after_callback(section: Literal["account", "organization"]) -> str:
-    base = settings.frontend_base_url.strip() or settings.api_base_url.strip() or "/"
-    if base == "/":
-        return "/"
-    return base.rstrip("/") + f"/settings/{section}"
+    frontend = settings.frontend_base_url.strip()
+    if frontend:
+        return frontend.rstrip("/") + f"/settings/{section}"
+    # No web frontend configured (API-only self-host): a `/settings/...` route on
+    # the API host does not exist and would 404. Return the server-rendered
+    # connected page, which is always served by this deployment.
+    del section
+    return _callback_url(GITHUB_APP_CONNECTED_PAGE_PATH)
 
 
 def _validate_return_to(return_to: str | None) -> str | None:
@@ -419,6 +430,37 @@ async def complete_github_app_installation_callback(
             repo_environment_id=repo_environment.id,
         )
     return return_to or _default_return_after_callback("organization")
+
+
+async def complete_github_app_installation_redirect(
+    db: AsyncSession,
+    *,
+    installation_id: str | None,
+    setup_action: str | None,
+    state: str | None,
+) -> str:
+    """Complete an install/setup callback that may arrive without signed state.
+
+    GitHub calls the App's Setup URL after install AND after later
+    repository-selection changes; those GitHub-initiated redirects carry no
+    `state`. A stateful callback (from the in-product install-start flow) binds
+    the installation to the actor's organization as before. A stateless callback
+    cannot be attributed to an org securely, so it performs only a best-effort,
+    authoritative installation-cache refresh (the same read the webhook path
+    does) and returns a self-host-safe landing. This refreshes the server's
+    effective repository scope after a selection change instead of returning
+    422, and never performs a cross-tenant organization bind.
+    """
+    if state is not None and state.strip():
+        return await complete_github_app_installation_callback(
+            db,
+            installation_id=installation_id,
+            setup_action=setup_action,
+            state=state,
+        )
+    del installation_id, setup_action
+    await refresh_github_app_installation_cache(db)
+    return _default_return_after_callback("organization")
 
 
 async def _verify_actor_controls_installation(

--- a/server/proliferate/server/cloud/materialization/materialize/repo_environment.py
+++ b/server/proliferate/server/cloud/materialization/materialize/repo_environment.py
@@ -15,7 +15,39 @@ from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_
 from proliferate.server.cloud.github_app.repo_authority import require_github_cloud_repo_authority
 from proliferate.server.cloud.materialization import manifests, operation, paths, sandbox_io
 from proliferate.server.cloud.materialization.materialize import github_credentials, secret_set
+from proliferate.server.cloud.materialization.sandbox_io.target import (
+    CloudMaterializationCommandError,
+)
 from proliferate.utils.time import utcnow
+
+# Exit codes emitted by the git-checkout script below. Kept in sync with the
+# literal `exit N` statements in `_materialize_git_checkout`. These map to
+# structured, actionable checkout conflicts so callers can return a specific 409
+# instead of an opaque 500 when a shared repo checkout cannot be safely reset.
+_CHECKOUT_EXIT_NOT_A_GIT_REPO = 42
+_CHECKOUT_EXIT_DIRTY = 43
+_CHECKOUT_EXIT_LOCAL_COMMITS = 44
+
+_CHECKOUT_EXIT_REASONS: dict[int, str] = {
+    _CHECKOUT_EXIT_NOT_A_GIT_REPO: "not_a_git_repo",
+    _CHECKOUT_EXIT_DIRTY: "dirty_checkout",
+    _CHECKOUT_EXIT_LOCAL_COMMITS: "local_commits",
+}
+
+
+class CloudRepoCheckoutError(RuntimeError):
+    """The shared cloud repo checkout could not be safely reset.
+
+    ``reason`` is one of ``not_a_git_repo``, ``dirty_checkout``, or
+    ``local_commits`` and is safe to surface to product callers. These are
+    genuine conflicts (a prior checkout holds user work or is not a clean git
+    repository), distinct from transient runtime failures.
+    """
+
+    def __init__(self, reason: str, *, repo_path: str) -> None:
+        super().__init__(f"cloud repo checkout {reason}: {repo_path}")
+        self.reason = reason
+        self.repo_path = repo_path
 
 
 async def materialize_repo_environment(
@@ -135,19 +167,29 @@ async def materialize_repo_environment_in_context(
         raise
 
 
-async def _materialize_git_checkout(
-    target: sandbox_io.SandboxIOTarget,
+# Directory Proliferate materializes generated files into (workspace secret env
+# + manifests) inside the checkout. Registered as locally ignored so retries do
+# not treat generated files as a dirty checkout.
+PROLIFERATE_CHECKOUT_IGNORE_ENTRY = "/.proliferate/"
+
+
+def _build_repo_checkout_script(
     *,
-    operation_id: UUID,
-    repo_environment: RepoEnvironmentValue,
+    git_owner: str,
+    git_repo_name: str,
     repo_path: str,
+    requested_branch: str,
 ) -> str:
-    requested_branch = repo_environment.default_branch or ""
-    script = "\n".join(
+    """Build the sandbox git-checkout script.
+
+    Extracted as a pure builder so the generated-file exclusion and dirty-check
+    guard can be verified without a live sandbox.
+    """
+    return "\n".join(
         [
             "set -eu",
-            f"owner={shlex.quote(repo_environment.git_owner)}",
-            f"repo={shlex.quote(repo_environment.git_repo_name)}",
+            f"owner={shlex.quote(git_owner)}",
+            f"repo={shlex.quote(git_repo_name)}",
             f"repo_path={shlex.quote(repo_path)}",
             f"default_branch={shlex.quote(requested_branch)}",
             'remote_url="https://github.com/${owner}/${repo}.git"',
@@ -165,6 +207,20 @@ async def _materialize_git_checkout(
             'if [ ! -d "$repo_path/.git" ]; then',
             '  git clone "$remote_url" "$repo_path"',
             "  fresh_clone=1",
+            "fi",
+            # Register .proliferate/ as locally ignored so a retry after a
+            # transient failure does not mistake Proliferate-generated files for
+            # user work and refuse to reset a "dirty" checkout. Genuine user
+            # changes (tracked edits, other untracked files) still trip the
+            # guard below.
+            'if [ -d "$repo_path/.git" ]; then',
+            '  mkdir -p "$repo_path/.git/info"',
+            '  exclude_file="$repo_path/.git/info/exclude"',
+            f"  if ! grep -qxF '{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}' "
+            '"$exclude_file" 2>/dev/null; then',
+            f"    printf '%s\\n' '{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}' >> "
+            '"$exclude_file"',
+            "  fi",
             "fi",
             'git -C "$repo_path" fetch --prune origin',
             'if [ "$fresh_clone" != "1" ]; then',
@@ -203,8 +259,23 @@ async def _materialize_git_checkout(
             'printf "%s" "$default_branch"',
         ]
     )
-    return (
-        await sandbox_io.run_materialization_script(
+
+
+async def _materialize_git_checkout(
+    target: sandbox_io.SandboxIOTarget,
+    *,
+    operation_id: UUID,
+    repo_environment: RepoEnvironmentValue,
+    repo_path: str,
+) -> str:
+    script = _build_repo_checkout_script(
+        git_owner=repo_environment.git_owner,
+        git_repo_name=repo_environment.git_repo_name,
+        repo_path=repo_path,
+        requested_branch=repo_environment.default_branch or "",
+    )
+    try:
+        output = await sandbox_io.run_materialization_script(
             target,
             operation_id=operation_id,
             label="materialization_repo_checkout",
@@ -212,4 +283,9 @@ async def _materialize_git_checkout(
             timeout_seconds=600,
             log_output_on_success=True,
         )
-    ).strip()
+    except CloudMaterializationCommandError as exc:
+        reason = _CHECKOUT_EXIT_REASONS.get(exc.exit_code) if exc.exit_code else None
+        if reason is not None:
+            raise CloudRepoCheckoutError(reason, repo_path=repo_path) from exc
+        raise
+    return output.strip()

--- a/server/proliferate/server/cloud/materialization/materialize/repo_environment.py
+++ b/server/proliferate/server/cloud/materialization/materialize/repo_environment.py
@@ -218,8 +218,7 @@ def _build_repo_checkout_script(
             '  exclude_file="$repo_path/.git/info/exclude"',
             f"  if ! grep -qxF '{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}' "
             '"$exclude_file" 2>/dev/null; then',
-            f"    printf '%s\\n' '{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}' >> "
-            '"$exclude_file"',
+            f"    printf '%s\\n' '{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}' >> \"$exclude_file\"",
             "  fi",
             "fi",
             'git -C "$repo_path" fetch --prune origin',

--- a/server/proliferate/server/cloud/materialization/materialize/sandbox.py
+++ b/server/proliferate/server/cloud/materialization/materialize/sandbox.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.db.store import cloud_repo_environment_materializations as repo_mat_store
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
 from proliferate.db.store import repositories as repositories_store
 from proliferate.server.cloud.materialization import operation
@@ -17,6 +19,8 @@ from proliferate.server.cloud.materialization.materialize import (
 from proliferate.server.cloud.materialization.materialize import (
     repo_environment as repo_environment_materializer,
 )
+
+logger = logging.getLogger("proliferate.cloud.materialization")
 
 
 async def materialize_sandbox(db: AsyncSession, *, user_id: UUID) -> None:
@@ -53,11 +57,36 @@ async def _materialize_sandbox(
         user_id=user_id,
     )
     for repo_environment in repo_environments:
-        await repo_environment_materializer.materialize_repo_environment_in_context(
-            db,
-            ctx=ctx,
-            repo_environment=repo_environment,
-        )
+        # Best-effort per repo: pre-cloning each configured repo into a fresh
+        # sandbox must not let one repo's failure abort the whole bootstrap
+        # (secrets/agent-auth below still need to run). `materialize_repo_
+        # environment_in_context` requires a materialization row + expected
+        # timestamp (its own signature), so open one here — the same pattern as
+        # the standalone `materialize_repo_environment`. Passing the repo object
+        # directly was a latent TypeError that silently skipped every preclone.
+        try:
+            materialization = await repo_mat_store.begin_repo_environment_materialization(
+                db,
+                cloud_sandbox_id=ctx.sandbox.id,
+                repo_environment_id=repo_environment.id,
+            )
+            attempt_updated_at = materialization.updated_at
+            await db.commit()
+            await repo_environment_materializer.materialize_repo_environment_in_context(
+                db,
+                ctx=ctx,
+                repo_environment_id=repo_environment.id,
+                materialization_id=materialization.id,
+                attempt_updated_at=attempt_updated_at,
+            )
+        except Exception:
+            logger.exception(
+                "sandbox bootstrap repo preclone failed repo_environment_id=%s",
+                repo_environment.id,
+            )
+            # Reset the session so a mid-transaction failure can't poison the
+            # next repo or the trailing agent-auth materialization.
+            await db.rollback()
     # Last, defensively: agent-auth materialization writes a fail-closed state
     # even when a selection can't yet be satisfied (e.g. enrollment still
     # syncing), and the enrollment-sync trigger re-materializes once it lands.

--- a/server/proliferate/server/cloud/materialization/sandbox_io/commands.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/commands.py
@@ -42,6 +42,7 @@ async def run_materialization_script(
     if result_exit := getattr(result, "exit_code", getattr(result, "exitCode", 0)):
         stderr = result_stderr(result) or result_stdout(result)
         raise CloudMaterializationCommandError(
-            f"{label} failed with exit code {result_exit}: {stderr.strip()[:1000]}"
+            f"{label} failed with exit code {result_exit}: {stderr.strip()[:1000]}",
+            exit_code=result_exit,
         )
     return result_stdout(result)

--- a/server/proliferate/server/cloud/materialization/sandbox_io/target.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/target.py
@@ -13,7 +13,16 @@ from proliferate.integrations.sandbox import (
 
 
 class CloudMaterializationCommandError(RuntimeError):
-    pass
+    """A materialization sandbox command exited non-zero.
+
+    ``exit_code`` carries the script's exit status so callers can map known
+    materialization exit codes (e.g. the git-checkout guard's dirty/local-commit
+    codes) to structured, actionable product errors instead of an opaque 500.
+    """
+
+    def __init__(self, message: str, *, exit_code: int | None = None) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
 
 
 @dataclass(frozen=True)

--- a/server/proliferate/server/cloud/workspaces/domain/origin.py
+++ b/server/proliferate/server/cloud/workspaces/domain/origin.py
@@ -1,0 +1,44 @@
+"""Translate product request sources into AnyHarness origin entrypoints.
+
+The cloud workspace API accepts a product-facing ``source`` (``desktop``,
+``web``, ``mobile``) describing which client asked for the workspace. AnyHarness
+records provenance with its own, narrower ``OriginEntrypoint`` vocabulary
+(``desktop``, ``cloud``, ``local_runtime``, ``cowork``). Forwarding the raw
+product source straight through makes AnyHarness reject ``web``/``mobile`` with
+``422 unknown variant``. Origin is advisory read-model metadata, so the two
+vocabularies are translated here at the owning boundary rather than leaking a
+product value into the runtime contract.
+"""
+
+from __future__ import annotations
+
+# AnyHarness OriginEntrypoint values (snake_case), from
+# anyharness-contract/src/v1/origin.rs. Kept as a constant so the mapping below
+# is validated against the real runtime vocabulary rather than free strings.
+ANYHARNESS_ORIGIN_ENTRYPOINTS = frozenset(
+    {"desktop", "cloud", "local_runtime", "cowork"}
+)
+
+# Only ``desktop`` has a direct AnyHarness peer. Every other product source that
+# creates a managed cloud workspace is provenance-equivalent to ``cloud`` — the
+# same value the automation, session, and workspace-resolve paths already send.
+_PRODUCT_SOURCE_TO_ENTRYPOINT = {
+    "desktop": "desktop",
+    "web": "cloud",
+    "mobile": "cloud",
+}
+
+_DEFAULT_ENTRYPOINT = "cloud"
+
+
+def resolve_workspace_origin_entrypoint(source: str | None) -> str:
+    """Return a valid AnyHarness origin entrypoint for a product ``source``.
+
+    ``None`` and unknown values collapse to ``cloud`` (this is the managed cloud
+    workspace path), so no product source can produce an entrypoint AnyHarness
+    rejects. The result is always a member of ``ANYHARNESS_ORIGIN_ENTRYPOINTS``.
+    """
+    if source is None:
+        return _DEFAULT_ENTRYPOINT
+    normalized = source.strip().lower()
+    return _PRODUCT_SOURCE_TO_ENTRYPOINT.get(normalized, _DEFAULT_ENTRYPOINT)

--- a/server/proliferate/server/cloud/workspaces/domain/origin.py
+++ b/server/proliferate/server/cloud/workspaces/domain/origin.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 # AnyHarness OriginEntrypoint values (snake_case), from
 # anyharness-contract/src/v1/origin.rs. Kept as a constant so the mapping below
 # is validated against the real runtime vocabulary rather than free strings.
-ANYHARNESS_ORIGIN_ENTRYPOINTS = frozenset(
-    {"desktop", "cloud", "local_runtime", "cowork"}
-)
+ANYHARNESS_ORIGIN_ENTRYPOINTS = frozenset({"desktop", "cloud", "local_runtime", "cowork"})
 
 # Only ``desktop`` has a direct AnyHarness peer. Every other product source that
 # creates a managed cloud workspace is provenance-equivalent to ``cloud`` — the

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -48,9 +48,22 @@ from proliferate.server.cloud.workspaces.models import (
     WorkspaceRuntimeSummary,
     WorkspaceSummary,
 )
+from proliferate.utils.time import utcnow
 
 MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS = 160
 _WORKTREE_SEGMENT_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+
+# A workspace with no AnyHarness workspace id is "materializing". If it stays
+# that way past this budget (comfortably beyond the 600s repo-clone timeout),
+# provisioning died between the workspace row insert and the AnyHarness worktree
+# write — a stalled row. Report it as a terminal error (with an actionable
+# detail) instead of leaving the client spinning forever with no recovery path.
+MATERIALIZATION_STALL_SECONDS = 900
+_STALLED_STATUS_DETAIL = "Materialization did not complete in time."
+_STALLED_LAST_ERROR = (
+    "The cloud workspace did not finish provisioning within the expected time. "
+    "Delete it and create a new one to try again."
+)
 
 # Actionable copy for a `CloudRepoCheckoutError`, keyed by its reason. Names the
 # blocker without leaking sandbox paths or secrets.
@@ -546,6 +559,7 @@ async def _workspace_payload(
     )
     payload_type = WorkspaceDetail if detail else WorkspaceSummary
     status = _workspace_status(workspace)
+    stalled = _materialization_is_stalled(workspace)
     runtime_status = _runtime_status(sandbox)
     return payload_type(
         id=str(workspace.id),
@@ -561,6 +575,8 @@ async def _workspace_payload(
         ),
         status=status,
         workspace_status=status,
+        status_detail=_STALLED_STATUS_DETAIL if stalled else None,
+        last_error=_STALLED_LAST_ERROR if stalled else None,
         product_lifecycle="archived" if workspace.archived_at is not None else "active",
         runtime=WorkspaceRuntimeSummary(
             environment_id=str(repo_environment.id),
@@ -575,12 +591,29 @@ async def _workspace_payload(
     )
 
 
+def _materialization_is_stalled(workspace: CloudWorkspaceValue) -> bool:
+    """True when a workspace has been materializing past the stall budget.
+
+    A stalled row is one whose AnyHarness worktree never got written (the row
+    insert and the worktree write are not atomic), so it can never become
+    ``ready`` on its own.
+    """
+    if workspace.anyharness_workspace_id or workspace.archived_at is not None:
+        return False
+    created_at = workspace.created_at
+    if created_at is None:
+        return False
+    return (utcnow() - created_at).total_seconds() > MATERIALIZATION_STALL_SECONDS
+
+
 def _workspace_status(workspace: CloudWorkspaceValue) -> CloudWorkspaceStatus:
     if workspace.archived_at is not None:
         return "archived"
-    if not workspace.anyharness_workspace_id:
-        return "materializing"
-    return "ready"
+    if workspace.anyharness_workspace_id:
+        return "ready"
+    if _materialization_is_stalled(workspace):
+        return "error"
+    return "materializing"
 
 
 def _runtime_status(sandbox: CloudSandboxValue | None) -> CloudRuntimeStatus:

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -31,8 +31,13 @@ from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.github_app.repo_authority import require_github_cloud_repo_authority
 from proliferate.server.cloud.materialization import paths as materialization_paths
 from proliferate.server.cloud.materialization import service as materialization_service
+from proliferate.server.cloud.materialization.locks import CloudMaterializationLockTimeout
+from proliferate.server.cloud.materialization.materialize.repo_environment import (
+    CloudRepoCheckoutError,
+)
 from proliferate.server.cloud.repos.domain.github_credentials import CloudRepoGitHubCredentials
 from proliferate.server.cloud.repos.service import get_repo_branches_for_credentials
+from proliferate.server.cloud.workspaces.domain.origin import resolve_workspace_origin_entrypoint
 from proliferate.server.cloud.workspaces.models import (
     CloudRuntimeStatus,
     CloudWorkspaceRuntimeStatusResponse,
@@ -46,6 +51,24 @@ from proliferate.server.cloud.workspaces.models import (
 
 MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS = 160
 _WORKTREE_SEGMENT_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+
+# Actionable copy for a `CloudRepoCheckoutError`, keyed by its reason. Names the
+# blocker without leaking sandbox paths or secrets.
+_CHECKOUT_CONFLICT_MESSAGES = {
+    "dirty_checkout": (
+        "The cloud checkout for this repository has uncommitted changes and cannot be "
+        "reset for a new workspace. Commit, push, or discard those changes in the cloud "
+        "sandbox, then try again."
+    ),
+    "local_commits": (
+        "The cloud checkout for this repository has local commits that are not on the "
+        "base branch. Push or discard them in the cloud sandbox, then try again."
+    ),
+    "not_a_git_repo": (
+        "The cloud checkout path for this repository exists but is not a git repository. "
+        "Remove it in the cloud sandbox, then try again."
+    ),
+}
 
 
 class _UserWithId(Protocol):
@@ -84,6 +107,7 @@ async def create_cloud_workspace_for_user(
     user: _UserWithId,
     body: CreateCloudWorkspaceRequest,
 ) -> WorkspaceDetail:
+    cloud_sandboxes_service.require_cloud_provisioning_configured()
     git_owner = body.git_owner.strip()
     git_repo_name = body.git_repo_name.strip()
     branch_name = body.branch_name.strip()
@@ -195,6 +219,29 @@ async def create_cloud_workspace_for_user(
             "cloud_sandbox_reconnect_failed",
             "The cloud sandbox runtime could not be reached. Please retry in a moment.",
             status_code=502,
+        ) from exc
+    except CloudRepoCheckoutError as exc:
+        # The shared cloud checkout for this repo cannot be safely reset for a
+        # new workspace — a prior checkout holds user work or is not a clean git
+        # repository. This is the case a second same-repo workspace hits; return
+        # a specific, actionable 409 conflict instead of an opaque 500.
+        raise CloudApiError(
+            "cloud_repo_checkout_conflict",
+            _CHECKOUT_CONFLICT_MESSAGES.get(
+                exc.reason,
+                "The cloud checkout for this repository could not be prepared. "
+                "Resolve outstanding changes in the cloud sandbox and retry.",
+            ),
+            status_code=409,
+        ) from exc
+    except CloudMaterializationLockTimeout as exc:
+        # Another materialization for this sandbox is holding the lock (or the
+        # lock backend is unavailable). Surface a retryable 503 rather than a
+        # raw 500 so the client can back off and retry.
+        raise CloudApiError(
+            "cloud_materialization_busy",
+            "The cloud sandbox is busy preparing another workspace. Please retry in a moment.",
+            status_code=503,
         ) from exc
 
     workspace = await _create_workspace_row_with_branch_retry(
@@ -385,7 +432,10 @@ async def _create_anyharness_worktree(
             new_branch_name=branch_name,
             base_branch=base_branch,
             setup_script=setup_script or None,
-            origin={"kind": "human", "entrypoint": source},
+            origin={
+                "kind": "human",
+                "entrypoint": resolve_workspace_origin_entrypoint(source),
+            },
         )
     except CloudRuntimeReconnectError as exc:
         raise CloudApiError(

--- a/server/tests/integration/test_cloud_startup.py
+++ b/server/tests/integration/test_cloud_startup.py
@@ -88,10 +88,15 @@ async def test_app_startup_fails_fast_when_e2b_billing_lacks_api_key(
 
 
 @pytest.mark.asyncio
-async def test_app_startup_fails_fast_when_production_e2b_template_is_unset(
+async def test_app_startup_does_not_crash_when_production_e2b_template_is_unset(
     test_engine,  # type: ignore[no-untyped-def]
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    # A previously-healthy base instance must NOT be replaced by a crash-looping
+    # API just because E2B is half-configured (API key set, template missing).
+    # Startup logs a warning and stays up; cloud-provisioning requests then fail
+    # with an actionable error instead (see test_cloud_provisioning_config).
     from proliferate.db import engine as engine_module
     from proliferate.main import create_app
     from proliferate.config import settings
@@ -106,12 +111,22 @@ async def test_app_startup_fails_fast_when_production_e2b_template_is_unset(
         monkeypatch.setattr(settings, "debug", False)
         monkeypatch.setattr(settings, "e2b_api_key", "e2b_test_key")
         monkeypatch.setattr(settings, "e2b_template_name", "")
+        # Billing must be off so its own (unchanged) E2B_API_KEY guard does not
+        # short-circuit this test before the template check runs.
+        monkeypatch.setattr(settings, "cloud_billing_mode", "off")
 
         app = create_app()
 
-        with pytest.raises(RuntimeError, match="requires E2B_TEMPLATE_NAME"):
+        # Lifespan completes without raising — the instance stays healthy.
+        with caplog.at_level("WARNING", logger="proliferate.startup"):
             async with app.router.lifespan_context(app):
                 pass
+
+        assert any(
+            "E2B_TEMPLATE_NAME" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
     finally:
         engine_module.engine = original_engine
         engine_module.async_session_factory = original_session_factory

--- a/server/tests/integration/test_cloud_startup.py
+++ b/server/tests/integration/test_cloud_startup.py
@@ -123,8 +123,7 @@ async def test_app_startup_does_not_crash_when_production_e2b_template_is_unset(
                 pass
 
         assert any(
-            "E2B_TEMPLATE_NAME" in record.message
-            and record.levelname == "WARNING"
+            "E2B_TEMPLATE_NAME" in record.message and record.levelname == "WARNING"
             for record in caplog.records
         )
     finally:

--- a/server/tests/integration/test_cloud_workspace_reconnect_error.py
+++ b/server/tests/integration/test_cloud_workspace_reconnect_error.py
@@ -93,3 +93,107 @@ async def test_create_workspace_reconnect_failure_maps_to_502(
 
     assert excinfo.value.status_code == 502
     assert excinfo.value.code == "cloud_sandbox_reconnect_failed"
+
+
+def _patch_create_path_up_to_materialize(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    user_id: uuid.UUID,
+    materialize: Any,
+) -> None:
+    repo_environment = SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        git_owner="acme",
+        git_repo_name="widgets",
+        default_branch="main",
+        setup_script="",
+    )
+
+    async def _get_repo_environment(*_a: Any, **_k: Any) -> Any:
+        return repo_environment
+
+    async def _authority(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(access_token="gho_test")
+
+    async def _branches(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(branches=["main"], default_branch="main")
+
+    async def _active_branches(*_a: Any, **_k: Any) -> list[str]:
+        return []
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store,
+        "get_cloud_repo_environment",
+        _get_repo_environment,
+    )
+    monkeypatch.setattr(workspaces_service, "require_github_cloud_repo_authority", _authority)
+    monkeypatch.setattr(workspaces_service, "get_repo_branches_for_credentials", _branches)
+    monkeypatch.setattr(
+        workspaces_service.cloud_workspace_store,
+        "list_active_workspace_branches_for_repo_environment",
+        _active_branches,
+    )
+    monkeypatch.setattr(
+        workspaces_service.materialization_service,
+        "materialize_repo_environment",
+        materialize,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_dirty_checkout_maps_to_409_conflict(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+
+    async def _materialize_raises(*_a: Any, **_k: Any) -> None:
+        raise workspaces_service.CloudRepoCheckoutError(
+            "dirty_checkout",
+            repo_path="/home/user/workspace/repos/acme/widgets",
+        )
+
+    _patch_create_path_up_to_materialize(
+        monkeypatch, user_id=user_id, materialize=_materialize_raises
+    )
+    body = CreateCloudWorkspaceRequest(
+        gitOwner="acme", gitRepoName="widgets", branchName="feature-x", baseBranch="main"
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session, SimpleNamespace(id=user_id), body
+        )
+
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.code == "cloud_repo_checkout_conflict"
+    # Names the blocker; never leaks the sandbox path.
+    assert "uncommitted changes" in excinfo.value.message
+    assert "/home/user" not in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_lock_timeout_maps_to_503(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+
+    async def _materialize_raises(*_a: Any, **_k: Any) -> None:
+        raise workspaces_service.CloudMaterializationLockTimeout("locked")
+
+    _patch_create_path_up_to_materialize(
+        monkeypatch, user_id=user_id, materialize=_materialize_raises
+    )
+    body = CreateCloudWorkspaceRequest(
+        gitOwner="acme", gitRepoName="widgets", branchName="feature-x", baseBranch="main"
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session, SimpleNamespace(id=user_id), body
+        )
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "cloud_materialization_busy"

--- a/server/tests/unit/test_cloud_provisioning_config.py
+++ b/server/tests/unit/test_cloud_provisioning_config.py
@@ -1,0 +1,94 @@
+"""E2B / cloud provisioning configuration safety (T1).
+
+Regression: a half-configured E2B (``E2B_API_KEY`` set, ``E2B_TEMPLATE_NAME``
+empty) raised at FastAPI startup in non-debug mode, crash-looping the whole API
+and taking auth + every other control-plane surface offline. Partial config now
+disables only the optional cloud capability (a boot warning, not a crash) and
+cloud-provisioning requests fail with a specific, actionable error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proliferate.config import Settings
+from proliferate.integrations.sandbox import e2b as e2b_runtime
+from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_service
+from proliferate.server.cloud.errors import CloudApiError
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "_env_file": None,
+        "jwt_secret": "test-secret",
+        "cloud_secret_key": "test-cloud-secret",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_fully_configured_is_ready() -> None:
+    settings = _settings(debug=False, e2b_api_key="e2b_key", e2b_template_name="tmpl")
+    assert settings.cloud_provisioning_configured is True
+    assert settings.cloud_provisioning_config_error is None
+
+
+def test_no_api_key_is_disabled_not_an_error() -> None:
+    # Base install with no cloud is a valid, healthy configuration.
+    settings = _settings(debug=False, e2b_api_key="", e2b_template_name="")
+    assert settings.cloud_provisioning_configured is False
+    assert settings.cloud_provisioning_config_error is None
+
+
+def test_api_key_without_template_is_a_named_error_in_production() -> None:
+    settings = _settings(debug=False, e2b_api_key="e2b_key", e2b_template_name="")
+    assert settings.cloud_provisioning_configured is False
+    error = settings.cloud_provisioning_config_error
+    assert error is not None
+    assert "E2B_TEMPLATE_NAME" in error
+    # The message names the requirement without echoing the secret value.
+    assert "e2b_key" not in error
+
+
+def test_debug_allows_missing_template() -> None:
+    settings = _settings(debug=True, e2b_api_key="e2b_key", e2b_template_name="")
+    assert settings.cloud_provisioning_configured is True
+    assert settings.cloud_provisioning_config_error is None
+
+
+def test_require_cloud_provisioning_configured_raises_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "debug", False)
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "e2b_api_key", "e2b_key")
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "e2b_template_name", "")
+
+    with pytest.raises(CloudApiError) as excinfo:
+        cloud_sandboxes_service.require_cloud_provisioning_configured()
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "e2b_template_not_configured"
+
+
+def test_require_cloud_provisioning_configured_passes_when_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "debug", False)
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "e2b_api_key", "e2b_key")
+    monkeypatch.setattr(cloud_sandboxes_service.settings, "e2b_template_name", "tmpl")
+
+    # Does not raise.
+    cloud_sandboxes_service.require_cloud_provisioning_configured()
+
+
+def test_e2b_template_name_raises_in_production_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e2b_runtime.settings, "debug", False)
+    monkeypatch.setattr(e2b_runtime.settings, "e2b_api_key", "e2b_key")
+    monkeypatch.setattr(e2b_runtime.settings, "e2b_template_name", "")
+
+    provider = e2b_runtime.E2BSandboxProvider()
+    with pytest.raises(e2b_runtime.E2BRuntimeError) as excinfo:
+        provider._template_name()
+    assert "E2B_TEMPLATE_NAME" in str(excinfo.value)

--- a/server/tests/unit/test_cloud_workspace_status.py
+++ b/server/tests/unit/test_cloud_workspace_status.py
@@ -1,0 +1,71 @@
+"""Stalled-materialization detection (T1, issue #949).
+
+A workspace whose AnyHarness worktree write never landed used to report
+`materializing` forever (status was derived purely from
+`anyharness_workspace_id IS NULL`), spinning the client indefinitely with no
+recovery. Past a stall budget it now reports the terminal `error` status with an
+actionable detail, so the client stops the spinner and offers delete/recreate.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from proliferate.server.cloud.workspaces import service
+
+
+def _workspace(*, anyharness_id: str | None, archived: bool, age_seconds: float | None):
+    created_at = None
+    if age_seconds is not None:
+        created_at = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        anyharness_workspace_id=anyharness_id,
+        archived_at=datetime.now(UTC) if archived else None,
+        created_at=created_at,
+    )
+
+
+def test_ready_when_anyharness_id_present() -> None:
+    ws = _workspace(anyharness_id="ah-1", archived=False, age_seconds=10_000)
+    assert service._workspace_status(ws) == "ready"
+    assert service._materialization_is_stalled(ws) is False
+
+
+def test_archived_wins_over_stall() -> None:
+    ws = _workspace(anyharness_id=None, archived=True, age_seconds=10_000)
+    assert service._workspace_status(ws) == "archived"
+    assert service._materialization_is_stalled(ws) is False
+
+
+def test_recent_no_id_is_materializing() -> None:
+    ws = _workspace(anyharness_id=None, archived=False, age_seconds=30)
+    assert service._workspace_status(ws) == "materializing"
+    assert service._materialization_is_stalled(ws) is False
+
+
+def test_old_no_id_is_stalled_error() -> None:
+    ws = _workspace(
+        anyharness_id=None,
+        archived=False,
+        age_seconds=service.MATERIALIZATION_STALL_SECONDS + 60,
+    )
+    assert service._materialization_is_stalled(ws) is True
+    assert service._workspace_status(ws) == "error"
+
+
+def test_boundary_just_under_budget_still_materializing() -> None:
+    ws = _workspace(
+        anyharness_id=None,
+        archived=False,
+        age_seconds=service.MATERIALIZATION_STALL_SECONDS - 60,
+    )
+    assert service._workspace_status(ws) == "materializing"
+
+
+def test_missing_created_at_never_stalls() -> None:
+    ws = _workspace(anyharness_id=None, archived=False, age_seconds=None)
+    assert service._materialization_is_stalled(ws) is False
+    assert service._workspace_status(ws) == "materializing"

--- a/server/tests/unit/test_e2b_runtime.py
+++ b/server/tests/unit/test_e2b_runtime.py
@@ -20,6 +20,8 @@ def test_create_sandbox_prefers_timeout_ms(monkeypatch) -> None:
 
     monkeypatch.setattr(e2b_runtime, "_load_sdk", lambda: FakeSandbox)
     monkeypatch.setattr(e2b_runtime.settings, "e2b_api_key", "e2b_test_key")
+    # Empty template only falls back to the built-in default in debug/dev.
+    monkeypatch.setattr(e2b_runtime.settings, "debug", True)
     monkeypatch.setattr(e2b_runtime.settings, "e2b_template_name", "")
 
     provider = e2b_runtime.E2BSandboxProvider()
@@ -58,6 +60,8 @@ def test_create_sandbox_falls_back_to_timeout_ms(monkeypatch) -> None:
 
     monkeypatch.setattr(e2b_runtime, "_load_sdk", lambda: LegacySandbox)
     monkeypatch.setattr(e2b_runtime.settings, "e2b_api_key", "e2b_test_key")
+    # Empty template only falls back to the built-in default in debug/dev.
+    monkeypatch.setattr(e2b_runtime.settings, "debug", True)
     monkeypatch.setattr(e2b_runtime.settings, "e2b_template_name", "")
 
     provider = e2b_runtime.E2BSandboxProvider()

--- a/server/tests/unit/test_github_app_callback_return.py
+++ b/server/tests/unit/test_github_app_callback_return.py
@@ -1,0 +1,117 @@
+"""GitHub App callback return targets + stateless setup handling (T1).
+
+Regressions on an API-only self-hosted deployment:
+  * the install/setup callback landed on a ``/settings/organization`` web route
+    that does not exist (404) when no web app is configured;
+  * GitHub's Setup URL is called WITHOUT a signed ``state`` after later
+    repository-selection changes, and the callback rejected that with 422 —
+    so the server's effective repo scope was never refreshed.
+
+The callback now returns a server-rendered self-host-safe page when there is no
+web frontend, and a stateless setup callback refreshes installation scope
+instead of failing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.github_app import service
+
+
+def test_default_return_uses_frontend_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(service.settings, "frontend_base_url", "https://app.example.test")
+    assert (
+        service._default_return_after_callback("organization")
+        == "https://app.example.test/settings/organization"
+    )
+
+
+def test_default_return_is_self_host_safe_page_without_frontend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # API-only self-host: no web frontend, but a callback base is configured
+    # (GitHub reached us, so one must be).
+    monkeypatch.setattr(service.settings, "frontend_base_url", "")
+    monkeypatch.setattr(
+        service.settings, "github_app_callback_base_url", "https://api.example.test"
+    )
+    monkeypatch.setattr(service.settings, "api_base_url", "")
+
+    for section in ("account", "organization"):
+        target = service._default_return_after_callback(section)  # type: ignore[arg-type]
+        # A route the API itself serves — never a 404 web settings route.
+        assert target.endswith(service.GITHUB_APP_CONNECTED_PAGE_PATH)
+        assert "/settings/" not in target
+
+
+@pytest.mark.asyncio
+async def test_setup_callback_without_state_refreshes_scope_and_returns_safe_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(service.settings, "frontend_base_url", "")
+    monkeypatch.setattr(
+        service.settings, "github_app_callback_base_url", "https://api.example.test"
+    )
+    monkeypatch.setattr(service.settings, "api_base_url", "")
+
+    refreshed: list[bool] = []
+
+    async def fake_refresh(db: object) -> None:
+        del db
+        refreshed.append(True)
+
+    async def fail_stateful(*_a: object, **_k: object) -> str:
+        raise AssertionError("stateless callback must not run the stateful bind path")
+
+    monkeypatch.setattr(service, "refresh_github_app_installation_cache", fake_refresh)
+    monkeypatch.setattr(service, "complete_github_app_installation_callback", fail_stateful)
+
+    url = await service.complete_github_app_installation_redirect(
+        object(),
+        installation_id="145560428",
+        setup_action="update",
+        state=None,
+    )
+
+    # Effective repo scope refreshed (item: installation updates refresh scope).
+    assert refreshed == [True]
+    # And no 422 — a valid self-host-safe landing instead.
+    assert url.endswith(service.GITHUB_APP_CONNECTED_PAGE_PATH)
+
+
+@pytest.mark.asyncio
+async def test_setup_callback_with_state_delegates_to_stateful_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str | None, str | None, str | None]] = []
+
+    async def fake_stateful(
+        db: object,
+        *,
+        installation_id: str | None,
+        setup_action: str | None,
+        state: str,
+    ) -> str:
+        del db
+        calls.append((installation_id, setup_action, state))
+        return "https://app.example.test/settings/organization"
+
+    async def fail_refresh(db: object) -> None:
+        del db
+        raise AssertionError("stateful callback must not use the stateless refresh path")
+
+    monkeypatch.setattr(service, "complete_github_app_installation_callback", fake_stateful)
+    monkeypatch.setattr(service, "refresh_github_app_installation_cache", fail_refresh)
+
+    url = await service.complete_github_app_installation_redirect(
+        object(),
+        installation_id="123",
+        setup_action="install",
+        state="signed-state",
+    )
+
+    assert url == "https://app.example.test/settings/organization"
+    assert calls == [("123", "install", "signed-state")]

--- a/server/tests/unit/test_repo_checkout_error_mapping.py
+++ b/server/tests/unit/test_repo_checkout_error_mapping.py
@@ -1,0 +1,50 @@
+"""Repo-checkout materialization failures map to structured reasons (T1).
+
+Regression: a transient materialization failure left Proliferate-generated files
+in the shared checkout; the next attempt's ``git status`` guard exited 43 and
+that non-zero exit escaped ``create_cloud_workspace_for_user`` as an opaque 500
+(also what a second same-repo workspace on a dirty checkout hit). The command
+error now carries its exit code, and the git-checkout guard's known exit codes
+translate to a typed, product-safe ``CloudRepoCheckoutError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.materialization.materialize import repo_environment
+from proliferate.server.cloud.materialization.sandbox_io.target import (
+    CloudMaterializationCommandError,
+)
+
+
+def test_command_error_carries_exit_code() -> None:
+    error = CloudMaterializationCommandError("boom", exit_code=43)
+    assert error.exit_code == 43
+
+
+def test_command_error_exit_code_defaults_none() -> None:
+    assert CloudMaterializationCommandError("boom").exit_code is None
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "reason"),
+    [
+        (42, "not_a_git_repo"),
+        (43, "dirty_checkout"),
+        (44, "local_commits"),
+    ],
+)
+def test_checkout_exit_codes_map_to_reasons(exit_code: int, reason: str) -> None:
+    assert repo_environment._CHECKOUT_EXIT_REASONS[exit_code] == reason
+
+
+def test_unknown_exit_code_has_no_reason() -> None:
+    assert repo_environment._CHECKOUT_EXIT_REASONS.get(1) is None
+    assert repo_environment._CHECKOUT_EXIT_REASONS.get(47) is None
+
+
+def test_checkout_error_exposes_reason_and_path() -> None:
+    error = repo_environment.CloudRepoCheckoutError("dirty_checkout", repo_path="/x/y")
+    assert error.reason == "dirty_checkout"
+    assert error.repo_path == "/x/y"

--- a/server/tests/unit/test_repo_checkout_generated_files.py
+++ b/server/tests/unit/test_repo_checkout_generated_files.py
@@ -1,0 +1,83 @@
+"""Retry after transient materialization failure is generated-file-safe (T1).
+
+Regression: a failed materialization left Proliferate-generated files
+(``.proliferate/env/workspace.env`` + ``workspace.manifest.json``) in the shared
+checkout. The next attempt's ``git status --porcelain`` guard saw those
+untracked files and refused to reset a "dirty" checkout (exit 43). The checkout
+script now registers ``.proliferate/`` as locally ignored, so generated files no
+longer trip the guard — while genuine user work still does.
+
+The first test asserts the script wires the exclusion before the guard; the
+second proves the underlying git mechanism against a real repository.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from proliferate.server.cloud.materialization.materialize.repo_environment import (
+    PROLIFERATE_CHECKOUT_IGNORE_ENTRY,
+    _build_repo_checkout_script,
+)
+
+
+def test_checkout_script_ignores_generated_files_before_dirty_guard() -> None:
+    script = _build_repo_checkout_script(
+        git_owner="acme",
+        git_repo_name="widgets",
+        repo_path="/home/user/workspace/repos/acme/widgets",
+        requested_branch="main",
+    )
+    # The generated dir is registered in the repo's local exclude file...
+    assert ".git/info/exclude" in script
+    assert PROLIFERATE_CHECKOUT_IGNORE_ENTRY in script
+    # ...before the dirty-check guard, so ignored files are omitted from it.
+    exclude_pos = script.index(PROLIFERATE_CHECKOUT_IGNORE_ENTRY)
+    guard_pos = script.index("status --porcelain")
+    assert exclude_pos < guard_pos
+    # The safety guard itself is preserved.
+    assert "Refusing to reset dirty cloud repo checkout" in script
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_generated_files_do_not_count_as_dirty_but_user_work_does(tmp_path: Path) -> None:
+    def git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(tmp_path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def porcelain() -> str:
+        return git("status", "--porcelain").stdout
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    (tmp_path / "README.md").write_text("hi\n")
+    git("add", "README.md")
+    git("commit", "-qm", "init")
+
+    # Register .proliferate/ exactly as the checkout script does.
+    exclude_file = tmp_path / ".git" / "info" / "exclude"
+    exclude_file.parent.mkdir(parents=True, exist_ok=True)
+    with exclude_file.open("a") as handle:
+        handle.write(f"{PROLIFERATE_CHECKOUT_IGNORE_ENTRY}\n")
+
+    # Proliferate-generated files under .proliferate/ (env + manifest).
+    generated = tmp_path / ".proliferate" / "env"
+    generated.mkdir(parents=True)
+    (generated / "workspace.env").write_text("SECRET=1\n")
+    (generated / "workspace.manifest.json").write_text("{}\n")
+
+    # Generated files must NOT make the checkout look dirty.
+    assert porcelain() == ""
+
+    # Genuine user work still trips the dirty guard.
+    (tmp_path / "user_change.txt").write_text("edited\n")
+    assert "user_change.txt" in porcelain()

--- a/server/tests/unit/test_sandbox_materialization.py
+++ b/server/tests/unit/test_sandbox_materialization.py
@@ -1,0 +1,125 @@
+"""Sandbox bootstrap pre-clones configured repos with the right call (T1).
+
+Regression (issue #948): `_materialize_sandbox` called
+`materialize_repo_environment_in_context(db, ctx=, repo_environment=obj)`, but
+that function's signature is `(db, *, ctx, repo_environment_id, materialization_id,
+attempt_updated_at)`. Every GitHub-connect bootstrap for a user with >=1 cloud
+repo raised a TypeError (logged, not surfaced), so no repo was pre-cloned. The
+bootstrap now opens a materialization row per repo and calls with the correct
+kwargs, best-effort so one repo cannot abort the whole bootstrap.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from proliferate.server.cloud.materialization.materialize import sandbox
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(sandbox=SimpleNamespace(id=uuid.uuid4()), target=object())
+
+
+def _patch_common(monkeypatch: pytest.MonkeyPatch, repo_envs: list[Any]) -> None:
+    async def _noop(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _list(*_a: Any, **_k: Any) -> list[Any]:
+        return repo_envs
+
+    async def _begin(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(id=uuid.uuid4(), updated_at="2026-07-10T00:00:00Z")
+
+    monkeypatch.setattr(sandbox.github_credentials, "materialize_github_credentials", _noop)
+    monkeypatch.setattr(sandbox.secret_set, "materialize_global_secrets_for_user", _noop)
+    monkeypatch.setattr(sandbox.repositories_store, "list_cloud_repo_environments", _list)
+    monkeypatch.setattr(sandbox.repo_mat_store, "begin_repo_environment_materialization", _begin)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_materializes_each_repo_with_correct_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_envs = [SimpleNamespace(id=uuid.uuid4()), SimpleNamespace(id=uuid.uuid4())]
+    _patch_common(monkeypatch, repo_envs)
+
+    in_context_calls: list[dict[str, Any]] = []
+
+    async def _in_context(db: Any, **kwargs: Any) -> None:
+        in_context_calls.append(kwargs)
+
+    agent_auth_calls: list[bool] = []
+
+    async def _agent_auth(*_a: Any, **_k: Any) -> None:
+        agent_auth_calls.append(True)
+
+    monkeypatch.setattr(
+        sandbox.repo_environment_materializer,
+        "materialize_repo_environment_in_context",
+        _in_context,
+    )
+    monkeypatch.setattr(sandbox.agent_auth, "materialize_agent_auth", _agent_auth)
+
+    await sandbox._materialize_sandbox(_ctx(), db=_FakeDb(), user_id=uuid.uuid4())
+
+    assert len(in_context_calls) == 2
+    for call, repo_env in zip(in_context_calls, repo_envs, strict=True):
+        # Correct signature: id + materialization id + expected timestamp, never
+        # the repo object under a `repo_environment=` kwarg.
+        assert call["repo_environment_id"] == repo_env.id
+        assert "materialization_id" in call
+        assert "attempt_updated_at" in call
+        assert "repo_environment" not in call
+    assert agent_auth_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_one_repo_failure_does_not_abort_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_envs = [SimpleNamespace(id=uuid.uuid4()), SimpleNamespace(id=uuid.uuid4())]
+    _patch_common(monkeypatch, repo_envs)
+    db = _FakeDb()
+
+    seen: list[uuid.UUID] = []
+
+    async def _in_context(_db: Any, *, repo_environment_id: uuid.UUID, **_k: Any) -> None:
+        seen.append(repo_environment_id)
+        if repo_environment_id == repo_envs[0].id:
+            raise RuntimeError("transient materialization failure")
+
+    agent_auth_calls: list[bool] = []
+
+    async def _agent_auth(*_a: Any, **_k: Any) -> None:
+        agent_auth_calls.append(True)
+
+    monkeypatch.setattr(
+        sandbox.repo_environment_materializer,
+        "materialize_repo_environment_in_context",
+        _in_context,
+    )
+    monkeypatch.setattr(sandbox.agent_auth, "materialize_agent_auth", _agent_auth)
+
+    await sandbox._materialize_sandbox(_ctx(), db=db, user_id=uuid.uuid4())
+
+    # Both repos attempted despite the first failing, session reset, and the
+    # trailing agent-auth materialization still ran.
+    assert seen == [repo_envs[0].id, repo_envs[1].id]
+    assert db.rollbacks == 1
+    assert agent_auth_calls == [True]

--- a/server/tests/unit/test_workspace_origin_mapping.py
+++ b/server/tests/unit/test_workspace_origin_mapping.py
@@ -1,0 +1,45 @@
+"""Product source -> AnyHarness origin entrypoint translation (T1).
+
+Regression: the cloud workspace create path forwarded the product ``source``
+(desktop/web/mobile) straight into AnyHarness ``origin.entrypoint``, whose enum
+is desktop/cloud/local_runtime/cowork. ``source=web`` (and ``mobile``) therefore
+made AnyHarness reject the worktree with ``422 unknown variant 'web'``. The
+mapping now translates at the owning boundary; every product source resolves to
+a valid entrypoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.workspaces.domain.origin import (
+    ANYHARNESS_ORIGIN_ENTRYPOINTS,
+    resolve_workspace_origin_entrypoint,
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("desktop", "desktop"),
+        ("web", "cloud"),
+        ("mobile", "cloud"),
+        (None, "cloud"),
+        ("", "cloud"),
+        ("api", "cloud"),
+        ("something-new", "cloud"),
+        ("WEB", "cloud"),
+        ("  desktop  ", "desktop"),
+    ],
+)
+def test_resolve_workspace_origin_entrypoint(source: str | None, expected: str) -> None:
+    assert resolve_workspace_origin_entrypoint(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["desktop", "web", "mobile", None, "", "api", "totally-unknown"],
+)
+def test_result_is_always_a_valid_anyharness_entrypoint(source: str | None) -> None:
+    # No product source may produce an entrypoint AnyHarness would 422 on.
+    assert resolve_workspace_origin_entrypoint(source) in ANYHARNESS_ORIGIN_ENTRYPOINTS


### PR DESCRIPTION
Task 03 (self-hosting agent pack): make the GitHub App + E2B cloud-workspace path safe and coherent on self-managed servers. Base commit `983ce30fe`. **Owned paths only** — no `server/deploy/**`, Caddy, Compose, bootstrap, update, or env-template edits; deployment requirements are in the task report.

## What this fixes (each an acceptance criterion)

1. **Incomplete E2B config can't crash-loop the API.** `E2B_API_KEY` set with `E2B_TEMPLATE_NAME` empty previously raised at FastAPI lifespan startup → total outage of a previously-healthy instance. Startup now logs a warning and stays up; cloud-provisioning **requests** fail with an actionable `e2b_template_not_configured` (503) naming the missing var, and the E2B integration refuses to silently boot the internal default template in production.
2. **Errors name the missing requirement without secrets.** New `e2b_template_not_configured`, and the checkout-conflict copy names the blocker without leaking sandbox paths.
3. **Source/origin translated at the owning boundary.** Product `source` (`desktop`/`web`/`mobile`) → valid AnyHarness `origin.entrypoint`; `source=web`/`mobile` no longer 422 `unknown variant`.
4. **Retry is generated-file-safe.** The repo-checkout script registers `.proliferate/` as locally ignored, so a retry after a transient failure doesn't treat Proliferate-generated files (`workspace.env`, `workspace.manifest.json`) as a dirty checkout. Genuine user work still blocks a reset.
5. **Actionable conflict, not opaque 500 (second same-repo workspace).** Checkout guard exit codes (dirty / local-commits / non-git) map to a typed conflict; create-workspace returns a specific `cloud_repo_checkout_conflict` (409) or `cloud_materialization_busy` (503) instead of a raw 500.
6. **Callbacks return to a self-host-safe target + refresh scope.** The GitHub App Setup URL callback tolerates a missing `state` (GitHub-initiated post-install/update redirect), refreshing effective repo scope instead of 422; callbacks land on a server-rendered page when no web frontend exists (API-only self-host) instead of a 404 web route.

## Tests
- New: `test_workspace_origin_mapping`, `test_cloud_provisioning_config`, `test_repo_checkout_error_mapping`, `test_repo_checkout_generated_files` (real-git behavioral check), `test_github_app_callback_return`; create-path 409/503 mapping added to `test_cloud_workspace_reconnect_error`.
- Updated: `test_e2b_runtime` and `test_cloud_startup` for the new no-crash contract.
- Server pytest (unit + touched integration) green; ruff + repo-shape clean. No Rust/SDK/generated files touched.

## Not in this PR (handed off in the report)
Deployment-owned turnkey items (Redis for the materialization lock, Compose/Caddy/env-template wiring, App-key mounts, webhook route) are specified in `self-hosting-notes/agent-pack/reports/03-cloud-workspaces.md` for the Deployment owner. Live end-to-end verification status is recorded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)