### PR TITLE
fix(desktop): make optimistic chat transitions transactional

### DIFF
--- a/apps/desktop/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/desktop/src/components/home/screen/HomeComposerForm.tsx
@@ -5,7 +5,6 @@ import { ChatComposerActions } from "@/components/workspace/chat/input/ChatCompo
 import { ChatComposerControlRowFrame } from "@proliferate/product-ui/chat/composer/ChatComposerControlRowFrame";
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
 import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
-import { UserMessage } from "@/components/workspace/chat/transcript/UserMessage";
 import { DebugProfiler } from "@/components/diagnostics/DebugProfiler";
 import { useHomeNextComposerState } from "@/hooks/home/ui/use-home-next-composer-state";
 import {
@@ -200,20 +199,6 @@ export function HomeComposerForm({
           {targetPickerSlot}
         </div>
       </DebugProfiler>
-
-      {composer.submittedPreview ? (
-        <div
-          key={composer.submittedPreview.id}
-          className="mt-5"
-          data-home-submit-preview
-        >
-          <UserMessage
-            sessionId={null}
-            content={composer.submittedPreview.text}
-            contentParts={[{ type: "text", text: composer.submittedPreview.text }]}
-          />
-        </div>
-      ) : null}
 
       {modelAvailabilityNoticeSlot}
 

--- a/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ReactNode, TextareaHTMLAttributes } from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "./HomeNextScreen";
 import { HOME_NEXT_TARGET_SELECTION_STORAGE_KEY } from "@/hooks/home/ui/use-home-next-target-selection-state";
@@ -158,28 +158,18 @@ vi.mock("@/components/workspace/chat/input/ChatComposerActions", () => ({
   ),
 }));
 
-vi.mock("@/components/workspace/chat/transcript/UserMessage", () => ({
-  UserMessage: ({ content }: { content: string }) => (
-    <div data-chat-user-message>{content}</div>
-  ),
-}));
-
 function installLocalStorageMock(options?: { throwOnSet?: boolean }) {
   const values = new Map<string, string>();
   Object.defineProperty(window, "localStorage", {
     configurable: true,
     value: {
-      get length() {
-        return values.size;
-      },
+      get length() { return values.size; },
       clear: () => values.clear(),
       getItem: (key: string) => values.get(key) ?? null,
       key: (index: number) => Array.from(values.keys())[index] ?? null,
       removeItem: (key: string) => values.delete(key),
       setItem: (key: string, value: string) => {
-        if (options?.throwOnSet) {
-          throw new Error("localStorage write failed");
-        }
+        if (options?.throwOnSet) throw new Error("localStorage write failed");
         values.set(key, String(value));
       },
     },
@@ -199,6 +189,14 @@ function resetHomeNext() {
   screenMocks.targetPickerProps = null;
   screenMocks.leadingControlsProps = null;
   screenMocks.trailingControlsProps = null;
+}
+
+function submitPrompt(text: string): HTMLTextAreaElement {
+  render(<HomeNextScreen />);
+  const prompt = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+  fireEvent.change(prompt, { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+  return prompt;
 }
 
 describe("HomeNextScreen model availability notices", () => {
@@ -282,20 +280,21 @@ describe("HomeNextScreen model availability notices", () => {
     expect(screen.getByText("Choose a repository")).toBeTruthy();
   });
 
-  it("does not render a submitted preview below the composer for cowork launches", () => {
-    render(<HomeNextScreen />);
-
-    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "start cowork" } });
-    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+  it("hands cowork prompts directly to launch without rendering a Home preview", () => {
+    submitPrompt("start cowork");
 
     expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
       text: "start cowork",
       target: { kind: "cowork" },
     }));
-    expect(screen.queryByText("start cowork")).toBeNull();
+    expect(document.querySelector("[data-home-submit-preview]")).toBeNull();
   });
 
-  it("keeps the submitted preview for repository launches", () => {
+  it("clears and hands a repository prompt off exactly once without waiting for a paint", async () => {
+    let resolveLaunch!: (succeeded: boolean) => void;
+    screenMocks.launch.mockReturnValue(new Promise<boolean>((resolve) => {
+      resolveLaunch = resolve;
+    }));
     screenMocks.homeNext.launchTarget = {
       kind: "worktree",
       repoRootId: "repo-root-1",
@@ -303,26 +302,54 @@ describe("HomeNextScreen model availability notices", () => {
       baseBranch: "main",
       defaultBranch: "main",
     };
-    render(<HomeNextScreen />);
+    const prompt = submitPrompt("start worktree");
+    fireEvent.submit(prompt.closest("form")!);
 
-    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "start worktree" } });
-    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    expect(prompt.value).toBe("");
+    expect(screenMocks.launch).toHaveBeenCalledTimes(1);
+    expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
+      text: "start worktree",
+      target: expect.objectContaining({ kind: "worktree" }),
+    }));
+    expect(document.querySelector("[data-home-submit-preview]")).toBeNull();
 
-    expect(screen.getByText("start worktree")).toBeTruthy();
+    resolveLaunch(true);
+    await waitFor(() => {
+      expect(screenMocks.launch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it.each([
+    { label: "returns false", fail: () => screenMocks.launch.mockResolvedValue(false) },
+    {
+      label: "rejects",
+      fail: () => screenMocks.launch.mockRejectedValue(new Error("unexpected launch failure")),
+    },
+  ])("restores the submitted draft when launch $label", async ({ fail }) => {
+    fail();
+    const prompt = submitPrompt("keep this draft");
+    await waitFor(() => expect(prompt.value).toBe("keep this draft"));
+    expect(document.querySelector("[data-home-submit-preview]")).toBeNull();
+  });
+
+  it("preserves a newer draft when the submitted launch fails", async () => {
+    let resolveLaunch!: (succeeded: boolean) => void;
+    screenMocks.launch.mockReturnValue(new Promise<boolean>((resolve) => {
+      resolveLaunch = resolve;
+    }));
+    const prompt = submitPrompt("launch this");
+    fireEvent.change(prompt, { target: { value: "newer draft" } });
+    await act(async () => {
+      resolveLaunch(false);
+    });
+    expect(prompt.value).toBe("newer draft");
+    expect(document.querySelector("[data-home-submit-preview]")).toBeNull();
   });
 
   it("renders onboarding cards as the only home onboarding actions", () => {
     screenMocks.onboardingCards.push(
-      {
-        id: "add-repository",
-        title: "Add a GitHub repo",
-        icon: "github",
-      },
-      {
-        id: "agent-defaults",
-        title: "Configure default harnesses",
-        icon: "sliders",
-      },
+      { id: "add-repository", title: "Add a GitHub repo", icon: "github" },
+      { id: "agent-defaults", title: "Configure default harnesses", icon: "sliders" },
     );
 
     render(<HomeNextScreen />);

--- a/apps/desktop/src/components/workspace/chat/ChatView.tsx
+++ b/apps/desktop/src/components/workspace/chat/ChatView.tsx
@@ -22,6 +22,7 @@ import { type ChatSurfaceState, useChatSurfaceState } from "@/hooks/chat/derived
 import {
   useActiveSessionId,
   useActiveSessionPromptCapabilities,
+  useSelectedWorkspaceUiKey,
 } from "@/hooks/chat/derived/use-active-session-identity";
 import { useChatAvailabilityState } from "@/hooks/chat/derived/use-chat-availability-state";
 import { useChatDockInset } from "@/hooks/chat/ui/use-chat-dock-inset";
@@ -112,7 +113,11 @@ export const ChatView = memo(function ChatView({
   const suppressSessionSlots = shellRenderSurface?.kind === "chat-shell"
     || shellRenderSurface?.kind === "chat-session-pending";
   const suppressComposerActiveSessionState = shellRenderSurface?.kind === "chat-session-pending";
+  const replacementSessionId = shellRenderSurface?.kind === "chat-session-pending"
+    ? shellRenderSurface.sessionId
+    : null;
   const activeSessionId = useActiveSessionId();
+  const workspaceUiKey = useSelectedWorkspaceUiKey();
   const activePromptCapabilities = useActiveSessionPromptCapabilities();
   const availability = useChatAvailabilityState();
   const queuedPromptEditStatus = useQueuedPromptEditStatus();
@@ -135,7 +140,7 @@ export const ChatView = memo(function ChatView({
     supportsAttachments,
   });
   const promptAttachments = useChatPromptAttachments({
-    activeSessionId,
+    scopeKey: workspaceUiKey,
     promptCapabilities,
     canAttachFiles: canAcceptFileDrop,
   });
@@ -160,9 +165,15 @@ export const ChatView = memo(function ChatView({
     <ChatInput
       attachments={promptAttachments}
       suppressActiveSessionState={suppressComposerActiveSessionState}
+      replacementSessionId={replacementSessionId}
       hasSessionTurns={hasSessionTurns}
     />
-  ), [hasSessionTurns, promptAttachments, suppressComposerActiveSessionState]);
+  ), [
+    hasSessionTurns,
+    promptAttachments,
+    replacementSessionId,
+    suppressComposerActiveSessionState,
+  ]);
 
   const handleFileDrag = useCallback((event: DragEvent<HTMLDivElement>) => {
     const dragInput = readFileDragInput(event.dataTransfer);

--- a/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ChatInput.tsx
@@ -65,10 +65,12 @@ const CHAT_INPUT_ATTACHMENT_ACCEPT =
 export function ChatInput({
   attachments,
   suppressActiveSessionState = false,
+  replacementSessionId = null,
   hasSessionTurns = false,
 }: {
   attachments: PromptAttachmentController;
   suppressActiveSessionState?: boolean;
+  replacementSessionId?: string | null;
   /** Flips the placeholder to the follow-up variant once the transcript has turns. */
   hasSessionTurns?: boolean;
 }) {
@@ -93,6 +95,7 @@ export function ChatInput({
   });
   const modelSelectorProps = useChatModelSelectorState({
     suppressActiveSessionState,
+    replacementSessionId,
   });
   const { agentKind, controls: sessionConfigControls, modeControl } = useChatSessionControls();
   const launchConfigControls = suppressActiveSessionState ? [] : modelSelectorProps.launchControls;
@@ -124,9 +127,11 @@ export function ChatInput({
     sdkWorkspaceId: materializedWorkspaceId,
   });
   const hasDraftAttachments = attachments.hasAttachments || planAttachments.hasPlans;
+  const hasSubmittableDraftAttachments =
+    attachments.hasSupportedAttachments || planAttachments.hasPlans;
   const effectiveIsEmpty = effectiveIsEditingQueuedPrompt
     ? editDraft.trim().length === 0
-    : isEmpty && !hasDraftAttachments;
+    : isEmpty && !hasSubmittableDraftAttachments;
   const canSubmit =
     !effectiveIsEmpty && !isDisabled && !isSubmitting;
   const canAcceptPastedAttachments =
@@ -191,7 +196,10 @@ export function ChatInput({
         finishOrCancelMeasurementOperation(measurementOperationId, "aborted");
         return;
       }
-      attachments.clearAttachments();
+      // A harness switch can temporarily make an existing attachment
+      // unsupported. Clear only attachments that were eligible for this send,
+      // leaving visible incompatible drafts available for another harness.
+      attachments.clearSubmittedAttachments(attachmentSnapshots);
       planAttachments.clearPlans();
     });
   }, [

--- a/apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PromptRecoveryPanel } from "@/components/workspace/chat/input/PromptRecoveryPanel";
+import type { ChatPromptRecovery } from "@/stores/chat/chat-prompt-recovery-store";
+import { createPromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+
+describe("PromptRecoveryPanel", () => {
+  it("identifies each failed prompt and retries the chosen one", () => {
+    const first = createRecovery("prompt-1", "Update the parser");
+    const second = createRecovery("prompt-2", "Run the integration tests");
+    const onRetry = vi.fn();
+
+    render(
+      <PromptRecoveryPanel
+        recoveries={[first, second]}
+        retryingId={null}
+        onRetry={onRetry}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Update the parser")).not.toBeNull();
+    expect(screen.getByText("Run the integration tests")).not.toBeNull();
+    expect(screen.getByRole("region", { name: "Messages not sent" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", {
+      name: "Retry unsent message: Run the integration tests",
+    }));
+    expect(onRetry).toHaveBeenCalledWith(second);
+  });
+});
+
+function createRecovery(id: string, text: string): ChatPromptRecovery {
+  return {
+    id,
+    workspaceId: "workspace-1",
+    agentKind: "claude",
+    modelId: "sonnet",
+    modeId: null,
+    errorMessage: "Session creation failed.",
+    prompt: createPromptOutboxEntry({
+      clientPromptId: id,
+      clientSessionId: "failed-replacement",
+      workspaceId: "workspace-1",
+      text,
+      blocks: [{ type: "text", text }],
+    }),
+  };
+}

--- a/apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { X } from "@proliferate/ui/icons";
+import { summarizeContentParts } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
+import { useChatPromptRecoveries } from "@/hooks/chat/derived/use-chat-prompt-recoveries";
+import { useChatPromptRecoveryActions } from "@/hooks/chat/workflows/use-chat-prompt-recovery-actions";
+import type { ChatPromptRecovery } from "@/stores/chat/chat-prompt-recovery-store";
+
+export function PromptRecoveryPanel({
+  recoveries,
+  retryingId,
+  onRetry,
+  onDismiss,
+}: {
+  recoveries: readonly ChatPromptRecovery[];
+  retryingId: string | null;
+  onRetry: (recovery: ChatPromptRecovery) => void;
+  onDismiss: (recoveryId: string) => void;
+}) {
+  if (recoveries.length === 0) {
+    return null;
+  }
+  return (
+    <div
+      className="relative overflow-hidden rounded-t-[13px] border-x-[0.5px] border-t-[0.5px] border-border bg-[color:color-mix(in_oklab,var(--color-foreground)_2%,var(--color-background))] px-1.5 py-1.5"
+      data-telemetry-mask
+      role="region"
+      aria-label="Messages not sent"
+    >
+      <div className="max-h-48 overflow-y-auto">
+        {recoveries.map((recovery) => {
+          const label = summarizeContentParts(
+            recovery.prompt.contentParts,
+            recovery.prompt.text,
+          ) || "Message with attachments";
+          return (
+            <div
+              key={recovery.id}
+              className="group/recovery flex min-h-8 items-center gap-2 rounded-lg px-2 py-1 hover:bg-accent"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-ui leading-[var(--text-ui--line-height)]" title={label}>
+                  {label}
+                </div>
+                <div
+                  className="truncate text-ui-sm text-destructive/80"
+                  title={recovery.errorMessage}
+                >
+                  Not sent · {recovery.errorMessage}
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={retryingId !== null}
+                onClick={() => onRetry(recovery)}
+                aria-label={`Retry unsent message: ${label}`}
+                className="h-7 px-2 text-ui-sm"
+              >
+                {retryingId === recovery.id ? "Retrying…" : "Retry"}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={retryingId === recovery.id}
+                onClick={() => onDismiss(recovery.id)}
+                aria-label={`Dismiss unsent message: ${label}`}
+              >
+                <X className="size-3.5" />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ConnectedPromptRecoveryPanel() {
+  const { recoveries, workspaceUiKey } = useChatPromptRecoveries();
+  const { dismissRecovery, retryRecovery } = useChatPromptRecoveryActions(workspaceUiKey);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const handleRetry = useCallback((recovery: ChatPromptRecovery) => {
+    setRetryingId(recovery.id);
+    void retryRecovery(recovery).finally(() => setRetryingId(null));
+  }, [retryRecovery]);
+
+  return (
+    <PromptRecoveryPanel
+      recoveries={recoveries}
+      retryingId={retryingId}
+      onRetry={handleRetry}
+      onDismiss={dismissRecovery}
+    />
+  );
+}

--- a/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.test.tsx
+++ b/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import {
+  beginEmptySessionReplacement,
+  type EmptySessionReplacementTransaction,
+} from "@/hooks/sessions/workflows/use-empty-session-replacement-cleanup";
+import {
+  resetReplacedSessionTombstonesForTests,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import { useCoworkManagedWorkspaces } from "./use-cowork-managed-workspaces";
+
+const mocks = vi.hoisted(() => ({
+  useCoworkManagedWorkspacesQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useCoworkManagedWorkspacesQuery: mocks.useCoworkManagedWorkspacesQuery,
+  useDismissSessionMutation: vi.fn(),
+}));
+
+beforeEach(() => {
+  mocks.useCoworkManagedWorkspacesQuery.mockClear();
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionTranscriptStore.getState().clearEntries();
+  resetReplacedSessionTombstonesForTests();
+  putSessionRecord(createEmptySessionRecord("runtime-old", "codex", {
+    workspaceId: "workspace-1",
+    materializedSessionId: "runtime-old",
+    modelId: "gpt-5",
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  resetReplacedSessionTombstonesForTests();
+});
+
+describe("useCoworkManagedWorkspaces replacement lifecycle", () => {
+  it("does not query a staged replacement and re-enables after rollback", () => {
+    renderHook(() => useCoworkManagedWorkspaces("runtime-old", true));
+    expect(mocks.useCoworkManagedWorkspacesQuery).toHaveBeenLastCalledWith(
+      "runtime-old",
+      { enabled: true },
+    );
+
+    let transaction: EmptySessionReplacementTransaction | null = null;
+    act(() => {
+      transaction = beginEmptySessionReplacement("runtime-old", "workspace-1", {
+        closeSessionSlotStream: vi.fn(),
+        removeWorkspaceSessionRecord: vi.fn(),
+        dismissSessionMutation: { mutateAsync: vi.fn() } as never,
+      });
+    });
+
+    expect(transaction).not.toBeNull();
+    expect(mocks.useCoworkManagedWorkspacesQuery).toHaveBeenLastCalledWith(
+      "runtime-old",
+      { enabled: false },
+    );
+
+    act(() => {
+      transaction?.rollback();
+    });
+
+    expect(mocks.useCoworkManagedWorkspacesQuery).toHaveBeenLastCalledWith(
+      "runtime-old",
+      { enabled: true },
+    );
+  });
+});

--- a/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts
+++ b/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts
@@ -2,6 +2,9 @@ import type { CoworkManagedWorkspaceSummary } from "@anyharness/sdk";
 import { useCoworkManagedWorkspacesQuery } from "@anyharness/sdk-react";
 import { isPendingSessionId } from "@/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import {
+  isReplacedSessionTombstonedInAnyWorkspace,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 const EMPTY_MANAGED_WORKSPACES: CoworkManagedWorkspaceSummary[] = [];
 
@@ -12,12 +15,20 @@ export function useCoworkManagedWorkspaces(
   // The runtime only knows materialized session ids; hot client-keyed
   // sessions (client-session:<kind>:...) 404 forever (and react-query
   // retries forever) if the raw id leaks into the request.
-  const materializedSessionId = useSessionDirectoryStore((state) =>
-    sessionId
-      ? state.entriesById[sessionId]?.materializedSessionId ?? sessionId
-      : null);
+  // Subscribe to the entry itself, not only its resolved id. A materialized
+  // session commonly uses the same client/runtime id, so removing its entry
+  // during replacement would otherwise leave the selector value unchanged and
+  // the stale query observer enabled.
+  const directoryEntry = useSessionDirectoryStore((state) =>
+    sessionId ? state.entriesById[sessionId] ?? null : null);
+  const materializedSessionId = sessionId
+    ? directoryEntry?.materializedSessionId ?? sessionId
+    : null;
   const query = useCoworkManagedWorkspacesQuery(materializedSessionId, {
-    enabled: enabled && !!materializedSessionId && !isPendingSessionId(materializedSessionId),
+    enabled: enabled
+      && !!materializedSessionId
+      && !isPendingSessionId(materializedSessionId)
+      && !isReplacedSessionTombstonedInAnyWorkspace(materializedSessionId),
   });
 
   return {

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { anyHarnessSessionsKey } from "@anyharness/sdk-react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  commitReplacedSessionTombstone,
+  committedReplacedSessionTombstonesForWorkspace,
+  isReplacedSessionTombstoned,
+  resetReplacedSessionTombstonesForTests,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  reconcileReplacedSessionTombstones,
+  useWorkspaceBootstrapCache,
+} from "./use-workspace-bootstrap-cache";
+import {
+  resetSessionReplacementDismissalsForTests,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+
+const mocks = vi.hoisted(() => ({
+  dismissSession: vi.fn(async () => undefined),
+  listWorkspaceSessions: vi.fn(),
+  writeSessionReplacementTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
+  readSessionReplacementTombstones: () => ({}),
+  writeSessionReplacementTombstones: mocks.writeSessionReplacementTombstones,
+}));
+
+vi.mock("@/lib/access/anyharness/sessions", () => ({
+  dismissSession: mocks.dismissSession,
+  listWorkspaceSessions: mocks.listWorkspaceSessions,
+}));
+
+beforeEach(() => {
+  mocks.dismissSession.mockClear();
+  mocks.listWorkspaceSessions.mockClear();
+  mocks.writeSessionReplacementTombstones.mockClear();
+  mocks.writeSessionReplacementTombstones.mockReturnValue(true);
+  resetReplacedSessionTombstonesForTests();
+  resetSessionReplacementDismissalsForTests();
+});
+
+describe("replacement tombstone reconciliation", () => {
+  it("clears only after an authoritative list omits the retired session", async () => {
+    const input = {
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    };
+    commitReplacedSessionTombstone("workspace-1", "runtime-old");
+
+    reconcileReplacedSessionTombstones(input, [{ id: "runtime-old" }]);
+
+    await vi.waitFor(() => {
+      expect(mocks.dismissSession).toHaveBeenCalledWith({}, "runtime-old");
+    });
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+
+    reconcileReplacedSessionTombstones(input, []);
+
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1")).toEqual([]);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+  });
+
+  it("does not dismiss a staged replacement during an authoritative list", () => {
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+
+    reconcileReplacedSessionTombstones({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    }, [{ id: "runtime-old" }]);
+
+    expect(mocks.dismissSession).not.toHaveBeenCalled();
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([]);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+  });
+
+  it("filters staged replacements from cache hits without reconciling them", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const runtimeUrl = "http://runtime.test";
+    queryClient.setQueryData(anyHarnessSessionsKey(runtimeUrl, "workspace-1"), [
+      { id: "runtime-old", workspaceId: "workspace-1" },
+      { id: "runtime-new", workspaceId: "workspace-1" },
+    ]);
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    const wrapper = ({ children }: { children: ReactNode }) => createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+    const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
+
+    const sessions = await result.current.loadWorkspaceSessions({
+      runtimeUrl,
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    });
+
+    expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
+    expect(mocks.listWorkspaceSessions).not.toHaveBeenCalled();
+    expect(mocks.dismissSession).not.toHaveBeenCalled();
+  });
+
+  it("does not clear a tombstone committed after the list request began", async () => {
+    const listGate = deferred<Array<{ id: string }>>();
+    mocks.listWorkspaceSessions.mockReturnValueOnce(listGate.promise);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+    const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
+    const firstList = result.current.fetchWorkspaceSessions({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    });
+    await vi.waitFor(() => expect(mocks.listWorkspaceSessions).toHaveBeenCalledTimes(1));
+
+    commitReplacedSessionTombstone("workspace-1", "runtime-created-later");
+    listGate.resolve([]);
+    await firstList;
+
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual(["runtime-created-later"]);
+
+    mocks.listWorkspaceSessions.mockResolvedValueOnce([]);
+    await result.current.fetchWorkspaceSessions({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    });
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1")).toEqual([]);
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
@@ -1,14 +1,24 @@
-import type {
-  AnyHarnessRequestOptions,
-} from "@anyharness/sdk";
+import type { AnyHarnessRequestOptions } from "@anyharness/sdk";
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import {
   anyHarnessSessionsKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { listWorkspaceSessions } from "@/lib/access/anyharness/sessions";
+import {
+  dismissSession,
+  listWorkspaceSessions,
+} from "@/lib/access/anyharness/sessions";
 import type { WorkspaceSession } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
+import {
+  captureReplacedSessionTombstoneGeneration,
+  clearReplacedSessionTombstoneFromAuthoritativeList,
+  committedReplacedSessionTombstonesForWorkspace,
+  filterReplacedSessionTombstones,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  runTrackedReplacementDismissal,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
 
 export type CacheDecision = "hit" | "stale" | "miss";
 
@@ -69,6 +79,8 @@ async function withAbortTimeout<T>(
 async function fetchWorkspaceSessionsWithConnection(
   input: FetchWorkspaceSessionsInput,
 ): Promise<WorkspaceSession[]> {
+  const tombstoneGenerationAtRequestStart =
+    captureReplacedSessionTombstoneGeneration();
   const sessions = await withAbortTimeout(
     input.timeoutMs,
     async (signal) => {
@@ -81,10 +93,46 @@ async function fetchWorkspaceSessionsWithConnection(
       return await listWorkspaceSessions(input.workspaceConnection, requestOptions);
     },
   );
-  return sessions.map((session) => ({
+  const visibleSessions = filterReplacedSessionTombstones(input.workspaceId, sessions) ?? [];
+  reconcileReplacedSessionTombstones(
+    input,
+    sessions,
+    tombstoneGenerationAtRequestStart,
+  );
+  return visibleSessions.map((session) => ({
     ...session,
     workspaceId: input.workspaceId,
   }));
+}
+
+export function reconcileReplacedSessionTombstones(
+  input: FetchWorkspaceSessionsInput,
+  sessions: readonly { id: string }[],
+  requestStartGeneration = captureReplacedSessionTombstoneGeneration(),
+): void {
+  const listedSessionIds = new Set(sessions.map((session) => session.id));
+  for (const sessionId of committedReplacedSessionTombstonesForWorkspace(
+    input.workspaceId,
+  )) {
+    if (!listedSessionIds.has(sessionId)) {
+      clearReplacedSessionTombstoneFromAuthoritativeList(
+        input.workspaceId,
+        sessionId,
+        requestStartGeneration,
+      );
+      continue;
+    }
+    // Dismiss best-effort, but retain the tombstone until a later authoritative
+    // list omits the id. Clearing on mutation success can expose a stale list
+    // response that began before dismissal and resurrect the retired session.
+    void runTrackedReplacementDismissal({
+      workspaceId: input.workspaceId,
+      runtimeSessionId: sessionId,
+      run: () => dismissSession(input.workspaceConnection, sessionId)
+        .then(() => undefined)
+        .catch(() => undefined),
+    });
+  }
 }
 
 // Owns AnyHarness React Query cache shape needed during workspace activation.
@@ -118,7 +166,10 @@ export function useWorkspaceBootstrapCache() {
       && cacheState?.dataUpdatedAt
       && !cacheState.isInvalidated
     ) {
-      return cachedSessions;
+      // Cache hits are not authoritative and must never reconcile staged
+      // suppression into destructive cleanup. They still need filtering so an
+      // intentionally retained rollback record cannot be reselected/reingested.
+      return filterReplacedSessionTombstones(input.workspaceId, cachedSessions) ?? [];
     }
 
     // Bootstrap/reconcile own workspace activation. Fetch directly instead of

--- a/apps/desktop/src/hooks/chat/derived/use-active-session-identity.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-active-session-identity.ts
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 
 export function useActiveSessionId(): string | null {
   return useSessionSelectionStore((state) => state.activeSessionId);
@@ -14,6 +15,14 @@ export function useActiveSessionWorkspaceId(): string | null {
   return useSessionDirectoryStore((state) =>
     activeSessionId ? state.entriesById[activeSessionId]?.workspaceId ?? null : null
   );
+}
+
+export function useSelectedWorkspaceUiKey(): string | null {
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  return resolveWorkspaceUiKey(selectedLogicalWorkspaceId, selectedWorkspaceId);
 }
 
 export function useActiveSessionPromptCapabilities(): PromptCapabilities | null {

--- a/apps/desktop/src/hooks/chat/derived/use-chat-prompt-recoveries.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-chat-prompt-recoveries.ts
@@ -1,0 +1,24 @@
+import { useChatPromptRecoveryStore } from "@/stores/chat/chat-prompt-recovery-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
+
+const EMPTY_RECOVERIES = [] as const;
+
+export function useChatPromptRecoveries() {
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const selectedWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedWorkspaceId,
+  );
+  const workspaceUiKey = resolveWorkspaceUiKey(
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+  );
+  const recoveries = useChatPromptRecoveryStore((state) => (
+    workspaceUiKey
+      ? state.recoveriesByWorkspaceUiKey[workspaceUiKey] ?? EMPTY_RECOVERIES
+      : EMPTY_RECOVERIES
+  ));
+  return { recoveries, workspaceUiKey };
+}

--- a/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
+++ b/apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts
@@ -23,7 +23,10 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 
 // Facade for the composer model selector: derived catalog/readiness state plus
 // the workflow callbacks needed by selector items and launch controls.
-export function useChatModelSelectorState(options?: { suppressActiveSessionState?: boolean }) {
+export function useChatModelSelectorState(options?: {
+  suppressActiveSessionState?: boolean;
+  replacementSessionId?: string | null;
+}) {
   const suppressActiveSessionState = options?.suppressActiveSessionState ?? false;
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
@@ -58,7 +61,10 @@ export function useChatModelSelectorState(options?: { suppressActiveSessionState
     scopedActiveSessionId,
     suppressActiveSessionState,
   ]);
-  const { handleLaunchSelect } = useChatLaunchActions({ suppressActiveSessionState });
+  const { handleLaunchSelect } = useChatLaunchActions({
+    suppressActiveSessionState,
+    replacementSessionId: options?.replacementSessionId ?? null,
+  });
   const configuredLaunch = useConfiguredLaunchReadiness(scopedLaunchIdentity ?? launchIntentIdentity);
   const launchCatalog = useChatLaunchCatalog({
     activeSelection: scopedLaunchIdentity ?? launchIntentIdentity ?? configuredLaunch.selection,

--- a/apps/desktop/src/hooks/chat/ui/use-chat-prompt-attachments.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-chat-prompt-attachments.ts
@@ -10,15 +10,15 @@ export type PromptAttachmentController = ReturnType<typeof usePromptAttachments>
 };
 
 export function useChatPromptAttachments({
-  activeSessionId,
+  scopeKey,
   promptCapabilities,
   canAttachFiles,
 }: {
-  activeSessionId: string | null;
+  scopeKey: string | null;
   promptCapabilities: PromptCapabilities | null;
   canAttachFiles: boolean;
 }): PromptAttachmentController {
-  const attachments = usePromptAttachments(activeSessionId, promptCapabilities);
+  const attachments = usePromptAttachments(scopeKey, promptCapabilities);
   const supportsAttachments = canAttachPromptContent(promptCapabilities);
   const pasteAttachmentsEnabled = useUserPreferencesStore((state) => state.pasteAttachmentsEnabled);
   const addFiles = useCallback((files: Iterable<File>) => {
@@ -40,8 +40,10 @@ export function useChatPromptAttachments({
     addTextPaste,
     removeAttachment: attachments.removeAttachment,
     clearAttachments: attachments.clearAttachments,
+    clearSubmittedAttachments: attachments.clearSubmittedAttachments,
     snapshotForSubmit: attachments.snapshotForSubmit,
     hasAttachments: attachments.hasAttachments,
+    hasSupportedAttachments: attachments.hasSupportedAttachments,
     canAttachFiles,
     supportsAttachments,
   }), [
@@ -49,7 +51,9 @@ export function useChatPromptAttachments({
     addTextPaste,
     attachments.attachments,
     attachments.clearAttachments,
+    attachments.clearSubmittedAttachments,
     attachments.hasAttachments,
+    attachments.hasSupportedAttachments,
     attachments.removeAttachment,
     attachments.snapshotForSubmit,
     canAttachFiles,

--- a/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.test.tsx
+++ b/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.test.tsx
@@ -17,6 +17,10 @@ const activeTodoTrackerState = vi.hoisted(() => ({
   value: null as { entries: unknown[] } | null,
 }));
 
+const promptRecoveryState = vi.hoisted(() => ({
+  value: [] as unknown[],
+}));
+
 vi.mock("@/hooks/chat/derived/use-active-pending-session-interactions", () => ({
   useActivePendingInteractionState: () => ({
     primaryPendingInteraction: primaryPendingInteractionState.value,
@@ -26,6 +30,13 @@ vi.mock("@/hooks/chat/derived/use-active-pending-session-interactions", () => ({
 
 vi.mock("@/hooks/chat/derived/use-active-todo-tracker", () => ({
   useActiveTodoTracker: () => activeTodoTrackerState.value,
+}));
+
+vi.mock("@/hooks/chat/derived/use-chat-prompt-recoveries", () => ({
+  useChatPromptRecoveries: () => ({
+    recoveries: promptRecoveryState.value,
+    workspaceUiKey: "workspace-1",
+  }),
 }));
 
 vi.mock("@/hooks/chat/facade/use-delegated-work-composer", () => ({
@@ -65,6 +76,10 @@ vi.mock("@/components/workspace/chat/input/PendingPromptList", () => ({
   ConnectedPendingPromptList: () => <div data-testid="pending-prompt-list" />,
 }));
 
+vi.mock("@/components/workspace/chat/input/PromptRecoveryPanel", () => ({
+  ConnectedPromptRecoveryPanel: () => <div data-testid="prompt-recovery-panel" />,
+}));
+
 vi.mock("@/components/workspace/chat/input/DelegatedWorkComposerPanel", () => ({
   DelegatedWorkComposerPanel: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -82,6 +97,7 @@ afterEach(() => {
   workspaceStatusPanelState.value = { kind: "pending" };
   primaryPendingInteractionState.value = null;
   activeTodoTrackerState.value = null;
+  promptRecoveryState.value = [];
 });
 
 describe("useComposerDockSlots", () => {
@@ -123,5 +139,14 @@ describe("useComposerDockSlots", () => {
 
     expect(screen.getByTestId("todo-tracker-panel")).not.toBeNull();
     expect(screen.queryByTestId("todo-tracker-strip")).toBeNull();
+  });
+
+  it("renders workspace-scoped prompt recoveries in the outbound slot", () => {
+    promptRecoveryState.value = [{}];
+    const { result } = renderHook(() => useComposerDockSlots());
+
+    render(<>{result.current.outboundSlot}</>);
+
+    expect(screen.getByTestId("prompt-recovery-panel")).not.toBeNull();
   });
 });

--- a/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
+++ b/apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx
@@ -8,6 +8,7 @@ import { ConnectedMcpElicitationCard } from "@/components/workspace/chat/input/M
 import { DelegatedWorkComposerPanel } from "@/components/workspace/chat/input/DelegatedWorkComposerPanel";
 import { DelegatedWorkComposerControl } from "@/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl";
 import { ConnectedUserInputCard } from "@/components/workspace/chat/input/UserInputCard";
+import { ConnectedPromptRecoveryPanel } from "@/components/workspace/chat/input/PromptRecoveryPanel";
 import { SessionActivityBar } from "@/components/workspace/activity/SessionActivityBar";
 import { useSessionGoalBarModel } from "@/hooks/activity/derived/use-session-goal";
 import { useSessionActivityChips } from "@/hooks/activity/derived/use-session-activity-chips";
@@ -20,6 +21,7 @@ import { useActiveTodoTracker } from "@/hooks/chat/derived/use-active-todo-track
 import { useComposerDockCardPresence } from "@/hooks/chat/ui/use-composer-dock-card-presence";
 import { useSelectedCloudRuntimeState } from "@/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { useWorkspaceStatusPanelState } from "@/hooks/workspaces/derived/use-workspace-status-panel-state";
+import { useChatPromptRecoveries } from "@/hooks/chat/derived/use-chat-prompt-recoveries";
 
 export interface ComposerDockSlots {
   outboundSlot: ReactNode | null;
@@ -35,6 +37,7 @@ export function useComposerDockSlots(options?: {
   const suppressWorkspaceStatusPanels = options?.suppressWorkspaceStatusPanels ?? false;
   const { primaryPendingInteraction } = useActivePendingInteractionState();
   const pendingPrompts = useActivePendingPrompts();
+  const promptRecoveries = useChatPromptRecoveries().recoveries;
   const activeTodoTracker = useActiveTodoTracker();
   const delegatedWorkComposer = useDelegatedWorkComposer();
   const sessionGoalBarModel = useSessionGoalBarModel();
@@ -47,6 +50,7 @@ export function useComposerDockSlots(options?: {
     suppressSessionSlots,
     suppressWorkspaceStatusPanels,
     pendingPromptCount: pendingPrompts.length,
+    recoveredPromptCount: promptRecoveries.length,
     primaryPendingInteractionKind: primaryPendingInteraction?.kind ?? null,
     hasActiveTodoTracker: !!activeTodoTracker,
     hasDelegatedWork: !!delegatedWorkComposer,
@@ -59,6 +63,7 @@ export function useComposerDockSlots(options?: {
     delegatedWorkComposer,
     hasCloudRuntimePanel,
     pendingPrompts.length,
+    promptRecoveries.length,
     primaryPendingInteraction?.kind,
     sessionActivityChips.length,
     sessionGoalBarModel,
@@ -144,17 +149,17 @@ export function useComposerDockSlots(options?: {
   ), [ambientContextSlot, delegatedWorkSlot, sessionActivitySlot]);
 
   return useMemo(() => ({
-    // Queued prompts now render IN THE TRANSCRIPT (renderableOutboxEntriesFor-
-    // Transcript includes queue-placed entries), so the dock's pending list is
-    // retired — rendering both would show the same message twice. NOTE: this
-    // also retires the dock's queued-prompt edit affordance (beginEdit was
-    // only reachable from that list); re-home it on the transcript pending row
-    // if we want it back.
-    outboundSlot: null,
+    // Ordinary queued prompts render in the transcript. A rollback recovery is
+    // workspace-scoped rather than session-scoped, so it owns the dock's
+    // outbound slot until the user retries or dismisses it.
+    outboundSlot: dockSlotResolution.outboundSlot?.kind === "prompt_recoveries"
+      ? <ConnectedPromptRecoveryPanel />
+      : null,
     activeSlot: activeAgentSlot,
     attachedSlot,
   }), [
     activeAgentSlot,
     attachedSlot,
+    dockSlotResolution.outboundSlot?.kind,
   ]);
 }

--- a/apps/desktop/src/hooks/chat/ui/use-prompt-attachments.test.tsx
+++ b/apps/desktop/src/hooks/chat/ui/use-prompt-attachments.test.tsx
@@ -74,4 +74,55 @@ describe("usePromptAttachments", () => {
 
     expect(result.current.snapshotForSubmit()).toEqual([]);
   });
+
+  it("keeps attachments across same-workspace harness capability changes", () => {
+    const { result, rerender } = renderHook(
+      ({ capabilities }: { capabilities: PromptCapabilities | null }) =>
+        usePromptAttachments("workspace-1", capabilities),
+      { initialProps: { capabilities: promptCapabilities as PromptCapabilities | null } },
+    );
+    const image = new File(["image-bytes"], "image.png", { type: "image/png" });
+    act(() => {
+      result.current.addFiles([image]);
+    });
+
+    rerender({ capabilities: null });
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.hasAttachments).toBe(true);
+    expect(result.current.hasSupportedAttachments).toBe(false);
+    expect(result.current.snapshotForSubmit()).toEqual([]);
+
+    act(() => {
+      result.current.clearSubmittedAttachments(result.current.snapshotForSubmit());
+    });
+    expect(result.current.attachments).toHaveLength(1);
+
+    rerender({ capabilities: promptCapabilities });
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.hasAttachments).toBe(true);
+    expect(result.current.hasSupportedAttachments).toBe(true);
+    const submitted = result.current.snapshotForSubmit();
+    expect(submitted).toHaveLength(1);
+
+    act(() => {
+      result.current.clearSubmittedAttachments(submitted);
+    });
+    expect(result.current.attachments).toEqual([]);
+  });
+
+  it("clears attachments when the selected workspace changes", () => {
+    const { result, rerender } = renderHook(
+      ({ scopeKey }) => usePromptAttachments(scopeKey, promptCapabilities),
+      { initialProps: { scopeKey: "workspace-1" } },
+    );
+    const image = new File(["image-bytes"], "image.png", { type: "image/png" });
+    act(() => {
+      result.current.addFiles([image]);
+    });
+
+    rerender({ scopeKey: "workspace-2" });
+
+    expect(result.current.attachments).toEqual([]);
+    expect(result.current.snapshotForSubmit()).toEqual([]);
+  });
 });

--- a/apps/desktop/src/hooks/chat/ui/use-prompt-attachments.ts
+++ b/apps/desktop/src/hooks/chat/ui/use-prompt-attachments.ts
@@ -55,7 +55,7 @@ export function usePromptAttachments(
     }
     entriesRef.current = [];
     setEntries([]);
-  }, [scopeKey, canAttachEmbeddedContext, canAttachImages]);
+  }, [scopeKey]);
 
   const descriptors = useMemo(
     () => entries.map((entry) => entry.descriptor),
@@ -170,11 +170,39 @@ export function usePromptAttachments(
     setEntries([]);
   }, []);
 
-  const snapshotForSubmit = useCallback((): PromptAttachmentSnapshot[] => {
-    return entriesRef.current.map((entry) =>
-      createPromptAttachmentSnapshot(entry.descriptor, entry.file)
-    );
+  const clearSubmittedAttachments = useCallback((
+    submitted: readonly Pick<PromptAttachmentSnapshot, "id">[],
+  ) => {
+    const submittedIds = new Set(submitted.map((entry) => entry.id));
+    if (submittedIds.size === 0) {
+      return;
+    }
+    const retained: AttachmentEntry[] = [];
+    for (const entry of entriesRef.current) {
+      if (submittedIds.has(entry.descriptor.id)) {
+        revokeAttachmentObjectUrl(entry);
+      } else {
+        retained.push(entry);
+      }
+    }
+    entriesRef.current = retained;
+    setEntries(retained);
   }, []);
+
+  const snapshotForSubmit = useCallback((): PromptAttachmentSnapshot[] => {
+    return entriesRef.current.flatMap((entry) => {
+      const isSupported = entry.descriptor.kind === "image"
+        ? canAttachImages
+        : canAttachEmbeddedContext;
+      return isSupported
+        ? [createPromptAttachmentSnapshot(entry.descriptor, entry.file)]
+        : [];
+    });
+  }, [canAttachEmbeddedContext, canAttachImages]);
+
+  const hasSupportedAttachments = entries.some((entry) => (
+    entry.descriptor.kind === "image" ? canAttachImages : canAttachEmbeddedContext
+  ));
 
   return useMemo(() => ({
     attachments: descriptors,
@@ -182,14 +210,18 @@ export function usePromptAttachments(
     addTextPaste,
     removeAttachment,
     clearAttachments,
+    clearSubmittedAttachments,
     snapshotForSubmit,
     hasAttachments: entries.length > 0,
+    hasSupportedAttachments,
   }), [
     addFiles,
     addTextPaste,
     clearAttachments,
+    clearSubmittedAttachments,
     descriptors,
     entries.length,
+    hasSupportedAttachments,
     removeAttachment,
     snapshotForSubmit,
   ]);

--- a/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx
+++ b/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatLaunchActions } from "./use-chat-launch-actions";
+
+const mocks = vi.hoisted(() => ({
+  createEmptySessionWithResolvedConfig: vi.fn(async () => "client-new"),
+  createThreadFromSelection: vi.fn(),
+  failLatencyFlow: vi.fn(),
+  persistPreferences: vi.fn(),
+  setActiveSessionConfigOption: vi.fn(),
+  setWorkspaceArrivalEvent: vi.fn(),
+  showToast: vi.fn(),
+  startLatencyFlow: vi.fn(() => "flow-1"),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createEmptySessionWithResolvedConfig: mocks.createEmptySessionWithResolvedConfig,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-config-actions", () => ({
+  useSessionConfigActions: () => ({
+    setActiveSessionConfigOption: mocks.setActiveSessionConfigOption,
+  }),
+}));
+
+vi.mock("@/hooks/cowork/workflows/use-cowork-thread-workflow", () => ({
+  useCoworkThreadWorkflow: () => ({
+    createThreadFromSelection: mocks.createThreadFromSelection,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({ data: { workspaces: [] } }),
+}));
+
+vi.mock("@/hooks/chat/derived/use-active-session-config-state", () => ({
+  useActiveSessionLaunchState: () => ({
+    activeSessionId: "store-active",
+    currentLaunchIdentity: { kind: "codex", modelId: "gpt-5" },
+    currentModelConfigId: "model",
+    modelControl: null,
+  }),
+}));
+
+vi.mock("@/hooks/chat/derived/use-configured-launch-readiness", () => ({
+  useConfiguredLaunchReadiness: () => ({
+    disabledReason: null,
+    launchCatalog: { launchAgents: [] },
+  }),
+}));
+
+vi.mock("@/lib/domain/chat/models/launch-selection-defaults", () => ({
+  resolveAvailableLaunchSelection: (_agents: unknown, selection: unknown) => selection,
+}));
+
+vi.mock("@/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: unknown) => unknown) => selector({
+    selectedWorkspaceId: "workspace-1",
+    selectedLogicalWorkspaceId: "logical-workspace-1",
+    setWorkspaceArrivalEvent: mocks.setWorkspaceArrivalEvent,
+  }),
+}));
+
+vi.mock("@/stores/chat/chat-input-store", () => ({
+  useChatInputStore: {
+    getState: () => ({ draftByWorkspaceId: {} }),
+  },
+}));
+
+vi.mock("@/stores/preferences/user-preferences-store", () => ({
+  useUserPreferencesStore: {
+    getState: () => ({
+      defaultChatModelIdByAgentKind: {},
+      setMultiple: mocks.persistPreferences,
+    }),
+  },
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: unknown) => unknown) => selector({
+    show: mocks.showToast,
+  }),
+}));
+
+vi.mock("@/lib/infra/measurement/latency-flow", () => ({
+  failLatencyFlow: mocks.failLatencyFlow,
+  startLatencyFlow: mocks.startLatencyFlow,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => cleanup());
+
+describe("useChatLaunchActions replacement identity", () => {
+  it("uses the rendered pending shell as the replacement while config state is suppressed", () => {
+    const { result } = renderHook(() => useChatLaunchActions({
+      suppressActiveSessionState: true,
+      replacementSessionId: "pending-visible",
+    }));
+
+    act(() => {
+      result.current.handleLaunchSelect({ kind: "claude", modelId: "sonnet" });
+    });
+
+    expect(mocks.createEmptySessionWithResolvedConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKind: "claude",
+        modelId: "sonnet",
+        replacesSessionId: "pending-visible",
+      }),
+    );
+  });
+
+  it("uses the active materialized session when no pending render identity exists", () => {
+    const { result } = renderHook(() => useChatLaunchActions());
+
+    act(() => {
+      result.current.handleLaunchSelect({ kind: "claude", modelId: "sonnet" });
+    });
+
+    expect(mocks.createEmptySessionWithResolvedConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ replacesSessionId: "store-active" }),
+    );
+  });
+});

--- a/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.ts
+++ b/apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.ts
@@ -26,8 +26,12 @@ import { withUpdatedDefaultModelIdByAgentKind } from "@/lib/domain/agents/model-
 
 const EMPTY_WORKSPACES: Workspace[] = [];
 
-export function useChatLaunchActions(options?: { suppressActiveSessionState?: boolean }) {
+export function useChatLaunchActions(options?: {
+  suppressActiveSessionState?: boolean;
+  replacementSessionId?: string | null;
+}) {
   const suppressActiveSessionState = options?.suppressActiveSessionState ?? false;
+  const replacementSessionId = options?.replacementSessionId ?? null;
   const showToast = useToastStore((store) => store.show);
   const setWorkspaceArrivalEvent = useSessionSelectionStore((state) => state.setWorkspaceArrivalEvent);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
@@ -131,13 +135,15 @@ export function useChatLaunchActions(options?: { suppressActiveSessionState?: bo
       targetWorkspaceId: selectedWorkspaceId,
     });
     // Pass the current session as replacesSessionId: the creation workflow
-    // cleans up the old empty session synchronously after activating the new
-    // optimistic record, so the tab swap is instant (no ghost tab).
+    // hides an unused old shell synchronously, then commits its cleanup only
+    // after the optimistic replacement materializes.
     void createEmptySessionWithResolvedConfig({
       agentKind: launchSelection.kind,
       modelId: launchSelection.modelId,
       latencyFlowId,
-      replacesSessionId: scopedActiveSessionId ?? null,
+      // Presentation suppression hides stale config/model state while a
+      // pending shell is projected; it must not erase the shell being replaced.
+      replacesSessionId: replacementSessionId ?? scopedActiveSessionId ?? null,
     })
       .then(() => {
         setWorkspaceArrivalEvent(null);
@@ -161,6 +167,7 @@ export function useChatLaunchActions(options?: { suppressActiveSessionState?: bo
     scopedCurrentLaunchIdentity,
     scopedCurrentModelConfigId,
     scopedModelControl,
+    replacementSessionId,
   ]);
 
   return {

--- a/apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.test.tsx
+++ b/apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatPromptRecoveryActions } from "@/hooks/chat/workflows/use-chat-prompt-recovery-actions";
+import {
+  useChatPromptRecoveryStore,
+  type ChatPromptRecovery,
+} from "@/stores/chat/chat-prompt-recovery-store";
+import { createPromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+
+const mocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createSessionWithResolvedConfig: mocks.createSession,
+  }),
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createSession.mockResolvedValue("pending-retry");
+  useChatPromptRecoveryStore.getState().clear();
+});
+
+describe("useChatPromptRecoveryActions", () => {
+  it("retries only the selected recovery and leaves its siblings untouched", async () => {
+    const first = createRecovery("prompt-1", "first");
+    const second = createRecovery("prompt-2", "second");
+    useChatPromptRecoveryStore.getState().addRecoveries("logical-1", [first, second]);
+    const { result } = renderHook(() => useChatPromptRecoveryActions("logical-1"));
+
+    await act(async () => {
+      await expect(result.current.retryRecovery(first)).resolves.toBe(true);
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledOnce();
+    expect(mocks.createSession).toHaveBeenCalledWith(expect.objectContaining({
+      text: "first",
+      promptId: "prompt-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+    }));
+    expect(useChatPromptRecoveryStore.getState()
+      .recoveriesByWorkspaceUiKey["logical-1"]?.map((entry) => entry.id))
+      .toEqual(["prompt-2"]);
+  });
+});
+
+function createRecovery(id: string, text: string): ChatPromptRecovery {
+  return {
+    id,
+    workspaceId: "workspace-1",
+    agentKind: "claude",
+    modelId: "sonnet",
+    modeId: "agent",
+    errorMessage: "Could not launch Claude.",
+    prompt: createPromptOutboxEntry({
+      clientPromptId: id,
+      clientSessionId: "failed-replacement",
+      workspaceId: "workspace-1",
+      text,
+      blocks: [{ type: "text", text }],
+    }),
+  };
+}

--- a/apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.ts
+++ b/apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.ts
@@ -1,0 +1,46 @@
+import { useCallback } from "react";
+import { useSessionCreationActions } from "@/hooks/sessions/workflows/use-session-creation-actions";
+import {
+  useChatPromptRecoveryStore,
+  type ChatPromptRecovery,
+} from "@/stores/chat/chat-prompt-recovery-store";
+import { useToastStore } from "@/stores/toast/toast-store";
+
+export function useChatPromptRecoveryActions(workspaceUiKey: string | null) {
+  const { createSessionWithResolvedConfig } = useSessionCreationActions();
+  const showToast = useToastStore((state) => state.show);
+
+  const dismissRecovery = useCallback((recoveryId: string) => {
+    if (workspaceUiKey) {
+      useChatPromptRecoveryStore.getState().removeRecovery(workspaceUiKey, recoveryId);
+    }
+  }, [workspaceUiKey]);
+
+  const retryRecovery = useCallback(async (recovery: ChatPromptRecovery) => {
+    if (!workspaceUiKey) {
+      return false;
+    }
+    try {
+      await createSessionWithResolvedConfig({
+        text: recovery.prompt.text,
+        blocks: recovery.prompt.blocks.map((block) => ({ ...block })),
+        attachmentSnapshots: recovery.prompt.attachmentSnapshots
+          .map((snapshot) => ({ ...snapshot })),
+        optimisticContentParts: recovery.prompt.contentParts.map((part) => ({ ...part })),
+        agentKind: recovery.agentKind,
+        modelId: recovery.modelId,
+        ...(recovery.modeId ? { modeId: recovery.modeId } : {}),
+        workspaceId: recovery.workspaceId,
+        promptId: recovery.prompt.clientPromptId,
+      });
+      useChatPromptRecoveryStore.getState().removeRecovery(workspaceUiKey, recovery.id);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      showToast(`Failed to retry message: ${message}`);
+      return false;
+    }
+  }, [createSessionWithResolvedConfig, showToast, workspaceUiKey]);
+
+  return { dismissRecovery, retryRecovery };
+}

--- a/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/desktop/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -9,13 +9,6 @@ import type {
   HomeNextModelSelection,
   ModelAvailabilityState,
 } from "@/lib/domain/home/home-next-launch";
-import { scheduleAfterNextPaint } from "@/lib/infra/scheduling/schedule-after-next-paint";
-
-function waitForNextPaint(): Promise<void> {
-  return new Promise((resolve) => {
-    scheduleAfterNextPaint(resolve);
-  });
-}
 
 interface UseHomeNextComposerStateArgs {
   targetDisabledReason: string | null;
@@ -37,11 +30,8 @@ export function useHomeNextComposerState({
   launchTarget,
 }: UseHomeNextComposerStateArgs) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const submitInFlightRef = useRef(false);
   const [draft, setDraft] = useState("");
-  const [submittedPreview, setSubmittedPreview] = useState<{
-    id: string;
-    text: string;
-  } | null>(null);
   const restoredDraftText = useHomeDraftHandoffStore((state) => state.draftText);
   const clearRestoredDraftText = useHomeDraftHandoffStore((state) => state.clearDraftText);
   const { isLaunching, launch } = useHomeNextLaunch();
@@ -62,7 +52,6 @@ export function useHomeNextComposerState({
     && canLaunchTarget
     && !!modelSelection
     && !!launchTarget
-    && submittedPreview === null
     && !isLaunching;
 
   // PERF: `getComputedStyle` twice per keystroke is avoidable work in the hot
@@ -102,33 +91,41 @@ export function useHomeNextComposerState({
   }, [draft]);
 
   const submit = useCallback(async () => {
-    if (!canSubmit || !modelSelection || !launchTarget) return;
+    if (
+      !canSubmit
+      || !modelSelection
+      || !launchTarget
+      || submitInFlightRef.current
+    ) return;
 
+    submitInFlightRef.current = true;
     const submittedDraft = draft;
-    const submittedText = submittedDraft.trim();
-    const shouldShowHomeSubmittedPreview = launchTarget.kind !== "cowork";
+    const restoreSubmittedDraft = () => {
+      setDraft((currentDraft) => (
+        currentDraft.length === 0 ? submittedDraft : currentDraft
+      ));
+    };
     flushSync(() => {
-      if (shouldShowHomeSubmittedPreview) {
-        setSubmittedPreview({
-          id: crypto.randomUUID(),
-          text: submittedText,
-        });
-      }
       setDraft("");
     });
-    if (shouldShowHomeSubmittedPreview) {
-      await waitForNextPaint();
-    }
-    const succeeded = await launch({
-      text: submittedDraft,
-      modelSelection,
-      modeId,
-      launchControlValues,
-      target: launchTarget,
-    });
-    if (!succeeded) {
-      setSubmittedPreview(null);
-      setDraft(submittedDraft);
+
+    try {
+      const succeeded = await launch({
+        text: submittedDraft,
+        modelSelection,
+        modeId,
+        launchControlValues,
+        target: launchTarget,
+      });
+      if (!succeeded) {
+        restoreSubmittedDraft();
+      }
+    } catch {
+      // `launch` normally converts workflow failures to `false`. Keep the
+      // composer rollback invariant even if an unexpected error escapes it.
+      restoreSubmittedDraft();
+    } finally {
+      submitInFlightRef.current = false;
     }
   }, [
     canSubmit,
@@ -142,7 +139,6 @@ export function useHomeNextComposerState({
 
   const cancel = useCallback(() => {
     if (!isLaunching) {
-      setSubmittedPreview(null);
       setDraft("");
     }
   }, [isLaunching]);
@@ -175,7 +171,6 @@ export function useHomeNextComposerState({
     textareaRef,
     draft,
     setDraft,
-    submittedPreview,
     submitDisabledReason,
     canSubmit,
     isLaunching,

--- a/apps/desktop/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/desktop/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderableOutboxEntriesForTranscript } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+} from "@/lib/domain/workspaces/creation/pending-entry";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import {
+  getPromptOutboxEntriesForSession,
+  useSessionIntentStore,
+} from "@/stores/sessions/session-intent-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import { useChatLaunchIntentStore } from "@/stores/chat/chat-launch-intent-store";
+import { useDeferredHomeLaunchStore } from "@/stores/home/deferred-home-launch-store";
+import { useToastStore } from "@/stores/toast/toast-store";
+import { useHomeNextLaunch } from "./use-home-next-launch";
+
+const mocks = vi.hoisted(() => ({
+  createCloudWorkspaceAndEnterWithResult: vi.fn(),
+  createEmptySessionWithResolvedConfig: vi.fn(),
+  createLocalWorkspaceAndEnterWithResult: vi.fn(),
+  createSessionWithResolvedConfig: vi.fn(),
+  createThreadFromSelection: vi.fn(),
+  createWorktreeAndEnterWithResult: vi.fn(),
+  navigate: vi.fn(),
+  selectWorkspace: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
+  useCreateCloudWorkspace: () => ({
+    createCloudWorkspaceAndEnterWithResult: mocks.createCloudWorkspaceAndEnterWithResult,
+  }),
+}));
+
+vi.mock("@/hooks/cowork/workflows/use-cowork-thread-workflow", () => ({
+  useCoworkThreadWorkflow: () => ({
+    createThreadFromSelection: mocks.createThreadFromSelection,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/use-workspace-entry-actions", () => ({
+  useWorkspaceEntryActions: () => ({
+    createLocalWorkspaceAndEnterWithResult: mocks.createLocalWorkspaceAndEnterWithResult,
+    createWorktreeAndEnterWithResult: mocks.createWorktreeAndEnterWithResult,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({
+    selectWorkspace: mocks.selectWorkspace,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createEmptySessionWithResolvedConfig: mocks.createEmptySessionWithResolvedConfig,
+    createSessionWithResolvedConfig: mocks.createSessionWithResolvedConfig,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/use-session-interaction-resolution-actions", () => ({
+  useSessionInteractionResolutionActions: () => ({
+    resolvePermission: vi.fn(),
+    resolveMcpElicitation: vi.fn(),
+    resolveUserInput: vi.fn(),
+    revealMcpElicitationUrl: vi.fn(),
+  }),
+}));
+
+describe("useHomeNextLaunch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useSessionSelectionStore.getState().clearSelection();
+    useChatLaunchIntentStore.setState({ activeIntent: null });
+    useDeferredHomeLaunchStore.setState({ launches: {} });
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it("projects one destination prompt for a Home worktree launch", async () => {
+    const sessionId = "client-session:codex:home-worktree";
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "home-worktree-attempt",
+      selectedWorkspaceId: null,
+      source: "worktree-created",
+      displayName: "home-worktree",
+      repoLabel: "repo",
+      baseBranchName: "main",
+      request: {
+        kind: "worktree",
+        input: {
+          repoRootId: "repo-root-1",
+          sourceWorkspaceId: null,
+          baseBranch: "main",
+          defaultBranch: "main",
+        },
+      },
+    });
+    const pendingWorkspaceId = buildPendingWorkspaceUiKey(pendingEntry);
+
+    mocks.createWorktreeAndEnterWithResult.mockImplementation(async () => {
+      putSessionRecord(createEmptySessionRecord(sessionId, "codex", {
+        workspaceId: pendingWorkspaceId,
+        materializedSessionId: null,
+        modelId: "gpt-5.4",
+      }));
+      useSessionSelectionStore.getState().enterPendingWorkspaceShell(pendingEntry, {
+        initialActiveSessionId: sessionId,
+      });
+      return {
+        workspaceId: "workspace-real",
+        projectedSessionId: sessionId,
+      };
+    });
+
+    const { result } = renderHook(() => useHomeNextLaunch());
+    let succeeded = false;
+    await act(async () => {
+      succeeded = await result.current.launch({
+        text: "build the projected destination",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: {
+          kind: "worktree",
+          repoRootId: "repo-root-1",
+          sourceWorkspaceId: null,
+          baseBranch: "main",
+          defaultBranch: "main",
+        },
+      });
+    });
+
+    const record = getSessionRecord(sessionId);
+    const promptIntents = getPromptOutboxEntriesForSession(sessionId);
+    const destinationPromptRows = record
+      ? renderableOutboxEntriesForTranscript(promptIntents, record.transcript)
+      : [];
+
+    expect(succeeded).toBe(true);
+    expect(promptIntents).toHaveLength(1);
+    expect(destinationPromptRows).toHaveLength(1);
+    expect(destinationPromptRows[0]?.text).toBe("build the projected destination");
+    expect(mocks.createSessionWithResolvedConfig).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-created-runtime-cleanup.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-created-runtime-cleanup.ts
@@ -1,0 +1,93 @@
+import { AnyHarnessError } from "@anyharness/sdk";
+import { dismissSession as dismissRuntimeSession } from "@/lib/access/anyharness/sessions";
+import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
+import {
+  commitReplacedSessionTombstone,
+  releaseReplacedSessionSuppression,
+  retireStagedReplacedSessionTombstone,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  runTrackedReplacementDismissal,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+
+const DISMISS_RETRY_DELAYS_MS = [0, 100, 500] as const;
+
+/**
+ * Retires a runtime created by a materializer that lost ownership of its
+ * projected shell. The runtime may stay hidden only when cleanup state is
+ * durable or dismissal confirms that it no longer exists.
+ */
+export async function scheduleCreatedRuntimeSessionCleanup(input: {
+  connection: Parameters<typeof dismissRuntimeSession>[0];
+  workspaceId: string;
+  runtimeSessionId: string;
+  clientSessionId: string;
+}): Promise<boolean> {
+  stageReplacedSessionTombstone(
+    input.workspaceId,
+    input.runtimeSessionId,
+    [input.clientSessionId],
+  );
+  const durablySuppressed = commitReplacedSessionTombstone(
+    input.workspaceId,
+    input.runtimeSessionId,
+    [input.clientSessionId],
+  );
+  const dismissal = runTrackedReplacementDismissal({
+    workspaceId: input.workspaceId,
+    runtimeSessionId: input.runtimeSessionId,
+    run: () => dismissCreatedRuntimeSessionWithRetry(
+      input.connection,
+      input.runtimeSessionId,
+    ),
+  });
+  if (durablySuppressed) {
+    void dismissal.catch(() => undefined);
+    return true;
+  }
+  try {
+    await dismissal;
+    retireStagedReplacedSessionTombstone(
+      input.workspaceId,
+      input.runtimeSessionId,
+    );
+    return true;
+  } catch {
+    releaseReplacedSessionSuppression(input.workspaceId, input.runtimeSessionId);
+    releaseReplacedSessionSuppression(input.workspaceId, input.clientSessionId);
+    return false;
+  }
+}
+
+async function dismissCreatedRuntimeSessionWithRetry(
+  connection: Parameters<typeof dismissRuntimeSession>[0],
+  sessionId: string,
+): Promise<void> {
+  let lastError: unknown = null;
+  for (const delayMs of DISMISS_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+    try {
+      await dismissRuntimeSession(connection, sessionId);
+      // Keep suppression until a later authoritative list omits the id; an
+      // older in-flight list can otherwise repopulate cache after this returns.
+      return;
+    } catch (error) {
+      if (error instanceof AnyHarnessError && error.problem.status === 404) {
+        return;
+      }
+      lastError = error;
+    }
+  }
+  if (lastError) {
+    captureTelemetryException(lastError, {
+      tags: {
+        action: "dismiss_superseded_session_creation",
+        domain: "sessions",
+      },
+    });
+    throw lastError;
+  }
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupSessionCreationFailure } from "@/hooks/sessions/workflows/session-creation-failure-cleanup";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useChatInputStore } from "@/stores/chat/chat-input-store";
+import { useChatPromptRecoveryStore } from "@/stores/chat/chat-prompt-recovery-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+
+beforeEach(() => {
+  useChatInputStore.setState({ draftByWorkspaceId: {} });
+  useChatPromptRecoveryStore.getState().clear();
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionIntentStore.getState().clear();
+  useSessionSelectionStore.getState().clearSelection();
+  useSessionTranscriptStore.getState().clearEntries();
+});
+
+describe("replacement session creation failure", () => {
+  it("restores the exact old shell and recovers user work acquired during materialization", () => {
+    const oldRecord = createEmptySessionRecord("old-session", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-old",
+      modelId: "gpt-5",
+    });
+    putSessionRecord(createEmptySessionRecord("pending-claude", "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "sonnet",
+    }));
+    useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "pending-claude",
+      workspaceId: "workspace-1",
+      text: "Use the attached context",
+      blocks: [
+        { type: "text", text: "Use the attached context" },
+        { type: "plan_reference", planId: "plan-1", snapshotHash: "hash-1" },
+      ],
+      attachmentSnapshots: [{
+        id: "attachment-1",
+        name: "context.txt",
+        mimeType: "text/plain",
+        size: 12,
+        kind: "text_resource",
+        source: "upload",
+        file: { name: "context.txt" },
+      }],
+    });
+    useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-2",
+      clientSessionId: "pending-claude",
+      workspaceId: "workspace-1",
+      text: "Then run the tests",
+      blocks: [{ type: "text", text: "Then run the tests" }],
+    });
+    useChatInputStore.getState().setDraftText("logical-workspace-1", "newer draft");
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-workspace-1",
+      workspaceId: "workspace-1",
+    });
+    useSessionSelectionStore.getState().setActiveSessionId("pending-claude");
+    const activateSession = vi.fn((sessionId: string) => {
+      useSessionSelectionStore.getState().setActiveSessionId(sessionId);
+    });
+    const rollbackPreferences = vi.fn();
+    const rollbackReplacement = vi.fn(() => putSessionRecord(oldRecord));
+
+    cleanupSessionCreationFailure({
+      agentKind: "claude",
+      currentOwnedSessionId: "pending-claude",
+      error: new Error("materialization failed"),
+      hadExistingProjectedRecord: false,
+      hasPrompt: false,
+      modeId: "agent",
+      modelId: "sonnet",
+      pendingSessionId: "pending-claude",
+      preserveProjectedSessionOnCreateFailure: false,
+      previousActiveSessionId: "old-session",
+      recoveryWorkspaceUiKey: "logical-workspace-1",
+      replacementShellPreferences: { rollback: rollbackPreferences },
+      replacementTransaction: {
+        replacedSessionId: "old-session",
+        commit: vi.fn(),
+        rollback: rollbackReplacement,
+      },
+      rollbackOwnedShellIntent: () => true,
+      workspaceId: "workspace-1",
+    }, { activateSession });
+
+    expect(getSessionRecord("old-session")).not.toBeNull();
+    expect(getSessionRecord("pending-claude")).toBeNull();
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("old-session");
+    expect(rollbackPreferences).toHaveBeenCalledOnce();
+    expect(rollbackReplacement).toHaveBeenCalledOnce();
+    expect(useChatInputStore.getState().draftByWorkspaceId["logical-workspace-1"])
+      .toEqual({ nodes: [{ type: "text", text: "newer draft" }] });
+    expect(useSessionIntentStore.getState().entriesById["prompt-1"]).toBeUndefined();
+    const recovered = useChatPromptRecoveryStore.getState()
+      .recoveriesByWorkspaceUiKey["logical-workspace-1"];
+    expect(recovered).toEqual([
+      expect.objectContaining({
+        agentKind: "claude",
+        modeId: "agent",
+        modelId: "sonnet",
+        prompt: expect.objectContaining({
+          blocks: expect.arrayContaining([
+            expect.objectContaining({ type: "plan_reference", planId: "plan-1" }),
+          ]),
+          attachmentSnapshots: [expect.objectContaining({ id: "attachment-1" })],
+        }),
+      }),
+      expect.objectContaining({
+        prompt: expect.objectContaining({ text: "Then run the tests" }),
+      }),
+    ]);
+  });
+
+  it("removes a replacement that remained empty before restoring the old shell", () => {
+    const oldRecord = createEmptySessionRecord("old-session", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-old",
+    });
+    putSessionRecord(createEmptySessionRecord("pending-claude", "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+    }));
+    useSessionSelectionStore.getState().setActiveSessionId("pending-claude");
+    const activateSession = vi.fn((sessionId: string) => {
+      useSessionSelectionStore.getState().setActiveSessionId(sessionId);
+    });
+
+    cleanupSessionCreationFailure({
+      agentKind: "claude",
+      currentOwnedSessionId: "pending-claude",
+      error: new Error("materialization failed"),
+      hadExistingProjectedRecord: false,
+      hasPrompt: false,
+      modeId: null,
+      modelId: "sonnet",
+      pendingSessionId: "pending-claude",
+      preserveProjectedSessionOnCreateFailure: false,
+      previousActiveSessionId: "old-session",
+      recoveryWorkspaceUiKey: "workspace-1",
+      replacementShellPreferences: null,
+      replacementTransaction: {
+        replacedSessionId: "old-session",
+        commit: vi.fn(),
+        rollback: () => putSessionRecord(oldRecord),
+      },
+      rollbackOwnedShellIntent: () => true,
+      workspaceId: "workspace-1",
+    }, { activateSession });
+
+    expect(getSessionRecord("pending-claude")).toBeNull();
+    expect(getSessionRecord("old-session")).not.toBeNull();
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("old-session");
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts
@@ -1,0 +1,164 @@
+import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
+import { logLatency } from "@/lib/infra/measurement/debug-latency";
+import { useChatLaunchIntentStore } from "@/stores/chat/chat-launch-intent-store";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import {
+  getSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useChatPromptRecoveryStore } from "@/stores/chat/chat-prompt-recovery-store";
+import {
+  getPromptOutboxEntriesForSession,
+  useSessionIntentStore,
+} from "@/stores/sessions/session-intent-store";
+import {
+  markProjectedSessionPromptCreateFailed,
+} from "@/hooks/sessions/workflows/session-creation-failure";
+import {
+  removeSessionRecordAndClearSelection,
+} from "@/hooks/sessions/workflows/session-creation-local-state";
+import type {
+  EmptySessionReplacementTransaction,
+} from "@/hooks/sessions/workflows/use-empty-session-replacement-cleanup";
+import type {
+  ReplacementShellPreferencesTransaction,
+} from "@/hooks/sessions/workflows/session-replacement-shell-preferences";
+
+interface SessionCreationFailureCleanupInput {
+  agentKind: string;
+  currentOwnedSessionId: string | null;
+  error: unknown;
+  hadExistingProjectedRecord: boolean;
+  hasPrompt: boolean;
+  launchIntentId?: string | null;
+  modeId: string | null;
+  modelId: string;
+  pendingSessionId: string;
+  preserveProjectedSessionOnCreateFailure: boolean;
+  previousActiveSessionId: string | null;
+  recoveryWorkspaceUiKey: string;
+  replacementShellPreferences: ReplacementShellPreferencesTransaction | null;
+  replacementTransaction: EmptySessionReplacementTransaction | null;
+  rollbackOwnedShellIntent: () => boolean;
+  workspaceId: string;
+}
+
+interface SessionCreationFailureCleanupDeps {
+  activateSession: (sessionId: string) => void;
+}
+
+export function cleanupSessionCreationFailure(
+  input: SessionCreationFailureCleanupInput,
+  deps: SessionCreationFailureCleanupDeps,
+): void {
+  logLatency("session.create.failed", {
+    clientSessionId: input.pendingSessionId,
+    workspaceId: input.workspaceId,
+    agentKind: input.agentKind,
+    modelId: input.modelId,
+    hasPrompt: input.hasPrompt,
+    hasExistingProjectedRecord: input.hadExistingProjectedRecord,
+    errorMessage: input.error instanceof Error
+      ? input.error.message
+      : String(input.error),
+  });
+
+  if (input.replacementTransaction) {
+    const activeSessionIdBeforeRemoval = useSessionSelectionStore.getState().activeSessionId;
+    const acquiredPrompts = getPromptOutboxEntriesForSession(input.pendingSessionId)
+      .filter((entry) => (
+        entry.dispatchedAt === null
+        && entry.deliveryState !== "cancelled"
+        && entry.deliveryState !== "echoed_tombstone"
+      ));
+    if (acquiredPrompts.length > 0) {
+      // The replacement began empty, but the still-usable composer may have
+      // queued work while it materialized. Move the complete payload into a
+      // workspace-scoped recovery surface before removing the failed shell.
+      const errorMessage = input.error instanceof Error && input.error.message.trim()
+        ? input.error.message
+        : "Session creation failed.";
+      useChatPromptRecoveryStore.getState().addRecoveries(
+        input.recoveryWorkspaceUiKey,
+        acquiredPrompts.map((prompt) => ({
+          id: prompt.clientPromptId,
+          workspaceId: input.workspaceId,
+          agentKind: input.agentKind,
+          modelId: input.modelId,
+          modeId: input.modeId,
+          errorMessage,
+          prompt,
+        })),
+      );
+    }
+    useSessionIntentStore.getState().clearSession(input.pendingSessionId);
+    removeSessionRecordAndClearSelection(input.pendingSessionId);
+    const rolledBackShellIntent = input.rollbackOwnedShellIntent();
+    input.replacementShellPreferences?.rollback();
+    input.replacementTransaction.rollback();
+    if (
+      rolledBackShellIntent
+      && activeSessionIdBeforeRemoval === input.currentOwnedSessionId
+      && input.previousActiveSessionId
+      && getSessionRecord(input.previousActiveSessionId)
+    ) {
+      deps.activateSession(input.previousActiveSessionId);
+    }
+    clearLaunchIntent(input.launchIntentId);
+    captureCreationFailure(input.error, "replace_empty_session");
+    return;
+  }
+
+  if (input.hasPrompt || input.preserveProjectedSessionOnCreateFailure) {
+    markProjectedSessionPromptCreateFailed(input.pendingSessionId, input.error);
+    clearLaunchIntent(input.launchIntentId);
+    captureCreationFailure(
+      input.error,
+      input.hasPrompt
+        ? "create_session_with_resolved_config"
+        : "create_projected_session_materialization",
+    );
+    return;
+  }
+
+  const activeSessionIdBeforeRemoval = useSessionSelectionStore.getState().activeSessionId;
+  useSessionIntentStore.getState().clearSession(input.pendingSessionId);
+  removeSessionRecordAndClearSelection(input.pendingSessionId);
+  const rolledBackShellIntent = input.rollbackOwnedShellIntent();
+  if (
+    rolledBackShellIntent
+    && activeSessionIdBeforeRemoval === input.currentOwnedSessionId
+  ) {
+    if (
+      input.previousActiveSessionId
+      && getSessionRecord(input.previousActiveSessionId)
+    ) {
+      deps.activateSession(input.previousActiveSessionId);
+    } else {
+      const remainingIds = useSessionDirectoryStore.getState()
+        .sessionIdsByWorkspaceId[input.workspaceId] ?? [];
+      const fallbackSessionId = remainingIds.find(
+        (id) => id !== input.pendingSessionId,
+      ) ?? null;
+      if (fallbackSessionId) {
+        deps.activateSession(fallbackSessionId);
+      } else {
+        useSessionSelectionStore.getState().setActiveSessionId(null);
+      }
+    }
+  }
+  clearLaunchIntent(input.launchIntentId);
+  captureCreationFailure(input.error, "create_session_with_resolved_config");
+}
+
+function clearLaunchIntent(launchIntentId: string | null | undefined): void {
+  if (launchIntentId) {
+    useChatLaunchIntentStore.getState().clearIfActive(launchIntentId);
+  }
+}
+
+function captureCreationFailure(error: unknown, action: string): void {
+  captureTelemetryException(error, {
+    tags: { action, domain: "sessions" },
+  });
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  committedReplacedSessionTombstonesForWorkspace,
+  isReplacedSessionTombstoned,
+  resetReplacedSessionTombstonesForTests,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  resetSessionReplacementDismissalsForTests,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+import { scheduleCreatedRuntimeSessionCleanup } from "./session-created-runtime-cleanup";
+import { materializeSessionCreation } from "./session-creation-materialization";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+  removeSessionRecord,
+} from "@/stores/sessions/session-records";
+import {
+  commitSupersededSessionCreation,
+  registerSessionCreation,
+  resetSessionCreationSupersessionForTests,
+  supersedeInFlightSessionCreation,
+} from "./session-creation-supersession";
+
+const mocks = vi.hoisted(() => ({
+  applySessionLaunchDefaults: vi.fn(),
+  createSession: vi.fn(),
+  dismissSession: vi.fn(() => new Promise<void>(() => undefined)),
+  writeTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/access/anyharness/sessions", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/lib/access/anyharness/sessions")>(),
+  createSession: mocks.createSession,
+  dismissSession: mocks.dismissSession,
+}));
+
+vi.mock("@/lib/workflows/sessions/session-launch-defaults", () => ({
+  applySessionLaunchDefaults: mocks.applySessionLaunchDefaults,
+}));
+
+vi.mock("@/lib/access/anyharness/runtime-target", () => ({
+  resolveRuntimeTargetForWorkspace: vi.fn(async () => ({
+    baseUrl: "http://runtime.test",
+    authToken: null,
+    anyharnessWorkspaceId: "workspace-1",
+    location: "local",
+    runtimeGeneration: 1,
+    cloudWorkspaceId: null,
+    targetId: null,
+  })),
+}));
+
+vi.mock("@/hooks/sessions/workflows/session-creation-runtime", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/hooks/sessions/workflows/session-creation-runtime")>(),
+  resolveDesktopRuntimeUrlForWorkspace: vi.fn(async () => "http://runtime.test"),
+}));
+
+vi.mock("@/lib/access/anyharness/direct-session-create-guard", () => ({
+  assertDirectSessionCreateSupported: vi.fn(),
+}));
+
+vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
+  readSessionReplacementTombstones: () => ({}),
+  writeSessionReplacementTombstones: mocks.writeTombstones,
+}));
+
+beforeEach(() => {
+  mocks.dismissSession.mockClear();
+  mocks.dismissSession.mockImplementation(() => new Promise<void>(() => undefined));
+  mocks.writeTombstones.mockReset();
+  mocks.writeTombstones.mockReturnValue(true);
+  mocks.applySessionLaunchDefaults.mockReset();
+  mocks.createSession.mockReset();
+  resetReplacedSessionTombstonesForTests();
+  resetSessionReplacementDismissalsForTests();
+  resetSessionCreationSupersessionForTests();
+});
+
+describe("created runtime cleanup", () => {
+  it("commits runtime and client suppression without awaiting dismissal", async () => {
+    const result = scheduleCreatedRuntimeSessionCleanup({
+      connection: {} as never,
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-created",
+      clientSessionId: "client-created",
+    });
+
+    await expect(result).resolves.toBe(true);
+    await vi.waitFor(() => {
+      expect(mocks.dismissSession).toHaveBeenCalledWith({}, "runtime-created");
+    });
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual(["runtime-created"]);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-created")).toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-created")).toBe(true);
+  });
+
+  it("releases suppression when neither persistence nor dismissal can retire the runtime", async () => {
+    mocks.writeTombstones.mockReturnValue(false);
+    mocks.dismissSession.mockRejectedValue(new Error("runtime unavailable"));
+
+    await expect(scheduleCreatedRuntimeSessionCleanup({
+      connection: {} as never,
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-created",
+      clientSessionId: "client-created",
+    })).resolves.toBe(false);
+
+    expect(mocks.dismissSession).toHaveBeenCalledTimes(3);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-created")).toBe(false);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-created")).toBe(false);
+  });
+
+  it("publishes a created runtime when launch failure cleanup cannot retire it", async () => {
+    const pendingSessionId = "pending-retained-runtime";
+    const projectedRecord = createEmptySessionRecord(pendingSessionId, "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "sonnet",
+    });
+    putSessionRecord(projectedRecord);
+    mocks.createSession.mockResolvedValue({
+      id: "runtime-retained",
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+      status: "idle",
+    });
+    mocks.applySessionLaunchDefaults.mockRejectedValue(new Error("defaults failed"));
+    mocks.writeTombstones.mockReturnValue(false);
+    mocks.dismissSession.mockRejectedValue(new Error("runtime unavailable"));
+    const upsertWorkspaceSessionRecord = vi.fn();
+
+    await expect(materializeSessionCreation({
+      ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
+      existingProjectedRecord: projectedRecord,
+      frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      options: {
+        text: "",
+        agentKind: "claude",
+        modelId: "sonnet",
+        workspaceId: "workspace-1",
+      },
+      pendingSessionId,
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord,
+      workspaceId: "workspace-1",
+    })).resolves.toBe(pendingSessionId);
+
+    expect(getSessionRecord(pendingSessionId)?.materializedSessionId)
+      .toBe("runtime-retained");
+    expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({ id: "runtime-retained" }),
+      { runtimeUrl: "http://runtime.test" },
+    );
+    removeSessionRecord(pendingSessionId);
+  });
+
+  it("recreates a removed superseded shell when its runtime cannot be retired", async () => {
+    const pendingSessionId = "pending-superseded-runtime";
+    const projectedRecord = createEmptySessionRecord(pendingSessionId, "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "sonnet",
+    });
+    putSessionRecord(projectedRecord);
+    const createGate = deferred<{
+      id: string;
+      workspaceId: string;
+      agentKind: string;
+      modelId: string;
+      status: string;
+    }>();
+    mocks.createSession.mockReturnValueOnce(createGate.promise);
+    mocks.writeTombstones.mockReturnValue(false);
+    mocks.dismissSession.mockRejectedValue(new Error("runtime unavailable"));
+    const upsertWorkspaceSessionRecord = vi.fn();
+    const unregister = registerSessionCreation(pendingSessionId);
+    const materialization = materializeSessionCreation({
+      ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
+      existingProjectedRecord: projectedRecord,
+      frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      options: {
+        text: "",
+        agentKind: "claude",
+        modelId: "sonnet",
+        workspaceId: "workspace-1",
+      },
+      pendingSessionId,
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord,
+      workspaceId: "workspace-1",
+    });
+    await vi.waitFor(() => expect(mocks.createSession).toHaveBeenCalledTimes(1));
+    supersedeInFlightSessionCreation(pendingSessionId);
+    commitSupersededSessionCreation(pendingSessionId);
+    removeSessionRecord(pendingSessionId);
+    createGate.resolve({
+      id: "runtime-superseded-retained",
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+      status: "idle",
+    });
+
+    await expect(materialization).resolves.toBe(pendingSessionId);
+    expect(getSessionRecord(pendingSessionId)?.materializedSessionId)
+      .toBe("runtime-superseded-retained");
+    expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({ id: "runtime-superseded-retained" }),
+      { runtimeUrl: "http://runtime.test" },
+    );
+    expect(mocks.applySessionLaunchDefaults).not.toHaveBeenCalled();
+    unregister();
+    removeSessionRecord(pendingSessionId);
+  });
+
+  it("retires a superseded runtime while launch defaults are still pending", async () => {
+    const pendingSessionId = "pending-blocked-defaults";
+    const projectedRecord = createEmptySessionRecord(pendingSessionId, "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "sonnet",
+    });
+    const runtimeSession = {
+      id: "runtime-blocked-defaults",
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+      status: "idle",
+    };
+    const defaultsGate = deferred<{
+      session: typeof runtimeSession;
+      liveConfig: null;
+    }>();
+    putSessionRecord(projectedRecord);
+    mocks.createSession.mockResolvedValue(runtimeSession);
+    mocks.applySessionLaunchDefaults.mockReturnValue(defaultsGate.promise);
+    const unregister = registerSessionCreation(pendingSessionId);
+    const materialization = materializeSessionCreation({
+      ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
+      existingProjectedRecord: projectedRecord,
+      frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      options: {
+        text: "",
+        agentKind: "claude",
+        modelId: "sonnet",
+        workspaceId: "workspace-1",
+      },
+      pendingSessionId,
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord: vi.fn(),
+      workspaceId: "workspace-1",
+    });
+    await vi.waitFor(() => {
+      expect(mocks.applySessionLaunchDefaults).toHaveBeenCalledTimes(1);
+    });
+
+    supersedeInFlightSessionCreation(pendingSessionId);
+    commitSupersededSessionCreation(pendingSessionId);
+    removeSessionRecord(pendingSessionId);
+
+    await expect(materialization).resolves.toBe(pendingSessionId);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toContain("runtime-blocked-defaults");
+    await vi.waitFor(() => {
+      expect(mocks.dismissSession).toHaveBeenCalledWith(
+        expect.anything(),
+        "runtime-blocked-defaults",
+      );
+    });
+    expect(getSessionRecord(pendingSessionId)).toBeNull();
+
+    defaultsGate.resolve({ session: runtimeSession, liveConfig: null });
+    unregister();
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts
@@ -1,0 +1,42 @@
+import {
+  subscribeToSessionCreationSupersession,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+
+/**
+ * Races a long materialization request with replace-in-place supersession.
+ * A rolled-back successor resumes the same request and rearms the signal;
+ * committed supersession lets the caller retire or publish the created runtime.
+ */
+export async function runInterruptibleSessionCreationStep<T>(input: {
+  sessionId: string;
+  step: Promise<T>;
+  onSuperseded: () => Promise<boolean>;
+}): Promise<{ discarded: true } | { discarded: false; value: T }> {
+  while (true) {
+    let unsubscribe: () => void = () => undefined;
+    const superseded = new Promise<{ kind: "superseded" }>((resolve) => {
+      unsubscribe = subscribeToSessionCreationSupersession(
+        input.sessionId,
+        () => resolve({ kind: "superseded" }),
+      );
+    });
+    const completed = input.step.then((value) => ({
+      kind: "completed" as const,
+      value,
+    }));
+    let outcome: Awaited<typeof completed> | { kind: "superseded" };
+    try {
+      outcome = await Promise.race([completed, superseded]);
+    } finally {
+      unsubscribe();
+    }
+    if (outcome.kind === "completed") {
+      return { discarded: false, value: outcome.value };
+    }
+    if (await input.onSuperseded()) {
+      return { discarded: true };
+    }
+    // The successor rolled back while the external step was in flight. Keep
+    // waiting on that same work, but subscribe again for a later replacement.
+  }
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -18,6 +18,7 @@ import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-s
 import {
   createEmptySessionRecord,
   getSessionRecord,
+  putSessionRecord,
 } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "@/stores/sessions/session-types";
@@ -46,6 +47,12 @@ import type { CreateSessionWithResolvedConfigOptions } from "@/hooks/sessions/wo
 import { resolveDesktopRuntimeUrlForWorkspace } from "@/hooks/sessions/workflows/session-creation-runtime";
 import { annotateLatencyFlow } from "@/lib/infra/measurement/latency-flow";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
+import {
+  shouldDiscardSupersededSessionCreation,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+import { filterReplacedSessionTombstones } from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import { scheduleCreatedRuntimeSessionCleanup } from "@/hooks/sessions/workflows/session-created-runtime-cleanup";
+import { runInterruptibleSessionCreationStep } from "@/hooks/sessions/workflows/session-creation-materialization-interruption";
 
 interface MaterializeSessionCreationInput {
   ensureCloudAgentCatalog: () => Promise<{
@@ -64,7 +71,32 @@ interface MaterializeSessionCreationInput {
   workspaceId: string;
 }
 
-export async function materializeSessionCreation({
+interface MaterializationLifecycle {
+  discardCreatedSession: (() => Promise<boolean>) | null;
+  retainCreatedSession: (() => void) | null;
+}
+
+export async function materializeSessionCreation(
+  input: MaterializeSessionCreationInput,
+): Promise<string> {
+  const lifecycle: MaterializationLifecycle = {
+    discardCreatedSession: null,
+    retainCreatedSession: null,
+  };
+  try {
+    return await runSessionCreationMaterialization(input, lifecycle);
+  } catch (error) {
+    if (await discardIfSuperseded(input.pendingSessionId, lifecycle)) {
+      return input.pendingSessionId;
+    }
+    if (!await discardCreatedRuntimeSession(lifecycle)) {
+      return input.pendingSessionId;
+    }
+    throw error;
+  }
+}
+
+async function runSessionCreationMaterialization({
   ensureCloudAgentCatalog,
   existingProjectedRecord,
   frozenDefaultLiveSessionControlValuesByAgentKind,
@@ -73,7 +105,7 @@ export async function materializeSessionCreation({
   resolvedModeId,
   upsertWorkspaceSessionRecord,
   workspaceId,
-}: MaterializeSessionCreationInput): Promise<string> {
+}: MaterializeSessionCreationInput, lifecycle: MaterializationLifecycle): Promise<string> {
   const materializeStartedAt = Date.now();
   const requestOptions = buildLatencyRequestOptions(options.latencyFlowId);
   logLatency("session.create.materialize.start", {
@@ -109,6 +141,9 @@ export async function materializeSessionCreation({
     ...targetConnection,
     anyharnessWorkspaceId: target.anyharnessWorkspaceId,
   };
+  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+    return pendingSessionId;
+  }
   if (shouldProbeCompatibleRuntimeSessions({
     preferExistingCompatibleSession: options.preferExistingCompatibleSession,
     runtimeLocation: target.location,
@@ -118,12 +153,15 @@ export async function materializeSessionCreation({
       requestOptions,
     )
       .then((sessions) => findCompatibleExistingSession({
-        sessions,
+        sessions: filterReplacedSessionTombstones(workspaceId, sessions) ?? [],
         agentKind: options.agentKind,
         modelId: options.modelId,
       }))
       .catch(() => null);
     if (existingSession) {
+      if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+        return pendingSessionId;
+      }
       return materializeExistingSession({
         existingProjectedRecord,
         existingSession,
@@ -149,6 +187,47 @@ export async function materializeSessionCreation({
     subagentsEnabled,
     origin: DESKTOP_ORIGIN,
   }, requestOptions);
+  lifecycle.discardCreatedSession = () => {
+    return scheduleCreatedRuntimeSessionCleanup({
+      connection: targetConnection,
+      workspaceId,
+      runtimeSessionId: session.id,
+      clientSessionId: pendingSessionId,
+    });
+  };
+  let sessionToRetain = session;
+  lifecycle.retainCreatedSession = () => {
+    if (!getSessionRecord(pendingSessionId)) {
+      putSessionRecord(createEmptySessionRecord(
+        pendingSessionId,
+        sessionToRetain.agentKind,
+        {
+          workspaceId,
+          materializedSessionId: null,
+          modelId: sessionToRetain.modelId ?? options.modelId,
+          requestedModelId: sessionToRetain.requestedModelId ?? options.modelId,
+          modeId: sessionToRetain.modeId ?? resolvedModeId,
+          title: sessionToRetain.title ?? existingProjectedRecord?.title ?? null,
+          sessionRelationship: { kind: "root" },
+        },
+      ));
+    }
+    materializeExistingSession({
+      existingProjectedRecord,
+      existingSession: sessionToRetain,
+      fallbackModelId: options.modelId,
+      latencyFlowId: options.latencyFlowId,
+      launchIntentId: options.launchIntentId,
+      pendingSessionId,
+      resolvedModeId,
+      runtimeUrl: target.baseUrl,
+      upsertWorkspaceSessionRecord,
+      workspaceId,
+    });
+  };
+  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+    return pendingSessionId;
+  }
   logLatency("session.create.materialize.session_created", {
     clientSessionId: pendingSessionId,
     materializedSessionId: session.id,
@@ -163,7 +242,15 @@ export async function materializeSessionCreation({
   });
 
   const queuedConfigValuesBeforeDefaults = pendingConfigValuesForSession(pendingSessionId);
-  const cloudLaunchCatalog = await ensureCloudAgentCatalog().catch(() => null);
+  const catalogStep = await runInterruptibleSessionCreationStep({
+    sessionId: pendingSessionId,
+    step: ensureCloudAgentCatalog().catch(() => null),
+    onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
+  });
+  if (catalogStep.discarded) {
+    return pendingSessionId;
+  }
+  const cloudLaunchCatalog = catalogStep.value;
   const modelRegistries = buildDesktopLaunchModelRegistries(
     cloudLaunchCatalog?.agents ?? [],
   );
@@ -172,17 +259,32 @@ export async function materializeSessionCreation({
     agentKind: options.agentKind,
     values: queuedConfigValuesBeforeDefaults,
   });
-  const launchDefaults = await applySessionLaunchDefaults({
-    client: createSessionLaunchDefaultsClient(targetConnection),
-    session,
-    agentKind: options.agentKind,
-    modelRegistries,
-    defaultLiveSessionControlValuesByAgentKind: liveDefaultsForLaunch,
+  const launchDefaultsStep = await runInterruptibleSessionCreationStep({
+    sessionId: pendingSessionId,
+    step: applySessionLaunchDefaults({
+      client: createSessionLaunchDefaultsClient(targetConnection),
+      session,
+      agentKind: options.agentKind,
+      modelRegistries,
+      defaultLiveSessionControlValuesByAgentKind: liveDefaultsForLaunch,
+    }),
+    onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
   });
+  if (launchDefaultsStep.discarded) {
+    return pendingSessionId;
+  }
+  const launchDefaults = launchDefaultsStep.value;
   const launchedSession = launchDefaults.session;
   const launchedLiveConfig = launchDefaults.liveConfig
     ?? launchedSession.liveConfig
     ?? null;
+  sessionToRetain = {
+    ...launchedSession,
+    liveConfig: launchedLiveConfig,
+  };
+  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+    return pendingSessionId;
+  }
   const realRecord: SessionRuntimeRecord = {
     ...createEmptySessionRecord(pendingSessionId, options.agentKind, {
       workspaceId,
@@ -252,5 +354,43 @@ export async function materializeSessionCreation({
     );
   }
 
+  lifecycle.discardCreatedSession = null;
+  lifecycle.retainCreatedSession = null;
   return pendingSessionId;
+}
+
+async function discardIfSuperseded(
+  sessionId: string,
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  if (!await shouldDiscardSupersededSessionCreation(sessionId)) {
+    return false;
+  }
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  // The successor already committed, but this created runtime could not be
+  // retired safely. Publish it honestly and stop this older materializer here.
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return true;
+}
+
+async function discardCreatedRuntimeSession(
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return false;
 }

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  commitSupersededSessionCreation,
+  registerSessionCreation,
+  resetSessionCreationSupersessionForTests,
+  rollbackSupersededSessionCreation,
+  shouldDiscardSupersededSessionCreation,
+  subscribeToSessionCreationSupersession,
+  supersedeInFlightSessionCreation,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+
+beforeEach(() => {
+  resetSessionCreationSupersessionForTests();
+});
+
+describe("session creation supersession", () => {
+  it("pauses an in-flight materializer until replacement commits", async () => {
+    const unregister = registerSessionCreation("old-session");
+    expect(supersedeInFlightSessionCreation("old-session")).toBe(true);
+
+    let settled = false;
+    const disposition = shouldDiscardSupersededSessionCreation("old-session")
+      .then((discard) => {
+        settled = true;
+        return discard;
+      });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    commitSupersededSessionCreation("old-session");
+    await expect(disposition).resolves.toBe(true);
+    unregister();
+  });
+
+  it("lets the original materializer continue after replacement rollback", async () => {
+    const unregister = registerSessionCreation("old-session");
+    supersedeInFlightSessionCreation("old-session");
+    const disposition = shouldDiscardSupersededSessionCreation("old-session");
+
+    rollbackSupersededSessionCreation("old-session");
+
+    await expect(disposition).resolves.toBe(false);
+    unregister();
+  });
+
+  it("signals a later replacement after an earlier replacement rolls back", async () => {
+    const unregister = registerSessionCreation("old-session");
+    supersedeInFlightSessionCreation("old-session");
+    rollbackSupersededSessionCreation("old-session");
+    const signalled = new Promise<void>((resolve) => {
+      subscribeToSessionCreationSupersession("old-session", resolve);
+    });
+
+    supersedeInFlightSessionCreation("old-session");
+    await expect(signalled).resolves.toBeUndefined();
+    commitSupersededSessionCreation("old-session");
+    await expect(shouldDiscardSupersededSessionCreation("old-session"))
+      .resolves.toBe(true);
+    unregister();
+  });
+
+  it("does not create a tombstone when no materialization is in flight", async () => {
+    expect(supersedeInFlightSessionCreation("materialized-session")).toBe(false);
+    commitSupersededSessionCreation("materialized-session");
+    await expect(shouldDiscardSupersededSessionCreation("materialized-session"))
+      .resolves.toBe(false);
+  });
+
+  it("composes A to B to C replacements without resurrecting either superseded create", async () => {
+    const unregisterA = registerSessionCreation("session-a");
+    supersedeInFlightSessionCreation("session-a");
+    const dispositionA = shouldDiscardSupersededSessionCreation("session-a");
+
+    const unregisterB = registerSessionCreation("session-b");
+    supersedeInFlightSessionCreation("session-b");
+    const dispositionB = shouldDiscardSupersededSessionCreation("session-b");
+
+    // C succeeds, so B is discarded. B's replacement promise can then settle
+    // successfully and commit A's transaction as well.
+    commitSupersededSessionCreation("session-b");
+    await expect(dispositionB).resolves.toBe(true);
+    commitSupersededSessionCreation("session-a");
+    await expect(dispositionA).resolves.toBe(true);
+
+    unregisterB();
+    unregisterA();
+  });
+
+  it("lets B continue when C fails during an A to B to C replacement chain", async () => {
+    const unregisterA = registerSessionCreation("session-a");
+    supersedeInFlightSessionCreation("session-a");
+    const dispositionA = shouldDiscardSupersededSessionCreation("session-a");
+
+    const unregisterB = registerSessionCreation("session-b");
+    supersedeInFlightSessionCreation("session-b");
+    const dispositionB = shouldDiscardSupersededSessionCreation("session-b");
+
+    rollbackSupersededSessionCreation("session-b");
+    await expect(dispositionB).resolves.toBe(false);
+    commitSupersededSessionCreation("session-a");
+    await expect(dispositionA).resolves.toBe(true);
+
+    unregisterB();
+    unregisterA();
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.ts
@@ -1,0 +1,132 @@
+type SupersessionDisposition = "committed" | "rolled_back";
+
+interface SupersessionEntry {
+  disposition: SupersessionDisposition | null;
+  promise: Promise<SupersessionDisposition>;
+  resolve: (disposition: SupersessionDisposition) => void;
+}
+
+const activeCreationTokensBySessionId = new Map<string, Set<symbol>>();
+const supersessionBySessionId = new Map<string, SupersessionEntry>();
+const supersessionListenersBySessionId = new Map<string, Set<() => void>>();
+
+/** Registers one materialization attempt so a later replace-in-place action can pause it. */
+export function registerSessionCreation(sessionId: string): () => void {
+  const token = Symbol(sessionId);
+  const tokens = activeCreationTokensBySessionId.get(sessionId) ?? new Set<symbol>();
+  tokens.add(token);
+  activeCreationTokensBySessionId.set(sessionId, tokens);
+
+  return () => {
+    const current = activeCreationTokensBySessionId.get(sessionId);
+    current?.delete(token);
+    if (current?.size === 0) {
+      activeCreationTokensBySessionId.delete(sessionId);
+      const supersession = supersessionBySessionId.get(sessionId);
+      if (supersession?.disposition) {
+        supersessionBySessionId.delete(sessionId);
+      }
+      supersessionListenersBySessionId.delete(sessionId);
+    }
+  };
+}
+
+/**
+ * Pauses an in-flight creation before it can write its materialized record.
+ * Returns false when the session has no creation that can race the replacement.
+ */
+export function supersedeInFlightSessionCreation(sessionId: string): boolean {
+  if (!activeCreationTokensBySessionId.has(sessionId)) {
+    return false;
+  }
+  const existing = supersessionBySessionId.get(sessionId);
+  if (existing && existing.disposition !== "rolled_back") {
+    return true;
+  }
+  if (existing) {
+    supersessionBySessionId.delete(sessionId);
+  }
+
+  let resolve!: (disposition: SupersessionDisposition) => void;
+  const promise = new Promise<SupersessionDisposition>((next) => {
+    resolve = next;
+  });
+  supersessionBySessionId.set(sessionId, {
+    disposition: null,
+    promise,
+    resolve,
+  });
+  const listeners = supersessionListenersBySessionId.get(sessionId);
+  supersessionListenersBySessionId.delete(sessionId);
+  for (const listener of listeners ?? []) {
+    listener();
+  }
+  return true;
+}
+
+/** Subscribe to the next active supersession request for a materializer. */
+export function subscribeToSessionCreationSupersession(
+  sessionId: string,
+  listener: () => void,
+): () => void {
+  const supersession = supersessionBySessionId.get(sessionId);
+  if (supersession && supersession.disposition !== "rolled_back") {
+    listener();
+    return () => undefined;
+  }
+  const listeners = supersessionListenersBySessionId.get(sessionId) ?? new Set();
+  listeners.add(listener);
+  supersessionListenersBySessionId.set(sessionId, listeners);
+  return () => {
+    const current = supersessionListenersBySessionId.get(sessionId);
+    current?.delete(listener);
+    if (current?.size === 0) {
+      supersessionListenersBySessionId.delete(sessionId);
+    }
+  };
+}
+
+export function commitSupersededSessionCreation(sessionId: string): void {
+  resolveSupersession(sessionId, "committed");
+}
+
+export function rollbackSupersededSessionCreation(sessionId: string): void {
+  resolveSupersession(sessionId, "rolled_back");
+}
+
+/**
+ * Materializers call this before every local write (and after external
+ * failures). A pending replacement pauses them; a committed replacement drops
+ * their result, while rollback lets the original creation continue normally.
+ */
+export async function shouldDiscardSupersededSessionCreation(
+  sessionId: string,
+): Promise<boolean> {
+  const supersession = supersessionBySessionId.get(sessionId);
+  if (!supersession) {
+    return false;
+  }
+  const disposition = supersession.disposition ?? await supersession.promise;
+  return disposition === "committed";
+}
+
+function resolveSupersession(
+  sessionId: string,
+  disposition: SupersessionDisposition,
+): void {
+  const supersession = supersessionBySessionId.get(sessionId);
+  if (!supersession || supersession.disposition) {
+    return;
+  }
+  supersession.disposition = disposition;
+  supersession.resolve(disposition);
+  if (!activeCreationTokensBySessionId.has(sessionId)) {
+    supersessionBySessionId.delete(sessionId);
+  }
+}
+
+export function resetSessionCreationSupersessionForTests(): void {
+  activeCreationTokensBySessionId.clear();
+  supersessionBySessionId.clear();
+  supersessionListenersBySessionId.clear();
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-types.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-types.ts
@@ -23,10 +23,10 @@ export interface CreateSessionWithResolvedConfigOptions {
   skipInitialPromptEnqueue?: boolean;
   onBeforeOptimisticPrompt?: (workspaceId: string) => Promise<void> | void;
   /**
-   * When set, the creation workflow performs local cleanup of this session
-   * immediately after the optimistic new session is activated — so the tab
-   * swap is instantaneous. The runtime dismiss for a materialized replaced
-   * session is fire-and-forget after local cleanup.
+   * When set, the creation workflow immediately hides this unused session
+   * after activating the optimistic replacement. Destructive cleanup and
+   * runtime dismissal commit only after the replacement materializes; failure
+   * restores the captured session shell.
    */
   replacesSessionId?: string | null;
 }
@@ -42,10 +42,10 @@ export interface CreateEmptySessionWithResolvedConfigOptions {
   reuseInFlightEmptySession?: boolean;
   preserveProjectedSessionOnCreateFailure?: boolean;
   /**
-   * When set, the creation workflow performs local cleanup of this session
-   * immediately after the optimistic new session is activated — so the tab
-   * swap is instantaneous. The runtime dismiss for a materialized replaced
-   * session is fire-and-forget after local cleanup.
+   * When set, the creation workflow immediately hides this unused session
+   * after activating the optimistic replacement. Destructive cleanup and
+   * runtime dismissal commit only after the replacement materializes; failure
+   * restores the captured session shell.
    */
   replacesSessionId?: string | null;
 }

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cancelQueuedReplacementDismissal,
+  resetSessionReplacementDismissalsForTests,
+  runTrackedReplacementDismissal,
+  withWorkspaceReplacementRestoreFence,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  resetSessionReplacementDismissalsForTests();
+});
+
+describe("replacement session dismissal coordination", () => {
+  it("publishes and deduplicates a dismissal before its async body begins", async () => {
+    const cleanupGate = deferred();
+    const nestedCleanup = vi.fn();
+    let nestedDismissal: Promise<void> | null = null;
+    const cleanup = vi.fn(async () => {
+      nestedDismissal = runTrackedReplacementDismissal({
+        workspaceId: "workspace-1",
+        runtimeSessionId: "runtime-1",
+        run: nestedCleanup,
+      });
+      await cleanupGate.promise;
+    });
+
+    const first = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-1",
+      run: cleanup,
+    });
+    const duplicate = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-1",
+      run: nestedCleanup,
+    });
+
+    expect(duplicate).toBe(first);
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(nestedCleanup).not.toHaveBeenCalled();
+
+    cleanupGate.resolve();
+    await first;
+    await nestedDismissal;
+    expect(nestedCleanup).not.toHaveBeenCalled();
+  });
+
+  it("waits for existing cleanup and drains deduplicated queued cleanup after restore", async () => {
+    const cleanupStarted = deferred();
+    const cleanupGate = deferred();
+    const cleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-old",
+      run: async () => {
+        cleanupStarted.resolve();
+        await cleanupGate.promise;
+      },
+    });
+    await cleanupStarted.promise;
+
+    const restoreGate = deferred();
+    const restoreStarted = deferred();
+    const restoreFn = vi.fn(async () => {
+      restoreStarted.resolve();
+      await restoreGate.promise;
+      return "restored";
+    });
+    const restore = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      restoreFn,
+    );
+    const cleanupDuringRestore = vi.fn();
+    const queuedCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-another",
+      run: cleanupDuringRestore,
+    });
+    const duplicateQueuedCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-another",
+      run: vi.fn(),
+    });
+
+    expect(duplicateQueuedCleanup).toBe(queuedCleanup);
+    expect(restoreFn).not.toHaveBeenCalled();
+    expect(cleanupDuringRestore).not.toHaveBeenCalled();
+
+    cleanupGate.resolve();
+    await cleanup;
+    await restoreStarted.promise;
+    expect(restoreFn).toHaveBeenCalledTimes(1);
+    expect(cleanupDuringRestore).not.toHaveBeenCalled();
+
+    restoreGate.resolve();
+    await expect(restore).resolves.toBe("restored");
+    await queuedCleanup;
+    expect(cleanupDuringRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels only the restored runtime's queued cleanup", async () => {
+    const restoreGate = deferred();
+    const restoredCleanup = vi.fn();
+    const unrelatedCleanup = vi.fn();
+    const restore = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      async () => {
+        await restoreGate.promise;
+        expect(cancelQueuedReplacementDismissal(
+          "workspace-1",
+          "runtime-restored",
+        )).toBe(true);
+        expect(cancelQueuedReplacementDismissal(
+          "workspace-1",
+          "runtime-missing",
+        )).toBe(false);
+      },
+    );
+    const canceledCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-restored",
+      run: restoredCleanup,
+    });
+    const drainedCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-unrelated",
+      run: unrelatedCleanup,
+    });
+
+    expect(restoredCleanup).not.toHaveBeenCalled();
+    expect(unrelatedCleanup).not.toHaveBeenCalled();
+
+    restoreGate.resolve();
+    await restore;
+    await Promise.all([canceledCleanup, drainedCleanup]);
+    expect(restoredCleanup).not.toHaveBeenCalled();
+    expect(unrelatedCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes concurrent restores and drains only after every fence closes", async () => {
+    const firstGate = deferred();
+    const firstStarted = deferred();
+    const secondGate = deferred();
+    const secondStarted = deferred();
+    const order: string[] = [];
+    const first = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      async () => {
+        order.push("first:start");
+        firstStarted.resolve();
+        await firstGate.promise;
+        order.push("first:end");
+      },
+    );
+    const second = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      async () => {
+        order.push("second:start");
+        secondStarted.resolve();
+        await secondGate.promise;
+        order.push("second:end");
+      },
+    );
+    const queuedCleanupFn = vi.fn();
+    const queuedCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-queued",
+      run: queuedCleanupFn,
+    });
+
+    await firstStarted.promise;
+    expect(order).toEqual(["first:start"]);
+
+    firstGate.resolve();
+    await first;
+    await secondStarted.promise;
+    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+    expect(queuedCleanupFn).not.toHaveBeenCalled();
+
+    secondGate.resolve();
+    await second;
+    await queuedCleanup;
+    expect(order).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+    expect(queuedCleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains queued cleanup when restore returns no session", async () => {
+    const restoreGate = deferred();
+    const restore = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      async () => {
+        await restoreGate.promise;
+        return null;
+      },
+    );
+    const cleanupFn = vi.fn();
+    const cleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-1",
+      run: cleanupFn,
+    });
+
+    restoreGate.resolve();
+    await expect(restore).resolves.toBeNull();
+    await cleanup;
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains queued cleanup and clears the fence when restore fails", async () => {
+    const restoreError = new Error("restore failed");
+    const restoreGate = deferred();
+    const restore = withWorkspaceReplacementRestoreFence(
+      "workspace-1",
+      async () => {
+        await restoreGate.promise;
+        throw restoreError;
+      },
+    );
+    const queuedCleanupFn = vi.fn();
+    const queuedCleanup = runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-1",
+      run: queuedCleanupFn,
+    });
+    expect(queuedCleanupFn).not.toHaveBeenCalled();
+
+    restoreGate.resolve();
+    await expect(restore).rejects.toBe(restoreError);
+    await queuedCleanup;
+    expect(queuedCleanupFn).toHaveBeenCalledTimes(1);
+
+    const cleanupAfterFailure = vi.fn();
+    await runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-2",
+      run: cleanupAfterFailure,
+    });
+    expect(cleanupAfterFailure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.ts
@@ -1,0 +1,236 @@
+interface TrackedReplacementDismissalInput {
+  workspaceId: string;
+  runtimeSessionId: string;
+  run: () => void | Promise<void>;
+}
+
+interface QueuedReplacementDismissal {
+  promise: Promise<void>;
+  reject: (error: unknown) => void;
+  resolve: () => void;
+  run: () => void | Promise<void>;
+}
+
+// Renderer-scoped workflow coordination; no remote data is cached here.
+const inFlightDismissalsByWorkspace = new Map<
+  string,
+  Map<string, Promise<void>>
+>();
+const queuedDismissalsByWorkspace = new Map<
+  string,
+  Map<string, QueuedReplacementDismissal>
+>();
+const activeRestoreFenceCountByWorkspace = new Map<string, number>();
+const restoreQueueTailByWorkspace = new Map<string, Promise<void>>();
+
+function hasActiveRestoreFence(workspaceId: string): boolean {
+  return (activeRestoreFenceCountByWorkspace.get(workspaceId) ?? 0) > 0;
+}
+
+function activateRestoreFence(workspaceId: string): void {
+  activeRestoreFenceCountByWorkspace.set(
+    workspaceId,
+    (activeRestoreFenceCountByWorkspace.get(workspaceId) ?? 0) + 1,
+  );
+}
+
+function deactivateRestoreFence(workspaceId: string): void {
+  const remaining = (
+    activeRestoreFenceCountByWorkspace.get(workspaceId) ?? 1
+  ) - 1;
+  if (remaining > 0) {
+    activeRestoreFenceCountByWorkspace.set(workspaceId, remaining);
+    return;
+  }
+  activeRestoreFenceCountByWorkspace.delete(workspaceId);
+  drainQueuedDismissals(workspaceId);
+}
+
+async function waitForTrackedDismissals(workspaceId: string): Promise<void> {
+  const dismissals = [
+    ...(inFlightDismissalsByWorkspace.get(workspaceId)?.values() ?? []),
+  ];
+  if (dismissals.length > 0) {
+    await Promise.allSettled(dismissals);
+  }
+}
+
+function createQueuedDismissal(
+  run: () => void | Promise<void>,
+): QueuedReplacementDismissal {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve, run };
+}
+
+function startTrackedDismissal(
+  workspaceId: string,
+  runtimeSessionId: string,
+  dismissal: QueuedReplacementDismissal,
+): Promise<void> {
+  let workspaceDismissals = inFlightDismissalsByWorkspace.get(workspaceId);
+  const existing = workspaceDismissals?.get(runtimeSessionId);
+  if (existing) {
+    void existing.then(dismissal.resolve, dismissal.reject);
+    return existing;
+  }
+
+  if (!workspaceDismissals) {
+    workspaceDismissals = new Map();
+    inFlightDismissalsByWorkspace.set(workspaceId, workspaceDismissals);
+  }
+
+  const tracked = dismissal.promise;
+  // Publish the promise before invoking `run`. Besides closing synchronous
+  // re-entry races, the microtask boundary lets a restore fence observe and
+  // await this cleanup even when it is requested in the same call stack.
+  workspaceDismissals.set(runtimeSessionId, tracked);
+  void Promise.resolve()
+    .then(dismissal.run)
+    .then(dismissal.resolve, dismissal.reject);
+
+  const removeTrackedDismissal = () => {
+    const currentWorkspaceDismissals = inFlightDismissalsByWorkspace.get(workspaceId);
+    if (currentWorkspaceDismissals?.get(runtimeSessionId) !== tracked) {
+      return;
+    }
+    currentWorkspaceDismissals.delete(runtimeSessionId);
+    if (currentWorkspaceDismissals.size === 0) {
+      inFlightDismissalsByWorkspace.delete(workspaceId);
+    }
+  };
+  void tracked.then(removeTrackedDismissal, removeTrackedDismissal);
+
+  return tracked;
+}
+
+function drainQueuedDismissals(workspaceId: string): void {
+  if (hasActiveRestoreFence(workspaceId)) {
+    return;
+  }
+  const queuedDismissals = queuedDismissalsByWorkspace.get(workspaceId);
+  if (!queuedDismissals) {
+    return;
+  }
+
+  // Remove the queue before scheduling work. A dismissal's async body can
+  // synchronously re-enter the coordinator and should see its tracked entry,
+  // not the stale queued copy.
+  queuedDismissalsByWorkspace.delete(workspaceId);
+  for (const [runtimeSessionId, dismissal] of queuedDismissals) {
+    startTrackedDismissal(workspaceId, runtimeSessionId, dismissal);
+  }
+}
+
+/**
+ * Runs one best-effort replacement dismissal per workspace/runtime pair.
+ * Restore fences defer new cleanup starts so an already-restored session
+ * cannot be dismissed by reconciliation that races with the restore. Deferred
+ * cleanup drains after the final same-workspace restore fence closes unless an
+ * explicit successful restore cancels that runtime's queued request.
+ */
+export function runTrackedReplacementDismissal({
+  workspaceId,
+  runtimeSessionId,
+  run,
+}: TrackedReplacementDismissalInput): Promise<void> {
+  const inFlight = inFlightDismissalsByWorkspace
+    .get(workspaceId)
+    ?.get(runtimeSessionId);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  if (hasActiveRestoreFence(workspaceId)) {
+    let queuedDismissals = queuedDismissalsByWorkspace.get(workspaceId);
+    const queued = queuedDismissals?.get(runtimeSessionId);
+    if (queued) {
+      return queued.promise;
+    }
+    if (!queuedDismissals) {
+      queuedDismissals = new Map();
+      queuedDismissalsByWorkspace.set(workspaceId, queuedDismissals);
+    }
+    const dismissal = createQueuedDismissal(run);
+    queuedDismissals.set(runtimeSessionId, dismissal);
+    return dismissal.promise;
+  }
+
+  return startTrackedDismissal(
+    workspaceId,
+    runtimeSessionId,
+    createQueuedDismissal(run),
+  );
+}
+
+/**
+ * Cancels cleanup that was deferred while an explicit restore was active.
+ * This is intentionally exact-runtime only; unrelated queued cleanup still
+ * drains when the final restore fence closes.
+ */
+export function cancelQueuedReplacementDismissal(
+  workspaceId: string,
+  runtimeSessionId: string,
+): boolean {
+  const queuedDismissals = queuedDismissalsByWorkspace.get(workspaceId);
+  const queued = queuedDismissals?.get(runtimeSessionId);
+  if (!queued || !queuedDismissals) {
+    return false;
+  }
+
+  queuedDismissals.delete(runtimeSessionId);
+  if (queuedDismissals.size === 0) {
+    queuedDismissalsByWorkspace.delete(workspaceId);
+  }
+  queued.resolve();
+  return true;
+}
+
+/**
+ * Serializes explicit restores for a workspace and fences them against tracked
+ * replacement dismissal. The fence is active synchronously, before waiting on
+ * cleanup that was already in flight.
+ */
+export function withWorkspaceReplacementRestoreFence<T>(
+  workspaceId: string,
+  restoreFn: () => T | Promise<T>,
+): Promise<T> {
+  activateRestoreFence(workspaceId);
+
+  const previousRestore = restoreQueueTailByWorkspace.get(workspaceId)
+    ?? Promise.resolve();
+  const restore = previousRestore.then(async () => {
+    await waitForTrackedDismissals(workspaceId);
+    return await restoreFn();
+  });
+  const queueTail = restore.then(
+    () => undefined,
+    () => undefined,
+  );
+  restoreQueueTailByWorkspace.set(workspaceId, queueTail);
+  void queueTail.then(() => {
+    if (restoreQueueTailByWorkspace.get(workspaceId) === queueTail) {
+      restoreQueueTailByWorkspace.delete(workspaceId);
+    }
+  });
+
+  return restore.finally(() => {
+    deactivateRestoreFence(workspaceId);
+  });
+}
+
+export function resetSessionReplacementDismissalsForTests(): void {
+  for (const queuedDismissals of queuedDismissalsByWorkspace.values()) {
+    for (const queued of queuedDismissals.values()) {
+      queued.resolve();
+    }
+  }
+  inFlightDismissalsByWorkspace.clear();
+  queuedDismissalsByWorkspace.clear();
+  activeRestoreFenceCountByWorkspace.clear();
+  restoreQueueTailByWorkspace.clear();
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+import { chatWorkspaceShellTabKey } from "@/lib/domain/workspaces/tabs/shell-tabs";
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import { beginReplacementShellPreferences } from "./session-replacement-shell-preferences";
+
+describe("replacement shell preferences", () => {
+  beforeEach(() => {
+    useWorkspaceUiStore.setState({
+      shellTabOrderByWorkspace: {},
+      visibleChatSessionIdsByWorkspace: {},
+      manualChatGroupsByWorkspace: {},
+    });
+  });
+
+  it("preserves position and grouping across a successful identity swap", () => {
+    seedPreferences();
+
+    beginReplacementShellPreferences({
+      shellWorkspaceId: "workspace-1",
+      materializedWorkspaceId: "workspace-1",
+      replacedSessionId: "old",
+      replacementSessionId: "new",
+    });
+
+    const state = useWorkspaceUiStore.getState();
+    expect(state.shellTabOrderByWorkspace["workspace-1"]).toEqual([
+      "file:README.md",
+      chatWorkspaceShellTabKey("new"),
+      chatWorkspaceShellTabKey("other"),
+    ]);
+    expect(state.visibleChatSessionIdsByWorkspace["workspace-1"])
+      .toEqual(["new", "other"]);
+    expect(state.manualChatGroupsByWorkspace["workspace-1"]?.[0]?.sessionIds)
+      .toEqual(["new", "other"]);
+  });
+
+  it("rolls back only its identity mapping while preserving concurrent tab edits", () => {
+    seedPreferences();
+    const transaction = beginReplacementShellPreferences({
+      shellWorkspaceId: "workspace-1",
+      materializedWorkspaceId: "workspace-1",
+      replacedSessionId: "old",
+      replacementSessionId: "new",
+    });
+    const state = useWorkspaceUiStore.getState();
+    state.setShellTabOrderForWorkspace("workspace-1", [
+      "file:README.md",
+      chatWorkspaceShellTabKey("new"),
+      chatWorkspaceShellTabKey("extra"),
+      chatWorkspaceShellTabKey("other"),
+    ]);
+    state.setVisibleChatSessionIdsForWorkspace(
+      "workspace-1",
+      ["new", "extra", "other"],
+    );
+    state.setManualChatGroupsForWorkspace("workspace-1", [{
+      id: createManualChatGroupId("group-1"),
+      label: "Renamed while pending",
+      colorId: "magenta",
+      sessionIds: ["new", "extra", "other"],
+    }]);
+
+    transaction.rollback();
+
+    const rolledBack = useWorkspaceUiStore.getState();
+    expect(rolledBack.shellTabOrderByWorkspace["workspace-1"]).toEqual([
+      "file:README.md",
+      chatWorkspaceShellTabKey("old"),
+      chatWorkspaceShellTabKey("extra"),
+      chatWorkspaceShellTabKey("other"),
+    ]);
+    expect(rolledBack.visibleChatSessionIdsByWorkspace["workspace-1"])
+      .toEqual(["old", "extra", "other"]);
+    expect(rolledBack.manualChatGroupsByWorkspace["workspace-1"]?.[0]).toEqual({
+      id: createManualChatGroupId("group-1"),
+      label: "Renamed while pending",
+      colorId: "magenta",
+      sessionIds: ["old", "extra", "other"],
+    });
+  });
+
+  it("rolls back a logical key populated from the materialized fallback while pending", () => {
+    seedPreferences("workspace-runtime");
+    const transaction = beginReplacementShellPreferences({
+      shellWorkspaceId: "workspace-logical",
+      materializedWorkspaceId: "workspace-runtime",
+      replacedSessionId: "old",
+      replacementSessionId: "new",
+    });
+    const state = useWorkspaceUiStore.getState();
+    state.setShellTabOrderForWorkspace(
+      "workspace-logical",
+      [...(state.shellTabOrderByWorkspace["workspace-runtime"] ?? [])],
+    );
+    state.setVisibleChatSessionIdsForWorkspace(
+      "workspace-logical",
+      [...(state.visibleChatSessionIdsByWorkspace["workspace-runtime"] ?? [])],
+    );
+    state.setManualChatGroupsForWorkspace(
+      "workspace-logical",
+      (state.manualChatGroupsByWorkspace["workspace-runtime"] ?? []).map((group) => ({
+        ...group,
+        sessionIds: [...group.sessionIds],
+      })),
+    );
+
+    transaction.rollback();
+
+    const rolledBack = useWorkspaceUiStore.getState();
+    for (const workspaceId of ["workspace-logical", "workspace-runtime"]) {
+      expect(rolledBack.shellTabOrderByWorkspace[workspaceId]).toEqual([
+        "file:README.md",
+        chatWorkspaceShellTabKey("old"),
+        chatWorkspaceShellTabKey("other"),
+      ]);
+      expect(rolledBack.visibleChatSessionIdsByWorkspace[workspaceId])
+        .toEqual(["old", "other"]);
+      expect(rolledBack.manualChatGroupsByWorkspace[workspaceId]?.[0]?.sessionIds)
+        .toEqual(["old", "other"]);
+    }
+  });
+});
+
+function seedPreferences(workspaceId = "workspace-1"): void {
+  const state = useWorkspaceUiStore.getState();
+  state.setShellTabOrderForWorkspace(workspaceId, [
+    "file:README.md",
+    chatWorkspaceShellTabKey("old"),
+    chatWorkspaceShellTabKey("other"),
+  ]);
+  state.setVisibleChatSessionIdsForWorkspace(workspaceId, ["old", "other"]);
+  state.setManualChatGroupsForWorkspace(workspaceId, [{
+    id: createManualChatGroupId("group-1"),
+    label: "Pair",
+    colorId: "blue",
+    sessionIds: ["old", "other"],
+  }]);
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
@@ -1,0 +1,182 @@
+import { useWorkspaceUiStore } from "@/stores/preferences/workspace-ui-store";
+import type { ManualChatGroup } from "@/lib/domain/workspaces/tabs/manual-groups";
+import {
+  replaceSessionIdInManualChatGroups,
+  replaceSessionIdInOrderedList,
+  replaceSessionIdInShellTabOrder,
+} from "@/lib/domain/workspaces/tabs/session-replacement";
+
+export interface ReplacementShellPreferencesTransaction {
+  rollback: () => void;
+}
+
+interface ReplacementShellPreferenceSnapshot {
+  workspaceId: string;
+}
+
+/**
+ * Moves only the session identity inside persisted tab preferences. Rollback
+ * reverses that owned identity mapping against the live arrays, so unrelated
+ * tab opens, reorders, visibility changes, and group edits survive a failed
+ * replacement.
+ */
+export function beginReplacementShellPreferences(input: {
+  shellWorkspaceId: string;
+  materializedWorkspaceId: string;
+  replacedSessionId: string;
+  replacementSessionId: string;
+}): ReplacementShellPreferencesTransaction {
+  const workspaceIds = Array.from(new Set([
+    input.shellWorkspaceId,
+    input.materializedWorkspaceId,
+  ]));
+  const snapshots: ReplacementShellPreferenceSnapshot[] = [];
+
+  for (const workspaceId of workspaceIds) {
+    const state = useWorkspaceUiStore.getState();
+    const beforeOrder = ownArray(state.shellTabOrderByWorkspace, workspaceId);
+    const beforeVisible = ownArray(
+      state.visibleChatSessionIdsByWorkspace,
+      workspaceId,
+    );
+    const beforeManualGroups = ownManualGroups(
+      state.manualChatGroupsByWorkspace,
+      workspaceId,
+    );
+    const afterOrder = beforeOrder
+      ? replaceSessionIdInShellTabOrder(
+        beforeOrder,
+        input.replacedSessionId,
+        input.replacementSessionId,
+      )
+      : null;
+    const afterVisible = beforeVisible
+      ? replaceSessionIdInOrderedList(
+        beforeVisible,
+        input.replacedSessionId,
+        input.replacementSessionId,
+      )
+      : null;
+    const afterManualGroups = beforeManualGroups
+      ? replaceSessionIdInManualChatGroups(
+        beforeManualGroups,
+        input.replacedSessionId,
+        input.replacementSessionId,
+      )
+      : null;
+    const changedOrder = !!afterOrder
+      && !sameStringList(beforeOrder ?? [], afterOrder);
+    const changedVisible = !!afterVisible
+      && !sameStringList(beforeVisible ?? [], afterVisible);
+    const changedManualGroups = !!afterManualGroups
+      && !sameManualChatGroups(beforeManualGroups ?? [], afterManualGroups);
+
+    if (changedOrder && afterOrder) {
+      state.setShellTabOrderForWorkspace(workspaceId, afterOrder);
+    }
+    if (changedVisible && afterVisible) {
+      state.setVisibleChatSessionIdsForWorkspace(workspaceId, afterVisible);
+    }
+    if (changedManualGroups && afterManualGroups) {
+      state.setManualChatGroupsForWorkspace(workspaceId, afterManualGroups);
+    }
+    snapshots.push({ workspaceId });
+  }
+
+  return {
+    rollback: () => {
+      for (const snapshot of snapshots) {
+        const state = useWorkspaceUiStore.getState();
+        const currentOrder = ownArray(
+          state.shellTabOrderByWorkspace,
+          snapshot.workspaceId,
+        );
+        const nextOrder = currentOrder
+          ? replaceSessionIdInShellTabOrder(
+            currentOrder,
+            input.replacementSessionId,
+            input.replacedSessionId,
+          )
+          : null;
+        if (nextOrder && !sameStringList(currentOrder ?? [], nextOrder)) {
+          state.setShellTabOrderForWorkspace(snapshot.workspaceId, nextOrder);
+        }
+        const currentVisible = ownArray(
+          state.visibleChatSessionIdsByWorkspace,
+          snapshot.workspaceId,
+        );
+        const nextVisible = currentVisible
+          ? replaceSessionIdInOrderedList(
+            currentVisible,
+            input.replacementSessionId,
+            input.replacedSessionId,
+          )
+          : null;
+        if (nextVisible && !sameStringList(currentVisible ?? [], nextVisible)) {
+          state.setVisibleChatSessionIdsForWorkspace(
+            snapshot.workspaceId,
+            nextVisible,
+          );
+        }
+        const currentManualGroups = ownManualGroups(
+          state.manualChatGroupsByWorkspace,
+          snapshot.workspaceId,
+        );
+        const nextManualGroups = currentManualGroups
+          ? replaceSessionIdInManualChatGroups(
+            currentManualGroups,
+            input.replacementSessionId,
+            input.replacedSessionId,
+          )
+          : null;
+        if (
+          nextManualGroups
+          && !sameManualChatGroups(currentManualGroups ?? [], nextManualGroups)
+        ) {
+          state.setManualChatGroupsForWorkspace(
+            snapshot.workspaceId,
+            nextManualGroups,
+          );
+        }
+      }
+    },
+  };
+}
+
+function ownArray<T>(source: Record<string, T[]>, workspaceId: string): T[] | null {
+  return Object.prototype.hasOwnProperty.call(source, workspaceId)
+    ? [...(source[workspaceId] ?? [])]
+    : null;
+}
+
+function ownManualGroups(
+  source: Record<string, ManualChatGroup[]>,
+  workspaceId: string,
+): ManualChatGroup[] | null {
+  return Object.prototype.hasOwnProperty.call(source, workspaceId)
+    ? (source[workspaceId] ?? []).map((group) => ({
+      ...group,
+      sessionIds: [...group.sessionIds],
+    }))
+    : null;
+}
+
+function sameStringList(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && left.every((value, index) => value === right[index]);
+}
+
+function sameManualChatGroups(
+  left: readonly ManualChatGroup[],
+  right: readonly ManualChatGroup[],
+): boolean {
+  return left.length === right.length
+    && left.every((group, index) => {
+      const candidate = right[index];
+      return candidate !== undefined
+        && group.id === candidate.id
+        && group.label === candidate.label
+        && group.colorId === candidate.colorId
+        && sameStringList(group.sessionIds, candidate.sessionIds);
+    });
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStagedReplacedClientSessionAlias,
+  clearReplacedSessionTombstone,
+  clearStagedReplacedSessionTombstone,
+  commitReplacedSessionTombstone,
+  committedReplacedSessionTombstonesForWorkspace,
+  filterReplacedSessionTombstones,
+  filterReplacedSessionIds,
+  isReplacedSessionTombstoned,
+  isReplacedSessionTombstonedInAnyWorkspace,
+  releaseReplacedSessionSuppression,
+  resetReplacedSessionTombstonesForTests,
+  retireStagedReplacedClientSessionAlias,
+  shouldPreserveStagedReplacementShell,
+  stageReplacedClientSessionAlias,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+
+const storageMocks = vi.hoisted(() => ({
+  writeTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
+  readSessionReplacementTombstones: () => ({}),
+  writeSessionReplacementTombstones: storageMocks.writeTombstones,
+}));
+
+beforeEach(() => {
+  storageMocks.writeTombstones.mockReset();
+  storageMocks.writeTombstones.mockReturnValue(true);
+  resetReplacedSessionTombstonesForTests();
+});
+
+describe("replacement session tombstones", () => {
+  it("suppresses a client-only replacement without making it dismissible", () => {
+    stageReplacedClientSessionAlias("workspace-1", "client-old");
+
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+    expect(filterReplacedSessionIds("workspace-1", ["client-old", "client-new"]))
+      .toEqual(["client-new"]);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([]);
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(true);
+
+    retireStagedReplacedClientSessionAlias("workspace-1", "client-old");
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(false);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+
+    clearStagedReplacedClientSessionAlias("workspace-1", "client-old");
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+    releaseReplacedSessionSuppression("workspace-1", "client-old");
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(false);
+  });
+
+  it("stages aliases for suppression without making the runtime dismissible", () => {
+    stageReplacedSessionTombstone(
+      "workspace-1",
+      "runtime-old",
+      ["client-old"],
+    );
+
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+    expect(isReplacedSessionTombstonedInAnyWorkspace("runtime-old")).toBe(true);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1")).toEqual([]);
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(true);
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-2"))
+      .toBe(false);
+    expect(filterReplacedSessionTombstones("workspace-1", [
+      { id: "runtime-old" },
+      { id: "runtime-new" },
+    ])).toEqual([{ id: "runtime-new" }]);
+    expect(filterReplacedSessionIds("workspace-1", ["client-old", "client-new"]))
+      .toEqual(["client-new"]);
+    expect(filterReplacedSessionTombstones("workspace-2", [
+      { id: "runtime-old" },
+    ])).toEqual([{ id: "runtime-old" }]);
+
+    clearStagedReplacedSessionTombstone("workspace-1", "runtime-old");
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(false);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
+    expect(isReplacedSessionTombstonedInAnyWorkspace("runtime-old")).toBe(false);
+  });
+
+  it("commits the runtime id and aliases until authoritative cleanup", () => {
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    commitReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual(["runtime-old"]);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+
+    clearReplacedSessionTombstone("workspace-1", "runtime-old");
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1")).toEqual([]);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+    expect(filterReplacedSessionTombstones("workspace-1", [{ id: "runtime-old" }]))
+      .toEqual([]);
+
+    releaseReplacedSessionSuppression("workspace-1", "runtime-old");
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(false);
+  });
+
+  it("keeps a durable tombstone when clearing persistence fails", () => {
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    expect(commitReplacedSessionTombstone(
+      "workspace-1",
+      "runtime-old",
+      ["client-old"],
+    )).toBe(true);
+    storageMocks.writeTombstones.mockReturnValue(false);
+
+    expect(clearReplacedSessionTombstone("workspace-1", "runtime-old")).toBe(false);
+    expect(releaseReplacedSessionSuppression("workspace-1", "runtime-old"))
+      .toBe(false);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual(["runtime-old"]);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+
+    storageMocks.writeTombstones.mockReturnValue(true);
+    expect(clearReplacedSessionTombstone("workspace-1", "runtime-old")).toBe(true);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.ts
@@ -1,0 +1,397 @@
+import {
+  readSessionReplacementTombstones,
+  writeSessionReplacementTombstones,
+} from "@/lib/access/browser/session-replacement-tombstones-storage";
+
+type SessionIdentity = { id: string };
+
+interface TombstoneEntry {
+  runtimeSessionId: string;
+  suppressedSessionIds: Set<string>;
+  committedGeneration: number;
+}
+
+type WorkspaceTombstones = Map<string, TombstoneEntry>;
+
+// Renderer-scoped staged entries are deliberately memory-only. If the app exits before the
+// replacement succeeds, the old runtime remains authoritative and reappears on
+// restart. Only committed cleanup is persisted and eligible for dismissal.
+const stagedByWorkspaceId = new Map<string, WorkspaceTombstones>();
+// An in-flight client session may be replaced before it has a runtime id. Keep
+// that alias out of optimistic/header projections without inventing a fake
+// runtime tombstone that background cleanup could try to dismiss.
+const stagedClientAliasesByWorkspaceId = new Map<string, Set<string>>();
+const committedByWorkspaceId = new Map<string, WorkspaceTombstones>(
+  Object.entries(readSessionReplacementTombstones()).map(([workspaceId, entries]) => [
+    workspaceId,
+    new Map(entries.map((entry) => [
+      entry.runtimeSessionId,
+      createEntry(entry.runtimeSessionId, entry.suppressedSessionIds),
+    ])),
+  ]),
+);
+// Authoritative omission removes persistence, but suppression remains for the
+// lifetime of this renderer. That prevents a slower pre-dismiss list response
+// from arriving after the omission and repopulating the retired id. A cold
+// renderer has no such in-flight requests, so this history need not persist.
+const retiredSuppressionByWorkspaceId = new Map<string, WorkspaceTombstones>();
+const retiredClientAliasesByWorkspaceId = new Map<string, Set<string>>();
+let latestCommittedGeneration = 0;
+
+export function stageReplacedClientSessionAlias(
+  workspaceId: string,
+  sessionId: string,
+): boolean {
+  const aliases = stagedClientAliasesByWorkspaceId.get(workspaceId) ?? new Set<string>();
+  const sizeBefore = aliases.size;
+  aliases.add(sessionId);
+  stagedClientAliasesByWorkspaceId.set(workspaceId, aliases);
+  return aliases.size !== sizeBefore;
+}
+
+export function retireStagedReplacedClientSessionAlias(
+  workspaceId: string,
+  sessionId: string,
+): void {
+  removeClientAlias(stagedClientAliasesByWorkspaceId, workspaceId, sessionId);
+  const aliases = retiredClientAliasesByWorkspaceId.get(workspaceId) ?? new Set<string>();
+  aliases.add(sessionId);
+  retiredClientAliasesByWorkspaceId.set(workspaceId, aliases);
+}
+
+export function clearStagedReplacedClientSessionAlias(
+  workspaceId: string,
+  sessionId: string,
+): void {
+  removeClientAlias(stagedClientAliasesByWorkspaceId, workspaceId, sessionId);
+}
+
+export function stageReplacedSessionTombstone(
+  workspaceId: string,
+  runtimeSessionId: string,
+  suppressedSessionIds: readonly string[] = [runtimeSessionId],
+): boolean {
+  if (committedByWorkspaceId.get(workspaceId)?.has(runtimeSessionId)) {
+    return false;
+  }
+  const workspace = stagedByWorkspaceId.get(workspaceId) ?? new Map();
+  const existing = workspace.get(runtimeSessionId);
+  if (existing) {
+    addSuppressedIds(existing, suppressedSessionIds);
+    return false;
+  }
+  workspace.set(runtimeSessionId, createEntry(runtimeSessionId, suppressedSessionIds));
+  stagedByWorkspaceId.set(workspaceId, workspace);
+  return true;
+}
+
+export function commitReplacedSessionTombstone(
+  workspaceId: string,
+  runtimeSessionId: string,
+  suppressedSessionIds: readonly string[] = [runtimeSessionId],
+): boolean {
+  const commitGeneration = latestCommittedGeneration + 1;
+  const stagedEntry = stagedByWorkspaceId.get(workspaceId)?.get(runtimeSessionId);
+  const nextCommitted = cloneTombstoneSource(committedByWorkspaceId);
+  const workspace = nextCommitted.get(workspaceId) ?? new Map();
+  const committedEntry = workspace.get(runtimeSessionId)
+    ?? createEntry(runtimeSessionId, suppressedSessionIds);
+  addSuppressedIds(committedEntry, suppressedSessionIds);
+  if (stagedEntry) {
+    addSuppressedIds(committedEntry, [...stagedEntry.suppressedSessionIds]);
+  }
+  committedEntry.committedGeneration = commitGeneration;
+  workspace.set(runtimeSessionId, committedEntry);
+  nextCommitted.set(workspaceId, workspace);
+  if (!persistCommittedTombstones(nextCommitted)) {
+    return false;
+  }
+  removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+  replaceTombstoneSource(committedByWorkspaceId, nextCommitted);
+  latestCommittedGeneration = commitGeneration;
+  return true;
+}
+
+export function clearStagedReplacedSessionTombstone(
+  workspaceId: string,
+  runtimeSessionId: string,
+): void {
+  removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+}
+
+/** Runtime absence is confirmed, but stale in-flight lists still need a renderer fence. */
+export function retireStagedReplacedSessionTombstone(
+  workspaceId: string,
+  runtimeSessionId: string,
+): void {
+  const stagedEntry = stagedByWorkspaceId.get(workspaceId)?.get(runtimeSessionId);
+  if (stagedEntry) {
+    const retired = retiredSuppressionByWorkspaceId.get(workspaceId) ?? new Map();
+    retired.set(runtimeSessionId, stagedEntry);
+    retiredSuppressionByWorkspaceId.set(workspaceId, retired);
+  }
+  removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+}
+
+/** Clear after an authoritative session list no longer contains the runtime id. */
+export function clearReplacedSessionTombstone(
+  workspaceId: string,
+  runtimeSessionId: string,
+): boolean {
+  const committedEntry = committedByWorkspaceId.get(workspaceId)?.get(runtimeSessionId);
+  if (!committedEntry) {
+    removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+    return true;
+  }
+  const nextCommitted = cloneTombstoneSource(committedByWorkspaceId);
+  removeEntry(nextCommitted, workspaceId, runtimeSessionId);
+  if (!persistCommittedTombstones(nextCommitted)) {
+    return false;
+  }
+  const retired = retiredSuppressionByWorkspaceId.get(workspaceId) ?? new Map();
+  retired.set(runtimeSessionId, committedEntry);
+  retiredSuppressionByWorkspaceId.set(workspaceId, retired);
+  removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+  replaceTombstoneSource(committedByWorkspaceId, nextCommitted);
+  return true;
+}
+
+/** Snapshot used to reject list responses that began before a tombstone commit. */
+export function captureReplacedSessionTombstoneGeneration(): number {
+  return latestCommittedGeneration;
+}
+
+/**
+ * Clears cleanup state only when it existed before the authoritative list
+ * request began. A list started before runtime creation can legitimately omit
+ * that runtime and must not erase its newer durable retirement fence.
+ */
+export function clearReplacedSessionTombstoneFromAuthoritativeList(
+  workspaceId: string,
+  runtimeSessionId: string,
+  requestStartGeneration: number,
+): boolean {
+  const committedEntry = committedByWorkspaceId.get(workspaceId)?.get(runtimeSessionId);
+  if (committedEntry && committedEntry.committedGeneration > requestStartGeneration) {
+    return false;
+  }
+  return clearReplacedSessionTombstone(workspaceId, runtimeSessionId);
+}
+
+export function isReplacedSessionTombstoned(
+  workspaceId: string,
+  sessionId: string,
+): boolean {
+  return suppressedIdsForWorkspace(workspaceId).has(sessionId);
+}
+
+export function isReplacedSessionTombstonedInAnyWorkspace(
+  sessionId: string,
+): boolean {
+  for (const workspaceId of allWorkspaceIds()) {
+    if (isReplacedSessionTombstoned(workspaceId, sessionId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function filterReplacedSessionTombstones<T extends SessionIdentity>(
+  workspaceId: string,
+  sessions: readonly T[] | undefined,
+): T[] | undefined {
+  if (!sessions) {
+    return undefined;
+  }
+  const suppressedIds = suppressedIdsForWorkspace(workspaceId);
+  return suppressedIds.size === 0
+    ? [...sessions]
+    : sessions.filter((session) => !suppressedIds.has(session.id));
+}
+
+export function filterReplacedSessionIds(
+  workspaceId: string,
+  sessionIds: readonly string[],
+): string[] {
+  const suppressedIds = suppressedIdsForWorkspace(workspaceId);
+  return suppressedIds.size === 0
+    ? [...sessionIds]
+    : sessionIds.filter((sessionId) => !suppressedIds.has(sessionId));
+}
+
+/** Runtime ids whose replacement committed and may be retried for dismissal. */
+export function committedReplacedSessionTombstonesForWorkspace(
+  workspaceId: string,
+): string[] {
+  return [...(committedByWorkspaceId.get(workspaceId)?.keys() ?? [])];
+}
+
+export function canPersistReplacedSessionTombstones(): boolean {
+  return persistCommittedTombstones();
+}
+
+export function hasStagedReplacedSessionTombstonesForWorkspace(
+  workspaceId: string,
+): boolean {
+  return (stagedByWorkspaceId.get(workspaceId)?.size ?? 0) > 0
+    || (stagedClientAliasesByWorkspaceId.get(workspaceId)?.size ?? 0) > 0;
+}
+
+export function shouldPreserveStagedReplacementShell(
+  workspaceId: string,
+  activeSessionWorkspaceId: string | null | undefined,
+): boolean {
+  return activeSessionWorkspaceId === workspaceId
+    && hasStagedReplacedSessionTombstonesForWorkspace(workspaceId);
+}
+
+/** Explicit user restore overrides cleanup and releases runtime plus client aliases. */
+export function releaseReplacedSessionSuppression(
+  workspaceId: string,
+  runtimeSessionId: string,
+): boolean {
+  if (committedByWorkspaceId.get(workspaceId)?.has(runtimeSessionId)) {
+    const nextCommitted = cloneTombstoneSource(committedByWorkspaceId);
+    removeEntry(nextCommitted, workspaceId, runtimeSessionId);
+    if (!persistCommittedTombstones(nextCommitted)) {
+      return false;
+    }
+    replaceTombstoneSource(committedByWorkspaceId, nextCommitted);
+  }
+  removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
+  removeEntry(retiredSuppressionByWorkspaceId, workspaceId, runtimeSessionId);
+  removeClientAlias(stagedClientAliasesByWorkspaceId, workspaceId, runtimeSessionId);
+  removeClientAlias(retiredClientAliasesByWorkspaceId, workspaceId, runtimeSessionId);
+  return true;
+}
+
+export function resetReplacedSessionTombstonesForTests(): void {
+  stagedByWorkspaceId.clear();
+  stagedClientAliasesByWorkspaceId.clear();
+  committedByWorkspaceId.clear();
+  retiredSuppressionByWorkspaceId.clear();
+  retiredClientAliasesByWorkspaceId.clear();
+  latestCommittedGeneration = 0;
+  persistCommittedTombstones();
+}
+
+function createEntry(
+  runtimeSessionId: string,
+  suppressedSessionIds: readonly string[],
+  committedGeneration = 0,
+): TombstoneEntry {
+  return {
+    runtimeSessionId,
+    suppressedSessionIds: new Set([runtimeSessionId, ...suppressedSessionIds]),
+    committedGeneration,
+  };
+}
+
+function addSuppressedIds(
+  entry: TombstoneEntry,
+  sessionIds: readonly string[],
+): void {
+  entry.suppressedSessionIds.add(entry.runtimeSessionId);
+  for (const sessionId of sessionIds) {
+    if (sessionId) {
+      entry.suppressedSessionIds.add(sessionId);
+    }
+  }
+}
+
+function removeEntry(
+  source: Map<string, WorkspaceTombstones>,
+  workspaceId: string,
+  runtimeSessionId: string,
+): boolean {
+  const workspace = source.get(workspaceId);
+  const removed = workspace?.delete(runtimeSessionId) ?? false;
+  if (workspace?.size === 0) {
+    source.delete(workspaceId);
+  }
+  return removed;
+}
+
+function suppressedIdsForWorkspace(workspaceId: string): Set<string> {
+  const suppressedIds = new Set<string>();
+  for (const sessionId of stagedClientAliasesByWorkspaceId.get(workspaceId) ?? []) {
+    suppressedIds.add(sessionId);
+  }
+  for (const sessionId of retiredClientAliasesByWorkspaceId.get(workspaceId) ?? []) {
+    suppressedIds.add(sessionId);
+  }
+  for (const source of [
+    stagedByWorkspaceId,
+    committedByWorkspaceId,
+    retiredSuppressionByWorkspaceId,
+  ]) {
+    for (const entry of source.get(workspaceId)?.values() ?? []) {
+      for (const sessionId of entry.suppressedSessionIds) {
+        suppressedIds.add(sessionId);
+      }
+    }
+  }
+  return suppressedIds;
+}
+
+function allWorkspaceIds(): Set<string> {
+  return new Set([
+    ...stagedByWorkspaceId.keys(),
+    ...stagedClientAliasesByWorkspaceId.keys(),
+    ...committedByWorkspaceId.keys(),
+    ...retiredSuppressionByWorkspaceId.keys(),
+    ...retiredClientAliasesByWorkspaceId.keys(),
+  ]);
+}
+
+function removeClientAlias(
+  source: Map<string, Set<string>>,
+  workspaceId: string,
+  sessionId: string,
+): void {
+  const aliases = source.get(workspaceId);
+  aliases?.delete(sessionId);
+  if (aliases?.size === 0) {
+    source.delete(workspaceId);
+  }
+}
+
+function persistCommittedTombstones(
+  source: Map<string, WorkspaceTombstones> = committedByWorkspaceId,
+): boolean {
+  return writeSessionReplacementTombstones(Object.fromEntries(
+    [...source.entries()].map(([workspaceId, entries]) => [
+      workspaceId,
+      [...entries.values()].map((entry) => ({
+        runtimeSessionId: entry.runtimeSessionId,
+        suppressedSessionIds: [...entry.suppressedSessionIds],
+      })),
+    ]),
+  ));
+}
+
+function cloneTombstoneSource(
+  source: Map<string, WorkspaceTombstones>,
+): Map<string, WorkspaceTombstones> {
+  return new Map([...source.entries()].map(([workspaceId, entries]) => [
+    workspaceId,
+    new Map([...entries.entries()].map(([runtimeSessionId, entry]) => [
+      runtimeSessionId,
+      createEntry(
+        entry.runtimeSessionId,
+        [...entry.suppressedSessionIds],
+        entry.committedGeneration,
+      ),
+    ])),
+  ]));
+}
+
+function replaceTombstoneSource(
+  target: Map<string, WorkspaceTombstones>,
+  source: Map<string, WorkspaceTombstones>,
+): void {
+  target.clear();
+  for (const [workspaceId, entries] of source) {
+    target.set(workspaceId, entries);
+  }
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearReplacedSessionTombstone,
+  commitReplacedSessionTombstone,
+  resetReplacedSessionTombstonesForTests,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import { fetchWorkspaceSessions } from "./session-selection-runtime";
+
+const mocks = vi.hoisted(() => ({
+  fetchWorkspaceSessionSummaries: vi.fn(),
+}));
+
+vi.mock("@/lib/access/anyharness/session-runtime", () => ({
+  fetchWorkspaceSessionSummaries: mocks.fetchWorkspaceSessionSummaries,
+}));
+
+vi.mock("@/lib/access/anyharness/runtime-bootstrap", () => ({
+  bootstrapHarnessRuntime: vi.fn(),
+}));
+
+beforeEach(() => {
+  mocks.fetchWorkspaceSessionSummaries.mockReset();
+  resetReplacedSessionTombstonesForTests();
+});
+
+describe("selection session-list filtering", () => {
+  it("does not return a staged replacement runtime", async () => {
+    mocks.fetchWorkspaceSessionSummaries.mockResolvedValue([
+      { id: "runtime-old" },
+      { id: "runtime-new" },
+    ]);
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+
+    const sessions = await fetchWorkspaceSessions("http://runtime.test", "workspace-1");
+
+    expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
+  });
+
+  it("filters an out-of-order old response after authoritative cleanup", async () => {
+    commitReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    clearReplacedSessionTombstone("workspace-1", "runtime-old");
+    mocks.fetchWorkspaceSessionSummaries.mockResolvedValue([{ id: "runtime-old" }]);
+
+    const sessions = await fetchWorkspaceSessions("http://runtime.test", "workspace-1");
+
+    expect(sessions).toEqual([]);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.ts
@@ -7,6 +7,9 @@ import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstr
 import { fetchWorkspaceSessionSummaries } from "@/lib/access/anyharness/session-runtime";
 import type { WorkspaceSession } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import {
+  filterReplacedSessionTombstones,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 export function buildLatencyRequestOptions(latencyFlowId?: string | null) {
   const headers = getLatencyFlowRequestHeaders(latencyFlowId);
@@ -44,7 +47,8 @@ export async function fetchWorkspaceSessions(
       headers: options?.requestHeaders,
     }),
   );
-  return sessions.map((session) => ({
+  const visibleSessions = filterReplacedSessionTombstones(workspaceId, sessions) ?? [];
+  return visibleSessions.map((session) => ({
     ...session,
     workspaceId,
   }));

--- a/apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginEmptySessionReplacement,
+  type EmptySessionReplacementDeps,
+} from "@/hooks/sessions/workflows/use-empty-session-replacement-cleanup";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "@/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "@/stores/sessions/session-transcript-store";
+import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
+import { resetSessionCreationSupersessionForTests } from "@/hooks/sessions/workflows/session-creation-supersession";
+import {
+  committedReplacedSessionTombstonesForWorkspace,
+  filterReplacedSessionIds,
+  filterReplacedSessionTombstones,
+  isReplacedSessionTombstoned,
+  resetReplacedSessionTombstonesForTests,
+  shouldPreserveStagedReplacementShell,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  resetSessionReplacementDismissalsForTests,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+
+const storageMocks = vi.hoisted(() => ({
+  writeTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
+  readSessionReplacementTombstones: () => ({}),
+  writeSessionReplacementTombstones: storageMocks.writeTombstones,
+}));
+
+function createDeps() {
+  const mutateAsync = vi.fn(async () => undefined);
+  const deps: EmptySessionReplacementDeps = {
+    closeSessionSlotStream: vi.fn(),
+    removeWorkspaceSessionRecord: vi.fn(),
+    dismissSessionMutation: { mutateAsync } as never,
+  };
+  return { deps, mutateAsync };
+}
+
+function putUnusedSession() {
+  const record = {
+    ...createEmptySessionRecord("old-session", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-old",
+      modelId: "gpt-5",
+    }),
+    events: [{ seq: 1, event: { type: "config_option_update" } } as never],
+    streamConnectionState: "open" as const,
+  };
+  putSessionRecord(record);
+  return record;
+}
+
+beforeEach(() => {
+  storageMocks.writeTombstones.mockReset();
+  storageMocks.writeTombstones.mockReturnValue(true);
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionTranscriptStore.getState().clearEntries();
+  useSessionIntentStore.getState().clear();
+  resetSessionCreationSupersessionForTests();
+  resetReplacedSessionTombstonesForTests();
+  resetSessionReplacementDismissalsForTests();
+});
+
+afterEach(() => {
+  storageMocks.writeTombstones.mockReturnValue(true);
+  resetReplacedSessionTombstonesForTests();
+  resetSessionReplacementDismissalsForTests();
+});
+
+describe("empty session replacement transaction", () => {
+  it("suppresses an unmaterialized old tab through commit", async () => {
+    putSessionRecord(createEmptySessionRecord("client-old", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "gpt-5",
+    }));
+    const { deps, mutateAsync } = createDeps();
+
+    const transaction = beginEmptySessionReplacement(
+      "client-old",
+      "workspace-1",
+      deps,
+    );
+
+    expect(transaction).not.toBeNull();
+    expect(filterReplacedSessionIds("workspace-1", ["client-old", "client-new"]))
+      .toEqual(["client-new"]);
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(true);
+
+    await transaction?.commit();
+
+    expect(shouldPreserveStagedReplacementShell("workspace-1", "workspace-1"))
+      .toBe(false);
+    expect(filterReplacedSessionIds("workspace-1", ["client-old", "client-new"]))
+      .toEqual(["client-new"]);
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("releases an unmaterialized old-tab suppression on rollback", () => {
+    putSessionRecord(createEmptySessionRecord("client-old", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "gpt-5",
+    }));
+    const { deps } = createDeps();
+
+    const transaction = beginEmptySessionReplacement(
+      "client-old",
+      "workspace-1",
+      deps,
+    );
+    transaction?.rollback();
+
+    expect(getSessionRecord("client-old")).not.toBeNull();
+    expect(filterReplacedSessionIds("workspace-1", ["client-old"]))
+      .toEqual(["client-old"]);
+  });
+
+  it("hides locally at begin and restores the captured shell on rollback", () => {
+    const original = putUnusedSession();
+    useSessionIntentStore.getState().enqueueConfig({
+      clientSessionId: "old-session",
+      workspaceId: "workspace-1",
+      configId: "mode",
+      value: "plan",
+    });
+    const { deps, mutateAsync } = createDeps();
+
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    expect(transaction).not.toBeNull();
+    expect(getSessionRecord("old-session")).toBeNull();
+    expect(deps.closeSessionSlotStream).toHaveBeenCalledWith("old-session");
+    expect(deps.removeWorkspaceSessionRecord).not.toHaveBeenCalled();
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "old-session")).toBe(true);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([]);
+
+    transaction?.rollback();
+
+    expect(getSessionRecord("old-session")).toMatchObject({
+      agentKind: original.agentKind,
+      events: original.events,
+      materializedSessionId: original.materializedSessionId,
+      modelId: original.modelId,
+      streamConnectionState: "disconnected",
+      transcript: original.transcript,
+      workspaceId: original.workspaceId,
+    });
+    expect(useSessionIntentStore.getState().intentIdsByClientSessionId["old-session"])
+      .toHaveLength(1);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
+  });
+
+  it("defers cache removal and runtime dismissal until commit", async () => {
+    putUnusedSession();
+    useSessionIntentStore.getState().enqueueConfig({
+      clientSessionId: "old-session",
+      workspaceId: "workspace-1",
+      configId: "mode",
+      value: "plan",
+    });
+    const { deps, mutateAsync } = createDeps();
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+
+    await transaction?.commit();
+
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual(["runtime-old"]);
+    expect(deps.removeWorkspaceSessionRecord)
+      .toHaveBeenCalledWith("workspace-1", "runtime-old");
+    expect(useSessionIntentStore.getState().intentIdsByClientSessionId["old-session"] ?? [])
+      .toEqual([]);
+    await vi.waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        sessionId: "runtime-old",
+      });
+    });
+  });
+
+  it("retries a transient dismissal and retains the tombstone until authoritative refresh", async () => {
+    putUnusedSession();
+    const { deps, mutateAsync } = createDeps();
+    mutateAsync.mockRejectedValueOnce(new Error("temporary disconnect"));
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    await transaction?.commit();
+
+    await vi.waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(2);
+    });
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+  });
+
+  it("keeps a failed dismissal tombstoned out of authoritative refreshes", async () => {
+    putUnusedSession();
+    const { deps, mutateAsync } = createDeps();
+    mutateAsync.mockRejectedValue(new Error("runtime unavailable"));
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    await transaction?.commit();
+
+    await vi.waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+    expect(filterReplacedSessionTombstones("workspace-1", [
+      { id: "runtime-old" },
+      { id: "runtime-new" },
+    ])).toEqual([{ id: "runtime-new" }]);
+  });
+
+  it("restores the old session when persistence and dismissal both fail", async () => {
+    const original = putUnusedSession();
+    storageMocks.writeTombstones.mockReturnValue(false);
+    const { deps, mutateAsync } = createDeps();
+    mutateAsync.mockRejectedValue(new Error("runtime unavailable"));
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    await expect(transaction?.commit()).resolves.toBe("retained");
+
+    expect(mutateAsync).toHaveBeenCalledTimes(3);
+    expect(getSessionRecord("old-session")).toMatchObject({
+      materializedSessionId: original.materializedSessionId,
+      streamConnectionState: "disconnected",
+    });
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
+    expect(deps.removeWorkspaceSessionRecord).not.toHaveBeenCalled();
+  });
+
+  it("does not replace a session with a queued prompt", () => {
+    putUnusedSession();
+    useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-1",
+      clientSessionId: "old-session",
+      workspaceId: "workspace-1",
+      text: "do work",
+      blocks: [{ type: "text", text: "do work" }],
+    });
+    const { deps } = createDeps();
+
+    const transaction = beginEmptySessionReplacement(
+      "old-session",
+      "workspace-1",
+      deps,
+    );
+
+    expect(transaction).toBeNull();
+    expect(getSessionRecord("old-session")).not.toBeNull();
+    expect(deps.closeSessionSlotStream).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts
@@ -1,8 +1,34 @@
 import { isSessionEmptyWithIntents } from "@/lib/domain/sessions/session-emptiness";
-import { getSessionRecord, removeSessionRecord } from "@/stores/sessions/session-records";
+import {
+  getSessionRecord,
+  putSessionRecord,
+  removeSessionRecord,
+} from "@/stores/sessions/session-records";
 import { useSessionIntentStore, getPromptOutboxEntriesForSession } from "@/stores/sessions/session-intent-store";
 import { clearViewedSessionErrors } from "@/stores/preferences/workspace-ui-store";
 import { useDismissSessionMutation } from "@anyharness/sdk-react";
+import { AnyHarnessError } from "@anyharness/sdk";
+import {
+  commitSupersededSessionCreation,
+  rollbackSupersededSessionCreation,
+  supersedeInFlightSessionCreation,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
+import {
+  clearStagedReplacedClientSessionAlias,
+  clearStagedReplacedSessionTombstone,
+  commitReplacedSessionTombstone,
+  releaseReplacedSessionSuppression,
+  retireStagedReplacedClientSessionAlias,
+  retireStagedReplacedSessionTombstone,
+  stageReplacedClientSessionAlias,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  runTrackedReplacementDismissal,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+
+const DISMISS_RETRY_DELAYS_MS = [0, 100, 500] as const;
 
 export interface EmptySessionReplacementDeps {
   closeSessionSlotStream: (sessionId: string) => void;
@@ -10,70 +36,196 @@ export interface EmptySessionReplacementDeps {
   dismissSessionMutation: ReturnType<typeof useDismissSessionMutation>;
 }
 
+export interface EmptySessionReplacementTransaction {
+  replacedSessionId: string;
+  commit: () => Promise<"retired" | "retained">;
+  rollback: () => void;
+}
+
 /**
- * Performs synchronous local cleanup of a replaced empty session and fires a
- * background runtime dismiss for materialized sessions. Returns whether cleanup
- * actually ran (false if the session had user work and was left alone).
- *
- * This is the pure-logic core used by both the hook wrapper and the session
- * creation workflow (which needs to run cleanup at an exact synchronous point).
+ * Begins a replace-in-place transaction for an unused session. The old local
+ * record is removed synchronously so the newly activated shell is the only tab,
+ * but destructive cleanup and runtime dismissal wait for commit. Rollback puts
+ * back the exact captured record and releases any paused materializer.
  */
-export function performEmptySessionReplacementCleanup(
+export function beginEmptySessionReplacement(
   sessionId: string,
   workspaceId: string | null | undefined,
   deps: EmptySessionReplacementDeps,
-): boolean {
+): EmptySessionReplacementTransaction | null {
   const record = getSessionRecord(sessionId);
   if (!record) {
-    return false;
+    return null;
   }
 
   // Check emptiness including queued prompt intents
   const outboxEntries = getPromptOutboxEntriesForSession(sessionId);
   if (!isSessionEmptyWithIntents(record, outboxEntries.length)) {
-    return false;
+    return null;
   }
 
-  // Capture materialized id before local removal destroys the record
+  // Capture everything needed for exact rollback before hiding the old shell.
   const materializedSessionId = record.materializedSessionId;
   const resolvedWorkspaceId = record.workspaceId ?? workspaceId ?? null;
-
-  // --- Local cleanup (order: stream close, intents, record, errors, cache) ---
-  deps.closeSessionSlotStream(sessionId);
-  useSessionIntentStore.getState().clearSession(sessionId);
-  removeSessionRecord(sessionId);
-  clearViewedSessionErrors([sessionId]);
-
-  if (resolvedWorkspaceId) {
-    deps.removeWorkspaceSessionRecord(resolvedWorkspaceId, sessionId);
-  }
-
-  // --- Runtime dismiss (fire-and-forget for materialized sessions) ---
+  // Stage before removing the directory record. That removal is the render
+  // signal that disables session-scoped observers while the replacement is
+  // pending. Staged suppression is memory-only and cannot trigger background
+  // dismissal until the replacement materializes successfully.
   if (materializedSessionId && resolvedWorkspaceId) {
-    void dismissMaterializedSession(
-      materializedSessionId,
+    stageReplacedSessionTombstone(
       resolvedWorkspaceId,
-      deps.dismissSessionMutation,
+      materializedSessionId,
+      [sessionId],
     );
   }
+  const stagedClientAlias = !materializedSessionId && resolvedWorkspaceId
+    ? stageReplacedClientSessionAlias(resolvedWorkspaceId, sessionId)
+    : false;
+  supersedeInFlightSessionCreation(sessionId);
 
-  return true;
+  // The replacement shell is already active. Hide only the old local record;
+  // intents, errors, query cache, and runtime truth remain untouched until the
+  // replacement materializes successfully.
+  deps.closeSessionSlotStream(sessionId);
+  removeSessionRecord(sessionId);
+
+  const restoreCapturedSession = () => {
+    if (materializedSessionId && resolvedWorkspaceId) {
+      clearStagedReplacedSessionTombstone(resolvedWorkspaceId, materializedSessionId);
+    }
+    if (stagedClientAlias && resolvedWorkspaceId) {
+      clearStagedReplacedClientSessionAlias(resolvedWorkspaceId, sessionId);
+    }
+    putSessionRecord({
+      ...record,
+      // The stream handle was closed when the shell was hidden. Restoring an
+      // "open" bit would strand the rolled-back session on a dead handle.
+      streamConnectionState: "disconnected",
+    });
+    rollbackSupersededSessionCreation(sessionId);
+  };
+  const finalizeRetirement = () => {
+    useSessionIntentStore.getState().clearSession(sessionId);
+    clearViewedSessionErrors([sessionId]);
+    if (resolvedWorkspaceId) {
+      deps.removeWorkspaceSessionRecord(
+        resolvedWorkspaceId,
+        materializedSessionId ?? sessionId,
+      );
+    }
+    commitSupersededSessionCreation(sessionId);
+    if (stagedClientAlias && resolvedWorkspaceId) {
+      retireStagedReplacedClientSessionAlias(resolvedWorkspaceId, sessionId);
+    }
+  };
+
+  let state: "pending" | "committing" | "committed" | "rolled_back" | "retained" = "pending";
+  let commitPromise: Promise<"retired" | "retained"> | null = null;
+  return {
+    replacedSessionId: sessionId,
+    commit: () => {
+      if (commitPromise) {
+        return commitPromise;
+      }
+      if (state !== "pending") {
+        return Promise.resolve(state === "committed" ? "retired" : "retained");
+      }
+      state = "committing";
+      commitPromise = (async () => {
+        if (!materializedSessionId || !resolvedWorkspaceId) {
+          finalizeRetirement();
+          state = "committed";
+          return "retired";
+        }
+
+        const durablySuppressed = commitReplacedSessionTombstone(
+          resolvedWorkspaceId,
+          materializedSessionId,
+          [sessionId],
+        );
+        const dismiss = () => runTrackedReplacementDismissal({
+          workspaceId: resolvedWorkspaceId,
+          runtimeSessionId: materializedSessionId,
+          run: () => dismissMaterializedSession(
+            materializedSessionId,
+            resolvedWorkspaceId,
+            deps.dismissSessionMutation,
+          ),
+        });
+        if (!durablySuppressed) {
+          try {
+            await dismiss();
+            retireStagedReplacedSessionTombstone(
+              resolvedWorkspaceId,
+              materializedSessionId,
+            );
+          } catch {
+            releaseReplacedSessionSuppression(
+              resolvedWorkspaceId,
+              materializedSessionId,
+            );
+            restoreCapturedSession();
+            state = "retained";
+            return "retained";
+          }
+        }
+
+        finalizeRetirement();
+        state = "committed";
+        if (durablySuppressed) {
+          void dismiss().catch(() => undefined);
+        }
+        return "retired";
+      })();
+      return commitPromise;
+    },
+    rollback: () => {
+      if (state !== "pending") {
+        return;
+      }
+      state = "rolled_back";
+      restoreCapturedSession();
+    },
+  };
 }
-
 
 async function dismissMaterializedSession(
   materializedSessionId: string,
   workspaceId: string,
   dismissMutation: ReturnType<typeof useDismissSessionMutation>,
 ): Promise<void> {
-  try {
-    await dismissMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
+  let lastError: unknown = null;
+  for (const delayMs of DISMISS_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+    try {
+      await dismissMutation.mutateAsync({
+        workspaceId,
+        sessionId: materializedSessionId,
+      });
+      // Keep the tombstone until a subsequent authoritative session list no
+      // longer contains this id. A list request that started before dismissal
+      // can otherwise refill the cache after local removal and resurrect the
+      // retired shell as soon as this mutation resolves.
+      return;
+    } catch (error) {
+      if (error instanceof AnyHarnessError && error.problem.status === 404) {
+        // A 404 confirms runtime absence, but an older in-flight list response
+        // may still be able to repopulate client cache. The next authoritative
+        // list is the safe point to clear the persisted tombstone.
+        return;
+      }
+      lastError = error;
+    }
+  }
+  if (lastError) {
+    captureTelemetryException(lastError, {
+      tags: {
+        action: "dismiss_replaced_empty_session",
+        domain: "sessions",
+      },
     });
-  } catch {
-    // Best-effort cleanup. The session is already removed locally; if the
-    // runtime dismiss fails the session will be garbage-collected by the
-    // runtime's normal idle-session reaper.
+    throw lastError;
   }
 }

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -9,7 +9,6 @@ import {
   pickLiveDefaultLaunchControls,
 } from "@/lib/domain/sessions/creation/launch-controls";
 import { resolveSessionCreationModeId } from "@/lib/domain/sessions/creation/mode";
-import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { useToastStore } from "@/stores/toast/toast-store";
 import {
@@ -40,12 +39,8 @@ import {
   useWorkspaceUiStore,
 } from "@/stores/preferences/workspace-ui-store";
 import {
-  removeSessionRecordAndClearSelection,
-} from "@/hooks/sessions/workflows/session-creation-local-state";
-import {
   inFlightSessionCreatesByWorkspace,
 } from "@/hooks/sessions/workflows/session-creation-in-flight";
-import { useSessionIntentStore } from "@/stores/sessions/session-intent-store";
 import { useCloudAgentCatalogCache } from "@/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog";
 import type {
   CreateEmptySessionWithResolvedConfigOptions,
@@ -55,16 +50,22 @@ import {
   sessionStreamPruningDeps,
 } from "@/hooks/sessions/workflows/session-creation-runtime";
 import {
-  markProjectedSessionPromptCreateFailed,
-} from "@/hooks/sessions/workflows/session-creation-failure";
-import {
   materializeSessionCreation,
 } from "@/hooks/sessions/workflows/session-creation-materialization";
 import { useDismissSessionMutation } from "@anyharness/sdk-react";
 import {
-  performEmptySessionReplacementCleanup,
+  beginEmptySessionReplacement,
+  type EmptySessionReplacementTransaction,
 } from "@/hooks/sessions/workflows/use-empty-session-replacement-cleanup";
-import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import {
+  registerSessionCreation,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+import {
+  beginReplacementShellPreferences,
+  type ReplacementShellPreferencesTransaction,
+} from "@/hooks/sessions/workflows/session-replacement-shell-preferences";
+import { cleanupSessionCreationFailure } from "@/hooks/sessions/workflows/session-creation-failure-cleanup";
+import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 
 export function useSessionCreationActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
@@ -84,6 +85,9 @@ export function useSessionCreationActions() {
     if (!workspaceId) {
       throw new Error("No workspace selected");
     }
+    const recoveryWorkspaceUiKey = resolveWorkspaceUiKey(
+      current.selectedLogicalWorkspaceId, workspaceId,
+    ) ?? workspaceId;
 
     const blockedReason = getWorkspaceRuntimeBlockReason(workspaceId);
     if (blockedReason) {
@@ -119,7 +123,7 @@ export function useSessionCreationActions() {
           });
         try {
           const resolvedClientSessionId = await inFlightCreate.promise;
-          if (pendingShellWrite) {
+          if (pendingShellWrite && getSessionRecord(resolvedClientSessionId)) {
             activateSession(resolvedClientSessionId);
           }
           return resolvedClientSessionId;
@@ -244,15 +248,24 @@ export function useSessionCreationActions() {
     writeOwnedShellIntent(pendingSessionId);
     pruneInactiveSessionStreams(sessionStreamPruningDeps);
 
-    // --- Replace-in-place: clean up the old empty session immediately so the
-    // tab swap is instant (no ghost tab until materialization completes). ---
-    let didReplaceOldSession = false;
-    if (options.replacesSessionId) {
-      didReplaceOldSession = performEmptySessionReplacementCleanup(
+    // Stage replacement after the optimistic shell is active. The old tab is
+    // hidden immediately, while destructive cleanup waits for materialization.
+    let replacementTransaction: EmptySessionReplacementTransaction | null = null;
+    let replacementShellPreferences: ReplacementShellPreferencesTransaction | null = null;
+    if (options.replacesSessionId && !hasPrompt) {
+      replacementTransaction = beginEmptySessionReplacement(
         options.replacesSessionId,
         workspaceId,
         { closeSessionSlotStream, removeWorkspaceSessionRecord, dismissSessionMutation },
       );
+      if (replacementTransaction && currentOwnedShellWorkspaceId) {
+        replacementShellPreferences = beginReplacementShellPreferences({
+          shellWorkspaceId: currentOwnedShellWorkspaceId,
+          materializedWorkspaceId: workspaceId,
+          replacedSessionId: replacementTransaction.replacedSessionId,
+          replacementSessionId: pendingSessionId,
+        });
+      }
     }
 
     if (shouldEnqueueInitialPrompt) {
@@ -274,6 +287,7 @@ export function useSessionCreationActions() {
       }
     }
 
+    const unregisterSessionCreation = registerSessionCreation(pendingSessionId);
     const createPromise = materializeSessionCreation({
       ensureCloudAgentCatalog,
       existingProjectedRecord,
@@ -283,7 +297,7 @@ export function useSessionCreationActions() {
       resolvedModeId: resolvedModeId ?? null,
       upsertWorkspaceSessionRecord,
       workspaceId,
-    });
+    }).finally(unregisterSessionCreation);
 
     if (!hasPrompt && shouldReuseInFlightEmptySession) {
       inFlightSessionCreatesByWorkspace.set(workspaceId, {
@@ -295,72 +309,25 @@ export function useSessionCreationActions() {
     }
 
     const cleanupCreateFailure = (error: unknown): void => {
-      logLatency("session.create.failed", {
-        clientSessionId: pendingSessionId,
-        workspaceId,
+      cleanupSessionCreationFailure({
         agentKind: options.agentKind,
-        modelId: options.modelId,
+        currentOwnedSessionId,
+        error,
+        hadExistingProjectedRecord: Boolean(existingProjectedRecord),
         hasPrompt,
-        hasExistingProjectedRecord: Boolean(existingProjectedRecord),
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-      if (hasPrompt) {
-        markProjectedSessionPromptCreateFailed(pendingSessionId, error);
-        if (options.launchIntentId) {
-          useChatLaunchIntentStore.getState().clearIfActive(options.launchIntentId);
-        }
-        captureTelemetryException(error, {
-          tags: {
-            action: "create_session_with_resolved_config",
-            domain: "sessions",
-          },
-        });
-        return;
-      }
-      if (options.preserveProjectedSessionOnCreateFailure) {
-        markProjectedSessionPromptCreateFailed(pendingSessionId, error);
-        if (options.launchIntentId) {
-          useChatLaunchIntentStore.getState().clearIfActive(options.launchIntentId);
-        }
-        captureTelemetryException(error, {
-          tags: {
-            action: "create_projected_session_materialization",
-            domain: "sessions",
-          },
-        });
-        return;
-      }
-      const activeSessionIdBeforeRemoval = useSessionSelectionStore.getState().activeSessionId;
-      useSessionIntentStore.getState().clearSession(pendingSessionId);
-      removeSessionRecordAndClearSelection(pendingSessionId);
-      const rolledBackShellIntent = rollbackOwnedShellIntent();
-      if (rolledBackShellIntent && activeSessionIdBeforeRemoval === currentOwnedSessionId) {
-        // If the old session was already deleted (replace-in-place), fall back
-        // to the workspace's remaining sessions rather than a deleted id.
-        const canRestorePrevious = previousActiveSessionId && !didReplaceOldSession;
-        if (canRestorePrevious) {
-          activateSession(previousActiveSessionId);
-        } else {
-          // Find the first remaining session in this workspace as fallback
-          const remainingIds = useSessionDirectoryStore.getState()
-            .sessionIdsByWorkspaceId[workspaceId] ?? [];
-          const fallbackSessionId = remainingIds.find((id) => id !== pendingSessionId) ?? null;
-          if (fallbackSessionId) {
-            activateSession(fallbackSessionId);
-          } else {
-            useSessionSelectionStore.getState().setActiveSessionId(null);
-          }
-        }
-      }
-      if (options.launchIntentId) {
-        useChatLaunchIntentStore.getState().clearIfActive(options.launchIntentId);
-      }
-      captureTelemetryException(error, {
-        tags: {
-          action: "create_session_with_resolved_config",
-          domain: "sessions",
-        },
-      });
+        launchIntentId: options.launchIntentId,
+        modeId: resolvedModeId ?? null,
+        modelId: options.modelId,
+        pendingSessionId,
+        preserveProjectedSessionOnCreateFailure:
+          options.preserveProjectedSessionOnCreateFailure === true,
+        previousActiveSessionId,
+        recoveryWorkspaceUiKey,
+        replacementShellPreferences,
+        replacementTransaction,
+        rollbackOwnedShellIntent,
+        workspaceId,
+      }, { activateSession });
     };
 
     const cleanupInFlight = (): void => {
@@ -379,7 +346,15 @@ export function useSessionCreationActions() {
     }
 
     try {
-      return await createPromise;
+      const resolvedSessionId = await createPromise;
+      const replacementOutcome = await replacementTransaction?.commit();
+      if (replacementOutcome === "retained") {
+        showToast(
+          "Opened the new chat, but kept the previous chat because it could not be removed safely.",
+          "info",
+        );
+      }
+      return resolvedSessionId;
     } catch (error) {
       cleanupCreateFailure(error);
       throw toSessionCreateFailureDisplayError(error);

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearReplacedSessionTombstone,
+  commitReplacedSessionTombstone,
+  isReplacedSessionTombstoned,
+  resetReplacedSessionTombstonesForTests,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  resetSessionReplacementDismissalsForTests,
+  runTrackedReplacementDismissal,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
+import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
+import { useSessionRestoreActions } from "./use-session-restore-actions";
+
+const mocks = vi.hoisted(() => ({
+  getWorkspaceClientAndId: vi.fn(async () => ({
+    target: {
+      anyharnessWorkspaceId: "workspace-1",
+      baseUrl: "http://runtime.test",
+    },
+  })),
+  dismissMutateAsync: vi.fn(),
+  restoreMutateAsync: vi.fn(),
+  showToast: vi.fn(),
+  upsertWorkspaceSessionRecord: vi.fn(),
+  writeSessionReplacementTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
+  readSessionReplacementTombstones: () => ({}),
+  writeSessionReplacementTombstones: mocks.writeSessionReplacementTombstones,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useDismissSessionMutation: () => ({ mutateAsync: mocks.dismissMutateAsync }),
+  useRestoreDismissedSessionMutation: () => ({ mutateAsync: mocks.restoreMutateAsync }),
+}));
+
+vi.mock("@/hooks/access/anyharness/sessions/use-workspace-session-cache", () => ({
+  useWorkspaceSessionCache: () => ({
+    upsertWorkspaceSessionRecord: mocks.upsertWorkspaceSessionRecord,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/session-selection-runtime", () => ({
+  buildLatencyRequestOptions: () => undefined,
+  ensureRuntimeReadyForSessions: async () => "http://runtime.test",
+}));
+
+vi.mock("@/lib/access/anyharness/session-runtime", () => ({
+  getWorkspaceClientAndId: mocks.getWorkspaceClientAndId,
+}));
+
+vi.mock("@/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.writeSessionReplacementTombstones.mockReturnValue(true);
+  resetReplacedSessionTombstonesForTests();
+  resetSessionReplacementDismissalsForTests();
+  useSessionSelectionStore.getState().clearSelection();
+  useSessionSelectionStore.getState().activateWorkspace({
+    logicalWorkspaceId: "logical-1",
+    workspaceId: "workspace-1",
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("useSessionRestoreActions", () => {
+  it("does not restore when cleanup state cannot be persisted", async () => {
+    mocks.writeSessionReplacementTombstones.mockReturnValue(false);
+    const { result } = renderHook(() => useSessionRestoreActions());
+
+    await act(async () => {
+      await expect(result.current.restoreLastDismissedSession()).rejects.toThrow(
+        "Could not save session cleanup state",
+      );
+    });
+
+    expect(mocks.restoreMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.upsertWorkspaceSessionRecord).not.toHaveBeenCalled();
+  });
+
+  it("releases retired runtime and client aliases before cache upsert", async () => {
+    commitReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    clearReplacedSessionTombstone("workspace-1", "runtime-old");
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
+    const restored = { id: "runtime-old" };
+    mocks.restoreMutateAsync.mockResolvedValue(restored);
+    const { result } = renderHook(() => useSessionRestoreActions());
+
+    let restoredId: string | null = null;
+    await act(async () => {
+      restoredId = await result.current.restoreLastDismissedSession();
+    });
+
+    expect(restoredId).toBe("runtime-old");
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(false);
+    expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
+      "workspace-1",
+      restored,
+      { runtimeUrl: "http://runtime.test" },
+    );
+  });
+
+  it("waits for an in-flight replacement dismissal before restoring", async () => {
+    const dismissalStarted = deferred();
+    const dismissalGate = deferred();
+    const order: string[] = [];
+    void runTrackedReplacementDismissal({
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-old",
+      run: async () => {
+        order.push("dismiss:start");
+        dismissalStarted.resolve();
+        await dismissalGate.promise;
+        order.push("dismiss:end");
+      },
+    });
+    await dismissalStarted.promise;
+
+    const restored = { id: "runtime-old" };
+    mocks.restoreMutateAsync.mockImplementation(async () => {
+      order.push("restore");
+      return restored;
+    });
+    const { result } = renderHook(() => useSessionRestoreActions());
+
+    let restorePromise!: Promise<string | null>;
+    act(() => {
+      restorePromise = result.current.restoreLastDismissedSession();
+    });
+    await vi.waitFor(() => {
+      expect(mocks.getWorkspaceClientAndId).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.restoreMutateAsync).not.toHaveBeenCalled();
+    expect(order).toEqual(["dismiss:start"]);
+
+    dismissalGate.resolve();
+    await act(async () => {
+      await expect(restorePromise).resolves.toBe("runtime-old");
+    });
+
+    expect(order).toEqual(["dismiss:start", "dismiss:end", "restore"]);
+    expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
+      "workspace-1",
+      restored,
+      { runtimeUrl: "http://runtime.test" },
+    );
+  });
+
+  it("cancels queued cleanup only for the runtime returned by restore", async () => {
+    const restored = { id: "runtime-restored" };
+    const dismissRestored = vi.fn();
+    const dismissUnrelated = vi.fn();
+    let restoredCleanup!: Promise<void>;
+    let unrelatedCleanup!: Promise<void>;
+    mocks.restoreMutateAsync.mockImplementation(async () => {
+      restoredCleanup = runTrackedReplacementDismissal({
+        workspaceId: "workspace-1",
+        runtimeSessionId: "runtime-restored",
+        run: dismissRestored,
+      });
+      unrelatedCleanup = runTrackedReplacementDismissal({
+        workspaceId: "workspace-1",
+        runtimeSessionId: "runtime-unrelated",
+        run: dismissUnrelated,
+      });
+      return restored;
+    });
+    const { result } = renderHook(() => useSessionRestoreActions());
+
+    let restoredId: string | null = null;
+    await act(async () => {
+      restoredId = await result.current.restoreLastDismissedSession();
+    });
+    await Promise.all([restoredCleanup, unrelatedCleanup]);
+
+    expect(restoredId).toBe("runtime-restored");
+    expect(dismissRestored).not.toHaveBeenCalled();
+    expect(dismissUnrelated).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
@@ -1,5 +1,8 @@
 import { useCallback } from "react";
-import { useRestoreDismissedSessionMutation } from "@anyharness/sdk-react";
+import {
+  useDismissSessionMutation,
+  useRestoreDismissedSessionMutation,
+} from "@anyharness/sdk-react";
 import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import type { SessionLatencyFlowOptions } from "@/hooks/sessions/workflows/session-selection-options";
 import {
@@ -19,11 +22,20 @@ import {
 import { getWorkspaceClientAndId } from "@/lib/access/anyharness/session-runtime";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
+import {
+  canPersistReplacedSessionTombstones,
+  releaseReplacedSessionSuppression,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  cancelQueuedReplacementDismissal,
+  withWorkspaceReplacementRestoreFence,
+} from "@/hooks/sessions/workflows/session-replacement-dismissals";
 
 export function useSessionRestoreActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const showToast = useToastStore((state) => state.show);
   const { upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
+  const dismissSessionMutation = useDismissSessionMutation();
   const restoreDismissedSessionMutation = useRestoreDismissedSessionMutation();
 
   const restoreLastDismissedSession = useCallback(async (
@@ -85,9 +97,36 @@ export function useSessionRestoreActions() {
 
       const requestOptions = buildLatencyRequestOptions(options?.latencyFlowId);
       const restoreRequestStartedAt = startLatencyTimer();
-      const restored = await restoreDismissedSessionMutation.mutateAsync({
-        workspaceId,
-        requestOptions,
+      const restored = await withWorkspaceReplacementRestoreFence(workspaceId, async () => {
+        if (!canPersistReplacedSessionTombstones()) {
+          throw new Error("Could not save session cleanup state. Try restoring again.");
+        }
+        const restoredSession = await restoreDismissedSessionMutation.mutateAsync({
+          workspaceId,
+          requestOptions,
+        });
+        if (!restoredSession) {
+          return null;
+        }
+
+        // Explicit restore is the user-authorized inverse of background cleanup.
+        // Cancel stale cleanup queued while the restore mutation invalidated
+        // session lists, then release runtime and client aliases before the
+        // summary reaches cache so selectors can observe it in this renderer.
+        if (!releaseReplacedSessionSuppression(workspaceId, restoredSession.id)) {
+          // Storage changed after the preflight. Put runtime truth back into
+          // the dismissed state covered by the still-durable tombstone.
+          await dismissSessionMutation.mutateAsync({
+            workspaceId,
+            sessionId: restoredSession.id,
+          }).catch(() => undefined);
+          throw new Error("Could not save restored session state. Try again.");
+        }
+        cancelQueuedReplacementDismissal(workspaceId, restoredSession.id);
+        upsertWorkspaceSessionRecord(workspaceId, restoredSession, {
+          runtimeUrl: target.baseUrl,
+        });
+        return restoredSession;
       });
       logLatency("session.restore.request_completed", {
         workspaceId,
@@ -110,9 +149,6 @@ export function useSessionRestoreActions() {
         targetSessionId: restored.id,
       });
 
-      upsertWorkspaceSessionRecord(workspaceId, restored, {
-        runtimeUrl: target.baseUrl,
-      });
       logLatency("session.restore.cache_upserted", {
         workspaceId,
         sessionId: restored.id,
@@ -138,6 +174,7 @@ export function useSessionRestoreActions() {
     }
   }, [
     getWorkspaceRuntimeBlockReason,
+    dismissSessionMutation,
     restoreDismissedSessionMutation,
     showToast,
     upsertWorkspaceSessionRecord,

--- a/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetReplacedSessionTombstonesForTests,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import { useWorkspaceSessionLoader } from "./use-workspace-session-loader";
+
+const mocks = vi.hoisted(() => ({
+  ensureRuntimeReadyForSessions: vi.fn(async () => "http://runtime.test"),
+  fetchWorkspaceSessions: vi.fn(),
+  getWorkspaceRuntimeBlockReason: vi.fn(() => null),
+  getWorkspaceSessionCacheSnapshot: vi.fn(),
+  setWorkspaceSessions: vi.fn(),
+}));
+
+vi.mock("@/hooks/access/anyharness/sessions/use-workspace-session-cache", () => ({
+  useWorkspaceSessionCache: () => ({
+    getWorkspaceSessionCacheSnapshot: mocks.getWorkspaceSessionCacheSnapshot,
+    setWorkspaceSessions: mocks.setWorkspaceSessions,
+  }),
+}));
+
+vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: mocks.getWorkspaceRuntimeBlockReason,
+  }),
+}));
+
+vi.mock("@/hooks/sessions/workflows/session-selection-runtime", () => ({
+  ensureRuntimeReadyForSessions: mocks.ensureRuntimeReadyForSessions,
+  fetchWorkspaceSessions: mocks.fetchWorkspaceSessions,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetReplacedSessionTombstonesForTests();
+});
+
+afterEach(() => cleanup());
+
+describe("useWorkspaceSessionLoader replacement filtering", () => {
+  it("filters a staged runtime from a cache hit", async () => {
+    mocks.getWorkspaceSessionCacheSnapshot.mockReturnValue({
+      sessions: [
+        { id: "runtime-old", workspaceId: "workspace-1" },
+        { id: "runtime-new", workspaceId: "workspace-1" },
+      ],
+      dataUpdatedAt: 1,
+      isInvalidated: false,
+    });
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    const { result } = renderHook(() => useWorkspaceSessionLoader());
+
+    const sessions = await result.current.ensureWorkspaceSessions("workspace-1");
+
+    expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
+    expect(mocks.fetchWorkspaceSessions).not.toHaveBeenCalled();
+  });
+
+  it("filters before writing a fetched session list back to cache", async () => {
+    mocks.getWorkspaceSessionCacheSnapshot.mockReturnValue({
+      sessions: undefined,
+      dataUpdatedAt: 0,
+      isInvalidated: false,
+    });
+    mocks.fetchWorkspaceSessions.mockResolvedValue([
+      { id: "runtime-old", workspaceId: "workspace-1" },
+      { id: "runtime-new", workspaceId: "workspace-1" },
+    ]);
+    stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
+    const { result } = renderHook(() => useWorkspaceSessionLoader());
+
+    const sessions = await result.current.ensureWorkspaceSessions("workspace-1");
+
+    expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
+    const updater = mocks.setWorkspaceSessions.mock.calls[0]?.[1] as
+      ((current: unknown) => unknown) | undefined;
+    expect(updater?.(undefined)).toEqual([
+      { id: "runtime-new", workspaceId: "workspace-1" },
+    ]);
+  });
+});

--- a/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
@@ -12,6 +12,9 @@ import { recordMeasurementMetric } from "@/lib/infra/measurement/debug-measureme
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import {
+  filterReplacedSessionTombstones,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 export function useWorkspaceSessionLoader() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
@@ -50,14 +53,17 @@ export function useWorkspaceSessionLoader() {
       && cacheSnapshot.dataUpdatedAt
       && !cacheSnapshot.isInvalidated
     ) {
-      return cacheSnapshot.sessions;
+      return filterReplacedSessionTombstones(
+        workspaceId,
+        cacheSnapshot.sessions,
+      ) ?? [];
     }
 
     // Do not join a possibly hung automatic query for the same selected
     // workspace. Session selection is the owning workflow and must either
     // complete or fail independently so the shell cannot stay on
     // "Preparing workspace" behind an unrelated header/sidebar fetch.
-    const sessions = await fetchWorkspaceSessions(
+    const loadedSessions = await fetchWorkspaceSessions(
       runtimeUrl,
       workspaceId,
       requestHeaders || options?.measurementOperationId
@@ -67,6 +73,10 @@ export function useWorkspaceSessionLoader() {
         }
         : undefined,
     );
+    const sessions = filterReplacedSessionTombstones(
+      workspaceId,
+      loadedSessions,
+    ) ?? [];
     setWorkspaceSessions(workspaceId, () => sessions, { runtimeUrl });
     return sessions;
   }, [

--- a/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.test.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearStagedReplacedSessionTombstone,
+  resetReplacedSessionTombstonesForTests,
+  stageReplacedSessionTombstone,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  shouldEnableHeaderSessionScopedQuery,
+} from "./use-workspace-header-subagent-hierarchy";
+
+beforeEach(() => {
+  resetReplacedSessionTombstonesForTests();
+});
+
+describe("header session-scoped query eligibility", () => {
+  it("disables every query family for a tombstoned session and re-enables after rollback", () => {
+    const input = {
+      workspaceId: "workspace-1",
+      sessionId: "runtime-old",
+      materializedSessionId: "runtime-old",
+      enabledByBatch: true,
+    };
+
+    expect(shouldEnableHeaderSessionScopedQuery(input)).toBe(true);
+
+    stageReplacedSessionTombstone("workspace-1", "runtime-old");
+    expect(shouldEnableHeaderSessionScopedQuery(input)).toBe(false);
+
+    clearStagedReplacedSessionTombstone("workspace-1", "runtime-old");
+    expect(shouldEnableHeaderSessionScopedQuery(input)).toBe(true);
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -34,6 +34,9 @@ import {
 } from "@/lib/domain/workspaces/tabs/workspace-header-cowork-hierarchy";
 import { useBatchedHeaderHierarchySessionIds } from "@/hooks/workspaces/ui/tabs/use-batched-header-hierarchy-session-ids";
 import {
+  isReplacedSessionTombstoned,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
+import {
   buildHierarchyQuerySignature,
   buildReviewRelationshipHintSignature,
   buildSubagentRelationshipHintSignature,
@@ -81,10 +84,12 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, args.workspaceId, sessionId),
-        enabled: !!args.workspaceId
-          && !!sessionId
-          && !!materializedSessionId
-          && enabledSessionIds.has(sessionId),
+        enabled: shouldEnableHeaderSessionScopedQuery({
+          workspaceId: args.workspaceId,
+          sessionId,
+          materializedSessionId,
+          enabledByBatch: enabledSessionIds.has(sessionId),
+        }),
         queryFn: async ({ signal }): Promise<SessionSubagentsResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -105,10 +110,12 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessSessionReviewsKey(runtimeUrl, args.workspaceId, sessionId),
-        enabled: !!args.workspaceId
-          && !!sessionId
-          && !!materializedSessionId
-          && enabledSessionIds.has(sessionId),
+        enabled: shouldEnableHeaderSessionScopedQuery({
+          workspaceId: args.workspaceId,
+          sessionId,
+          materializedSessionId,
+          enabledByBatch: enabledSessionIds.has(sessionId),
+        }),
         queryFn: async ({ signal }): Promise<SessionReviewsResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -129,10 +136,12 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
       const materializedSessionId = materializedSessionIds[index];
       return {
         queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, materializedSessionId),
-        enabled: !!args.workspaceId
-          && !!sessionId
-          && !!materializedSessionId
-          && enabledSessionIds.has(sessionId),
+        enabled: shouldEnableHeaderSessionScopedQuery({
+          workspaceId: args.workspaceId,
+          sessionId,
+          materializedSessionId,
+          enabledByBatch: enabledSessionIds.has(sessionId),
+        }),
         queryFn: async ({ signal }): Promise<CoworkManagedWorkspacesResponse> => {
           if (!materializedSessionId) {
             throw new Error("Session is still starting. Try again in a moment.");
@@ -294,4 +303,17 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     hierarchyQueryRows,
     resolveClientSessionId,
   ]);
+}
+
+export function shouldEnableHeaderSessionScopedQuery(input: {
+  workspaceId: string | null;
+  sessionId: string | null | undefined;
+  materializedSessionId: string | null | undefined;
+  enabledByBatch: boolean;
+}): boolean {
+  return !!input.workspaceId
+    && !!input.sessionId
+    && !!input.materializedSessionId
+    && input.enabledByBatch
+    && !isReplacedSessionTombstoned(input.workspaceId, input.materializedSessionId);
 }

--- a/apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-view-model.ts
+++ b/apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-view-model.ts
@@ -36,6 +36,10 @@ import { useWorkspaceHeaderTabsWorkspaceState } from "@/hooks/workspaces/facade/
 import { useWorkspaceHeaderTabsDebugLogging } from "@/hooks/workspaces/lifecycle/use-workspace-header-tabs-debug-logging";
 import { useWorkspaceHeaderTabsPreferences } from "@/hooks/workspaces/facade/tabs/use-workspace-header-tabs-preferences";
 import { useWorkspaceHeaderTabsVisibility } from "@/hooks/workspaces/facade/tabs/use-workspace-header-tabs-visibility";
+import {
+  filterReplacedSessionIds,
+  filterReplacedSessionTombstones,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 export function useWorkspaceHeaderTabsViewModel() {
   const {
@@ -104,9 +108,22 @@ export function useWorkspaceHeaderTabsViewModel() {
       ],
       count: (map) => map.size,
     }, () => {
+      // Resolve tombstones inside the live-slot memo. Beginning a replacement
+      // removes the old slot while intentionally leaving the runtime query
+      // cache untouched for rollback; the liveSlots dependency is therefore
+      // the render signal that hides the retired cached header row immediately.
+      const visibleWorkspaceSessions = selectedWorkspaceId
+        ? filterReplacedSessionTombstones(
+          selectedWorkspaceId,
+          workspaceSessionsQuery.data,
+        )
+        : workspaceSessionsQuery.data;
+      const visibleOptimisticSessionIds = selectedWorkspaceId
+        ? filterReplacedSessionIds(selectedWorkspaceId, optimisticHeaderSessionIds)
+        : optimisticHeaderSessionIds;
       return buildKnownHeaderSessions({
-        optimisticSessionIds: optimisticHeaderSessionIds,
-        sessions: workspaceSessionsQuery.data,
+        optimisticSessionIds: visibleOptimisticSessionIds,
+        sessions: visibleWorkspaceSessions,
         selectedWorkspaceId,
         clientSessionIdByMaterializedSessionId,
         liveSlots,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -53,6 +53,9 @@ import {
 } from "@/lib/domain/workspaces/selection/optimistic-session-shell";
 import { handleEmptyWorkspaceBootstrap } from "@/hooks/workspaces/workflows/workspace-bootstrap-empty-session";
 import { handleRememberedWorkspaceSessionBootstrap } from "@/hooks/workspaces/workflows/workspace-bootstrap-remembered-session";
+import {
+  shouldPreserveStagedReplacementShell,
+} from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 interface BootstrapWorkspaceInput {
   workspaceId: string;
@@ -242,13 +245,19 @@ export function useWorkspaceBootstrapActions() {
     }
 
     const activeSessionIdAfterLoad = useSessionSelectionStore.getState().activeSessionId;
+    const activeSessionRecordAfterLoad = activeSessionIdAfterLoad
+      ? getSessionRecord(activeSessionIdAfterLoad)
+      : null;
+    const preserveStagedReplacementShell = shouldPreserveStagedReplacementShell(
+      workspaceId,
+      activeSessionRecordAfterLoad?.workspaceId,
+    );
     const loadedActiveSession = activeSessionIdAfterLoad
       ? findLoadedSessionForClientSession(activeSessionIdAfterLoad, sessions)
       : null;
     if (activeSessionIdAfterLoad && loadedActiveSession) {
-      const activeSessionBeforePatch = getSessionRecord(activeSessionIdAfterLoad);
       const wasOptimisticPlaceholder =
-        isOptimisticWorkspaceSessionPlaceholder(activeSessionBeforePatch);
+        isOptimisticWorkspaceSessionPlaceholder(activeSessionRecordAfterLoad);
       applySessionSummary(activeSessionIdAfterLoad, loadedActiveSession, workspaceId);
       if (wasOptimisticPlaceholder) {
         logLatency("workspace.select.optimistic_session_validated", {
@@ -259,7 +268,7 @@ export function useWorkspaceBootstrapActions() {
           agentKind: loadedActiveSession.agentKind,
         });
       }
-    } else if (!sessionsLoadFailed) {
+    } else if (!sessionsLoadFailed && !preserveStagedReplacementShell) {
       clearInvalidOptimisticActiveSession({
         workspaceId,
         logicalWorkspaceId,
@@ -267,6 +276,18 @@ export function useWorkspaceBootstrapActions() {
     }
 
     if (sessions.length === 0) {
+      if (preserveStagedReplacementShell) {
+        logLatency("workspace.select.initial_session_open.skipped", {
+          workspaceId,
+          sessionId: activeSessionIdAfterLoad,
+          reason: "staged_session_replacement",
+          totalElapsedMs: elapsedMs(startedAt),
+        });
+        if (isCurrent()) {
+          markWorkspaceBootstrappedInSession(workspaceId);
+        }
+        return { sessions };
+      }
       const emptyBootstrap = await handleEmptyWorkspaceBootstrap({
         agentsByKind,
         latencyFlowId,

--- a/apps/desktop/src/lib/access/browser/session-replacement-tombstones-storage.test.ts
+++ b/apps/desktop/src/lib/access/browser/session-replacement-tombstones-storage.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  readSessionReplacementTombstones,
+  writeSessionReplacementTombstones,
+} from "@/lib/access/browser/session-replacement-tombstones-storage";
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, String(value)),
+    },
+  });
+  window.localStorage.clear();
+});
+
+describe("session replacement tombstone storage", () => {
+  it("persists and clears workspace-scoped cleanup records", () => {
+    expect(writeSessionReplacementTombstones({
+      "workspace-1": [{
+        runtimeSessionId: "runtime-old",
+        suppressedSessionIds: ["client-old", "runtime-old"],
+      }],
+    })).toBe(true);
+
+    expect(readSessionReplacementTombstones()).toEqual({
+      "workspace-1": [{
+        runtimeSessionId: "runtime-old",
+        suppressedSessionIds: ["runtime-old", "client-old"],
+      }],
+    });
+
+    expect(writeSessionReplacementTombstones({})).toBe(true);
+    expect(readSessionReplacementTombstones()).toEqual({});
+  });
+
+  it("reads legacy runtime-id arrays", () => {
+    window.localStorage.setItem(
+      "proliferate.session-replacement-tombstones.v1",
+      JSON.stringify({ "workspace-1": ["runtime-old"] }),
+    );
+
+    expect(readSessionReplacementTombstones()).toEqual({
+      "workspace-1": [{
+        runtimeSessionId: "runtime-old",
+        suppressedSessionIds: ["runtime-old"],
+      }],
+    });
+  });
+
+  it("reports failed writes and removals instead of accepting volatile cleanup", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        removeItem: () => {
+          throw new Error("storage unavailable");
+        },
+        setItem: () => {
+          throw new Error("storage unavailable");
+        },
+      },
+    });
+
+    expect(writeSessionReplacementTombstones({
+      "workspace-1": [{
+        runtimeSessionId: "runtime-old",
+        suppressedSessionIds: ["runtime-old"],
+      }],
+    })).toBe(false);
+    expect(writeSessionReplacementTombstones({})).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/access/browser/session-replacement-tombstones-storage.ts
+++ b/apps/desktop/src/lib/access/browser/session-replacement-tombstones-storage.ts
@@ -1,0 +1,94 @@
+const SESSION_REPLACEMENT_TOMBSTONES_STORAGE_KEY =
+  "proliferate.session-replacement-tombstones.v1";
+
+export interface PersistedSessionReplacementTombstone {
+  runtimeSessionId: string;
+  suppressedSessionIds: string[];
+}
+
+export type PersistedSessionReplacementTombstones = Record<
+  string,
+  PersistedSessionReplacementTombstone[]
+>;
+
+export function readSessionReplacementTombstones(): PersistedSessionReplacementTombstones {
+  if (typeof window === "undefined") {
+    return {};
+  }
+  try {
+    const raw = window.localStorage.getItem(SESSION_REPLACEMENT_TOMBSTONES_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).flatMap(([workspaceId, entries]) => {
+        if (!Array.isArray(entries)) {
+          return [];
+        }
+        const normalized = entries.flatMap(normalizePersistedTombstone);
+        return normalized.length > 0 ? [[workspaceId, normalized]] : [];
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function normalizePersistedTombstone(
+  value: unknown,
+): PersistedSessionReplacementTombstone[] {
+  // v1 stored only runtime ids. Read those as a one-id suppression set so
+  // existing cleanup state survives the richer alias-aware representation.
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [{
+      runtimeSessionId: value,
+      suppressedSessionIds: [value],
+    }];
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const runtimeSessionId = typeof record.runtimeSessionId === "string"
+    ? record.runtimeSessionId.trim()
+    : "";
+  if (!runtimeSessionId) {
+    return [];
+  }
+  const aliases = Array.isArray(record.suppressedSessionIds)
+    ? record.suppressedSessionIds.filter((id): id is string => (
+      typeof id === "string" && id.trim().length > 0
+    ))
+    : [];
+  return [{
+    runtimeSessionId,
+    suppressedSessionIds: [...new Set([runtimeSessionId, ...aliases])],
+  }];
+}
+
+export function writeSessionReplacementTombstones(
+  value: PersistedSessionReplacementTombstones,
+): boolean {
+  // Replacement workflows cannot run during SSR. Treat the no-window path as
+  // a no-op success so pure workflow tests do not need a fake browser.
+  if (typeof window === "undefined") {
+    return true;
+  }
+  try {
+    if (Object.keys(value).length === 0) {
+      window.localStorage.removeItem(SESSION_REPLACEMENT_TOMBSTONES_STORAGE_KEY);
+      return true;
+    }
+    window.localStorage.setItem(
+      SESSION_REPLACEMENT_TOMBSTONES_STORAGE_KEY,
+      JSON.stringify(value),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/lib/domain/sessions/session-emptiness.test.ts
+++ b/apps/desktop/src/lib/domain/sessions/session-emptiness.test.ts
@@ -7,10 +7,20 @@ import {
 
 function makeSnapshot(overrides?: Partial<SessionEmptinessSnapshot>): SessionEmptinessSnapshot {
   return {
-    transcript: { turnOrder: [] },
+    transcript: {
+      isStreaming: false,
+      pendingInteractions: [],
+      pendingPrompts: [],
+      turnOrder: [],
+    },
     events: [],
     optimisticPrompt: null,
     hasAttemptedPrompt: false,
+    activeGoal: null,
+    executionSummary: null,
+    lastPromptAt: null,
+    sessionActivity: null,
+    status: "idle",
     ...overrides,
   };
 }
@@ -22,7 +32,12 @@ describe("isSessionEmpty", () => {
 
   it("returns false when transcript has turns", () => {
     expect(isSessionEmpty(makeSnapshot({
-      transcript: { turnOrder: ["turn-1"] },
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+        pendingPrompts: [],
+        turnOrder: ["turn-1"],
+      },
     }))).toBe(false);
   });
 
@@ -32,10 +47,10 @@ describe("isSessionEmpty", () => {
     }))).toBe(false);
   });
 
-  it("returns false when events have been received from the runtime stream", () => {
+  it("ignores harmless runtime and config events", () => {
     expect(isSessionEmpty(makeSnapshot({
       events: [{ kind: "config_option_update" }],
-    }))).toBe(false);
+    }))).toBe(true);
   });
 
   it("returns false when hasAttemptedPrompt is true", () => {
@@ -44,9 +59,99 @@ describe("isSessionEmpty", () => {
     }))).toBe(false);
   });
 
+  it("returns false when a goal is active", () => {
+    expect(isSessionEmpty(makeSnapshot({
+      activeGoal: { id: "goal-1" },
+    }))).toBe(false);
+  });
+
+  it("returns false when the transcript has a pending interaction", () => {
+    expect(isSessionEmpty(makeSnapshot({
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [{ requestId: "request-1" } as never],
+        pendingPrompts: [],
+        turnOrder: [],
+      },
+    }))).toBe(false);
+  });
+
+  it("returns false when the execution summary has a pending interaction", () => {
+    expect(isSessionEmpty(makeSnapshot({
+      executionSummary: {
+        pendingInteractions: [{ requestId: "request-1" } as never],
+        phase: "awaiting_interaction",
+      },
+    }))).toBe(false);
+  });
+
+  it.each([
+    ["a queued runtime prompt", { transcript: {
+      isStreaming: false,
+      pendingInteractions: [],
+      pendingPrompts: [{ seq: 1 } as never],
+      turnOrder: [],
+    } }],
+    ["a prior prompt timestamp", { lastPromptAt: "2026-07-10T00:00:00Z" }],
+    ["a live activity loop", { sessionActivity: {
+      turn: { status: "idle" },
+      loops: [{ loopId: "loop-1" } as never],
+    } }],
+  ])("returns false for %s", (_label, overrides) => {
+    expect(isSessionEmpty(makeSnapshot(overrides as Partial<SessionEmptinessSnapshot>)))
+      .toBe(false);
+  });
+
+  it("allows the canonical materialized idle activity snapshot", () => {
+    expect(isSessionEmpty(makeSnapshot({
+      sessionActivity: {
+        turn: { status: "idle" },
+        loops: [],
+        processes: [],
+        agents: [],
+      },
+    }))).toBe(true);
+  });
+
+  it("ignores startup liveness without durable user work", () => {
+    expect(isSessionEmpty(makeSnapshot({
+      transcript: {
+        isStreaming: true,
+        pendingInteractions: [],
+        pendingPrompts: [],
+        turnOrder: [],
+      },
+      events: [
+        { kind: "session_started" },
+        { kind: "config_option_update" },
+        { kind: "available_commands_update" },
+      ],
+      executionSummary: {
+        pendingInteractions: [],
+        phase: "running",
+      },
+      sessionActivity: {
+        turn: {
+          status: "running",
+          turnId: "startup-only",
+          startedAt: "2026-07-10T00:00:00Z",
+        },
+        loops: [],
+        processes: [],
+        agents: [],
+      },
+      status: "running",
+    }))).toBe(true);
+  });
+
   it("returns false when multiple emptiness conditions are violated", () => {
     expect(isSessionEmpty(makeSnapshot({
-      transcript: { turnOrder: ["turn-1"] },
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+        pendingPrompts: [],
+        turnOrder: ["turn-1"],
+      },
       hasAttemptedPrompt: true,
       optimisticPrompt: { text: "hi" },
     }))).toBe(false);
@@ -64,7 +169,12 @@ describe("isSessionEmptyWithIntents", () => {
 
   it("returns false when session has transcript turns regardless of intent count", () => {
     expect(isSessionEmptyWithIntents(makeSnapshot({
-      transcript: { turnOrder: ["turn-1"] },
+      transcript: {
+        isStreaming: false,
+        pendingInteractions: [],
+        pendingPrompts: [],
+        turnOrder: ["turn-1"],
+      },
     }), 0)).toBe(false);
   });
 

--- a/apps/desktop/src/lib/domain/sessions/session-emptiness.ts
+++ b/apps/desktop/src/lib/domain/sessions/session-emptiness.ts
@@ -1,28 +1,44 @@
-import type { TranscriptState } from "@anyharness/sdk";
+import type {
+  SessionActivity,
+  SessionExecutionSummary,
+  SessionStatus,
+  TranscriptState,
+} from "@anyharness/sdk";
 
 /**
  * Snapshot of the fields needed to determine whether a session has ever had
  * user work. Intentionally decoupled from the full SessionRuntimeRecord so
  * the predicate stays pure and testable without store dependencies.
  *
- * `events` are the raw session event envelopes from the runtime stream. A
- * session that has received any events has been connected to a live runtime and
- * may have had system-level work (config acknowledgements, status changes) even
- * without user-initiated turns — it should not be silently replaced in place.
+ * Runtime event envelopes are deliberately not part of the decision. Fresh
+ * sessions receive status and config acknowledgements before the user does any
+ * work, and those transport details must not turn an unused chat into a kept
+ * chat.
  */
 export interface SessionEmptinessSnapshot {
-  transcript: Pick<TranscriptState, "turnOrder">;
+  transcript: Pick<
+    TranscriptState,
+    "isStreaming" | "pendingInteractions" | "pendingPrompts" | "turnOrder"
+  >;
   events: readonly unknown[];
   optimisticPrompt: unknown | null;
   hasAttemptedPrompt: boolean;
+  activeGoal: unknown | null;
+  executionSummary: Pick<SessionExecutionSummary, "pendingInteractions" | "phase"> | null;
+  lastPromptAt: string | null;
+  sessionActivity: Pick<
+    SessionActivity,
+    "agents" | "goal" | "loops" | "processes" | "turn"
+  > | null;
+  status: SessionStatus | null;
 }
 
 /**
  * A session is "empty" when the user has never submitted meaningful work to it:
  * - No transcript turns (no messages sent or received)
- * - No runtime stream events received (no system-level work has occurred)
  * - No optimistic prompt currently in flight
  * - No prior attempted prompt (even if it failed or was retracted)
+ * - No active goal or pending interaction
  *
  * This is used to decide whether a harness switch can replace the session in
  * place rather than leaving an unused tab around.
@@ -30,10 +46,27 @@ export interface SessionEmptinessSnapshot {
 export function isSessionEmpty(snapshot: SessionEmptinessSnapshot): boolean {
   return (
     snapshot.transcript.turnOrder.length === 0
-    && snapshot.events.length === 0
     && !snapshot.optimisticPrompt
     && !snapshot.hasAttemptedPrompt
+    && !snapshot.activeGoal
+    && !snapshot.lastPromptAt
+    && !hasDurableSessionActivity(snapshot.sessionActivity)
+    && snapshot.transcript.pendingInteractions.length === 0
+    && snapshot.transcript.pendingPrompts.length === 0
+    && (snapshot.executionSummary?.pendingInteractions?.length ?? 0) === 0
   );
+}
+
+function hasDurableSessionActivity(
+  activity: SessionEmptinessSnapshot["sessionActivity"],
+): boolean {
+  if (!activity) {
+    return false;
+  }
+  return Boolean(activity.goal)
+    || (activity.loops?.length ?? 0) > 0
+    || (activity.processes?.length ?? 0) > 0
+    || (activity.agents?.length ?? 0) > 0;
 }
 
 /**

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
@@ -60,6 +60,93 @@ describe("pending sidebar projection", () => {
     });
   });
 
+  it("projects a first local workspace into its existing repo-root group", () => {
+    const pendingWorkspaceEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-local-1",
+      selectedWorkspaceId: null,
+      source: "local-created",
+      displayName: "landing",
+      request: {
+        kind: "local",
+        sourceRoot: "/tmp/landing/",
+      },
+    });
+    const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(pendingWorkspaceEntry);
+    const repoRoot = makeRepoRoot({
+      id: "landing-root",
+      repoName: "landing",
+      sourceRoot: "/tmp/landing",
+    });
+
+    const groups = buildGroups({
+      logicalWorkspaces: [],
+      repoRoots: [repoRoot],
+      pendingWorkspaceEntry,
+      selectedLogicalWorkspaceId: pendingWorkspaceUiKey,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      sourceRoot: "/tmp/landing",
+      name: "landing",
+      repoRootId: "landing-root",
+    });
+    expect(groups[0]?.items).toHaveLength(1);
+    expect(groups[0]?.items[0]).toMatchObject({
+      id: pendingWorkspaceUiKey,
+      name: "landing",
+      active: true,
+      variant: "local",
+    });
+  });
+
+  it("keeps a materializing first local workspace in one repo group", () => {
+    const pendingWorkspaceEntry = {
+      ...buildSubmittingPendingWorkspaceEntry({
+        attemptId: "attempt-local-1",
+        selectedWorkspaceId: null,
+        source: "local-created",
+        displayName: "landing",
+        request: {
+          kind: "local" as const,
+          sourceRoot: "/tmp/landing",
+        },
+      }),
+      workspaceId: "workspace-real",
+    };
+    const repoRoot = makeRepoRoot({
+      id: "landing-root",
+      repoName: "landing",
+      sourceRoot: "/tmp/landing",
+    });
+
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "real-logical",
+          workspaceId: "workspace-real",
+          repoKey: "github:proliferate-ai:landing",
+          repoName: "landing",
+        }),
+      ],
+      repoRoots: [repoRoot],
+      pendingWorkspaceEntry,
+      selectedWorkspaceId: "workspace-real",
+      selectedLogicalWorkspaceId: "real-logical",
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.repoRootId).toBe("landing-root");
+    expect(groups[0]?.allLogicalWorkspaceIds).toEqual(["real-logical"]);
+    expect(groups[0]?.items).toHaveLength(1);
+    expect(groups[0]?.items[0]).toMatchObject({
+      id: "real-logical",
+      name: "landing",
+      active: true,
+      variant: "local",
+    });
+  });
+
   it("counts pending creation as activity in the sort recency", () => {
     const pendingWorkspaceEntry = buildSubmittingPendingWorkspaceEntry({
       attemptId: "attempt-1",

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -41,9 +41,7 @@ export function buildPendingSidebarProjection(args: {
   const id = materializedSelectedLogicalId ?? pendingWorkspaceUiKey;
   const createdAt = new Date(entry.createdAt).toISOString();
   const variant = pendingSidebarVariant(entry);
-  const repoRoot = entry.request.kind === "worktree"
-    ? repoRootsById.get(entry.request.input.repoRootId) ?? null
-    : null;
+  const repoRoot = pendingSidebarRepoRoot(entry, repoRootsById);
   const repoKey = pendingSidebarRepoKey(entry, repoRoot);
   if (!repoKey) {
     return null;
@@ -100,6 +98,36 @@ export function buildPendingSidebarProjection(args: {
       displayAt: null,
     },
   };
+}
+
+function pendingSidebarRepoRoot(
+  entry: PendingWorkspaceEntry,
+  repoRootsById: Map<string, RepoRoot>,
+): RepoRoot | null {
+  if (entry.request.kind === "worktree") {
+    return repoRootsById.get(entry.request.input.repoRootId) ?? null;
+  }
+
+  if (entry.request.kind !== "local") {
+    return null;
+  }
+
+  const sourceRoot = normalizedLocalSourceRoot(entry.request.sourceRoot);
+  if (!sourceRoot) {
+    return null;
+  }
+
+  for (const repoRoot of repoRootsById.values()) {
+    if (normalizedLocalSourceRoot(repoRoot.path) === sourceRoot) {
+      return repoRoot;
+    }
+  }
+  return null;
+}
+
+function normalizedLocalSourceRoot(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.replace(/[\\/]+$/, "") || trimmed;
 }
 
 function pendingSidebarVariant(entry: PendingWorkspaceEntry): SidebarWorkspaceVariant {

--- a/apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  replaceSessionIdInManualChatGroups,
+  replaceSessionIdInOrderedList,
+  replaceSessionIdInShellTabOrder,
+} from "./session-replacement";
+import { createManualChatGroupId } from "@/lib/domain/workspaces/tabs/manual-groups";
+
+describe("session replacement tab identity", () => {
+  it("keeps the replacement in the old chat's exact order position", () => {
+    expect(replaceSessionIdInShellTabOrder(
+      ["chat:first", "file:src/App.tsx", "chat:old", "chat:last"],
+      "old",
+      "new",
+    )).toEqual(["chat:first", "file:src/App.tsx", "chat:new", "chat:last"]);
+  });
+
+  it("deduplicates an already projected replacement without moving it", () => {
+    expect(replaceSessionIdInOrderedList(
+      ["first", "old", "new", "last"],
+      "old",
+      "new",
+    )).toEqual(["first", "new", "last"]);
+  });
+
+  it("keeps the replacement in the old chat's manual group", () => {
+    expect(replaceSessionIdInManualChatGroups([{
+      id: createManualChatGroupId("group-1"),
+      label: "Pair",
+      colorId: "blue",
+      sessionIds: ["old", "other"],
+    }], "old", "new")).toEqual([{
+      id: createManualChatGroupId("group-1"),
+      label: "Pair",
+      colorId: "blue",
+      sessionIds: ["new", "other"],
+    }]);
+  });
+});

--- a/apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.ts
+++ b/apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.ts
@@ -1,0 +1,52 @@
+import {
+  chatWorkspaceShellTabKey,
+  type WorkspaceShellTabKey,
+} from "@/lib/domain/workspaces/tabs/shell-tabs";
+import type { ManualChatGroup } from "@/lib/domain/workspaces/tabs/manual-groups";
+
+export function replaceSessionIdInOrderedList(
+  values: readonly string[],
+  replacedSessionId: string,
+  replacementSessionId: string,
+): string[] {
+  if (!values.includes(replacedSessionId)) {
+    return [...values];
+  }
+  const seen = new Set<string>();
+  const next: string[] = [];
+  for (const value of values) {
+    const mapped = value === replacedSessionId ? replacementSessionId : value;
+    if (!seen.has(mapped)) {
+      seen.add(mapped);
+      next.push(mapped);
+    }
+  }
+  return next;
+}
+
+export function replaceSessionIdInShellTabOrder(
+  values: readonly WorkspaceShellTabKey[],
+  replacedSessionId: string,
+  replacementSessionId: string,
+): WorkspaceShellTabKey[] {
+  return replaceSessionIdInOrderedList(
+    values,
+    chatWorkspaceShellTabKey(replacedSessionId),
+    chatWorkspaceShellTabKey(replacementSessionId),
+  );
+}
+
+export function replaceSessionIdInManualChatGroups(
+  groups: readonly ManualChatGroup[],
+  replacedSessionId: string,
+  replacementSessionId: string,
+): ManualChatGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    sessionIds: replaceSessionIdInOrderedList(
+      group.sessionIds,
+      replacedSessionId,
+      replacementSessionId,
+    ),
+  }));
+}

--- a/apps/desktop/src/stores/chat/chat-prompt-recovery-store.test.ts
+++ b/apps/desktop/src/stores/chat/chat-prompt-recovery-store.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  useChatPromptRecoveryStore,
+  type ChatPromptRecovery,
+} from "@/stores/chat/chat-prompt-recovery-store";
+import {
+  createPromptOutboxEntry,
+} from "@proliferate/product-domain/sessions/intents/session-intent-model";
+
+beforeEach(() => {
+  useChatPromptRecoveryStore.getState().clear();
+});
+
+describe("chat prompt recovery store", () => {
+  it("keeps distinct failed prompts scoped to their workspace shell", () => {
+    const first = createRecovery("prompt-1", "first");
+    const second = createRecovery("prompt-2", "second");
+
+    useChatPromptRecoveryStore.getState().addRecoveries(
+      "logical-workspace-1",
+      [first, second],
+    );
+
+    expect(useChatPromptRecoveryStore.getState()
+      .recoveriesByWorkspaceUiKey["logical-workspace-1"])
+      .toEqual([first, second]);
+    useChatPromptRecoveryStore.getState().removeRecovery(
+      "logical-workspace-1",
+      "prompt-1",
+    );
+    expect(useChatPromptRecoveryStore.getState()
+      .recoveriesByWorkspaceUiKey["logical-workspace-1"]?.map((entry) => entry.id))
+      .toEqual(["prompt-2"]);
+  });
+});
+
+function createRecovery(id: string, text: string): ChatPromptRecovery {
+  return {
+    id,
+    workspaceId: "workspace-1",
+    agentKind: "claude",
+    modelId: "sonnet",
+    modeId: null,
+    errorMessage: "Session creation failed.",
+    prompt: createPromptOutboxEntry({
+      clientPromptId: id,
+      clientSessionId: "pending-claude",
+      workspaceId: "workspace-1",
+      text,
+      blocks: [{ type: "text", text }],
+    }),
+  };
+}

--- a/apps/desktop/src/stores/chat/chat-prompt-recovery-store.ts
+++ b/apps/desktop/src/stores/chat/chat-prompt-recovery-store.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+import type {
+  PromptOutboxEntry,
+} from "@proliferate/product-domain/sessions/intents/session-intent-model";
+
+export interface ChatPromptRecovery {
+  id: string;
+  workspaceId: string;
+  agentKind: string;
+  modelId: string;
+  modeId: string | null;
+  errorMessage: string;
+  prompt: PromptOutboxEntry;
+}
+
+interface ChatPromptRecoveryState {
+  recoveriesByWorkspaceUiKey: Record<string, ChatPromptRecovery[]>;
+  addRecoveries: (workspaceUiKey: string, recoveries: readonly ChatPromptRecovery[]) => void;
+  removeRecovery: (workspaceUiKey: string, recoveryId: string) => void;
+  clear: () => void;
+}
+
+export const useChatPromptRecoveryStore = create<ChatPromptRecoveryState>((set) => ({
+  recoveriesByWorkspaceUiKey: {},
+
+  addRecoveries: (workspaceUiKey, recoveries) => set((state) => {
+    if (recoveries.length === 0) {
+      return state;
+    }
+    const incomingIds = new Set(recoveries.map((entry) => entry.id));
+    const current = state.recoveriesByWorkspaceUiKey[workspaceUiKey] ?? [];
+    return {
+      recoveriesByWorkspaceUiKey: {
+        ...state.recoveriesByWorkspaceUiKey,
+        [workspaceUiKey]: [
+          ...current.filter((entry) => !incomingIds.has(entry.id)),
+          ...recoveries.map(cloneRecovery),
+        ],
+      },
+    };
+  }),
+
+  removeRecovery: (workspaceUiKey, recoveryId) => set((state) => {
+    const current = state.recoveriesByWorkspaceUiKey[workspaceUiKey] ?? [];
+    const next = current.filter((entry) => entry.id !== recoveryId);
+    if (next.length === current.length) {
+      return state;
+    }
+    const recoveriesByWorkspaceUiKey = { ...state.recoveriesByWorkspaceUiKey };
+    if (next.length === 0) {
+      delete recoveriesByWorkspaceUiKey[workspaceUiKey];
+    } else {
+      recoveriesByWorkspaceUiKey[workspaceUiKey] = next;
+    }
+    return { recoveriesByWorkspaceUiKey };
+  }),
+
+  clear: () => set({ recoveriesByWorkspaceUiKey: {} }),
+}));
+
+function cloneRecovery(recovery: ChatPromptRecovery): ChatPromptRecovery {
+  return {
+    ...recovery,
+    prompt: {
+      ...recovery.prompt,
+      blocks: recovery.prompt.blocks.map((block) => ({ ...block })),
+      attachmentSnapshots: recovery.prompt.attachmentSnapshots.map((snapshot) => ({ ...snapshot })),
+      contentParts: recovery.prompt.contentParts.map((part) => ({ ...part })),
+    },
+  };
+}

--- a/apps/packages/product-domain/src/chats/composer/resolve-dock-slots.test.ts
+++ b/apps/packages/product-domain/src/chats/composer/resolve-dock-slots.test.ts
@@ -54,6 +54,7 @@ describe("resolveComposerDockSlots", () => {
       ...BASE_INPUT,
       suppressSessionSlots: true,
       pendingPromptCount: 2,
+      recoveredPromptCount: 1,
       primaryPendingInteractionKind: "user_input",
       hasActiveTodoTracker: true,
       hasDelegatedWork: true,
@@ -70,6 +71,14 @@ describe("resolveComposerDockSlots", () => {
         sessionActivity: false,
       },
     });
+  });
+
+  it("surfaces recoverable prompts ahead of ordinary queued prompts", () => {
+    expect(resolveComposerDockSlots({
+      ...BASE_INPUT,
+      pendingPromptCount: 2,
+      recoveredPromptCount: 1,
+    }).outboundSlot).toEqual({ kind: "prompt_recoveries" });
   });
 
   it("attaches the session goal bar on its own", () => {

--- a/apps/packages/product-domain/src/chats/composer/resolve-dock-slots.ts
+++ b/apps/packages/product-domain/src/chats/composer/resolve-dock-slots.ts
@@ -3,9 +3,9 @@ export type ComposerDockInteractionKind =
   | "user_input"
   | "mcp_elicitation";
 
-export type ComposerDockOutboundSlot = {
-  kind: "pending_prompts";
-};
+export type ComposerDockOutboundSlot =
+  | { kind: "pending_prompts" }
+  | { kind: "prompt_recoveries" };
 
 export type ComposerDockActiveSlot =
   | { kind: "permission" }
@@ -52,6 +52,7 @@ export interface ResolveComposerDockSlotsInput {
   suppressSessionSlots?: boolean;
   suppressWorkspaceStatusPanels?: boolean;
   pendingPromptCount: number;
+  recoveredPromptCount?: number;
   primaryPendingInteractionKind: ComposerDockInteractionKind | null;
   hasActiveTodoTracker: boolean;
   hasDelegatedWork: boolean;
@@ -65,6 +66,7 @@ export function resolveComposerDockSlots({
   suppressSessionSlots = false,
   suppressWorkspaceStatusPanels = false,
   pendingPromptCount,
+  recoveredPromptCount = 0,
   primaryPendingInteractionKind,
   hasActiveTodoTracker,
   hasDelegatedWork,
@@ -73,8 +75,9 @@ export function resolveComposerDockSlots({
   hasWorkspaceStatusPanel,
   hasCloudRuntimePanel,
 }: ResolveComposerDockSlotsInput): ComposerDockSlotResolution {
-  const outboundSlot =
-    !suppressSessionSlots && pendingPromptCount > 0
+  const outboundSlot = !suppressSessionSlots && recoveredPromptCount > 0
+    ? { kind: "prompt_recoveries" as const }
+    : !suppressSessionSlots && pendingPromptCount > 0
       ? { kind: "pending_prompts" as const }
       : null;
   const activeSlot = !suppressSessionSlots

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -23,5 +23,4 @@ apps/desktop/src/components/workspace/git/GitPanel.tsx 429 git panel pending sta
 apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx 404 git review file row pending action-cluster split
 apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 410 workspace sidebar item pending indicator/menu split
 apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
-apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts 424 session creation actions pending action-group split
 apps/packages/product-domain/src/chats/transcript/transcript-row-model.ts 940 transcript row model pending row-kind module split

--- a/specs/codebase/features/pending-workspace-shell.md
+++ b/specs/codebase/features/pending-workspace-shell.md
@@ -282,6 +282,63 @@ This fast-open placeholder is only shell scaffolding. It must not invent
 transcript content, runtime activity, or action capabilities. The real session
 summary and stream replace it as soon as AnyHarness session data is available.
 
+Changing harnesses in an unused chat is a transactional replacement, not a
+second visible tab:
+
+```text
+user selects a different harness
+  -> create and activate the replacement's projected session shell
+  -> hide the old unused session locally and pause any in-flight materializer
+  -> materialize the replacement session
+  -> on success, durably retire or confirm the absence of the old session
+  -> on failure, move any acquired prompts into workspace recovery state,
+     remove the replacement, and restore the exact old shell
+```
+
+Replaceability is based on user work, not raw runtime event count. Startup,
+status, and config acknowledgement events do not make an otherwise unused chat
+non-empty. Transcript turns, attempted/queued/optimistic prompts, goals,
+pending interactions, or active runtime work do. A superseded materializer must
+never reinsert its session after replacement, and composer drafts and
+attachments remain owned by the workspace across the swap.
+
+Prompts submitted after the replacement shell becomes active but before it
+materializes are part of the transaction. If materialization fails, each
+acquired prompt moves into a visible, workspace-scoped recovery surface before
+the replacement shell is removed. Recovery retains the complete prompt payload,
+including structured blocks, attachment snapshots, content parts, and resolved
+agent/model/mode configuration. It must not overwrite a newer workspace draft.
+Retry and dismissal act only on the explicitly selected recovered prompt, so
+multiple failed submissions remain independently identifiable and recoverable.
+
+Replacement suppression has two phases. While the new session is still
+materializing, the old runtime id and its client-session alias are staged only
+in memory: UI/query projections hide them, but bootstrap reconciliation must
+not dismiss them, and an app restart naturally restores the old runtime. Once
+the replacement succeeds, the old session may remain suppressed only after its
+tombstone is persisted or its runtime absence is confirmed by dismissal. If
+both persistence and dismissal fail, the old session is restored to the visible
+session model rather than being left as a hidden runtime. A persisted tombstone
+remains in force until a later authoritative session
+list omits the retired runtime id; mutation success alone is not sufficient,
+because a list request that began before dismissal can still refill cache.
+Only a list request that began after the tombstone commit may clear it; an
+older request can omit a runtime that had not been created when it started.
+After that authoritative omission removes persisted cleanup state, the current
+renderer keeps an in-memory retired-id fence until reload so any older response
+that arrives out of order is still filtered. Every session-list owner must
+filter both cache hits and fetched results through the staged, committed, and
+retired suppression set. An explicit user restore is the sole inverse: it
+first fences the workspace against new replacement cleanup, waits for any
+already-started replacement dismissals to settle, then restores and releases
+the restored runtime id and its client aliases before cache upsert. Restore must
+first prove that the cleanup-state update is durable; if that preflight fails,
+it must not republish the runtime. Replacement
+dismissals are deduplicated per workspace and runtime id. Cleanup requested
+during a restore is queued until the final same-workspace restore fence closes;
+the runtime id actually restored is removed from that queue, while unrelated
+queued cleanup drains immediately in the background.
+
 ## 7. Begin Flow
 
 All workspace creation entrypoints should converge on this shape:


### PR DESCRIPTION
## Summary

- Make empty-chat harness switching a replace-in-place transaction: ignore harmless startup acknowledgements, swap the visible shell immediately, preserve attachments/tab position/manual groups, suppress stale queries, dismiss the old runtime only after the replacement materializes, and restore the old session on failure.
- Remove the Home submitted-message preview and frame delay so the optimistic prompt appears exactly once in the destination transcript; restore the draft safely if launch fails.
- Group the first pending local workspace under its existing repository instead of briefly rendering a duplicate repository group.

## Why

The prior flow treated any runtime event as user activity and deleted the old session before the replacement was durable. That produced duplicate tabs, blank failure states, resurrection races, attachment loss, and repeated 404s from retired-session observers. Home also deliberately rendered a transient submitted preview before navigation, and a pending local workspace could be projected under both its repository and a temporary group.

## Impact

The transaction keeps runtime truth recoverable until commit, persists only committed cleanup tombstones, fences explicit restore against background dismissal, and handles chained/in-flight materialization without letting an older creation reappear. Rollback updates only the transaction-owned session identity so concurrent tab and group edits are preserved.

## Verification

- `pnpm --dir apps/desktop run build`
- 19 focused Vitest files, 91 tests passed
- `python3 scripts/check_frontend_boundaries.py`
- `git diff --check origin/main...HEAD`
- Isolated `codex4df1` full-stack profile manually validated
- Three independent diff reviews; no remaining P0-P2 findings