### PR TITLE
fix(desktop): route settings links to their intended sections

### DIFF
--- a/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -235,7 +235,7 @@ export function SidebarAccountFooter() {
                     icon={<CreditCard className="size-4" />}
                     trailing={<span>{planLabel}</span>}
                     onClick={() => {
-                      navigate("/settings");
+                      navigate("/settings?section=billing");
                       close();
                     }}
                   />
@@ -260,7 +260,7 @@ export function SidebarAccountFooter() {
                   icon={<Settings className="size-4" />}
                   trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openSettings)}</span>}
                   onClick={() => {
-                    navigate("/settings");
+                    navigate("/settings?section=account");
                     close();
                   }}
                 />

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
@@ -291,6 +291,36 @@ describe("SettingsSidebar layout and shortcuts", () => {
     expect(onSelectSection).toHaveBeenLastCalledWith("general");
   });
 
+  it("numbers Org sections in their visible sidebar order", async () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    const onSelectSection = vi.fn();
+    renderSettingsSidebar({
+      activeScope: "org",
+      activeSection: "organization",
+      onSelectSection,
+    });
+
+    await waitFor(() => {
+      expect(getShortcutHandler("settings.section-by-index")).not.toBeNull();
+    });
+
+    expect(runShortcutHandler("settings.section-by-index", {
+      source: "keyboard",
+      digit: 1,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("organization");
+
+    expect(runShortcutHandler("settings.section-by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(onSelectSection).toHaveBeenLastCalledWith("organization-members");
+  });
+
   it("keeps disabled sections in numbering but declines their shortcut", async () => {
     vi.stubGlobal("navigator", {
       platform: "MacIntel",

--- a/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx
@@ -24,7 +24,6 @@ import { SidebarAccountFooter } from "@/components/app/sidebar/SidebarAccountFoo
 import { HarnessStatusDot } from "@/components/settings/sidebar/HarnessStatusDot";
 import { SHORTCUTS } from "@/config/shortcuts/registry";
 import {
-  SETTINGS_SHORTCUT_SECTION_ORDER,
   TEMPORARILY_SHOW_ADMIN_SETTINGS_FOR_UI_ITERATION,
   type SettingsSection,
 } from "@/config/settings";
@@ -211,13 +210,10 @@ export function SettingsSidebar({
     })).filter((group) => group.items.length > 0),
   [activeScope, adminAccess?.isAdmin]);
   const visibleShortcutSections = useMemo(() => {
-    const visibleSections = new Set(
-      visibleNavGroups.flatMap((group) =>
-        group.items.flatMap((item) => item.kind === "section" ? [item.id] : [])
-      ),
-    );
-    return SETTINGS_SHORTCUT_SECTION_ORDER.filter((section) =>
-      visibleSections.has(section)
+    return visibleNavGroups.flatMap((group) =>
+      group.items.flatMap((item) =>
+        item.kind === "section" ? [item.id] : []
+      )
     );
   }, [visibleNavGroups]);
   const effectiveDisabledSections = useMemo(() => {

--- a/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
+++ b/apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts
@@ -29,7 +29,7 @@ export function useAppNavigationCommandActions(): AppNavigationCommandActions {
   const { goToTopLevelRoute } = useWorkspaceNavigationWorkflow();
 
   const openSettings = useCallback(() => {
-    navigate("/settings");
+    navigate("/settings?section=account");
   }, [navigate]);
   const openShortcutsDialog = useKeyboardShortcutsDialogStore((state) => state.setOpen);
   const showKeyboardShortcuts = useCallback(() => {

--- a/apps/desktop/src/hooks/home/facade/use-home-screen.ts
+++ b/apps/desktop/src/hooks/home/facade/use-home-screen.ts
@@ -110,10 +110,10 @@ export function useHomeScreen() {
         openAddRepoFlow();
         return;
       case "agent-defaults":
-        navigate("/settings?section=agents");
+        navigate(buildSettingsHref({ section: "agent-claude" }));
         return;
       case "agent-settings":
-        navigate("/settings?section=agents");
+        navigate(buildSettingsHref({ section: "agent-claude" }));
         return;
       case "repository-settings": {
         const firstRepository = repositoryToConfigure ?? repositories[0];


### PR DESCRIPTION
## What changed

- route the home model availability and agent setup actions to the Claude agent settings pane
- route the account menu Plan action to Billing and Settings actions to Account
- number settings shortcuts in the visible sidebar order for each scope
- add regression coverage for organization shortcut ordering

## Why

Several settings entry points used either an invalid `agents` section or no section at all, causing navigation to fall back to General. Organization shortcut labels were derived from a global section order instead of the visible organization navigation order.

## Impact

Settings links now land on the section users selected, and organization shortcut labels/actions are sequential and aligned with the sidebar.

## Verification

- `pnpm exec vitest run src/components/settings/sidebar/SettingsSidebar.test.tsx -t "numbers Org sections"`
- `pnpm exec vitest run src/hooks/app/workflows/use-app-navigation-command-actions.test.tsx`
- `pnpm exec tsc --noEmit`
- `git diff --check`