### PR TITLE
fix(agents): expose session controls and harden catalog reconciliation

### DIFF
--- a/.github/workflows/catalog-probe.yml
+++ b/.github/workflows/catalog-probe.yml
@@ -1,9 +1,11 @@
 name: Catalog Probe
 
 # The measuring instrument on a schedule: run the harness x auth-context probe
-# matrix, rebuild the catalog draft, and open a PR with the diff. Contexts
-# whose credentials are missing are skipped (run-probes.sh), so partial runs
-# are useful. Follow-ups tracked in specs/tbd/agents-catalog-registry-
+# matrix, rebuild the catalog draft, and open a PR with the diff. Promotion is
+# fail-closed: every configured context must probe the newly resolved exact pin.
+# Cursor is retained because its ACP process requires a machine-local login;
+# run `make catalog-update CATALOG_PROBE_ARGS=--include-cursor` on such a host.
+# Follow-ups tracked in specs/tbd/agents-catalog-registry-
 # migration.md §8: bedrock/vertex contexts and deliberate precedence
 # experiments land once the probe binary grows those auth contexts.
 
@@ -32,8 +34,10 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+      CODEX_AUTH_JSON_B64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
     steps:
       - uses: actions/checkout@v6
 
@@ -52,21 +56,30 @@ jobs:
         with:
           workspaces: anyharness
 
-      - name: Run probe matrix (skips missing credentials)
-        run: ./scripts/agent-catalog/run-probes.sh
-
-      - name: Rebuild catalog draft, resolve pins, promote to bundled + viewer
-        working-directory: scripts/agent-catalog
+      - name: Materialize isolated Codex OAuth input
         run: |
-          node build-catalog.mjs
-          # Freeze the fresh draft into a fenced lockfile (resolve every harness
-          # source + sha, reusing the previously-shipped shas for unchanged
-          # URLs), then promote it to the bundled catalog the runtime loads.
-          node resolve-pins.mjs \
-            --catalog catalog.draft.json \
-            --reuse-from ../../catalogs/agents/catalog.json
-          cp catalog.draft.json ../../catalogs/agents/catalog.json
-          node render-catalog.mjs
+          if [[ -n "${CODEX_AUTH_JSON_B64:-}" ]]; then
+            auth_path="$RUNNER_TEMP/codex-auth.json"
+            printf '%s' "$CODEX_AUTH_JSON_B64" | base64 --decode > "$auth_path"
+            chmod 600 "$auth_path"
+            echo "PROBE_CODEX_OAUTH_AUTH_JSON=$auth_path" >> "$GITHUB_ENV"
+          fi
+
+      - name: Resolve, install, probe, and finalize catalog
+        run: make catalog-update
+
+      - name: Summarize probe completeness
+        if: always()
+        run: |
+          state=scripts/agent-catalog/generated/.probe-logs/run.state
+          if [[ -f "$state" ]]; then
+            {
+              echo "### Catalog probe state"
+              echo '```text'
+              cat "$state"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload viewer artifact
         uses: actions/upload-artifact@v7
@@ -92,5 +105,5 @@ jobs:
           git push -u origin "$branch"
           gh pr create \
             --title "chore(catalog): probe run $(date -u +%Y-%m-%d)" \
-            --label "release:internal-or-chore" --label "area:anyharness" \
-            --body "Automated catalog probe run. Review the per-context diffs in \`scripts/agent-catalog/generated/\` and the draft; download the catalog-viewer artifact from the workflow run for the rendered diff vs main. Skipped contexts (missing credentials) are listed in the run log."
+            --label "release:maintenance" --label "area:anyharness" \
+            --body "Automated exact-pin catalog probe run. Every promoted agent was resolved, installed, and probed in the same run. Review the per-context diffs in \`scripts/agent-catalog/generated/\` and the draft; download the catalog-viewer artifact from the workflow run for the rendered diff vs main. Cursor remains at its prior pin because scheduled runners do not have the required machine-local login."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,20 @@ jobs:
           node --check scripts/ci-cd/prepare-artifact-release.mjs
           node --check scripts/ci-cd/publish-product-release.mjs
           node --check scripts/ci-cd/resolve-deploy-base.mjs
+          node --check scripts/agent-catalog/build-catalog.mjs
+          node --check scripts/agent-catalog/check-version-discipline.mjs
+          node --check scripts/agent-catalog/resolve-pins.mjs
 
       - name: Test CI/CD scripts
         run: node --test scripts/ci-cd/*.test.mjs
+
+      - name: Validate agent catalog generation discipline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+        run: |
+          node scripts/validate-agent-catalog.mjs
+          node --test scripts/agent-catalog/*.test.mjs
+          node scripts/agent-catalog/check-version-discipline.mjs --base "$BASE_SHA"
 
       - name: Check workflow YAML parses
         run: ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/*.yml

--- a/Makefile
+++ b/Makefile
@@ -979,14 +979,31 @@ catalog-view:
 # Rebuild the draft, resolve every harness into a fenced pin (per-platform
 # {url,sha256} or npm/git, reusing prior shas for unchanged URLs), and promote
 # it to the bundled lockfile the runtime loads (catalogs/agents/catalog.json).
+# This target finalizes already-committed probe snapshots; use catalog-update
+# when discovering new upstream harness versions.
 catalog-pin:
+	@state=scripts/agent-catalog/generated/.probe-logs/run.state; \
+		if [ -f "$$state" ] && ! grep -q '^complete=true$$' "$$state"; then \
+			echo "Refusing catalog promotion after an incomplete diagnostic probe run." >&2; \
+			echo "Run a complete catalog-update or remove the local probe state intentionally." >&2; \
+			exit 1; \
+		fi
 	cd scripts/agent-catalog && node build-catalog.mjs \
 		&& node resolve-pins.mjs --catalog catalog.draft.json --reuse-from ../../catalogs/agents/catalog.json \
 		&& cp catalog.draft.json ../../catalogs/agents/catalog.json \
 		&& node render-catalog.mjs
+	node scripts/validate-agent-catalog.mjs
 
-# Re-run the full probe matrix (skips contexts missing credentials; reads
-# .probe-secrets.env at the repo root), then re-pin the bundled lockfile.
+# Resolve current upstream pins, install those exact artifacts, run the complete
+# probe matrix, then promote only agents backed by fresh successful probes.
+# Set CATALOG_PROBE_AGENTS=codex (comma-separated for more than one) for a
+# focused authoritative update; agents outside that selection are retained
+# byte-for-byte. Cursor additionally requires CATALOG_PROBE_ARGS=--include-cursor
+# on a machine with a working cursor-agent login. --allow-partial is diagnostics
+# only: the completeness gate below deliberately refuses to promote it.
 catalog-update:
-	./scripts/agent-catalog/run-probes.sh
-	$(MAKE) catalog-pin
+	CATALOG_PROBE_AGENTS="$(CATALOG_PROBE_AGENTS)" ./scripts/agent-catalog/run-probes.sh $(CATALOG_PROBE_ARGS)
+	cd scripts/agent-catalog && node build-catalog.mjs --require-complete-probe \
+		&& cp catalog.draft.json ../../catalogs/agents/catalog.json \
+		&& node render-catalog.mjs
+	node scripts/validate-agent-catalog.mjs

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs
@@ -16,6 +16,9 @@ use super::managed_npm::npm_package_version;
 pub enum ReinstallReason {
     /// Caller explicitly asked (the Reinstall button).
     Requested,
+    /// A catalog pin exists, but the durable manifest cannot prove which
+    /// version is installed. Existence alone is not sufficient reconciliation.
+    MissingRecordedVersion { pinned: String },
     /// The manifest's recorded version no longer matches the declared pin.
     VersionDrift { pinned: String, recorded: String },
     /// The artifact on disk no longer matches the manifest's recorded hash.
@@ -26,6 +29,9 @@ impl std::fmt::Display for ReinstallReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Requested => write!(f, "requested"),
+            Self::MissingRecordedVersion { pinned } => {
+                write!(f, "version proof missing for pinned {pinned}")
+            }
             Self::VersionDrift { pinned, recorded } => {
                 write!(f, "version drift: pinned {pinned}, recorded {recorded}")
             }
@@ -75,12 +81,20 @@ pub fn plan_artifact(facts: &ArtifactFacts, reinstall_requested: bool) -> Option
     if reinstall_requested {
         return Some(ReinstallReason::Requested);
     }
-    if let (Some(pinned), Some(recorded)) = (&facts.pinned_version, &facts.manifest_version) {
-        if pinned != recorded {
-            return Some(ReinstallReason::VersionDrift {
-                pinned: pinned.clone(),
-                recorded: recorded.clone(),
-            });
+    if let Some(pinned) = &facts.pinned_version {
+        match &facts.manifest_version {
+            Some(recorded) if pinned != recorded => {
+                return Some(ReinstallReason::VersionDrift {
+                    pinned: pinned.clone(),
+                    recorded: recorded.clone(),
+                });
+            }
+            None => {
+                return Some(ReinstallReason::MissingRecordedVersion {
+                    pinned: pinned.clone(),
+                });
+            }
+            _ => {}
         }
     }
     if facts.checksum_matches == Some(false) {
@@ -229,13 +243,17 @@ mod tests {
     }
 
     #[test]
-    fn missing_manifest_or_pin_defers_to_the_mechanism() {
-        // No manifest yet (fresh target): mechanisms decide install-vs-skip.
+    fn a_pin_without_manifest_version_forces_reinstall() {
         assert_eq!(
             plan_artifact(&facts(Some("0.25.0"), None, None), false),
-            None
+            Some(ReinstallReason::MissingRecordedVersion {
+                pinned: "0.25.0".into(),
+            })
         );
-        // No pin declared (unpinned native CLI): attested, never forced.
+    }
+
+    #[test]
+    fn an_unpinned_artifact_without_manifest_version_defers_to_the_mechanism() {
         assert_eq!(
             plan_artifact(&facts(None, Some("1.2.3"), None), false),
             None

--- a/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/probe.rs
@@ -553,22 +553,22 @@ fn model_entries_from_model_state(
     (!entries.is_empty()).then_some(entries)
 }
 
-/// Best-effort identification of the native CLI the adapter will use:
-/// the CLAUDE_CODE_EXECUTABLE-style env override, else the managed native
-/// artifact. Runs `--version` to record the actual version string.
+/// Best-effort identification of the native CLI the adapter will use. Claude
+/// may use its provider-specific executable override; every other harness uses
+/// only its own managed native artifact. Runs `--version` to record the actual
+/// version string.
 fn detect_native_cli(
     resolved: &crate::domains::agents::model::ResolvedAgent,
 ) -> Option<ProbeNativeCli> {
-    let path = std::env::var("CLAUDE_CODE_EXECUTABLE")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .map(PathBuf::from)
-        .or_else(|| {
-            resolved
-                .native
-                .as_ref()
-                .and_then(|artifact| artifact.path.clone())
-        })?;
+    let kind = &resolved.descriptor.kind;
+    let claude_executable = (kind == &AgentKind::Claude)
+        .then(|| std::env::var("CLAUDE_CODE_EXECUTABLE").ok())
+        .flatten();
+    let managed_native = resolved
+        .native
+        .as_ref()
+        .and_then(|artifact| artifact.path.clone());
+    let path = native_cli_path(kind, managed_native, claude_executable.as_deref())?;
     let version = std::process::Command::new(&path)
         .arg("--version")
         .output()
@@ -579,6 +579,19 @@ fn detect_native_cli(
         path: path.to_string_lossy().into_owned(),
         version,
     })
+}
+
+fn native_cli_path(
+    kind: &AgentKind,
+    managed_native: Option<PathBuf>,
+    claude_executable: Option<&str>,
+) -> Option<PathBuf> {
+    let claude_override = (kind == &AgentKind::Claude)
+        .then(|| claude_executable)
+        .flatten()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from);
+    claude_override.or(managed_native)
 }
 
 fn probe_workspace_dir(kind: &AgentKind) -> anyhow::Result<PathBuf> {
@@ -597,58 +610,4 @@ fn probe_workspace_dir(kind: &AgentKind) -> anyhow::Result<PathBuf> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::model_entries_from_model_state;
-    use serde_json::json;
-
-    #[test]
-    fn maps_model_id_name_and_description() {
-        let state = json!({
-            "currentModelId": "grok-build-0.1",
-            "availableModels": [
-                { "modelId": "grok-build-0.1", "name": "Grok Build", "description": "coding" },
-                { "modelId": "grok-4.3", "name": "Grok 4.3" }
-            ]
-        });
-        assert_eq!(
-            model_entries_from_model_state(&state).expect("entries"),
-            vec![
-                (
-                    "grok-build-0.1".to_string(),
-                    "Grok Build".to_string(),
-                    Some("coding".to_string())
-                ),
-                ("grok-4.3".to_string(), "Grok 4.3".to_string(), None),
-            ]
-        );
-    }
-
-    #[test]
-    fn falls_back_to_model_id_when_name_absent() {
-        let state = json!({ "availableModels": [{ "modelId": "grok-4.3" }] });
-        assert_eq!(
-            model_entries_from_model_state(&state).expect("entries"),
-            vec![("grok-4.3".to_string(), "grok-4.3".to_string(), None)]
-        );
-    }
-
-    #[test]
-    fn skips_entries_without_a_model_id() {
-        let state = json!({ "availableModels": [{ "name": "no id" }, { "modelId": "grok-4.3" }] });
-        assert_eq!(
-            model_entries_from_model_state(&state).expect("entries"),
-            vec![("grok-4.3".to_string(), "grok-4.3".to_string(), None)]
-        );
-    }
-
-    #[test]
-    fn none_when_no_usable_models() {
-        assert!(model_entries_from_model_state(&json!({})).is_none());
-        assert!(model_entries_from_model_state(&json!({ "availableModels": [] })).is_none());
-        assert!(model_entries_from_model_state(&json!({ "currentModelId": "x" })).is_none());
-        assert!(
-            model_entries_from_model_state(&json!({ "availableModels": [{ "name": "x" }] }))
-                .is_none()
-        );
-    }
-}
+mod tests;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/probe/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/probe/tests.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use serde_json::json;
+
+use super::{model_entries_from_model_state, native_cli_path};
+use crate::domains::agents::model::AgentKind;
+
+#[test]
+fn maps_model_id_name_and_description() {
+    let state = json!({
+        "currentModelId": "grok-build-0.1",
+        "availableModels": [
+            { "modelId": "grok-build-0.1", "name": "Grok Build", "description": "coding" },
+            { "modelId": "grok-4.3", "name": "Grok 4.3" }
+        ]
+    });
+    assert_eq!(
+        model_entries_from_model_state(&state).expect("entries"),
+        vec![
+            (
+                "grok-build-0.1".to_string(),
+                "Grok Build".to_string(),
+                Some("coding".to_string())
+            ),
+            ("grok-4.3".to_string(), "Grok 4.3".to_string(), None),
+        ]
+    );
+}
+
+#[test]
+fn falls_back_to_model_id_when_name_absent() {
+    let state = json!({ "availableModels": [{ "modelId": "grok-4.3" }] });
+    assert_eq!(
+        model_entries_from_model_state(&state).expect("entries"),
+        vec![("grok-4.3".to_string(), "grok-4.3".to_string(), None)]
+    );
+}
+
+#[test]
+fn skips_entries_without_a_model_id() {
+    let state = json!({ "availableModels": [{ "name": "no id" }, { "modelId": "grok-4.3" }] });
+    assert_eq!(
+        model_entries_from_model_state(&state).expect("entries"),
+        vec![("grok-4.3".to_string(), "grok-4.3".to_string(), None)]
+    );
+}
+
+#[test]
+fn none_when_no_usable_models() {
+    assert!(model_entries_from_model_state(&json!({})).is_none());
+    assert!(model_entries_from_model_state(&json!({ "availableModels": [] })).is_none());
+    assert!(model_entries_from_model_state(&json!({ "currentModelId": "x" })).is_none());
+    assert!(
+        model_entries_from_model_state(&json!({ "availableModels": [{ "name": "x" }] })).is_none()
+    );
+}
+
+#[test]
+fn claude_executable_override_is_scoped_to_claude() {
+    let managed_codex = PathBuf::from("/managed/codex");
+    assert_eq!(
+        native_cli_path(
+            &AgentKind::Codex,
+            Some(managed_codex.clone()),
+            Some("/managed/claude")
+        ),
+        Some(managed_codex)
+    );
+    assert_eq!(
+        native_cli_path(&AgentKind::OpenCode, None, Some("/managed/claude")),
+        None
+    );
+    assert_eq!(
+        native_cli_path(
+            &AgentKind::Claude,
+            Some(PathBuf::from("/fallback/claude")),
+            Some("/managed/claude")
+        ),
+        Some(PathBuf::from("/managed/claude"))
+    );
+}

--- a/apps/desktop/src-tauri/src/commands/cloud_worker.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker.rs
@@ -14,7 +14,10 @@ use tokio::{
     time::{sleep, Duration},
 };
 
-use crate::{app_config, sidecar::resolve_shell_path};
+use crate::{
+    app_config,
+    sidecar::{resolve_shell_path, SharedSidecar},
+};
 
 mod launcher;
 
@@ -77,17 +80,19 @@ pub fn create_cloud_worker_state() -> SharedCloudWorkerState {
 #[tauri::command]
 pub async fn ensure_desktop_dispatch_worker(
     input: EnsureDesktopDispatchWorkerInput,
-    state: State<'_, SharedCloudWorkerState>,
+    sidecar: State<'_, SharedSidecar>,
+    worker_state: State<'_, SharedCloudWorkerState>,
 ) -> Result<EnsureDesktopDispatchWorkerResult, String> {
     let target_id = non_empty("targetId", input.target_id)?;
     let cloud_base_url = configured_cloud_base_url()?;
     let integration_gateway_home = app_config::anyharness_runtime_home_path()?;
+    let runtime_base_url = sidecar.lock().await.info.url.clone();
     let enrollment_token = input
         .enrollment_token
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
-    let mut guard = state.process.lock().await;
+    let mut guard = worker_state.process.lock().await;
     if let Some(process) = guard.as_mut() {
         match process.child.try_wait() {
             // A fresh enrollment token is a rotation request (e.g. a different
@@ -145,6 +150,7 @@ pub async fn ensure_desktop_dispatch_worker(
         enrollment_token.as_deref(),
         &paths.database,
         &integration_gateway_home,
+        &runtime_base_url,
     )?;
     drop(mutation_lock);
 
@@ -378,6 +384,7 @@ fn write_worker_config(
     enrollment_token: Option<&str>,
     worker_db_path: &Path,
     integration_gateway_home: &Path,
+    runtime_base_url: &str,
 ) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
@@ -396,6 +403,10 @@ fn write_worker_config(
     lines.push(format!(
         "integration_gateway_home = {}",
         toml_string(&integration_gateway_home.to_string_lossy())
+    ));
+    lines.push(format!(
+        "runtime_base_url = {}",
+        toml_string(runtime_base_url)
     ));
     // The desktop app bundle owns the worker binary; the worker must never
     // self-swap here. Explicit (the worker also defaults to false) so the
@@ -478,3 +489,6 @@ fn set_private_dir_permissions(path: &Path) -> Result<(), String> {
 fn set_private_dir_permissions(_path: &Path) -> Result<(), String> {
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
@@ -1,0 +1,28 @@
+use std::{env, fs};
+
+use super::write_worker_config;
+
+#[test]
+fn worker_config_uses_the_desktop_sidecar_url() {
+    let root = env::temp_dir().join(format!(
+        "proliferate-worker-config-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let config_path = root.join("config.toml");
+    let worker_db_path = root.join("worker.sqlite3");
+    let integration_gateway_home = root.join("anyharness");
+
+    write_worker_config(
+        &config_path,
+        "https://app.proliferate.com/api",
+        Some("enrollment-token"),
+        &worker_db_path,
+        &integration_gateway_home,
+        "http://127.0.0.1:50746",
+    )
+    .expect("write worker config");
+
+    let contents = fs::read_to_string(config_path).expect("read worker config");
+    assert!(contents.contains("runtime_base_url = \"http://127.0.0.1:50746\""));
+    fs::remove_dir_all(root).expect("remove temporary worker config root");
+}

--- a/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.tsx
@@ -14,8 +14,8 @@ import { useHomeNextTargetSelectionState } from "@/hooks/home/ui/use-home-next-t
 import { useHomeNextState } from "@/hooks/home/derived/use-home-next-state";
 import { useHomeScreen } from "@/hooks/home/facade/use-home-screen";
 import {
-  buildHomeModeControlDescriptor,
   buildHomeModelSelectorProps,
+  buildHomeSessionConfigControls,
 } from "@/lib/domain/home/home-composer-controls";
 import { type HomeNextModelSelection } from "@/lib/domain/home/home-next-launch";
 import { resolveHomeModelProbeCardState } from "@/lib/domain/home/home-screen";
@@ -69,18 +69,14 @@ export function HomeNextScreen() {
   // their own gating (goal needs activeSessionId; attachments read
   // supportsAttachments=false → chat's exact pre-session detail).
   const homeAgentKind = homeNext.effectiveModelSelection?.kind ?? null;
-  // Mode always comes from the home adapter: useHomeNextLaunchControls filters
-  // mode keys out of `controls`, so the mode descriptor must be prepended for
-  // buildComposerSessionControlGroups to pick it up (same key-based gating as
-  // chat).
-  const homeModeControl = buildHomeModeControlDescriptor({
+  const homeSessionConfigControls = buildHomeSessionConfigControls({
+    destination,
+    agentKind: homeAgentKind,
     modes: homeNext.modeOptions,
     selectedModeId: homeNext.effectiveMode?.value ?? null,
-    onSelect: setModeOverrideId,
+    launchControls: homeLaunchControls.controls,
+    onSelectMode: setModeOverrideId,
   });
-  const homeSessionConfigControls = homeModeControl
-    ? [homeModeControl, ...homeLaunchControls.controls]
-    : homeLaunchControls.controls;
   const homeModelSelectorProps = buildHomeModelSelectorProps({
     groups: homeNext.modelGroups,
     selectedModel: homeNext.selectedModel,

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
+
+const state = vi.hoisted(() => ({
+  cloudActive: false,
+  selections: {
+    data: [{
+      id: "cached-gateway-selection",
+      harnessKind: "codex",
+      surface: "local",
+      sourceKind: "gateway",
+      apiKeyId: null,
+      keyTitle: null,
+      envVarName: null,
+      providerHint: null,
+      enabled: true,
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-01T00:00:00Z",
+    }],
+  },
+  launchOptions: {
+    data: {
+      agents: [{
+        kind: "codex",
+        displayName: "Codex",
+        defaultModelId: "gpt-5.5",
+        models: [{ id: "gpt-5.5", displayName: "GPT 5.5", isDefault: true }],
+      }],
+    },
+    isLoading: false,
+    isFetching: false,
+  },
+  gatewayModels: {
+    data: {
+      models: [{ id: "cloud-only", displayName: "Cloud-only model" }],
+      source: "seed",
+    },
+    isLoading: false,
+  },
+}));
+
+const refreshCatalog = vi.hoisted(() => vi.fn());
+const upsertOverride = vi.hoisted(() => vi.fn());
+const refreshGatewayModels = vi.hoisted(() => vi.fn());
+const refetchLaunchOptions = vi.hoisted(() => vi.fn());
+const showToast = vi.hoisted(() => vi.fn());
+const authSelectionsQuery = vi.hoisted(() => vi.fn());
+const cloudCatalogQuery = vi.hoisted(() => vi.fn());
+const gatewayModelsQuery = vi.hoisted(() => vi.fn());
+const launchOptionsQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useAuthSelections: (...args: unknown[]) => {
+    authSelectionsQuery(...args);
+    return state.selections;
+  },
+  useAgentCatalog: (...args: unknown[]) => {
+    cloudCatalogQuery(...args);
+    return { data: undefined, isLoading: false };
+  },
+  useRefreshAgentCatalog: () => ({ mutate: refreshCatalog, isPending: false }),
+  useUpsertCatalogOverride: () => ({ mutate: upsertOverride, isPending: false }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useAgentGatewayModelsQuery: (...args: unknown[]) => {
+    gatewayModelsQuery(...args);
+    return state.gatewayModels;
+  },
+  useRefreshAgentGatewayModelsMutation: () => ({
+    mutate: refreshGatewayModels,
+    isPending: false,
+  }),
+  useAgentLaunchOptionsQuery: (...args: unknown[]) => {
+    launchOptionsQuery(...args);
+    return {
+      ...state.launchOptions,
+      refetch: refetchLaunchOptions,
+    };
+  },
+}));
+
+vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (value: { show: typeof showToast }) => unknown) =>
+    selector({ show: showToast }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  state.cloudActive = false;
+});
+
+describe("HarnessAllModelsSection signed-out behavior", () => {
+  it("lists local runtime models read-only and refreshes without Cloud mutations", () => {
+    render(
+      <HarnessAllModelsSection
+        harnessKind="codex"
+        displayName="Codex"
+        surface="local"
+      />,
+    );
+
+    expect(screen.queryByText("GPT 5.5")).not.toBeNull();
+    expect(screen.queryByText("Cloud-only model")).toBeNull();
+    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(true);
+    expect(authSelectionsQuery).toHaveBeenCalledWith(null, false);
+    expect(cloudCatalogQuery).toHaveBeenCalledWith(
+      { harnessKind: "codex", surface: "local", route: "native" },
+      false,
+    );
+    expect(gatewayModelsQuery).toHaveBeenCalledWith("codex", { enabled: false });
+    expect(launchOptionsQuery).toHaveBeenCalledWith({ enabled: true });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Refresh$/ }));
+
+    expect(refetchLaunchOptions).toHaveBeenCalledTimes(1);
+    expect(refreshCatalog).not.toHaveBeenCalled();
+    expect(upsertOverride).not.toHaveBeenCalled();
+    expect(refreshGatewayModels).not.toHaveBeenCalled();
+  });
+
+  it("keeps the signed-out Cloud surface gated", () => {
+    render(
+      <HarnessAllModelsSection
+        harnessKind="codex"
+        displayName="Codex"
+        surface="cloud"
+      />,
+    );
+
+    expect(screen.queryByText("GPT 5.5")).toBeNull();
+    expect(
+      screen.queryByText(
+        "Sign in to Proliferate Cloud to manage how Codex authenticates to models.",
+      ),
+    ).not.toBeNull();
+    expect(cloudCatalogQuery).toHaveBeenCalledWith(
+      { harnessKind: "codex", surface: "cloud", route: "gateway" },
+      false,
+    );
+    expect(gatewayModelsQuery).toHaveBeenCalledWith("codex", { enabled: false });
+    expect(launchOptionsQuery).toHaveBeenCalledWith({ enabled: false });
+  });
+});

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -25,6 +25,7 @@ import {
   catalogRouteForSurface,
   normalizeCatalogModels,
   normalizeGatewayModels,
+  normalizeRuntimeLaunchModels,
 } from "@/lib/domain/settings/harness-catalog";
 
 interface HarnessAllModelsSectionProps {
@@ -45,13 +46,14 @@ export function HarnessAllModelsSection({
   const route = catalogRouteForSurface(
     harnessKind,
     surface,
-    selectionsQuery.data ?? [],
+    cloudActive ? selectionsQuery.data ?? [] : [],
   );
   // Local surface + gateway route: the RUNTIME has already resolved what its
   // harness + auth can actually reach (contract §5) — read that directly
   // instead of the cloud catalog snapshot, which never sees the runtime's own
   // gateway probes.
   const isRuntimeGateway = surface === "local" && route === "gateway";
+  const isSignedOutLocal = surface === "local" && !cloudActive;
   // native/api_key routes probe on the client (catalog.py's refresh_catalog
   // contract) — the server rejects a refresh with no uploaded payload for
   // these routes, so Refresh sources one from the local AnyHarness runtime's
@@ -66,20 +68,29 @@ export function HarnessAllModelsSection({
   const upsertOverride = useUpsertCatalogOverride();
 
   const gatewayModelsQuery = useAgentGatewayModelsQuery(harnessKind, {
-    enabled: isRuntimeGateway,
+    enabled: cloudActive && isRuntimeGateway,
   });
   const refreshGatewayModels = useRefreshAgentGatewayModelsMutation();
   const runtimeLaunchOptionsQuery = useAgentLaunchOptionsQuery({
-    enabled: isRuntimeProbedRoute,
+    enabled: isRuntimeProbedRoute || isSignedOutLocal,
   });
 
-  const models = useMemo(
-    () =>
-      isRuntimeGateway
-        ? normalizeGatewayModels(gatewayModelsQuery.data?.models ?? [])
-        : normalizeCatalogModels(catalogQuery.data?.models ?? []),
-    [isRuntimeGateway, gatewayModelsQuery.data?.models, catalogQuery.data?.models],
-  );
+  const models = useMemo(() => {
+    if (isSignedOutLocal) {
+      return normalizeRuntimeLaunchModels(harnessKind, runtimeLaunchOptionsQuery.data);
+    }
+    if (isRuntimeGateway) {
+      return normalizeGatewayModels(gatewayModelsQuery.data?.models ?? []);
+    }
+    return normalizeCatalogModels(catalogQuery.data?.models ?? []);
+  }, [
+    isSignedOutLocal,
+    harnessKind,
+    runtimeLaunchOptionsQuery.data,
+    isRuntimeGateway,
+    gatewayModelsQuery.data?.models,
+    catalogQuery.data?.models,
+  ]);
   // Each row carries its own enriched metadata (contract §1); probe-only models
   // stay sparse (Provider "—" when unmatched — no harness-name fallback).
   // Runtime-resolved gateway models have no override endpoint yet, so their
@@ -94,10 +105,10 @@ export function HarnessAllModelsSection({
     modes: model.modes,
     fastMode: model.fastMode,
     enabled: model.enabled,
-    toggleDisabled: isRuntimeGateway || upsertOverride.isPending,
+    toggleDisabled: isSignedOutLocal || isRuntimeGateway || upsertOverride.isPending,
   }));
 
-  if (!cloudActive) {
+  if (surface === "cloud" && !cloudActive) {
     return (
       <SettingsSection title={HARNESS_PANE_COPY.tabAllModels}>
         <p className="py-3 text-sm text-muted-foreground">
@@ -108,6 +119,10 @@ export function HarnessAllModelsSection({
   }
 
   function handleRefresh() {
+    if (isSignedOutLocal) {
+      void runtimeLaunchOptionsQuery.refetch();
+      return;
+    }
     if (isRuntimeGateway) {
       refreshGatewayModels.mutate(harnessKind, {
         onError: (error) => {
@@ -146,7 +161,7 @@ export function HarnessAllModelsSection({
   }
 
   function handleToggle(modelId: string, enabled: boolean) {
-    if (isRuntimeGateway) {
+    if (isSignedOutLocal || isRuntimeGateway) {
       return;
     }
     upsertOverride.mutate(
@@ -162,8 +177,16 @@ export function HarnessAllModelsSection({
     );
   }
 
-  const isLoading = isRuntimeGateway ? gatewayModelsQuery.isLoading : catalogQuery.isLoading;
-  const isRefreshing = isRuntimeGateway ? refreshGatewayModels.isPending : refreshCatalog.isPending;
+  const isLoading = isSignedOutLocal
+    ? runtimeLaunchOptionsQuery.isLoading
+    : isRuntimeGateway
+      ? gatewayModelsQuery.isLoading
+      : catalogQuery.isLoading;
+  const isRefreshing = isSignedOutLocal
+    ? runtimeLaunchOptionsQuery.isFetching
+    : isRuntimeGateway
+      ? refreshGatewayModels.isPending
+      : refreshCatalog.isPending;
 
   // Auto-probe an empty catalog: landing on a resolved-but-empty catalog kicks
   // off the same refresh the button uses, exactly once per (harnessKind, surface,
@@ -200,7 +223,9 @@ export function HarnessAllModelsSection({
   // Empty catalog with a probe in flight (auto or manual) shows the probing state
   // instead of the static empty copy.
   const isProbingEmpty = models.length === 0 && isRefreshing;
-  const freshnessLine = isRuntimeGateway
+  const freshnessLine = isSignedOutLocal
+    ? ""
+    : isRuntimeGateway
     ? gatewayModelsQuery.data
       ? gatewayModelsQuery.data.source === "probe" && gatewayModelsQuery.data.probedAt
         ? HARNESS_PANE_COPY.allModelsFreshnessProbed(

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { AgentSummary } from "@anyharness/sdk";
+import { afterEach, expect, it, vi } from "vitest";
+import { HarnessConfigIssueBanner } from "./HarnessConfigIssueBanner";
+
+const agent = {
+  kind: "codex",
+  displayName: "Codex",
+  installState: "install_required",
+  readiness: "install_required",
+  message: "Not installed. Use the install endpoint to set up.",
+} as AgentSummary;
+
+afterEach(cleanup);
+
+it("renders the managed install action beside an install-required warning", () => {
+  const onInstall = vi.fn();
+  render(
+    <HarnessConfigIssueBanner
+      agent={agent}
+      installAction={{
+        label: "Install",
+        loading: false,
+        disabled: false,
+        onInstall,
+      }}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+  expect(onInstall).toHaveBeenCalledOnce();
+  expect(screen.getByText("Install required")).toBeTruthy();
+  expect(screen.getByText("Install this managed harness to use it in this profile.")).toBeTruthy();
+});
+
+it("keeps non-install configuration warnings actionless", () => {
+  render(<HarnessConfigIssueBanner agent={agent} />);
+
+  expect(screen.queryByRole("button")).toBeNull();
+});

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx
@@ -1,5 +1,6 @@
 import type { AgentSummary } from "@anyharness/sdk";
 import { ProviderIcon } from "@proliferate/ui/provider-icons";
+import { Button } from "@proliferate/ui/primitives/Button";
 import {
   configurationDetailForAgent,
 } from "@/lib/domain/agents/configuration-issues-presentation";
@@ -7,13 +8,22 @@ import { getAgentStatusDisplay } from "@/lib/domain/agents/status-presentation";
 
 interface HarnessConfigIssueBannerProps {
   agent: AgentSummary;
+  installAction?: {
+    label: string;
+    loading: boolean;
+    disabled: boolean;
+    onInstall: () => void;
+  } | null;
 }
 
 /**
  * Inline warning banner shown at the top of a harness settings page when the
  * agent has configuration issues (needs login, credentials, or install).
  */
-export function HarnessConfigIssueBanner({ agent }: HarnessConfigIssueBannerProps) {
+export function HarnessConfigIssueBanner({
+  agent,
+  installAction = null,
+}: HarnessConfigIssueBannerProps) {
   const status = getAgentStatusDisplay(agent, {});
 
   return (
@@ -29,6 +39,18 @@ export function HarnessConfigIssueBanner({ agent }: HarnessConfigIssueBannerProp
           {configurationDetailForAgent(agent)}
         </p>
       </div>
+      {installAction ? (
+        <Button
+          variant="outline"
+          size="sm"
+          loading={installAction.loading}
+          disabled={installAction.disabled}
+          onClick={installAction.onInstall}
+          className="shrink-0"
+        >
+          {installAction.label}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HarnessPane } from "./HarnessPane";
 
@@ -107,6 +108,7 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   useAgentApiKeys: () => state.apiKeys,
   useAgentCatalog: () => state.catalog,
   useAgentAuthState: () => ({ data: undefined, isLoading: false }),
+  useOrgAgentPolicy: () => ({ data: undefined, isLoading: false }),
   usePutAuthSelections: () => ({ mutate: putMutate, isPending: false }),
   useCreateAgentApiKey: () => ({ mutate: createKeyMutate, isPending: false }),
   useRefreshAgentCatalog: () => ({ mutate: refreshMutate, isPending: false }),
@@ -211,7 +213,9 @@ vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
 vi.mock("@/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: () => ({ agentsByKind: state.agentsByKind, agentsNeedingSetup: [] }),
 }));
-
+vi.mock("@/hooks/agents/workflows/use-harness-install-action", () => ({
+  useHarnessInstallAction: () => null,
+}));
 vi.mock("@/stores/sessions/harness-connection-store", () => ({
   useHarnessConnectionStore: (selector: (s: { runtimeUrl: string }) => unknown) =>
     selector({ runtimeUrl: "http://127.0.0.1:8457" }),
@@ -250,7 +254,18 @@ vi.mock("@/stores/ui/agent-surface-store", () => ({
 }));
 
 function renderPane(harnessKind = "claude") {
-  return render(<HarnessPane harnessKind={harnessKind} />);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HarnessPane harnessKind={harnessKind} />
+    </QueryClientProvider>,
+  );
 }
 
 function gatewayCard() {

--- a/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
+++ b/apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx
@@ -11,6 +11,7 @@ import { HarnessAuthSection, deriveSelectedMethod } from "./HarnessAuthSection";
 import { HarnessConfigIssueBanner } from "./HarnessConfigIssueBanner";
 import { HarnessSettingsSection } from "./HarnessSettingsSection";
 import { useHarnessAuthEditor } from "@/hooks/agents/workflows/use-harness-auth-editor";
+import { useHarnessInstallAction } from "@/hooks/agents/workflows/use-harness-install-action";
 
 interface HarnessPaneProps {
   harnessKind: string;
@@ -23,12 +24,15 @@ export function HarnessPane({ harnessKind }: HarnessPaneProps) {
   const displayName =
     agentsByKind.get(harnessKind)?.displayName ?? getProviderDisplayName(harnessKind);
   const issueAgent = agentsNeedingSetup.find((agent) => agent.kind === harnessKind);
+  const installAction = useHarnessInstallAction(issueAgent ?? null);
 
   return (
     <section className="space-y-6">
       <SettingsPageHeader title={displayName} />
 
-      {issueAgent ? <HarnessConfigIssueBanner agent={issueAgent} /> : null}
+      {issueAgent ? (
+        <HarnessConfigIssueBanner agent={issueAgent} installAction={installAction} />
+      ) : null}
 
       {surface === "cloud" ? (
         <HarnessSurfaceCloud harnessKind={harnessKind} displayName={displayName} />

--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -35,6 +35,7 @@ import { serializeChatDraftToPrompt } from "@/lib/domain/chat/composer/file-ment
 import { promptAttachmentSnapshotsToContentParts } from "@proliferate/product-domain/chats/composer/prompt-attachment-snapshot";
 import { useChatInputStore } from "@/stores/chat/chat-input-store";
 import { mergeSessionConfigControlDescriptors } from "@/lib/domain/chat/session-controls/session-controls";
+import { buildComposerSessionControlGroups } from "@/lib/domain/chat/session-controls/composer-control-groups";
 import {
   finishOrCancelMeasurementOperation,
   recordMeasurementWorkflowStep,
@@ -105,8 +106,7 @@ export function ChatInput({
     : agentKind ?? modelSelectorProps.launchAgentKind;
   const effectiveModeControl = suppressActiveSessionState
     ? null
-    : effectiveSessionConfigControls.find((control) => control.key === "collaboration_mode")
-      ?? effectiveSessionConfigControls.find((control) => control.key === "mode")
+    : buildComposerSessionControlGroups(effectiveSessionConfigControls).modeControl
       ?? modeControl
       ?? null;
   const { handleSubmit, handleCancel } = useChatPromptActions();

--- a/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -111,6 +111,24 @@ function createControls(): LiveSessionControlDescriptor[] {
   ];
 }
 
+function createAccessModeControl(): LiveSessionControlDescriptor {
+  return {
+    key: "mode",
+    label: "Permissions",
+    detail: "Auto",
+    rawConfigId: "mode",
+    settable: true,
+    pendingState: null,
+    kind: "select",
+    options: [
+      { value: "read-only", label: "Read Only", selected: false },
+      { value: "auto", label: "Auto", selected: true },
+      { value: "full-access", label: "Full Access", selected: false },
+    ],
+    onSelect: vi.fn(),
+  };
+}
+
 function renderControlRow(overrides?: Partial<Parameters<typeof ChatInputControlRow>[0]>) {
   return render(
     <MemoryRouter>
@@ -144,13 +162,44 @@ describe("ChatInputControlRow", () => {
 
   it("renders effort bars control", () => {
     renderControlRow();
-    // The LevelBarsButton renders with the current level's label
-    expect(screen.getByText("Medium")).toBeTruthy();
+    const reasoning = screen.getByRole("button", { name: "Reasoning: Medium" });
+    expect(reasoning.getAttribute("title")?.startsWith("Reasoning: Medium")).toBe(true);
+    expect(screen.getByText("Medium").className).toContain("sr-only");
   });
 
-  it("renders mode control", () => {
+  it("renders working mode as text with a subtle disclosure chevron", () => {
     renderControlRow();
+    const mode = screen.getByRole("button", { name: "Mode: Default" });
     expect(screen.getByText("Default")).toBeTruthy();
+    expect(mode.querySelectorAll("svg")).toHaveLength(1);
+    expect(mode.querySelector('path[d="m6 9 6 6 6-6"]')).toBeTruthy();
+  });
+
+  it("does not imply disclosure for a non-settable working mode", () => {
+    const controls = createControls();
+    const modeControl = controls.find((control) => control.key === "collaboration_mode")!;
+    modeControl.settable = false;
+    renderControlRow({ sessionConfigControls: controls });
+
+    const mode = screen.getByRole("button", { name: "Default" });
+    expect(mode).toHaveProperty("disabled", true);
+    expect(mode.querySelector("svg")).toBeNull();
+  });
+
+  it("orders model, reasoning bars, fast mode, and working mode in the visible row", () => {
+    renderControlRow();
+
+    const model = screen.getByRole("button", { name: "Model: Opus 4.1" });
+    const reasoning = screen.getByRole("button", { name: "Reasoning: Medium" });
+    const fast = screen.getByRole("button", { name: "Fast mode: Slow" });
+    const mode = screen.getByRole("button", { name: "Mode: Default" });
+
+    expect(model.compareDocumentPosition(reasoning) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+    expect(reasoning.compareDocumentPosition(fast) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+    expect(fast.compareDocumentPosition(mode) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
   });
 
   it("renders plus button for file attach", () => {
@@ -181,22 +230,119 @@ describe("ChatInputControlRow", () => {
     const effortControl = controls.find((c) => c.key === "effort")!;
     renderControlRow({ sessionConfigControls: controls });
 
-    // The LevelBarsButton is rendered with label "Medium"
-    const barsButton = screen.getByText("Medium").closest("button")!;
+    const barsButton = screen.getByRole("button", { name: "Reasoning: Medium" });
     fireEvent.click(barsButton);
     // Clicking should advance from index 1 (Medium) to index 2 (High)
     expect(effortControl.onSelect).toHaveBeenCalledWith("high");
   });
 
+  it("visually distinguishes Fast off and on while preserving its accessible state", () => {
+    const controls = createControls();
+    const fastControl = controls.find((control) => control.key === "fast_mode")!;
+    const { rerender } = renderControlRow({ sessionConfigControls: controls });
+
+    const offButton = screen.getByRole("button", { name: "Fast mode: Slow" });
+    expect(offButton.querySelector("svg")?.getAttribute("class")).toContain("opacity-100");
+    expect(offButton.querySelector("svg")?.getAttribute("class")).toContain("fill-none");
+    expect(offButton.querySelector("svg")?.getAttribute("class")).toContain("stroke-current");
+
+    fastControl.isEnabled = true;
+    fastControl.detail = "On";
+    fastControl.options = fastControl.options.map((option) => ({
+      ...option,
+      selected: option.value === "on",
+    }));
+    rerender(
+      <MemoryRouter>
+        <ChatInputControlRow
+          runtimeControlsDisabled={false}
+          modelSelectorProps={createModelSelectorProps()}
+          agentKind="claude"
+          sessionConfigControls={controls}
+          isEditingQueuedPrompt={false}
+          chatDisabled={false}
+          isSubmitting={false}
+          supportsAttachments
+          canAttachFiles
+          activeSessionId="test-session"
+          onAttachFile={vi.fn()}
+          isRunning={false}
+          isEmpty
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const onButton = screen.getByRole("button", { name: "Fast mode: Fast" });
+    expect(onButton.className).toContain("bg-[var(--color-composer-control-hover)]");
+    expect(onButton.querySelector("svg")?.getAttribute("class")).toContain("fill-current");
+    expect(onButton.querySelector("svg")?.getAttribute("class")).toContain("stroke-none");
+    expect(onButton.querySelector("svg")?.getAttribute("class")).toContain("opacity-100");
+  });
+
   it("does not render overflow when no extra controls exist", () => {
-    // Only effort, fast_mode, and collaboration_mode — all excluded from overflow
+    // Effort, fast_mode, and collaboration_mode each own a visible slot.
     renderControlRow();
     expect(screen.queryByRole("button", { name: "More configuration options" })).toBeNull();
   });
 
+  it("keeps Codex permissions independent from working mode in overflow", () => {
+    const controls = [createAccessModeControl(), ...createControls()];
+    renderControlRow({ agentKind: "codex", sessionConfigControls: controls });
+
+    expect(screen.getByRole("button", { name: "Mode: Default" })).toBeTruthy();
+    expect(screen.queryByText("Auto")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "More configuration options" }));
+
+    expect(screen.getByText("Permissions")).toBeTruthy();
+    expect(screen.getByText("Read Only")).toBeTruthy();
+    expect(screen.getByText("Auto")).toBeTruthy();
+    expect(screen.getByText("Full Access")).toBeTruthy();
+  });
+
+  it("renders two-level reasoning with bars when effort is unavailable", () => {
+    const controls = createControls().filter((control) => control.key !== "effort");
+    const reasoningControl: LiveSessionControlDescriptor = {
+      key: "reasoning",
+      label: "Reasoning",
+      detail: "On",
+      rawConfigId: "reasoning",
+      settable: true,
+      pendingState: null,
+      kind: "toggle",
+      enabledValue: "on",
+      disabledValue: "off",
+      isEnabled: true,
+      options: [
+        { value: "off", label: "Off", selected: false },
+        { value: "on", label: "On", selected: true },
+      ],
+      onSelect: vi.fn(),
+    };
+    controls.push(reasoningControl);
+    renderControlRow({ sessionConfigControls: controls });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reasoning: On" }));
+    expect(reasoningControl.onSelect).toHaveBeenCalledWith("off");
+    expect(screen.queryByRole("button", { name: "More configuration options" })).toBeNull();
+  });
+
+  it("shows non-settable reasoning effort as disabled bars", () => {
+    const controls = createControls();
+    const effortControl = controls.find((control) => control.key === "effort")!;
+    effortControl.settable = false;
+    renderControlRow({ sessionConfigControls: controls });
+
+    expect(screen.getByRole("button", { name: "Reasoning: Medium" }))
+      .toHaveProperty("disabled", true);
+  });
+
   it("renders overflow button when extra controls exist", () => {
     const controls = createControls();
-    // "reasoning" is NOT excluded from overflow
+    // Effort owns the single reasoning-level slot, so a second reasoning
+    // control remains available as an additional option.
     controls.push({
       key: "reasoning",
       label: "Reasoning",

--- a/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -45,7 +45,7 @@ export interface ComposerLeadingControlsProps {
 }
 
 /**
- * The leading control cluster (model selector, effort bars, mode, goal,
+ * The leading control cluster (model selector, reasoning bars, fast mode, mode, goal,
  * integrations). Shared verbatim between the in-session chat composer
  * (ChatInputControlRow) and the home/new-chat composer (HomeNextScreen slot):
  * home feeds it launch-time control descriptors instead of live-session
@@ -70,11 +70,6 @@ export function ComposerLeadingControls({
     && sessionGoal.capabilities.supported
     && deriveGoalBarState(sessionGoal.goal).kind !== "live";
 
-  const effortControl = controlGroups.modelConfigControls.find((c) => c.key === "effort") ?? null;
-  const fastModeControl = controlGroups.modelConfigControls.find(
-    (c) => c.key === "fast_mode" && c.kind === "toggle",
-  ) ?? null;
-
   return (
     <>
       {/* 1. Model/harness selector — leftmost */}
@@ -86,30 +81,29 @@ export function ComposerLeadingControls({
         <ComposerModelSelectorControl modelSelectorProps={modelSelectorProps} />
       </div>
 
-      {/* 2a. Fast mode toggle — sits before the reasoning bars so speed and
-          effort read as one model-tuning cluster */}
-      {fastModeControl && (
+      {/* 2. Reasoning/effort bars */}
+      {controlGroups.reasoningEffortControl && (
         <span
           className={`inline-flex shrink-0 ${
             runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
           }`}
         >
-          <ComposerFastModeToggle control={fastModeControl} />
+          <ComposerReasoningEffortBars control={controlGroups.reasoningEffortControl} />
         </span>
       )}
 
-      {/* 2. Reasoning effort bars */}
-      {effortControl && (
+      {/* 3. Fast mode toggle */}
+      {controlGroups.fastModeControl && (
         <span
           className={`inline-flex shrink-0 ${
             runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
           }`}
         >
-          <ComposerReasoningEffortBars control={effortControl} />
+          <ComposerFastModeToggle control={controlGroups.fastModeControl} />
         </span>
       )}
 
-      {/* 3. Mode control (bypass/plan/etc) */}
+      {/* 4. Primary working mode control (bypass/plan/etc) */}
       {controlGroups.modeControl && (
         <span
           className={`inline-flex min-w-0 ${
@@ -124,7 +118,7 @@ export function ComposerLeadingControls({
         </span>
       )}
 
-      {/* 4. Goal button */}
+      {/* 5. Goal button */}
       {canSetGoal && (
         <ComposerControlButton
           icon={<Target className="size-4" />}
@@ -139,7 +133,7 @@ export function ComposerLeadingControls({
         />
       )}
 
-      {/* 5. Integrations control */}
+      {/* 6. Integrations control */}
       <ComposerIntegrationsControl />
     </>
   );
@@ -191,7 +185,7 @@ export function ComposerTrailingControls({
 
   return (
     <>
-      {/* 6. Plus button — direct file attach */}
+      {/* 7. Plus button — direct file attach */}
       {!isEditingQueuedPrompt && (
         <ComposerControlButton
           iconOnly
@@ -204,10 +198,10 @@ export function ComposerTrailingControls({
         />
       )}
 
-      {/* 7. Runtime pressure */}
+      {/* 8. Runtime pressure */}
       <RuntimePressureIndicator />
 
-      {/* 8. Overflow three-dots */}
+      {/* 9. Overflow three-dots */}
       <span
         className={`inline-flex shrink-0 ${
           runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
@@ -215,7 +209,7 @@ export function ComposerTrailingControls({
       >
         <ComposerOverflowControl
           agentKind={agentKind}
-          controls={controlGroups.modelConfigControls}
+          controls={controlGroups.overflowControls}
         />
       </span>
     </>

--- a/apps/desktop/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
@@ -28,13 +28,20 @@ export function ComposerFastModeToggle({ control }: ComposerFastModeToggleProps)
         iconOnly
         disabled={!control.settable || !nextValue}
         active={!!control.isEnabled}
+        className={control.isEnabled ? "bg-[var(--color-composer-control-hover)]" : ""}
         icon={
           <Zap
-            className={`size-3.5 ${control.isEnabled ? "fill-current" : "opacity-65"}`}
+            className={`size-3.5 transition-[color,fill,opacity] ${
+              control.isEnabled
+                ? "fill-current stroke-none opacity-100"
+                : "fill-none stroke-current stroke-[1.5] text-[color:var(--color-composer-control-muted-foreground)] opacity-100"
+            }`}
           />
         }
         label="Fast"
-        trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+        trailing={control.pendingState
+          ? <PendingConfigIndicator pendingState={control.pendingState} />
+          : null}
         aria-label={tooltip}
         title={tooltip}
         onClick={() => {

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -68,7 +68,9 @@ export function ComposerModelSelectorControl({
           emphasizeLabel
           icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="size-4 shrink-0" /> : undefined}
           label={triggerLabel}
-          trailing={<PendingConfigIndicator pendingState={currentModel?.pendingState ?? null} />}
+          trailing={currentModel?.pendingState
+            ? <PendingConfigIndicator pendingState={currentModel.pendingState} />
+            : null}
           aria-label={`Model: ${triggerLabel}`}
           className="max-w-[15rem]"
         />

--- a/apps/desktop/src/components/workspace/chat/input/ComposerOverflowControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerOverflowControl.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   resolveComposerControlOptionLabel,
 } from "@/lib/domain/chat/session-controls/composer-config-submenu-presentation";
@@ -10,8 +9,6 @@ import { Check, MoreHorizontal } from "@proliferate/ui/icons";
 import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
 import { PendingConfigIndicator } from "./PendingConfigIndicator";
 
-const EXCLUDED_OVERFLOW_KEYS = new Set(["mode", "collaboration_mode", "effort", "fast_mode"]);
-
 interface ComposerOverflowControlProps {
   agentKind: string | null;
   controls: LiveSessionControlDescriptor[];
@@ -21,12 +18,7 @@ export function ComposerOverflowControl({
   agentKind,
   controls,
 }: ComposerOverflowControlProps) {
-  const overflowControls = useMemo(
-    () => controls.filter((control) => !EXCLUDED_OVERFLOW_KEYS.has(control.key)),
-    [controls],
-  );
-
-  if (overflowControls.length === 0) {
+  if (controls.length === 0) {
     return null;
   }
 
@@ -48,7 +40,7 @@ export function ComposerOverflowControl({
     >
       {() => (
         <ComposerPopoverSurface className="w-56 p-1">
-          {overflowControls.map((control) => (
+          {controls.map((control) => (
             <OverflowControlSection
               key={control.key}
               agentKind={agentKind}

--- a/apps/desktop/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -24,9 +24,12 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
     currentOption?.value ?? null,
     currentOption?.label,
   );
+  const currentLevel =
+    currentPresentation.shortLabel ?? control.detail ?? control.label;
+  const ariaLabel = `Reasoning: ${currentLevel}`;
   const tooltip = resolveSessionControlTooltip(
-    control.label,
-    currentPresentation.shortLabel ?? control.detail ?? control.label,
+    "Reasoning",
+    currentLevel,
     currentOption?.description ?? null,
   ) + ". Click to step.";
 
@@ -38,9 +41,10 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
             levels={levels}
             currentIndex={effectiveIndex}
             onStep={(nextValue: string) => control.onSelect(nextValue)}
+            iconOnly
             disabled={!control.settable}
             title={tooltip}
-            aria-label={tooltip}
+            aria-label={ariaLabel}
           />
           <PendingConfigIndicator pendingState={control.pendingState} />
         </span>
@@ -54,9 +58,10 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
         levels={levels}
         currentIndex={effectiveIndex}
         onStep={(nextValue: string) => control.onSelect(nextValue)}
+        iconOnly
         disabled={!control.settable}
         title={tooltip}
-        aria-label={tooltip}
+        aria-label={ariaLabel}
       />
     </Tooltip>
   );

--- a/apps/desktop/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -6,7 +6,7 @@ import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-con
 import type { ConfiguredSessionControlKey } from "@/lib/domain/chat/session-controls/presentation";
 import { SessionControlIcon } from "@/components/session-controls/SessionControlIcon";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
-import { Check } from "@proliferate/ui/icons";
+import { Check, ChevronDown } from "@proliferate/ui/icons";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
 import { PendingConfigIndicator } from "./PendingConfigIndicator";
@@ -36,16 +36,33 @@ export function SessionModeControl({
   const currentDetail = currentPresentation.shortLabel ?? currentOption?.label ?? control.detail;
   const triggerLabel = triggerStyle === "value" ? currentDetail ?? control.label : control.label;
   const triggerDetail = triggerStyle === "value" ? null : currentDetail;
+  const compactTrigger = triggerStyle === "value";
+  const triggerIcon = compactTrigger
+    ? undefined
+    : <SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />;
+  const triggerTrailing = control.pendingState || (compactTrigger && control.settable)
+    ? (
+      <span className="flex items-center gap-1">
+        <PendingConfigIndicator pendingState={control.pendingState} />
+        {compactTrigger && control.settable && (
+          <ChevronDown
+            className="size-3 shrink-0 text-[color:var(--color-composer-control-muted-foreground)]"
+            aria-hidden
+          />
+        )}
+      </span>
+    )
+    : null;
 
   if (!control.settable) {
     return (
       <ComposerControlButton
         disabled
         emphasizeLabel={triggerStyle === "value"}
-        icon={<SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />}
+        icon={triggerIcon}
         label={triggerLabel}
         detail={triggerDetail}
-        trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+        trailing={triggerTrailing}
         className="max-w-[12rem]"
       />
     );
@@ -56,10 +73,10 @@ export function SessionModeControl({
       trigger={
         <ComposerControlButton
           emphasizeLabel={triggerStyle === "value"}
-          icon={<SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />}
+          icon={triggerIcon}
           label={triggerLabel}
           detail={triggerDetail}
-          trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+          trailing={triggerTrailing}
           title={`${CHAT_MODE_CONTROL_LABELS.cycleHint} (${CHAT_MODE_CONTROL_LABELS.shortcut})`}
           aria-label={`${control.label}: ${currentOption?.label ?? currentDetail ?? ""}`}
           className="max-w-[12rem]"

--- a/apps/desktop/src/copy/settings/harness-pane.ts
+++ b/apps/desktop/src/copy/settings/harness-pane.ts
@@ -69,5 +69,10 @@ export const HARNESS_PANE_COPY = {
     `Local runtime unavailable — could not read ${displayName} models.`,
   catalogOverrideError: (displayName: string) =>
     `Could not update the ${displayName} model catalog.`,
+  installAction: "Install",
+  retryInstallAction: "Retry install",
+  installingAction: "Installing...",
+  installError: (displayName: string) =>
+    `Could not install ${displayName}.`,
   readyToast: (displayName: string) => `${displayName} is ready.`,
 } as const;

--- a/apps/desktop/src/hooks/agents/workflows/use-harness-install-action.test.tsx
+++ b/apps/desktop/src/hooks/agents/workflows/use-harness-install-action.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import type { AgentSummary } from "@anyharness/sdk";
+import { beforeEach, expect, it, vi } from "vitest";
+import { useHarnessInstallAction } from "./use-harness-install-action";
+
+const installAgent = vi.hoisted(() => vi.fn());
+const refreshAgentResources = vi.hoisted(() => vi.fn());
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/agents/workflows/use-agent-installation-actions", () => ({
+  useAgentInstallationActions: () => ({
+    installAgent,
+    isAgentSeedHydrating: false,
+    isInstallingAgent: false,
+    refreshAgentResources,
+  }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof showToast }) => unknown) =>
+    selector({ show: showToast }),
+}));
+
+const agent = {
+  kind: "codex",
+  displayName: "Codex",
+  installState: "install_required",
+  readiness: "install_required",
+} as AgentSummary;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installAgent.mockResolvedValue({});
+  refreshAgentResources.mockResolvedValue(undefined);
+});
+
+it("force-installs a missing managed harness from its settings action", async () => {
+  const { result } = renderHook(() => useHarnessInstallAction(agent));
+
+  await act(async () => {
+    result.current?.onInstall();
+    await vi.waitFor(() => expect(refreshAgentResources).toHaveBeenCalledOnce());
+  });
+
+  expect(installAgent).toHaveBeenCalledWith("codex", { reinstall: true });
+  expect(showToast).toHaveBeenCalledWith("Codex is ready.");
+});
+
+it("does not offer installation for an already installed harness", () => {
+  const readyAgent = {
+    ...agent,
+    installState: "installed",
+    readiness: "ready",
+  } as AgentSummary;
+  const { result } = renderHook(() => useHarnessInstallAction(readyAgent));
+
+  expect(result.current).toBeNull();
+});

--- a/apps/desktop/src/hooks/agents/workflows/use-harness-install-action.ts
+++ b/apps/desktop/src/hooks/agents/workflows/use-harness-install-action.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import type { AgentSummary } from "@anyharness/sdk";
+import { HARNESS_PANE_COPY } from "@/copy/settings/harness-pane";
+import { useAgentInstallationActions } from "@/hooks/agents/workflows/use-agent-installation-actions";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+export interface HarnessInstallAction {
+  label: string;
+  loading: boolean;
+  disabled: boolean;
+  onInstall: () => void;
+}
+
+export function useHarnessInstallAction(
+  agent: AgentSummary | null,
+): HarnessInstallAction | null {
+  const showToast = useToastStore((state) => state.show);
+  const {
+    installAgent,
+    isAgentSeedHydrating,
+    isInstallingAgent,
+    refreshAgentResources,
+  } = useAgentInstallationActions();
+
+  const canInstall = agent?.installState === "install_required"
+    || agent?.installState === "failed";
+  const handleInstall = useCallback(async () => {
+    if (!agent || !canInstall) {
+      return;
+    }
+
+    try {
+      await installAgent(agent.kind, { reinstall: true });
+      await refreshAgentResources();
+      showToast(HARNESS_PANE_COPY.readyToast(agent.displayName));
+    } catch (error) {
+      const message = error instanceof Error && error.message.trim()
+        ? error.message
+        : HARNESS_PANE_COPY.installError(agent.displayName);
+      showToast(message);
+    }
+  }, [agent, canInstall, installAgent, refreshAgentResources, showToast]);
+
+  return useMemo(() => {
+    if (!agent || !canInstall) {
+      return null;
+    }
+    return {
+      label: isInstallingAgent
+        ? HARNESS_PANE_COPY.installingAction
+        : agent.installState === "failed"
+          ? HARNESS_PANE_COPY.retryInstallAction
+          : HARNESS_PANE_COPY.installAction,
+      loading: isInstallingAgent,
+      disabled: isInstallingAgent || isAgentSeedHydrating,
+      onInstall: () => {
+        void handleInstall();
+      },
+    };
+  }, [agent, canInstall, handleInstall, isAgentSeedHydrating, isInstallingAgent]);
+}

--- a/apps/desktop/src/hooks/chat/facade/use-chat-session-controls.ts
+++ b/apps/desktop/src/hooks/chat/facade/use-chat-session-controls.ts
@@ -3,6 +3,10 @@ import {
   buildLiveSessionControlDescriptors,
   type LiveSessionControlDescriptor,
 } from "@/lib/domain/chat/session-controls/session-controls";
+import {
+  buildComposerSessionControlGroups,
+  filterComposerSessionControlsForSurface,
+} from "@/lib/domain/chat/session-controls/composer-control-groups";
 import { useSessionConfigActions } from "@/hooks/sessions/workflows/use-session-config-actions";
 import { useWorkspaceSurfaceLookup } from "@/hooks/workspaces/derived/use-workspace-surface-lookup";
 import { useToastStore } from "@/stores/toast/toast-store";
@@ -37,14 +41,9 @@ export function useChatSessionControls(): {
       activeSessionConfig.pendingConfigChanges,
       onSelect,
     );
-    if (getWorkspaceSurface(activeSessionConfig.workspaceId) !== "cowork") {
-      return nextControls;
-    }
-
-    // Cowork hides both permission mode controls and always uses product-defined
-    // defaults for new sessions instead of user-managed mode preferences.
-    return nextControls.filter((control) =>
-      control.key !== "mode" && control.key !== "collaboration_mode"
+    return filterComposerSessionControlsForSurface(
+      nextControls,
+      getWorkspaceSurface(activeSessionConfig.workspaceId),
     );
   }, [
     activeSessionConfig.normalizedControls,
@@ -55,10 +54,7 @@ export function useChatSessionControls(): {
   ]);
 
   const modeControl = useMemo(
-    () =>
-      controls.find((control) => control.key === "collaboration_mode")
-      ?? controls.find((control) => control.key === "mode")
-      ?? null,
+    () => buildComposerSessionControlGroups(controls).modeControl,
     [controls],
   );
 

--- a/apps/desktop/src/hooks/home/derived/use-home-next-launch-controls.ts
+++ b/apps/desktop/src/hooks/home/derived/use-home-next-launch-controls.ts
@@ -107,9 +107,10 @@ export function useHomeNextLaunchControls({
   );
 
   return {
-    controls: descriptors.filter((control) =>
-      control.key !== "mode" && control.key !== "collaboration_mode"
-    ),
+    // The create-time `mode` field still comes from Home's dedicated mode
+    // selection state. Collaboration mode is a distinct live-default control
+    // and must remain available to the shared composer grouping.
+    controls: descriptors.filter((control) => control.key !== "mode"),
     launchControlValues,
     isLoading: cloudCatalogQuery.isLoading || runtimeLaunchOptions.isLoading,
   };

--- a/apps/desktop/src/lib/domain/agents/configuration-issues-presentation.ts
+++ b/apps/desktop/src/lib/domain/agents/configuration-issues-presentation.ts
@@ -27,11 +27,11 @@ export function configurationDetailForAgent(
   if (agent.readiness === "login_required") {
     return `Sign in with ${agent.displayName} in Proliferate.`;
   }
+  if (agent.readiness === "install_required") {
+    return "Install this managed harness to use it in this profile.";
+  }
   if (agent.message?.trim()) {
     return agent.message;
-  }
-  if (agent.readiness === "install_required") {
-    return "The managed harness install has not completed yet.";
   }
   if (agent.readiness === "error") {
     return "Review setup details, then refresh the runtime once the issue is fixed.";

--- a/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.test.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildComposerSessionControlGroups,
+  filterComposerSessionControlsForSurface,
 } from "./composer-control-groups";
 import type { LiveSessionControlDescriptor } from "./session-controls";
 
@@ -28,11 +29,17 @@ describe("buildComposerSessionControlGroups", () => {
       key: "effort",
       label: "Reasoning effort",
       detail: "High",
+      options: [
+        { value: "low", label: "Low", selected: false },
+        { value: "high", label: "High", selected: true },
+      ],
     });
 
     expect(buildComposerSessionControlGroups([approvalMode, effort, collaborationMode])).toEqual({
       modeControl: collaborationMode,
-      modelConfigControls: [approvalMode, effort],
+      reasoningEffortControl: effort,
+      fastModeControl: null,
+      overflowControls: [approvalMode],
     });
   });
 
@@ -58,7 +65,9 @@ describe("buildComposerSessionControlGroups", () => {
 
     expect(buildComposerSessionControlGroups([staleMode, liveMode])).toEqual({
       modeControl: liveMode,
-      modelConfigControls: [],
+      reasoningEffortControl: null,
+      fastModeControl: null,
+      overflowControls: [],
     });
   });
 
@@ -77,12 +86,197 @@ describe("buildComposerSessionControlGroups", () => {
       key: "effort",
       label: "Reasoning effort",
       detail: "High",
+      options: [
+        { value: "low", label: "Low", selected: false },
+        { value: "high", label: "High", selected: true },
+      ],
     });
 
     expect(buildComposerSessionControlGroups([effort, cursorMode])).toEqual({
       modeControl: cursorMode,
-      modelConfigControls: [effort],
+      reasoningEffortControl: effort,
+      fastModeControl: null,
+      overflowControls: [],
     });
+  });
+
+  it("keeps an access-only mode in overflow instead of promoting it as working mode", () => {
+    const approvalMode = descriptor({
+      key: "mode",
+      label: "Permissions",
+      detail: "Auto",
+      options: [
+        { value: "read-only", label: "Read Only", selected: false },
+        { value: "auto", label: "Auto", selected: true },
+        { value: "full-access", label: "Full Access", selected: false },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([approvalMode])).toEqual({
+      modeControl: null,
+      reasoningEffortControl: null,
+      fastModeControl: null,
+      overflowControls: [approvalMode],
+    });
+  });
+
+  it("prefers collaboration mode whenever it exposes a real choice", () => {
+    const collaborationMode = descriptor({
+      key: "collaboration_mode",
+      label: "Mode",
+      detail: "Pair",
+      options: [
+        { value: "default", label: "Default", selected: false },
+        { value: "pair", label: "Pair", selected: true },
+      ],
+    });
+    const workingMode = descriptor({
+      key: "mode",
+      label: "Mode",
+      detail: "Build",
+      options: [
+        { value: "build", label: "Build", selected: true },
+        { value: "plan", label: "Plan", selected: false },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([workingMode, collaborationMode])).toEqual({
+      modeControl: collaborationMode,
+      reasoningEffortControl: null,
+      fastModeControl: null,
+      overflowControls: [workingMode],
+    });
+  });
+
+  it("uses a two-level reasoning control as the bars fallback", () => {
+    const reasoning = descriptor({
+      key: "reasoning",
+      label: "Reasoning",
+      detail: "On",
+      kind: "toggle",
+      enabledValue: "on",
+      disabledValue: "off",
+      isEnabled: true,
+      options: [
+        { value: "off", label: "Off", selected: false },
+        { value: "on", label: "On", selected: true },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([reasoning])).toEqual({
+      modeControl: null,
+      reasoningEffortControl: reasoning,
+      fastModeControl: null,
+      overflowControls: [],
+    });
+  });
+
+  it("prefers effort over reasoning and leaves the unclaimed control in overflow", () => {
+    const reasoning = descriptor({
+      key: "reasoning",
+      label: "Reasoning",
+      detail: "High",
+      options: [
+        { value: "low", label: "Low", selected: false },
+        { value: "high", label: "High", selected: true },
+      ],
+    });
+    const effort = descriptor({
+      key: "effort",
+      label: "Reasoning effort",
+      detail: "Medium",
+      options: [
+        { value: "low", label: "Low", selected: false },
+        { value: "medium", label: "Medium", selected: true },
+        { value: "high", label: "High", selected: false },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([reasoning, effort])).toEqual({
+      modeControl: null,
+      reasoningEffortControl: effort,
+      fastModeControl: null,
+      overflowControls: [reasoning],
+    });
+  });
+
+  it("keeps a non-settable reasoning level visible as disabled bars", () => {
+    const effort = descriptor({
+      key: "effort",
+      label: "Reasoning effort",
+      detail: "High",
+      settable: false,
+      options: [
+        { value: "low", label: "Low", selected: false },
+        { value: "high", label: "High", selected: true },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([effort])).toEqual({
+      modeControl: null,
+      reasoningEffortControl: effort,
+      fastModeControl: null,
+      overflowControls: [],
+    });
+  });
+
+  it("promotes fast mode independently from reasoning and working mode", () => {
+    const fastMode = descriptor({
+      key: "fast_mode",
+      label: "Fast mode",
+      detail: "Off",
+      kind: "toggle",
+      enabledValue: "on",
+      disabledValue: "off",
+      isEnabled: false,
+      options: [
+        { value: "off", label: "Off", selected: true },
+        { value: "on", label: "On", selected: false },
+      ],
+    });
+
+    expect(buildComposerSessionControlGroups([fastMode])).toEqual({
+      modeControl: null,
+      reasoningEffortControl: null,
+      fastModeControl: fastMode,
+      overflowControls: [],
+    });
+  });
+});
+
+describe("filterComposerSessionControlsForSurface", () => {
+  it("keeps Cowork working mode and fast mode while hiding its permission preset", () => {
+    const approvalMode = descriptor({
+      key: "mode",
+      label: "Permissions",
+      detail: "Full Access",
+    });
+    const collaborationMode = descriptor({
+      key: "collaboration_mode",
+      label: "Mode",
+      detail: "Default",
+    });
+    const fastMode = descriptor({
+      key: "fast_mode",
+      label: "Fast mode",
+      detail: "Off",
+    });
+
+    expect(filterComposerSessionControlsForSurface(
+      [approvalMode, collaborationMode, fastMode],
+      "cowork",
+    )).toEqual([collaborationMode, fastMode]);
+  });
+
+  it("does not filter standard-workspace controls", () => {
+    const approvalMode = descriptor({
+      key: "mode",
+      label: "Permissions",
+      detail: "Full Access",
+    });
+
+    expect(filterComposerSessionControlsForSurface([approvalMode], "standard"))
+      .toEqual([approvalMode]);
   });
 });
 

--- a/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.ts
+++ b/apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.ts
@@ -3,6 +3,7 @@ import type {
   SupportedLiveControlKey,
 } from "@/lib/domain/chat/session-controls/session-controls";
 import type { ConfiguredSessionControlKey } from "@/lib/domain/chat/session-controls/presentation";
+import type { WorkspaceSurface } from "@anyharness/sdk";
 
 export type ComposerModeControlDescriptor = LiveSessionControlDescriptor & {
   key: ConfiguredSessionControlKey;
@@ -10,21 +11,55 @@ export type ComposerModeControlDescriptor = LiveSessionControlDescriptor & {
 
 export interface ComposerSessionControlGroups {
   modeControl: ComposerModeControlDescriptor | null;
-  modelConfigControls: LiveSessionControlDescriptor[];
+  reasoningEffortControl: LiveSessionControlDescriptor | null;
+  fastModeControl: LiveSessionControlDescriptor | null;
+  overflowControls: LiveSessionControlDescriptor[];
 }
 
-const PRIMARY_MODE_KEYS: SupportedLiveControlKey[] = ["collaboration_mode", "mode"];
+const WORKING_MODE_MARKERS = new Set([
+  "agent",
+  "ask",
+  "build",
+  "bypass",
+  "chat",
+  "plan",
+]);
 
 export function buildComposerSessionControlGroups(
   controls: LiveSessionControlDescriptor[],
 ): ComposerSessionControlGroups {
   const uniqueControls = uniqueSessionControls(controls);
   const modeControl = resolveComposerModeControl(uniqueControls);
+  const reasoningEffortControl = resolveReasoningEffortControl(uniqueControls);
+  const fastModeControl = uniqueControls.find((control) =>
+    control.key === "fast_mode" && control.kind === "toggle"
+  ) ?? null;
+  const promotedControls = new Set<LiveSessionControlDescriptor>([
+    ...(modeControl ? [modeControl] : []),
+    ...(reasoningEffortControl ? [reasoningEffortControl] : []),
+    ...(fastModeControl ? [fastModeControl] : []),
+  ]);
 
   return {
     modeControl,
-    modelConfigControls: uniqueControls.filter((control) => control !== modeControl),
+    reasoningEffortControl,
+    fastModeControl,
+    overflowControls: uniqueControls.filter((control) => !promotedControls.has(control)),
   };
+}
+
+export function filterComposerSessionControlsForSurface(
+  controls: LiveSessionControlDescriptor[],
+  surface: WorkspaceSurface | null | undefined,
+): LiveSessionControlDescriptor[] {
+  if (surface !== "cowork") {
+    return controls;
+  }
+
+  // Cowork owns its access policy, so the raw approval preset remains hidden.
+  // Working mode (`collaboration_mode`) and independent tuning dimensions such
+  // as reasoning and fast mode still belong in the composer.
+  return controls.filter((control) => control.key !== "mode");
 }
 
 export function uniqueSessionControls(
@@ -48,20 +83,49 @@ export function uniqueSessionControls(
 function resolveComposerModeControl(
   controls: LiveSessionControlDescriptor[],
 ): ComposerModeControlDescriptor | null {
-  for (const key of PRIMARY_MODE_KEYS) {
-    const control = controls.find((candidate) => candidate.key === key);
-    if (control && hasPlanningModeChoice(control)) {
-      return control as ComposerModeControlDescriptor;
-    }
+  const collaborationMode = controls.find((control) =>
+    control.key === "collaboration_mode" && control.options.length >= 2
+  );
+  if (collaborationMode) {
+    return collaborationMode as ComposerModeControlDescriptor;
+  }
+
+  const legacyMode = controls.find((control) => control.key === "mode");
+  if (legacyMode && hasWorkingModeChoice(legacyMode)) {
+    return legacyMode as ComposerModeControlDescriptor;
   }
 
   return null;
 }
 
-function hasPlanningModeChoice(control: LiveSessionControlDescriptor): boolean {
-  const normalizedOptions = control.options.map((option) =>
-    `${option.value} ${option.label}`.toLowerCase()
-  );
+function resolveReasoningEffortControl(
+  controls: LiveSessionControlDescriptor[],
+): LiveSessionControlDescriptor | null {
+  return controls.find((control) => isOrderedReasoningLevelControl(control, "effort"))
+    ?? controls.find((control) => isOrderedReasoningLevelControl(control, "reasoning"))
+    ?? null;
+}
+
+function isOrderedReasoningLevelControl(
+  control: LiveSessionControlDescriptor,
+  key: SupportedLiveControlKey,
+): boolean {
+  return control.key === key && control.options.length >= 2;
+}
+
+function hasWorkingModeChoice(control: LiveSessionControlDescriptor): boolean {
   return control.options.length >= 2
-    && normalizedOptions.some((option) => option.includes("plan"));
+    && control.options.some((option) =>
+      optionTokens(`${option.value} ${option.label}`).some((token) =>
+        WORKING_MODE_MARKERS.has(token)
+      )
+    );
+}
+
+function optionTokens(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
 }

--- a/apps/desktop/src/lib/domain/home/home-composer-controls.test.ts
+++ b/apps/desktop/src/lib/domain/home/home-composer-controls.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
+import {
+  buildHomeModeControlDescriptor,
+  buildHomeSessionConfigControls,
+} from "./home-composer-controls";
+
+const CODEX_ACCESS_MODES = [
+  {
+    value: "auto",
+    label: "Auto",
+    icon: "edit" as const,
+    isDefault: true,
+  },
+  {
+    value: "full-access",
+    label: "Full Access",
+    icon: "zap" as const,
+  },
+];
+
+describe("home composer controls", () => {
+  it("uses the supplied access label without changing create-time mode semantics", () => {
+    const descriptor = buildHomeModeControlDescriptor({
+      modes: CODEX_ACCESS_MODES,
+      selectedModeId: "auto",
+      label: "Permissions",
+      onSelect: vi.fn(),
+    });
+
+    expect(descriptor).toMatchObject({
+      key: "mode",
+      rawConfigId: "mode",
+      label: "Permissions",
+      options: [
+        { value: "auto", selected: true },
+        { value: "full-access", selected: false },
+      ],
+    });
+  });
+
+  it("keeps Codex collaboration and access controls independent for repository launches", () => {
+    const collaborationMode = descriptor({
+      key: "collaboration_mode",
+      label: "Collaboration Mode",
+      options: [
+        { value: "default", label: "Default", selected: true },
+        { value: "plan", label: "Plan", selected: false },
+      ],
+    });
+
+    expect(buildHomeSessionConfigControls({
+      destination: "repository",
+      agentKind: "codex",
+      modes: CODEX_ACCESS_MODES,
+      selectedModeId: "auto",
+      launchControls: [collaborationMode],
+      onSelectMode: vi.fn(),
+    })).toMatchObject([
+      {
+        key: "mode",
+        label: "Permissions",
+        options: [
+          { value: "auto", selected: true },
+          { value: "full-access", selected: false },
+        ],
+      },
+      {
+        key: "collaboration_mode",
+        options: [
+          { value: "default", selected: true },
+          { value: "plan", selected: false },
+        ],
+      },
+    ]);
+  });
+
+  it("labels Codex access mode as permissions before collaboration mode is available", () => {
+    expect(buildHomeSessionConfigControls({
+      destination: "repository",
+      agentKind: "codex",
+      modes: CODEX_ACCESS_MODES,
+      selectedModeId: "auto",
+      launchControls: [],
+      onSelectMode: vi.fn(),
+    })).toMatchObject([
+      {
+        key: "mode",
+        label: "Permissions",
+      },
+    ]);
+  });
+
+  it("hides Cowork permission mode while retaining independent collaboration mode", () => {
+    const collaborationMode = descriptor({
+      key: "collaboration_mode",
+      label: "Collaboration Mode",
+    });
+    const permissionMode = descriptor({ key: "mode", label: "Permissions" });
+    const effort = descriptor({ key: "effort", label: "Reasoning effort" });
+
+    expect(buildHomeSessionConfigControls({
+      destination: "cowork",
+      agentKind: "codex",
+      modes: CODEX_ACCESS_MODES,
+      selectedModeId: "auto",
+      launchControls: [collaborationMode, permissionMode, effort],
+      onSelectMode: vi.fn(),
+    })).toEqual([collaborationMode, effort]);
+  });
+});
+
+function descriptor({
+  key,
+  label,
+  options = [],
+}: {
+  key: LiveSessionControlDescriptor["key"];
+  label: string;
+  options?: LiveSessionControlDescriptor["options"];
+}): LiveSessionControlDescriptor {
+  return {
+    key,
+    label,
+    detail: null,
+    rawConfigId: key,
+    settable: true,
+    pendingState: null,
+    kind: "select",
+    options,
+    onSelect: vi.fn(),
+  };
+}

--- a/apps/desktop/src/lib/domain/home/home-composer-controls.ts
+++ b/apps/desktop/src/lib/domain/home/home-composer-controls.ts
@@ -8,7 +8,10 @@ import type {
 } from "@/lib/domain/chat/models/model-selector-types";
 import type { LiveSessionControlDescriptor } from "@/lib/domain/chat/session-controls/session-controls";
 import type { ConfiguredSessionControlValue } from "@/lib/domain/chat/session-controls/presentation";
-import type { ModelAvailabilityState } from "@/lib/domain/home/home-next-launch";
+import type {
+  HomeNextDestination,
+  ModelAvailabilityState,
+} from "@/lib/domain/home/home-next-launch";
 
 /**
  * Adapters that let the home screen drive the SAME composer controls the chat
@@ -60,10 +63,12 @@ export function buildHomeModelSelectorProps({
 export function buildHomeModeControlDescriptor({
   modes,
   selectedModeId,
+  label = "Mode",
   onSelect,
 }: {
   modes: ConfiguredSessionControlValue[];
   selectedModeId: string | null;
+  label?: string;
   onSelect: (modeId: string) => void;
 }): (LiveSessionControlDescriptor & { key: "mode" }) | null {
   if (modes.length === 0 || selectedModeId === null) {
@@ -71,7 +76,7 @@ export function buildHomeModeControlDescriptor({
   }
   return {
     key: "mode",
-    label: "Mode",
+    label,
     detail: null,
     rawConfigId: "mode",
     settable: true,
@@ -85,4 +90,36 @@ export function buildHomeModeControlDescriptor({
     })),
     onSelect,
   };
+}
+
+export function buildHomeSessionConfigControls({
+  destination,
+  agentKind,
+  modes,
+  selectedModeId,
+  launchControls,
+  onSelectMode,
+}: {
+  destination: HomeNextDestination;
+  agentKind: string | null;
+  modes: ConfiguredSessionControlValue[];
+  selectedModeId: string | null;
+  launchControls: LiveSessionControlDescriptor[];
+  onSelectMode: (modeId: string) => void;
+}): LiveSessionControlDescriptor[] {
+  if (destination === "cowork") {
+    return launchControls.filter((control) => control.key !== "mode");
+  }
+
+  const hasCollaborationMode = launchControls.some(
+    (control) => control.key === "collaboration_mode",
+  );
+  const modeControl = buildHomeModeControlDescriptor({
+    modes,
+    selectedModeId,
+    label: hasCollaborationMode || agentKind === "codex" ? "Permissions" : "Mode",
+    onSelect: onSelectMode,
+  });
+
+  return modeControl ? [modeControl, ...launchControls] : launchControls;
 }

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.test.ts
@@ -7,6 +7,7 @@ import {
   defaultRouteForSurface,
   normalizeCatalogModels,
   normalizeGatewayModels,
+  normalizeRuntimeLaunchModels,
 } from "./harness-catalog";
 
 function selection(
@@ -197,6 +198,60 @@ describe("normalizeCatalogModels", () => {
         enabled: true,
       },
     ]);
+  });
+});
+
+describe("normalizeRuntimeLaunchModels", () => {
+  it("reads enriched models for the requested harness from the local runtime", () => {
+    const launchOptions: AgentLaunchOptionsResponse = {
+      agents: [
+        {
+          kind: "codex",
+          displayName: "Codex",
+          defaultModelId: "gpt-5.5",
+          models: [
+            {
+              id: "gpt-5.5",
+              displayName: "GPT 5.5",
+              isDefault: true,
+              description: "Latest coding model",
+              provider: "openai",
+              status: "active",
+              effort: { values: ["low", "medium", "high"], default: "medium" },
+              fastMode: true,
+              modes: ["default", "plan"],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(normalizeRuntimeLaunchModels("codex", launchOptions)).toEqual([
+      {
+        id: "gpt-5.5",
+        displayName: "GPT 5.5",
+        description: "Latest coding model",
+        provider: "openai",
+        status: "active",
+        effort: { values: ["low", "medium", "high"], default: "medium" },
+        fastMode: true,
+        modes: ["default", "plan"],
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("does not leak another harness's runtime models", () => {
+    const launchOptions: AgentLaunchOptionsResponse = {
+      agents: [{
+        kind: "claude",
+        displayName: "Claude Code",
+        defaultModelId: "sonnet",
+        models: [{ id: "sonnet", displayName: "Sonnet", isDefault: true }],
+      }],
+    };
+
+    expect(normalizeRuntimeLaunchModels("codex", launchOptions)).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/desktop/src/lib/domain/settings/harness-catalog.ts
@@ -115,6 +115,31 @@ export function normalizeGatewayModels(
     }));
 }
 
+// Local Settings must be useful without a Proliferate Cloud session. The
+// AnyHarness launch catalog is already the runtime-resolved source used by the
+// composer, so normalize that response directly instead of requiring a cloud
+// catalog snapshot merely to display the models installed on this machine.
+export function normalizeRuntimeLaunchModels(
+  harnessKind: string,
+  launchOptions: AgentLaunchOptionsResponse | undefined,
+): HarnessCatalogModel[] {
+  const models = launchOptions?.agents.find(
+    (agent) => agent.kind === harnessKind,
+  )?.models ?? [];
+
+  return models.map((model) => ({
+    id: model.id,
+    displayName: model.displayName,
+    description: normalizeString(model.description),
+    provider: normalizeString(model.provider),
+    status: normalizeString(model.status),
+    effort: normalizeEffort(model.effort),
+    fastMode: typeof model.fastMode === "boolean" ? model.fastMode : null,
+    modes: normalizeModes(model.modes),
+    enabled: true,
+  }));
+}
+
 // native/api_key routes probe on the CLIENT (catalog.py's refresh_catalog
 // contract): rich live probing is deferred, so v1 sources the payload from the
 // local AnyHarness runtime's already-resolved launch catalog (the same

--- a/apps/packages/ui/src/primitives/ComposerControlButton.tsx
+++ b/apps/packages/ui/src/primitives/ComposerControlButton.tsx
@@ -39,7 +39,7 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
     const baseClassName = `gap-1 rounded-full border border-transparent bg-transparent transition-colors hover:bg-[var(--color-composer-control-hover)] hover:text-current focus:outline-none data-[state=open]:bg-[var(--color-composer-control-hover)] ${classes}`;
     const buttonClassName = iconOnly
       ? `h-7 w-7 shrink-0 !justify-center px-0 ${baseClassName} ${className}`
-      : `h-7 min-w-0 max-w-full !justify-start px-2 py-0 text-left text-ui ${baseClassName} ${className}`;
+      : `h-7 min-w-0 max-w-full !justify-start px-1.5 py-0 text-left text-ui ${baseClassName} ${className}`;
     const iconOnlyLabel = typeof label === "string"
       ? label
       : typeof props["aria-label"] === "string"

--- a/apps/packages/ui/src/primitives/LevelBarsButton.tsx
+++ b/apps/packages/ui/src/primitives/LevelBarsButton.tsx
@@ -10,6 +10,7 @@ interface LevelBarsButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonEleme
   levels: Level[];
   currentIndex: number;
   onStep: (nextValue: string) => void;
+  iconOnly?: boolean;
 }
 
 function LevelBarsIcon({ levels, currentIndex }: { levels: Level[]; currentIndex: number }) {
@@ -42,7 +43,7 @@ function LevelBarsIcon({ levels, currentIndex }: { levels: Level[]; currentIndex
   return (
     <svg
       viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
-      className="size-[0.9375rem]"
+      className="size-3.5"
       aria-hidden="true"
     >
       {bars}
@@ -51,7 +52,14 @@ function LevelBarsIcon({ levels, currentIndex }: { levels: Level[]; currentIndex
 }
 
 export const LevelBarsButton = forwardRef<HTMLButtonElement, LevelBarsButtonProps>(
-  function LevelBarsButton({ levels, currentIndex, onStep, onClick, ...props }, ref) {
+  function LevelBarsButton({
+    levels,
+    currentIndex,
+    onStep,
+    onClick,
+    iconOnly = false,
+    ...props
+  }, ref) {
     const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
       const nextIndex = (currentIndex + 1) % levels.length;
       const nextValue = levels[nextIndex]?.value ?? levels[0]?.value;
@@ -67,6 +75,7 @@ export const LevelBarsButton = forwardRef<HTMLButtonElement, LevelBarsButtonProp
       <ComposerControlButton
         ref={ref}
         icon={<LevelBarsIcon levels={levels} currentIndex={currentIndex} />}
+        iconOnly={iconOnly}
         label={currentLabel}
         onClick={handleClick}
         {...props}

--- a/apps/packages/ui/test/LevelBarsButton.test.tsx
+++ b/apps/packages/ui/test/LevelBarsButton.test.tsx
@@ -30,6 +30,23 @@ describe("LevelBarsButton", () => {
     expect(svg?.querySelectorAll("rect").length).toBe(3);
   });
 
+  it("can render the bars without visible level text", () => {
+    const onStep = vi.fn();
+    render(
+      <LevelBarsButton
+        levels={levels}
+        currentIndex={1}
+        onStep={onStep}
+        iconOnly
+        aria-label="Reasoning: Medium"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reasoning: Medium" }).className)
+      .toContain("w-7");
+    expect(screen.getByText("Medium").className).toContain("sr-only");
+  });
+
   it("advances to the next level on click", () => {
     const onStep = vi.fn();
     render(<LevelBarsButton levels={levels} currentIndex={0} onStep={onStep} />);

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-02.1",
+  "catalogVersion": "2026-07-11.1",
   "probedAgainst": {
-    "registryVersion": "2026-06-10.1"
+    "registryVersion": "2026-07-10.1"
   },
-  "generatedAt": "2026-06-18T06:23:46.960Z",
+  "generatedAt": "2026-07-11T00:36:38.653Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -194,7 +194,7 @@
           {
             "id": "opus[1m]",
             "displayName": "Opus 4.8 (1M context)",
-            "description": "Opus 4.8 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+            "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -244,7 +244,7 @@
           {
             "id": "sonnet",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -288,7 +288,7 @@
           {
             "id": "sonnet[1m]",
             "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -330,7 +330,7 @@
           {
             "id": "haiku",
             "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+            "description": "Haiku 4.5 · Fastest for quick answers",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -364,7 +364,7 @@
           {
             "id": "opus",
             "displayName": "Opus 4.6",
-            "description": "Opus 4.6 \u00b7 Legacy",
+            "description": "Opus 4.6 · Legacy",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -519,7 +519,7 @@
           {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -601,7 +601,7 @@
           {
             "id": "us.anthropic.claude-fable-5",
             "displayName": "Fable 5",
-            "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
+            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -643,7 +643,7 @@
           {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
-            "description": "Opus 4.1 \u00b7 Legacy",
+            "description": "Opus 4.1 · Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -674,7 +674,7 @@
           {
             "id": "us.anthropic.claude-opus-4-8",
             "displayName": "Opus 4.8",
-            "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+            "description": "Opus 4.8 · Best for everyday, complex tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -758,7 +758,7 @@
           {
             "id": "us.anthropic.claude-opus-4-7",
             "displayName": "Opus 4.7",
-            "description": "Opus 4.7 \u00b7 Legacy",
+            "description": "Opus 4.7 · Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -1198,33 +1198,33 @@
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.16.0-proliferate.1",
+          "version": "0.17.0-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "c66f9f3b9bf4811fa8ebdfc9ad908bf37845e50f",
+            "gitRef": "8baae51210acd4912f5aab9054b124a43287030e",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }
         },
         "native": {
-          "version": "rust-v0.141.0",
+          "version": "rust-v0.144.1",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-aarch64-apple-darwin.tar.gz",
-                "sha256": "abdead5feebc259decaaec33465423bbb7904b3049fa28e92209cb924693c0f4",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-aarch64-apple-darwin.tar.gz",
+                "sha256": "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
                 "expectedBinary": "codex-aarch64-apple-darwin"
               },
               "macos_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-x86_64-apple-darwin.tar.gz",
-                "sha256": "7b7398b93dd16a3123c87286e312a7942be3c13f9619fc587dfc05563fcbc888",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-apple-darwin.tar.gz",
+                "sha256": "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
                 "expectedBinary": "codex-x86_64-apple-darwin"
               },
               "linux_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-x86_64-unknown-linux-musl.tar.gz",
-                "sha256": "f1e2bf9fa0ba6eb82119d621b6b71bc38edd33c06dc2867b31a027052358957d",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-unknown-linux-musl.tar.gz",
+                "sha256": "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28",
                 "expectedBinary": "codex-x86_64-unknown-linux-musl"
               }
             },
@@ -1301,15 +1301,37 @@
             }
           },
           {
+            "key": "collaboration_mode",
+            "values": [
+              "default",
+              "plan"
+            ],
+            "mapping": {
+              "liveConfigId": "collaboration_mode"
+            }
+          },
+          {
             "key": "reasoning_effort",
             "values": [
               "low",
               "medium",
               "high",
-              "xhigh"
+              "xhigh",
+              "max",
+              "ultra"
             ],
             "mapping": {
               "liveConfigId": "reasoning_effort"
+            }
+          },
+          {
+            "key": "fast_mode",
+            "values": [
+              "off",
+              "on"
+            ],
+            "mapping": {
+              "liveConfigId": "fast_mode"
             }
           }
         ],
@@ -1331,6 +1353,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               }
             },
             "status": "active",
@@ -1360,6 +1389,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1399,6 +1435,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1413,6 +1456,311 @@
             "provenance": {
               "observedIn": [
                 "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-sol",
+            "displayName": "GPT-5.6 Sol",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-terra",
+            "displayName": "GPT-5.6 Terra",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-luna",
+            "displayName": "GPT-5.6 Luna",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-sol",
+            "displayName": "GPT-5.6-Sol",
+            "description": "Latest frontier agentic coding model.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-terra",
+            "displayName": "GPT-5.6-Terra",
+            "description": "Balanced agentic coding model for everyday work.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-luna",
+            "displayName": "GPT-5.6-Luna",
+            "description": "Fast and affordable agentic coding model.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
               ],
               "observedInAllContexts": false,
               "viaTrialOnly": false
@@ -1438,6 +1786,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1445,7 +1800,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
               }
             },
             "status": "active",
@@ -1478,6 +1840,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1485,7 +1854,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
               }
             },
             "status": "active",
@@ -1518,44 +1894,12 @@
                 ],
                 "observedValue": "read-only"
               },
-              "reasoning_effort": {
+              "collaboration_mode": {
                 "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
+                  "default",
+                  "plan"
                 ],
-                "observedValue": "medium"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "codex.openai-api",
-                "codex.openai-oauth"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "gpt-5.3-codex",
-            "displayName": "GPT-5.3-Codex",
-            "description": "Coding-optimized model.",
-            "availability": {
-              "anyOf": [
-                "openai-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "read-only",
-                  "auto",
-                  "full-access"
-                ],
-                "observedValue": "read-only"
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1564,13 +1908,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
             "provenance": {
               "observedIn": [
-                "codex.openai-api"
+                "codex.openai-api",
+                "codex.openai-oauth"
               ],
               "observedInAllContexts": false,
               "viaTrialOnly": false
@@ -1596,6 +1941,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1603,7 +1955,7 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
@@ -1633,6 +1985,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1752,8 +2111,8 @@
         },
         "observedDefaults": {
           "bedrock": "openai.gpt-oss-120b",
-          "openai-api": "gpt-5.5",
-          "openai-oauth": "gpt-5.5"
+          "openai-api": "gpt-5.6-sol",
+          "openai-oauth": "gpt-5.6-sol"
         },
         "gatewayPolicy": {
           "providers": [
@@ -1768,10 +2127,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:52:32.817407+00:00",
+        "probedAt": "2026-07-11T00:36:25.416008+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.16.0-proliferate.1",
+          "version": "0.17.0-proliferate.1",
           "title": "Codex"
         },
         "runs": [

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "registryVersion": "2026-06-10.1",
+  "registryVersion": "2026-07-10.1",
   "generatedAt": "2026-05-31T00:00:00Z",
   "agents": [
     {
@@ -133,7 +133,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/codex-acp.git#c66f9f3b9bf4811fa8ebdfc9ad908bf37845e50f",
+          "package": "git+https://github.com/proliferate-ai/codex-acp.git#8baae51210acd4912f5aab9054b124a43287030e",
           "packageSubdir": "npm",
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/codex-acp"

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -22,6 +22,128 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const generatedDir = join(here, "generated");
 const outPath = join(here, "catalog.draft.json");
+const bundledPath = join(here, "..", "..", "catalogs", "agents", "catalog.json");
+const probeStatePath = join(generatedDir, ".probe-logs", "run.state");
+const resolvedCandidatePath = join(generatedDir, ".probe-logs", "resolved-candidate.json");
+const allowedArgs = new Set(["--require-complete-probe"]);
+for (const arg of process.argv.slice(2)) {
+  if (!allowedArgs.has(arg)) throw new Error(`unexpected argument ${arg}`);
+}
+const requireCompleteProbe = process.argv.includes("--require-complete-probe");
+let previousCatalog = null;
+try { previousCatalog = JSON.parse(readFileSync(bundledPath, "utf8")); } catch {}
+const previousByKind = new Map((previousCatalog?.agents ?? []).map((agent) => [agent.kind, agent]));
+
+function normalizedNativeVersion(value) {
+  if (typeof value !== "string") return null;
+  return value.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/)?.[0] ?? null;
+}
+
+function readCompleteProbeState() {
+  let text;
+  try {
+    text = readFileSync(probeStatePath, "utf8");
+  } catch (error) {
+    throw new Error(`complete probe state is required at ${probeStatePath}: ${error.message}`);
+  }
+  const state = {};
+  for (const line of text.split("\n")) {
+    const separator = line.indexOf("=");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator);
+    const value = line.slice(separator + 1);
+    (state[key] ??= []).push(value);
+  }
+  if (state.complete?.at(-1) !== "true") {
+    throw new Error("probe run is partial or failed; refusing to build a promotable catalog");
+  }
+  const required = new Set(state.required ?? []);
+  const passed = new Set(state.passed ?? []);
+  const missing = [...required].filter((id) => !passed.has(id));
+  if (missing.length) {
+    throw new Error(`probe state is incomplete; missing successful contexts: ${missing.join(", ")}`);
+  }
+  const startedAt = Date.parse(state.startedAt?.at(-1) ?? "");
+  if (!Number.isFinite(startedAt)) throw new Error("probe state has no valid startedAt timestamp");
+  const snapshotsByAgent = new Map();
+  for (const id of passed) {
+    const separator = id.indexOf(".");
+    const agent = id.slice(0, separator);
+    const context = id.slice(separator + 1);
+    const snapshotPath = join(generatedDir, `${id}.probe.json`);
+    const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+    if (snapshot.agentKind !== agent || snapshot.authContext !== context) {
+      throw new Error(`${id}: probe state does not match ${snapshotPath}`);
+    }
+    const probedAt = Date.parse(snapshot.probedAt);
+    if (!Number.isFinite(probedAt) || probedAt < startedAt) {
+      throw new Error(`${id}: snapshot is missing or predates the authoritative probe run`);
+    }
+    if (!snapshotsByAgent.has(agent)) snapshotsByAgent.set(agent, []);
+    snapshotsByAgent.get(agent).push(snapshot);
+  }
+  const activeAgents = new Set(state.agent ?? []);
+  const candidate = JSON.parse(readFileSync(resolvedCandidatePath, "utf8"));
+  const candidateByKind = new Map(candidate.agents.map((agent) => [agent.kind, agent]));
+  for (const agent of snapshotsByAgent.keys()) {
+    if (!activeAgents.has(agent)) {
+      throw new Error(`${agent}: passed probe snapshots are not tied to a resolved agent`);
+    }
+  }
+  for (const agent of activeAgents) {
+    const agentSnapshots = snapshotsByAgent.get(agent) ?? [];
+    if (!agentSnapshots.length) {
+      throw new Error(`${agent}: resolved agent has no fresh successful probe context`);
+    }
+    const candidateAgent = candidateByKind.get(agent);
+    if (!candidateAgent?.harness?.agentProcess?.source) {
+      throw new Error(`${agent}: resolved candidate has no fenced agent-process source`);
+    }
+    const attestationVersions = agentSnapshots.map((snapshot) => {
+      const version = snapshot.attestation?.version;
+      if (typeof version !== "string" || !version.trim()) {
+        throw new Error(
+          `${agent}.${snapshot.authContext}: successful probe is missing agent-process attestation version`,
+        );
+      }
+      return version;
+    });
+    const observedVersions = new Set(attestationVersions);
+    if (observedVersions.size > 1 || (
+      observedVersions.size === 1 &&
+      !observedVersions.has(candidateAgent.harness.agentProcess.version)
+    )) {
+      throw new Error(
+        `${agent}: probe attestation (${[...observedVersions].join(", ") || "missing"}) ` +
+        `does not match resolved candidate ${candidateAgent.harness.agentProcess.version}`,
+      );
+    }
+    const candidateNative = candidateAgent.harness.native;
+    if (candidateNative) {
+      const observedNativeVersions = agentSnapshots.map((snapshot) => {
+        const version = snapshot.nativeCli?.version;
+        if (typeof version !== "string" || !version.trim()) {
+          throw new Error(
+            `${agent}.${snapshot.authContext}: successful probe is missing native CLI version ` +
+            `required by resolved candidate ${candidateNative.version}`,
+          );
+        }
+        return version;
+      });
+      const expected = normalizedNativeVersion(candidateNative.version);
+      const observed = new Set(observedNativeVersions.map(normalizedNativeVersion));
+      if (!expected || observed.has(null) || observed.size !== 1 || !observed.has(expected)) {
+        throw new Error(
+          `${agent}: native CLI versions (${observedNativeVersions.join(", ")}) ` +
+          `do not match resolved candidate ${candidateNative.version}`,
+        );
+      }
+    }
+  }
+  return { activeAgents, candidateByKind, passed };
+}
+
+const probeState = requireCompleteProbe ? readCompleteProbeState() : null;
 
 const AGENT_DISPLAY_NAMES = { claude: "Claude", codex: "Codex", cursor: "Cursor", opencode: "OpenCode", grok: "Grok" };
 // Which registry auth slot satisfies each probe auth context (curation-owned).
@@ -258,6 +380,11 @@ const warnings = [];
 // ---- load snapshots, grouped by agent kind --------------------------------
 const snapshots = readdirSync(generatedDir)
   .filter((name) => name.endsWith(".probe.json"))
+  .filter((name) => {
+    if (!probeState) return true;
+    const id = name.slice(0, -".probe.json".length);
+    return probeState.passed.has(id);
+  })
   .map((name) => ({ name, data: JSON.parse(readFileSync(join(generatedDir, name), "utf8")) }));
 
 const byAgent = new Map();
@@ -448,6 +575,42 @@ function mergeMatrices(matrices) {
   return merged;
 }
 
+// Gateway rows and policy are curated runtime-route metadata, not probe
+// observations. Preserve that overlay from the bundled lockfile while fresh
+// probe facts are rebuilt. Inactive agents are copied wholesale below.
+function applyBundledCuration(agent) {
+  const previous = previousByKind.get(agent.kind);
+  if (!previous) return agent;
+
+  const gatewayContext = previous.authContexts?.find((context) => context.id === "gateway");
+  if (gatewayContext && !agent.authContexts.some((context) => context.id === "gateway")) {
+    agent.authContexts.push(structuredClone(gatewayContext));
+  }
+
+  for (const previousModel of previous.session?.models ?? []) {
+    if (!previousModel.availability?.anyOf?.includes("gateway")) continue;
+    const currentModel = agent.session.models.find((model) => model.id === previousModel.id);
+    if (!currentModel) {
+      agent.session.models.push(structuredClone(previousModel));
+      continue;
+    }
+    if (!currentModel.availability.anyOf.includes("gateway")) {
+      currentModel.availability.anyOf.push("gateway");
+    }
+  }
+
+  if (previous.session?.defaults?.gateway) {
+    agent.session.defaults.gateway = previous.session.defaults.gateway;
+  }
+  if (previous.session?.gatewayPolicy) {
+    agent.session.gatewayPolicy = structuredClone(previous.session.gatewayPolicy);
+  }
+  if (probeState) {
+    agent.harness = structuredClone(probeState.candidateByKind.get(agent.kind).harness);
+  }
+  return agent;
+}
+
 // ---- per-agent collation ----------------------------------------------------
 const agents = [];
 for (const [kind, runs] of byAgent) {
@@ -600,7 +763,7 @@ for (const [kind, runs] of byAgent) {
     throw new Error(`${kind}: runs used different native CLI versions: ${[...nativeVersions].join(", ")}`);
   }
   const nativeVersion = [...nativeVersions][0];
-  agents.push({
+  agents.push(applyBundledCuration({
     kind,
     displayName: AGENT_DISPLAY_NAMES[kind] ?? kind,
     harness: {
@@ -641,7 +804,15 @@ for (const [kind, runs] of byAgent) {
       attestation,
       runs: runs.map((r) => ({ id: `${kind}.${r.data.authContext}`, snapshotPath: `generated/${r.name}` })),
     },
-  });
+  }));
+}
+
+if (probeState) {
+  for (const previous of previousCatalog?.agents ?? []) {
+    if (!probeState.activeAgents.has(previous.kind)) {
+      agents.push(structuredClone(previous));
+    }
+  }
 }
 
 // Pair the catalog with the registry it was probed against (catalog owns
@@ -664,6 +835,9 @@ const catalog = {
   catalogVersion: `${today}.${revision}`,
   probedAgainst: { registryVersion },
   generatedAt: new Date().toISOString(),
+  ...(previousCatalog?.defaultAgentKind
+    ? { defaultAgentKind: previousCatalog.defaultAgentKind }
+    : {}),
   agents: agents.sort((a, b) => a.kind.localeCompare(b.kind)),
 };
 

--- a/scripts/agent-catalog/build-catalog.test.mjs
+++ b/scripts/agent-catalog/build-catalog.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const sourceDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(sourceDir, "..", "..");
+
+function withFixture(run) {
+  const root = mkdtempSync(join(tmpdir(), "catalog-build-test-"));
+  try {
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    mkdirSync(join(root, "catalogs"), { recursive: true });
+    cpSync(sourceDir, join(root, "scripts", "agent-catalog"), { recursive: true });
+    cpSync(join(repoRoot, "catalogs", "agents"), join(root, "catalogs", "agents"), {
+      recursive: true,
+    });
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writeCompleteState(root, selectedAgents = null) {
+  const generated = join(root, "scripts", "agent-catalog", "generated");
+  const logDir = join(generated, ".probe-logs");
+  mkdirSync(logDir, { recursive: true });
+  const contexts = readdirSync(generated)
+    .filter((name) => name.endsWith(".probe.json") && !name.startsWith("cursor."))
+    .map((name) => {
+      const snapshot = JSON.parse(readFileSync(join(generated, name), "utf8"));
+      return `${snapshot.agentKind}.${snapshot.authContext}`;
+    })
+    .filter((context) => !selectedAgents || selectedAgents.includes(context.split(".")[0]));
+  const agents = [...new Set(contexts.map((context) => context.split(".")[0]))];
+  const state = [
+    "startedAt=2000-01-01T00:00:00Z",
+    ...contexts.flatMap((context) => [`required=${context}`, `passed=${context}`]),
+    ...agents.map((agent) => `agent=${agent}`),
+    "retained=cursor.cursor-login",
+    "complete=true",
+    "",
+  ].join("\n");
+  writeFileSync(join(logDir, "run.state"), state);
+  cpSync(
+    join(root, "catalogs", "agents", "catalog.json"),
+    join(logDir, "resolved-candidate.json"),
+  );
+}
+
+function alignProbeVersions(root) {
+  const generated = join(root, "scripts", "agent-catalog", "generated");
+  const catalog = JSON.parse(
+    readFileSync(join(root, "catalogs", "agents", "catalog.json"), "utf8"),
+  );
+  const harnesses = new Map(catalog.agents.map((agent) => [agent.kind, agent.harness]));
+  for (const name of readdirSync(generated).filter((name) => name.endsWith(".probe.json"))) {
+    const path = join(generated, name);
+    const snapshot = JSON.parse(readFileSync(path, "utf8"));
+    const harness = harnesses.get(snapshot.agentKind);
+    snapshot.attestation = {
+      ...(snapshot.attestation ?? {}),
+      version: harness.agentProcess.version,
+    };
+    const nativeVersion = harness.native?.version ?? null;
+    snapshot.nativeCli = nativeVersion
+      ? {
+          path: `/managed/${snapshot.agentKind}`,
+          version: snapshot.agentKind === "codex"
+            ? `codex-cli ${nativeVersion.replace(/^rust-v/, "")}`
+            : `${nativeVersion} (Claude Code)`,
+        }
+      : null;
+    writeFileSync(path, `${JSON.stringify(snapshot, null, 2)}\n`);
+  }
+}
+
+test("complete probe builds use the exact resolved candidate pins", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root);
+    const staleCursorSnapshot = join(
+      root,
+      "scripts",
+      "agent-catalog",
+      "generated",
+      "cursor.cursor-login.probe.json",
+    );
+    writeFileSync(staleCursorSnapshot, "stale retained snapshot must not be parsed");
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    execFileSync(process.execPath, [script, "--require-complete-probe"]);
+
+    const candidate = JSON.parse(
+      readFileSync(join(root, "catalogs", "agents", "catalog.json"), "utf8"),
+    );
+    const draft = JSON.parse(
+      readFileSync(join(root, "scripts", "agent-catalog", "catalog.draft.json"), "utf8"),
+    );
+    const candidateHarnesses = Object.fromEntries(
+      candidate.agents.map((agent) => [agent.kind, agent.harness]),
+    );
+    for (const agent of draft.agents) {
+      assert.deepEqual(agent.harness, candidateHarnesses[agent.kind]);
+      assert.ok(agent.harness.agentProcess.source);
+    }
+    assert.deepEqual(
+      draft.agents.find((agent) => agent.kind === "cursor"),
+      candidate.agents.find((agent) => agent.kind === "cursor"),
+    );
+  });
+});
+
+test("focused complete probes preserve every unselected agent unchanged", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root, ["codex"]);
+    const bundled = JSON.parse(
+      readFileSync(join(root, "catalogs", "agents", "catalog.json"), "utf8"),
+    );
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    execFileSync(process.execPath, [script, "--require-complete-probe"]);
+
+    const draft = JSON.parse(
+      readFileSync(join(root, "scripts", "agent-catalog", "catalog.draft.json"), "utf8"),
+    );
+    const draftByKind = new Map(draft.agents.map((agent) => [agent.kind, agent]));
+    for (const previous of bundled.agents) {
+      if (previous.kind !== "codex") {
+        assert.deepEqual(draftByKind.get(previous.kind), previous);
+      }
+    }
+  });
+});
+
+test("candidate native versions compare across vendor output formats", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root);
+    const snapshotPath = join(
+      root,
+      "scripts",
+      "agent-catalog",
+      "generated",
+      "codex.openai-api.probe.json",
+    );
+    const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+    snapshot.nativeCli.version = "2.1.181 (Claude Code)";
+    writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    const result = spawnSync(process.execPath, [script, "--require-complete-probe"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /native CLI versions.*do not match resolved candidate/s);
+  });
+});
+
+test("complete probes reject missing agent-process attestation versions", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root);
+    const snapshotPath = join(
+      root,
+      "scripts",
+      "agent-catalog",
+      "generated",
+      "codex.openai-api.probe.json",
+    );
+    const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+    delete snapshot.attestation.version;
+    writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    const result = spawnSync(process.execPath, [script, "--require-complete-probe"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /codex\.openai-api.*missing agent-process attestation version/s);
+  });
+});
+
+test("complete probes reject missing native CLI versions for native pins", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root);
+    const snapshotPath = join(
+      root,
+      "scripts",
+      "agent-catalog",
+      "generated",
+      "codex.openai-api.probe.json",
+    );
+    const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+    delete snapshot.nativeCli.version;
+    writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    const result = spawnSync(process.execPath, [script, "--require-complete-probe"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /codex\.openai-api.*missing native CLI version/s);
+  });
+});
+
+test("partial probe state cannot build a promotable catalog", () => {
+  withFixture((root) => {
+    const logDir = join(root, "scripts", "agent-catalog", "generated", ".probe-logs");
+    mkdirSync(logDir, { recursive: true });
+    writeFileSync(join(logDir, "run.state"), "complete=false\n");
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    const result = spawnSync(process.execPath, [script, "--require-complete-probe"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /partial or failed/);
+  });
+});

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-02.1",
+  "catalogVersion": "2026-07-11.1",
   "probedAgainst": {
-    "registryVersion": "2026-06-10.1"
+    "registryVersion": "2026-07-10.1"
   },
-  "generatedAt": "2026-06-18T06:23:46.960Z",
+  "generatedAt": "2026-07-11T00:36:38.653Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -87,6 +87,7 @@
         }
       ],
       "session": {
+        "supportsGoals": true,
         "controls": [
           {
             "key": "model",
@@ -193,7 +194,7 @@
           {
             "id": "opus[1m]",
             "displayName": "Opus 4.8 (1M context)",
-            "description": "Opus 4.8 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+            "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -243,7 +244,7 @@
           {
             "id": "sonnet",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -287,7 +288,7 @@
           {
             "id": "sonnet[1m]",
             "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -329,7 +330,7 @@
           {
             "id": "haiku",
             "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 \u00b7 Fastest for quick answers",
+            "description": "Haiku 4.5 · Fastest for quick answers",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -363,7 +364,7 @@
           {
             "id": "opus",
             "displayName": "Opus 4.6",
-            "description": "Opus 4.6 \u00b7 Legacy",
+            "description": "Opus 4.6 · Legacy",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -415,7 +416,7 @@
           },
           {
             "id": "claude-fable-5",
-            "displayName": "Claude-Fable-5",
+            "displayName": "Fable 5",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -466,7 +467,7 @@
           },
           {
             "id": "claude-opus-4-8",
-            "displayName": "Claude-Opus-4-8",
+            "displayName": "Opus 4.8",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -518,7 +519,7 @@
           {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 \u00b7 Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -600,7 +601,7 @@
           {
             "id": "us.anthropic.claude-fable-5",
             "displayName": "Fable 5",
-            "description": "Fable 5 \u00b7 Most capable for your hardest and longest-running tasks",
+            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -642,7 +643,7 @@
           {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
-            "description": "Opus 4.1 \u00b7 Legacy",
+            "description": "Opus 4.1 · Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -673,7 +674,7 @@
           {
             "id": "us.anthropic.claude-opus-4-8",
             "displayName": "Opus 4.8",
-            "description": "Opus 4.8 \u00b7 Best for everyday, complex tasks",
+            "description": "Opus 4.8 · Best for everyday, complex tasks",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -757,7 +758,7 @@
           {
             "id": "us.anthropic.claude-opus-4-7",
             "displayName": "Opus 4.7",
-            "description": "Opus 4.7 \u00b7 Legacy",
+            "description": "Opus 4.7 · Legacy",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -881,7 +882,7 @@
           },
           {
             "id": "global.anthropic.claude-fable-5",
-            "displayName": "Global.anthropic.claude-Fable-5",
+            "displayName": "Fable 5",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -1197,33 +1198,33 @@
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.16.0-proliferate.1",
+          "version": "0.17.0-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "c66f9f3b9bf4811fa8ebdfc9ad908bf37845e50f",
+            "gitRef": "8baae51210acd4912f5aab9054b124a43287030e",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }
         },
         "native": {
-          "version": "rust-v0.141.0",
+          "version": "rust-v0.144.1",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-aarch64-apple-darwin.tar.gz",
-                "sha256": "abdead5feebc259decaaec33465423bbb7904b3049fa28e92209cb924693c0f4",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-aarch64-apple-darwin.tar.gz",
+                "sha256": "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
                 "expectedBinary": "codex-aarch64-apple-darwin"
               },
               "macos_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-x86_64-apple-darwin.tar.gz",
-                "sha256": "7b7398b93dd16a3123c87286e312a7942be3c13f9619fc587dfc05563fcbc888",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-apple-darwin.tar.gz",
+                "sha256": "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
                 "expectedBinary": "codex-x86_64-apple-darwin"
               },
               "linux_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.141.0/codex-x86_64-unknown-linux-musl.tar.gz",
-                "sha256": "f1e2bf9fa0ba6eb82119d621b6b71bc38edd33c06dc2867b31a027052358957d",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-unknown-linux-musl.tar.gz",
+                "sha256": "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28",
                 "expectedBinary": "codex-x86_64-unknown-linux-musl"
               }
             },
@@ -1277,6 +1278,7 @@
         }
       ],
       "session": {
+        "supportsGoals": true,
         "controls": [
           {
             "key": "model",
@@ -1299,15 +1301,37 @@
             }
           },
           {
+            "key": "collaboration_mode",
+            "values": [
+              "default",
+              "plan"
+            ],
+            "mapping": {
+              "liveConfigId": "collaboration_mode"
+            }
+          },
+          {
             "key": "reasoning_effort",
             "values": [
               "low",
               "medium",
               "high",
-              "xhigh"
+              "xhigh",
+              "max",
+              "ultra"
             ],
             "mapping": {
               "liveConfigId": "reasoning_effort"
+            }
+          },
+          {
+            "key": "fast_mode",
+            "values": [
+              "off",
+              "on"
+            ],
+            "mapping": {
+              "liveConfigId": "fast_mode"
             }
           }
         ],
@@ -1329,6 +1353,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               }
             },
             "status": "active",
@@ -1358,6 +1389,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1397,6 +1435,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1411,6 +1456,311 @@
             "provenance": {
               "observedIn": [
                 "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-sol",
+            "displayName": "GPT-5.6 Sol",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-terra",
+            "displayName": "GPT-5.6 Terra",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai.gpt-5.6-luna",
+            "displayName": "GPT-5.6 Luna",
+            "description": "Frontier model for complex coding, research, and real-world work.",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "medium"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-sol",
+            "displayName": "GPT-5.6-Sol",
+            "description": "Latest frontier agentic coding model.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-terra",
+            "displayName": "GPT-5.6-Terra",
+            "description": "Balanced agentic coding model for everyday work.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "gpt-5.6-luna",
+            "displayName": "GPT-5.6-Luna",
+            "description": "Fast and affordable agentic coding model.",
+            "availability": {
+              "anyOf": [
+                "openai-api",
+                "openai-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "read-only",
+                  "auto",
+                  "full-access"
+                ],
+                "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
+              "reasoning_effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "codex.openai-api",
+                "codex.openai-oauth"
               ],
               "observedInAllContexts": false,
               "viaTrialOnly": false
@@ -1436,6 +1786,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1443,7 +1800,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
               }
             },
             "status": "active",
@@ -1476,6 +1840,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1483,7 +1854,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
+              },
+              "fast_mode": {
+                "values": [
+                  "off",
+                  "on"
+                ],
+                "observedValue": "off"
               }
             },
             "status": "active",
@@ -1516,44 +1894,12 @@
                 ],
                 "observedValue": "read-only"
               },
-              "reasoning_effort": {
+              "collaboration_mode": {
                 "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
+                  "default",
+                  "plan"
                 ],
-                "observedValue": "medium"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "codex.openai-api",
-                "codex.openai-oauth"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "gpt-5.3-codex",
-            "displayName": "GPT-5.3-Codex",
-            "description": "Coding-optimized model.",
-            "availability": {
-              "anyOf": [
-                "openai-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "read-only",
-                  "auto",
-                  "full-access"
-                ],
-                "observedValue": "read-only"
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1562,13 +1908,14 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
             "provenance": {
               "observedIn": [
-                "codex.openai-api"
+                "codex.openai-api",
+                "codex.openai-oauth"
               ],
               "observedInAllContexts": false,
               "viaTrialOnly": false
@@ -1594,6 +1941,13 @@
                 ],
                 "observedValue": "read-only"
               },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
+              },
               "reasoning_effort": {
                 "values": [
                   "low",
@@ -1601,7 +1955,7 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
@@ -1631,6 +1985,13 @@
                   "full-access"
                 ],
                 "observedValue": "read-only"
+              },
+              "collaboration_mode": {
+                "values": [
+                  "default",
+                  "plan"
+                ],
+                "observedValue": "default"
               },
               "reasoning_effort": {
                 "values": [
@@ -1750,12 +2111,11 @@
         },
         "observedDefaults": {
           "bedrock": "openai.gpt-oss-120b",
-          "openai-api": "gpt-5.5",
-          "openai-oauth": "gpt-5.5"
+          "openai-api": "gpt-5.6-sol",
+          "openai-oauth": "gpt-5.6-sol"
         },
         "gatewayPolicy": {
           "providers": [
-            "anthropic",
             "openai"
           ],
           "seedModels": [
@@ -1767,10 +2127,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:52:32.817407+00:00",
+        "probedAt": "2026-07-11T00:36:25.416008+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.16.0-proliferate.1",
+          "version": "0.17.0-proliferate.1",
           "title": "Codex"
         },
         "runs": [

--- a/scripts/agent-catalog/check-version-discipline.mjs
+++ b/scripts/agent-catalog/check-version-discipline.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+const DOCUMENTS = [
+  {
+    label: "agent catalog",
+    path: "catalogs/agents/catalog.json",
+    versionKey: "catalogVersion",
+  },
+  {
+    label: "agent registry",
+    path: "catalogs/agents/registry.json",
+    versionKey: "registryVersion",
+  },
+];
+
+export function parseVersion(version) {
+  const match = /^(\d{4}-\d{2}-\d{2})\.(\d+)$/.exec(version ?? "");
+  if (!match) return null;
+  return { date: match[1], revision: Number(match[2]) };
+}
+
+export function compareVersions(left, right) {
+  const leftVersion = parseVersion(left);
+  const rightVersion = parseVersion(right);
+  if (!leftVersion || !rightVersion) return null;
+  if (leftVersion.date !== rightVersion.date) {
+    return leftVersion.date.localeCompare(rightVersion.date);
+  }
+  return leftVersion.revision - rightVersion.revision;
+}
+
+export function checkDocumentVersion({ label, current, base, versionKey }) {
+  const errors = [];
+  const currentVersion = current?.[versionKey];
+  const baseVersion = base?.[versionKey];
+  if (!parseVersion(currentVersion)) {
+    errors.push(`${label}: ${versionKey} '${currentVersion}' must use YYYY-MM-DD.revision`);
+    return errors;
+  }
+  if (!parseVersion(baseVersion)) {
+    errors.push(`${label}: base ${versionKey} '${baseVersion}' must use YYYY-MM-DD.revision`);
+    return errors;
+  }
+
+  const currentContent = structuredClone(current);
+  const baseContent = structuredClone(base);
+  delete currentContent[versionKey];
+  delete baseContent[versionKey];
+  const contentChanged = !isDeepStrictEqual(currentContent, baseContent);
+  if (contentChanged && currentVersion === baseVersion) {
+    errors.push(`${label}: content changed without bumping ${versionKey}`);
+  }
+  if (currentVersion !== baseVersion && compareVersions(currentVersion, baseVersion) <= 0) {
+    errors.push(
+      `${label}: ${versionKey} must increase (${baseVersion} -> ${currentVersion})`,
+    );
+  }
+  return errors;
+}
+
+function parseArgs(argv) {
+  const result = { base: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--base") {
+      result.base = argv[index + 1] ?? "";
+      index += 1;
+    } else {
+      throw new Error(`unexpected argument ${argv[index]}`);
+    }
+  }
+  return result;
+}
+
+function readAtRevision(revision, filePath) {
+  return JSON.parse(
+    execFileSync("git", ["show", `${revision}:${filePath}`], { encoding: "utf8" }),
+  );
+}
+
+function main() {
+  const { base } = parseArgs(process.argv.slice(2));
+  if (!base) {
+    console.log("catalog version discipline skipped: no base revision supplied");
+    return;
+  }
+  const errors = [];
+  for (const document of DOCUMENTS) {
+    const current = JSON.parse(readFileSync(document.path, "utf8"));
+    const baseDocument = readAtRevision(base, document.path);
+    errors.push(...checkDocumentVersion({
+      label: document.label,
+      current,
+      base: baseDocument,
+      versionKey: document.versionKey,
+    }));
+  }
+  if (errors.length) {
+    for (const error of errors) console.error(`catalog version discipline failed: ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`catalog version discipline OK against ${base}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/agent-catalog/check-version-discipline.test.mjs
+++ b/scripts/agent-catalog/check-version-discipline.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  checkDocumentVersion,
+  compareVersions,
+  parseVersion,
+} from "./check-version-discipline.mjs";
+
+test("parses and compares date-revision versions", () => {
+  assert.deepEqual(parseVersion("2026-07-10.2"), { date: "2026-07-10", revision: 2 });
+  assert.equal(parseVersion("v2"), null);
+  assert.ok(compareVersions("2026-07-10.2", "2026-07-10.1") > 0);
+  assert.ok(compareVersions("2026-07-11.1", "2026-07-10.9") > 0);
+});
+
+test("requires a version bump when document content changes", () => {
+  const errors = checkDocumentVersion({
+    label: "catalog",
+    versionKey: "catalogVersion",
+    base: { catalogVersion: "2026-07-10.1", agents: ["claude"] },
+    current: { catalogVersion: "2026-07-10.1", agents: ["claude", "codex"] },
+  });
+  assert.deepEqual(errors, ["catalog: content changed without bumping catalogVersion"]);
+});
+
+test("accepts changed content with an increasing version", () => {
+  const errors = checkDocumentVersion({
+    label: "registry",
+    versionKey: "registryVersion",
+    base: { registryVersion: "2026-07-10.1", agents: ["claude"] },
+    current: { registryVersion: "2026-07-10.2", agents: ["claude", "codex"] },
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("rejects a version rollback", () => {
+  const errors = checkDocumentVersion({
+    label: "catalog",
+    versionKey: "catalogVersion",
+    base: { catalogVersion: "2026-07-10.2", agents: [] },
+    current: { catalogVersion: "2026-07-10.1", agents: [] },
+  });
+  assert.match(errors.join("\n"), /must increase/);
+});

--- a/scripts/agent-catalog/generated/codex.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/codex.bedrock.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-06-18T02:52:32.494571+00:00",
+  "probedAt": "2026-07-11T00:36:25.132627+00:00",
   "agentKind": "codex",
   "authContext": "bedrock",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.16.0-proliferate.1",
+    "version": "0.17.0-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
+    "version": "codex-cli 0.144.1"
   },
   "trials": [],
   "currentModelId": null,
@@ -62,6 +62,26 @@
       "type": "select"
     },
     {
+      "category": "collaboration_mode",
+      "currentValue": "default",
+      "description": "Choose whether Codex should work in default or planning mode",
+      "id": "collaboration_mode",
+      "name": "Collaboration Mode",
+      "options": [
+        {
+          "description": "Work directly on the task",
+          "name": "Default",
+          "value": "default"
+        },
+        {
+          "description": "Plan before making changes",
+          "name": "Plan",
+          "value": "plan"
+        }
+      ],
+      "type": "select"
+    },
+    {
       "category": "model",
       "currentValue": "openai.gpt-oss-120b",
       "description": "Choose which model Codex should use",
@@ -79,8 +99,23 @@
         },
         {
           "description": "Strong model for everyday coding.",
-          "name": "gpt-5.4",
+          "name": "GPT-5.4",
           "value": "openai.gpt-5.4"
+        },
+        {
+          "description": "Frontier model for complex coding, research, and real-world work.",
+          "name": "GPT-5.6 Sol",
+          "value": "openai.gpt-5.6-sol"
+        },
+        {
+          "description": "Frontier model for complex coding, research, and real-world work.",
+          "name": "GPT-5.6 Terra",
+          "value": "openai.gpt-5.6-terra"
+        },
+        {
+          "description": "Frontier model for complex coding, research, and real-world work.",
+          "name": "GPT-5.6 Luna",
+          "value": "openai.gpt-5.6-luna"
         }
       ],
       "type": "select"
@@ -113,6 +148,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -155,6 +210,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -203,7 +278,7 @@
     },
     {
       "modelId": "openai.gpt-5.4",
-      "name": "gpt-5.4",
+      "name": "GPT-5.4",
       "description": "Strong model for everyday coding.",
       "configOptions": [
         {
@@ -227,6 +302,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -267,6 +362,297 @@
               "description": "Extra high reasoning depth for complex problems",
               "name": "Xhigh",
               "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.6-sol",
+      "name": "GPT-5.6 Sol",
+      "description": "Frontier model for complex coding, research, and real-world work.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.6-sol",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.6-terra",
+      "name": "GPT-5.6 Terra",
+      "description": "Frontier model for complex coding, research, and real-world work.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.6-terra",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai.gpt-5.6-luna",
+      "name": "GPT-5.6 Luna",
+      "description": "Frontier model for complex coding, research, and real-world work.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "openai.gpt-5.6-luna",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
             }
           ],
           "type": "select"

--- a/scripts/agent-catalog/generated/codex.openai-api.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-api.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-06-18T02:52:32.498119+00:00",
+  "probedAt": "2026-07-11T00:36:25.133691+00:00",
   "agentKind": "codex",
   "authContext": "openai-api",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.16.0-proliferate.1",
+    "version": "0.17.0-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
+    "version": "codex-cli 0.144.1"
   },
   "trials": [],
   "currentModelId": null,
@@ -62,12 +62,47 @@
       "type": "select"
     },
     {
+      "category": "collaboration_mode",
+      "currentValue": "default",
+      "description": "Choose whether Codex should work in default or planning mode",
+      "id": "collaboration_mode",
+      "name": "Collaboration Mode",
+      "options": [
+        {
+          "description": "Work directly on the task",
+          "name": "Default",
+          "value": "default"
+        },
+        {
+          "description": "Plan before making changes",
+          "name": "Plan",
+          "value": "plan"
+        }
+      ],
+      "type": "select"
+    },
+    {
       "category": "model",
-      "currentValue": "gpt-5.5",
+      "currentValue": "gpt-5.6-sol",
       "description": "Choose which model Codex should use",
       "id": "model",
       "name": "Model",
       "options": [
+        {
+          "description": "Latest frontier agentic coding model.",
+          "name": "GPT-5.6-Sol",
+          "value": "gpt-5.6-sol"
+        },
+        {
+          "description": "Balanced agentic coding model for everyday work.",
+          "name": "GPT-5.6-Terra",
+          "value": "gpt-5.6-terra"
+        },
+        {
+          "description": "Fast and affordable agentic coding model.",
+          "name": "GPT-5.6-Luna",
+          "value": "gpt-5.6-luna"
+        },
         {
           "description": "Frontier model for complex coding, research, and real-world work.",
           "name": "GPT-5.5",
@@ -75,7 +110,7 @@
         },
         {
           "description": "Strong model for everyday coding.",
-          "name": "gpt-5.4",
+          "name": "GPT-5.4",
           "value": "gpt-5.4"
         },
         {
@@ -84,13 +119,8 @@
           "value": "gpt-5.4-mini"
         },
         {
-          "description": "Coding-optimized model.",
-          "name": "gpt-5.3-codex",
-          "value": "gpt-5.3-codex"
-        },
-        {
           "description": "Optimized for professional work and long-running agents.",
-          "name": "gpt-5.2",
+          "name": "GPT-5.2",
           "value": "gpt-5.2"
         }
       ],
@@ -98,7 +128,7 @@
     },
     {
       "category": "thought_level",
-      "currentValue": "medium",
+      "currentValue": "low",
       "description": "Choose how much reasoning effort the model should use",
       "id": "reasoning_effort",
       "name": "Reasoning Effort",
@@ -122,12 +152,403 @@
           "description": "Extra high reasoning depth for complex problems",
           "name": "Xhigh",
           "value": "xhigh"
+        },
+        {
+          "description": "Maximum reasoning depth for the hardest problems",
+          "name": "Max",
+          "value": "max"
+        },
+        {
+          "description": "Maximum reasoning with automatic task delegation",
+          "name": "Ultra",
+          "value": "ultra"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "fast_mode",
+      "currentValue": "off",
+      "description": "Choose whether Codex should use fast mode",
+      "id": "fast_mode",
+      "name": "Fast Mode",
+      "options": [
+        {
+          "description": "Use standard model routing",
+          "name": "Off",
+          "value": "off"
+        },
+        {
+          "description": "Request the model's fast service tier",
+          "name": "On",
+          "value": "on"
         }
       ],
       "type": "select"
     }
   ],
   "models": [
+    {
+      "modelId": "gpt-5.6-sol",
+      "name": "GPT-5.6-Sol",
+      "description": "Latest frontier agentic coding model.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-sol",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            },
+            {
+              "description": "Maximum reasoning with automatic task delegation",
+              "name": "Ultra",
+              "value": "ultra"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-terra",
+      "name": "GPT-5.6-Terra",
+      "description": "Balanced agentic coding model for everyday work.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-terra",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            },
+            {
+              "description": "Maximum reasoning with automatic task delegation",
+              "name": "Ultra",
+              "value": "ultra"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-luna",
+      "name": "GPT-5.6-Luna",
+      "description": "Fast and affordable agentic coding model.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-luna",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
     {
       "modelId": "gpt-5.5",
       "name": "GPT-5.5",
@@ -159,6 +580,26 @@
           "type": "select"
         },
         {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
           "category": "model",
           "currentValue": "gpt-5.5",
           "description": "Choose which model Codex should use",
@@ -170,7 +611,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -197,12 +638,32 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
         }
       ]
     },
     {
       "modelId": "gpt-5.4",
-      "name": "gpt-5.4",
+      "name": "GPT-5.4",
       "description": "Strong model for everyday coding.",
       "configOptions": [
         {
@@ -231,6 +692,26 @@
           "type": "select"
         },
         {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
           "category": "model",
           "currentValue": "gpt-5.4",
           "description": "Choose which model Codex should use",
@@ -242,7 +723,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -266,6 +747,26 @@
               "description": "Extra high reasoning depth for complex problems",
               "name": "Xhigh",
               "value": "xhigh"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
             }
           ],
           "type": "select"
@@ -303,6 +804,26 @@
           "type": "select"
         },
         {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
           "category": "model",
           "currentValue": "gpt-5.4-mini",
           "description": "Choose which model Codex should use",
@@ -314,79 +835,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
-          "description": "Choose how much reasoning effort the model should use",
-          "id": "reasoning_effort",
-          "name": "Reasoning Effort",
-          "options": [
-            {
-              "description": "Fast responses with lighter reasoning",
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "description": "Balances speed and reasoning depth for everyday tasks",
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "description": "Greater reasoning depth for complex problems",
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "description": "Extra high reasoning depth for complex problems",
-              "name": "Xhigh",
-              "value": "xhigh"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "gpt-5.3-codex",
-      "name": "gpt-5.3-codex",
-      "description": "Coding-optimized model.",
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "read-only",
-          "description": "Choose an approval and sandboxing preset for your session",
-          "id": "mode",
-          "name": "Approval Preset",
-          "options": [
-            {
-              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
-              "name": "Read Only",
-              "value": "read-only"
-            },
-            {
-              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
-              "name": "Default",
-              "value": "auto"
-            },
-            {
-              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
-              "name": "Full Access",
-              "value": "full-access"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "gpt-5.3-codex",
-          "description": "Choose which model Codex should use",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -418,7 +867,7 @@
     },
     {
       "modelId": "gpt-5.2",
-      "name": "gpt-5.2",
+      "name": "GPT-5.2",
       "description": "Optimized for professional work and long-running agents.",
       "configOptions": [
         {
@@ -447,6 +896,26 @@
           "type": "select"
         },
         {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
           "category": "model",
           "currentValue": "gpt-5.2",
           "description": "Choose which model Codex should use",
@@ -458,7 +927,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",

--- a/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-06-18T02:52:32.817407+00:00",
+  "probedAt": "2026-07-11T00:36:25.416008+00:00",
   "agentKind": "codex",
   "authContext": "openai-oauth",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.16.0-proliferate.1",
+    "version": "0.17.0-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
+    "version": "codex-cli 0.144.1"
   },
   "trials": [],
   "currentModelId": null,
@@ -62,12 +62,47 @@
       "type": "select"
     },
     {
+      "category": "collaboration_mode",
+      "currentValue": "default",
+      "description": "Choose whether Codex should work in default or planning mode",
+      "id": "collaboration_mode",
+      "name": "Collaboration Mode",
+      "options": [
+        {
+          "description": "Work directly on the task",
+          "name": "Default",
+          "value": "default"
+        },
+        {
+          "description": "Plan before making changes",
+          "name": "Plan",
+          "value": "plan"
+        }
+      ],
+      "type": "select"
+    },
+    {
       "category": "model",
-      "currentValue": "gpt-5.5",
+      "currentValue": "gpt-5.6-sol",
       "description": "Choose which model Codex should use",
       "id": "model",
       "name": "Model",
       "options": [
+        {
+          "description": "Latest frontier agentic coding model.",
+          "name": "GPT-5.6-Sol",
+          "value": "gpt-5.6-sol"
+        },
+        {
+          "description": "Balanced agentic coding model for everyday work.",
+          "name": "GPT-5.6-Terra",
+          "value": "gpt-5.6-terra"
+        },
+        {
+          "description": "Fast and affordable agentic coding model.",
+          "name": "GPT-5.6-Luna",
+          "value": "gpt-5.6-luna"
+        },
         {
           "description": "Frontier model for complex coding, research, and real-world work.",
           "name": "GPT-5.5",
@@ -117,12 +152,403 @@
           "description": "Extra high reasoning depth for complex problems",
           "name": "Xhigh",
           "value": "xhigh"
+        },
+        {
+          "description": "Maximum reasoning depth for the hardest problems",
+          "name": "Max",
+          "value": "max"
+        },
+        {
+          "description": "Maximum reasoning with automatic task delegation",
+          "name": "Ultra",
+          "value": "ultra"
+        }
+      ],
+      "type": "select"
+    },
+    {
+      "category": "fast_mode",
+      "currentValue": "off",
+      "description": "Choose whether Codex should use fast mode",
+      "id": "fast_mode",
+      "name": "Fast Mode",
+      "options": [
+        {
+          "description": "Use standard model routing",
+          "name": "Off",
+          "value": "off"
+        },
+        {
+          "description": "Request the model's fast service tier",
+          "name": "On",
+          "value": "on"
         }
       ],
       "type": "select"
     }
   ],
   "models": [
+    {
+      "modelId": "gpt-5.6-sol",
+      "name": "GPT-5.6-Sol",
+      "description": "Latest frontier agentic coding model.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-sol",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            },
+            {
+              "description": "Maximum reasoning with automatic task delegation",
+              "name": "Ultra",
+              "value": "ultra"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-terra",
+      "name": "GPT-5.6-Terra",
+      "description": "Balanced agentic coding model for everyday work.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-terra",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            },
+            {
+              "description": "Maximum reasoning with automatic task delegation",
+              "name": "Ultra",
+              "value": "ultra"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-luna",
+      "name": "GPT-5.6-Luna",
+      "description": "Fast and affordable agentic coding model.",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "read-only",
+          "description": "Choose an approval and sandboxing preset for your session",
+          "id": "mode",
+          "name": "Approval Preset",
+          "options": [
+            {
+              "description": "Codex can read files in the current workspace. Approval is required to edit files or access the internet.",
+              "name": "Read Only",
+              "value": "read-only"
+            },
+            {
+              "description": "Codex can read and edit files in the current workspace, and run commands. Approval is required to access the internet or edit other files. (Identical to Agent mode)",
+              "name": "Default",
+              "value": "auto"
+            },
+            {
+              "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
+              "name": "Full Access",
+              "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-luna",
+          "description": "Choose which model Codex should use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "medium",
+          "description": "Choose how much reasoning effort the model should use",
+          "id": "reasoning_effort",
+          "name": "Reasoning Effort",
+          "options": [
+            {
+              "description": "Fast responses with lighter reasoning",
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "description": "Balances speed and reasoning depth for everyday tasks",
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "description": "Greater reasoning depth for complex problems",
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "description": "Extra high reasoning depth for complex problems",
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "description": "Maximum reasoning depth for the hardest problems",
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
     {
       "modelId": "gpt-5.5",
       "name": "GPT-5.5",
@@ -149,6 +575,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -192,6 +638,26 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
         }
       ]
     },
@@ -221,6 +687,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -264,6 +750,26 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "fast_mode",
+          "currentValue": "off",
+          "description": "Choose whether Codex should use fast mode",
+          "id": "fast_mode",
+          "name": "Fast Mode",
+          "options": [
+            {
+              "description": "Use standard model routing",
+              "name": "Off",
+              "value": "off"
+            },
+            {
+              "description": "Request the model's fast service tier",
+              "name": "On",
+              "value": "on"
+            }
+          ],
+          "type": "select"
         }
       ]
     },
@@ -293,6 +799,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"
@@ -365,6 +891,26 @@
               "description": "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.",
               "name": "Full Access",
               "value": "full-access"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "collaboration_mode",
+          "currentValue": "default",
+          "description": "Choose whether Codex should work in default or planning mode",
+          "id": "collaboration_mode",
+          "name": "Collaboration Mode",
+          "options": [
+            {
+              "description": "Work directly on the task",
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "description": "Plan before making changes",
+              "name": "Plan",
+              "value": "plan"
             }
           ],
           "type": "select"

--- a/scripts/agent-catalog/run-probes.sh
+++ b/scripts/agent-catalog/run-probes.sh
@@ -1,112 +1,385 @@
 #!/usr/bin/env bash
-# Run the full catalog probe matrix. Skips contexts whose credentials are
-# missing (with a warning) so partial runs are possible. Credentials come
-# from .probe-secrets.env at the repo root when present; the probe scrubs
-# them from spawned agents' environments, injecting only per-context.
+# Resolve exact pins, install those pins, then run the catalog probe matrix.
 #
-# Probes fan out concurrently — one process per (agent, auth-context).
-# Each invocation is fully isolated (own config dirs, own env, own output
-# file) and shares only the read-only agent installs, so wall-clock is
-# roughly the slowest single probe. install-agents stays serial up front:
-# probes must all observe the same installed versions (collation enforces
-# version equality across a harness's runs).
+# Authoritative runs are fail-closed: every required auth context for every
+# selected agent must be available and every launched probe must succeed.
+# Cursor is opt-in because its ACP process requires a machine-local login. Use
+# --allow-partial only for diagnostics; partial state is recorded and cannot be
+# promoted by `make catalog-update`.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BIN="$ROOT/target/debug/anyharness"
 SECRETS="$ROOT/.probe-secrets.env"
-LOGS="$ROOT/scripts/agent-catalog/generated/.probe-logs"
+GENERATED="$ROOT/scripts/agent-catalog/generated"
+LOGS="$GENERATED/.probe-logs"
+STATE="$LOGS/run.state"
+CANDIDATE="$LOGS/resolved-candidate.json"
+TIMEOUT_RUNNER="$ROOT/scripts/agent-catalog/run-with-timeout.py"
+CATALOG="$ROOT/catalogs/agents/catalog.json"
+REGISTRY="$ROOT/catalogs/agents/registry.json"
+
+allow_partial="${ALLOW_PARTIAL:-0}"
+include_cursor="${CATALOG_PROBE_CURSOR:-0}"
+known_agents=(claude codex opencode grok cursor)
+default_agents=(claude codex opencode grok)
+cli_agents=()
+selected_agents=()
+
+is_known_agent() {
+  case "$1" in
+    claude|codex|opencode|grok|cursor) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+add_agent() { # add_agent <array-name> <agent>
+  local array_name="$1" candidate="$2" existing
+  local current=()
+  is_known_agent "$candidate" || {
+    echo "unknown catalog probe agent '$candidate' (expected: ${known_agents[*]})" >&2
+    exit 2
+  }
+  case "$array_name" in
+    cli_agents) current=("${cli_agents[@]-}") ;;
+    selected_agents) current=("${selected_agents[@]-}") ;;
+    *) echo "internal error: unknown agent selection '$array_name'" >&2; exit 2 ;;
+  esac
+  for existing in "${current[@]}"; do
+    [ "$existing" = "$candidate" ] && return
+  done
+  case "$array_name" in
+    cli_agents) cli_agents+=("$candidate") ;;
+    selected_agents) selected_agents+=("$candidate") ;;
+  esac
+}
+
+add_agent_list() { # add_agent_list <array-name> <comma-or-space-separated-list>
+  local array_name="$1" raw="$2" agent
+  local parsed=()
+  raw="${raw//,/ }"
+  [ -n "${raw//[[:space:]]/}" ] || {
+    echo "catalog probe agent selection cannot be empty" >&2
+    exit 2
+  }
+  read -r -a parsed <<< "$raw"
+  for agent in "${parsed[@]}"; do
+    add_agent "$array_name" "$agent"
+  done
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-partial)
+      allow_partial=1
+      shift
+      ;;
+    --include-cursor)
+      include_cursor=1
+      shift
+      ;;
+    --agent)
+      [ "$#" -ge 2 ] || { echo "--agent requires a value" >&2; exit 2; }
+      add_agent_list cli_agents "$2"
+      shift 2
+      ;;
+    --agent=*)
+      add_agent_list cli_agents "${1#--agent=}"
+      shift
+      ;;
+    *)
+      echo "unexpected argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "${cli_agents[*]-}" ]; then
+  selected_agents=("${cli_agents[@]}")
+elif [ -n "${CATALOG_PROBE_AGENTS:-}" ]; then
+  add_agent_list selected_agents "$CATALOG_PROBE_AGENTS"
+else
+  selected_agents=("${default_agents[@]}")
+fi
+
+agent_selected() {
+  local candidate="$1" selected
+  for selected in "${selected_agents[@]}"; do
+    [ "$selected" = "$candidate" ] && return 0
+  done
+  return 1
+}
+
+if agent_selected cursor && [ "$include_cursor" != "1" ]; then
+  echo "cursor probing is opt-in; select it together with --include-cursor" >&2
+  exit 2
+fi
+if [ "$include_cursor" = "1" ] && ! agent_selected cursor; then
+  add_agent selected_agents cursor
+fi
 
 [ -f "$SECRETS" ] && source "$SECRETS"
 
-echo "── building anyharness"
+mkdir -p "$LOGS"
+rm -f "$LOGS"/*.log "$LOGS"/*.timeout "$STATE" "$CANDIDATE"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'startedAt=%s\n' "$started_at" > "$STATE"
+
+contexts_for_agent() {
+  case "$1" in
+    claude) echo "claude.anthropic-api claude.anthropic-oauth claude.bedrock" ;;
+    codex) echo "codex.openai-api codex.openai-oauth codex.bedrock" ;;
+    opencode) echo "opencode.baseline opencode.anthropic-api opencode.openai-api opencode.gemini-api opencode.opencode-zen" ;;
+    grok) echo "grok.xai-api" ;;
+    cursor) echo "cursor.cursor-login" ;;
+  esac
+}
+
+required_contexts=()
+for agent in "${selected_agents[@]}"; do
+  for id in $(contexts_for_agent "$agent"); do
+    required_contexts+=("$id")
+  done
+done
+for agent in "${known_agents[@]}"; do
+  if ! agent_selected "$agent"; then
+    for id in $(contexts_for_agent "$agent"); do
+      printf 'retained=%s\n' "$id" >> "$STATE"
+    done
+    echo "── retain $agent at its existing catalog pin"
+  fi
+done
+for id in "${required_contexts[@]}"; do
+  printf 'required=%s\n' "$id" >> "$STATE"
+done
+
+need_env() { [ -n "${!1:-}" ]; }
+codex_oauth_path() {
+  printf '%s' "${PROBE_CODEX_OAUTH_AUTH_JSON:-$HOME/.codex/auth.json}"
+}
+context_available() {
+  case "$1" in
+    claude.anthropic-api|opencode.anthropic-api) need_env ANTHROPIC_API_KEY ;;
+    claude.anthropic-oauth) need_env CLAUDE_CODE_OAUTH_TOKEN ;;
+    claude.bedrock|codex.bedrock) need_env AWS_BEARER_TOKEN_BEDROCK ;;
+    codex.openai-api|opencode.openai-api) need_env OPENAI_API_KEY ;;
+    codex.openai-oauth) [ -f "$(codex_oauth_path)" ] ;;
+    opencode.baseline) return 0 ;;
+    opencode.gemini-api) need_env GEMINI_API_KEY ;;
+    opencode.opencode-zen) need_env OPENCODE_API_KEY ;;
+    grok.xai-api) need_env XAI_API_KEY ;;
+    cursor.cursor-login) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+context_requirement() {
+  case "$1" in
+    claude.anthropic-api|opencode.anthropic-api) echo "ANTHROPIC_API_KEY" ;;
+    claude.anthropic-oauth) echo "CLAUDE_CODE_OAUTH_TOKEN" ;;
+    claude.bedrock|codex.bedrock) echo "AWS_BEARER_TOKEN_BEDROCK" ;;
+    codex.openai-api|opencode.openai-api) echo "OPENAI_API_KEY" ;;
+    codex.openai-oauth) echo "PROBE_CODEX_OAUTH_AUTH_JSON (a readable codex auth.json)" ;;
+    opencode.gemini-api) echo "GEMINI_API_KEY" ;;
+    opencode.opencode-zen) echo "OPENCODE_API_KEY" ;;
+    grok.xai-api) echo "XAI_API_KEY" ;;
+    cursor.cursor-login) echo "a working machine-local cursor-agent login" ;;
+    *) echo "no credential" ;;
+  esac
+}
+
+missing=()
+for id in "${required_contexts[@]}"; do
+  if ! context_available "$id"; then
+    missing+=("$id")
+    printf 'missing=%s\n' "$id" >> "$STATE"
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ] && [ "$allow_partial" -ne 1 ]; then
+  echo "catalog probe preflight failed; required contexts are unavailable:" >&2
+  for id in "${missing[@]}"; do
+    echo "  - $id: $(context_requirement "$id")" >&2
+  done
+  printf 'complete=false\n' >> "$STATE"
+  echo "Use --allow-partial for diagnostics only; partial runs are not promotable." >&2
+  exit 2
+fi
+
+active_agents=()
+add_active_agent() {
+  local candidate="$1" existing
+  # Bash 3.2 treats an empty array expansion as unbound under `set -u`.
+  # macOS still ships that Bash version, so guard the first insertion.
+  for existing in "${active_agents[@]-}"; do
+    [ "$existing" = "$candidate" ] && return
+  done
+  active_agents+=("$candidate")
+}
+for id in "${required_contexts[@]}"; do
+  if context_available "$id"; then
+    add_active_agent "${id%%.*}"
+  fi
+done
+if [ "${#active_agents[@]}" -eq 0 ]; then
+  printf 'complete=false\n' >> "$STATE"
+  echo "no probe contexts are available" >&2
+  exit 2
+fi
+for agent in "${active_agents[@]}"; do
+  printf 'agent=%s\n' "$agent" >> "$STATE"
+done
+agent_csv="$(IFS=,; echo "${active_agents[*]}")"
+
+catalog_backup="$(mktemp)" || exit 1
+cp "$CATALOG" "$catalog_backup" || exit 1
+restore_catalog() {
+  cp "$catalog_backup" "$CATALOG"
+  rm -f "$catalog_backup"
+}
+trap restore_catalog EXIT
+
+echo "── resolving exact pins before installation ($agent_csv)"
+node "$ROOT/scripts/agent-catalog/resolve-pins.mjs" \
+  --catalog "$CATALOG" \
+  --registry "$REGISTRY" \
+  --reuse-from "$CATALOG" \
+  --agent "$agent_csv" || exit 1
+cp "$CATALOG" "$CANDIDATE" || exit 1
+
+echo "── building anyharness against the resolved lockfile"
 (cd "$ROOT/anyharness" && cargo build -q -p anyharness) || exit 1
 
-echo "── reconciling harness installs"
-"$BIN" install-agents 2>/dev/null | grep -E "^agent=" || true
+echo "── reconciling resolved harness installs"
+install_args=()
+for agent in "${active_agents[@]}"; do
+  install_args+=(--agent "$agent")
+done
+"$BIN" install-agents "${install_args[@]}" || exit 1
 
-mkdir -p "$LOGS"
-rm -f "$LOGS"/*.log
-
-skipped=0
 pids=()
 labels=()
 logs=()
+ids=()
 
 probe() { # probe <agent> <context> [extra args...]
-  local agent="$1" context="$2"; shift 2
-  local log="$LOGS/$agent.$context.log"
-  echo "── probe $agent × $context"
-  RUST_LOG=warn "$BIN" catalog-probe --agent "$agent" --auth-context "$context" "$@" \
-    > "$log" 2>&1 &
-  pids+=($!)
+  local agent="$1" context="$2" timeout log snapshot; shift 2
+  log="$LOGS/$agent.$context.log"
+  snapshot="$GENERATED/$agent.$context.probe.json"
+  timeout="${CATALOG_PROBE_TIMEOUT_SECS:-300}"
+  [ "$agent" = "cursor" ] && timeout="${CATALOG_CURSOR_PROBE_TIMEOUT_SECS:-60}"
+  rm -f "$snapshot" "$log.timeout"
+  echo "── probe $agent × $context (timeout ${timeout}s)"
+  RUST_LOG=warn python3 "$TIMEOUT_RUNNER" "$timeout" \
+    "$BIN" catalog-probe --agent "$agent" --auth-context "$context" \
+    --out "$GENERATED" "$@" > "$log" 2>&1 &
+  pids+=("$!")
   labels+=("$agent × $context")
   logs+=("$log")
+  ids+=("$agent.$context")
 }
 
-skip() { echo "── skip $1 × $2 ($3)"; skipped=$((skipped + 1)); }
-
-need_env() { [ -n "${!1:-}" ]; }
+skip() {
+  echo "── skip $1 ($2)"
+  printf 'skipped=%s\n' "$1" >> "$STATE"
+}
 
 CLAUDE_TRIALS=(--trial-model claude-fable-5 --trial-model claude-opus-4-8)
 BEDROCK_TRIALS=(--trial-model global.anthropic.claude-fable-5 --trial-model us.anthropic.claude-opus-4-8)
 
-if need_env ANTHROPIC_API_KEY; then
-  probe claude anthropic-api "${CLAUDE_TRIALS[@]}"
-else skip claude anthropic-api "ANTHROPIC_API_KEY not set"; fi
-
-if need_env CLAUDE_CODE_OAUTH_TOKEN; then
-  probe claude anthropic-oauth "${CLAUDE_TRIALS[@]}"
-else skip claude anthropic-oauth "CLAUDE_CODE_OAUTH_TOKEN not set (run \`claude setup-token\`)"; fi
-
-if need_env AWS_BEARER_TOKEN_BEDROCK; then
-  probe claude bedrock "${BEDROCK_TRIALS[@]}"
-else skip claude bedrock "AWS_BEARER_TOKEN_BEDROCK not set (Bedrock API key)"; fi
-
-if need_env OPENAI_API_KEY; then
-  probe codex openai-api
-else skip codex openai-api "OPENAI_API_KEY not set"; fi
-
-if [ -f "${PROBE_CODEX_OAUTH_AUTH_JSON:-$HOME/.codex/auth.json}" ]; then
-  probe codex openai-oauth
-else skip codex openai-oauth "no codex auth.json (run \`codex login\`)"; fi
-
-if need_env AWS_BEARER_TOKEN_BEDROCK; then
-  probe codex bedrock
-else skip codex bedrock "AWS_BEARER_TOKEN_BEDROCK not set (Bedrock API key)"; fi
-
-probe opencode baseline --model-switch-timeout-secs 6
-if need_env ANTHROPIC_API_KEY; then
-  probe opencode anthropic-api --model-switch-timeout-secs 6
-else skip opencode anthropic-api "ANTHROPIC_API_KEY not set"; fi
-if need_env OPENAI_API_KEY; then
-  probe opencode openai-api --model-switch-timeout-secs 6
-else skip opencode openai-api "OPENAI_API_KEY not set"; fi
-if need_env GEMINI_API_KEY; then
-  probe opencode gemini-api --model-switch-timeout-secs 6
-else skip opencode gemini-api "GEMINI_API_KEY not set"; fi
-if need_env OPENCODE_API_KEY; then
-  probe opencode opencode-zen --model-switch-timeout-secs 6
-else skip opencode opencode-zen "OPENCODE_API_KEY not set (opencode zen subscription)"; fi
-
-# cursor: machine login (keychain); probe fails cleanly if not logged in
-probe cursor cursor-login --model-switch-timeout-secs 5
-
-if need_env XAI_API_KEY; then
-  probe grok xai-api --model-switch-timeout-secs 3
-else skip grok xai-api "XAI_API_KEY not set (xAI Grok)"; fi
+if agent_selected claude; then
+  if context_available claude.anthropic-api; then
+    probe claude anthropic-api "${CLAUDE_TRIALS[@]}"
+  else
+    skip claude.anthropic-api "$(context_requirement claude.anthropic-api)"
+  fi
+  if context_available claude.anthropic-oauth; then
+    probe claude anthropic-oauth "${CLAUDE_TRIALS[@]}"
+  else
+    skip claude.anthropic-oauth "$(context_requirement claude.anthropic-oauth)"
+  fi
+  if context_available claude.bedrock; then
+    probe claude bedrock "${BEDROCK_TRIALS[@]}"
+  else
+    skip claude.bedrock "$(context_requirement claude.bedrock)"
+  fi
+fi
+if agent_selected codex; then
+  if context_available codex.openai-api; then
+    probe codex openai-api
+  else
+    skip codex.openai-api "$(context_requirement codex.openai-api)"
+  fi
+  if context_available codex.openai-oauth; then
+    probe codex openai-oauth
+  else
+    skip codex.openai-oauth "$(context_requirement codex.openai-oauth)"
+  fi
+  if context_available codex.bedrock; then
+    probe codex bedrock
+  else
+    skip codex.bedrock "$(context_requirement codex.bedrock)"
+  fi
+fi
+if agent_selected opencode; then
+  probe opencode baseline --model-switch-timeout-secs 6
+  if context_available opencode.anthropic-api; then
+    probe opencode anthropic-api --model-switch-timeout-secs 6
+  else
+    skip opencode.anthropic-api "$(context_requirement opencode.anthropic-api)"
+  fi
+  if context_available opencode.openai-api; then
+    probe opencode openai-api --model-switch-timeout-secs 6
+  else
+    skip opencode.openai-api "$(context_requirement opencode.openai-api)"
+  fi
+  if context_available opencode.gemini-api; then
+    probe opencode gemini-api --model-switch-timeout-secs 6
+  else
+    skip opencode.gemini-api "$(context_requirement opencode.gemini-api)"
+  fi
+  if context_available opencode.opencode-zen; then
+    probe opencode opencode-zen --model-switch-timeout-secs 6
+  else
+    skip opencode.opencode-zen "$(context_requirement opencode.opencode-zen)"
+  fi
+fi
+if agent_selected grok; then
+  if context_available grok.xai-api; then
+    probe grok xai-api --model-switch-timeout-secs 3
+  else
+    skip grok.xai-api "$(context_requirement grok.xai-api)"
+  fi
+fi
+if agent_selected cursor; then
+  probe cursor cursor-login --model-switch-timeout-secs 5
+fi
 
 echo "── waiting on ${#pids[@]} probes"
 failures=0
 for i in "${!pids[@]}"; do
   if wait "${pids[$i]}"; then
     echo "✓ ${labels[$i]}"
+    printf 'passed=%s\n' "${ids[$i]}" >> "$STATE"
   else
-    echo "✗ ${labels[$i]} FAILED — $(tail -1 "${logs[$i]}" 2>/dev/null | cut -c1-160)"
+    code=$?
+    if [ "$code" -eq 124 ]; then
+      echo "✗ ${labels[$i]} TIMED OUT"
+    else
+      echo "✗ ${labels[$i]} FAILED — $(tail -1 "${logs[$i]}" 2>/dev/null | cut -c1-160)"
+    fi
     echo "  log: ${logs[$i]}"
+    printf 'failed=%s\n' "${ids[$i]}" >> "$STATE"
     failures=$((failures + 1))
   fi
 done
 
-echo "── done: ${failures} failed, ${skipped} skipped"
+if [ "$failures" -eq 0 ] && [ "${#missing[@]}" -eq 0 ]; then
+  printf 'complete=true\n' >> "$STATE"
+  echo "── complete authoritative probe run"
+  exit 0
+fi
+
+printf 'complete=false\n' >> "$STATE"
+echo "── diagnostic run only: ${failures} failed, ${#missing[@]} unavailable"
+[ "$failures" -eq 0 ] && exit 0
 exit "$failures"

--- a/scripts/agent-catalog/run-probes.test.mjs
+++ b/scripts/agent-catalog/run-probes.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const sourceDir = dirname(fileURLToPath(import.meta.url));
+const sourceScript = join(sourceDir, "run-probes.sh");
+
+function runPreflight(args = [], extraEnv = {}) {
+  const root = mkdtempSync(join(tmpdir(), "catalog-probe-selection-"));
+  const scriptDir = join(root, "scripts", "agent-catalog");
+  const home = join(root, "home");
+  mkdirSync(scriptDir, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  cpSync(sourceScript, join(scriptDir, "run-probes.sh"));
+  const result = spawnSync("bash", [join(scriptDir, "run-probes.sh"), ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      HOME: home,
+      PATH: process.env.PATH,
+      ...extraEnv,
+    },
+  });
+  const statePath = join(scriptDir, "generated", ".probe-logs", "run.state");
+  let state = "";
+  try {
+    state = readFileSync(statePath, "utf8");
+  } catch {}
+  rmSync(root, { recursive: true, force: true });
+  return { ...result, state };
+}
+
+function stateValues(state, key) {
+  return state
+    .split("\n")
+    .filter((line) => line.startsWith(`${key}=`))
+    .map((line) => line.slice(key.length + 1));
+}
+
+test("a Codex-only run requires every Codex context and no unrelated credentials", () => {
+  const result = runPreflight(["--agent", "codex"]);
+
+  assert.equal(result.status, 2);
+  assert.deepEqual(stateValues(result.state, "required"), [
+    "codex.openai-api",
+    "codex.openai-oauth",
+    "codex.bedrock",
+  ]);
+  assert.match(result.stderr, /codex\.openai-api/);
+  assert.match(result.stderr, /codex\.openai-oauth/);
+  assert.match(result.stderr, /codex\.bedrock/);
+  assert.doesNotMatch(result.stderr, /claude\.|opencode\.|grok\.|cursor\./);
+  assert.ok(stateValues(result.state, "retained").includes("claude.anthropic-api"));
+  assert.ok(stateValues(result.state, "retained").includes("cursor.cursor-login"));
+});
+
+test("CATALOG_PROBE_AGENTS accepts a comma-separated focused selection", () => {
+  const result = runPreflight([], { CATALOG_PROBE_AGENTS: "codex,grok" });
+
+  assert.equal(result.status, 2);
+  assert.deepEqual(stateValues(result.state, "required"), [
+    "codex.openai-api",
+    "codex.openai-oauth",
+    "codex.bedrock",
+    "grok.xai-api",
+  ]);
+  assert.doesNotMatch(result.stderr, /claude\.|opencode\.|cursor\./);
+});
+
+test("a credential-complete focused run selects its active agent on Bash 3.2", () => {
+  const result = runPreflight(["--agent", "codex"], {
+    OPENAI_API_KEY: "test-openai-key",
+    AWS_BEARER_TOKEN_BEDROCK: "test-bedrock-token",
+    PROBE_CODEX_OAUTH_AUTH_JSON: sourceScript,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(stateValues(result.state, "agent"), ["codex"]);
+  assert.doesNotMatch(result.stderr, /active_agents\[@\]: unbound variable/);
+});
+
+test("agent selections reject unknown names before changing probe state", () => {
+  const result = runPreflight(["--agent=not-a-harness"]);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /unknown catalog probe agent 'not-a-harness'/);
+  assert.equal(result.state, "");
+});
+
+test("Cursor remains opt-in even when it is explicitly selected", () => {
+  const result = runPreflight(["--agent", "cursor"]);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /cursor probing is opt-in/);
+  assert.equal(result.state, "");
+});
+
+test("the default authoritative selection retains Cursor", () => {
+  const result = runPreflight();
+
+  assert.equal(result.status, 2);
+  assert.ok(stateValues(result.state, "required").includes("claude.anthropic-api"));
+  assert.ok(stateValues(result.state, "required").includes("codex.openai-api"));
+  assert.ok(stateValues(result.state, "required").includes("opencode.baseline"));
+  assert.ok(stateValues(result.state, "required").includes("grok.xai-api"));
+  assert.ok(!stateValues(result.state, "required").includes("cursor.cursor-login"));
+  assert.ok(stateValues(result.state, "retained").includes("cursor.cursor-login"));
+});

--- a/scripts/agent-catalog/run-with-timeout.py
+++ b/scripts/agent-catalog/run-with-timeout.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run a command with a wall-clock timeout and terminate its process group."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: run-with-timeout.py <seconds> <command> [args...]", file=sys.stderr)
+        return 2
+
+    timeout_seconds = float(sys.argv[1])
+    process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+        print(
+            f"command timed out after {timeout_seconds:g}s: {sys.argv[2]}",
+            file=sys.stderr,
+        )
+        return 124
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-cd/detect-deploy-surfaces.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.mjs
@@ -183,6 +183,7 @@ export function classifyFile(path) {
       "apps/desktop",
       "apps/packages",
       "anyharness",
+      "catalogs/agents",
     ]) ||
     [
       "Cargo.lock",

--- a/scripts/ci-cd/detect-deploy-surfaces.test.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildResult,
+  classifyFile,
   parseSurfaceList,
   selectSurfaces,
 } from "./detect-deploy-surfaces.mjs";
@@ -67,6 +68,15 @@ test("litellm config changes select the litellm surface", () => {
   });
 
   assert.deepEqual([...selection.selected].sort(), ["litellm", "server"]);
+});
+
+test("agent catalog changes select desktop seed and runtime surfaces", () => {
+  assert.deepEqual([...classifyFile("catalogs/agents/catalog.json")].sort(), [
+    "desktop",
+    "e2b",
+    "runtime",
+    "server",
+  ]);
 });
 
 test("invalid surfaces fail fast", () => {

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -23,7 +23,7 @@ anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 15
 anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 680 existing AnyHarness oversized test file
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
-anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 654 catalog probe with per-harness model-source fallbacks and tests
+anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 774 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 773 existing generated cloud SDK type surface (+billing budget-limit/usage types)
@@ -32,7 +32,7 @@ anyharness/sdk/src/reducer/transcript.ts 1591 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 622 existing desktop diff viewer component
 apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
-apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 885 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock
+apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 900 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file

--- a/scripts/validate-agent-catalog.mjs
+++ b/scripts/validate-agent-catalog.mjs
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const CATALOG_PATH = path.resolve("catalogs/agents/catalog.json");
+const DRAFT_PATH = path.resolve("scripts/agent-catalog/catalog.draft.json");
 const REGISTRY_PATH = path.resolve("catalogs/agents/registry.json");
 const VALID_AGENT_KINDS = new Set(["claude", "codex", "cursor", "opencode", "grok"]);
 const VALID_STATUSES = new Set(["candidate", "active", "deprecated", "hidden"]);
@@ -233,6 +234,15 @@ function validateAgentSettings(kind, settings) {
 }
 
 function validateRegistryPairing(catalog, registry) {
+  if (typeof registry.registryVersion !== "string" || !registry.registryVersion.trim()) {
+    fail("registryVersion must be a non-empty string");
+  }
+  if (catalog.probedAgainst?.registryVersion !== registry.registryVersion) {
+    fail(
+      `catalog probedAgainst.registryVersion '${catalog.probedAgainst?.registryVersion}' ` +
+      `does not match registryVersion '${registry.registryVersion}'`,
+    );
+  }
   const registryAgents = new Map((registry.agents ?? []).map((agent) => [agent.kind, agent]));
   for (const agent of catalog.agents ?? []) {
     if (!registryAgents.has(agent.kind)) {
@@ -241,7 +251,12 @@ function validateRegistryPairing(catalog, registry) {
   }
 }
 
-const catalog = JSON.parse(fs.readFileSync(CATALOG_PATH, "utf8"));
+const catalogRaw = fs.readFileSync(CATALOG_PATH, "utf8");
+const draftRaw = fs.readFileSync(DRAFT_PATH, "utf8");
+if (catalogRaw !== draftRaw) {
+  fail("catalog.draft.json must exactly match the bundled catalog.json lockfile");
+}
+const catalog = JSON.parse(catalogRaw);
 const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8"));
 validateCatalog(catalog);
 validateRegistryPairing(catalog, registry);

--- a/specs/codebase/features/chat-composer.md
+++ b/specs/codebase/features/chat-composer.md
@@ -94,6 +94,41 @@ Any provider-specific compatibility mapping in Desktop must be backed by a
 domain-level selector test and, when possible, a recorded AnyHarness fixture
 showing the raw session values that required the mapping.
 
+## 1.2 Session control placement
+
+The chat and Home composers use the same control partition and visible order:
+
+1. model/harness selector
+2. one reasoning-level control rendered as increasing bars (`effort` takes
+   precedence over `reasoning` when both describe the same tuning dimension)
+3. `fast_mode` rendered as the zap control
+4. the primary working mode selector
+
+Reasoning/effort renders as bars only; its level remains available through a
+`Reasoning: <level>` tooltip and accessible label. The primary working mode is
+compact text plus a subtle disclosure chevron, without a leading mode icon.
+The Fast zap remains visibly outlined when off, then fills and uses the active
+control treatment when on.
+
+Visible controls use one consistent inter-item rhythm. Compact controls must
+not reserve a trailing pending-state slot when no pending state exists; that
+empty flex child shifts icon-only controls and creates uneven visual gaps.
+
+`collaboration_mode` is the primary working mode whenever it exposes a choice.
+Otherwise a legacy fused `mode` control is primary only when its choices carry
+working-mode semantics such as plan, agent, ask, build, bypass, or chat. This
+keeps Codex's collaboration mode independent from its read-only/auto/full-access
+permissions while preserving harnesses such as Claude, Cursor, and OpenCode
+whose working and access behavior still share one mode control.
+
+Permission/access mode and every other unclaimed configuration control render
+only under the rightmost three-dot configuration menu. A reasoning-level
+control with two or more ordered values remains visible as disabled bars when
+the runtime reports it as non-settable. Cowork hides the permission/access
+`mode` because its access policy is product-defined, but retains independent
+working-mode controls such as `collaboration_mode` together with reasoning and
+fast-mode controls.
+
 ## 2. Dock Regions
 
 `resolveComposerDockSlots`

--- a/specs/codebase/features/settings-admin-ia.md
+++ b/specs/codebase/features/settings-admin-ia.md
@@ -76,6 +76,11 @@ Three rules every settings page follows:
 3. Page chrome uses SettingsPageHeader + SettingsSection + SettingsRow
    (from @proliferate/product-ui/settings). New pages do not invent
    new wrappers.
+
+4. The Agents `Local` surface remains useful without a Cloud session. Its
+   model list comes directly from the local AnyHarness launch catalog; Cloud
+   sign-in gates the `Cloud` surface, gateway management, catalog overrides,
+   and other Cloud-backed mutations, not local model discovery.
 ```
 
 Ownership rule:

--- a/specs/codebase/primitives/agent-catalog-readiness.md
+++ b/specs/codebase/primitives/agent-catalog-readiness.md
@@ -19,11 +19,14 @@ It does not answer:
 - how to speak provider-specific CLI, ACP registry, or MCP protocols
 - how a session actor processes turns
 
-AnyHarness uses two bundled, versioned agent inputs and does not support remote
-model/launch catalog paths. `catalog.json` owns model/mode/control metadata;
-`registry.json` owns trusted runtime behavior such as install, launch, auth
-slots, and materialization policy. Credentials, readiness resolution, reconcile
-execution, install, seed, and portability code live outside `catalog/**`.
+AnyHarness starts from two bundled, versioned agent inputs and does not support
+remote model/launch URL configuration. `catalog.json` owns
+model/mode/control metadata and exact artifact pins; its validated active
+document may be replaced by control-plane catalog sync. `registry.json` owns
+trusted runtime behavior such as install, launch, auth slots, and
+materialization policy and remains compiled/bundled with the runtime.
+Credentials, readiness resolution, reconcile execution, install, seed, and
+portability code live outside `catalog/**`.
 
 ## Truth Sources
 
@@ -58,8 +61,8 @@ Consequences:
   must not mutate the bundled catalog or influence trusted executable behavior.
 - A live session's active model/config truth comes from ACP live config, not
   from the static AnyHarness catalog.
-- AnyHarness catalog endpoints, if exposed, are target capability/readiness
-  endpoints, not the primary product UI catalog.
+- Runtime catalog sync/version endpoints are control-plane convergence
+  transport, not the primary product UI catalog.
 
 ## Bundled Agent Inputs
 
@@ -99,11 +102,17 @@ old model/launch cache writers
 split launch catalog directory
 ```
 
-Runtime catalog refresh/fetch/cache behavior is not supported in the migrated
-runtime. The bundled `AgentCatalogDocument` and `AgentRegistryDocument` are the
-only runtime agent inputs. Dynamic model refresh is a separate
-`model_registry/**` concern and stores target-local snapshots in SQLite; it must
-not rewrite catalog or registry JSON.
+The runtime does not fetch arbitrary catalog URLs or accept a remotely supplied
+registry. It boots from the bundled `AgentCatalogDocument` and
+`AgentRegistryDocument`. Cloud convergence may replace only the active catalog:
+the worker compares `catalogVersion`, fetches the server-owned document, and
+submits it to the runtime's validated catalog-apply endpoint. A successful
+activation persists the active catalog and starts installed-only reconcile.
+The trusted registry remains the compiled/bundled method boundary throughout.
+
+Dynamic model refresh is a separate `model_registry/**` concern and stores
+target-local snapshots in SQLite; it must not rewrite the active agent catalog
+or bundled registry.
 
 ## Trust Boundary
 
@@ -137,6 +146,57 @@ This boundary should be visible in code. The projection that produces
 `AgentDescriptor` is sourced from trusted registry data only (method, auth,
 launch). Catalog data enriches it with the resolved, sha-anchored version pin
 and model/control display options.
+
+## Catalog Producer And Promotion
+
+New upstream versions are discovered and promoted through the repository
+pipeline, never by a runtime install:
+
+```text
+resolve exact pins for selected agents
+  -> compile AnyHarness with that candidate lockfile
+  -> reconcile/install those exact artifacts
+  -> probe every configured required auth context
+  -> collate only snapshots passed by this run
+  -> finalize exact candidate pins only for freshly probed agents
+  -> copy inactive/retained agents unchanged from the prior lockfile
+  -> make catalog.draft.json and catalog.json byte-identical
+```
+
+`make catalog-update` is the authoritative path. With no selector it updates
+Claude, Codex, OpenCode, and Grok. A focused authoritative update uses an
+explicit agent selection:
+
+```bash
+make catalog-update CATALOG_PROBE_AGENTS=codex
+# Equivalent direct-script form:
+./scripts/agent-catalog/run-probes.sh --agent codex
+```
+
+`CATALOG_PROBE_AGENTS` accepts comma-separated agent kinds, and `--agent` may
+be repeated or given a comma-separated value. Every configured auth context
+for every selected agent remains mandatory; a focused run does not turn those
+contexts into an optional subset. The complete-probe builder rebuilds only the
+selected agents from snapshots passed by that run and copies every unselected
+agent unchanged from the prior bundled lockfile.
+
+Missing credentials, install failures, probe failures, and probe timeouts stop
+promotion. Cursor is retained at its existing pin unless the run explicitly
+selects it and opts in on a machine with a working machine-local Cursor login:
+
+```bash
+make catalog-update CATALOG_PROBE_AGENTS=cursor \
+  CATALOG_PROBE_ARGS=--include-cursor
+```
+
+`--allow-partial` is diagnostic only; the same mode is available as
+`ALLOW_PARTIAL=1`. The complete-probe gate refuses to promote its output, and
+`catalog-pin` refuses an incomplete local probe state.
+
+`catalogVersion` changes with catalog content. `registryVersion` changes with
+registry content, and `probedAgainst.registryVersion` must pair the promoted
+catalog with that registry version. CI enforces those version bumps and exact
+draft/bundled equality.
 
 ## Source Shape
 
@@ -333,7 +393,13 @@ flag: full (install missing too) or installed-only (only update agents already o
 disk; skip missing ones). The runtime drives an installed-only reconcile at
 startup (`AgentRuntime::spawn_startup_pass`, after seed hydration) so installed
 agents track the catalog pins on desktop and cloud workers — non-blocking,
-best-effort, idempotent.
+best-effort, idempotent. Activating a validated synced catalog also starts an
+installed-only reconcile so already-managed artifacts converge to its pins.
+An existing executable is not proof of convergence: when a catalog pin exists
+but the durable install manifest has no comparable version, reconcile forces a
+reinstall. Binary/archive roles compare the declared version; git roles compare
+the immutable git ref while ACP attestation separately verifies the package's
+human-readable version.
 
 It should not own per-provider install mechanics.
 
@@ -439,8 +505,10 @@ After live session starts:
 
 ## Public API Behavior
 
-AnyHarness does not expose public runtime catalog endpoints in this migration.
-The remaining public target capability endpoints are:
+AnyHarness exposes transport-authenticated catalog version/apply endpoints for
+control-plane convergence. They report/replace the validated active lockfile;
+they are not product catalog browsing APIs and cannot replace the trusted
+registry. The user-facing target capability endpoints remain:
 
 - agent list/readiness endpoint: target-local support and readiness
 - install endpoint: mutate target-local managed artifacts

--- a/specs/codebase/structures/desktop-native/specs/anyharness-sidecar.md
+++ b/specs/codebase/structures/desktop-native/specs/anyharness-sidecar.md
@@ -35,6 +35,12 @@ The Proliferate Worker binary follows the same staging/bundling model, but it
 is not the AnyHarness sidecar. It is launched on demand by desktop dispatch
 logic in `commands/cloud_worker.rs`.
 
+Desktop worker config must set `runtime_base_url` from the current
+`SharedSidecar.info.url`. The sidecar normally uses a dynamically selected
+loopback port (and may use `ANYHARNESS_DEV_URL` in development), so the worker
+must not rely on its sandbox-oriented `127.0.0.1:8457` default when connecting
+to the local runtime for catalog convergence or command delivery.
+
 ## Boot Flow
 
 1. `lib.rs` calls `sidecar::create_sidecar_with_auto_port()`.

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -722,8 +722,8 @@
 - name: ANTHROPIC_API_KEY
   secret: true
   default: ""
-  description: Anthropic API key for AI session title generation
-  tags: [local-dev, self-hosted, production]
+  description: Anthropic API key for AI session title generation and catalog probe contexts
+  tags: [local-dev, self-hosted, production, ci]
 
 - name: AI_MAGIC_SESSION_TITLE_MODEL
   secret: false
@@ -736,9 +736,54 @@
 # ═══════════════════════════════════════════════════════════════════════
 # Provider credentials consumed only by the nightly catalog-probe workflow
 # (.github/workflows/catalog-probe.yml) to enumerate each harness's models.
-# NOTE: the other probe provider secrets (OPENAI_API_KEY, GEMINI_API_KEY,
-# CURSOR_API_KEY, CLAUDE_CODE_OAUTH_TOKEN) are also CI-only and not yet
-# enumerated here — a pre-existing gap, tracked separately.
+
+- name: CATALOG_PROBE_AGENTS
+  secret: false
+  default: ""
+  description: Optional comma-separated agent kinds for a focused authoritative catalog update; blank selects every non-Cursor agent
+  tags: [local-dev, ci]
+
+- name: CATALOG_PROBE_CURSOR
+  secret: false
+  default: "0"
+  description: Explicit opt-in for Cursor catalog probes; Cursor still requires a working machine-local login
+  tags: [local-dev, ci]
+
+- name: CLAUDE_CODE_OAUTH_TOKEN
+  secret: true
+  default: ""
+  description: Claude Code OAuth token used only by the catalog probe's Anthropic OAuth context
+  tags: [ci]
+
+- name: OPENAI_API_KEY
+  secret: true
+  default: ""
+  description: OpenAI API key used by the catalog probe's Codex and OpenCode contexts
+  tags: [ci]
+
+- name: CODEX_AUTH_JSON_B64
+  secret: true
+  default: ""
+  description: Base64-encoded Codex auth.json used only by the catalog probe's OpenAI OAuth context
+  tags: [ci]
+
+- name: GEMINI_API_KEY
+  secret: true
+  default: ""
+  description: Gemini API key used by the catalog probe's OpenCode Gemini context
+  tags: [ci]
+
+- name: OPENCODE_API_KEY
+  secret: true
+  default: ""
+  description: OpenCode Zen subscription key used by the catalog probe's Zen context
+  tags: [ci]
+
+- name: AWS_BEARER_TOKEN_BEDROCK
+  secret: true
+  default: ""
+  description: Bedrock bearer token used by the catalog probe's Claude and Codex Bedrock contexts
+  tags: [ci]
 
 - name: XAI_API_KEY
   secret: true


### PR DESCRIPTION
## Summary

- expose reasoning effort, capability-gated Fast, and primary collaboration modes in the composer while keeping permission and secondary settings in overflow
- make signed-out Local agent settings list and refresh models from AnyHarness, and add a safe install/retry action for missing harnesses
- make catalog reconciliation replace managed artifacts whose installed version cannot be proven, and make focused catalog updates fail closed across every required auth context
- publish and pin codex-acp 0.17.0-proliferate.1 at 8baae512, update native Codex to rust-v0.144.1, and regenerate the catalog with Sol, Terra, Luna, Plan, Fast, and current effort matrices
- harden catalog CI/version discipline and use the runtime sidecar's actual dynamic port for local cloud workers

## Validation

- authoritative Codex probe: OpenAI API, OpenAI OAuth, and Bedrock passed
- catalog equality, schema validation, version discipline, YAML parse, max-lines, and credential-redaction passed
- 23 catalog/CI tests
- 86 AnyHarness catalog tests, 44 installer/reconcile tests, 5 probe tests
- 80 desktop settings/composer tests and 6 shared-control tests
- desktop and shared UI typechecks
- desktop native cloud-worker test
- codex-acp release matrix passed macOS, Linux, and Windows x64/ARM64