### PR TITLE
fix(deploy): scope preflight section OK lines to their own section's errors

### DIFF
--- a/server/deploy/preflight.sh
+++ b/server/deploy/preflight.sh
@@ -105,6 +105,7 @@ fi
 # the profiled services up.
 
 if proliferate_is_truthy "$(get AGENT_GATEWAY_ENABLED)"; then
+  GATEWAY_ERRORS_BEFORE="$ERRORS"
   GATEWAY_MASTER="$(get AGENT_GATEWAY_LITELLM_MASTER_KEY)"
   LITELLM_MASTER="$(get LITELLM_MASTER_KEY)"
   LITELLM_PG_PW="$(get LITELLM_POSTGRES_PASSWORD)"
@@ -124,7 +125,7 @@ if proliferate_is_truthy "$(get AGENT_GATEWAY_ENABLED)"; then
   if [[ -z "$(get ANTHROPIC_API_KEY)" && -z "$(get OPENAI_API_KEY)" && -z "$(get XAI_API_KEY)" ]]; then
     err "AGENT_GATEWAY_ENABLED=true but none of ANTHROPIC_API_KEY / OPENAI_API_KEY / XAI_API_KEY is set. LiteLLM has no provider credentials to serve models with; set at least one."
   fi
-  if [[ "$ERRORS" -eq 0 ]]; then
+  if [[ "$ERRORS" -eq "$GATEWAY_ERRORS_BEFORE" ]]; then
     ok "Agent gateway config is internally consistent (profile: agent-gateway)."
   fi
 fi
@@ -156,6 +157,7 @@ fi
 # catches the same incompleteness before an operator discovers it at sign-in.
 
 if proliferate_is_truthy "$(get SSO_ENABLED)"; then
+  SSO_ERRORS_BEFORE="$ERRORS"
   SSO_CLIENT_ID="$(get SSO_OIDC_CLIENT_ID)"
   SSO_CLIENT_SECRET="$(get SSO_OIDC_CLIENT_SECRET)"
   SSO_AUTH_METHOD="$(get SSO_OIDC_TOKEN_ENDPOINT_AUTH_METHOD)"
@@ -183,7 +185,7 @@ if proliferate_is_truthy "$(get SSO_ENABLED)"; then
   if [[ "${SSO_JIT:-disabled}" == "disabled" && -z "$ADMIN_EMAILS_VAL" ]]; then
     warn "SSO_ENABLED=true with SSO_JIT_POLICY=disabled (the default) and ADMIN_EMAILS empty. No SSO sign-in can create the first user; either set ADMIN_EMAILS so an admin can sign in with password first, or set SSO_JIT_POLICY=create_member."
   fi
-  if [[ "$ERRORS" -eq 0 ]]; then
+  if [[ "$ERRORS" -eq "$SSO_ERRORS_BEFORE" ]]; then
     ok "SSO OIDC config is complete."
   fi
 fi

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -217,6 +217,16 @@ pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
 echo "$pfout" | grep -q "GitHub sign-in stays unavailable" && ok "GitHub OAuth partial config warns" || no "expected a GitHub OAuth partial-config warning"
 pf "$t" && ok "GitHub OAuth partial config does not block" || no "GitHub OAuth partial config should not block"
 
+# -- per-section OK lines must not be suppressed by an UNRELATED earlier
+# error: missing SITE_ADDRESS still blocks the run, but a fully consistent
+# gateway and a complete SSO config must still print their confirmations so
+# the operator can tell which sections actually validated.
+printf 'AGENT_GATEWAY_ENABLED=true\nLITELLM_MASTER_KEY=a\nAGENT_GATEWAY_LITELLM_MASTER_KEY=a\nLITELLM_POSTGRES_PASSWORD=p\nAGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL=https://api.example.com/llm\nANTHROPIC_API_KEY=sk-ant-x\nSSO_ENABLED=true\nSSO_OIDC_CLIENT_ID=abc\nSSO_OIDC_CLIENT_SECRET=shh\nSSO_OIDC_ISSUER_URL=https://idp.example.com\nADMIN_EMAILS=admin@example.com\n' >"$t"
+pfout="$("$DEPLOY_DIR/preflight.sh" "$t" 2>&1 || true)"
+echo "$pfout" | grep -q "Agent gateway config is internally consistent" && ok "gateway OK line survives an unrelated error" || no "gateway OK line suppressed by an unrelated error"
+echo "$pfout" | grep -q "SSO OIDC config is complete" && ok "SSO OK line survives an unrelated error" || no "SSO OK line suppressed by an unrelated error"
+pf "$t" && no "missing SITE_ADDRESS should still BLOCK" || ok "unrelated error still blocks the run"
+
 # ---------------------------------------------------------------------------
 group "4. Installer: release selection + fetch + verify"
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `preflight.sh` sections 3 (agent gateway) and 5 (SSO) print their "config is internally consistent" / "config is complete" confirmations gated on the **global** `$ERRORS` counter, so any unrelated earlier error (for example an empty `SITE_ADDRESS`) silently suppresses them. An operator reading the output cannot tell whether those sections validated or were skipped.
- Snapshot the error counter at section entry (`GATEWAY_ERRORS_BEFORE` / `SSO_ERRORS_BEFORE`) and compare against the snapshot instead, so each section's confirmation reflects only that section's result.
- Adds a group-3 regression test: an env with a missing `SITE_ADDRESS` plus a fully consistent gateway and complete SSO config must still print both OK lines, and the run must still block.

## PR Metadata

- Intended labels (cannot set as an outside contributor): `release:fix` + `area:server`

## Verification

Repro env: empty `SITE_ADDRESS`, fully valid gateway config, complete SSO config.

Before:
```
preflight ERROR: SITE_ADDRESS is empty and PROLIFERATE_USE_SSLIP_FALLBACK is not true. ...
preflight: 1 error(s), 0 warning(s). Refusing to continue.
```
(no gateway/SSO confirmations despite both being valid)

After:
```
preflight ERROR: SITE_ADDRESS is empty and PROLIFERATE_USE_SSLIP_FALLBACK is not true. ...
preflight OK:    Agent gateway config is internally consistent (profile: agent-gateway).
preflight OK:    SSO OIDC config is complete.
preflight: 1 error(s), 0 warning(s). Refusing to continue.
```

Full suite: `server/deploy/tests/run.sh` passes 96/96 (including the 3 new assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)