### PR TITLE
feat(desktop): server-declared self-host capability contract + Desktop gating

### DIFF
--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -32,7 +32,6 @@ import { SHORTCUTS } from "@/config/shortcuts/registry";
 import { useAppCapabilities } from "@/hooks/capabilities/derived/use-app-capabilities";
 import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useAppSidebarSignOutAction } from "@/hooks/app/workflows/use-app-sidebar-sign-out-action";
-import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
 import { useCloudBilling } from "@/hooks/cloud/facade/use-cloud-billing";
 import { useCurrentUserOrganizationInvitations } from "@/hooks/access/cloud/organizations/use-current-user-organization-invitations";
 import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-organization-actions";
@@ -49,6 +48,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import { OrganizationSwitchDialog } from "./OrganizationSwitchDialog";
+import { SidebarAppVersionRow } from "./SidebarAppVersionRow";
 import { ConsumptionCard } from "./SidebarConsumptionCard";
 
 const PROLIFERATE_CHANGELOG_URL = "https://proliferate.com/changelog";
@@ -359,7 +359,7 @@ export function SidebarAccountFooter() {
                 />
               </div>
 
-              <AppVersionRow
+              <SidebarAppVersionRow
                 connectedServerName={
                   capabilities.isSelfManaged ? capabilities.serverDisplayName : null
                 }
@@ -389,35 +389,6 @@ export function SidebarAccountFooter() {
         target={switchTarget}
         onClose={() => setSwitchTarget(null)}
       />
-    </div>
-  );
-}
-
-/**
- * Popover footer: `Proliferate v{x}`, plus a persistent "Connected to {server}"
- * line when the desktop is pointed at a self-managed server. This is the one
- * always-present place a user can tell which server they are on (the app is
- * otherwise identical across Cloud and self-hosted). Hosted product shows only
- * the version, exactly as before.
- */
-function AppVersionRow({
-  connectedServerName,
-}: {
-  connectedServerName?: string | null;
-}) {
-  const { data: appVersion } = useAppVersion();
-
-  return (
-    <div className="mt-1 border-t border-border px-2.5 pb-1 pt-2">
-      <div className="truncate text-ui-sm text-faint">{`Proliferate v${appVersion ?? "…"}`}</div>
-      {connectedServerName ? (
-        <div
-          className="truncate text-ui-sm text-faint"
-          title={connectedServerName}
-        >
-          {`Connected to ${connectedServerName}`}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -1,23 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  BookMarked,
-  BookOpen,
-  CreditCard,
-  Globe,
-  Keyboard,
-  Lightbulb,
-  LogOut,
-  MessageSquare,
-  Settings,
-} from "lucide-react";
-import {
-  ArrowUpRight,
-  Check,
-  ChevronUpDown,
-  Discord,
-  Mail,
-} from "@proliferate/ui/icons";
+import { CreditCard, LogOut, Settings } from "lucide-react";
+import { Check, ChevronUpDown, Mail } from "@proliferate/ui/icons";
 import { useUsageSummary } from "@proliferate/cloud-sdk-react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
@@ -27,7 +11,6 @@ import {
 } from "@proliferate/ui/primitives/PopoverButton";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { OrganizationAvatar } from "@/components/organizations/OrganizationAvatar";
-import { PROLIFERATE_DOCS_URL } from "@/config/capabilities";
 import { SHORTCUTS } from "@/config/shortcuts/registry";
 import { useAppCapabilities } from "@/hooks/capabilities/derived/use-app-capabilities";
 import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
@@ -38,6 +21,7 @@ import { useOrganizationActions } from "@/hooks/access/cloud/organizations/use-o
 import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows/use-joined-organization-activation";
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
+import { useSupportMenuAction } from "@/hooks/support/derived/use-support-menu-action";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
 import type {
@@ -49,10 +33,8 @@ import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-sho
 import { useToastStore } from "@/stores/toast/toast-store";
 import { OrganizationSwitchDialog } from "./OrganizationSwitchDialog";
 import { SidebarAppVersionRow } from "./SidebarAppVersionRow";
+import { SidebarHelpSection } from "./SidebarHelpSection";
 import { ConsumptionCard } from "./SidebarConsumptionCard";
-
-const PROLIFERATE_CHANGELOG_URL = "https://proliferate.com/changelog";
-const PROLIFERATE_DISCORD_URL = "https://discord.gg/7b5afMTqW";
 
 /**
  * The single sidebar bottom-left account block, shared verbatim by the main
@@ -72,6 +54,7 @@ export function SidebarAccountFooter() {
     openFeature: openPrompt,
     disabledReason: supportDisabledReason,
   } = useOpenSupportReportWindow({ source: "sidebar" });
+  const supportAction = useSupportMenuAction();
   const showToast = useToastStore((state) => state.show);
   const capabilities = useAppCapabilities();
   const webApp = useWebAppTarget();
@@ -259,83 +242,16 @@ export function SidebarAccountFooter() {
                 </div>
               ) : null}
 
-              <div className="border-t border-border-light py-1">
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Keyboard shortcuts"
-                  icon={<Keyboard className="size-4" />}
-                  trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.showKeyboardShortcuts)}</span>}
-                  onClick={() => {
-                    close();
-                    openShortcutsDialog(true);
-                  }}
-                />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Docs"
-                  icon={<BookOpen className="size-4" />}
-                  trailing={<ArrowUpRight className="size-3" />}
-                  onClick={() => {
-                    openExternalUrl(PROLIFERATE_DOCS_URL);
-                    close();
-                  }}
-                />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Changelog"
-                  icon={<BookMarked className="size-4" />}
-                  trailing={<ArrowUpRight className="size-3" />}
-                  onClick={() => {
-                    openExternalUrl(PROLIFERATE_CHANGELOG_URL);
-                    close();
-                  }}
-                />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Discord"
-                  icon={<Discord className="size-4" />}
-                  trailing={<ArrowUpRight className="size-3" />}
-                  onClick={() => {
-                    openExternalUrl(PROLIFERATE_DISCORD_URL);
-                    close();
-                  }}
-                />
-                {webApp.available && webApp.baseUrl ? (
-                  <PopoverMenuItem
-                    variant="sidebar"
-                    label="Go to web"
-                    icon={<Globe className="size-4" />}
-                    trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
-                    onClick={() => {
-                      openExternalUrl(webApp.baseUrl!);
-                      close();
-                    }}
-                  />
-                ) : null}
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Send feedback"
-                  icon={<MessageSquare className="size-4" />}
-                  trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openSupport)}</span>}
-                  disabled={Boolean(supportDisabledReason)}
-                  title={supportDisabledReason ?? undefined}
-                  onClick={() => {
-                    openSupport();
-                    close();
-                  }}
-                />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Submit a prompt"
-                  icon={<Lightbulb className="size-4" />}
-                  disabled={Boolean(supportDisabledReason)}
-                  title={supportDisabledReason ?? undefined}
-                  onClick={() => {
-                    openPrompt();
-                    close();
-                  }}
-                />
-              </div>
+              <SidebarHelpSection
+                webApp={webApp}
+                supportAction={supportAction}
+                supportDisabledReason={supportDisabledReason}
+                openSupport={openSupport}
+                openPrompt={openPrompt}
+                openExternalUrl={openExternalUrl}
+                onShowKeyboardShortcuts={() => openShortcutsDialog(true)}
+                onClose={close}
+              />
 
               <div className="border-t border-border-light py-1">
                 <PopoverMenuItem

--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -29,6 +29,8 @@ import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { OrganizationAvatar } from "@/components/organizations/OrganizationAvatar";
 import { PROLIFERATE_DOCS_URL } from "@/config/capabilities";
 import { SHORTCUTS } from "@/config/shortcuts/registry";
+import { useAppCapabilities } from "@/hooks/capabilities/derived/use-app-capabilities";
+import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useAppSidebarSignOutAction } from "@/hooks/app/workflows/use-app-sidebar-sign-out-action";
 import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
 import { useCloudBilling } from "@/hooks/cloud/facade/use-cloud-billing";
@@ -38,7 +40,6 @@ import { useJoinedOrganizationActivation } from "@/hooks/organizations/workflows
 import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
-import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
 import type {
   OrganizationInvitationRecord,
@@ -72,6 +73,8 @@ export function SidebarAccountFooter() {
     disabledReason: supportDisabledReason,
   } = useOpenSupportReportWindow({ source: "sidebar" });
   const showToast = useToastStore((state) => state.show);
+  const capabilities = useAppCapabilities();
+  const webApp = useWebAppTarget();
   const { data: billingPlan } = useCloudBilling();
   const { data: usageSummary } = useUsageSummary(undefined, authStatus === "authenticated");
   const {
@@ -94,7 +97,8 @@ export function SidebarAccountFooter() {
   const displayName = user?.display_name?.trim() || user?.email || "Account";
   const initials = displayName.trim().slice(0, 2).toUpperCase() || "PR";
   const organizationName = activeOrganization?.name ?? null;
-  const planLabel = billingPlan
+  // Vendor plan/credits only mean something where the server offers billing.
+  const planLabel = capabilities.billingEnabled && billingPlan
     ? (billingPlan.isPaidCloud ? "Pro" : "Free")
     : null;
 
@@ -120,7 +124,7 @@ export function SidebarAccountFooter() {
 
   return (
     <div className="shrink-0">
-      {usageSummary ? (
+      {capabilities.usageMeteringEnabled && usageSummary ? (
         <ConsumptionCard
           usageSummary={usageSummary}
           onTopUp={() => {
@@ -296,16 +300,18 @@ export function SidebarAccountFooter() {
                     close();
                   }}
                 />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Go to web"
-                  icon={<Globe className="size-4" />}
-                  trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
-                  onClick={() => {
-                    openExternalUrl(getProliferateWebBaseUrl());
-                    close();
-                  }}
-                />
+                {webApp.available && webApp.baseUrl ? (
+                  <PopoverMenuItem
+                    variant="sidebar"
+                    label="Go to web"
+                    icon={<Globe className="size-4" />}
+                    trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
+                    onClick={() => {
+                      openExternalUrl(webApp.baseUrl!);
+                      close();
+                    }}
+                  />
+                ) : null}
                 <PopoverMenuItem
                   variant="sidebar"
                   label="Send feedback"
@@ -353,7 +359,11 @@ export function SidebarAccountFooter() {
                 />
               </div>
 
-              <AppVersionRow />
+              <AppVersionRow
+                connectedServerName={
+                  capabilities.isSelfManaged ? capabilities.serverDisplayName : null
+                }
+              />
             </div>
           )}
         </PopoverButton>
@@ -384,15 +394,30 @@ export function SidebarAccountFooter() {
 }
 
 /**
- * Popover footer line: `Proliferate v{x}` only. Harness versions (and their
- * tooltip) were dropped by owner decision 2026-07-01.
+ * Popover footer: `Proliferate v{x}`, plus a persistent "Connected to {server}"
+ * line when the desktop is pointed at a self-managed server. This is the one
+ * always-present place a user can tell which server they are on (the app is
+ * otherwise identical across Cloud and self-hosted). Hosted product shows only
+ * the version, exactly as before.
  */
-function AppVersionRow() {
+function AppVersionRow({
+  connectedServerName,
+}: {
+  connectedServerName?: string | null;
+}) {
   const { data: appVersion } = useAppVersion();
 
   return (
     <div className="mt-1 border-t border-border px-2.5 pb-1 pt-2">
       <div className="truncate text-ui-sm text-faint">{`Proliferate v${appVersion ?? "…"}`}</div>
+      {connectedServerName ? (
+        <div
+          className="truncate text-ui-sm text-faint"
+          title={connectedServerName}
+        >
+          {`Connected to ${connectedServerName}`}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/app/sidebar/SidebarAppVersionRow.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAppVersionRow.tsx
@@ -1,0 +1,30 @@
+import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
+
+/**
+ * Sidebar footer: `Proliferate v{x}`, plus a persistent "Connected to {server}"
+ * line when the desktop is pointed at a self-managed server. This is the one
+ * always-present place a user can tell which server they are on (the app is
+ * otherwise identical across Cloud and self-hosted). Hosted product shows only
+ * the version, exactly as before.
+ */
+export function SidebarAppVersionRow({
+  connectedServerName,
+}: {
+  connectedServerName?: string | null;
+}) {
+  const { data: appVersion } = useAppVersion();
+
+  return (
+    <div className="mt-1 border-t border-border px-2.5 pb-1 pt-2">
+      <div className="truncate text-ui-sm text-faint">{`Proliferate v${appVersion ?? "…"}`}</div>
+      {connectedServerName ? (
+        <div
+          className="truncate text-ui-sm text-faint"
+          title={connectedServerName}
+        >
+          {`Connected to ${connectedServerName}`}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/app/sidebar/SidebarHelpSection.test.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarHelpSection.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SupportMenuAction } from "@/lib/domain/support/support-menu-action";
+import type { WebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
+import { SidebarHelpSection } from "./SidebarHelpSection";
+
+const AVAILABLE_WEB_APP: WebAppTarget = {
+  available: true,
+  baseUrl: "https://web.proliferate.com",
+};
+const NO_WEB_APP: WebAppTarget = { available: false, baseUrl: null };
+
+function renderSection(overrides: {
+  webApp?: WebAppTarget;
+  supportAction?: SupportMenuAction;
+  supportDisabledReason?: string | null;
+} = {}) {
+  const openSupport = vi.fn();
+  const openPrompt = vi.fn();
+  const openExternalUrl = vi.fn();
+  const onShowKeyboardShortcuts = vi.fn();
+  const onClose = vi.fn();
+
+  render(
+    <SidebarHelpSection
+      webApp={overrides.webApp ?? AVAILABLE_WEB_APP}
+      supportAction={overrides.supportAction ?? { kind: "vendor" }}
+      supportDisabledReason={overrides.supportDisabledReason ?? null}
+      openSupport={openSupport}
+      openPrompt={openPrompt}
+      openExternalUrl={openExternalUrl}
+      onShowKeyboardShortcuts={onShowKeyboardShortcuts}
+      onClose={onClose}
+    />,
+  );
+
+  return { openSupport, openPrompt, openExternalUrl, onShowKeyboardShortcuts, onClose };
+}
+
+describe("SidebarHelpSection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("Docs/Changelog/Discord are always rendered regardless of support kind", () => {
+    renderSection({ supportAction: { kind: "none" } });
+
+    // getByRole throws if absent, which is itself the presence assertion.
+    expect(screen.getByRole("button", { name: "Docs" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Changelog" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Discord" })).not.toBeNull();
+  });
+
+  describe("support routing", () => {
+    it("vendor: renders the existing feedback/prompt actions wired to the report window", () => {
+      const { openSupport, openPrompt, onClose } = renderSection({
+        supportAction: { kind: "vendor" },
+      });
+
+      // Exact match would miss the trailing keyboard-shortcut label ("⌘S").
+      fireEvent.click(screen.getByRole("button", { name: /^Send feedback/ }));
+      expect(openSupport).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("button", { name: "Submit a prompt" }));
+      expect(openPrompt).toHaveBeenCalledTimes(1);
+
+      expect(screen.queryByRole("button", { name: "Contact support" })).toBeNull();
+    });
+
+    it("operator: renders a single action that opens the operator's configured target", () => {
+      const { openExternalUrl, onClose } = renderSection({
+        supportAction: { kind: "operator", url: "https://acme.example.com/support" },
+      });
+
+      expect(screen.queryByRole("button", { name: "Send feedback" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Submit a prompt" })).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Contact support" }));
+      expect(openExternalUrl).toHaveBeenCalledWith("https://acme.example.com/support");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("operator with only an email: opens a mailto: link", () => {
+      const { openExternalUrl } = renderSection({
+        supportAction: { kind: "operator", url: "mailto:it-help@acme.example.com" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Contact support" }));
+      expect(openExternalUrl).toHaveBeenCalledWith("mailto:it-help@acme.example.com");
+    });
+
+    it("none: hides the support action entirely instead of disabling it", () => {
+      renderSection({ supportAction: { kind: "none" } });
+
+      expect(screen.queryByRole("button", { name: "Send feedback" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Submit a prompt" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Contact support" })).toBeNull();
+    });
+  });
+
+  describe("web-app handoff", () => {
+    it("renders 'Go to web' when this deployment has a web app", () => {
+      renderSection({ webApp: AVAILABLE_WEB_APP });
+
+      // Exact match would miss the trailing keyboard-shortcut label.
+      expect(screen.getByRole("button", { name: /^Go to web/ })).not.toBeNull();
+    });
+
+    it("hides 'Go to web' entirely when this deployment has no web app", () => {
+      renderSection({ webApp: NO_WEB_APP });
+
+      expect(screen.queryByRole("button", { name: /^Go to web/ })).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/components/app/sidebar/SidebarHelpSection.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarHelpSection.tsx
@@ -1,0 +1,147 @@
+import {
+  BookMarked,
+  BookOpen,
+  Globe,
+  Keyboard,
+  Lightbulb,
+  MessageSquare,
+} from "lucide-react";
+import { ArrowUpRight, Discord, Mail } from "@proliferate/ui/icons";
+import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
+import { PROLIFERATE_DOCS_URL } from "@/config/capabilities";
+import { SHORTCUTS } from "@/config/shortcuts/registry";
+import type { WebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
+import type { SupportMenuAction } from "@/lib/domain/support/support-menu-action";
+import { getShortcutDisplayLabel } from "@/lib/domain/shortcuts/matching";
+
+const PROLIFERATE_CHANGELOG_URL = "https://proliferate.com/changelog";
+const PROLIFERATE_DISCORD_URL = "https://discord.gg/7b5afMTqW";
+
+export interface SidebarHelpSectionProps {
+  webApp: WebAppTarget;
+  supportAction: SupportMenuAction;
+  supportDisabledReason: string | null;
+  openSupport: () => void;
+  openPrompt: () => void;
+  openExternalUrl: (url: string) => void;
+  onShowKeyboardShortcuts: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Docs/Changelog/Discord/keyboard-shortcuts (always universal — no gating) plus
+ * the capability-gated "Go to web" and support actions:
+ *
+ * - `supportAction.kind === "vendor"` (hosted): unchanged "Send feedback" /
+ *   "Submit a prompt" actions into the vendor support-report window.
+ * - `"operator"` (self-managed with a configured destination): a single
+ *   "Contact support" action that opens the operator's url/mailto directly.
+ * - `"none"` (self-managed with nothing configured): no support action at all.
+ *
+ * Extracted from `SidebarAccountFooter` to keep that file under the strict
+ * frontend line-count threshold.
+ */
+export function SidebarHelpSection({
+  webApp,
+  supportAction,
+  supportDisabledReason,
+  openSupport,
+  openPrompt,
+  openExternalUrl,
+  onShowKeyboardShortcuts,
+  onClose,
+}: SidebarHelpSectionProps) {
+  return (
+    <div className="border-t border-border-light py-1">
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Keyboard shortcuts"
+        icon={<Keyboard className="size-4" />}
+        trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.showKeyboardShortcuts)}</span>}
+        onClick={() => {
+          onClose();
+          onShowKeyboardShortcuts();
+        }}
+      />
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Docs"
+        icon={<BookOpen className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_DOCS_URL);
+          onClose();
+        }}
+      />
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Changelog"
+        icon={<BookMarked className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_CHANGELOG_URL);
+          onClose();
+        }}
+      />
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Discord"
+        icon={<Discord className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_DISCORD_URL);
+          onClose();
+        }}
+      />
+      {webApp.available && webApp.baseUrl ? (
+        <PopoverMenuItem
+          variant="sidebar"
+          label="Go to web"
+          icon={<Globe className="size-4" />}
+          trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
+          onClick={() => {
+            openExternalUrl(webApp.baseUrl!);
+            onClose();
+          }}
+        />
+      ) : null}
+      {supportAction.kind === "vendor" ? (
+        <>
+          <PopoverMenuItem
+            variant="sidebar"
+            label="Send feedback"
+            icon={<MessageSquare className="size-4" />}
+            trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openSupport)}</span>}
+            disabled={Boolean(supportDisabledReason)}
+            title={supportDisabledReason ?? undefined}
+            onClick={() => {
+              openSupport();
+              onClose();
+            }}
+          />
+          <PopoverMenuItem
+            variant="sidebar"
+            label="Submit a prompt"
+            icon={<Lightbulb className="size-4" />}
+            disabled={Boolean(supportDisabledReason)}
+            title={supportDisabledReason ?? undefined}
+            onClick={() => {
+              openPrompt();
+              onClose();
+            }}
+          />
+        </>
+      ) : supportAction.kind === "operator" ? (
+        <PopoverMenuItem
+          variant="sidebar"
+          label="Contact support"
+          icon={<Mail className="size-4" />}
+          onClick={() => {
+            openExternalUrl(supportAction.url);
+            onClose();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/auth/ConnectServerDialog.tsx
+++ b/apps/desktop/src/components/auth/ConnectServerDialog.tsx
@@ -31,6 +31,7 @@ export function ConnectServerDialog({ controller, context }: ConnectServerDialog
     close,
     submitUrl,
     confirmConnect,
+    versionWarning,
   } = controller;
 
   const open = step !== "closed";
@@ -118,6 +119,9 @@ export function ConnectServerDialog({ controller, context }: ConnectServerDialog
               {CONNECT_SERVER_LABELS.serverVersionLabel(pendingMeta.serverVersion)}
             </p>
           )}
+          {versionWarning ? (
+            <p className="text-xs text-warning">{versionWarning}</p>
+          ) : null}
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>
       )}

--- a/apps/desktop/src/components/settings/panes/BillingPane.tsx
+++ b/apps/desktop/src/components/settings/panes/BillingPane.tsx
@@ -20,7 +20,7 @@ export function BillingPane() {
     organizationsQuery,
   } = useActiveOrganization();
   const admin = useIsAdmin(activeOrganizationId);
-  const { billingEnabled } = useAppCapabilities();
+  const { billingEnabled, pricing } = useAppCapabilities();
   const { cloudActive } = useCloudAvailabilityState();
   const { openExternal } = useTauriShellActions();
   const [searchParams] = useSearchParams();
@@ -40,7 +40,7 @@ export function BillingPane() {
       organizationLoading={organizationsQuery.isLoading || (activeOrganization ? admin.isLoading : false)}
       checkoutReturnState={checkoutReturnStateFromParams(searchParams)}
       onOpenUrl={openExternal}
-      onOpenPricingPage={() => openExternal(PROLIFERATE_PRICING_URL)}
+      onOpenPricingPage={() => openExternal(pricing.url ?? PROLIFERATE_PRICING_URL)}
       onOpenOrganizationSettings={() => {
         navigate(buildSettingsHref({ section: "organization" }));
       }}

--- a/apps/desktop/src/copy/auth/auth-copy.ts
+++ b/apps/desktop/src/copy/auth/auth-copy.ts
@@ -49,6 +49,11 @@ export const CONNECT_SERVER_LABELS = {
   cancel: "Cancel",
   trustDescription: (host: string) => `You're connecting to ${host}.`,
   serverVersionLabel: (version: string) => `Server version ${version}`,
+  // Shown when this desktop is older than the server's minimum supported
+  // version. Not a hard block — the server advertises the floor and the user
+  // is warned to update the desktop app.
+  minVersionWarning: (minVersion: string) =>
+    `This server needs desktop ${minVersion} or newer. Update the app if you hit problems.`,
   connect: "Connect",
   connecting: "Connecting…",
   useDifferentAddress: "Use a different address",

--- a/apps/desktop/src/hooks/access/cloud/server-capabilities/query-keys.ts
+++ b/apps/desktop/src/hooks/access/cloud/server-capabilities/query-keys.ts
@@ -1,0 +1,5 @@
+import { cloudRootKey } from "@proliferate/cloud-sdk-react/lib/query-keys";
+
+export function serverCapabilitiesKey(apiBaseUrl: string) {
+  return [...cloudRootKey(), "server-capabilities", apiBaseUrl] as const;
+}

--- a/apps/desktop/src/hooks/access/cloud/server-capabilities/use-server-capabilities.ts
+++ b/apps/desktop/src/hooks/access/cloud/server-capabilities/use-server-capabilities.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchServerCapabilities } from "@/lib/access/cloud/server-capabilities";
+import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
+import type { ServerCapabilityContract } from "@/lib/domain/capabilities/server-capability-contract";
+import { serverCapabilitiesKey } from "./query-keys";
+
+/**
+ * The connected control plane's self-host capability contract (`GET /meta`).
+ *
+ * `null` data means the server declared no contract (older server) — callers
+ * degrade conservatively. Keyed by API base URL so switching servers refetches.
+ */
+export function useServerCapabilities() {
+  const apiBaseUrl = getProliferateApiBaseUrl();
+
+  return useQuery<ServerCapabilityContract | null>({
+    queryKey: serverCapabilitiesKey(apiBaseUrl),
+    queryFn: fetchServerCapabilities,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+}

--- a/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -160,6 +160,28 @@ describe("useAppShortcuts", () => {
     expect(runShortcutHandler("app.open-web", { source: "keyboard" })).toBe(true);
     expect(actions.openWebApp.execute).toHaveBeenCalledWith("shortcut");
   });
+
+  describe("app.open-support gating", () => {
+    // Mirrors the sidebar/palette hiding the support action under
+    // `support.kind === "none"` (`SidebarHelpSection`): Cmd+S must not just
+    // no-op, the shortcut must not be registered at all.
+    it("routes Cmd+S through app command actions when the action is visible", () => {
+      const actions = commandActions();
+      renderHook(() => useAppShortcuts(actions));
+
+      expect(runShortcutHandler("app.open-support", { source: "keyboard" })).toBe(true);
+      expect(actions.openSupport.execute).toHaveBeenCalledWith("shortcut");
+    });
+
+    it("leaves Cmd+S unregistered (inert) when the action is hidden", () => {
+      const actions = commandActions();
+      actions.openSupport = { ...actions.openSupport, hidden: true };
+      renderHook(() => useAppShortcuts(actions));
+
+      expect(runShortcutHandler("app.open-support", { source: "keyboard" })).toBe(false);
+      expect(actions.openSupport.execute).not.toHaveBeenCalled();
+    });
+  });
 });
 
 function commandActions(): AppCommandActions {

--- a/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -44,9 +44,16 @@ export function useAppShortcuts(actions: AppCommandActions): void {
     actions.openWebApp.execute("shortcut");
   });
 
-  useShortcutHandler("app.open-support", () => {
-    actions.openSupport.execute("shortcut");
-  });
+  // Mirrors the sidebar/palette hiding the support action under
+  // `support.kind === "none"`: the shortcut is unregistered entirely rather
+  // than bound to a no-op, so Cmd+S is inert when nothing is configured.
+  useShortcutHandler(
+    "app.open-support",
+    () => {
+      actions.openSupport.execute("shortcut");
+    },
+    { enabled: !actions.openSupport.hidden },
+  );
 
   useShortcutHandler("app.show-keyboard-shortcuts", () => {
     actions.showKeyboardShortcuts.execute("shortcut");

--- a/apps/desktop/src/hooks/app/workflows/app-command-action-types.ts
+++ b/apps/desktop/src/hooks/app/workflows/app-command-action-types.ts
@@ -3,6 +3,14 @@ export type AppCommandInvocation = "shortcut" | "palette";
 export interface AppCommandAction {
   execute: (invocation: AppCommandInvocation) => void;
   disabledReason: string | null;
+  /**
+   * When true, callers should not register/offer this action at all (as
+   * opposed to registering it disabled). Used for actions whose availability
+   * depends on server capabilities rather than transient app state — e.g.
+   * `openSupport` under a self-managed server with no configured support
+   * destination. Defaults to visible when omitted.
+   */
+  hidden?: boolean;
 }
 
 export interface AppCommandActions {

--- a/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
+++ b/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
@@ -162,6 +162,13 @@ vi.mock("@/lib/infra/measurement/latency-flow", () => ({
   startLatencyFlow: vi.fn(() => "latency-flow-1"),
 }));
 
+vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
+  useWebAppTarget: () => ({
+    available: true,
+    baseUrl: "https://web.proliferate.com",
+  }),
+}));
+
 function wrapper({ children }: { children: ReactNode }) {
   return <MemoryRouter initialEntries={["/"]}>{children}</MemoryRouter>;
 }

--- a/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
+++ b/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
@@ -173,6 +173,14 @@ vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
   useWebAppTarget: () => webAppMocks.webApp,
 }));
 
+// Support-kind routing itself is covered by
+// use-app-navigation-command-actions.test.tsx; here we only need it not to
+// pull in `useAppCapabilities`'s react-query calls (no QueryClientProvider
+// in this suite's wrapper).
+vi.mock("@/hooks/support/derived/use-support-menu-action", () => ({
+  useSupportMenuAction: () => ({ kind: "vendor" as const }),
+}));
+
 function wrapper({ children }: { children: ReactNode }) {
   return <MemoryRouter initialEntries={["/"]}>{children}</MemoryRouter>;
 }

--- a/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
+++ b/apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx
@@ -162,11 +162,15 @@ vi.mock("@/lib/infra/measurement/latency-flow", () => ({
   startLatencyFlow: vi.fn(() => "latency-flow-1"),
 }));
 
+const webAppMocks = vi.hoisted(() => ({
+  webApp: { available: true, baseUrl: "https://web.proliferate.com" } as {
+    available: boolean;
+    baseUrl: string | null;
+  },
+}));
+
 vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
-  useWebAppTarget: () => ({
-    available: true,
-    baseUrl: "https://web.proliferate.com",
-  }),
+  useWebAppTarget: () => webAppMocks.webApp,
 }));
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -188,6 +192,7 @@ describe("useAppCommandActions", () => {
     hookMocks.activeNewWorkspaceScope = null;
     hookMocks.homeTargetSelection.baseBranchOverride = "stale/from-other-repo";
     hookMocks.homeRepositorySelection.selectedBranchName = "main";
+    webAppMocks.webApp = { available: true, baseUrl: "https://web.proliferate.com" };
   });
 
   afterEach(() => {
@@ -222,5 +227,21 @@ describe("useAppCommandActions", () => {
 
     expect(hookMocks.openExternal).toHaveBeenCalledWith("https://web.proliferate.com");
     expect(hookMocks.showToast).toHaveBeenCalledWith("Opening web app...", "info");
+  });
+
+  it("disables the web-app action and never opens anything when this deployment has no web app", () => {
+    webAppMocks.webApp = { available: false, baseUrl: null };
+    const { result } = renderHook(() => useAppCommandActions(), { wrapper });
+
+    expect(result.current.openWebApp.disabledReason).toBe(
+      "The web app is not available for this server.",
+    );
+
+    act(() => {
+      result.current.openWebApp.execute("shortcut");
+    });
+
+    expect(hookMocks.openExternal).not.toHaveBeenCalled();
+    expect(hookMocks.showToast).toHaveBeenCalledWith("The web app is not available for this server.");
   });
 });

--- a/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.test.tsx
+++ b/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupportMenuAction } from "@/lib/domain/support/support-menu-action";
+import { useAppNavigationCommandActions } from "@/hooks/app/workflows/use-app-navigation-command-actions";
+
+// This mirrors the sidebar's support-kind gating (`SidebarHelpSection`):
+// vendor keeps the auth-gated feedback modal, operator routes straight to the
+// operator's configured destination, and none hides the action entirely. The
+// command-palette/Cmd+S "Open Support" action must follow the same rules.
+const hookMocks = vi.hoisted(() => ({
+  supportMenuAction: { kind: "vendor" } as SupportMenuAction,
+  openBug: vi.fn(),
+  supportDisabledReason: null as string | null,
+  openExternal: vi.fn(() => Promise.resolve()),
+  goToTopLevelRoute: vi.fn(),
+  webApp: { available: true, baseUrl: "https://web.proliferate.com" } as {
+    available: boolean;
+    baseUrl: string | null;
+  },
+}));
+
+vi.mock("@/hooks/support/derived/use-support-menu-action", () => ({
+  useSupportMenuAction: () => hookMocks.supportMenuAction,
+}));
+
+vi.mock("@/hooks/support/workflows/use-open-support-report-window", () => ({
+  useOpenSupportReportWindow: () => ({
+    openBug: hookMocks.openBug,
+    openFeature: vi.fn(),
+    canSubmit: true,
+    disabledReason: hookMocks.supportDisabledReason,
+  }),
+}));
+
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => ({
+    openExternal: hookMocks.openExternal,
+  }),
+}));
+
+vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
+  useWebAppTarget: () => hookMocks.webApp,
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    goToTopLevelRoute: hookMocks.goToTopLevelRoute,
+  }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter initialEntries={["/"]}>{children}</MemoryRouter>;
+}
+
+describe("useAppNavigationCommandActions support routing", () => {
+  beforeEach(() => {
+    hookMocks.supportMenuAction = { kind: "vendor" };
+    hookMocks.openBug.mockClear();
+    hookMocks.supportDisabledReason = null;
+    hookMocks.openExternal.mockClear();
+    hookMocks.goToTopLevelRoute.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("vendor: routes through the existing feedback report window, visible", () => {
+    hookMocks.supportMenuAction = { kind: "vendor" };
+    hookMocks.supportDisabledReason = "Sign in to Proliferate Cloud to send feedback.";
+    const { result } = renderHook(() => useAppNavigationCommandActions(), { wrapper });
+
+    expect(result.current.openSupport.hidden).toBeFalsy();
+    expect(result.current.openSupport.disabledReason).toBe(
+      "Sign in to Proliferate Cloud to send feedback.",
+    );
+
+    act(() => {
+      result.current.openSupport.execute("palette");
+    });
+
+    expect(hookMocks.openBug).toHaveBeenCalledTimes(1);
+    expect(hookMocks.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("operator: opens the resolved destination directly, not gated by vendor auth", () => {
+    hookMocks.supportMenuAction = {
+      kind: "operator",
+      url: "https://acme.example.com/support",
+    };
+    // Vendor auth would otherwise disable it; operator must ignore that.
+    hookMocks.supportDisabledReason = "Sign in to Proliferate Cloud to send feedback.";
+    const { result } = renderHook(() => useAppNavigationCommandActions(), { wrapper });
+
+    expect(result.current.openSupport.hidden).toBeFalsy();
+    expect(result.current.openSupport.disabledReason).toBeNull();
+
+    act(() => {
+      result.current.openSupport.execute("palette");
+    });
+
+    expect(hookMocks.openExternal).toHaveBeenCalledWith("https://acme.example.com/support");
+    expect(hookMocks.openBug).not.toHaveBeenCalled();
+  });
+
+  it("operator with only an email: opens a mailto: link", () => {
+    hookMocks.supportMenuAction = {
+      kind: "operator",
+      url: "mailto:it-help@acme.example.com",
+    };
+    const { result } = renderHook(() => useAppNavigationCommandActions(), { wrapper });
+
+    act(() => {
+      result.current.openSupport.execute("shortcut");
+    });
+
+    expect(hookMocks.openExternal).toHaveBeenCalledWith("mailto:it-help@acme.example.com");
+  });
+
+  it("none: hides the action and no-ops instead of opening anything", () => {
+    hookMocks.supportMenuAction = { kind: "none" };
+    const { result } = renderHook(() => useAppNavigationCommandActions(), { wrapper });
+
+    expect(result.current.openSupport.hidden).toBe(true);
+
+    act(() => {
+      result.current.openSupport.execute("palette");
+    });
+
+    expect(hookMocks.openBug).not.toHaveBeenCalled();
+    expect(hookMocks.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
+++ b/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
@@ -5,9 +5,10 @@ import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
 import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
+import { useSupportMenuAction } from "@/hooks/support/derived/use-support-menu-action";
 import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "@/stores/toast/toast-store";
-import type { AppCommandActions } from "./app-command-action-types";
+import type { AppCommandAction, AppCommandActions } from "./app-command-action-types";
 
 export type AppNavigationCommandActions = Pick<
   AppCommandActions,
@@ -55,6 +56,36 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
     openBug: openSupport,
     disabledReason: supportDisabledReason,
   } = useOpenSupportReportWindow({ source: "sidebar" });
+  const supportMenuAction = useSupportMenuAction();
+  const openExternalSupportUrl = useCallback((url: string) => {
+    void openExternal(url).catch(() => {
+      showToast("Failed to open the link.");
+    });
+  }, [openExternal, showToast]);
+
+  // Mirrors the sidebar's support routing (`SidebarHelpSection`): vendor
+  // keeps the auth-gated feedback modal, operator routes straight to the
+  // configured destination, and none hides the action entirely rather than
+  // offering it disabled.
+  const openSupportAction = useMemo<AppCommandAction>(() => {
+    if (supportMenuAction.kind === "operator") {
+      return {
+        execute: () => openExternalSupportUrl(supportMenuAction.url),
+        disabledReason: null,
+      };
+    }
+    if (supportMenuAction.kind === "none") {
+      return {
+        execute: () => {},
+        disabledReason: null,
+        hidden: true,
+      };
+    }
+    return {
+      execute: openSupport,
+      disabledReason: supportDisabledReason,
+    };
+  }, [openExternalSupportUrl, openSupport, supportDisabledReason, supportMenuAction]);
 
   return useMemo<AppNavigationCommandActions>(() => ({
     openSettings: {
@@ -79,16 +110,12 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
         ? null
         : "The web app is not available for this server.",
     },
-    openSupport: {
-      execute: openSupport,
-      disabledReason: supportDisabledReason,
-    },
+    openSupport: openSupportAction,
   }), [
     goHome,
     goWorkflows,
     openSettings,
-    openSupport,
-    supportDisabledReason,
+    openSupportAction,
     openWebApp,
     webApp.available,
     showKeyboardShortcuts,

--- a/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
+++ b/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
@@ -2,8 +2,8 @@ import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { APP_ROUTES } from "@/config/app-routes";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useWorkspaceNavigationWorkflow } from "@/hooks/workspaces/workflows/use-workspace-navigation-workflow";
-import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { useOpenSupportReportWindow } from "@/hooks/support/workflows/use-open-support-report-window";
 import { useKeyboardShortcutsDialogStore } from "@/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "@/stores/toast/toast-store";
@@ -24,6 +24,7 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
   const navigate = useNavigate();
   const showToast = useToastStore((state) => state.show);
   const { openExternal } = useTauriShellActions();
+  const webApp = useWebAppTarget();
   const { goToTopLevelRoute } = useWorkspaceNavigationWorkflow();
 
   const openSettings = useCallback(() => {
@@ -39,12 +40,17 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
   const goWorkflows = useCallback(() => {
     goToTopLevelRoute(APP_ROUTES.workflows);
   }, [goToTopLevelRoute]);
+  const webAppBaseUrl = webApp.baseUrl;
   const openWebApp = useCallback(() => {
+    if (!webAppBaseUrl) {
+      showToast("The web app is not available for this server.");
+      return;
+    }
     showToast("Opening web app...", "info");
-    void openExternal(getProliferateWebBaseUrl()).catch(() => {
+    void openExternal(webAppBaseUrl).catch(() => {
       showToast("Failed to open the web app.");
     });
-  }, [openExternal, showToast]);
+  }, [openExternal, showToast, webAppBaseUrl]);
   const {
     openBug: openSupport,
     disabledReason: supportDisabledReason,
@@ -69,7 +75,9 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
     },
     openWebApp: {
       execute: openWebApp,
-      disabledReason: null,
+      disabledReason: webApp.available
+        ? null
+        : "The web app is not available for this server.",
     },
     openSupport: {
       execute: openSupport,
@@ -82,6 +90,7 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
     openSupport,
     supportDisabledReason,
     openWebApp,
+    webApp.available,
     showKeyboardShortcuts,
   ]);
 }

--- a/apps/desktop/src/hooks/auth/workflows/use-connect-server.ts
+++ b/apps/desktop/src/hooks/auth/workflows/use-connect-server.ts
@@ -1,10 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
+import { CONNECT_SERVER_LABELS } from "@/copy/auth/auth-copy";
 import {
   fetchServerMeta,
   isTauriRuntimeAvailable,
 } from "@/lib/access/tauri/connect-server";
 import { setDesktopAppConfig } from "@/lib/access/tauri/config";
-import { relaunch } from "@/lib/access/tauri/updater";
+import { getAppVersion, relaunch } from "@/lib/access/tauri/updater";
+import { isDesktopVersionSupported } from "@/lib/domain/capabilities/version-compat";
 import {
   getRuntimeDesktopAppConfig,
   isOfficialHostedApiBaseUrl,
@@ -32,6 +34,12 @@ export interface UseConnectServerResult {
   error: string | null;
   pendingMeta: ServerMeta | null;
   pendingHost: string | null;
+  /**
+   * A warning when this desktop is older than the candidate server's minimum
+   * supported version, or null. Computed once during the `/meta` check so the
+   * dialog stays presentational (no render-time version query).
+   */
+  versionWarning: string | null;
   open: () => void;
   /**
    * Open the flow already pointed at a supplied server URL — runs the same
@@ -61,6 +69,7 @@ export function useConnectServer(): UseConnectServerResult {
   const [pendingMeta, setPendingMeta] = useState<ServerMeta | null>(null);
   const [pendingHost, setPendingHost] = useState<string | null>(null);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [versionWarning, setVersionWarning] = useState<string | null>(null);
 
   const currentConfig = getRuntimeDesktopAppConfig();
   const connectedServerHost = useMemo(() => {
@@ -81,6 +90,7 @@ export function useConnectServer(): UseConnectServerResult {
     setPendingMeta(null);
     setPendingHost(null);
     setPendingUrl(null);
+    setVersionWarning(null);
     setStep("entry");
   }, [available]);
 
@@ -110,6 +120,18 @@ export function useConnectServer(): UseConnectServerResult {
     setPendingUrl(normalized.url);
     setPendingHost(normalized.host);
     setPendingMeta(result.meta);
+    // Compute the desktop<->server version-compat warning imperatively here so
+    // the dialog stays presentational. Fail open: any error leaves no warning.
+    let warning: string | null = null;
+    try {
+      const appVersion = await getAppVersion();
+      if (!isDesktopVersionSupported(appVersion, result.meta.minDesktopVersion)) {
+        warning = CONNECT_SERVER_LABELS.minVersionWarning(result.meta.minDesktopVersion);
+      }
+    } catch {
+      warning = null;
+    }
+    setVersionWarning(warning);
     setStep("trust-confirm");
   }, [available]);
 
@@ -124,6 +146,7 @@ export function useConnectServer(): UseConnectServerResult {
     setPendingMeta(null);
     setPendingHost(null);
     setPendingUrl(null);
+    setVersionWarning(null);
     // Falls into "entry" on any validation/reachability failure, so the user
     // can retype the address rather than being stranded on a blank dialog.
     await runCheck(serverUrl);
@@ -164,6 +187,7 @@ export function useConnectServer(): UseConnectServerResult {
     error,
     pendingMeta,
     pendingHost,
+    versionWarning,
     open,
     openForUrl,
     close,

--- a/apps/desktop/src/hooks/capabilities/derived/use-app-capabilities.ts
+++ b/apps/desktop/src/hooks/capabilities/derived/use-app-capabilities.ts
@@ -1,15 +1,50 @@
 import { useMemo } from "react";
+import { PROLIFERATE_PRICING_URL, SUPPORT_EMAIL_ADDRESS } from "@/config/capabilities";
+import { useServerCapabilities } from "@/hooks/access/cloud/server-capabilities/use-server-capabilities";
 import { useControlPlaneHealth } from "@/hooks/access/cloud/use-control-plane-health";
-import { CLOUD_COMPUTE_TEMPORARILY_DISABLED } from "@/lib/domain/capabilities/cloud-compute";
+import {
+  type AppCapabilities,
+  deriveAppCapabilities,
+  resolveEffectiveContract,
+} from "@/lib/domain/capabilities/app-capabilities";
+import {
+  getProliferateApiBaseUrl,
+  isOfficialHostedApiBaseUrl,
+} from "@/lib/infra/proliferate-api";
 
-export function useAppCapabilities() {
+function connectedServerHost(): string | null {
+  try {
+    return new URL(getProliferateApiBaseUrl()).host || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * App-wide capability state, derived from the server-declared capability
+ * contract rather than mere reachability. A self-managed server exposes only
+ * the capabilities its operator configured; an older server (no contract) that
+ * is the official hosted product keeps the current hosted posture, and any
+ * other older server degrades conservatively.
+ */
+export function useAppCapabilities(): AppCapabilities {
   const { data: reachable = false } = useControlPlaneHealth();
+  const { data: contract = null } = useServerCapabilities();
+  const isOfficialOrigin = isOfficialHostedApiBaseUrl();
+  const host = connectedServerHost();
 
-  return useMemo(() => ({
-    cloudEnabled: reachable,
-    billingEnabled: reachable,
-    // Cloud compute (workspaces, remote access, mobility) is temporarily
-    // disabled for this release; identity and billing stay available.
-    cloudComputeEnabled: reachable && !CLOUD_COMPUTE_TEMPORARILY_DISABLED,
-  }), [reachable]);
+  return useMemo(() => {
+    const effective = resolveEffectiveContract(contract, {
+      isOfficialOrigin,
+      fallback: {
+        supportEmail: SUPPORT_EMAIL_ADDRESS,
+        pricingUrl: PROLIFERATE_PRICING_URL,
+      },
+    });
+    return deriveAppCapabilities({
+      reachable,
+      contract: effective,
+      connectedServerHost: host,
+    });
+  }, [reachable, contract, isOfficialOrigin, host]);
 }

--- a/apps/desktop/src/hooks/capabilities/derived/use-web-app-target.ts
+++ b/apps/desktop/src/hooks/capabilities/derived/use-web-app-target.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
+import { useAppCapabilities } from "./use-app-capabilities";
+
+export interface WebAppTarget {
+  /** Whether this deployment has a hosted web app to hand off to. */
+  available: boolean;
+  /** Runtime-resolved web base URL, or null when no web app is available. */
+  baseUrl: string | null;
+}
+
+/**
+ * Runtime-safe web-app handoff target.
+ *
+ * Web handoffs must never hardcode the vendor web origin: a self-managed
+ * deployment has no hosted web app (`available` false → hide the affordance),
+ * and the hosted product's web URL comes from the server contract when
+ * declared, falling back to the build-time default only for the official host.
+ */
+export function useWebAppTarget(): WebAppTarget {
+  const { webApp } = useAppCapabilities();
+
+  return useMemo(() => {
+    if (!webApp.available) {
+      return { available: false, baseUrl: null };
+    }
+    return {
+      available: true,
+      baseUrl: webApp.baseUrl ?? getProliferateWebBaseUrl(),
+    };
+  }, [webApp.available, webApp.baseUrl]);
+}

--- a/apps/desktop/src/hooks/support/derived/use-support-menu-action.ts
+++ b/apps/desktop/src/hooks/support/derived/use-support-menu-action.ts
@@ -1,0 +1,16 @@
+import { useAppCapabilities } from "@/hooks/capabilities/derived/use-app-capabilities";
+import {
+  deriveSupportMenuAction,
+  type SupportMenuAction,
+} from "@/lib/domain/support/support-menu-action";
+
+/**
+ * What the sidebar/command-palette support action should do for the
+ * connected server: keep the vendor feedback flow on hosted, route to the
+ * operator's configured destination on a self-managed server that has one,
+ * or offer no support action at all when nothing is configured.
+ */
+export function useSupportMenuAction(): SupportMenuAction {
+  const { support } = useAppCapabilities();
+  return deriveSupportMenuAction(support);
+}

--- a/apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.test.ts
+++ b/apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppCommandActions } from "@/hooks/app/workflows/app-command-action-types";
+import { buildWorkspaceCommandPaletteEntries } from "./workspace-command-palette-entries";
+
+// Mirrors the sidebar hiding its support action under `support.kind ===
+// "none"` (`SidebarHelpSection`): the command-palette "Open Support" entry
+// must not merely be disabled, it must not be registered at all.
+
+function commandAction() {
+  return { execute: vi.fn(), disabledReason: null as string | null };
+}
+
+function baseAppActions(): AppCommandActions {
+  return {
+    openSettings: commandAction(),
+    showKeyboardShortcuts: commandAction(),
+    goHome: commandAction(),
+    goWorkflows: commandAction(),
+    openWebApp: commandAction(),
+    openSupport: commandAction(),
+    addRepository: commandAction(),
+    newLocalWorkspace: commandAction(),
+    newWorktreeWorkspace: commandAction(),
+    newCloudWorkspace: commandAction(),
+    copyWorkspacePath: commandAction(),
+    copyBranchName: commandAction(),
+  };
+}
+
+function baseArgs(appActions: AppCommandActions) {
+  return {
+    activeSessionId: null,
+    appActions,
+    canActivateRelativeTab: true,
+    canOpenNewSessionTab: true,
+    canOpenRepositorySettings: true,
+    hasWorkspaceShell: true,
+    navigate: vi.fn(),
+    newSessionDisabledReason: null,
+    onToggleLeftSidebar: vi.fn(),
+    onToggleRightPanel: vi.fn(),
+    openNewSessionTab: vi.fn(),
+    openTerminalPanel: vi.fn(() => true),
+    activateRelativeTab: vi.fn(),
+    relativeTabDisabledReason: null,
+    repoSettingsHref: null,
+    repositorySettingsDisabledReason: null,
+    restoreLastDismissedTab: vi.fn(),
+    restoreTabDisabledReason: null,
+    runCommand: {
+      onRun: vi.fn(),
+      canRun: true,
+      disabledReason: null,
+      isLaunching: false,
+    },
+    selectedWorkspaceId: "workspace-1",
+    workspaceRemoteAccessActions: {
+      syncToWeb: vi.fn(),
+      syncToWebDisabledReason: null,
+    },
+    workspaceWebActions: {
+      openCurrentWorkspaceInWeb: vi.fn(),
+      disabledReason: null,
+    },
+  };
+}
+
+describe("buildWorkspaceCommandPaletteEntries support routing", () => {
+  it("registers 'Open Support' when the action is visible (vendor/operator)", () => {
+    const appActions = baseAppActions();
+    const entries = buildWorkspaceCommandPaletteEntries(baseArgs(appActions));
+
+    expect(entries.find((entry) => entry.id === "app.open-support")).not.toBeUndefined();
+  });
+
+  it("does not register 'Open Support' at all when the action is hidden (support.kind === 'none')", () => {
+    const appActions = baseAppActions();
+    appActions.openSupport = { ...commandAction(), hidden: true };
+    const entries = buildWorkspaceCommandPaletteEntries(baseArgs(appActions));
+
+    expect(entries.find((entry) => entry.id === "app.open-support")).toBeUndefined();
+    // Sanity: hiding support doesn't drop unrelated entries.
+    expect(entries.find((entry) => entry.id === "app.open-web")).not.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.ts
+++ b/apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.ts
@@ -50,7 +50,7 @@ export function buildWorkspaceCommandPaletteEntries(args: {
   workspaceRemoteAccessActions: WorkspaceRemoteAccessActionState;
   workspaceWebActions: WorkspaceWebActionState;
 }): CommandPaletteEntry[] {
-  return [
+  const entries: CommandPaletteEntry[] = [
     {
       id: "workspace.focus-chat",
       value: commandPaletteCommandValue("workspace.focus-chat"),
@@ -312,4 +312,10 @@ export function buildWorkspaceCommandPaletteEntries(args: {
       execute: () => args.appActions.newCloudWorkspace.execute("palette"),
     },
   ];
+
+  // Mirrors the sidebar hiding its support action under `support.kind ===
+  // "none"`: don't just disable the palette entry, don't register it at all.
+  return args.appActions.openSupport.hidden
+    ? entries.filter((entry) => entry.id !== "app.open-support")
+    : entries;
 }

--- a/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx
@@ -29,11 +29,15 @@ vi.mock("@/hooks/workspaces/derived/use-selected-logical-workspace", () => ({
   }),
 }));
 
+const webAppMocks = vi.hoisted(() => ({
+  webApp: { available: true, baseUrl: "https://web.proliferate.com" } as {
+    available: boolean;
+    baseUrl: string | null;
+  },
+}));
+
 vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
-  useWebAppTarget: () => ({
-    available: true,
-    baseUrl: "https://web.proliferate.com",
-  }),
+  useWebAppTarget: () => webAppMocks.webApp,
 }));
 
 vi.mock("@/stores/toast/toast-store", () => ({
@@ -50,6 +54,7 @@ describe("useWorkspaceOpenInWebActions", () => {
       cloudWorkspace: { id: "cloud-workspace-1" },
       mobilityWorkspace: null,
     };
+    webAppMocks.webApp = { available: true, baseUrl: "https://web.proliferate.com" };
   });
 
   afterEach(() => {
@@ -72,5 +77,22 @@ describe("useWorkspaceOpenInWebActions", () => {
         "info",
       );
     });
+  });
+
+  it("disables the action and never opens anything when this deployment has no web app", () => {
+    webAppMocks.webApp = { available: false, baseUrl: null };
+    const { result } = renderHook(() => useWorkspaceOpenInWebActions());
+
+    expect(result.current.disabled).toBe(true);
+    expect(result.current.disabledReason).toBe("The web app is not available for this server.");
+    expect(result.current.url).toBeNull();
+
+    act(() => {
+      result.current.openCurrentWorkspaceInWeb();
+    });
+
+    expect(hookMocks.copyText).not.toHaveBeenCalled();
+    expect(hookMocks.openExternal).not.toHaveBeenCalled();
+    expect(hookMocks.showToast).toHaveBeenCalledWith("The web app is not available for this server.");
   });
 });

--- a/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx
@@ -29,8 +29,11 @@ vi.mock("@/hooks/workspaces/derived/use-selected-logical-workspace", () => ({
   }),
 }));
 
-vi.mock("@/lib/infra/proliferate-web", () => ({
-  getProliferateWebBaseUrl: () => "https://web.proliferate.com",
+vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
+  useWebAppTarget: () => ({
+    available: true,
+    baseUrl: "https://web.proliferate.com",
+  }),
 }));
 
 vi.mock("@/stores/toast/toast-store", () => ({

--- a/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.ts
@@ -1,25 +1,29 @@
 import { useCallback, useMemo } from "react";
 import { webWorkspaceDeepLink } from "@proliferate/cloud-sdk";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useSelectedLogicalWorkspace } from "@/hooks/workspaces/derived/use-selected-logical-workspace";
-import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { useToastStore } from "@/stores/toast/toast-store";
 
 export function useWorkspaceOpenInWebActions() {
   const { selectedLogicalWorkspace } = useSelectedLogicalWorkspace();
   const { copyText, openExternal } = useTauriShellActions();
+  const webApp = useWebAppTarget();
   const showToast = useToastStore((state) => state.show);
   const cloudWorkspaceId = selectedLogicalWorkspace?.cloudWorkspace?.id
     ?? selectedLogicalWorkspace?.mobilityWorkspace?.cloudWorkspaceId
     ?? null;
+  const webBaseUrl = webApp.baseUrl;
   const url = useMemo(() => (
-    cloudWorkspaceId
-      ? webWorkspaceDeepLink(cloudWorkspaceId, getProliferateWebBaseUrl())
+    cloudWorkspaceId && webBaseUrl
+      ? webWorkspaceDeepLink(cloudWorkspaceId, webBaseUrl)
       : null
-  ), [cloudWorkspaceId]);
+  ), [cloudWorkspaceId, webBaseUrl]);
   const disabledReason = url
     ? null
-    : "Enable remote access first.";
+    : !webApp.available
+      ? "The web app is not available for this server."
+      : "Enable remote access first.";
   const title = url
     ? "Open this workspace in the web app."
     : "Enable remote access first to open this workspace from web and mobile.";

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
@@ -75,6 +75,13 @@ vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
   }),
 }));
 
+vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
+  useWebAppTarget: () => ({
+    available: true,
+    baseUrl: "https://web.proliferate.com",
+  }),
+}));
+
 vi.mock("@/stores/toast/toast-store", () => ({
   useToastStore: (selector: (state: { show: typeof toastMocks.show }) => unknown) =>
     selector({ show: toastMocks.show }),

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
@@ -75,11 +75,15 @@ vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
   }),
 }));
 
+const webAppMocks = vi.hoisted(() => ({
+  webApp: { available: true, baseUrl: "https://web.proliferate.com" } as {
+    available: boolean;
+    baseUrl: string | null;
+  },
+}));
+
 vi.mock("@/hooks/capabilities/derived/use-web-app-target", () => ({
-  useWebAppTarget: () => ({
-    available: true,
-    baseUrl: "https://web.proliferate.com",
-  }),
+  useWebAppTarget: () => webAppMocks.webApp,
 }));
 
 vi.mock("@/stores/toast/toast-store", () => ({
@@ -109,6 +113,7 @@ beforeEach(() => {
   logicalWorkspaceMocks.logicalWorkspaces = [];
   selectionMocks.selectWorkspace.mockResolvedValue(undefined);
   shellMocks.openExternal.mockResolvedValue(undefined);
+  webAppMocks.webApp = { available: true, baseUrl: "https://web.proliferate.com" };
 });
 
 describe("useWorkspaceNavigationWorkflow", () => {
@@ -183,5 +188,28 @@ describe("useWorkspaceNavigationWorkflow", () => {
     );
     expect(selectionMocks.selectWorkspace).not.toHaveBeenCalled();
     expect(routerMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("falls through to normal in-desktop selection when this deployment has no web app", () => {
+    webAppMocks.webApp = { available: false, baseUrl: null };
+    logicalWorkspaceMocks.logicalWorkspaces = [{
+      id: "logical-unclaimed",
+      localWorkspace: null,
+      mobilityWorkspace: null,
+      cloudWorkspace: {
+        id: "cloud-unclaimed-1",
+        visibility: "shared_unclaimed",
+      },
+    }];
+    const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
+
+    act(() => result.current.selectWorkspaceFromSurface("logical-unclaimed", "sidebar"));
+
+    // No dead vendor-web link when the deployment has no web app: normal
+    // desktop workspace selection runs instead.
+    expect(shellMocks.openExternal).not.toHaveBeenCalled();
+    expect(selectionMocks.selectWorkspace).toHaveBeenCalledWith("logical-unclaimed", {
+      latencyFlowId: "flow-1",
+    });
   });
 });

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { webWorkspaceDeepLink } from "@proliferate/cloud-sdk";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import { useWebAppTarget } from "@/hooks/capabilities/derived/use-web-app-target";
 import { useWorkspaceSelection } from "@/hooks/workspaces/workflows/selection/use-workspace-selection";
 import { useLogicalWorkspaces } from "@/hooks/workspaces/derived/use-logical-workspaces";
 import { logicalWorkspaceMatchesId } from "@/lib/domain/workspaces/cloud/logical-workspace-lookup";
@@ -9,7 +10,6 @@ import {
   failLatencyFlow,
   startLatencyFlow,
 } from "@/lib/infra/measurement/latency-flow";
-import { getProliferateWebBaseUrl } from "@/lib/infra/proliferate-web";
 import { resetWorkspaceEditorState } from "@/stores/editor/workspace-editor-state";
 import { markWorkspaceViewed } from "@/stores/preferences/workspace-ui-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
@@ -29,6 +29,7 @@ export function useWorkspaceNavigationWorkflow() {
   const { selectWorkspace } = useWorkspaceSelection();
   const { logicalWorkspaces } = useLogicalWorkspaces();
   const { openExternal } = useTauriShellActions();
+  const webApp = useWebAppTarget();
   const showToast = useToastStore((state) => state.show);
 
   const navigateToWorkspaceShell = useCallback(() => {
@@ -56,10 +57,13 @@ export function useWorkspaceNavigationWorkflow() {
       logicalWorkspaceMatchesId(workspace, workspaceId) &&
       workspace.cloudWorkspace?.visibility === "shared_unclaimed"
     )?.cloudWorkspace;
-    if (unclaimedCloudWorkspace) {
+    // Unclaimed shared-cloud workspaces are claimed from the web app. Only hand
+    // off to web when this deployment actually has one; otherwise fall through
+    // to normal in-desktop selection rather than opening a dead vendor link.
+    if (unclaimedCloudWorkspace && webApp.available && webApp.baseUrl) {
       const url = webWorkspaceDeepLink(
         unclaimedCloudWorkspace.id,
-        getProliferateWebBaseUrl(),
+        webApp.baseUrl,
       );
       void openExternal(url).catch(() => {
         showToast("Failed to open the web workspace.");
@@ -88,6 +92,8 @@ export function useWorkspaceNavigationWorkflow() {
     selectedLogicalWorkspaceId,
     selectWorkspace,
     showToast,
+    webApp.available,
+    webApp.baseUrl,
   ]);
 
   return {

--- a/apps/desktop/src/lib/access/cloud/server-capabilities.ts
+++ b/apps/desktop/src/lib/access/cloud/server-capabilities.ts
@@ -1,0 +1,42 @@
+import { buildProliferateApiUrl } from "@/lib/infra/proliferate-api";
+import {
+  parseServerCapabilities,
+  type ServerCapabilityContract,
+} from "@/lib/domain/capabilities/server-capability-contract";
+
+const SERVER_CAPABILITIES_TIMEOUT_MS = 2_500;
+
+/**
+ * Fetch the connected control plane's capability contract from `GET /meta`.
+ *
+ * Returns `null` when the server is unreachable, the response is malformed, or
+ * the server is too old to declare capabilities. Callers treat `null`
+ * conservatively; the official-hosted fallback is applied one layer up.
+ */
+export async function fetchServerCapabilities(): Promise<ServerCapabilityContract | null> {
+  const abortController =
+    typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timeoutId = abortController
+    ? globalThis.setTimeout(
+        () => abortController.abort(),
+        SERVER_CAPABILITIES_TIMEOUT_MS,
+      )
+    : null;
+
+  try {
+    const response = await fetch(buildProliferateApiUrl("/meta"), {
+      headers: { Accept: "application/json" },
+      signal: abortController?.signal,
+    });
+    if (!response.ok) return null;
+    const body: unknown = await response.json();
+    if (typeof body !== "object" || body === null) return null;
+    return parseServerCapabilities((body as Record<string, unknown>).capabilities);
+  } catch {
+    return null;
+  } finally {
+    if (timeoutId) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/desktop/src/lib/domain/capabilities/app-capabilities.ts
+++ b/apps/desktop/src/lib/domain/capabilities/app-capabilities.ts
@@ -1,4 +1,144 @@
+import { CLOUD_COMPUTE_TEMPORARILY_DISABLED } from "./cloud-compute";
+import type {
+  DeploymentMode,
+  PricingCapability,
+  ServerCapabilityContract,
+  SupportCapability,
+  WebAppCapability,
+} from "./server-capability-contract";
+
+/**
+ * The app-wide capability state the desktop renders from.
+ *
+ * Derived from the server-declared capability contract, not from mere
+ * reachability. A self-managed server exposes only the capabilities its
+ * operator configured; an older server (no contract) degrades conservatively.
+ *
+ * `cloudEnabled` intentionally stays reachability-based: a self-managed server
+ * is a control plane you sign into just like Cloud, so sign-in must not be
+ * gated on deployment mode. Vendor/cloud *surfaces* are gated on the more
+ * specific flags below.
+ */
 export interface AppCapabilities {
+  /** The connected control plane answered a health check. */
+  reachable: boolean;
+  /** Control plane usable for sign-in. True whenever reachable. */
   cloudEnabled: boolean;
+  /** Vendor billing / credits / Stripe / pricing surfaces are usable. */
   billingEnabled: boolean;
+  /** Consumption / usage-metering surfaces (usage bars) are meaningful. */
+  usageMeteringEnabled: boolean;
+  /** Cloud compute (cloud workspaces, remote access) is usable. */
+  cloudComputeEnabled: boolean;
+  /** The bundled agent LLM gateway is enabled on this server. */
+  agentGatewayEnabled: boolean;
+  /** Server-declared deployment mode. */
+  deploymentMode: DeploymentMode;
+  /** True when the connected server is not the hosted product. */
+  isSelfManaged: boolean;
+  /** Identity to show persistently for a self-managed server; null when hosted. */
+  serverDisplayName: string | null;
+  serverLogoUrl: string | null;
+  webApp: WebAppCapability;
+  support: SupportCapability;
+  pricing: PricingCapability;
+}
+
+export interface DeriveAppCapabilitiesInput {
+  reachable: boolean;
+  /** Parsed server capability contract, or null for older/unknown servers. */
+  contract: ServerCapabilityContract | null;
+  /** Origin host shown as identity for a self-managed server (from apiBaseUrl). */
+  connectedServerHost: string | null;
+}
+
+/** Vendor destinations used to synthesize the official-hosted fallback contract.
+ * Injected (not imported) so this domain module stays config-free and testable. */
+export interface OfficialHostedFallback {
+  supportEmail: string;
+  pricingUrl: string;
+}
+
+/**
+ * Resolve the contract the desktop should render from.
+ *
+ * When the connected server declares a contract, that is authoritative. When
+ * it does not (an older server that predates the contract), fall back on the
+ * one client-side signal that is safe: whether the origin is the official
+ * hosted product. An older *official* server gets the current hosted posture
+ * synthesized so hosted behavior is preserved during rollout; any other origin
+ * stays `null` and is treated conservatively downstream.
+ */
+export function resolveEffectiveContract(
+  contract: ServerCapabilityContract | null,
+  opts: { isOfficialOrigin: boolean; fallback: OfficialHostedFallback },
+): ServerCapabilityContract | null {
+  if (contract) return contract;
+  if (!opts.isOfficialOrigin) return null;
+  return {
+    contractVersion: 0,
+    deployment: { mode: "hosted_product", displayName: "", logoUrl: null },
+    billing: true,
+    usageMetering: true,
+    cloudWorkspaces: true,
+    agentGateway: true,
+    webApp: { available: true, baseUrl: null },
+    support: { kind: "vendor", email: opts.fallback.supportEmail, url: null },
+    pricing: { available: true, url: opts.fallback.pricingUrl },
+  };
+}
+
+/**
+ * Pure mapping from the server capability contract (plus reachability) to the
+ * app-wide capability state. No I/O — unit-tested directly.
+ *
+ * The official-hosted fallback for an older server that returns no contract is
+ * synthesized by the hook (which knows the connected origin), so this function
+ * only ever sees a real contract or `null`. A `null` contract is treated as a
+ * conservative self-managed server: sign-in works, every vendor/cloud surface
+ * is off until declared.
+ */
+export function deriveAppCapabilities(
+  input: DeriveAppCapabilitiesInput,
+): AppCapabilities {
+  const { reachable, contract, connectedServerHost } = input;
+
+  if (!contract) {
+    return {
+      reachable,
+      cloudEnabled: reachable,
+      billingEnabled: false,
+      usageMeteringEnabled: false,
+      cloudComputeEnabled: false,
+      agentGatewayEnabled: false,
+      deploymentMode: "self_managed",
+      isSelfManaged: true,
+      serverDisplayName: connectedServerHost,
+      serverLogoUrl: null,
+      webApp: { available: false, baseUrl: null },
+      support: { kind: "none", email: null, url: null },
+      pricing: { available: false, url: null },
+    };
+  }
+
+  const hosted = contract.deployment.mode === "hosted_product";
+
+  return {
+    reachable,
+    cloudEnabled: reachable,
+    billingEnabled: reachable && contract.billing,
+    usageMeteringEnabled: reachable && contract.usageMetering,
+    cloudComputeEnabled:
+      reachable && contract.cloudWorkspaces && !CLOUD_COMPUTE_TEMPORARILY_DISABLED,
+    agentGatewayEnabled: reachable && contract.agentGateway,
+    deploymentMode: contract.deployment.mode,
+    isSelfManaged: !hosted,
+    serverDisplayName: hosted
+      ? null
+      : contract.deployment.displayName || connectedServerHost,
+    serverLogoUrl: hosted ? null : contract.deployment.logoUrl,
+    webApp: contract.webApp,
+    support: contract.support,
+    pricing: contract.pricing,
+  };
 }

--- a/apps/desktop/src/lib/domain/capabilities/derive-app-capabilities.test.ts
+++ b/apps/desktop/src/lib/domain/capabilities/derive-app-capabilities.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveAppCapabilities,
+  resolveEffectiveContract,
+} from "./app-capabilities";
+import type { ServerCapabilityContract } from "./server-capability-contract";
+
+const FALLBACK = {
+  supportEmail: "support@proliferate.com",
+  pricingUrl: "https://proliferate.com/pricing",
+};
+
+function contract(
+  overrides: Partial<ServerCapabilityContract> = {},
+): ServerCapabilityContract {
+  return {
+    contractVersion: 1,
+    deployment: { mode: "self_managed", displayName: "", logoUrl: null },
+    billing: false,
+    usageMetering: false,
+    cloudWorkspaces: false,
+    agentGateway: false,
+    webApp: { available: false, baseUrl: null },
+    support: { kind: "none", email: null, url: null },
+    pricing: { available: false, url: null },
+    ...overrides,
+  };
+}
+
+describe("deriveAppCapabilities", () => {
+  it("maps a hosted contract to full capabilities and no self-managed identity", () => {
+    const caps = deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "app.proliferate.com",
+      contract: contract({
+        deployment: { mode: "hosted_product", displayName: "Proliferate", logoUrl: null },
+        billing: true,
+        usageMetering: true,
+        cloudWorkspaces: true,
+        agentGateway: true,
+        webApp: { available: true, baseUrl: "https://web.proliferate.com" },
+        support: { kind: "vendor", email: "support@proliferate.com", url: null },
+        pricing: { available: true, url: "https://proliferate.com/pricing" },
+      }),
+    });
+
+    expect(caps.cloudEnabled).toBe(true);
+    expect(caps.billingEnabled).toBe(true);
+    expect(caps.usageMeteringEnabled).toBe(true);
+    expect(caps.cloudComputeEnabled).toBe(true);
+    expect(caps.agentGatewayEnabled).toBe(true);
+    expect(caps.isSelfManaged).toBe(false);
+    expect(caps.serverDisplayName).toBeNull();
+    expect(caps.serverLogoUrl).toBeNull();
+    expect(caps.webApp.baseUrl).toBe("https://web.proliferate.com");
+    expect(caps.support.kind).toBe("vendor");
+    expect(caps.pricing.available).toBe(true);
+  });
+
+  it("keeps every vendor/cloud surface off for a base self-managed contract", () => {
+    const caps = deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "acme.example.com",
+      contract: contract({ deployment: { mode: "self_managed", displayName: "", logoUrl: null } }),
+    });
+
+    // Sign-in still works against a self-managed control plane.
+    expect(caps.cloudEnabled).toBe(true);
+    expect(caps.billingEnabled).toBe(false);
+    expect(caps.usageMeteringEnabled).toBe(false);
+    expect(caps.cloudComputeEnabled).toBe(false);
+    expect(caps.agentGatewayEnabled).toBe(false);
+    expect(caps.isSelfManaged).toBe(true);
+    // No operator name -> fall back to the connected origin host.
+    expect(caps.serverDisplayName).toBe("acme.example.com");
+    expect(caps.webApp.available).toBe(false);
+    expect(caps.support.kind).toBe("none");
+    expect(caps.pricing.available).toBe(false);
+  });
+
+  it("shows only the configured add-ons on a self-managed contract", () => {
+    const caps = deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "acme.example.com",
+      contract: contract({
+        deployment: { mode: "self_managed", displayName: "Acme Internal", logoUrl: "https://acme.example.com/logo.svg" },
+        cloudWorkspaces: true,
+        agentGateway: true,
+      }),
+    });
+
+    expect(caps.isSelfManaged).toBe(true);
+    expect(caps.serverDisplayName).toBe("Acme Internal");
+    expect(caps.serverLogoUrl).toBe("https://acme.example.com/logo.svg");
+    expect(caps.cloudComputeEnabled).toBe(true);
+    expect(caps.agentGatewayEnabled).toBe(true);
+    // Billing/web/pricing stay off unless declared.
+    expect(caps.billingEnabled).toBe(false);
+    expect(caps.webApp.available).toBe(false);
+  });
+
+  it("treats a missing contract as a conservative self-managed server", () => {
+    const caps = deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "unknown.example.com",
+      contract: null,
+    });
+
+    expect(caps.cloudEnabled).toBe(true);
+    expect(caps.billingEnabled).toBe(false);
+    expect(caps.cloudComputeEnabled).toBe(false);
+    expect(caps.agentGatewayEnabled).toBe(false);
+    expect(caps.isSelfManaged).toBe(true);
+    expect(caps.deploymentMode).toBe("self_managed");
+    expect(caps.serverDisplayName).toBe("unknown.example.com");
+    expect(caps.webApp.available).toBe(false);
+    expect(caps.support.kind).toBe("none");
+    expect(caps.pricing.available).toBe(false);
+  });
+
+  it("gates capabilities on reachability", () => {
+    const caps = deriveAppCapabilities({
+      reachable: false,
+      connectedServerHost: "app.proliferate.com",
+      contract: contract({
+        deployment: { mode: "hosted_product", displayName: "Proliferate", logoUrl: null },
+        billing: true,
+        cloudWorkspaces: true,
+        agentGateway: true,
+      }),
+    });
+
+    expect(caps.cloudEnabled).toBe(false);
+    expect(caps.billingEnabled).toBe(false);
+    expect(caps.cloudComputeEnabled).toBe(false);
+    expect(caps.agentGatewayEnabled).toBe(false);
+  });
+});
+
+describe("resolveEffectiveContract", () => {
+  it("returns the server contract verbatim when present", () => {
+    const c = contract({ billing: true });
+    expect(
+      resolveEffectiveContract(c, { isOfficialOrigin: false, fallback: FALLBACK }),
+    ).toBe(c);
+  });
+
+  it("synthesizes the hosted posture for an older official server", () => {
+    const resolved = resolveEffectiveContract(null, {
+      isOfficialOrigin: true,
+      fallback: FALLBACK,
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.deployment.mode).toBe("hosted_product");
+    expect(resolved?.billing).toBe(true);
+    expect(resolved?.cloudWorkspaces).toBe(true);
+    expect(resolved?.agentGateway).toBe(true);
+    expect(resolved?.webApp.available).toBe(true);
+    expect(resolved?.support.email).toBe("support@proliferate.com");
+    expect(resolved?.pricing.url).toBe("https://proliferate.com/pricing");
+  });
+
+  it("stays null (conservative) for an older non-official server", () => {
+    expect(
+      resolveEffectiveContract(null, { isOfficialOrigin: false, fallback: FALLBACK }),
+    ).toBeNull();
+  });
+
+  it("preserves current hosted behavior end to end for an older official server", () => {
+    const resolved = resolveEffectiveContract(null, {
+      isOfficialOrigin: true,
+      fallback: FALLBACK,
+    });
+    const caps = deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "app.proliferate.com",
+      contract: resolved,
+    });
+
+    expect(caps.billingEnabled).toBe(true);
+    expect(caps.cloudComputeEnabled).toBe(true);
+    expect(caps.isSelfManaged).toBe(false);
+    expect(caps.serverDisplayName).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/domain/capabilities/server-capability-contract.test.ts
+++ b/apps/desktop/src/lib/domain/capabilities/server-capability-contract.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { parseServerCapabilities } from "./server-capability-contract";
+
+function validRaw(): Record<string, unknown> {
+  return {
+    contractVersion: 1,
+    deployment: {
+      mode: "self_managed",
+      displayName: "Acme Internal",
+      logoUrl: "https://acme.example.com/logo.svg",
+    },
+    billing: false,
+    usageMetering: false,
+    cloudWorkspaces: true,
+    agentGateway: true,
+    webApp: { available: false, baseUrl: null },
+    support: { kind: "operator", email: "it@acme.example.com", url: null },
+    pricing: { available: false, url: null },
+  };
+}
+
+describe("parseServerCapabilities", () => {
+  it("parses a well-formed contract", () => {
+    const parsed = parseServerCapabilities(validRaw());
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.contractVersion).toBe(1);
+    expect(parsed?.deployment.mode).toBe("self_managed");
+    expect(parsed?.deployment.displayName).toBe("Acme Internal");
+    expect(parsed?.cloudWorkspaces).toBe(true);
+    expect(parsed?.agentGateway).toBe(true);
+    expect(parsed?.support.kind).toBe("operator");
+    expect(parsed?.support.email).toBe("it@acme.example.com");
+  });
+
+  it("returns null when the block is absent or not an object", () => {
+    expect(parseServerCapabilities(undefined)).toBeNull();
+    expect(parseServerCapabilities(null)).toBeNull();
+    expect(parseServerCapabilities("nope")).toBeNull();
+    expect(parseServerCapabilities(42)).toBeNull();
+  });
+
+  it("returns null when deployment.mode is missing or invalid", () => {
+    const noMode = validRaw();
+    delete (noMode.deployment as Record<string, unknown>).mode;
+    expect(parseServerCapabilities(noMode)).toBeNull();
+
+    const badMode = validRaw();
+    (badMode.deployment as Record<string, unknown>).mode = "franchise";
+    expect(parseServerCapabilities(badMode)).toBeNull();
+  });
+
+  it("defaults unknown/missing capability booleans to false", () => {
+    const sparse: Record<string, unknown> = {
+      deployment: { mode: "self_managed" },
+    };
+    const parsed = parseServerCapabilities(sparse);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.contractVersion).toBe(0);
+    expect(parsed?.billing).toBe(false);
+    expect(parsed?.usageMetering).toBe(false);
+    expect(parsed?.cloudWorkspaces).toBe(false);
+    expect(parsed?.agentGateway).toBe(false);
+    expect(parsed?.deployment.displayName).toBe("");
+    expect(parsed?.webApp.available).toBe(false);
+    expect(parsed?.support.kind).toBe("none");
+    expect(parsed?.pricing.available).toBe(false);
+  });
+
+  it("rejects unsafe URLs but keeps safe ones", () => {
+    const raw = validRaw();
+    (raw.deployment as Record<string, unknown>).logoUrl = "javascript:alert(1)";
+    (raw.webApp as Record<string, unknown>) = {
+      available: true,
+      baseUrl: "https://web.example.com",
+    };
+    (raw.support as Record<string, unknown>) = {
+      kind: "operator",
+      email: "not-an-email",
+      url: "ftp://sketchy",
+    };
+    const parsed = parseServerCapabilities(raw);
+
+    expect(parsed?.deployment.logoUrl).toBeNull();
+    expect(parsed?.webApp.baseUrl).toBe("https://web.example.com");
+    expect(parsed?.support.email).toBeNull();
+    expect(parsed?.support.url).toBeNull();
+  });
+
+  it("accepts a mailto support url", () => {
+    const raw = validRaw();
+    (raw.support as Record<string, unknown>) = {
+      kind: "operator",
+      email: null,
+      url: "mailto:help@acme.example.com",
+    };
+    const parsed = parseServerCapabilities(raw);
+    expect(parsed?.support.url).toBe("mailto:help@acme.example.com");
+  });
+});

--- a/apps/desktop/src/lib/domain/capabilities/server-capability-contract.ts
+++ b/apps/desktop/src/lib/domain/capabilities/server-capability-contract.ts
@@ -1,0 +1,155 @@
+/**
+ * The server-declared self-host capability contract, as it arrives on the
+ * public `GET /meta` `capabilities` block.
+ *
+ * This is the source of truth for what the desktop renders. The desktop must
+ * not infer Cloud/billing/gateway from mere reachability — a self-managed
+ * server declares only the capabilities its operator configured. An older
+ * server omits this block entirely; the parser returns `null` for anything
+ * that is not a well-formed contract, and the derivation layer degrades
+ * conservatively.
+ *
+ * Pure domain: no React, no access, no platform APIs.
+ */
+
+export type DeploymentMode = "local_dev" | "self_managed" | "hosted_product";
+
+export type SupportKind = "vendor" | "operator" | "none";
+
+export interface DeploymentIdentity {
+  mode: DeploymentMode;
+  /** Operator instance name; empty means "use the connected origin". */
+  displayName: string;
+  logoUrl: string | null;
+}
+
+export interface WebAppCapability {
+  available: boolean;
+  baseUrl: string | null;
+}
+
+export interface SupportCapability {
+  kind: SupportKind;
+  email: string | null;
+  url: string | null;
+}
+
+export interface PricingCapability {
+  available: boolean;
+  url: string | null;
+}
+
+export interface ServerCapabilityContract {
+  contractVersion: number;
+  deployment: DeploymentIdentity;
+  billing: boolean;
+  usageMetering: boolean;
+  cloudWorkspaces: boolean;
+  agentGateway: boolean;
+  webApp: WebAppCapability;
+  support: SupportCapability;
+  pricing: PricingCapability;
+}
+
+const DEPLOYMENT_MODES: readonly DeploymentMode[] = [
+  "local_dev",
+  "self_managed",
+  "hosted_product",
+];
+
+const SUPPORT_KINDS: readonly SupportKind[] = ["vendor", "operator", "none"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** A trimmed non-empty https(s)/mailto string, or null. Blocks unsafe schemes. */
+function safeUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("mailto:")
+  ) {
+    return trimmed;
+  }
+  return null;
+}
+
+function safeEmail(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed && trimmed.includes("@") ? trimmed : null;
+}
+
+function asBool(value: unknown): boolean {
+  return value === true;
+}
+
+/**
+ * Normalize the raw `/meta` `capabilities` object into a validated contract.
+ *
+ * Returns `null` when the block is absent or not a well-formed contract (older
+ * servers, garbage) so callers fall back to conservative defaults. Individual
+ * unknown/invalid fields default to their conservative value rather than
+ * failing the whole parse, so a newer server that adds fields still parses.
+ */
+export function parseServerCapabilities(
+  raw: unknown,
+): ServerCapabilityContract | null {
+  if (!isRecord(raw)) return null;
+
+  const deploymentRaw = raw.deployment;
+  if (!isRecord(deploymentRaw)) return null;
+
+  const mode = deploymentRaw.mode;
+  if (typeof mode !== "string" || !DEPLOYMENT_MODES.includes(mode as DeploymentMode)) {
+    return null;
+  }
+
+  const contractVersion =
+    typeof raw.contractVersion === "number" ? raw.contractVersion : 0;
+
+  const displayName =
+    typeof deploymentRaw.displayName === "string"
+      ? deploymentRaw.displayName.trim()
+      : "";
+
+  const webAppRaw = isRecord(raw.webApp) ? raw.webApp : {};
+  const supportRaw = isRecord(raw.support) ? raw.support : {};
+  const pricingRaw = isRecord(raw.pricing) ? raw.pricing : {};
+
+  const supportKind =
+    typeof supportRaw.kind === "string" &&
+    SUPPORT_KINDS.includes(supportRaw.kind as SupportKind)
+      ? (supportRaw.kind as SupportKind)
+      : "none";
+
+  return {
+    contractVersion,
+    deployment: {
+      mode: mode as DeploymentMode,
+      displayName,
+      logoUrl: safeUrl(deploymentRaw.logoUrl),
+    },
+    billing: asBool(raw.billing),
+    usageMetering: asBool(raw.usageMetering),
+    cloudWorkspaces: asBool(raw.cloudWorkspaces),
+    agentGateway: asBool(raw.agentGateway),
+    webApp: {
+      available: asBool(webAppRaw.available),
+      baseUrl: safeUrl(webAppRaw.baseUrl),
+    },
+    support: {
+      kind: supportKind,
+      email: safeEmail(supportRaw.email),
+      url: safeUrl(supportRaw.url),
+    },
+    pricing: {
+      available: asBool(pricingRaw.available),
+      url: safeUrl(pricingRaw.url),
+    },
+  };
+}

--- a/apps/desktop/src/lib/domain/capabilities/version-compat.test.ts
+++ b/apps/desktop/src/lib/domain/capabilities/version-compat.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { compareSemver, isDesktopVersionSupported } from "./version-compat";
+
+describe("compareSemver", () => {
+  it("orders by major, minor, then patch", () => {
+    expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+    expect(compareSemver("1.2.0", "1.1.9")).toBe(1);
+    expect(compareSemver("1.1.1", "1.1.2")).toBe(-1);
+    expect(compareSemver("3.4.5", "3.4.5")).toBe(0);
+  });
+
+  it("ignores pre-release and build suffixes", () => {
+    expect(compareSemver("0.3.2-dev", "0.3.2")).toBe(0);
+    expect(compareSemver("1.0.0+build.7", "1.0.0")).toBe(0);
+  });
+
+  it("returns null for unparseable versions", () => {
+    expect(compareSemver("nightly", "1.0.0")).toBeNull();
+    expect(compareSemver("1.0.0", "")).toBeNull();
+  });
+});
+
+describe("isDesktopVersionSupported", () => {
+  it("is supported when the desktop meets or exceeds the floor", () => {
+    expect(isDesktopVersionSupported("0.3.2", "0.3.2")).toBe(true);
+    expect(isDesktopVersionSupported("0.4.0", "0.3.2")).toBe(true);
+  });
+
+  it("is unsupported when the desktop is confidently older than the floor", () => {
+    expect(isDesktopVersionSupported("0.3.1", "0.3.2")).toBe(false);
+    expect(isDesktopVersionSupported("0.2.9", "1.0.0")).toBe(false);
+  });
+
+  it("fails open on unparseable versions (dev builds, empty pins)", () => {
+    expect(isDesktopVersionSupported("0.0.0-dev", "0.3.2")).toBe(true);
+    expect(isDesktopVersionSupported("0.3.2", "")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/domain/capabilities/version-compat.ts
+++ b/apps/desktop/src/lib/domain/capabilities/version-compat.ts
@@ -1,0 +1,62 @@
+/**
+ * Desktop <-> server version compatibility.
+ *
+ * The server advertises the lowest desktop version it accepts (`/meta`
+ * `minDesktopVersion`). The desktop has historically parsed this but never
+ * acted on it. This module owns the pure comparison so the connect surface can
+ * warn a user whose desktop is older than the connected server requires.
+ *
+ * Scope note: this is a compatibility *check*, not server-rooted updater
+ * convergence. The Tauri updater still uses the static vendor CDN feed; making
+ * the updater endpoint server-controlled is deliberately out of this slice
+ * (see reports/04-capabilities-desktop.md). Pure domain: no React, no I/O.
+ */
+
+interface SemverParts {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Parse `major.minor.patch` from a version string, ignoring any pre-release
+ * suffix (`-dev`, `-rc.1`, build metadata). Returns null if not parseable. */
+function parseSemver(version: string): SemverParts | null {
+  const core = version.trim().split(/[-+]/, 1)[0];
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(core);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/** -1 if a < b, 0 if equal, 1 if a > b; null if either is unparseable. */
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (pa[key] < pb[key]) return -1;
+    if (pa[key] > pb[key]) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Is `desktopVersion` allowed to talk to a server requiring `minDesktopVersion`?
+ *
+ * Fail-open on anything unparseable (dev builds, empty pins): only a
+ * confidently-older desktop is reported unsupported, so the check never blocks
+ * a user on a version string it cannot understand.
+ */
+export function isDesktopVersionSupported(
+  desktopVersion: string,
+  minDesktopVersion: string,
+): boolean {
+  // Dev/unstamped builds report the `0.0.0(-dev)` sentinel; never warn those.
+  if (compareSemver(desktopVersion, "0.0.0") === 0) return true;
+  const cmp = compareSemver(desktopVersion, minDesktopVersion);
+  if (cmp === null) return true;
+  return cmp >= 0;
+}

--- a/apps/desktop/src/lib/domain/support/support-menu-action.test.ts
+++ b/apps/desktop/src/lib/domain/support/support-menu-action.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { SupportCapability } from "@/lib/domain/capabilities/server-capability-contract";
+import { deriveSupportMenuAction } from "./support-menu-action";
+
+describe("deriveSupportMenuAction", () => {
+  it("vendor: routes to the existing feedback/prompt report flow", () => {
+    const support: SupportCapability = { kind: "vendor", email: "support@proliferate.com", url: null };
+
+    expect(deriveSupportMenuAction(support)).toEqual({ kind: "vendor" });
+  });
+
+  it("operator with a url: opens the operator's url directly", () => {
+    const support: SupportCapability = {
+      kind: "operator",
+      email: null,
+      url: "https://acme.example.com/support",
+    };
+
+    expect(deriveSupportMenuAction(support)).toEqual({
+      kind: "operator",
+      url: "https://acme.example.com/support",
+    });
+  });
+
+  it("operator with only an email: mailto:s the configured email", () => {
+    const support: SupportCapability = {
+      kind: "operator",
+      email: "it-help@acme.example.com",
+      url: null,
+    };
+
+    expect(deriveSupportMenuAction(support)).toEqual({
+      kind: "operator",
+      url: "mailto:it-help@acme.example.com",
+    });
+  });
+
+  it("operator prefers url over email when both are configured", () => {
+    const support: SupportCapability = {
+      kind: "operator",
+      email: "it-help@acme.example.com",
+      url: "https://acme.example.com/support",
+    };
+
+    expect(deriveSupportMenuAction(support)).toEqual({
+      kind: "operator",
+      url: "https://acme.example.com/support",
+    });
+  });
+
+  it("operator with neither destination configured degrades to none", () => {
+    const support: SupportCapability = { kind: "operator", email: null, url: null };
+
+    expect(deriveSupportMenuAction(support)).toEqual({ kind: "none" });
+  });
+
+  it("none: no support action at all", () => {
+    const support: SupportCapability = { kind: "none", email: null, url: null };
+
+    expect(deriveSupportMenuAction(support)).toEqual({ kind: "none" });
+  });
+});

--- a/apps/desktop/src/lib/domain/support/support-menu-action.ts
+++ b/apps/desktop/src/lib/domain/support/support-menu-action.ts
@@ -1,0 +1,42 @@
+import type { SupportCapability } from "@/lib/domain/capabilities/server-capability-contract";
+
+/**
+ * What the sidebar/command-palette support action should do, derived from the
+ * server-declared `support` capability.
+ *
+ * - `vendor` (hosted product): the existing feedback/prompt report flow.
+ * - `operator` (self-managed, operator configured a destination): route to
+ *   that destination directly — no vendor support-report window.
+ * - `none` (self-managed, no destination configured): no support action at
+ *   all. The desktop must not offer a vendor support address to a
+ *   self-managed user, and there is nothing configured to route to instead.
+ *
+ * Pure domain: no React, no platform APIs.
+ */
+export type SupportMenuAction =
+  | { kind: "vendor" }
+  | { kind: "operator"; url: string }
+  | { kind: "none" };
+
+/**
+ * Resolve the operator's configured destination into a single openable URL:
+ * prefer `support.url`, else a `mailto:` built from `support.email`.
+ */
+function resolveOperatorUrl(support: SupportCapability): string | null {
+  if (support.url) return support.url;
+  if (support.email) return `mailto:${support.email}`;
+  return null;
+}
+
+export function deriveSupportMenuAction(support: SupportCapability): SupportMenuAction {
+  if (support.kind === "vendor") {
+    return { kind: "vendor" };
+  }
+  if (support.kind === "operator") {
+    const url = resolveOperatorUrl(support);
+    // The server only declares `operator` when it configured an email or a
+    // url, but degrade to `none` rather than crash if that ever drifts.
+    return url ? { kind: "operator", url } : { kind: "none" };
+  }
+  return { kind: "none" };
+}

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -236,6 +236,32 @@ class Settings(BaseSettings):
     resend_api_key: str = ""
     resend_from_email: str = "hello@proliferate.dev"
     frontend_base_url: str = ""
+
+    # Self-managed instance identity + operator support routing. Surfaced on the
+    # public /meta capability contract so the desktop renders a self-hosted
+    # server as itself (name/logo) and points users at the operator's own
+    # support destination instead of the vendor's. All optional: an empty value
+    # means "use the safe default" — for identity the desktop falls back to the
+    # connected server origin, and for support it offers no vendor address.
+    instance_name: str = Field(
+        default="",
+        validation_alias=AliasChoices("INSTANCE_NAME", "PROLIFERATE_INSTANCE_NAME"),
+    )
+    instance_logo_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("INSTANCE_LOGO_URL", "PROLIFERATE_INSTANCE_LOGO_URL"),
+    )
+    instance_support_email: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "INSTANCE_SUPPORT_EMAIL", "PROLIFERATE_INSTANCE_SUPPORT_EMAIL"
+        ),
+    )
+    instance_support_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("INSTANCE_SUPPORT_URL", "PROLIFERATE_INSTANCE_SUPPORT_URL"),
+    )
+
     anonymous_telemetry_endpoint: str = Field(
         default="https://app.proliferate.com/api/v1/telemetry/anonymous",
         validation_alias=AliasChoices(

--- a/server/proliferate/constants/deployment.py
+++ b/server/proliferate/constants/deployment.py
@@ -1,0 +1,35 @@
+"""Constants for the public deployment capability contract (``GET /meta``).
+
+The capability contract lets the desktop render the connected control plane as
+what it actually is: the hosted Proliferate product, or a self-managed server
+that only offers the capabilities its operator configured.
+
+The values here describe the *hosted product itself* — the identity and vendor
+destinations the desktop should show when it is connected to the official
+hosted control plane. They are product identity, not operator config: a
+self-managed operator's instance name, logo, and support destination come from
+``settings.instance_*`` and are only surfaced for non-hosted deployments.
+"""
+
+from __future__ import annotations
+
+# Bump when the ``capabilities`` wire shape on ``/meta`` changes. The desktop
+# treats an absent contract (older servers) conservatively and may branch on
+# this version to stay forward-compatible with newer contracts.
+SELF_HOST_CAPABILITY_CONTRACT_VERSION = 1
+
+# Deployment modes mirror the desktop telemetry runtime modes so the contract
+# and telemetry routing speak the same vocabulary.
+DEPLOYMENT_MODE_LOCAL_DEV = "local_dev"
+DEPLOYMENT_MODE_SELF_MANAGED = "self_managed"
+DEPLOYMENT_MODE_HOSTED_PRODUCT = "hosted_product"
+
+# Support routing kinds returned in the contract.
+SUPPORT_KIND_VENDOR = "vendor"
+SUPPORT_KIND_OPERATOR = "operator"
+SUPPORT_KIND_NONE = "none"
+
+# Hosted-product identity and vendor destinations.
+VENDOR_DISPLAY_NAME = "Proliferate"
+VENDOR_SUPPORT_EMAIL = "support@proliferate.com"
+VENDOR_PRICING_URL = "https://proliferate.com/pricing"

--- a/server/proliferate/server/meta.py
+++ b/server/proliferate/server/meta.py
@@ -1,7 +1,8 @@
-"""Public version metadata + desktop updater redirect.
+"""Public version metadata, capability contract, and desktop updater redirect.
 
 ``GET /meta`` reports the versions this server pins so desktop, runtime, and
-operators all converge on the version the API controls. ``GET
+operators all converge on the version the API controls, plus a ``capabilities``
+contract describing what this deployment actually offers. ``GET
 /desktop/updater/latest.json`` 302-redirects to the versioned updater manifest
 on the official downloads CDN.
 
@@ -10,6 +11,13 @@ contain per-platform minisign signatures that are a desktop-release artifact,
 and the minisign pubkey baked into the app verifies those artifacts no matter
 which endpoint served the manifest. A self-hosted server can therefore choose
 the desktop version but can never ship an unofficial build.
+
+The ``capabilities`` block is the source of truth for what the desktop renders.
+The desktop must not infer Cloud/billing/gateway from mere reachability: a
+self-managed server declares only the capabilities its operator configured, so
+the desktop shows only those. Everything here is derived from operator config;
+no secret material or per-secret presence is exposed, only product capability
+booleans and safe, user-facing destinations (support email, pricing/web URL).
 """
 
 from __future__ import annotations
@@ -18,6 +26,21 @@ from fastapi import APIRouter, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
+from proliferate.config import Settings, settings
+from proliferate.constants.billing import (
+    BILLING_MODE_ENFORCE,
+    BILLING_MODE_OBSERVE,
+    BILLING_MODE_OFF,
+)
+from proliferate.constants.deployment import (
+    SELF_HOST_CAPABILITY_CONTRACT_VERSION,
+    SUPPORT_KIND_NONE,
+    SUPPORT_KIND_OPERATOR,
+    SUPPORT_KIND_VENDOR,
+    VENDOR_DISPLAY_NAME,
+    VENDOR_PRICING_URL,
+    VENDOR_SUPPORT_EMAIL,
+)
 from proliferate.integrations.desktop_downloads import (
     downloads_base_url as _downloads_base_url,
 )
@@ -35,12 +58,136 @@ from proliferate.server.version import (
 router = APIRouter()
 
 
+class DeploymentIdentity(BaseModel):
+    """How this control plane identifies itself.
+
+    ``mode`` mirrors the desktop telemetry runtime modes. ``displayName`` is the
+    operator's instance name; empty means "use the connected origin" so the
+    desktop never mislabels a self-managed server as the vendor product.
+    """
+
+    mode: str
+    displayName: str
+    logoUrl: str | None
+
+
+class WebAppCapability(BaseModel):
+    """Whether a hosted web app exists for this deployment, and where it lives.
+
+    Self-managed deployments have no hosted web app (users connect the signed
+    desktop app), so ``available`` is false and the desktop hides web handoffs.
+    """
+
+    available: bool
+    baseUrl: str | None
+
+
+class SupportCapability(BaseModel):
+    """Where a user of this deployment should go for support.
+
+    ``vendor`` is the hosted product's own support; ``operator`` is a
+    self-managed operator's configured destination; ``none`` means the desktop
+    offers no support-email affordance for this server.
+    """
+
+    kind: str
+    email: str | None
+    url: str | None
+
+
+class PricingCapability(BaseModel):
+    """Whether a vendor pricing page is meaningful for this deployment."""
+
+    available: bool
+    url: str | None
+
+
+class ServerCapabilities(BaseModel):
+    """Versioned, conservative declaration of what this deployment offers.
+
+    Defaults are disabled: a capability is true only when the operator
+    configured the underlying feature. The desktop treats an absent contract
+    (older servers) as all-off + self-managed.
+    """
+
+    contractVersion: int
+    deployment: DeploymentIdentity
+    billing: bool
+    usageMetering: bool
+    cloudWorkspaces: bool
+    agentGateway: bool
+    webApp: WebAppCapability
+    support: SupportCapability
+    pricing: PricingCapability
+
+
+def build_server_capabilities(config: Settings) -> ServerCapabilities:
+    """Derive the public capability contract from operator configuration.
+
+    Pure over ``config`` (no I/O), so it is unit-tested directly against a
+    ``Settings`` instance. Exposes product capability booleans and safe,
+    user-facing destinations only — never secret material or per-secret
+    presence.
+    """
+    mode = config.telemetry_mode
+    hosted = mode == "hosted_product"
+
+    billing = config.cloud_billing_mode != BILLING_MODE_OFF
+    usage_metering = config.cloud_billing_mode in {
+        BILLING_MODE_OBSERVE,
+        BILLING_MODE_ENFORCE,
+    }
+    cloud_workspaces = bool(config.e2b_api_key.strip() and config.e2b_template_name.strip())
+    agent_gateway = config.agent_gateway_enabled
+
+    web_base = config.frontend_base_url.strip()
+    web_app = WebAppCapability(
+        available=hosted,
+        baseUrl=(web_base or None) if hosted else None,
+    )
+
+    if hosted:
+        support = SupportCapability(kind=SUPPORT_KIND_VENDOR, email=VENDOR_SUPPORT_EMAIL, url=None)
+        pricing = PricingCapability(available=True, url=VENDOR_PRICING_URL)
+        display_name = config.instance_name.strip() or VENDOR_DISPLAY_NAME
+    else:
+        support_email = config.instance_support_email.strip()
+        support_url = config.instance_support_url.strip()
+        if support_email or support_url:
+            support = SupportCapability(
+                kind=SUPPORT_KIND_OPERATOR,
+                email=support_email or None,
+                url=support_url or None,
+            )
+        else:
+            support = SupportCapability(kind=SUPPORT_KIND_NONE, email=None, url=None)
+        pricing = PricingCapability(available=False, url=None)
+        display_name = config.instance_name.strip()
+
+    return ServerCapabilities(
+        contractVersion=SELF_HOST_CAPABILITY_CONTRACT_VERSION,
+        deployment=DeploymentIdentity(
+            mode=mode,
+            displayName=display_name,
+            logoUrl=config.instance_logo_url.strip() or None,
+        ),
+        billing=billing,
+        usageMetering=usage_metering,
+        cloudWorkspaces=cloud_workspaces,
+        agentGateway=agent_gateway,
+        webApp=web_app,
+        support=support,
+        pricing=pricing,
+    )
+
+
 class MetaResponse(BaseModel):
     serverVersion: str
     desktopVersion: str
     runtimeVersion: str
     workerVersion: str
     minDesktopVersion: str
+    capabilities: ServerCapabilities
 
 
 @router.get("/meta", response_model=MetaResponse)
@@ -51,6 +198,7 @@ async def meta() -> MetaResponse:
         runtimeVersion=runtime_version(),
         workerVersion=worker_version(),
         minDesktopVersion=min_desktop_version(),
+        capabilities=build_server_capabilities(settings),
     )
 
 

--- a/server/proliferate/server/meta.py
+++ b/server/proliferate/server/meta.py
@@ -137,7 +137,10 @@ def build_server_capabilities(config: Settings) -> ServerCapabilities:
         BILLING_MODE_OBSERVE,
         BILLING_MODE_ENFORCE,
     }
-    cloud_workspaces = bool(config.e2b_api_key.strip() and config.e2b_template_name.strip())
+    # Shared with the actual provisioning gate (Settings.cloud_provisioning_configured)
+    # so the advertised capability never diverges from what the server will actually
+    # provision (e.g. a debug box with only E2B_API_KEY set).
+    cloud_workspaces = config.cloud_provisioning_configured
     agent_gateway = config.agent_gateway_enabled
 
     web_base = config.frontend_base_url.strip()

--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -6,14 +6,25 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from proliferate.config import Settings
 from proliferate.integrations import desktop_downloads as downloads_module
 from proliferate.server import meta as meta_module
 from proliferate.server import version as version_module
 from proliferate.server.health import router as health_router
+from proliferate.server.meta import build_server_capabilities
 from proliferate.server.meta import router as meta_router
 
 # server/tests/unit/test_meta_endpoint.py -> repo root is four parents up.
 REPO_VERSION = (Path(__file__).resolve().parents[3] / "VERSION").read_text().strip()
+
+# The version pins reported by /meta, separate from the capabilities block.
+_VERSION_FIELDS = (
+    "serverVersion",
+    "desktopVersion",
+    "runtimeVersion",
+    "workerVersion",
+    "minDesktopVersion",
+)
 
 _PIN_ENV_VARS = (
     "SERVER_VERSION",
@@ -47,13 +58,15 @@ def test_meta_reports_stamped_pins(monkeypatch) -> None:  # type: ignore[no-unty
 
     body = _client().get("/meta").json()
 
-    assert body == {
+    assert {field: body[field] for field in _VERSION_FIELDS} == {
         "serverVersion": "0.3.0",
         "desktopVersion": "0.3.2",
         "runtimeVersion": "0.3.1",
         "workerVersion": "0.3.4",
         "minDesktopVersion": "0.3.0",
     }
+    # The capability contract rides alongside the version pins.
+    assert isinstance(body["capabilities"], dict)
 
 
 def test_meta_shape_and_types_without_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -61,15 +74,10 @@ def test_meta_shape_and_types_without_env(monkeypatch) -> None:  # type: ignore[
 
     body = _client().get("/meta").json()
 
-    assert set(body) == {
-        "serverVersion",
-        "desktopVersion",
-        "runtimeVersion",
-        "workerVersion",
-        "minDesktopVersion",
-    }
-    for value in body.values():
-        assert isinstance(value, str) and value
+    assert set(body) == set(_VERSION_FIELDS) | {"capabilities"}
+    for field in _VERSION_FIELDS:
+        assert isinstance(body[field], str) and body[field]
+    assert isinstance(body["capabilities"], dict)
 
 
 # T1-SH-3 (specs/developing/testing/self-hosting.md): the /meta wire contract.
@@ -86,6 +94,7 @@ _META_GOLDEN_FIELDS = [
     "runtimeVersion",
     "workerVersion",
     "minDesktopVersion",
+    "capabilities",
 ]
 
 
@@ -111,6 +120,163 @@ def test_meta_pins_fall_back_to_server_version(monkeypatch) -> None:  # type: ig
     assert body["runtimeVersion"] == "1.2.3"
     assert body["workerVersion"] == "1.2.3"
     assert body["minDesktopVersion"] == "1.2.3"
+
+
+# --- Capability contract (server/proliferate/server/meta.py) ------------------
+#
+# The capabilities block is the source of truth the desktop renders from. These
+# tests exercise the pure builder against a Settings instance so the behavior is
+# deterministic regardless of ambient env. Every capability-relevant field is
+# reset to a known base and then overridden per test, so ambient env / .env
+# values cannot leak into the assertions.
+
+_CAPABILITY_FIELDS = {
+    "deployment": ("mode", "displayName", "logoUrl"),
+    "billing": None,
+    "usageMetering": None,
+    "cloudWorkspaces": None,
+    "agentGateway": None,
+    "webApp": ("available", "baseUrl"),
+    "support": ("kind", "email", "url"),
+    "pricing": ("available", "url"),
+}
+
+
+def _cfg(**overrides):  # type: ignore[no-untyped-def]
+    cfg = Settings()
+    # Reset every capability-relevant field to a known base, then apply
+    # overrides, so ambient env cannot leak into the assertion.
+    base = {
+        "telemetry_mode": "self_managed",
+        "cloud_billing_mode": "off",
+        "agent_gateway_enabled": False,
+        "e2b_api_key": "",
+        "e2b_template_name": "",
+        "frontend_base_url": "",
+        "instance_name": "",
+        "instance_logo_url": "",
+        "instance_support_email": "",
+        "instance_support_url": "",
+    }
+    base.update(overrides)
+    for key, value in base.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def test_capabilities_shape_and_version() -> None:
+    caps = build_server_capabilities(_cfg())
+
+    assert caps.contractVersion == 1
+    dumped = caps.model_dump()
+    assert set(dumped) == {
+        "contractVersion",
+        "deployment",
+        "billing",
+        "usageMetering",
+        "cloudWorkspaces",
+        "agentGateway",
+        "webApp",
+        "support",
+        "pricing",
+    }
+    for field, subfields in _CAPABILITY_FIELDS.items():
+        if subfields is not None:
+            assert set(dumped[field]) == set(subfields)
+
+
+def test_capabilities_hosted_product() -> None:
+    caps = build_server_capabilities(
+        _cfg(
+            telemetry_mode="hosted_product",
+            cloud_billing_mode="enforce",
+            agent_gateway_enabled=True,
+            e2b_api_key="e2b-key",
+            e2b_template_name="proliferate-runtime-cloud",
+            frontend_base_url="https://web.proliferate.com",
+        )
+    )
+
+    assert caps.deployment.mode == "hosted_product"
+    assert caps.deployment.displayName == "Proliferate"
+    assert caps.billing is True
+    assert caps.usageMetering is True
+    assert caps.cloudWorkspaces is True
+    assert caps.agentGateway is True
+    assert caps.webApp.available is True
+    assert caps.webApp.baseUrl == "https://web.proliferate.com"
+    assert caps.support.kind == "vendor"
+    assert caps.support.email == "support@proliferate.com"
+    assert caps.pricing.available is True
+    assert caps.pricing.url == "https://proliferate.com/pricing"
+
+
+def test_capabilities_self_managed_base_is_all_off() -> None:
+    caps = build_server_capabilities(_cfg(telemetry_mode="self_managed"))
+
+    assert caps.deployment.mode == "self_managed"
+    # No instance name configured -> empty, so the desktop uses the origin.
+    assert caps.deployment.displayName == ""
+    assert caps.deployment.logoUrl is None
+    assert caps.billing is False
+    assert caps.usageMetering is False
+    assert caps.cloudWorkspaces is False
+    assert caps.agentGateway is False
+    assert caps.webApp.available is False
+    assert caps.webApp.baseUrl is None
+    assert caps.support.kind == "none"
+    assert caps.support.email is None
+    assert caps.pricing.available is False
+    assert caps.pricing.url is None
+
+
+def test_capabilities_self_managed_with_addons() -> None:
+    caps = build_server_capabilities(
+        _cfg(
+            telemetry_mode="self_managed",
+            cloud_billing_mode="observe",
+            agent_gateway_enabled=True,
+            e2b_api_key="e2b-key",
+            e2b_template_name="company-runtime",
+            instance_name="Acme Internal",
+            instance_logo_url="https://acme.example.com/logo.svg",
+            instance_support_email="it-help@acme.example.com",
+        )
+    )
+
+    assert caps.deployment.mode == "self_managed"
+    assert caps.deployment.displayName == "Acme Internal"
+    assert caps.deployment.logoUrl == "https://acme.example.com/logo.svg"
+    # Billing off but observe metering on: metering true, billing (mode != off) true.
+    assert caps.billing is True
+    assert caps.usageMetering is True
+    assert caps.cloudWorkspaces is True
+    assert caps.agentGateway is True
+    # Web app is never self-hosted, even with add-ons configured.
+    assert caps.webApp.available is False
+    assert caps.support.kind == "operator"
+    assert caps.support.email == "it-help@acme.example.com"
+    assert caps.support.url is None
+    # No vendor pricing on a self-managed deployment.
+    assert caps.pricing.available is False
+
+
+def test_capabilities_cloud_workspaces_requires_both_e2b_fields() -> None:
+    only_key = build_server_capabilities(_cfg(e2b_api_key="e2b-key"))
+    only_template = build_server_capabilities(_cfg(e2b_template_name="company-runtime"))
+
+    assert only_key.cloudWorkspaces is False
+    assert only_template.cloudWorkspaces is False
+
+
+def test_capabilities_local_dev_is_self_managed_posture() -> None:
+    caps = build_server_capabilities(_cfg(telemetry_mode="local_dev"))
+
+    assert caps.deployment.mode == "local_dev"
+    assert caps.billing is False
+    assert caps.webApp.available is False
+    assert caps.support.kind == "none"
+    assert caps.pricing.available is False
 
 
 def _stub_manifest_probe(monkeypatch, exists: bool) -> list[str]:  # type: ignore[no-untyped-def]

--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -145,11 +145,13 @@ _CAPABILITY_FIELDS = {
 def _cfg(**overrides):  # type: ignore[no-untyped-def]
     cfg = Settings()
     # Reset every capability-relevant field to a known base, then apply
-    # overrides, so ambient env cannot leak into the assertion.
+    # overrides, so ambient env (including ambient DEBUG=true, which the test
+    # suite runs under) cannot leak into the assertion.
     base = {
         "telemetry_mode": "self_managed",
         "cloud_billing_mode": "off",
         "agent_gateway_enabled": False,
+        "debug": False,
         "e2b_api_key": "",
         "e2b_template_name": "",
         "frontend_base_url": "",
@@ -262,11 +264,26 @@ def test_capabilities_self_managed_with_addons() -> None:
 
 
 def test_capabilities_cloud_workspaces_requires_both_e2b_fields() -> None:
+    # Outside debug mode, cloudWorkspaces shares Settings.cloud_provisioning_configured,
+    # which requires both an API key and a template name.
     only_key = build_server_capabilities(_cfg(e2b_api_key="e2b-key"))
     only_template = build_server_capabilities(_cfg(e2b_template_name="company-runtime"))
 
     assert only_key.cloudWorkspaces is False
     assert only_template.cloudWorkspaces is False
+
+
+def test_capabilities_cloud_workspaces_matches_provisioning_predicate_in_debug() -> None:
+    # Same predicate as actual provisioning (Settings.cloud_provisioning_configured):
+    # in debug mode a blank template name is fine as long as an API key is set, so
+    # the advertised capability never diverges from what the server will provision.
+    key_only_debug = _cfg(debug=True, e2b_api_key="e2b-key")
+    no_key_debug = _cfg(debug=True, e2b_template_name="company-runtime")
+
+    assert build_server_capabilities(key_only_debug).cloudWorkspaces is True
+    assert key_only_debug.cloud_provisioning_configured is True
+    assert build_server_capabilities(no_key_debug).cloudWorkspaces is False
+    assert no_key_debug.cloud_provisioning_configured is False
 
 
 def test_capabilities_local_dev_is_self_managed_posture() -> None:


### PR DESCRIPTION
## Summary

Make the Desktop render a connected self-hosted server as **itself**, not as Proliferate Cloud, and derive capability/version claims from an explicit **server contract** instead of control-plane reachability. (Self-hosting agent pack, Task 04.)

- **Server** — extend `GET /meta` with a versioned, conservative `capabilities` block: deployment identity (mode, display name, logo), billing, usage metering, cloud workspaces, agent gateway, web app (+ base URL), support, pricing. All derived from operator config; defaults disabled; hosted mode declares the vendor posture. No secret material or per-secret presence is exposed. Adds `instance_name`/`instance_logo_url`/`instance_support_email`/`instance_support_url` settings and vendor constants.
- **Desktop** — `useAppCapabilities` now derives from the contract (fetched off `/meta`). A missing contract from the **official host** keeps current hosted behavior; any other older server degrades conservatively. Gates vendor billing/credits, usage bars, pricing, and web handoffs; adds a persistent "Connected to \<server\>" line in the account footer, a runtime-safe web-app target, and a desktop↔server version-compatibility warning in the connect dialog. `cloudEnabled` stays reachability-based so sign-in is never gated on deployment mode.

## Hosted behavior is preserved

The one client-side "is this Cloud" signal (`isOfficialHostedApiBaseUrl`) becomes the **fallback** when a server returns no contract: an older official server gets the current hosted posture synthesized, so hosted behavior is unchanged during rollout and after. Once a server declares a contract, it is authoritative.

## Verification

- **Server**: `test_meta_endpoint.py` — 17 passed (capability builder across hosted / self-managed / local + add-ons, `/meta` golden contract extended in lockstep). Ruff + format clean.
- **Desktop**: 21 new domain unit tests (derivation, contract parsing, version comparison) pass; `tsc --noEmit` clean; frontend-boundary + max-lines repo-shape checks pass. Full desktop suite shows the **same 50 pre-existing failures as clean origin/main** — zero regressions introduced (4 hook/component tests that render the new query paths were updated to mock the new hooks).
- Live desktop-against-a-box verification is **BLOCKED** in this environment (no packaged release build); see report.

## Scope / ownership

Stays inside Task 04's owned paths (server capability metadata, Desktop gating/identity/links, focused tests). Does **not** touch `server/deploy/**`, AWS templates, gateway readiness, cloud materialization, or landing docs. SSO/auth-method advertisement is deliberately left to Authentication's existing endpoints. Cloud SDK openapi regen deferred (pre-existing unrelated drift; `/meta` is consumed via raw fetch, not the generated client).

Full details, capability matrix, and documentation facts: `self-hosting-notes/agent-pack/reports/04-capabilities-desktop.md`.

Do not merge — integrator owns sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)