### PR TITLE
fix(desktop): simplify workspace sidebar icons

### DIFF
--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -5,11 +5,13 @@ import { describe, expect, it } from "vitest";
 import {
   Clock,
   Spinner,
+  Tree,
 } from "@proliferate/ui/icons";
 import type { SidebarStatusIndicator } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 import {
   SidebarStatusGlyph,
 } from "./SidebarIndicators";
+import { SidebarWorkspaceVariantIcon } from "./SidebarWorkspaceVariantIcon";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
@@ -71,5 +73,14 @@ describe("SidebarStatusGlyph", () => {
     const glyph = renderGlyph("queued_prompt");
 
     expect(countElementsByType(glyph, Spinner)).toBe(1);
+  });
+});
+
+describe("SidebarWorkspaceVariantIcon", () => {
+  it("uses the Home worktree glyph in sidebar surfaces", () => {
+    const glyph = SidebarWorkspaceVariantIcon({ variant: "worktree" });
+
+    expect(isValidElement(glyph)).toBe(true);
+    expect(isValidElement(glyph) ? glyph.type : null).toBe(Tree);
   });
 });

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
@@ -1,23 +1,25 @@
-import { GitPullRequest } from "@proliferate/ui/icons";
+import { GitBranchIcon } from "@proliferate/ui/icons";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type { SidebarGitGlyph } from "@/lib/domain/workspaces/git-status/pr-status-presentation";
+import type { PrStatusView } from "@proliferate/product-ui/workspaces/PrStatusBadge";
 
 interface SidebarWorkspaceGitGlyphProps {
   glyph: SidebarGitGlyph;
+  status: PrStatusView;
 }
 
 /**
- * Leading-well PR glyph for sidebar rows (§3.2): rendered only for rows with
- * a real PR (the glyph is null otherwise — no branch fallback), decorated
- * with the status dot by the row, and drawn in the destructive tone when the
- * worktree has merge conflicts. Wraps the icon in a tooltip when the glyph
- * carries one.
+ * Compact git/PR glyph for the sidebar detail cluster. The branch shape
+ * matches the Home target picker; status is expressed through the glyph tone
+ * instead of adding a second dot on top of it.
  */
-export function SidebarWorkspaceGitGlyph({ glyph }: SidebarWorkspaceGitGlyphProps) {
+export function SidebarWorkspaceGitGlyph({ glyph, status }: SidebarWorkspaceGitGlyphProps) {
   const icon = (
-    <GitPullRequest
-      className={`size-3.5 ${glyph.conflicted ? "text-destructive" : "text-sidebar-muted-foreground"}`}
-    />
+    <span role="img" aria-label={glyph.tooltip ?? "Pull request"}>
+      <GitBranchIcon
+        className={`size-3.5 ${glyph.conflicted ? "text-destructive" : gitStatusTone(status.kind)}`}
+      />
+    </span>
   );
 
   if (!glyph.tooltip) {
@@ -32,4 +34,22 @@ export function SidebarWorkspaceGitGlyph({ glyph }: SidebarWorkspaceGitGlyphProp
       {icon}
     </Tooltip>
   );
+}
+
+function gitStatusTone(kind: PrStatusView["kind"]): string {
+  switch (kind) {
+    case "open":
+      return "text-success";
+    case "merged":
+      return "text-pr-merged";
+    case "pending":
+    case "changes_requested":
+      return "text-warning";
+    case "checks_failing":
+    case "closed":
+      return "text-destructive";
+    case "draft":
+    default:
+      return "text-sidebar-muted-foreground";
+  }
 }

--- a/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx
@@ -1,12 +1,12 @@
 import { ComputeTargetSwatch } from "@/components/compute/ComputeTargetSwatch";
-import { CloudIcon, GitBranch, Monitor, Terminal } from "@proliferate/ui/icons";
+import { CloudIcon, Monitor, Terminal, Tree } from "@proliferate/ui/icons";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import type { ComputeTargetAppearance } from "@/lib/domain/compute/target-appearance";
 import type { SidebarWorkspaceVariant } from "@/lib/domain/workspaces/sidebar/sidebar-indicators";
 
 const VARIANT_ICONS: Record<SidebarWorkspaceVariant, typeof Monitor> = {
   local: Monitor,
-  worktree: GitBranch,
+  worktree: Tree,
   cloud: CloudIcon,
   ssh: Terminal,
 };

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -111,7 +111,7 @@ describe("WorkspaceItem", () => {
     expect(onCopyBranchName).toHaveBeenCalledTimes(1);
   });
 
-  it("renders the PR status dot on the leading git glyph", () => {
+  it("renders PR status as a compact git detail glyph", () => {
     render(
       <WorkspaceItem
         name="Feature worktree"
@@ -123,7 +123,7 @@ describe("WorkspaceItem", () => {
     expect(screen.getByRole("img", { name: "PR #805 · Open" })).toBeTruthy();
   });
 
-  it("renders the activity indicator in the right slot, keeping the PR glyph", () => {
+  it("renders activity and PR state together in the right-side details", () => {
     render(
       <WorkspaceItem
         name="Feature worktree"
@@ -134,11 +134,11 @@ describe("WorkspaceItem", () => {
     );
 
     expect(screen.getByRole("img", { name: "Iterating" })).toBeTruthy();
-    // The status no longer evicts the PR glyph + dot from the leading well.
+    // Live activity does not evict the compact PR detail glyph.
     expect(screen.getByRole("img", { name: "PR #805 · Open" })).toBeTruthy();
   });
 
-  it("renders no leading glyph for an authoritative no-PR branch", () => {
+  it("renders no git glyph for an authoritative no-PR branch", () => {
     const { container } = render(
       <WorkspaceItem
         name="Feature worktree"
@@ -156,11 +156,11 @@ describe("WorkspaceItem", () => {
     );
 
     expect(screen.queryByRole("img")).toBeNull();
-    // No branch-glyph fallback: the leading well stays empty.
+    // No branch-glyph fallback is shown without a PR.
     expect(container.querySelector("svg")).toBeNull();
   });
 
-  it("renders no leading glyph when PR data is unknown", () => {
+  it("renders no git glyph when PR data is unknown", () => {
     const { container } = render(
       <WorkspaceItem
         name="Feature worktree"

--- a/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -72,10 +72,9 @@ interface WorkspaceItemProps {
    */
   lastInteracted?: string | null;
   /**
-   * Composed git/PR status (§3.2/§3.3). Drives the leading PR glyph, the PR
-   * status dot, tooltips, and the "Open pull request" menu item. The well is
-   * empty whenever the row has no real PR (pr null/unknown or state "none"),
-   * so no-git-data rows degrade gracefully.
+   * Composed git/PR status. Drives the compact right-side git glyph and tone,
+   * its tooltip, and the "Open pull request" menu item. Rows without a real
+   * PR omit the glyph, so missing git data degrades gracefully.
    */
   gitStatus?: WorkspaceGitStatus | null;
   /** Renders the trailing unseen-activity dot (§3.4, codex pattern). */
@@ -161,7 +160,12 @@ export function WorkspaceItem({
     onUnarchive: handleUnarchiveCommand,
     onMarkDone: handleMarkDoneCommand,
   });
-  const detail = detailIndicators.length > 0 || cloudStatusDefinition ? (
+  const gitGlyph = sidebarGitGlyphForStatus(gitStatus);
+  const prStatusView = gitGlyph ? prStatusViewFromGitStatus(gitStatus) : null;
+  const gitDetail = gitGlyph && prStatusView
+    ? <SidebarWorkspaceGitGlyph glyph={gitGlyph} status={prStatusView} />
+    : null;
+  const detail = detailIndicators.length > 0 || cloudStatusDefinition || gitDetail ? (
     <>
       <SidebarDetailIndicatorsView
         indicators={detailIndicators}
@@ -173,6 +177,7 @@ export function WorkspaceItem({
           {cloudStatusDefinition.label}
         </span>
       )}
+      {gitDetail}
     </>
   ) : null;
   const pullRequestUrl = gitStatus?.pr?.url ?? null;
@@ -206,15 +211,11 @@ export function WorkspaceItem({
     />
   ) : null;
 
-  // Leading well (§3.2): PR glyph + dot for real PR states only — rows with
-  // no PR (null/unknown or authoritative "none") leave the well empty.
+  // Git/PR state lives in the right-side detail cluster, matching the compact
+  // Codex row treatment and keeping the left edge free of stacked glyphs.
   // Activity indicators live in the row's RIGHT slot (trailingStatus).
   // Relative timestamp (trailingLabel) is also in the RIGHT slot, with lower
   // precedence than trailingStatus and unreadDot.
-  const gitGlyph = sidebarGitGlyphForStatus(gitStatus);
-  const prStatusView = gitGlyph ? prStatusViewFromGitStatus(gitStatus) : null;
-  const leadingGlyph = gitGlyph ? <SidebarWorkspaceGitGlyph glyph={gitGlyph} /> : null;
-
   const timestampLabel = lastInteracted ? formatSidebarRelativeTime(lastInteracted) : null;
 
   const row = (
@@ -228,10 +229,8 @@ export function WorkspaceItem({
         />
       ) : null}
       trailingLabel={timestampLabel}
-      leadingGlyph={leadingGlyph}
       label={name}
       detail={detail}
-      prStatus={prStatusView}
       unreadDot={needsReview}
       shortcutLabel={shortcutLabel}
       shortcutRevealVisible={shortcutRevealVisible}

--- a/apps/desktop/src/lib/domain/workspaces/git-status/pr-status-presentation.ts
+++ b/apps/desktop/src/lib/domain/workspaces/git-status/pr-status-presentation.ts
@@ -98,20 +98,18 @@ export function prStatusViewFromGitStatus(
 }
 
 export interface SidebarGitGlyph {
-  /** attention === "conflicts" — render destructive tone. */
+  /** attention === "conflicts" — render the detail glyph in destructive tone. */
   conflicted: boolean;
   /** Tooltip content; null renders the glyph without a tooltip. */
   tooltip: string | null;
 }
 
 /**
- * Leading-well PR glyph for sidebar rows (§3.2): rendered ONLY when the row
- * has a real PR (open/draft/merged/closed). No PR (authoritative "none") and
- * unknown PR data (`pr: null`) both leave the well empty — there is no
- * branch-glyph fallback. Conflict attention keeps the destructive tone on PR
- * rows; conflicted rows WITHOUT a PR get no leading glyph — attention there
- * surfaces via the right-slot affordances (status indicator / unread dot),
- * not a leading icon.
+ * Compact PR detail glyph for sidebar rows: rendered only when the row has a
+ * real PR (open/draft/merged/closed). No PR (authoritative "none") and unknown
+ * PR data (`pr: null`) both omit it — there is no branch-glyph fallback.
+ * Conflict attention keeps the destructive tone on PR rows; conflicted rows
+ * without a PR surface attention through other status affordances.
  */
 export function sidebarGitGlyphForStatus(
   status: WorkspaceGitStatus | null | undefined,

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -53,11 +53,13 @@ export function buildPendingSidebarProjection(args: {
   const sourceRoot = repoRoot?.path
     ?? pendingSidebarSourceRoot(entry)
     ?? repoKey;
-  const detailIndicators: SidebarDetailIndicator[] = [{
-    kind: "materialization",
-    variant,
-    tooltip: pendingMaterializationTooltip(variant),
-  }];
+  const detailIndicators: SidebarDetailIndicator[] = variant === "local"
+    ? []
+    : [{
+      kind: "materialization",
+      variant,
+      tooltip: pendingMaterializationTooltip(variant),
+    }];
 
   return {
     repoKey,

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts
@@ -56,12 +56,12 @@ export function detailIndicatorsForWorkspace(
     ...(origin ? [origin] : []),
     ...(cloudAccess ? [cloudAccess] : []),
     ...(cloudExposure ? [cloudExposure] : []),
-    {
+    ...(variant === "local" ? [] : [{
       kind: "materialization" as const,
       variant,
       tooltip: materializationTooltip(variant, targetAppearance),
       targetAppearance: variant === "ssh" ? targetAppearance ?? null : null,
-    },
+    }]),
   ];
 }
 

--- a/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -280,11 +280,10 @@ describe("sidebar indicators", () => {
         tone: "neutral",
         tooltip: "Cloud access enabled · live",
       },
-      {
-        kind: "materialization",
-        variant: "local",
-      },
     ]);
+    expect(groups[0]?.items[0]?.detailIndicators).not.toContainEqual(
+      expect.objectContaining({ kind: "materialization", variant: "local" }),
+    );
   });
 
   it("uses cloud activity for dual rows when cloud is the effective materialization", () => {


### PR DESCRIPTION
## What changed

- hide the local computer/materialization glyph from workspace rows
- reuse the Home target picker's filled worktree glyph in the sidebar
- move PR state into the right-side detail cluster with a single status-colored branch glyph
- remove the stacked leading PR icon and status-dot treatment
- keep pending workspace rows consistent with materialized rows

## Why

Workspace rows mixed environment and git indicators across both sides of the row. Local rows showed a redundant computer icon, worktree rows used a different glyph from Home, and PR state stacked an extra dot over a leading icon. The result was visually noisy and inconsistent with the compact Codex reference.

## Impact

Local workspace rows are quieter, worktree identity is consistent across Home and the sidebar, and PR status remains accessible through a compact colored glyph and tooltip.

## Review

Rebased onto current `main` before publishing so newer pending-workspace repo-root behavior is preserved. The final PR diff is limited to nine sidebar files.

## Verification

- 78 focused sidebar, pending-workspace, and git-status tests passed
- `pnpm exec tsc --noEmit`
- `git diff --check origin/main`
- profile `codex255b` running with renderer `1772`, API `8176`, and AnyHarness `8633`