### PR TITLE
fix(desktop): hide the Org settings scope from non-admin members

### DIFF
--- a/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/desktop/src/components/settings/screen/SettingsScreen.tsx
@@ -21,6 +21,7 @@ import {
   SETTINGS_SCOPE_ORDER,
   getFirstSectionForScope,
   getSettingsScopeForSection,
+  isSettingsAdminOnlyScope,
   isSettingsAdminOnlySection,
   isSettingsHarnessSection,
 } from "@/lib/domain/settings/navigation-presentation";
@@ -73,18 +74,23 @@ export function SettingsScreen({
   });
   const activeSectionIsAdminOnly = isSettingsAdminOnlySection(activeSection);
   const adminAccessLoading = organizationsQuery.isLoading || admin.isLoading;
+  const isAdminConfirmed = admin.isAdmin === true;
+  // Single gating source: until admin status resolves to true, treat the
+  // user as non-admin so admin-only panes/tabs never flash during the
+  // useIsAdmin loading window.
+  const showAdminSettings = TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION || isAdminConfirmed;
   const shouldRedirectAdminSection =
     activeSectionIsAdminOnly
     && !TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION
     && !adminAccessLoading
-    && admin.isAdmin !== true;
+    && !isAdminConfirmed;
   const effectiveActiveSection =
-    activeSectionIsAdminOnly
-    && !TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION
-    && !adminAccessLoading
-    && admin.isAdmin !== true
+    activeSectionIsAdminOnly && !showAdminSettings
       ? SETTINGS_DEFAULT_SECTION
       : activeSection;
+  const visibleScopeOrder = SETTINGS_SCOPE_ORDER.filter(
+    (scope) => !isSettingsAdminOnlyScope(scope) || showAdminSettings,
+  );
   const redirectedAdminSectionRef = useRef<SettingsSection | null>(null);
 
   useEffect(() => {
@@ -126,7 +132,7 @@ export function SettingsScreen({
         </div>
         <div className="flex h-[46px] items-center gap-4 px-4">
           <SettingsScopeTabs
-            items={SETTINGS_SCOPE_ORDER.map((scope) => ({
+            items={visibleScopeOrder.map((scope) => ({
               id: scope,
               label: SETTINGS_SCOPE_LABELS[scope],
             }))}

--- a/apps/desktop/src/lib/domain/settings/navigation-presentation.test.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation-presentation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSettingsAdminOnlyScope,
+  SETTINGS_SCOPE_ORDER,
+} from "@/lib/domain/settings/navigation-presentation";
+
+describe("isSettingsAdminOnlyScope", () => {
+  it("flags the org scope as admin-only, since every one of its sections is", () => {
+    expect(isSettingsAdminOnlyScope("org")).toBe(true);
+  });
+
+  it("does not flag the user, repo, or agents scopes", () => {
+    for (const scope of SETTINGS_SCOPE_ORDER) {
+      if (scope === "org") {
+        continue;
+      }
+      expect(isSettingsAdminOnlyScope(scope)).toBe(false);
+    }
+  });
+});

--- a/apps/desktop/src/lib/domain/settings/navigation-presentation.ts
+++ b/apps/desktop/src/lib/domain/settings/navigation-presentation.ts
@@ -237,3 +237,14 @@ const SETTINGS_ADMIN_ONLY_SECTIONS = new Set<SettingsSection>(
 export function isSettingsAdminOnlySection(section: SettingsSection): boolean {
   return SETTINGS_ADMIN_ONLY_SECTIONS.has(section);
 }
+
+/**
+ * A scope is admin-only when every section registered under it is
+ * admin-gated (e.g. "org" today — every SETTINGS_SCOPES["org"] entry sets
+ * adminOnly: true). Derived from the same per-section metadata that gates
+ * the sidebar rows, so the scope tab and its contents can never disagree.
+ */
+export function isSettingsAdminOnlyScope(scope: SettingsScope): boolean {
+  const sections = scopeSectionItems(getSettingsScopeNav(scope));
+  return sections.length > 0 && sections.every((item) => item.adminOnly === true);
+}


### PR DESCRIPTION
## Problem

Non-admin org members could see the "Org" scope tab in desktop Settings. Every sidebar row inside that scope is already admin-gated, and deep links into admin-only sections redirect non-admins away, but the horizontal scope tabs themselves were built from the full, unconditional `SETTINGS_SCOPE_ORDER`, so the tab showed for everyone. On top of that, while `useIsAdmin` was still loading, the redirect logic let an admin-only section render for a beat before flipping to non-admin, which is a content flash on top of the tab flash.

## Fix

Added `isSettingsAdminOnlyScope` to `navigation-presentation.ts`, derived from the same `adminOnly` metadata that already gates individual sidebar rows (a scope counts as admin-only when every section registered under it is admin-only — true for "org" today). `SettingsScreen` now filters the scope tab list through this helper and a single `showAdminSettings` flag (confirmed admin, or the `TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION` escape hatch). The same flag now drives which section actually renders: during the `useIsAdmin` loading window the effective section falls back to the default instead of rendering an admin-only pane, closing the flash instead of just narrowing it.

No new "role === admin" checks were added — everything routes through the existing `useIsAdmin` result, matching the single-gating-source rule in the settings admin IA spec.

## Verification

- `pnpm exec tsc --noEmit` in `apps/desktop` is clean (after `make shared-build`).
- Added `navigation-presentation.test.ts` covering `isSettingsAdminOnlyScope` for all four scopes.
- Ran `SettingsSidebar.test.tsx` and the new test file; no new failures. Two `SettingsSidebar.test.tsx` cases (a support-modal wait and the Agents-scope ordering assertion) fail identically on main before this change — confirmed with a stash/pop comparison — and are unrelated to this fix.