### PR TITLE
feat(self-host): deployment shared-integration — gateway/cloud/auth/instance profiles, routes, env, doctor

### DIFF
--- a/server/deploy/.env.production.example
+++ b/server/deploy/.env.production.example
@@ -57,9 +57,83 @@ ADMIN_EMAILS=
 ALLOWED_EMAIL_DOMAINS=
 
 # Desktop GitHub sign-in. Optional: when unset, the desktop app signs in with
-# email and password instead.
+# email and password instead. Both must be set together (one alone advertises
+# a sign-in button that fails). Register exactly one OAuth callback URL with
+# GitHub: <API_BASE_URL>/auth/github/callback (this is a separate credential
+# set from the GitHub App below, which grants cloud-workspace repo access).
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
+
+# Deployment SSO (optional add-on). All fields below are required together to
+# get a usable OIDC connection: SSO_OIDC_CLIENT_ID, an issuer/discovery URL
+# (SSO_OIDC_ISSUER_URL or SSO_OIDC_DISCOVERY_URL, or the full static endpoint
+# set), and SSO_OIDC_CLIENT_SECRET (unless SSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD
+# is "none"). Register the IdP redirect URI as
+# <SSO_OIDC_CALLBACK_BASE_URL or API_BASE_URL>/auth/sso/oidc/callback.
+SSO_ENABLED=false
+SSO_OIDC_CLIENT_ID=
+SSO_OIDC_CLIENT_SECRET=
+SSO_OIDC_ISSUER_URL=
+SSO_OIDC_DISCOVERY_URL=
+# First-time-user policy for SSO sign-ins. disabled (default) rejects unknown
+# users with an actionable sso_jit_disabled error; create_member
+# auto-provisions new users; existing_user allows sign-in only for users
+# already invited/registered by another path. A disabled policy with no
+# pre-provisioned admin can lock every SSO user out — see the doctor warning.
+SSO_JIT_POLICY=disabled
+SSO_DEFAULT_ROLE=member
+# Optional comma-separated allowlist of email domains for SSO JIT provisioning.
+SSO_ALLOWED_DOMAINS=
+# Set true ONLY for an internal/private/http IdP. This disables the HTTPS +
+# private-IP SSRF guard for all OIDC provider URLs; leave false for a public IdP.
+SSO_OIDC_ALLOW_PRIVATE_PROVIDER_URLS=false
+
+# GitHub App for cloud-workspace repository access (a separate credential set
+# from GITHUB_OAUTH_* sign-in above). Set all of these together to enable the
+# App; leave all blank to run without it. Provide the private key either
+# inline (GITHUB_APP_PRIVATE_KEY, \n-escaped PEM) or as a mounted file path
+# (GITHUB_APP_PRIVATE_KEY_PATH) — see GITHUB_APP_PRIVATE_KEY_HOST_PATH below
+# for the bundled bind-mount. The App needs four public routes reachable
+# through Caddy (already served by the default `handle { reverse_proxy
+# api:8000 }` route, no Caddyfile change needed):
+#   GET  /auth/github-app/user-authorization/callback
+#   GET  /auth/github-app/installation/callback
+#   GET  /integrations/github/callback   (the App's Setup URL)
+#   POST /v1/cloud/webhooks/github-app    (webhook delivery)
+# A self-host-safe landing page is served at GET /auth/github-app/connected
+# with no extra config once the App is set up.
+GITHUB_APP_ID=
+GITHUB_APP_SLUG=
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_CLIENT_SECRET=
+GITHUB_APP_WEBHOOK_SECRET=
+# Base URL for the App's own callbacks; defaults to API_BASE_URL when unset.
+GITHUB_APP_CALLBACK_BASE_URL=
+# Inline PEM (escape newlines as \n). Leave blank if using the mounted-file
+# form below.
+GITHUB_APP_PRIVATE_KEY=
+# Mounted-file form: point this at the in-container path
+# /run/secrets/github-app/<filename>, and place the actual PEM on the host at
+# GITHUB_APP_PRIVATE_KEY_HOST_PATH (docker-compose.production.yml bind-mounts
+# that host directory read-only; install.sh creates the default path shown
+# below at install time). Leave both blank to use the inline form above
+# instead.
+GITHUB_APP_PRIVATE_KEY_PATH=
+GITHUB_APP_PRIVATE_KEY_HOST_PATH=/opt/proliferate/secrets/github-app
+
+# Transactional email (invitations). Optional: without RESEND_API_KEY,
+# invitation delivery is marked "skipped" and admins recover with the
+# always-available copy-link in the members UI. No SMTP path exists.
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+
+# Instance branding and support routing shown in the connected Desktop app.
+# All optional; empty means the Desktop shows the connected origin host and no
+# operator support address.
+INSTANCE_NAME=
+INSTANCE_LOGO_URL=
+INSTANCE_SUPPORT_EMAIL=
+INSTANCE_SUPPORT_URL=
 
 # Cloud MCP.
 CLOUD_MCP_ENABLED=true
@@ -69,11 +143,14 @@ CLOUD_MCP_SLACK_CLIENT_ID=
 CLOUD_MCP_SLACK_CLIENT_SECRET=
 CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_post
 
-# Agent LLM gateway (optional LiteLLM add-on). Enabling it is two steps: set
-# AGENT_GATEWAY_ENABLED=true here, then start the profiled services with
-# `docker compose --env-file .env.runtime -f docker-compose.production.yml
-# --profile agent-gateway up -d`. Plain bootstrap.sh/update.sh runs never
-# start litellm/litellm-db. Docs: /docs/deployment/add-ons/model-gateway
+# Agent LLM gateway (optional LiteLLM add-on). Set AGENT_GATEWAY_ENABLED=true
+# and rerun bootstrap.sh/update.sh: they detect this flag and bring up the
+# profiled litellm + litellm-db services (and wait for litellm to report
+# healthy) automatically — no separate `docker compose --profile` command
+# needed. Also set the paired LITELLM_MASTER_KEY/AGENT_GATEWAY_LITELLM_MASTER_KEY,
+# LITELLM_POSTGRES_PASSWORD, AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL, and at
+# least one provider key below; preflight.sh blocks an incomplete combination
+# before it can take down a healthy instance. Docs: /docs/deployment/add-ons/model-gateway
 AGENT_GATEWAY_ENABLED=false
 AGENT_GATEWAY_LITELLM_BASE_URL=http://litellm:4000
 # Public URL agents use to reach LiteLLM, for example https://llm.company.com
@@ -95,9 +172,15 @@ XAI_API_KEY=
 # are a pair: set BOTH to enable cloud workspaces, or leave BOTH blank to run
 # without them. Setting E2B_API_KEY while E2B_TEMPLATE_NAME is empty makes the
 # API refuse to start (it restart-loops the whole control plane), so preflight.sh
-# blocks that combination before bootstrap/update touch the stack.
+# blocks that combination before bootstrap/update touch the stack. Setting
+# this pair also brings up the bundled `redis` service (cloud materialization
+# lock) automatically via the cloud-workspaces compose profile — no separate
+# add-on step needed.
 # E2B_TEMPLATE_NAME is the published runtime template ref, for example
-# your-team/proliferate-runtime-cloud:production.
+# your-team/proliferate-runtime-cloud:production. Build one against your own
+# E2B account with `node scripts/build-template.mjs --alias <name>
+# --rebuild-runtime` (needs Docker + zig + an E2B API key) — see
+# specs/developing/deploying/self-hosted-deploy.md for the full recipe.
 E2B_API_KEY=
 E2B_TEMPLATE_NAME=
 

--- a/server/deploy/Caddyfile
+++ b/server/deploy/Caddyfile
@@ -1,4 +1,19 @@
 {$SITE_ADDRESS} {
-  encode zstd gzip
-  reverse_proxy api:8000
+	encode zstd gzip
+
+	# Agent LLM gateway (optional add-on, AGENT_GATEWAY_ENABLED). handle_path
+	# strips the /llm prefix before proxying, so AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL
+	# should be set to https://<SITE_ADDRESS>/llm — the CLI's
+	# ANTHROPIC_BASE_URL=.../llm/v1/messages then reaches litellm's /v1/messages.
+	# This route always exists; when the gateway profile is not running there is
+	# simply no `litellm` host to resolve, so a request here 502s instead of
+	# affecting the rest of the site. Must stay before the default `handle`
+	# below (Caddy evaluates handle_path/handle in file order, first match wins).
+	handle_path /llm/* {
+		reverse_proxy litellm:4000
+	}
+
+	handle {
+		reverse_proxy api:8000
+	}
 }

--- a/server/deploy/README.md
+++ b/server/deploy/README.md
@@ -35,8 +35,8 @@ flags (`--version`, `--eval`, `--no-start`, `--dry-run`, `--yes`).
 | File | Purpose |
 | --- | --- |
 | `install.sh` | Guided installer + one-line entrypoint (self-contained). |
-| `docker-compose.production.yml` | The stack: `caddy`, `db`, `migrate`, `api`, and the profiled `litellm`/`litellm-db`. |
-| `Caddyfile` | Public HTTPS via Caddy (Let's Encrypt). |
+| `docker-compose.production.yml` | The stack: `caddy`, `db`, `migrate`, `api`, and the profiled `litellm`/`litellm-db` (agent-gateway) and `redis` (cloud-workspaces). |
+| `Caddyfile` | Public HTTPS via Caddy (Let's Encrypt), plus the `/llm` route to the agent gateway when enabled. |
 | `.env.production.example` | Copy to `.env.static` and fill in; the installer does this for you. |
 | `bootstrap.sh` | First-run: generate secrets, migrate, boot, wait for health, print the claim token. |
 | `update.sh` | Pull + migrate + restart, including any enabled optional profile. |
@@ -67,10 +67,27 @@ overrides that survive infra rewrites). Secrets are generated into
 
 - **Cloud workspaces:** set `E2B_API_KEY` **and** `E2B_TEMPLATE_NAME` together
   (setting only the key refuses to boot). Requires the Linux runtime bundle.
+  `bootstrap.sh`/`update.sh` bring up the bundled `redis` service (the cloud
+  materialization lock) automatically via the `cloud-workspaces` profile.
+  Cloud repo access additionally needs a GitHub App (`GITHUB_APP_*`, separate
+  from GitHub OAuth sign-in below) — see `.env.production.example`.
 - **Agent LLM gateway:** set `AGENT_GATEWAY_ENABLED=true` and the paired
   `LITELLM_MASTER_KEY`/`AGENT_GATEWAY_LITELLM_MASTER_KEY` +
-  `LITELLM_POSTGRES_PASSWORD`. `bootstrap.sh`/`update.sh` then manage the
-  `agent-gateway` profile automatically.
+  `LITELLM_POSTGRES_PASSWORD` + `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL`
+  (`https://<host>/llm`) + at least one provider key. `bootstrap.sh`/`update.sh`
+  then manage the `agent-gateway` profile automatically and wait for `litellm`
+  to report healthy before finishing.
+- **GitHub sign-in / SSO / invitation email:** `GITHUB_OAUTH_CLIENT_ID`+`_SECRET`,
+  `SSO_ENABLED`+`SSO_OIDC_*`, and `RESEND_API_KEY`+`RESEND_FROM_EMAIL` are all
+  optional and independent of each other — see `.env.production.example` for
+  the full set and `preflight.sh`/`doctor.sh` for the completeness checks each
+  one gets.
+- **Instance branding:** `INSTANCE_NAME`, `INSTANCE_LOGO_URL`,
+  `INSTANCE_SUPPORT_EMAIL`, `INSTANCE_SUPPORT_URL` — shown in the connected
+  Desktop app; all optional.
+
+Run `./preflight.sh` any time to check for a half-configured add-on before it
+takes down a healthy instance, and `./doctor.sh` to see live status.
 
 Point the official desktop app at the control plane by writing
 `~/.proliferate/config.json`: `{ "apiBaseUrl": "https://api.company.com" }`.

--- a/server/deploy/bootstrap.sh
+++ b/server/deploy/bootstrap.sh
@@ -63,14 +63,27 @@ while IFS= read -r _profile_token; do
   [[ -n "$_profile_token" ]] && PROFILE_ARGS+=("$_profile_token")
 done < <(proliferate_profile_args "$RUNTIME_ENV_FILE")
 
+PROFILE_SERVICES=()
+while IFS= read -r _profile_service; do
+  [[ -n "$_profile_service" ]] && PROFILE_SERVICES+=("$_profile_service")
+done < <(proliferate_profile_services "$RUNTIME_ENV_FILE")
+
 docker compose "${COMPOSE_ARGS[@]}" up -d db
 docker compose "${COMPOSE_ARGS[@]}" run --rm migrate
 docker compose "${COMPOSE_ARGS[@]}" up -d api caddy
 
 # Bring up any enabled optional-profile services (agent-gateway litellm +
-# litellm-db). No-op for a base install with no optional capabilities enabled.
-if ((${#PROFILE_ARGS[@]})); then
-  docker compose "${COMPOSE_ARGS[@]}" "${PROFILE_ARGS[@]}" up -d
+# litellm-db, cloud-workspaces redis) and WAIT for their healthchecks before
+# continuing. No-op for a base install with no optional capabilities enabled.
+# --wait matters here specifically for litellm: the API mints per-user
+# gateway virtual keys against it lazily at signup, so litellm must already
+# be healthy by the time wait-for-health.sh below hands the operator the
+# claim URL, not merely "started". Explicitly scoped to PROFILE_SERVICES (not
+# a bare `up -d --wait` across the whole compose file): otherwise it would
+# also try to reconcile the one-shot `migrate` job, which always exits after
+# running and would make --wait report a false failure.
+if ((${#PROFILE_SERVICES[@]})); then
+  docker compose "${COMPOSE_ARGS[@]}" "${PROFILE_ARGS[@]}" up -d --wait --wait-timeout "${PROLIFERATE_PROFILE_WAIT_TIMEOUT_SECONDS:-300}" "${PROFILE_SERVICES[@]}"
 fi
 
 # Waits for /health, then prints the first-run setup token and claim URL when

--- a/server/deploy/common.sh
+++ b/server/deploy/common.sh
@@ -100,7 +100,13 @@ proliferate_latest_server_version() {
 # `docker compose` call so pull/up/down stay consistent. Add a capability here
 # and it is covered everywhere at once.
 #
-# agent-gateway: the bundled LiteLLM proxy (services litellm + litellm-db).
+# agent-gateway:    the bundled LiteLLM proxy (services litellm + litellm-db).
+# cloud-workspaces: the durable Redis used for the cloud-materialization lock
+#                    (service redis). Mirrors the E2B_API_KEY +
+#                    E2B_TEMPLATE_NAME "complete pair" gate preflight.sh
+#                    already enforces, so Redis comes up automatically exactly
+#                    when cloud workspaces are actually usable — never as an
+#                    ad-hoc container an operator has to remember to add.
 
 # proliferate_enabled_profiles <runtime_env_file>: print the space-separated
 # compose profile names enabled by the resolved config.
@@ -110,6 +116,11 @@ proliferate_enabled_profiles() {
 
   if proliferate_is_truthy "$(proliferate_read_env "$env_file" AGENT_GATEWAY_ENABLED)"; then
     profiles+=("agent-gateway")
+  fi
+
+  if [[ -n "$(proliferate_read_env "$env_file" E2B_API_KEY)" && \
+        -n "$(proliferate_read_env "$env_file" E2B_TEMPLATE_NAME)" ]]; then
+    profiles+=("cloud-workspaces")
   fi
 
   if ((${#profiles[@]})); then
@@ -134,5 +145,27 @@ proliferate_profile_args() {
   profiles="$(proliferate_enabled_profiles "$env_file")"
   for name in $profiles; do
     printf -- '--profile\n%s\n' "$name"
+  done
+}
+
+# proliferate_profile_services <runtime_env_file>: print newline-separated
+# compose SERVICE names (not profile names) for every enabled profile. Callers
+# pass this list explicitly to `docker compose ... up -d --wait <services>` so
+# the reconciliation touches ONLY the profiled services. Without an explicit
+# service list, `up` reconciles every service the active --profile flags make
+# visible, including base services like `migrate` — a restart:"no" one-shot
+# job that always exits after running, which `--wait` would then report as a
+# failure. Scoping to just the profiled services avoids that entirely.
+proliferate_profile_services() {
+  local env_file="$1"
+  local profiles
+  local name
+
+  profiles="$(proliferate_enabled_profiles "$env_file")"
+  for name in $profiles; do
+    case "$name" in
+      agent-gateway) printf 'litellm-db\nlitellm\n' ;;
+      cloud-workspaces) printf 'redis\n' ;;
+    esac
   done
 }

--- a/server/deploy/docker-compose.production.yml
+++ b/server/deploy/docker-compose.production.yml
@@ -30,11 +30,30 @@ services:
       timeout: 3s
       retries: 10
 
+  # redis is `profiles: [cloud-workspaces]`: only needed when E2B_API_KEY and
+  # E2B_TEMPLATE_NAME are both set (the same complete-pair gate preflight.sh
+  # already enforces for the whole capability). Cloud materialization takes a
+  # per-sandbox lock here (REDBEAT_REDIS_URL); without it, private-repo
+  # workspace creation fails at the lock-acquire step. bootstrap.sh/update.sh
+  # compute this profile automatically from common.sh's
+  # proliferate_enabled_profiles, so a base install with no E2B config never
+  # pulls or starts this container.
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    profiles: ["cloud-workspaces"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   # litellm-db and litellm are both `profiles: [agent-gateway]`: only needed
   # when AGENT_GATEWAY_ENABLED=true. Bare `up -d`/`pull` (what bootstrap.sh
   # and update.sh run) skip profiled services entirely, so self-hosters who
-  # leave the gateway disabled never pull or start these. Bring the gateway
-  # up explicitly with:
+  # leave the gateway disabled never pull or start these. Bootstrap/update
+  # compute this profile automatically too; a manual bring-up (e.g. after
+  # hand-editing .env.static without rerunning bootstrap) looks like:
   #   docker compose --profile agent-gateway -f docker-compose.production.yml up -d
   litellm-db:
     image: postgres:16-alpine
@@ -99,6 +118,13 @@ services:
       # First-run setup token plaintext lives here until the instance is
       # claimed. A named volume so restarts and image updates do not rotate it.
       - setup_state:/var/lib/proliferate/setup
+      # Optional GitHub App private key, mounted read-only. Empty/absent by
+      # default (Docker creates an empty host directory here on first boot
+      # when the operator has not set GITHUB_APP_PRIVATE_KEY_HOST_PATH); set
+      # GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app/<filename> to use
+      # a file placed in this directory instead of the inline
+      # GITHUB_APP_PRIVATE_KEY form.
+      - ${GITHUB_APP_PRIVATE_KEY_HOST_PATH:-/opt/proliferate/secrets/github-app}:/run/secrets/github-app:ro
     depends_on:
       db:
         condition: service_healthy

--- a/server/deploy/doctor.sh
+++ b/server/deploy/doctor.sh
@@ -253,14 +253,20 @@ fi
 # --- Redis (only when a capability requires it) ------------------------------
 
 section "Redis"
-# Cloud materialization uses a Redis lock; the base bundle does not ship a
-# redis service, so only check when the cloud capability is configured.
+# Cloud materialization uses a Redis lock. The bundled `redis` service comes
+# up automatically under the cloud-workspaces profile whenever the E2B pair
+# is complete (see common.sh), so only check when that capability is on.
 if [[ -n "$(get E2B_API_KEY)" && -n "$(get E2B_TEMPLATE_NAME)" ]]; then
   redis_url="$(get REDBEAT_REDIS_URL)"
-  if docker info >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -qi 'redis'; then
-    pass "a redis container is running (cloud materialization lock)."
+  if [[ -f "$RUNTIME_ENV_FILE" ]] && docker info >/dev/null 2>&1; then
+    redis_state="$(compose --profile cloud-workspaces ps --format '{{.State}}' redis 2>/dev/null | head -n1)"
+    if [[ "$redis_state" == "running" ]]; then
+      pass "service redis: running (${redis_url:-redis://redis:6379/0})"
+    else
+      fail "service redis: ${redis_state:-not created}. Cloud materialization cannot acquire its lock without it. Check: $DEPLOY_DIR/update.sh and docker compose logs redis"
+    fi
   else
-    warn "cloud workspaces are configured but no redis container is running. Cloud materialization needs Redis (${redis_url:-redis://redis:6379/0}); the base bundle does not yet ship one — see the deployment requirements in the self-hosting docs."
+    warn "Stack not started; cannot check the redis service state."
   fi
 else
   info "cloud workspaces not configured; Redis not required."
@@ -272,26 +278,46 @@ section "Agent gateway"
 if proliferate_is_truthy "$(get AGENT_GATEWAY_ENABLED)"; then
   info "AGENT_GATEWAY_ENABLED=true (profile: agent-gateway)"
   info "LITELLM_MASTER_KEY: $(shape LITELLM_MASTER_KEY); AGENT_GATEWAY_LITELLM_MASTER_KEY: $(shape AGENT_GATEWAY_LITELLM_MASTER_KEY)"
-  if docker info >/dev/null 2>&1; then
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qi 'litellm'; then
-      pass "litellm container running"
+  if [[ -f "$RUNTIME_ENV_FILE" ]] && docker info >/dev/null 2>&1; then
+    litellm_state="$(compose --profile agent-gateway ps --format '{{.State}}' litellm 2>/dev/null | head -n1)"
+    litellm_health="$(compose --profile agent-gateway ps --format '{{.Health}}' litellm 2>/dev/null | head -n1)"
+    if [[ "$litellm_state" == "running" && ( "$litellm_health" == "healthy" || -z "$litellm_health" ) ]]; then
+      pass "service litellm: running (:4000 ${litellm_health:-no healthcheck reported}))"
     else
-      fail "AGENT_GATEWAY_ENABLED=true but no litellm container is running. Start it: docker compose --env-file $RUNTIME_ENV_FILE -f $COMPOSE_FILE --profile agent-gateway up -d (bootstrap.sh/update.sh do this automatically)."
+      fail "service litellm: ${litellm_state:-not created} (health: ${litellm_health:-unknown}). Start it: docker compose --env-file $RUNTIME_ENV_FILE -f $COMPOSE_FILE --profile agent-gateway up -d (bootstrap.sh/update.sh do this automatically). Check: docker compose logs litellm"
     fi
   fi
   pub_gw="$(get AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL)"
   if [[ -n "$pub_gw" ]]; then
     if curl -fsS --max-time 8 "${pub_gw%/}/health/liveliness" >/dev/null 2>&1 \
       || curl -fsS --max-time 8 "${pub_gw%/}/health" >/dev/null 2>&1; then
-      pass "public gateway endpoint reachable ($pub_gw)"
+      pass "public gateway endpoint reachable via Caddy /llm ($pub_gw)"
     else
-      warn "public gateway endpoint did not respond ($pub_gw). Confirm the Caddy route to litellm:4000 is configured (see the model-gateway add-on docs)."
+      warn "public gateway endpoint did not respond ($pub_gw). Confirm AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL points at .../llm and DNS/TLS for it are ready."
     fi
   else
     warn "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is not set; sandboxes cannot reach the gateway."
   fi
+  if [[ -z "$(get ANTHROPIC_API_KEY)" && -z "$(get OPENAI_API_KEY)" && -z "$(get XAI_API_KEY)" ]]; then
+    warn "No provider key (ANTHROPIC_API_KEY / OPENAI_API_KEY / XAI_API_KEY) is set for litellm; it has no model to serve."
+  fi
 else
   info "agent gateway disabled."
+fi
+
+# --- Deployment SSO (only when enabled) ---------------------------------------
+
+section "Deployment SSO"
+if proliferate_is_truthy "$(get SSO_ENABLED)"; then
+  info "SSO_ENABLED=true; client id: $(shape SSO_OIDC_CLIENT_ID); client secret: $(shape SSO_OIDC_CLIENT_SECRET)"
+  sso_jit="$(get SSO_JIT_POLICY)"
+  if [[ "${sso_jit:-disabled}" == "disabled" && -z "$(get ADMIN_EMAILS)" ]]; then
+    warn "SSO_JIT_POLICY=disabled (or unset) and ADMIN_EMAILS is empty: no SSO sign-in can create the first user. Set ADMIN_EMAILS (password sign-in) or SSO_JIT_POLICY=create_member."
+  else
+    pass "SSO first-user path is reachable (ADMIN_EMAILS set or SSO_JIT_POLICY auto-provisions)."
+  fi
+else
+  info "SSO disabled."
 fi
 
 # --- Optional add-on config shape (redacted) ---------------------------------
@@ -299,13 +325,18 @@ fi
 section "Add-on configuration (redacted)"
 info "GitHub OAuth client id: $(shape GITHUB_OAUTH_CLIENT_ID); secret: $(shape GITHUB_OAUTH_CLIENT_SECRET)"
 if [[ -n "$(get GITHUB_APP_ID)" ]]; then
-  info "GitHub App: id set; private key: $(shape GITHUB_APP_PRIVATE_KEY); webhook secret: $(shape GITHUB_APP_WEBHOOK_SECRET)"
+  info "GitHub App: id set; private key: $(shape GITHUB_APP_PRIVATE_KEY); private key path: $(get GITHUB_APP_PRIVATE_KEY_PATH); webhook secret: $(shape GITHUB_APP_WEBHOOK_SECRET)"
 fi
 e2b_key="$(get E2B_API_KEY)"
 e2b_tmpl="$(get E2B_TEMPLATE_NAME)"
 if [[ -n "$e2b_key" || -n "$e2b_tmpl" ]]; then
   # Template name is not a secret; showing it aids debugging.
   info "E2B: api key $(shape E2B_API_KEY); template ${e2b_tmpl:-<empty>}"
+fi
+if [[ -n "$(get RESEND_API_KEY)" ]]; then
+  info "Resend: api key $(shape RESEND_API_KEY); from address $(get RESEND_FROM_EMAIL)"
+else
+  info "RESEND_API_KEY not set; invitation email delivery is 'skipped' (admins use the copy-link)."
 fi
 
 # --- Summary -----------------------------------------------------------------

--- a/server/deploy/install.sh
+++ b/server/deploy/install.sh
@@ -335,7 +335,7 @@ download_and_verify_bundle() {
 install_bundle_files() {
   # Refresh scripts/compose/example/VERSION without ever clobbering operator
   # config or data (.env.static, .env.local, .env.generated, .env.runtime).
-  mkdir -p "$DEPLOY_DIR" "$INSTALL_ROOT/bin"
+  mkdir -p "$DEPLOY_DIR" "$INSTALL_ROOT/bin" "$INSTALL_ROOT/secrets/github-app"
   local src="$FETCH_TMP/proliferate-deploy"
   local rel
   while IFS= read -r -d '' rel; do

--- a/server/deploy/preflight.sh
+++ b/server/deploy/preflight.sh
@@ -121,12 +121,110 @@ if proliferate_is_truthy "$(get AGENT_GATEWAY_ENABLED)"; then
   if [[ -z "$GATEWAY_PUBLIC" ]]; then
     warn "AGENT_GATEWAY_ENABLED=true but AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is empty. Sandboxes cannot reach the gateway until you set the public URL and expose it (see the model-gateway add-on docs)."
   fi
+  if [[ -z "$(get ANTHROPIC_API_KEY)" && -z "$(get OPENAI_API_KEY)" && -z "$(get XAI_API_KEY)" ]]; then
+    err "AGENT_GATEWAY_ENABLED=true but none of ANTHROPIC_API_KEY / OPENAI_API_KEY / XAI_API_KEY is set. LiteLLM has no provider credentials to serve models with; set at least one."
+  fi
   if [[ "$ERRORS" -eq 0 ]]; then
     ok "Agent gateway config is internally consistent (profile: agent-gateway)."
   fi
 fi
 
-# --- 4. Runtime binaries for cloud workspaces --------------------------------
+# --- 4. Redis for cloud materialization ---------------------------------------
+#
+# Cloud materialization takes a per-sandbox Redis lock (REDBEAT_REDIS_URL).
+# The bundled `redis` service comes up automatically under the cloud-workspaces
+# profile whenever the E2B pair (section 2) is complete, so this is a sanity
+# check on an operator override rather than a "missing service" case.
+
+if [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" ]]; then
+  REDIS_URL="$(get REDBEAT_REDIS_URL)"
+  if [[ -z "$REDIS_URL" ]]; then
+    warn "Cloud workspaces are configured (E2B_API_KEY + E2B_TEMPLATE_NAME) but REDBEAT_REDIS_URL is empty. Cloud materialization cannot acquire its lock without a Redis URL (it will fail requests with cloud_materialization_busy, not crash the instance); leave it at the bundled default (redis://redis:6379/0) or point it at a reachable Redis."
+  elif [[ "$REDIS_URL" != *"redis://redis:"* && "$REDIS_URL" != *"@redis:"* ]]; then
+    warn "REDBEAT_REDIS_URL ('$REDIS_URL') does not point at the bundled 'redis' service. The cloud-workspaces profile still starts the bundled redis container; confirm your override is reachable, or remove it to use the bundled one."
+  else
+    ok "Redis is configured for cloud materialization (profile: cloud-workspaces)."
+  fi
+fi
+
+# --- 5. Deployment SSO (OIDC) completeness ------------------------------------
+#
+# A usable OIDC connection needs a client id, an issuer/discovery/static
+# endpoint source, and a client secret (unless the token-endpoint auth method
+# is "none", e.g. a public client). Mirrors
+# auth.sso.deployment_config.deployment_sso_configuration_error() so preflight
+# catches the same incompleteness before an operator discovers it at sign-in.
+
+if proliferate_is_truthy "$(get SSO_ENABLED)"; then
+  SSO_CLIENT_ID="$(get SSO_OIDC_CLIENT_ID)"
+  SSO_CLIENT_SECRET="$(get SSO_OIDC_CLIENT_SECRET)"
+  SSO_AUTH_METHOD="$(get SSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD)"
+  SSO_ISSUER="$(get SSO_OIDC_ISSUER_URL)"
+  SSO_DISCOVERY="$(get SSO_OIDC_DISCOVERY_URL)"
+  SSO_AUTHZ_EP="$(get SSO_OIDC_AUTHORIZATION_ENDPOINT)"
+  SSO_TOKEN_EP="$(get SSO_OIDC_TOKEN_ENDPOINT)"
+  SSO_JWKS_EP="$(get SSO_OIDC_JWKS_URI)"
+  SSO_JIT="$(get SSO_JIT_POLICY)"
+  ADMIN_EMAILS_VAL="$(get ADMIN_EMAILS)"
+
+  if [[ -z "$SSO_CLIENT_ID" ]]; then
+    err "SSO_ENABLED=true but SSO_OIDC_CLIENT_ID is empty."
+  fi
+  if [[ -z "$SSO_CLIENT_SECRET" && "$SSO_AUTH_METHOD" != "none" ]]; then
+    err "SSO_ENABLED=true but SSO_OIDC_CLIENT_SECRET is empty (required unless SSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD=none)."
+  fi
+  if [[ -z "$SSO_ISSUER" && -z "$SSO_DISCOVERY" \
+        && ! ( -n "$SSO_AUTHZ_EP" && -n "$SSO_TOKEN_EP" && -n "$SSO_JWKS_EP" ) ]]; then
+    err "SSO_ENABLED=true but no endpoint source is set. Set SSO_OIDC_ISSUER_URL or SSO_OIDC_DISCOVERY_URL, or all of SSO_OIDC_AUTHORIZATION_ENDPOINT/SSO_OIDC_TOKEN_ENDPOINT/SSO_OIDC_JWKS_URI."
+  fi
+  # First-user lockout: a disabled JIT policy rejects every unknown user, so
+  # with no ADMIN_EMAILS floor and (by definition, at first boot) no
+  # pre-provisioned user, nobody can complete a first SSO login.
+  if [[ "${SSO_JIT:-disabled}" == "disabled" && -z "$ADMIN_EMAILS_VAL" ]]; then
+    warn "SSO_ENABLED=true with SSO_JIT_POLICY=disabled (the default) and ADMIN_EMAILS empty. No SSO sign-in can create the first user; either set ADMIN_EMAILS so an admin can sign in with password first, or set SSO_JIT_POLICY=create_member."
+  fi
+  if [[ "$ERRORS" -eq 0 ]]; then
+    ok "SSO OIDC config is complete."
+  fi
+fi
+
+# --- 6. GitHub sign-in (OAuth) partial config ---------------------------------
+
+GITHUB_OAUTH_ID="$(get GITHUB_OAUTH_CLIENT_ID)"
+GITHUB_OAUTH_SECRET="$(get GITHUB_OAUTH_CLIENT_SECRET)"
+if [[ -n "$GITHUB_OAUTH_ID" && -z "$GITHUB_OAUTH_SECRET" ]]; then
+  warn "GITHUB_OAUTH_CLIENT_ID is set but GITHUB_OAUTH_CLIENT_SECRET is empty. GitHub sign-in stays unavailable until both are set."
+elif [[ -z "$GITHUB_OAUTH_ID" && -n "$GITHUB_OAUTH_SECRET" ]]; then
+  warn "GITHUB_OAUTH_CLIENT_SECRET is set but GITHUB_OAUTH_CLIENT_ID is empty. GitHub sign-in stays unavailable until both are set."
+elif [[ -n "$GITHUB_OAUTH_ID" && -n "$GITHUB_OAUTH_SECRET" ]]; then
+  ok "GitHub OAuth sign-in config is a complete pair."
+fi
+
+# --- 7. GitHub App (cloud repo access) partial config -------------------------
+#
+# Distinct credential set from GitHub OAuth sign-in above. Not required for
+# the base install or for cloud workspaces themselves (E2B is what gates
+# workspace creation); flagged here only so a half-entered App config does not
+# silently fail to authorize repos later.
+
+GITHUB_APP_ID_VAL="$(get GITHUB_APP_ID)"
+if [[ -n "$GITHUB_APP_ID_VAL" ]]; then
+  GITHUB_APP_CLIENT_ID_VAL="$(get GITHUB_APP_CLIENT_ID)"
+  GITHUB_APP_CLIENT_SECRET_VAL="$(get GITHUB_APP_CLIENT_SECRET)"
+  GITHUB_APP_WEBHOOK_SECRET_VAL="$(get GITHUB_APP_WEBHOOK_SECRET)"
+  GITHUB_APP_KEY_INLINE="$(get GITHUB_APP_PRIVATE_KEY)"
+  GITHUB_APP_KEY_PATH="$(get GITHUB_APP_PRIVATE_KEY_PATH)"
+  if [[ -z "$GITHUB_APP_CLIENT_ID_VAL" || -z "$GITHUB_APP_CLIENT_SECRET_VAL" || -z "$GITHUB_APP_WEBHOOK_SECRET_VAL" ]]; then
+    warn "GITHUB_APP_ID is set but one of GITHUB_APP_CLIENT_ID / GITHUB_APP_CLIENT_SECRET / GITHUB_APP_WEBHOOK_SECRET is empty. Set all of them together to use the GitHub App."
+  fi
+  if [[ -z "$GITHUB_APP_KEY_INLINE" && -z "$GITHUB_APP_KEY_PATH" ]]; then
+    warn "GITHUB_APP_ID is set but neither GITHUB_APP_PRIVATE_KEY nor GITHUB_APP_PRIVATE_KEY_PATH is set. The App needs its private key to authenticate."
+  elif [[ -n "$GITHUB_APP_KEY_INLINE" && -n "$GITHUB_APP_KEY_PATH" ]]; then
+    warn "Both GITHUB_APP_PRIVATE_KEY and GITHUB_APP_PRIVATE_KEY_PATH are set; only one form is needed (inline takes precedence)."
+  fi
+fi
+
+# --- 8. Runtime binaries for cloud workspaces --------------------------------
 #
 # install-runtime.sh fails when a CLOUD_*_SOURCE_BINARY_PATH points at a missing
 # file and no RUNTIME_BINARY_URL is set to fetch it. Surface that here rather
@@ -140,7 +238,7 @@ for var in CLOUD_RUNTIME_SOURCE_BINARY_PATH CLOUD_WORKER_SOURCE_BINARY_PATH CLOU
   fi
 done
 
-# --- 5. Unknown / likely-typo keys -------------------------------------------
+# --- 9. Unknown / likely-typo keys -------------------------------------------
 #
 # Compare the operator's env keys against the shipped example schema plus the
 # small set of generated/managed keys the scripts add. An unknown key is
@@ -152,31 +250,26 @@ trap 'rm -f "$known_keys_file"' EXIT
   if [[ -f "$EXAMPLE_ENV_FILE" ]]; then
     grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' "$EXAMPLE_ENV_FILE" | sed 's/=$//'
   fi
-  # Keys the deploy scripts / AWS stack manage that are not in the example.
+  # Keys the deploy scripts / AWS stack manage, or advanced overrides
+  # documented in env-secrets-matrix.md, that are not in the shipped example.
   cat <<'MANAGED'
 DATABASE_URL
 API_BASE_URL
 PROLIFERATE_USE_SSLIP_FALLBACK
-E2B_TEMPLATE_NAME
-GITHUB_APP_ID
-GITHUB_APP_SLUG
-GITHUB_APP_CLIENT_ID
-GITHUB_APP_CLIENT_SECRET
-GITHUB_APP_WEBHOOK_SECRET
-GITHUB_APP_PRIVATE_KEY
-GITHUB_APP_PRIVATE_KEY_PATH
-RESEND_API_KEY
-RESEND_FROM_EMAIL
-SSO_ENABLED
-SSO_OIDC_ISSUER_URL
-SSO_OIDC_CLIENT_ID
-SSO_OIDC_CLIENT_SECRET
-SSO_JIT_POLICY
-SSO_OIDC_ALLOW_PRIVATE_PROVIDER_URLS
 LITELLM_POSTGRES_DB
 LITELLM_POSTGRES_USER
 PROLIFERATE_LITELLM_IMAGE
 PROLIFERATE_LITELLM_IMAGE_TAG
+SSO_OIDC_AUTHORIZATION_ENDPOINT
+SSO_OIDC_TOKEN_ENDPOINT
+SSO_OIDC_JWKS_URI
+SSO_OIDC_USERINFO_ENDPOINT
+SSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD
+SSO_OIDC_CALLBACK_BASE_URL
+SSO_PROTOCOL
+SSO_DISPLAY_NAME
+SSO_LOGIN_POLICY
+SSO_OIDC_SCOPES
 MANAGED
 } | sort -u >"$known_keys_file"
 
@@ -187,7 +280,7 @@ while IFS= read -r key; do
   fi
 done < <(grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" | sed 's/=$//' | sort -u)
 
-# --- 6. Duplicate keys -------------------------------------------------------
+# --- 10. Duplicate keys -------------------------------------------------------
 
 dupes="$(grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" | sed 's/=$//' | sort | uniq -d || true)"
 if [[ -n "$dupes" ]]; then

--- a/server/deploy/smoke/run-smoke.sh
+++ b/server/deploy/smoke/run-smoke.sh
@@ -83,9 +83,10 @@ fi
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/proliferate-smoke.XXXXXX")"
 STACK_DIR="$WORK_DIR/deploy"
 BIN_DIR="$WORK_DIR/bin"
+GITHUB_APP_SECRETS_DIR="$WORK_DIR/github-app-secrets"
 
 cp -R "$DEPLOY_DIR" "$STACK_DIR"
-mkdir -p "$BIN_DIR"
+mkdir -p "$BIN_DIR" "$GITHUB_APP_SECRETS_DIR"
 
 # Drop any env state copied from a previously bootstrapped checkout.
 find "$STACK_DIR" -maxdepth 1 -name ".env*" ! -name ".env.production.example" -exec rm -f {} +
@@ -151,6 +152,7 @@ PROLIFERATE_PUBLIC_HEALTHCHECK_URL=http://localhost:${HTTP_PORT}/health
 PROLIFERATE_SERVER_IMAGE=${IMAGE_REPOSITORY}
 PROLIFERATE_SERVER_IMAGE_TAG=${IMAGE_TAG}
 PROLIFERATE_HOST_BIN_DIR=${BIN_DIR}
+GITHUB_APP_PRIVATE_KEY_HOST_PATH=${GITHUB_APP_SECRETS_DIR}
 PROLIFERATE_SMOKE_HTTP_PORT=${HTTP_PORT}
 PROLIFERATE_SMOKE_API_PORT=${API_PORT}
 PROLIFERATE_ANONYMOUS_TELEMETRY_DISABLED=true

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -133,6 +133,18 @@ args="$(proliferate_profile_args "$env_on" | tr '\n' ' ')"
 [[ "$args" == "--profile agent-gateway " ]] && ok "profile args formatted for gateway" || no "profile args wrong: '$args'"
 [[ -z "$(proliferate_profile_args "$env_off")" ]] && ok "profile args empty when off" || no "profile args should be empty when off"
 
+env_e2b_partial="$SCRATCH/e2b-partial.env"
+printf 'E2B_API_KEY=k\nE2B_TEMPLATE_NAME=\n' >"$env_e2b_partial"
+[[ -z "$(proliferate_enabled_profiles "$env_e2b_partial")" ]] && ok "E2B key without template -> no cloud-workspaces profile" || no "half-configured E2B should not enable the profile"
+
+env_e2b_complete="$SCRATCH/e2b-complete.env"
+printf 'E2B_API_KEY=k\nE2B_TEMPLATE_NAME=t/x:production\n' >"$env_e2b_complete"
+[[ "$(proliferate_enabled_profiles "$env_e2b_complete")" == "cloud-workspaces" ]] && ok "complete E2B pair -> cloud-workspaces profile" || no "complete E2B pair -> expected cloud-workspaces"
+
+env_both="$SCRATCH/both.env"
+printf 'AGENT_GATEWAY_ENABLED=true\nE2B_API_KEY=k\nE2B_TEMPLATE_NAME=t/x:production\n' >"$env_both"
+[[ "$(proliferate_enabled_profiles "$env_both")" == "agent-gateway cloud-workspaces" ]] && ok "gateway + cloud both on -> both profiles" || no "expected both profiles: got '$(proliferate_enabled_profiles "$env_both")'"
+
 mv="$(printf '0.3.2\n0.3.18\n0.10.0\n2.0.0\n0.3.9\n' | proliferate_max_version)"
 [[ "$mv" == "2.0.0" ]] && ok "max_version picks 2.0.0" || no "max_version wrong: $mv"
 mv2="$(printf '0.3.2\n0.3.18\n0.3.9\n' | proliferate_max_version)"
@@ -165,6 +177,45 @@ printf 'SITE_ADDRESS=api.example.com\nTYPOKEY_XYZ=1\n' >"$t"
 pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
 echo "$pfout" | grep -q "Unknown config key 'TYPOKEY_XYZ'" && ok "unknown key warns" || no "unknown key should warn"
 pf "$t" && ok "unknown key is a warning, not a block" || no "unknown key should not block"
+
+# -- gateway: enabled but no provider key -> BLOCK (litellm would have no
+# models to serve). Master key pair + PG password + public URL all present so
+# only the missing-provider-key case is under test.
+printf 'SITE_ADDRESS=api.example.com\nAGENT_GATEWAY_ENABLED=true\nLITELLM_MASTER_KEY=a\nAGENT_GATEWAY_LITELLM_MASTER_KEY=a\nLITELLM_POSTGRES_PASSWORD=p\nAGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=https://api.example.com/llm\n' >"$t"
+pf "$t" && no "gateway with no provider key should BLOCK" || ok "gateway with no provider key blocks"
+
+# -- gateway: fully consistent config (matching keys + a provider key) -> pass.
+printf 'SITE_ADDRESS=api.example.com\nAGENT_GATEWAY_ENABLED=true\nLITELLM_MASTER_KEY=a\nAGENT_GATEWAY_LITELLM_MASTER_KEY=a\nLITELLM_POSTGRES_PASSWORD=p\nAGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=https://api.example.com/llm\nANTHROPIC_API_KEY=sk-ant-x\n' >"$t"
+pf "$t" && ok "fully consistent gateway config passes" || no "fully consistent gateway config should pass"
+
+# -- cloud workspaces: complete E2B pair with no REDBEAT_REDIS_URL -> warns,
+# does not block (materialization degrades to a 503, it does not crash-loop).
+printf 'SITE_ADDRESS=api.example.com\nE2B_API_KEY=k\nE2B_TEMPLATE_NAME=t/x:production\nREDBEAT_REDIS_URL=\n' >"$t"
+pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
+echo "$pfout" | grep -q "REDBEAT_REDIS_URL is empty" && ok "cloud workspaces with empty REDBEAT_REDIS_URL warns" || no "expected a REDBEAT_REDIS_URL warning"
+pf "$t" && ok "empty REDBEAT_REDIS_URL does not block" || no "empty REDBEAT_REDIS_URL should not block"
+
+# -- SSO: enabled but missing client secret and no endpoint source -> BLOCK.
+printf 'SITE_ADDRESS=api.example.com\nSSO_ENABLED=true\nSSO_OIDC_CLIENT_ID=abc\n' >"$t"
+pf "$t" && no "incomplete SSO config should BLOCK" || ok "incomplete SSO config blocks"
+
+# -- SSO: complete public-client config (token endpoint auth method "none"
+# needs no client secret) with an admin floor set -> pass, no lockout warning.
+printf 'SITE_ADDRESS=api.example.com\nSSO_ENABLED=true\nSSO_OIDC_CLIENT_ID=abc\nSSO_OIDC_ISSUER_URL=https://idp.example.com\nSSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD=none\nADMIN_EMAILS=admin@example.com\n' >"$t"
+pf "$t" && ok "complete public-client SSO config passes" || no "complete public-client SSO config should pass"
+
+# -- SSO: complete config, default JIT policy, no ADMIN_EMAILS floor -> warns
+# about a first-user lockout but does not block.
+printf 'SITE_ADDRESS=api.example.com\nSSO_ENABLED=true\nSSO_OIDC_CLIENT_ID=abc\nSSO_OIDC_CLIENT_SECRET=shh\nSSO_OIDC_ISSUER_URL=https://idp.example.com\n' >"$t"
+pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
+echo "$pfout" | grep -q "No SSO sign-in can create the first user" && ok "SSO first-user-lockout warns" || no "expected a first-user-lockout warning"
+pf "$t" && ok "SSO first-user-lockout warning does not block" || no "SSO first-user-lockout warning should not block"
+
+# -- GitHub OAuth: one of client id / secret set -> warns, does not block.
+printf 'SITE_ADDRESS=api.example.com\nGITHUB_OAUTH_CLIENT_ID=abc\n' >"$t"
+pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
+echo "$pfout" | grep -q "GitHub sign-in stays unavailable" && ok "GitHub OAuth partial config warns" || no "expected a GitHub OAuth partial-config warning"
+pf "$t" && ok "GitHub OAuth partial config does not block" || no "GitHub OAuth partial config should not block"
 
 # ---------------------------------------------------------------------------
 group "4. Installer: release selection + fetch + verify"
@@ -300,6 +351,42 @@ if [[ "${PROLIFERATE_TEST_AWS:-0}" == "1" ]] && command -v aws >/dev/null 2>&1; 
 else
   printf '  skip  aws validate-template (set PROLIFERATE_TEST_AWS=1 with creds to run)\n'
 fi
+
+# ---------------------------------------------------------------------------
+group "10. Compose + Caddy shape (agent-gateway / cloud-workspaces add-ons)"
+# ---------------------------------------------------------------------------
+COMPOSE_FILE="$DEPLOY_DIR/docker-compose.production.yml"
+CADDYFILE="$DEPLOY_DIR/Caddyfile"
+
+grep -q '^  redis:' "$COMPOSE_FILE" && ok "compose defines a redis service" || no "compose missing a redis service"
+grep -A3 '^  redis:' "$COMPOSE_FILE" | grep -q 'profiles: \["cloud-workspaces"\]' \
+  && ok "redis is behind the cloud-workspaces profile" || no "redis should be profiles: [\"cloud-workspaces\"]"
+grep -A10 '^  redis:' "$COMPOSE_FILE" | grep -q 'redis-cli' \
+  && ok "redis has a healthcheck" || no "redis missing a healthcheck"
+
+grep -q '^  litellm:' "$COMPOSE_FILE" && ok "compose defines a litellm service" || no "compose missing a litellm service"
+grep -A5 '^  litellm:' "$COMPOSE_FILE" | grep -q 'profiles: \["agent-gateway"\]' \
+  && ok "litellm is behind the agent-gateway profile" || no "litellm should be profiles: [\"agent-gateway\"]"
+grep -A20 '^  litellm:' "$COMPOSE_FILE" | grep -q 'health/liveliness' \
+  && ok "litellm has a healthcheck" || no "litellm missing a healthcheck"
+
+grep -q 'GITHUB_APP_PRIVATE_KEY_HOST_PATH' "$COMPOSE_FILE" \
+  && ok "api mounts the GitHub App secrets directory" || no "api missing the GitHub App secrets mount"
+
+# The /llm handle_path must come before the default handle so Caddy's
+# first-match-wins evaluation routes /llm/* to litellm instead of the api.
+llm_line="$(grep -n 'handle_path /llm' "$CADDYFILE" | head -1 | cut -d: -f1)"
+default_line="$(grep -n 'handle {' "$CADDYFILE" | head -1 | cut -d: -f1)"
+[[ -n "$llm_line" ]] && ok "Caddyfile has a /llm route" || no "Caddyfile missing the /llm route"
+[[ -n "$default_line" ]] && ok "Caddyfile has a default handle route" || no "Caddyfile missing the default handle route"
+if [[ -n "$llm_line" && -n "$default_line" ]]; then
+  [[ "$llm_line" -lt "$default_line" ]] && ok "/llm route precedes the default route" || no "/llm route must precede the default route (first match wins)"
+fi
+grep -q 'reverse_proxy litellm:4000' "$CADDYFILE" && ok "/llm proxies to litellm:4000" || no "/llm route does not proxy to litellm:4000"
+grep -q 'reverse_proxy api:8000' "$CADDYFILE" && ok "default route still proxies to api:8000" || no "default route does not proxy to api:8000"
+
+# common.sh profile mechanism agrees with the compose file's profile names.
+grep -q '"cloud-workspaces"' "$DEPLOY_DIR/common.sh" && ok "common.sh knows the cloud-workspaces profile name" || no "common.sh missing the cloud-workspaces profile name"
 
 # ---------------------------------------------------------------------------
 printf '\n== Summary ==\n  %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/server/deploy/update.sh
+++ b/server/deploy/update.sh
@@ -37,15 +37,29 @@ export PROLIFERATE_ENV_FILE="$RUNTIME_ENV_FILE"
 COMPOSE_ARGS=(--env-file "$RUNTIME_ENV_FILE" -f "$COMPOSE_FILE")
 
 # Update every service enabled through the deployment contract, including
-# optional-profile services (agent-gateway litellm + litellm-db) when the
-# capability flag is on. Same one mechanism bootstrap.sh uses.
+# optional-profile services (agent-gateway litellm + litellm-db, cloud-workspaces
+# redis) when the capability flag is on. Same one mechanism bootstrap.sh uses.
 PROFILE_ARGS=()
 while IFS= read -r _profile_token; do
   [[ -n "$_profile_token" ]] && PROFILE_ARGS+=("$_profile_token")
 done < <(proliferate_profile_args "$RUNTIME_ENV_FILE")
 
+PROFILE_SERVICES=()
+while IFS= read -r _profile_service; do
+  [[ -n "$_profile_service" ]] && PROFILE_SERVICES+=("$_profile_service")
+done < <(proliferate_profile_services "$RUNTIME_ENV_FILE")
+
 docker compose "${COMPOSE_ARGS[@]}" ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} pull
 docker compose "${COMPOSE_ARGS[@]}" run --rm migrate
-docker compose "${COMPOSE_ARGS[@]}" ${PROFILE_ARGS[@]+"${PROFILE_ARGS[@]}"} up -d
+docker compose "${COMPOSE_ARGS[@]}" up -d db api caddy
+# --wait, scoped explicitly to the profiled services: an enabled optional
+# service (litellm, redis) must be healthy before this script hands back
+# control, not merely "started". Deliberately NOT a bare `up -d --wait`
+# across the whole compose file — that would also try to reconcile the
+# one-shot `migrate` job above, which always exits after running and would
+# make --wait report a false failure.
+if ((${#PROFILE_SERVICES[@]})); then
+  docker compose "${COMPOSE_ARGS[@]}" "${PROFILE_ARGS[@]}" up -d --wait --wait-timeout "${PROLIFERATE_PROFILE_WAIT_TIMEOUT_SECONDS:-300}" "${PROFILE_SERVICES[@]}"
+fi
 
 "$SCRIPT_DIR/wait-for-health.sh"

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -369,7 +369,7 @@ Resources:
             03-enable-docker:
               command: systemctl enable --now docker
             04-create-directories:
-              command: mkdir -p /opt/proliferate/server/deploy /opt/proliferate/bin /etc/cfn/hooks.d
+              command: mkdir -p /opt/proliferate/server/deploy /opt/proliferate/bin /opt/proliferate/secrets/github-app /etc/cfn/hooks.d
 
         fetch_bundle:
           commands:


### PR DESCRIPTION
## Summary

Deployment-owner shared-integration pass for the self-hosting beta. Integrates the consolidated deployment requirements reported by the model-gateway (#1117), cloud-workspaces (#1116), capabilities/desktop (#1119), and authentication (#1120) tracks into the one owned deployment layer — `server/deploy/**` and `server/infra/self-hosted-aws/**` only. No gateway/cloud/auth/desktop domain logic is touched.

- **Caddy `/llm` route** (`handle_path /llm/* { reverse_proxy litellm:4000 }`, before the default `handle`): this route did not exist before this PR, so every gateway turn 404'd through the public path even with the gateway profile running.
- **New `redis` service** behind a new `cloud-workspaces` compose profile, auto-enabled by the same `E2B_API_KEY`+`E2B_TEMPLATE_NAME` complete-pair gate `preflight.sh` already enforces. Cloud materialization needed an ad-hoc `redis` container before this; now it's a first-class, versioned part of the bundle.
- **`--wait` (bounded via `--wait-timeout`) for profiled services** in `bootstrap.sh`/`update.sh`, scoped explicitly to the profiled service names (not a bare `up -d --wait` across the whole compose file — that would also try to reconcile the one-shot `migrate` job, which always exits after running and would make `--wait` report a false failure; caught this live in manual verification).
- **New env vars in `.env.production.example`**: `GITHUB_APP_*` (7 vars + a secure PEM mount path via `GITHUB_APP_PRIVATE_KEY_HOST_PATH`), `SSO_*` (OIDC + JIT policy + allowed domains + private-provider escape hatch), `RESEND_API_KEY`/`RESEND_FROM_EMAIL`, `INSTANCE_*` (branding/support), plus an updated `GITHUB_OAUTH_*` comment naming the callback URL to register.
- **`preflight.sh`**: new checks for SSO completeness, GitHub OAuth/App partial config, gateway-enabled-without-provider-key, and E2B-configured-without-Redis-URL — all warn/block consistently with the existing E2B crash-loop guard.
- **`doctor.sh`**: compose-level health for `redis` + `litellm` (was a `docker ps` name-grep before; now uses `.State`/`.Health`), a new "Deployment SSO" section with a first-user-lockout warning, and redacted GitHub App/Resend add-on shape.
- **`install.sh` / AWS template**: create the GitHub App secrets directory at install time so the new read-only bind mount never fails on a fresh host (Docker also auto-creates it if missing, verified).

Base: `origin/main` @ `862b327fb` (includes #1116/#1117/#1118/#1120).

## Test plan

- [x] `server/deploy/tests/run.sh` — 95/95 passed (25 new cases added: profile-mechanism for `cloud-workspaces`, preflight SSO/GitHub-OAuth/gateway-provider-key/Redis checks, compose+Caddy shape assertions), including a live `aws cloudformation validate-template` run (`PROLIFERATE_TEST_AWS=1`).
- [x] `bash -n` + `shellcheck -x --severity=warning` clean on every changed script.
- [x] `server/deploy/smoke/run-smoke.sh` (base install, no add-ons) — full boot→migrate→claim→login→invite→register→membership journey passes unchanged.
- [x] Manual end-to-end: booted both new profiles together (`AGENT_GATEWAY_ENABLED=true` + a complete E2B pair) via `bootstrap.sh` against the real `ghcr.io/proliferate-ai/proliferate-litellm:stable` image — `litellm`, `litellm-db`, and `redis` all reach `healthy`; hit `http://<site>/llm/health/liveliness` and `/llm/v1/models` through the actual Caddyfile and got real LiteLLM responses (200, configured model list including `claude-sonnet-4-5`, `gpt-5.2`, `grok-4`, etc.); ran `doctor.sh` against the live stack and confirmed the new Redis/Agent-gateway/SSO sections report correctly; re-ran `update.sh`'s profile-scoped `up -d --wait` sequence directly to confirm the `migrate`-false-failure bug is fixed.
- [x] `docker compose config` and `caddy validate` both clean on the changed compose/Caddyfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)