### PR TITLE
fix(desktop): add GitHub App CTAs to the repo Configure authority gate

### DIFF
--- a/apps/desktop/src/components/settings/panes/repo/RepoCloudGate.tsx
+++ b/apps/desktop/src/components/settings/panes/repo/RepoCloudGate.tsx
@@ -6,6 +6,9 @@ import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmp
 import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { Button } from "@proliferate/ui/primitives/Button";
+import type { GitHubRepoAuthorityAction } from "@proliferate/cloud-sdk";
+import { useActiveOrganization } from "@/hooks/organizations/facade/use-active-organization";
+import { useGitHubAppInstallation } from "@/hooks/settings/workflows/use-github-app-installation";
 import { useGitHubAppUserAuthorization } from "@/hooks/settings/workflows/use-github-app-user-authorization";
 import { type CloudRepoEnvironmentEditor } from "@/hooks/settings/workflows/use-cloud-repo-environment-editor";
 
@@ -13,6 +16,8 @@ import { type CloudRepoEnvironmentEditor } from "@/hooks/settings/workflows/use-
 // surface (the same return target the add-repo flow uses).
 const USER_AUTHORIZATION_RETURN_TO =
   "proliferate://settings/environments?source=github_app_callback";
+const INSTALLATION_RETURN_TO =
+  "proliferate://settings/environments?source=github_app_installation_callback";
 
 interface RepoCloudGateProps {
   editor: CloudRepoEnvironmentEditor;
@@ -107,6 +112,7 @@ export function RepoCloudGate({
     return (
       <RepoCloudAuthorizationRequired
         status={editor.authority.data.status}
+        action={editor.authority.data.action ?? null}
         message={editor.authority.data.message ?? null}
         onAuthorizationReturn={() => {
           void editor.authority.refetch();
@@ -147,36 +153,43 @@ export function RepoCloudGate({
 }
 
 /**
- * The not-authorized branch of the gate. User-authorization gaps get an inline
- * "Connect GitHub App" action (the shared authorize flow); installation and
- * repo-access gaps a non-admin can't self-serve stay explanatory messages.
+ * The not-authorized branch of the gate. Each authority action gets the same
+ * inline CTA the Add Cloud repo picker offers: connect/reconnect the GitHub
+ * App, install it for the org, or open the installation settings to grant this
+ * repository access. Gaps a user can't self-serve (no active org for install)
+ * stay explanatory messages.
  */
 function RepoCloudAuthorizationRequired({
   status,
+  action,
   message,
   onAuthorizationReturn,
 }: {
   status: string;
+  action: GitHubRepoAuthorityAction | null;
   message: string | null;
   onAuthorizationReturn: () => void;
 }) {
-  const needsUserAuthorization =
-    status === "missing_user_authorization" || status === "expired_user_authorization";
-  const { authorize, authorizing, error } = useGitHubAppUserAuthorization({
+  const { activeOrganizationId } = useActiveOrganization();
+  const userAuthorization = useGitHubAppUserAuthorization({
     returnTo: USER_AUTHORIZATION_RETURN_TO,
     onAuthorizationReturn,
   });
+  const installation = useGitHubAppInstallation({
+    organizationId: activeOrganizationId,
+    returnTo: INSTALLATION_RETURN_TO,
+    onInstallationReturn: onAuthorizationReturn,
+  });
 
-  if (needsUserAuthorization) {
-    const reconnect = status === "expired_user_authorization";
-    const actionLabel = authorizing
+  if (action === "authorize_user" || action === "reauthorize_user") {
+    const reconnect = action === "reauthorize_user";
+    const actionLabel = userAuthorization.authorizing
       ? "Opening GitHub…"
       : reconnect
         ? "Reconnect GitHub App"
         : "Connect GitHub App";
     return (
-      <SettingsEmptyState
-        icon={<GitHub aria-hidden="true" />}
+      <RepoAuthorityActionState
         title={reconnect ? "Reconnect GitHub App" : "Connect GitHub App"}
         description={
           message
@@ -184,23 +197,42 @@ function RepoCloudAuthorizationRequired({
             ? "Your GitHub App authorization expired. Reconnect it to configure cloud environments for this repository."
             : "Authorize the Proliferate GitHub App to configure cloud environments for this repository.")
         }
-        action={
-          <div className="flex flex-col items-center gap-2">
-            <Button
-              type="button"
-              variant="secondary"
-              loading={authorizing}
-              disabled={authorizing}
-              onClick={authorize}
-            >
-              {!authorizing ? (
-                <ProviderBrandIcon provider="github" className="size-[13px]" />
-              ) : null}
-              {actionLabel}
-            </Button>
-            {error ? <p className="text-ui-sm text-destructive">{error}</p> : null}
-          </div>
+        actionLabel={actionLabel}
+        withGitHubIcon={!userAuthorization.authorizing}
+        loading={userAuthorization.authorizing}
+        error={userAuthorization.error}
+        onAction={userAuthorization.authorize}
+      />
+    );
+  }
+
+  if (action === "install_app" && activeOrganizationId) {
+    return (
+      <RepoAuthorityActionState
+        title="Install Proliferate GitHub App"
+        description={
+          message
+          ?? "Install the Proliferate GitHub App for your organization to configure cloud environments for this repository."
         }
+        actionLabel={installation.installing ? "Opening GitHub…" : "Install Proliferate GitHub App"}
+        loading={installation.installing}
+        error={installation.error}
+        onAction={installation.install}
+      />
+    );
+  }
+
+  if (action === "grant_repo_access") {
+    return (
+      <RepoAuthorityActionState
+        title="Grant repository access"
+        description={
+          message
+          ?? "Update the Proliferate GitHub App installation so it has access to this repository."
+        }
+        actionLabel="Grant repository access"
+        error={installation.error}
+        onAction={installation.openInstallationSettings}
       />
     );
   }
@@ -210,6 +242,49 @@ function RepoCloudAuthorizationRequired({
       icon={<GitHub aria-hidden="true" />}
       title={authorizationRequiredTitle(status)}
       description={message ?? repoAuthorityNotice(status)}
+    />
+  );
+}
+
+function RepoAuthorityActionState({
+  title,
+  description,
+  actionLabel,
+  withGitHubIcon = false,
+  loading = false,
+  error,
+  onAction,
+}: {
+  title: string;
+  description: string;
+  actionLabel: string;
+  withGitHubIcon?: boolean;
+  loading?: boolean;
+  error: string | null;
+  onAction: () => void;
+}) {
+  return (
+    <SettingsEmptyState
+      icon={<GitHub aria-hidden="true" />}
+      title={title}
+      description={description}
+      action={
+        <div className="flex flex-col items-center gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            loading={loading}
+            disabled={loading}
+            onClick={onAction}
+          >
+            {withGitHubIcon ? (
+              <ProviderBrandIcon provider="github" className="size-[13px]" />
+            ) : null}
+            {actionLabel}
+          </Button>
+          {error ? <p className="text-ui-sm text-destructive">{error}</p> : null}
+        </div>
+      }
     />
   );
 }

--- a/apps/desktop/src/hooks/settings/workflows/use-github-app-installation.ts
+++ b/apps/desktop/src/hooks/settings/workflows/use-github-app-installation.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import { useStartGitHubAppInstallation } from "@proliferate/cloud-sdk-react";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+
+// Same staggered refetch cadence the user-authorization flow uses: the GitHub
+// return may land on another settings surface, so poll the caller's authority
+// query for a while in case the user comes back to this view directly.
+const INSTALLATION_REFRESH_DELAYS_MS = [2_000, 5_000, 10_000, 20_000, 40_000, 80_000];
+
+// GitHub's per-user installation settings page — where repository access for an
+// existing installation is managed. The same target the Account and
+// Organization panes open for "Manage repository access".
+const INSTALLATION_SETTINGS_URL = "https://github.com/settings/installations";
+
+export interface GitHubAppInstallationFlow {
+  /** Start installation for the active org, then open GitHub. */
+  install: () => void;
+  /** Open the installation settings page to grant repository access. */
+  openInstallationSettings: () => void;
+  installing: boolean;
+  error: string | null;
+}
+
+/**
+ * Starts the GitHub App installation flow — the same
+ * `useStartGitHubAppInstallation` mutation + external-browser handoff the
+ * Organization settings GitHub App section drives — and, for the repo-access
+ * gap, opens the installation settings page. Both schedule a few refetches of
+ * the caller's authority query so a returning user self-heals out of the gate.
+ */
+export function useGitHubAppInstallation({
+  organizationId,
+  returnTo,
+  onInstallationReturn,
+}: {
+  organizationId: string | null;
+  returnTo: string;
+  onInstallationReturn?: () => void;
+}): GitHubAppInstallationFlow {
+  const start = useStartGitHubAppInstallation();
+  const { openExternal } = useTauriShellActions();
+  const [error, setError] = useState<string | null>(null);
+  const timersRef = useRef<number[]>([]);
+  const onReturnRef = useRef(onInstallationReturn);
+  onReturnRef.current = onInstallationReturn;
+
+  useEffect(() => () => {
+    for (const timerId of timersRef.current) {
+      window.clearTimeout(timerId);
+    }
+  }, []);
+
+  function scheduleReturnRefresh() {
+    for (const timerId of timersRef.current) {
+      window.clearTimeout(timerId);
+    }
+    timersRef.current = INSTALLATION_REFRESH_DELAYS_MS.map((delayMs) =>
+      window.setTimeout(() => onReturnRef.current?.(), delayMs),
+    );
+  }
+
+  function install() {
+    if (!organizationId) {
+      return;
+    }
+    setError(null);
+    void (async () => {
+      try {
+        const response = await start.mutateAsync({
+          organizationId,
+          options: { returnTo },
+        });
+        await openExternal(response.installationUrl);
+        scheduleReturnRefresh();
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : "GitHub App installation failed.");
+      }
+    })();
+  }
+
+  function openInstallationSettings() {
+    setError(null);
+    void (async () => {
+      try {
+        await openExternal(INSTALLATION_SETTINGS_URL);
+        scheduleReturnRefresh();
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : "Could not open GitHub settings.");
+      }
+    })();
+  }
+
+  return { install, openInstallationSettings, installing: start.isPending, error };
+}


### PR DESCRIPTION
## Problem

The repo Configure settings pane routed GitHub App authority failures through the Cloud gate, which rendered the authority message as dead-end text. The authorize and reauthorize cases already had a Connect/Reconnect button, but the install and grant-repo-access cases stayed explanatory with no way for the user to act. This leaves anyone hitting `install_app` or `grant_repo_access` stuck, even though the Add Cloud repo picker already offers those actions.

## Fix

The not-authorized branch of `RepoCloudGate` now switches on the authority `action` field and offers the same CTAs the Add Cloud repo picker does:

- `authorize_user` / `reauthorize_user`: Connect / Reconnect GitHub App (existing user-authorization flow).
- `install_app`: Install Proliferate GitHub App for the active organization, wired to the same installation start mutation the Organization pane uses. When there is no active organization the state falls back to the explanatory message.
- `grant_repo_access`: Grant repository access, which opens the GitHub App installation settings page.

A new `useGitHubAppInstallation` hook mirrors the existing `useGitHubAppUserAuthorization` hook: it starts installation (or opens the installation settings page for the grant case) via the Tauri shell, then schedules staggered refetches of the authority query so a returning user self-heals out of the gate. Visual treatment reuses the existing `SettingsEmptyState` plus secondary `Button` pattern already used by the pane, with no new visual treatments.

## Verification

- `make shared-build` then `cd apps/desktop && pnpm exec tsc --noEmit` is clean.
- No unit tests cover these files; there are none to run for the changed modules.