### PR TITLE
feat(desktop): add version-aware release notices

### DIFF
--- a/.github/workflows/_deploy-desktop.yml
+++ b/.github/workflows/_deploy-desktop.yml
@@ -18,6 +18,9 @@ on:
       publish_updater:
         default: false
         type: boolean
+      release_title:
+        default: ""
+        type: string
       target_os:
         default: all
         type: string
@@ -178,5 +181,6 @@ jobs:
       version: ${{ needs.plan.outputs.version }}
       dry_run: ${{ inputs.dry_run }}
       publish_updater: ${{ inputs.publish_updater }}
+      release_title: ${{ inputs.release_title }}
       target_os: ${{ inputs.target_os }}
     secrets: inherit

--- a/.github/workflows/hotfix-production.yml
+++ b/.github/workflows/hotfix-production.yml
@@ -15,6 +15,10 @@ on:
         description: Short operator-facing reason for the hotfix.
         required: true
         type: string
+      release_title:
+        description: Optional one-line Desktop changelog title.
+        required: false
+        type: string
       version_bump:
         description: Public Proliferate version bump for this hotfix. Use none only for SHA-based surfaces.
         default: patch
@@ -300,6 +304,7 @@ jobs:
       enabled: ${{ needs.prepare.outputs.desktop == 'true' }}
       dry_run: false
       publish_updater: true
+      release_title: ${{ github.event.inputs.release_title || '' }}
     secrets: inherit
 
   publish-product-release:

--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -22,6 +22,10 @@ on:
           - patch
           - minor
           - major
+      release_title:
+        description: Optional one-line Desktop changelog title (for example, Introducing Grok).
+        required: false
+        type: string
       dry_run:
         description: Plan only; do not push commits, tags, releases, or deploys.
         default: false
@@ -238,6 +242,7 @@ jobs:
     with:
       git_sha: ${{ needs.prepare.outputs.head_sha }}
       version: ${{ needs.prepare.outputs.desktop_version }}
+      release_title: ${{ github.event.inputs.release_title || '' }}
       dry_run: false
       # Zero-touch auto-prod: publish the updater/download assets so existing
       # installs auto-update on every train. release-desktop.yml is not bound to a

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -15,6 +15,10 @@ on:
         description: Exact comma-separated surfaces to promote, or all. Overrides detection and force_surfaces.
         required: false
         type: string
+      release_title:
+        description: Optional one-line Desktop changelog title.
+        required: false
+        type: string
       require_staging_success:
         description: Require a successful Deploy Staging run for this exact SHA.
         default: true
@@ -218,6 +222,7 @@ jobs:
       enabled: ${{ needs.plan.outputs.desktop == 'true' }}
       dry_run: false
       publish_updater: true
+      release_title: ${{ github.event.inputs.release_title || '' }}
     secrets: inherit
 
   summary:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -25,6 +25,11 @@ on:
         description: "Allow ad-hoc (unsigned) macOS builds when APPLE_SIGNING_IDENTITY is not configured"
         type: boolean
         default: false
+      release_title:
+        description: "Optional one-line release notice title (80 characters maximum)"
+        type: string
+        required: false
+        default: ""
   workflow_call:
     inputs:
       git_sha:
@@ -51,6 +56,11 @@ on:
         description: "Allow ad-hoc (unsigned) macOS builds when APPLE_SIGNING_IDENTITY is not configured"
         type: boolean
         default: false
+      release_title:
+        description: "Optional one-line release notice title (80 characters maximum)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -75,6 +85,13 @@ env:
   ANYHARNESS_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.ANYHARNESS_SENTRY_TRACES_SAMPLE_RATE || vars.E2B_RUNTIME_SENTRY_TRACES_SAMPLE_RATE }}
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+# Reusable callers provide a bare version, while tag-push and manual tag runs
+# identify the same release with desktop-v*. Normalize both to one lock key so
+# a queued same-version run cannot reach shared release assets concurrently.
+concurrency:
+  group: release-desktop-${{ inputs.version && format('desktop-v{0}', inputs.version) || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   build-desktop:
@@ -152,6 +169,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+
+      - name: Validate release title
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          RELEASE_TITLE: ${{ inputs.release_title || '' }}
+        run: |
+          node scripts/generate-updater-manifest.mjs \
+            --notes "$RELEASE_TITLE" \
+            --validate-notes-only true
 
       - name: Resolve release metadata
         if: steps.filter.outputs.skip != 'true'
@@ -636,6 +662,7 @@ jobs:
       - name: Generate updater manifest
         env:
           INPUT_VERSION: ${{ inputs.version || '' }}
+          RELEASE_TITLE: ${{ inputs.release_title || '' }}
         run: |
           version="$INPUT_VERSION"
           if [[ "${GITHUB_REF_NAME:-}" == desktop-v* ]]; then
@@ -647,6 +674,7 @@ jobs:
             --version "$version" \
             --artifacts-dir all-artifacts \
             --base-url "${{ vars.DESKTOP_DOWNLOADS_BASE_URL }}/desktop/stable" \
+            --notes "$RELEASE_TITLE" \
             --output latest.json
 
       - name: Generate installer manifest
@@ -663,6 +691,24 @@ jobs:
             --artifacts-dir all-artifacts \
             --base-url "${{ vars.DESKTOP_DOWNLOADS_BASE_URL }}/desktop/stable" \
             --output installers.json
+
+      - name: Refuse an existing immutable updater manifest
+        run: |
+          set -euo pipefail
+          BUCKET="${{ vars.DESKTOP_DOWNLOADS_S3_BUCKET }}"
+          : "${DESKTOP_RELEASE_VERSION:?Missing desktop release version.}"
+          VERSIONED_KEY="desktop/stable/${DESKTOP_RELEASE_VERSION}/latest.json"
+
+          if head_error="$(aws s3api head-object --bucket "${BUCKET}" --key "${VERSIONED_KEY}" 2>&1)"; then
+            echo "::error::s3://${BUCKET}/${VERSIONED_KEY} already exists. Same-version publishes are refused before any updater asset or rolling manifest is changed."
+            exit 1
+          fi
+
+          if [[ "$head_error" != *"(404)"* ]]; then
+            echo "$head_error" >&2
+            echo "::error::Could not prove that s3://${BUCKET}/${VERSIONED_KEY} is absent; refusing to publish."
+            exit 1
+          fi
 
       - name: Upload desktop assets to S3
         run: |
@@ -681,6 +727,23 @@ jobs:
         run: |
           set -euo pipefail
           BUCKET="${{ vars.DESKTOP_DOWNLOADS_S3_BUCKET }}"
+          # Versioned snapshot the self-hosted server's /desktop/updater/latest.json
+          # 302-redirects to (desktop/stable/<version>/latest.json). Immutable, so
+          # cache it long and skip CloudFront invalidation. Create it atomically
+          # before changing the rolling feed so same-version or concurrent runs
+          # cannot make the two manifests disagree.
+          : "${DESKTOP_RELEASE_VERSION:?Missing desktop release version.}"
+          VERSIONED_KEY="desktop/stable/${DESKTOP_RELEASE_VERSION}/latest.json"
+          if ! aws s3api put-object \
+            --bucket "${BUCKET}" \
+            --key "${VERSIONED_KEY}" \
+            --body latest.json \
+            --content-type "application/json" \
+            --cache-control "max-age=31536000, immutable" \
+            --if-none-match "*"; then
+            echo "::error::Failed to create s3://${BUCKET}/${VERSIONED_KEY} atomically. The rolling updater manifest was not changed."
+            exit 1
+          fi
           aws s3 cp latest.json \
             "s3://${BUCKET}/desktop/stable/latest.json" \
             --content-type "application/json" \
@@ -689,22 +752,6 @@ jobs:
             "s3://${BUCKET}/desktop/stable/installers.json" \
             --content-type "application/json" \
             --cache-control "max-age=300"
-          # Versioned snapshot the self-hosted server's /desktop/updater/latest.json
-          # 302-redirects to (desktop/stable/<version>/latest.json). Immutable, so
-          # cache it long and skip CloudFront invalidation. Because edges may hold
-          # it for up to a year, never overwrite an existing key: a same-version
-          # pipeline re-run would leave edges serving stale signatures. Skip the
-          # upload instead so re-runs stay idempotent.
-          : "${DESKTOP_RELEASE_VERSION:?Missing desktop release version.}"
-          VERSIONED_KEY="desktop/stable/${DESKTOP_RELEASE_VERSION}/latest.json"
-          if aws s3api head-object --bucket "${BUCKET}" --key "${VERSIONED_KEY}" >/dev/null 2>&1; then
-            echo "::warning::s3://${BUCKET}/${VERSIONED_KEY} already exists; skipping the immutable versioned manifest upload (idempotent re-run). If ${DESKTOP_RELEASE_VERSION} was re-signed, delete the key and re-run, then wait out edge caches."
-          else
-            aws s3 cp latest.json \
-              "s3://${BUCKET}/${VERSIONED_KEY}" \
-              --content-type "application/json" \
-              --cache-control "max-age=31536000, immutable"
-          fi
 
       - name: Invalidate CloudFront cache
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,9 @@ at the start of the task, not halfway through implementation.
    - `specs/codebase/features/pending-workspace-shell.md` for pending workspace
      entry, projected session shell, optimistic prompts, or
      workspace/session materialization handoff
+   - `specs/codebase/features/desktop-updates.md` for updater checks,
+     download/restart UX, version-aware release notices, or release-notice
+     acknowledgment
    - `specs/codebase/features/workspace-files.md` for workspace file browsing,
      file viewing, diff viewing, Changes, or all-changes review
 
@@ -153,6 +156,8 @@ Applies to `.github/workflows/**`, `apps/desktop/infra/**`, `server/infra/**`,
 updater publishing, and the desktop updater flow.
 
 1. `specs/developing/deploying/ci-cd.md`
+2. `specs/codebase/features/desktop-updates.md` when changing updater manifest
+   metadata or in-app updater/release-notice behavior.
 
 If a release or deployment change also touches frontend, server, SDK, or
 AnyHarness code, read the relevant area doc too.

--- a/apps/desktop/infra/main.tf
+++ b/apps/desktop/infra/main.tf
@@ -43,6 +43,18 @@ resource "aws_s3_bucket_versioning" "desktop_downloads" {
   }
 }
 
+resource "aws_s3_bucket_cors_configuration" "desktop_downloads" {
+  bucket = aws_s3_bucket.desktop_downloads.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 86400
+  }
+}
+
 # --------------------------------------------------------------------------
 # CloudFront distribution
 # --------------------------------------------------------------------------
@@ -52,6 +64,33 @@ resource "aws_cloudfront_origin_access_control" "desktop_downloads" {
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_response_headers_policy" "desktop_downloads_cors" {
+  name = "proliferate-desktop-downloads-cors"
+
+  cors_config {
+    access_control_allow_credentials = false
+
+    access_control_allow_headers {
+      items = ["*"]
+    }
+
+    access_control_allow_methods {
+      items = ["GET", "HEAD", "OPTIONS"]
+    }
+
+    access_control_allow_origins {
+      items = ["*"]
+    }
+
+    access_control_expose_headers {
+      items = ["ETag"]
+    }
+
+    access_control_max_age_sec = 86400
+    origin_override            = true
+  }
 }
 
 resource "aws_cloudfront_distribution" "desktop_downloads" {
@@ -68,14 +107,20 @@ resource "aws_cloudfront_distribution" "desktop_downloads" {
   }
 
   default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "s3-desktop-downloads"
-    viewer_protocol_policy = "redirect-to-https"
-    compress               = true
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = "s3-desktop-downloads"
+    viewer_protocol_policy     = "redirect-to-https"
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.desktop_downloads_cors.id
 
     forwarded_values {
       query_string = false
+      headers = [
+        "Access-Control-Request-Headers",
+        "Access-Control-Request-Method",
+        "Origin",
+      ]
       cookies {
         forward = "none"
       }
@@ -200,6 +245,7 @@ resource "aws_iam_role_policy" "desktop_release" {
         Sid    = "S3Upload"
         Effect = "Allow"
         Action = [
+          "s3:GetObject",
           "s3:PutObject",
           "s3:ListBucket",
         ]

--- a/apps/desktop/src/components/feedback/UpdateToastPresenter.test.tsx
+++ b/apps/desktop/src/components/feedback/UpdateToastPresenter.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   UpdateToastPresenter,
@@ -11,6 +11,7 @@ import {
 const updaterMocks = vi.hoisted(() => ({
   phase: "available",
   availableVersion: "0.1.24",
+  availableTitle: "Introducing Grok" as string | null,
   errorMessage: null as string | null,
   errorSource: null as "check" | "download" | null,
   downloadProgress: null as number | null,
@@ -47,6 +48,7 @@ afterEach(() => {
   vi.clearAllMocks();
   updaterMocks.phase = "available";
   updaterMocks.availableVersion = "0.1.24";
+  updaterMocks.availableTitle = "Introducing Grok";
   updaterMocks.errorMessage = null;
   updaterMocks.errorSource = null;
   updaterMocks.downloadProgress = null;
@@ -56,7 +58,28 @@ afterEach(() => {
 });
 
 describe("UpdateToastPresenter", () => {
-  it("shows the available toast with a Download action", () => {
+  it("shows the authored release title with an UPDATE eyebrow and Download action", () => {
+    render(<UpdateToastPresenter />);
+
+    const [title, options] = sonnerMocks.toast.mock.calls[0] ?? [];
+    render(<>{title}</>);
+
+    expect(screen.getByText("UPDATE")).toBeTruthy();
+    expect(screen.getByText("Introducing Grok")).toBeTruthy();
+    expect(options).toEqual(
+      expect.objectContaining({
+        id: UPDATE_TOAST_ID,
+        description: "Proliferate 0.1.24 — downloads in the background.",
+      }),
+    );
+
+    options.action.onClick({ preventDefault: () => {} });
+    expect(updaterMocks.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the generic available copy when the manifest has no title", () => {
+    updaterMocks.availableTitle = null;
+
     render(<UpdateToastPresenter />);
 
     expect(sonnerMocks.toast).toHaveBeenCalledWith(
@@ -66,11 +89,25 @@ describe("UpdateToastPresenter", () => {
         description: "Proliferate 0.1.24 — downloads in the background.",
       }),
     );
-
-    const options = sonnerMocks.toast.mock.calls[0]?.[1];
-    options.action.onClick({ preventDefault: () => {} });
-    expect(updaterMocks.downloadUpdate).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ["downloading", "Downloading update"],
+    ["ready", "Restart to update"],
+  ] as const)(
+    "keeps the generic %s heading when the manifest has no title",
+    (phase, heading) => {
+      updaterMocks.phase = phase;
+      updaterMocks.availableTitle = null;
+
+      render(<UpdateToastPresenter />);
+
+      expect(sonnerMocks.toast).toHaveBeenCalledWith(
+        heading,
+        expect.objectContaining({ id: UPDATE_TOAST_ID }),
+      );
+    },
+  );
 
   it("supersedes the up-to-date toast when an update enters the flow", () => {
     updaterMocks.phase = "available";
@@ -79,32 +116,44 @@ describe("UpdateToastPresenter", () => {
     expect(sonnerMocks.toast.dismiss).toHaveBeenCalledWith(UP_TO_DATE_TOAST_ID);
   });
 
-  it("shows the downloading toast without actions", () => {
+  it("keeps the authored title visible while downloading", () => {
     updaterMocks.phase = "downloading";
     updaterMocks.downloadProgress = 42;
 
     render(<UpdateToastPresenter />);
 
-    expect(sonnerMocks.toast).toHaveBeenCalledWith(
-      "Downloading update",
-      expect.objectContaining({ id: UPDATE_TOAST_ID, action: undefined }),
+    const [title, options] = sonnerMocks.toast.mock.calls[0] ?? [];
+    render(<>{title}</>);
+    render(<>{options.description}</>);
+
+    expect(screen.getByText("UPDATE")).toBeTruthy();
+    expect(screen.getByText("Introducing Grok")).toBeTruthy();
+    expect(screen.getByText("Downloading Proliferate 0.1.24.")).toBeTruthy();
+    expect(options).toEqual(
+      expect.objectContaining({
+        id: UPDATE_TOAST_ID,
+        action: undefined,
+      }),
     );
   });
 
-  it("routes the ready toast's Restart action to the restart prompt", () => {
+  it("keeps the authored title visible through the Restart action", () => {
     updaterMocks.phase = "ready";
 
     render(<UpdateToastPresenter />);
 
-    expect(sonnerMocks.toast).toHaveBeenCalledWith(
-      "Restart to update",
+    const [title, options] = sonnerMocks.toast.mock.calls[0] ?? [];
+    render(<>{title}</>);
+
+    expect(screen.getByText("UPDATE")).toBeTruthy();
+    expect(screen.getByText("Introducing Grok")).toBeTruthy();
+    expect(options).toEqual(
       expect.objectContaining({
         id: UPDATE_TOAST_ID,
         description: "Proliferate 0.1.24 is ready.",
       }),
     );
 
-    const options = sonnerMocks.toast.mock.calls[0]?.[1];
     options.action.onClick({ preventDefault: () => {} });
     expect(updaterMocks.openRestartPrompt).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/components/feedback/UpdateToastPresenter.tsx
+++ b/apps/desktop/src/components/feedback/UpdateToastPresenter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { toast } from "@proliferate/ui/kit/Sonner";
 import { CircleAlert } from "@proliferate/ui/icons";
+import { Badge } from "@proliferate/ui/primitives/Badge";
 import { useUpdater, type UpdaterPhase } from "@/hooks/access/tauri/use-updater";
 import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
 
@@ -45,6 +46,37 @@ function DownloadProgressBar({ progress }: { progress: number | null }) {
   );
 }
 
+function AuthoredUpdateTitle({ title }: { title: string }) {
+  return (
+    <span className="flex min-w-0 flex-col items-start gap-1.5">
+      <Badge className="shrink-0">UPDATE</Badge>
+      <span
+        className="min-w-0 whitespace-normal break-words [overflow-wrap:anywhere]"
+        title={title}
+      >
+        {title}
+      </span>
+    </span>
+  );
+}
+
+function TitledDownloadProgress({
+  version,
+  progress,
+}: {
+  version: string | null;
+  progress: number | null;
+}) {
+  return (
+    <span className="block">
+      <span className="block">
+        {version ? `Downloading Proliferate ${version}.` : "Downloading update."}
+      </span>
+      <DownloadProgressBar progress={progress} />
+    </span>
+  );
+}
+
 /**
  * Update lifecycle notifications as toasts (UX spec §12): available →
  * downloading (progress bar) → ready ("Restart to update", the toast's one
@@ -55,6 +87,7 @@ export function UpdateToastPresenter() {
   const {
     phase,
     availableVersion,
+    availableTitle,
     errorMessage,
     errorSource,
     downloadProgress,
@@ -136,12 +169,15 @@ export function UpdateToastPresenter() {
     toast.dismiss(UP_TO_DATE_TOAST_ID);
 
     const versionLabel = availableVersion ? ` ${availableVersion}` : "";
+    const authoredTitle = availableTitle ? (
+      <AuthoredUpdateTitle title={availableTitle} />
+    ) : null;
     const onDismiss = () => {
       dismissedKeyRef.current = dismissalKey;
     };
 
     if (phase === "available") {
-      toast("Update available", {
+      toast(authoredTitle ?? "Update available", {
         id: UPDATE_TOAST_ID,
         description: `Proliferate${versionLabel} — downloads in the background.`,
         duration: Infinity,
@@ -169,9 +205,16 @@ export function UpdateToastPresenter() {
     }
 
     if (phase === "downloading") {
-      toast("Downloading update", {
+      toast(authoredTitle ?? "Downloading update", {
         id: UPDATE_TOAST_ID,
-        description: <DownloadProgressBar progress={downloadProgress} />,
+        description: authoredTitle ? (
+          <TitledDownloadProgress
+            version={availableVersion}
+            progress={downloadProgress}
+          />
+        ) : (
+          <DownloadProgressBar progress={downloadProgress} />
+        ),
         duration: Infinity,
         closeButton: true,
         onDismiss,
@@ -182,7 +225,7 @@ export function UpdateToastPresenter() {
     }
 
     // ready
-    toast("Restart to update", {
+    toast(authoredTitle ?? "Restart to update", {
       id: UPDATE_TOAST_ID,
       description: `Proliferate${versionLabel} is ready.`,
       duration: Infinity,
@@ -207,6 +250,7 @@ export function UpdateToastPresenter() {
       },
     });
   }, [
+    availableTitle,
     availableVersion,
     downloadProgress,
     downloadUpdate,

--- a/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
+++ b/apps/desktop/src/components/playground/UpdateUiPlayground.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { UPDATE_PREVIEW_STATES } from "@/config/update-playground";
 import { UpdateDialogContent } from "@/components/feedback/UpdateDialogContent";
+import { ReleaseNoticeCard } from "@/components/workspace/shell/sidebar/ReleaseNoticeCard";
 import { SidebarUpdatePill } from "@/components/workspace/shell/sidebar/SidebarUpdatePill";
 import { UpdateUiPlaygroundControls } from "@/components/playground/UpdateUiPlaygroundControls";
 
@@ -74,8 +75,23 @@ export function UpdateUiPlayground() {
         </PreviewSection>
 
         <PreviewSection
+          title="Release notice card (sidebar footer)"
+          description="The installed-release changelog card shown after an update. This is the production component at its sidebar-width constraint."
+        >
+          <div className="rounded-lg border border-border bg-card/60 p-5">
+            <div className="w-64 rounded-lg bg-sidebar py-2">
+              <ReleaseNoticeCard
+                notice={{ version: "0.1.42", title: "Introducing Grok" }}
+                onDismiss={() => {}}
+                onOpenChangelog={() => {}}
+              />
+            </div>
+          </div>
+        </PreviewSection>
+
+        <PreviewSection
           title="Production Surfaces"
-          description="Live updater components driven by the dev updater mock. The toast renders in the app toast position; the restart dialog renders as the real app modal; the pill below is the real sidebar pill fed by the same mock. Use “+ standard toast” to drop a real app toast beside the update toast and confirm they match."
+          description="Live updater components driven by the dev updater mock. The toast keeps the authored release title while its Download, progress, and Restart states morph in place; the restart dialog renders as the real app modal; the pill below is fed by the same mock. Use “+ standard toast” to confirm the toast treatment matches the rest of the app."
         >
           <UpdateUiPlaygroundControls />
         </PreviewSection>

--- a/apps/desktop/src/components/playground/UpdateUiPlaygroundControls.tsx
+++ b/apps/desktop/src/components/playground/UpdateUiPlaygroundControls.tsx
@@ -23,6 +23,7 @@ type ProductionSurfacePreview =
   | "download-error";
 
 const PREVIEW_VERSION = "0.1.42";
+const PREVIEW_TITLE = "Introducing Grok";
 const CHECK_ERROR_MESSAGE = "Couldn't reach the update server.";
 const DOWNLOAD_ERROR_MESSAGE = "Couldn't finish downloading the update.";
 const PRODUCTION_SURFACE_PREVIEWS: {
@@ -55,6 +56,7 @@ function setDevUpdaterMockErrorSource(source: UpdaterErrorSource): void {
 function buildProductionSurfaceMock(preview: ProductionSurfacePreview): DevUpdaterMockState {
   const baseState = {
     version: PREVIEW_VERSION,
+    title: PREVIEW_TITLE,
     downloadProgress: null,
     restartPromptOpen: false,
     restartWhenIdle: false,
@@ -148,6 +150,7 @@ export function UpdateUiPlaygroundControls() {
   const {
     phase: livePhase,
     availableVersion: liveVersion,
+    availableTitle: liveTitle,
     errorSource: liveErrorSource,
     downloadProgress: liveDownloadProgress,
     restartWhenIdle: liveRestartWhenIdle,
@@ -295,6 +298,7 @@ export function UpdateUiPlaygroundControls() {
         </div>
         <LiveStateDatum label="Phase" value={livePhase} />
         <LiveStateDatum label="Version" value={liveVersion ?? "—"} />
+        <LiveStateDatum label="Title" value={liveTitle ?? "—"} />
         <LiveStateDatum label="Error source" value={liveErrorSource ?? "—"} />
         <LiveStateDatum
           label="Restart armed"

--- a/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -7,6 +7,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { MainSidebar } from "@/components/workspace/shell/sidebar/MainSidebar";
 import { useSupportModalStore } from "@/stores/support/support-modal-store";
 
+const releaseNoticeState = vi.hoisted(() => ({
+  notice: null as null | {
+    version: string;
+    title: string;
+  },
+  dismissNotice: vi.fn(),
+  openChangelog: vi.fn(),
+}));
+
+vi.mock("@/hooks/updates/facade/use-release-notice", () => ({
+  useReleaseNotice: () => releaseNoticeState,
+}));
+
 vi.mock("@/components/diagnostics/DebugProfiler", () => ({
   DebugProfiler: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -162,6 +175,7 @@ vi.mock("@/stores/sessions/session-selection-store", () => ({
 const workspaceUiState = vi.hoisted(() => ({
   archiveWorkspace: vi.fn(),
   hideRepoRoot: vi.fn(),
+  sidebarOpen: true,
   unarchiveWorkspace: vi.fn(),
   unarchiveWorkspaces: vi.fn(),
   workspaceTypes: ["local", "worktree", "cloud"],
@@ -255,6 +269,8 @@ vi.mock("@/stores/ui/repo-setup-modal-store", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  releaseNoticeState.notice = null;
+  workspaceUiState.sidebarOpen = true;
 });
 
 function renderMainSidebar() {
@@ -275,5 +291,61 @@ describe("MainSidebar support modal", () => {
       expect(useSupportModalStore.getState().open).toBe(true);
       expect(useSupportModalStore.getState().kind).toBe("bug");
     });
+  });
+});
+
+describe("MainSidebar release notice", () => {
+  it("omits the card when the facade has no notice", () => {
+    renderMainSidebar();
+
+    expect(screen.queryByRole("complementary")).toBeNull();
+  });
+
+  it("keeps the card out of the tab order when the sidebar is collapsed", () => {
+    releaseNoticeState.notice = {
+      version: "0.3.25",
+      title: "Introducing Grok",
+    };
+    workspaceUiState.sidebarOpen = false;
+
+    renderMainSidebar();
+
+    expect(screen.queryByRole("complementary")).toBeNull();
+    expect(screen.queryByRole("button", {
+      name: "Dismiss release notice for 0.3.25",
+    })).toBeNull();
+  });
+
+  it("renders the release card immediately above the account footer", () => {
+    releaseNoticeState.notice = {
+      version: "0.3.25",
+      title: "Introducing Grok",
+    };
+
+    renderMainSidebar();
+
+    const card = screen.getByRole("complementary", {
+      name: "What's new in 0.3.25: Introducing Grok",
+    });
+    const footer = screen.getByTestId("sidebar-account-footer");
+    expect(card.nextElementSibling).toBe(footer);
+  });
+
+  it("wires release notice actions through the facade", () => {
+    releaseNoticeState.notice = {
+      version: "0.3.25",
+      title: "Introducing Grok",
+    };
+
+    renderMainSidebar();
+    fireEvent.click(screen.getByRole("button", {
+      name: "Dismiss release notice for 0.3.25",
+    }));
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open changelog for 0.3.25",
+    }));
+
+    expect(releaseNoticeState.dismissNotice).toHaveBeenCalledTimes(1);
+    expect(releaseNoticeState.openChangelog).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -5,6 +5,7 @@ import { useRepositories } from "@proliferate/cloud-sdk-react";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
 import { DebugProfiler } from "@/components/diagnostics/DebugProfiler";
 import { SidebarAccountFooter } from "@/components/app/sidebar/SidebarAccountFooter";
+import { ReleaseNoticeCard } from "./ReleaseNoticeCard";
 import { SidebarPrimaryNavigation } from "./SidebarPrimaryNavigation";
 import { SidebarRepositoriesHeader } from "./SidebarRepositoriesHeader";
 import { SidebarWorkspaceContent } from "./SidebarWorkspaceContent";
@@ -48,6 +49,7 @@ import { buildShortcutRangeLabelById } from "@/lib/domain/shortcuts/presentation
 import { startMeasurementOperation } from "@/lib/infra/measurement/debug-measurement";
 import { useShortcutRevealVisible } from "@/providers/ShortcutRevealProvider";
 import { useToastStore } from "@/stores/toast/toast-store";
+import { useReleaseNotice } from "@/hooks/updates/facade/use-release-notice";
 
 interface ArchiveConfirmationState {
   workspaceId: string;
@@ -58,6 +60,7 @@ interface ArchiveConfirmationState {
 export const MainSidebar = memo(function MainSidebar() {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
+  const { notice, dismissNotice, openChangelog } = useReleaseNotice();
   const actions = useWorkspaceSidebarActions();
   const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
   const shortcutRevealVisible = useShortcutRevealVisible();
@@ -74,9 +77,11 @@ export const MainSidebar = memo(function MainSidebar() {
   const showToast = useToastStore((state) => state.show);
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
   const {
+    sidebarOpen,
     workspaceTypes,
     toggleSidebarWorkspaceType,
   } = useWorkspaceUiStore(useShallow((state) => ({
+    sidebarOpen: state.sidebarOpen,
     workspaceTypes: state.workspaceTypes,
     toggleSidebarWorkspaceType: state.toggleSidebarWorkspaceType,
   })));
@@ -265,6 +270,13 @@ export const MainSidebar = memo(function MainSidebar() {
     <DebugProfiler id="workspace-sidebar">
       <ProductSidebarFrame footer={(
         <DebugProfiler id="workspace-sidebar-footer">
+          {sidebarOpen && notice ? (
+            <ReleaseNoticeCard
+              notice={notice}
+              onDismiss={dismissNotice}
+              onOpenChangelog={openChangelog}
+            />
+          ) : null}
           <SidebarAccountFooter />
         </DebugProfiler>
       )}>

--- a/apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.test.tsx
@@ -1,0 +1,104 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReleaseNoticeCard } from "./ReleaseNoticeCard";
+
+afterEach(cleanup);
+
+describe("ReleaseNoticeCard", () => {
+  it("renders an installed release as NEW with a quiet changelog action", () => {
+    render(
+      <ReleaseNoticeCard
+        notice={{ version: "0.3.25", title: "Introducing Grok" }}
+        onDismiss={vi.fn()}
+        onOpenChangelog={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("complementary", {
+      name: "What's new in 0.3.25: Introducing Grok",
+    })).not.toBeNull();
+    const badge = screen.getByText("NEW");
+    expect(badge.className).toContain("bg-sidebar-accent");
+    expect(badge.className).toContain("text-sidebar-muted-foreground");
+    expect(screen.queryByText("UPDATE")).toBeNull();
+    expect(screen.getByText("Introducing Grok")).not.toBeNull();
+    const changelog = screen.getByRole("button", {
+      name: "Open changelog for 0.3.25",
+    });
+    expect(changelog.className).toContain("underline");
+    expect(changelog.className).not.toContain("hover:bg-sidebar-accent");
+  });
+
+  it("forwards the dismiss and changelog actions with explicit accessible names", () => {
+    const onDismiss = vi.fn();
+    const onOpenChangelog = vi.fn();
+    render(
+      <ReleaseNoticeCard
+        notice={{ version: "0.3.25", title: "Introducing Grok" }}
+        onDismiss={onDismiss}
+        onOpenChangelog={onOpenChangelog}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Dismiss release notice for 0.3.25",
+    }));
+    fireEvent.click(screen.getByRole("button", {
+      name: "Open changelog for 0.3.25",
+    }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onOpenChangelog).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports keyboard focus and activation for both actions", async () => {
+    const onDismiss = vi.fn();
+    const onOpenChangelog = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ReleaseNoticeCard
+        notice={{ version: "0.3.25", title: "Introducing Grok" }}
+        onDismiss={onDismiss}
+        onOpenChangelog={onOpenChangelog}
+      />,
+    );
+    const dismissButton = screen.getByRole("button", {
+      name: "Dismiss release notice for 0.3.25",
+    });
+    const changelogButton = screen.getByRole("button", {
+      name: "Open changelog for 0.3.25",
+    });
+
+    await user.tab();
+    expect(document.activeElement).toBe(dismissButton);
+    await user.keyboard("{Enter}");
+    await user.tab();
+    expect(document.activeElement).toBe(changelogButton);
+    await user.keyboard(" ");
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onOpenChangelog).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps the maximum-length title without overflowing the card", () => {
+    const title = "A".repeat(80);
+    expect(title).toHaveLength(80);
+
+    render(
+      <ReleaseNoticeCard
+        notice={{ version: "0.3.25", title }}
+        onDismiss={vi.fn()}
+        onOpenChangelog={vi.fn()}
+      />,
+    );
+
+    const heading = screen.getByText(title);
+    expect(heading.getAttribute("title")).toBe(title);
+    expect(heading.className).toContain("whitespace-normal");
+    expect(heading.className).toContain("break-words");
+    expect(heading.className).toContain("[overflow-wrap:anywhere]");
+  });
+});

--- a/apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx
+++ b/apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx
@@ -1,0 +1,64 @@
+import { ArrowRight, X } from "@proliferate/ui/icons";
+import { Badge } from "@proliferate/ui/primitives/Badge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { IconButton } from "@proliferate/ui/primitives/IconButton";
+
+export interface ReleaseNoticeCardProps {
+  notice: {
+    version: string;
+    title: string;
+  };
+  onDismiss: () => void;
+  onOpenChangelog: () => void;
+}
+
+export function ReleaseNoticeCard({
+  notice,
+  onDismiss,
+  onOpenChangelog,
+}: ReleaseNoticeCardProps) {
+  return (
+    <aside
+      aria-label={`What's new in ${notice.version}: ${notice.title}`}
+      className="mx-2 shrink-0 overflow-hidden rounded-lg border border-sidebar-border bg-foreground/5 px-3 py-3 text-sidebar-foreground"
+    >
+      <div className="flex min-w-0 items-start gap-2">
+        <Badge
+          tone="sidebar"
+          className="shrink-0"
+        >
+          NEW
+        </Badge>
+        <IconButton
+          aria-label={`Dismiss release notice for ${notice.version}`}
+          title="Dismiss"
+          tone="sidebar"
+          size="xs"
+          className="-mr-1 -mt-1 ml-auto shrink-0"
+          onClick={onDismiss}
+        >
+          <X className="size-3.5" />
+        </IconButton>
+      </div>
+
+      <p
+        className="mt-2 min-w-0 whitespace-normal break-words text-ui font-[520] [overflow-wrap:anywhere]"
+        title={notice.title}
+      >
+        {notice.title}
+      </p>
+
+      <Button
+        type="button"
+        variant="sidebar-link"
+        size="unstyled"
+        aria-label={`Open changelog for ${notice.version}`}
+        className="mt-2 justify-start"
+        onClick={onOpenChangelog}
+      >
+        Changelog
+        <ArrowRight className="size-3.5" />
+      </Button>
+    </aside>
+  );
+}

--- a/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WorkspaceActionsMenu } from "./WorkspaceActionsMenu";
+import { WorkspaceActions } from "./WorkspaceActionsMenu";
 
 const nativeMenuState = vi.hoisted(() => ({
   show: vi.fn<() => Promise<boolean>>(),
@@ -29,7 +29,7 @@ describe("WorkspaceActionsMenu", () => {
 
   it("keeps the DOM menu closed when the native menu opens", async () => {
     nativeMenuState.show.mockResolvedValue(true);
-    render(<WorkspaceActionsMenu session={session} />);
+    render(<WorkspaceActions session={session} />);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Chat actions" }), {
       button: 0,
@@ -42,7 +42,7 @@ describe("WorkspaceActionsMenu", () => {
 
   it("opens the DOM fallback when the native menu cannot open", async () => {
     nativeMenuState.show.mockResolvedValue(false);
-    render(<WorkspaceActionsMenu session={session} />);
+    render(<WorkspaceActions session={session} />);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Chat actions" }), {
       button: 0,

--- a/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx
@@ -34,7 +34,7 @@ interface WorkspaceActionsMenuProps {
  * Chat-only overflow actions. In Tauri the click opens an OS-native menu;
  * Radix remains the browser/failure fallback used by tests and playgrounds.
  */
-export function WorkspaceActionsMenu({ session }: WorkspaceActionsMenuProps) {
+export function WorkspaceActions({ session }: WorkspaceActionsMenuProps) {
   const [fallbackOpen, setFallbackOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const { showNativeMenu } = useWorkspaceActionsNativeMenu(session);

--- a/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenuContainer.tsx
+++ b/apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenuContainer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { WorkspaceActionsMenu } from "@/components/workspace/shell/topbar/WorkspaceActionsMenu";
+import { WorkspaceActions } from "@/components/workspace/shell/topbar/WorkspaceActionsMenu";
 import {
   useOptionalWorkspaceHeaderTabsViewModelContext,
 } from "@/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext";
@@ -77,7 +77,7 @@ export function WorkspaceActionsMenuContainer() {
   }
 
   return (
-    <WorkspaceActionsMenu
+    <WorkspaceActions
       session={{
         canRename: activeTab !== null && !activeTab.isReviewAgentChild,
         canFork: activeTab !== null

--- a/apps/desktop/src/config/release-notice.ts
+++ b/apps/desktop/src/config/release-notice.ts
@@ -1,0 +1,2 @@
+export const RELEASE_NOTICE_CHANGELOG_URL =
+  "https://proliferate.com/changelog";

--- a/apps/desktop/src/hooks/access/downloads/desktop-releases/query-keys.ts
+++ b/apps/desktop/src/hooks/access/downloads/desktop-releases/query-keys.ts
@@ -1,0 +1,3 @@
+export function desktopReleaseManifestKey(version: string | null) {
+  return ["downloads", "desktop-release-manifest", version] as const;
+}

--- a/apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.test.tsx
+++ b/apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const downloadsMocks = vi.hoisted(() => ({
+  fetchDesktopReleaseManifest: vi.fn(),
+}));
+
+vi.mock("@/lib/access/downloads/desktop-release-manifest", () => downloadsMocks);
+
+import { useDesktopReleaseManifest } from "./use-desktop-release-manifest";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useDesktopReleaseManifest", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a normalized title for an exact version match", async () => {
+    downloadsMocks.fetchDesktopReleaseManifest.mockResolvedValue({
+      version: "0.3.25",
+      notes: "  Introducing Grok  ",
+    });
+
+    const { result } = renderHook(
+      () => useDesktopReleaseManifest(" 0.3.25 "),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(downloadsMocks.fetchDesktopReleaseManifest).toHaveBeenCalledWith("0.3.25");
+    expect(result.current.data).toEqual({
+      version: "0.3.25",
+      title: "Introducing Grok",
+    });
+  });
+
+  it("rejects a response for another version", async () => {
+    downloadsMocks.fetchDesktopReleaseManifest.mockResolvedValue({
+      version: "0.3.26",
+      notes: "Introducing Grok",
+    });
+
+    const { result } = renderHook(
+      () => useDesktopReleaseManifest("0.3.25"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("keeps a no-title manifest successful and disables an invalid request", async () => {
+    downloadsMocks.fetchDesktopReleaseManifest.mockResolvedValue({ version: "0.3.25" });
+    const valid = renderHook(
+      () => useDesktopReleaseManifest("0.3.25"),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(valid.result.current.isSuccess).toBe(true));
+    expect(valid.result.current.data).toEqual({ version: "0.3.25", title: null });
+
+    downloadsMocks.fetchDesktopReleaseManifest.mockClear();
+    const invalid = renderHook(
+      () => useDesktopReleaseManifest("  "),
+      { wrapper: createWrapper() },
+    );
+    expect(invalid.result.current.fetchStatus).toBe("idle");
+    expect(downloadsMocks.fetchDesktopReleaseManifest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts
+++ b/apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchDesktopReleaseManifest } from "@/lib/access/downloads/desktop-release-manifest";
+import {
+  normalizeReleaseVersion,
+  parseDesktopReleaseManifest,
+  type DesktopReleaseManifest,
+} from "@/lib/domain/updates/release-notice";
+import { desktopReleaseManifestKey } from "./query-keys";
+
+export function useDesktopReleaseManifest(version: string | null | undefined) {
+  const requestedVersion = normalizeReleaseVersion(version);
+
+  return useQuery<DesktopReleaseManifest>({
+    queryKey: desktopReleaseManifestKey(requestedVersion),
+    queryFn: async () => {
+      if (!requestedVersion) {
+        throw new Error("Desktop release manifest version is unavailable");
+      }
+
+      const value = await fetchDesktopReleaseManifest(requestedVersion);
+      const manifest = parseDesktopReleaseManifest(value, requestedVersion);
+      if (!manifest) {
+        throw new Error("Desktop release manifest did not match the installed version");
+      }
+      return manifest;
+    },
+    enabled: requestedVersion !== null,
+    retry: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    meta: { telemetryHandled: true },
+  });
+}

--- a/apps/desktop/src/hooks/access/tauri/updater-dev-mock.test.ts
+++ b/apps/desktop/src/hooks/access/tauri/updater-dev-mock.test.ts
@@ -57,6 +57,15 @@ describe("updater dev mock", () => {
     });
   });
 
+  it("round-trips and normalizes an authored release title", () => {
+    writeDevUpdaterMock(baseState({ title: "  Introducing Grok  " }));
+
+    expect(readDevUpdaterMock()?.title).toBe("Introducing Grok");
+
+    writeDevUpdaterMock(baseState({ title: "line one\nline two" }));
+    expect(readDevUpdaterMock()?.title).toBeNull();
+  });
+
   it("round-trips an armed restart only for the ready phase", () => {
     writeDevUpdaterMock(baseState({ phase: "ready", restartWhenIdle: true }));
     expect(readDevUpdaterMock()).toMatchObject({ phase: "ready", restartWhenIdle: true });

--- a/apps/desktop/src/hooks/access/tauri/updater-dev-mock.ts
+++ b/apps/desktop/src/hooks/access/tauri/updater-dev-mock.ts
@@ -1,8 +1,10 @@
 import type { UpdaterErrorSource, UpdaterPhase } from "@/stores/updater/updater-store";
+import { normalizeReleaseTitle } from "@/lib/domain/updates/release-notice";
 
 const DEV_UPDATER_MOCK_KEY = "proliferate.dev.updaterMock";
 export const DEV_UPDATER_MOCK_EVENT = "proliferate:dev-updater-mock";
 const DEV_UPDATER_MOCK_VERSION = "0.1.3";
+const DEV_UPDATER_MOCK_TITLE = "Introducing release notices";
 const DEV_UPDATER_MOCK_ERROR_MESSAGE = "Simulated updater failure";
 const DEV_UPDATER_MOCK_DOWNLOAD_DELAYS_MS = [200, 450, 700];
 const DEV_UPDATER_MOCK_DOWNLOAD_PROGRESS = [32, 68, 100];
@@ -15,6 +17,7 @@ type DevUpdaterMockPhase = Extract<
 export interface DevUpdaterMockState {
   phase: DevUpdaterMockPhase;
   version: string;
+  title?: string | null;
   downloadProgress: number | null;
   restartPromptOpen: boolean;
   restartWhenIdle: boolean;
@@ -175,6 +178,7 @@ function normalizeDevUpdaterMock(raw: unknown): DevUpdaterMockState | null {
     return {
       phase: raw,
       version: DEV_UPDATER_MOCK_VERSION,
+      title: DEV_UPDATER_MOCK_TITLE,
       downloadProgress: raw === "downloading" ? 0 : null,
       restartPromptOpen: raw === "ready",
       restartWhenIdle: false,
@@ -197,6 +201,7 @@ function normalizeDevUpdaterMock(raw: unknown): DevUpdaterMockState | null {
   return {
     phase: candidate.phase,
     version: candidate.version?.trim() || DEV_UPDATER_MOCK_VERSION,
+    title: normalizeReleaseTitle(candidate.title),
     downloadProgress:
       candidate.phase === "downloading"
         ? Math.max(0, Math.min(100, candidate.downloadProgress ?? 0))

--- a/apps/desktop/src/hooks/access/tauri/use-updater.test.ts
+++ b/apps/desktop/src/hooks/access/tauri/use-updater.test.ts
@@ -81,6 +81,7 @@ describe("useUpdater", () => {
     tauriUpdaterMocks.checkForUpdate.mockResolvedValue({
       kind: "available",
       version: "0.2.0",
+      title: "  Introducing Grok  ",
       update: {},
     });
 
@@ -91,6 +92,8 @@ describe("useUpdater", () => {
 
     expect(useUpdaterStore.getState().phase).toBe("available");
     expect(useUpdaterStore.getState().manualCheckCompletedAt).toBeNull();
+    expect(useUpdaterStore.getState().availableTitle).toBe("Introducing Grok");
+    expect(result.current.availableTitle).toBe("Introducing Grok");
   });
 
   it("attributes a failed check to the check step", async () => {

--- a/apps/desktop/src/hooks/access/tauri/use-updater.ts
+++ b/apps/desktop/src/hooks/access/tauri/use-updater.ts
@@ -16,6 +16,7 @@ import {
   captureTelemetryException,
 } from "@/lib/integrations/telemetry/client";
 import { classifyTelemetryFailure } from "@/lib/domain/telemetry/failures";
+import { normalizeReleaseTitle } from "@/lib/domain/updates/release-notice";
 import {
   clearDevUpdaterMockDownload,
   DEV_UPDATER_MOCK_EVENT,
@@ -72,7 +73,11 @@ async function runUpdateCheck(options: { userInitiated?: boolean } = {}): Promis
     void persistUpdaterMetadata({ lastCheckedAt: timestamp });
 
     if (result.kind === "available") {
-      useUpdaterStore.getState().setAvailable(result.version, result.update);
+      useUpdaterStore.getState().setAvailable(
+        result.version,
+        result.update,
+        normalizeReleaseTitle(result.title),
+      );
       trackProductEvent("app_update_available", { version: result.version });
     } else if (result.kind === "current") {
       useUpdaterStore.getState().setPhase("current");
@@ -186,6 +191,7 @@ async function ensureAutoCheckScheduler(): Promise<void> {
 export function useUpdater() {
   const storePhase = useUpdaterStore((s) => s.phase);
   const storeAvailableVersion = useUpdaterStore((s) => s.availableVersion);
+  const storeAvailableTitle = useUpdaterStore((s) => s.availableTitle);
   const storeLastCheckedAt = useUpdaterStore((s) => s.lastCheckedAt);
   const storeErrorMessage = useUpdaterStore((s) => s.errorMessage);
   const storeErrorSource = useUpdaterStore((s) => s.errorSource);
@@ -198,6 +204,9 @@ export function useUpdater() {
 
   const phase = devMock?.phase ?? storePhase;
   const availableVersion = devMock?.version ?? storeAvailableVersion;
+  const availableTitle = devMock
+    ? devMock.title ?? null
+    : storeAvailableTitle;
   const lastCheckedAt = devMock?.lastCheckedAt ?? storeLastCheckedAt;
   const errorMessage = devMock?.errorMessage ?? storeErrorMessage;
   const errorSource = devMock ? devMock.errorSource : storeErrorSource;
@@ -344,6 +353,7 @@ export function useUpdater() {
   return {
     phase,
     availableVersion,
+    availableTitle,
     lastCheckedAt,
     errorMessage,
     errorSource,

--- a/apps/desktop/src/hooks/updates/cache/use-release-notice-model.ts
+++ b/apps/desktop/src/hooks/updates/cache/use-release-notice-model.ts
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import { useDesktopReleaseManifest } from "@/hooks/access/downloads/desktop-releases/use-desktop-release-manifest";
+import { useAppVersion } from "@/hooks/access/tauri/app/use-app-version";
+import { useUpdater } from "@/hooks/access/tauri/use-updater";
+import {
+  normalizeReleaseVersion,
+  resolveInstalledReleaseTitle,
+  selectReleaseNotice,
+  type DesktopReleaseManifest,
+  type InstalledReleaseManifestStatus,
+  type ReleaseNotice,
+} from "@/lib/domain/updates/release-notice";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+export interface ReleaseNoticeModel {
+  notice: ReleaseNotice | null;
+  installedManifest: {
+    currentVersion: string | null;
+    status: InstalledReleaseManifestStatus;
+    data: DesktopReleaseManifest | null;
+  };
+}
+
+// Composes updater, installed-manifest, and local preference state into one
+// release-notice read model. Persistence and actions stay in owning hooks.
+export function useReleaseNoticeModel(): ReleaseNoticeModel {
+  const { updatesSupported } = useUpdater();
+  const appVersionQuery = useAppVersion();
+  const currentVersion = normalizeReleaseVersion(appVersionQuery.data);
+  const installedVersion = updatesSupported ? currentVersion : null;
+  const installedManifestQuery = useDesktopReleaseManifest(installedVersion);
+  const hydrated = useUserPreferencesStore((state) => state._hydrated);
+  const acknowledgedReleaseVersion = useUserPreferencesStore(
+    (state) => state.acknowledgedReleaseVersion,
+  );
+  const cachedInstalledRelease = useUserPreferencesStore(
+    (state) => state.cachedInstalledRelease,
+  );
+
+  const installedRelease = useMemo(() => resolveInstalledReleaseTitle({
+    currentVersion: installedVersion,
+    manifestStatus: installedManifestQuery.status,
+    manifest: installedManifestQuery.data,
+    cachedRelease: cachedInstalledRelease,
+  }), [
+    cachedInstalledRelease,
+    installedVersion,
+    installedManifestQuery.data,
+    installedManifestQuery.status,
+  ]);
+
+  const notice = useMemo(() => (
+    hydrated
+      ? selectReleaseNotice({
+          installedRelease,
+          acknowledgedReleaseVersion,
+        })
+      : null
+  ), [
+    acknowledgedReleaseVersion,
+    hydrated,
+    installedRelease,
+  ]);
+
+  return useMemo(() => ({
+    notice,
+    installedManifest: {
+      currentVersion: installedVersion,
+      status: installedManifestQuery.status,
+      data: installedManifestQuery.data ?? null,
+    },
+  }), [
+    installedVersion,
+    installedManifestQuery.data,
+    installedManifestQuery.status,
+    notice,
+  ]);
+}

--- a/apps/desktop/src/hooks/updates/facade/use-release-notice.test.tsx
+++ b/apps/desktop/src/hooks/updates/facade/use-release-notice.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+const accessMocks = vi.hoisted(() => ({
+  updater: {
+    updatesSupported: true,
+    availableVersion: "0.3.25" as string | null,
+    availableTitle: "Introducing Grok" as string | null,
+  },
+  appVersion: { data: "0.3.24" as string | undefined },
+  installedManifest: {
+    status: "success" as "pending" | "error" | "success",
+    data: {
+      version: "0.3.24",
+      title: "Faster workspaces",
+    } as { version: string; title: string | null } | undefined,
+  },
+  openExternal: vi.fn(async () => undefined),
+  requestedManifestVersion: null as string | null,
+}));
+
+vi.mock("@/hooks/access/tauri/use-updater", () => ({
+  useUpdater: () => accessMocks.updater,
+}));
+vi.mock("@/hooks/access/tauri/app/use-app-version", () => ({
+  useAppVersion: () => accessMocks.appVersion,
+}));
+vi.mock("@/hooks/access/downloads/desktop-releases/use-desktop-release-manifest", () => ({
+  useDesktopReleaseManifest: (version: string | null) => {
+    accessMocks.requestedManifestVersion = version;
+    return accessMocks.installedManifest;
+  },
+}));
+vi.mock("@/hooks/access/tauri/use-shell-actions", () => ({
+  useTauriShellActions: () => ({ openExternal: accessMocks.openExternal }),
+}));
+
+import { useReleaseNotice } from "./use-release-notice";
+
+describe("useReleaseNotice", () => {
+  beforeEach(() => {
+    accessMocks.updater.updatesSupported = true;
+    accessMocks.updater.availableVersion = "0.3.25";
+    accessMocks.updater.availableTitle = "Introducing Grok";
+    accessMocks.appVersion.data = "0.3.24";
+    accessMocks.installedManifest.status = "success";
+    accessMocks.installedManifest.data = {
+      version: "0.3.24",
+      title: "Faster workspaces",
+    };
+    accessMocks.openExternal.mockResolvedValue(undefined);
+    useUserPreferencesStore.setState({
+      ...USER_PREFERENCE_DEFAULTS,
+      _hydrated: true,
+      _persistedMetadata: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("ignores a titled available update and shows only the installed release", () => {
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toEqual({
+      version: "0.3.24",
+      title: "Faster workspaces",
+    });
+    expect(result.current.notice?.title).not.toBe("Introducing Grok");
+  });
+
+  it("never resurrects an acknowledged installed release as available targets change", () => {
+    useUserPreferencesStore.getState().set(
+      "acknowledgedReleaseVersion",
+      "0.3.24",
+    );
+    const { result, rerender } = renderHook(() => useReleaseNotice());
+    expect(result.current.notice).toBeNull();
+
+    accessMocks.updater.availableVersion = "0.3.26";
+    accessMocks.updater.availableTitle = "Another release";
+    rerender();
+    expect(result.current.notice).toBeNull();
+
+    accessMocks.updater.availableVersion = "0.3.27";
+    accessMocks.updater.availableTitle = "Newest release";
+    rerender();
+    expect(result.current.notice).toBeNull();
+    expect(useUserPreferencesStore.getState().acknowledgedReleaseVersion)
+      .toBe("0.3.24");
+  });
+
+  it("shows a titled release only after that version is running", () => {
+    accessMocks.appVersion.data = "0.3.25";
+    accessMocks.installedManifest.data = {
+      version: "0.3.25",
+      title: "Introducing Grok",
+    };
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toEqual({
+      version: "0.3.25",
+      title: "Introducing Grok",
+    });
+  });
+
+  it("acknowledges an installed notice when it is dismissed", () => {
+    const { result } = renderHook(() => useReleaseNotice());
+
+    act(() => result.current.dismissNotice());
+
+    expect(useUserPreferencesStore.getState().acknowledgedReleaseVersion)
+      .toBe("0.3.24");
+    expect(result.current.notice).toBeNull();
+  });
+
+  it("opens the fixed changelog and then acknowledges the installed version", async () => {
+    const { result } = renderHook(() => useReleaseNotice());
+
+    act(() => result.current.openChangelog());
+
+    expect(accessMocks.openExternal).toHaveBeenCalledWith(
+      "https://proliferate.com/changelog",
+    );
+    await waitFor(() => {
+      expect(useUserPreferencesStore.getState().acknowledgedReleaseVersion)
+        .toBe("0.3.24");
+    });
+    expect(result.current.notice).toBeNull();
+  });
+
+  it("keeps the notice eligible when the changelog cannot be opened", async () => {
+    accessMocks.openExternal.mockRejectedValueOnce(new Error("shell unavailable"));
+    const { result } = renderHook(() => useReleaseNotice());
+
+    act(() => result.current.openChangelog());
+
+    await waitFor(() => expect(accessMocks.openExternal).toHaveBeenCalledTimes(1));
+    expect(useUserPreferencesStore.getState().acknowledgedReleaseVersion).toBeNull();
+    expect(result.current.notice?.version).toBe("0.3.24");
+  });
+
+  it("uses a matching cached installed title when the CDN is unavailable", () => {
+    accessMocks.installedManifest.status = "error";
+    accessMocks.installedManifest.data = undefined;
+    useUserPreferencesStore.getState().set("cachedInstalledRelease", {
+      version: "0.3.24",
+      title: "Cached release",
+    });
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toEqual({
+      version: "0.3.24",
+      title: "Cached release",
+    });
+  });
+
+  it("drops an old-version cache after the installed version changes", async () => {
+    accessMocks.appVersion.data = "0.3.25";
+    accessMocks.installedManifest.status = "error";
+    accessMocks.installedManifest.data = undefined;
+    useUserPreferencesStore.getState().set("cachedInstalledRelease", {
+      version: "0.3.24",
+      title: "Old release",
+    });
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toBeNull();
+    await waitFor(() => {
+      expect(useUserPreferencesStore.getState().cachedInstalledRelease).toBeNull();
+    });
+  });
+
+  it("caches the current valid installed title as the bounded offline fallback", async () => {
+    renderHook(() => useReleaseNotice());
+
+    await waitFor(() => {
+      expect(useUserPreferencesStore.getState().cachedInstalledRelease).toEqual({
+        version: "0.3.24",
+        title: "Faster workspaces",
+      });
+    });
+  });
+
+  it("clears a stale cache after a successful no-title response", async () => {
+    accessMocks.installedManifest.data = { version: "0.3.24", title: null };
+    useUserPreferencesStore.getState().set("cachedInstalledRelease", {
+      version: "0.3.24",
+      title: "Stale release",
+    });
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toBeNull();
+    await waitFor(() => {
+      expect(useUserPreferencesStore.getState().cachedInstalledRelease).toBeNull();
+    });
+  });
+
+  it("waits for preference hydration before showing a notice", () => {
+    useUserPreferencesStore.setState({ _hydrated: false });
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(result.current.notice).toBeNull();
+  });
+
+  it("does not request or show an installed manifest when updates are unsupported", () => {
+    accessMocks.updater.updatesSupported = false;
+
+    const { result } = renderHook(() => useReleaseNotice());
+
+    expect(accessMocks.requestedManifestVersion).toBeNull();
+    expect(result.current.notice).toBeNull();
+  });
+});

--- a/apps/desktop/src/hooks/updates/facade/use-release-notice.ts
+++ b/apps/desktop/src/hooks/updates/facade/use-release-notice.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { useReleaseNoticeModel } from "@/hooks/updates/cache/use-release-notice-model";
+import { useInstalledReleaseTitleCacheLifecycle } from "@/hooks/updates/lifecycle/use-installed-release-title-cache-lifecycle";
+import { useReleaseNoticeActions } from "@/hooks/updates/workflows/use-release-notice-actions";
+import type { ReleaseNotice } from "@/lib/domain/updates/release-notice";
+
+export function useReleaseNotice(): {
+  notice: ReleaseNotice | null;
+  dismissNotice: () => void;
+  openChangelog: () => void;
+} {
+  const model = useReleaseNoticeModel();
+  useInstalledReleaseTitleCacheLifecycle(model.installedManifest);
+  const actions = useReleaseNoticeActions(model.notice);
+
+  return useMemo(() => ({
+    notice: model.notice,
+    dismissNotice: actions.dismissNotice,
+    openChangelog: actions.openChangelog,
+  }), [actions.dismissNotice, actions.openChangelog, model.notice]);
+}

--- a/apps/desktop/src/hooks/updates/lifecycle/use-installed-release-title-cache-lifecycle.ts
+++ b/apps/desktop/src/hooks/updates/lifecycle/use-installed-release-title-cache-lifecycle.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import {
+  normalizeReleaseTitlePair,
+  type DesktopReleaseManifest,
+  type InstalledReleaseManifestStatus,
+} from "@/lib/domain/updates/release-notice";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+// Keeps exactly one valid current installed version/title pair as the quiet
+// offline fallback. A successful no-title manifest clears any stale pair.
+export function useInstalledReleaseTitleCacheLifecycle(input: {
+  currentVersion: string | null;
+  status: InstalledReleaseManifestStatus;
+  data: DesktopReleaseManifest | null;
+}): void {
+  const hydrated = useUserPreferencesStore((state) => state._hydrated);
+  const cachedInstalledRelease = useUserPreferencesStore(
+    (state) => state.cachedInstalledRelease,
+  );
+  const setPreference = useUserPreferencesStore((state) => state.set);
+
+  useEffect(() => {
+    if (!hydrated || !input.currentVersion) {
+      return;
+    }
+
+    const normalizedCachedRelease = normalizeReleaseTitlePair(
+      cachedInstalledRelease,
+    );
+    if (
+      cachedInstalledRelease !== null
+      && (
+        normalizedCachedRelease?.version !== input.currentVersion
+        || JSON.stringify(normalizedCachedRelease)
+          !== JSON.stringify(cachedInstalledRelease)
+      )
+    ) {
+      setPreference("cachedInstalledRelease", null);
+      return;
+    }
+
+    if (input.status !== "success") {
+      return;
+    }
+
+    const nextCachedRelease = input.data?.version === input.currentVersion
+      ? normalizeReleaseTitlePair(input.data)
+      : null;
+    if (
+      JSON.stringify(nextCachedRelease)
+      === JSON.stringify(cachedInstalledRelease)
+    ) {
+      return;
+    }
+
+    setPreference("cachedInstalledRelease", nextCachedRelease);
+  }, [
+    cachedInstalledRelease,
+    hydrated,
+    input.currentVersion,
+    input.data,
+    input.status,
+    setPreference,
+  ]);
+}

--- a/apps/desktop/src/hooks/updates/workflows/use-release-notice-actions.ts
+++ b/apps/desktop/src/hooks/updates/workflows/use-release-notice-actions.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from "react";
+import { RELEASE_NOTICE_CHANGELOG_URL } from "@/config/release-notice";
+import { useTauriShellActions } from "@/hooks/access/tauri/use-shell-actions";
+import type { ReleaseNotice } from "@/lib/domain/updates/release-notice";
+import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
+
+export function useReleaseNoticeActions(notice: ReleaseNotice | null) {
+  const setPreference = useUserPreferencesStore(
+    (state) => state.set,
+  );
+  const { openExternal } = useTauriShellActions();
+
+  const dismissNotice = useCallback(() => {
+    if (!notice) {
+      return;
+    }
+
+    setPreference("acknowledgedReleaseVersion", notice.version);
+  }, [notice, setPreference]);
+
+  const openChangelog = useCallback(() => {
+    if (!notice) {
+      return;
+    }
+
+    void openExternal(RELEASE_NOTICE_CHANGELOG_URL)
+      .then(() => {
+        setPreference("acknowledgedReleaseVersion", notice.version);
+      })
+      .catch(() => undefined);
+  }, [notice, openExternal, setPreference]);
+
+  return useMemo(() => ({
+    dismissNotice,
+    openChangelog,
+  }), [dismissNotice, openChangelog]);
+}

--- a/apps/desktop/src/lib/access/downloads/desktop-release-manifest.test.ts
+++ b/apps/desktop/src/lib/access/downloads/desktop-release-manifest.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchDesktopReleaseManifest } from "@/lib/access/downloads/desktop-release-manifest";
+
+describe("desktop release manifest access", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("encodes the installed version as one immutable path segment", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "0.3.25+arm-test" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDesktopReleaseManifest("0.3.25+arm-test");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://downloads.proliferate.com/desktop/stable/0.3.25%2Barm-test/latest.json",
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      },
+    );
+  });
+
+  it("rejects non-success responses without parsing their body", async () => {
+    const json = vi.fn();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404, json })));
+
+    await expect(fetchDesktopReleaseManifest("0.3.25"))
+      .rejects.toThrow("Desktop release manifest request failed (404)");
+    expect(json).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/access/downloads/desktop-release-manifest.ts
+++ b/apps/desktop/src/lib/access/downloads/desktop-release-manifest.ts
@@ -1,0 +1,21 @@
+const DESKTOP_RELEASE_MANIFEST_BASE_URL =
+  "https://downloads.proliferate.com/desktop/stable";
+
+export async function fetchDesktopReleaseManifest(
+  version: string,
+): Promise<unknown> {
+  const encodedVersion = encodeURIComponent(version);
+  const response = await fetch(
+    `${DESKTOP_RELEASE_MANIFEST_BASE_URL}/${encodedVersion}/latest.json`,
+    {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Desktop release manifest request failed (${response.status})`);
+  }
+
+  return await response.json();
+}

--- a/apps/desktop/src/lib/access/tauri/updater.test.ts
+++ b/apps/desktop/src/lib/access/tauri/updater.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updaterMocks = vi.hoisted(() => ({
+  check: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => updaterMocks);
+
+import { checkForUpdate } from "@/lib/access/tauri/updater";
+
+describe("Tauri updater access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves manifest notes from the Tauri body as the target title", async () => {
+    const update = {
+      version: "0.3.25",
+      body: "Introducing Grok",
+      downloadAndInstall: vi.fn(),
+    };
+    updaterMocks.check.mockResolvedValue(update);
+
+    await expect(checkForUpdate()).resolves.toEqual({
+      kind: "available",
+      version: "0.3.25",
+      title: "Introducing Grok",
+      update,
+    });
+  });
+
+  it("keeps an available update valid when the manifest has no notes", async () => {
+    const update = { version: "0.3.25", downloadAndInstall: vi.fn() };
+    updaterMocks.check.mockResolvedValue(update);
+
+    await expect(checkForUpdate()).resolves.toEqual({
+      kind: "available",
+      version: "0.3.25",
+      title: null,
+      update,
+    });
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/updater.ts
+++ b/apps/desktop/src/lib/access/tauri/updater.ts
@@ -3,7 +3,12 @@ export type UpdateHandle = unknown;
 
 export type UpdateCheckResult =
   | { kind: "current" }
-  | { kind: "available"; version: string; update: UpdateHandle }
+  | {
+      kind: "available";
+      version: string;
+      title: string | null;
+      update: UpdateHandle;
+    }
   | { kind: "error"; message: string };
 
 export async function checkForUpdate(): Promise<UpdateCheckResult> {
@@ -11,7 +16,12 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
     const { check } = await import("@tauri-apps/plugin-updater");
     const update = await check();
     if (!update) return { kind: "current" };
-    return { kind: "available", version: update.version, update };
+    return {
+      kind: "available",
+      version: update.version,
+      title: typeof update.body === "string" ? update.body : null,
+      update,
+    };
   } catch (e) {
     return {
       kind: "error",

--- a/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
+++ b/apps/desktop/src/lib/domain/preferences/persisted-metadata.ts
@@ -69,6 +69,8 @@ export function selectPersistedUserPreferencesSlice(
     pasteAttachmentsEnabled: preferences.pasteAttachmentsEnabled,
     reviewDefaultsByKind: preferences.reviewDefaultsByKind,
     reviewPersonalitiesByKind: preferences.reviewPersonalitiesByKind,
+    acknowledgedReleaseVersion: preferences.acknowledgedReleaseVersion,
+    cachedInstalledRelease: preferences.cachedInstalledRelease,
   };
 }
 

--- a/apps/desktop/src/lib/domain/preferences/user/migration.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/migration.ts
@@ -19,6 +19,10 @@ import {
 } from "@/lib/domain/preferences/user/model";
 import { isValidWorktreeAutoDeleteLimit } from "@/lib/domain/preferences/user/worktree-auto-delete";
 import type { LegacyUserPreferencesInput } from "@/lib/domain/preferences/user/persisted-keys";
+import {
+  normalizeReleaseTitlePair,
+  normalizeReleaseVersion,
+} from "@/lib/domain/updates/release-notice";
 
 export function migrateUserPreferences(preferences: LegacyUserPreferencesInput): {
   preferences: UserPreferences;
@@ -176,6 +180,25 @@ export function migrateUserPreferences(preferences: LegacyUserPreferencesInput):
     !== JSON.stringify(next.reviewPersonalitiesByKind)
   ) {
     next.reviewPersonalitiesByKind = sanitizedReviewPersonalitiesByKind;
+    changed = true;
+  }
+
+  const acknowledgedReleaseVersion = normalizeReleaseVersion(
+    next.acknowledgedReleaseVersion,
+  );
+  if (acknowledgedReleaseVersion !== next.acknowledgedReleaseVersion) {
+    next.acknowledgedReleaseVersion = acknowledgedReleaseVersion;
+    changed = true;
+  }
+
+  const cachedInstalledRelease = normalizeReleaseTitlePair(
+    next.cachedInstalledRelease,
+  );
+  if (
+    JSON.stringify(cachedInstalledRelease)
+    !== JSON.stringify(next.cachedInstalledRelease)
+  ) {
+    next.cachedInstalledRelease = cachedInstalledRelease;
     changed = true;
   }
 

--- a/apps/desktop/src/lib/domain/preferences/user/model.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/model.ts
@@ -14,6 +14,7 @@ import type {
   ReviewPersonalitiesByKind,
 } from "@/lib/domain/preferences/review-preferences";
 import { DEFAULT_OPEN_IN_TARGET_ID } from "@/config/open-target-defaults";
+import type { ReleaseTitle } from "@/lib/domain/updates/release-notice";
 
 export type BranchPrefixType = "none" | "proliferate" | "github_username";
 export type TurnEndSoundId = "ding";
@@ -49,6 +50,8 @@ export interface UserPreferences {
   pasteAttachmentsEnabled: boolean;
   reviewDefaultsByKind: ReviewDefaultsByKind;
   reviewPersonalitiesByKind: ReviewPersonalitiesByKind;
+  acknowledgedReleaseVersion: string | null;
+  cachedInstalledRelease: ReleaseTitle | null;
 }
 
 export const NEW_USER_DEFAULTS: UserPreferences = {
@@ -74,6 +77,8 @@ export const NEW_USER_DEFAULTS: UserPreferences = {
   pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
+  acknowledgedReleaseVersion: null,
+  cachedInstalledRelease: null,
 };
 
 export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
@@ -101,6 +106,8 @@ export const PERSISTED_RECORD_BACKFILL: UserPreferences = {
   pasteAttachmentsEnabled: true,
   reviewDefaultsByKind: { plan: null, code: null },
   reviewPersonalitiesByKind: { plan: [], code: [] },
+  acknowledgedReleaseVersion: null,
+  cachedInstalledRelease: null,
 };
 
 export const USER_PREFERENCE_DEFAULTS = NEW_USER_DEFAULTS;

--- a/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts
@@ -23,6 +23,8 @@ const USER_PREFERENCE_KEYS = [
   "pasteAttachmentsEnabled",
   "reviewDefaultsByKind",
   "reviewPersonalitiesByKind",
+  "acknowledgedReleaseVersion",
+  "cachedInstalledRelease",
 ] as const satisfies readonly (keyof UserPreferences)[];
 
 const USER_PREFERENCE_KEY_SET = new Set<string>(USER_PREFERENCE_KEYS);
@@ -39,6 +41,8 @@ const DEPRECATED_USER_PREFERENCE_KEYS = [
   "pluginsInCodingSessionsEnabled",
   "powersInCodingSessionsEnabled",
   "cloudRuntimeInputSyncEnabled",
+  "dismissedAvailableVersion",
+  "acknowledgedAvailableVersion",
 ] as const;
 
 const DEPRECATED_USER_PREFERENCE_KEY_SET = new Set<string>(DEPRECATED_USER_PREFERENCE_KEYS);

--- a/apps/desktop/src/lib/domain/preferences/user/release-notice-preferences.test.ts
+++ b/apps/desktop/src/lib/domain/preferences/user/release-notice-preferences.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { migrateUserPreferences } from "@/lib/domain/preferences/user/migration";
+import { USER_PREFERENCE_DEFAULTS } from "@/lib/domain/preferences/user/model";
+import type { LegacyUserPreferencesInput } from "@/lib/domain/preferences/user/persisted-keys";
+
+describe("release notice preference migration", () => {
+  it("preserves exact normalized version keys and one current cached title", () => {
+    const result = migrateUserPreferences({
+      ...USER_PREFERENCE_DEFAULTS,
+      acknowledgedReleaseVersion: " 0.3.24 ",
+      cachedInstalledRelease: {
+        version: " 0.3.24 ",
+        title: " Faster workspaces ",
+      },
+    });
+
+    expect(result.preferences).toMatchObject({
+      acknowledgedReleaseVersion: "0.3.24",
+      cachedInstalledRelease: {
+        version: "0.3.24",
+        title: "Faster workspaces",
+      },
+    });
+    expect(result.changed).toBe(true);
+  });
+
+  it("drops malformed and unbounded release-notice state", () => {
+    const input = {
+      ...USER_PREFERENCE_DEFAULTS,
+      acknowledgedReleaseVersion: 25,
+      cachedInstalledRelease: {
+        version: "0.3.25",
+        title: "x".repeat(81),
+      },
+    } as unknown as LegacyUserPreferencesInput;
+
+    const result = migrateUserPreferences(input);
+
+    expect(result.preferences.acknowledgedReleaseVersion).toBeNull();
+    expect(result.preferences.cachedInstalledRelease).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/domain/updates/release-notice.test.ts
+++ b/apps/desktop/src/lib/domain/updates/release-notice.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeReleaseTitle,
+  normalizeReleaseTitlePair,
+  normalizeReleaseVersion,
+  parseDesktopReleaseManifest,
+  resolveInstalledReleaseTitle,
+  selectReleaseNotice,
+} from "@/lib/domain/updates/release-notice";
+
+describe("release notice normalization", () => {
+  it("normalizes transport whitespace without changing version identity", () => {
+    expect(normalizeReleaseVersion(" 0.3.25-beta.1 ")).toBe("0.3.25-beta.1");
+    expect(normalizeReleaseVersion("0.3.25\n0.3.26")).toBeNull();
+    expect(normalizeReleaseVersion("0.3.25/next")).toBeNull();
+  });
+
+  it("accepts a trimmed 80-character title and rejects invalid titles", () => {
+    const exactLimit = "a".repeat(80);
+    expect(normalizeReleaseTitle(`  ${exactLimit}  `)).toBe(exactLimit);
+    expect(normalizeReleaseTitle("a".repeat(81))).toBeNull();
+    expect(normalizeReleaseTitle("Introducing Grok\nRead more")).toBeNull();
+    expect(normalizeReleaseTitle("\nIntroducing Grok\n")).toBeNull();
+    expect(normalizeReleaseTitle("Introducing Grok\u2028Read more")).toBeNull();
+    expect(normalizeReleaseTitle("   ")).toBeNull();
+  });
+
+  it("bounds the offline cache to one valid version/title pair", () => {
+    expect(normalizeReleaseTitlePair({
+      version: " 0.3.25 ",
+      title: " Introducing Grok ",
+    })).toEqual({ version: "0.3.25", title: "Introducing Grok" });
+    expect(normalizeReleaseTitlePair({
+      version: "0.3.25",
+      title: "line one\nline two",
+    })).toBeNull();
+  });
+});
+
+describe("desktop release manifest parsing", () => {
+  it("requires the response version to match the requested version exactly", () => {
+    expect(parseDesktopReleaseManifest({
+      version: "0.3.25",
+      notes: "Introducing Grok",
+    }, "0.3.25")).toEqual({
+      version: "0.3.25",
+      title: "Introducing Grok",
+    });
+
+    expect(parseDesktopReleaseManifest({
+      version: "0.3.26",
+      notes: "Introducing Grok",
+    }, "0.3.25")).toBeNull();
+  });
+
+  it("keeps a matching manifest valid when notes are absent or malformed", () => {
+    expect(parseDesktopReleaseManifest({ version: "0.3.25" }, "0.3.25"))
+      .toEqual({ version: "0.3.25", title: null });
+    expect(parseDesktopReleaseManifest({
+      version: "0.3.25",
+      notes: "a".repeat(81),
+    }, "0.3.25")).toEqual({ version: "0.3.25", title: null });
+  });
+});
+
+describe("release notice selection", () => {
+  const installedRelease = {
+    version: "0.3.24",
+    title: "Faster workspaces",
+  };
+
+  it("shows only the installed release", () => {
+    expect(selectReleaseNotice({
+      installedRelease,
+      acknowledgedReleaseVersion: null,
+    })).toEqual(installedRelease);
+  });
+
+  it("uses exact version keys for installed acknowledgments", () => {
+    expect(selectReleaseNotice({
+      installedRelease,
+      acknowledgedReleaseVersion: "0.3.24",
+    })).toBeNull();
+    expect(selectReleaseNotice({
+      installedRelease,
+      acknowledgedReleaseVersion: "0.3.24-beta.1",
+    })).toEqual(installedRelease);
+  });
+
+  it("uses only the current version's cached title while offline", () => {
+    const cachedRelease = { version: "0.3.25", title: "Introducing Grok" };
+    expect(resolveInstalledReleaseTitle({
+      currentVersion: "0.3.25",
+      manifestStatus: "error",
+      manifest: undefined,
+      cachedRelease,
+    })).toEqual(cachedRelease);
+    expect(resolveInstalledReleaseTitle({
+      currentVersion: "0.3.26",
+      manifestStatus: "error",
+      manifest: undefined,
+      cachedRelease,
+    })).toBeNull();
+  });
+
+  it("lets a successful no-title manifest override the offline cache", () => {
+    expect(resolveInstalledReleaseTitle({
+      currentVersion: "0.3.25",
+      manifestStatus: "success",
+      manifest: { version: "0.3.25", title: null },
+      cachedRelease: { version: "0.3.25", title: "Stale title" },
+    })).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/domain/updates/release-notice.ts
+++ b/apps/desktop/src/lib/domain/updates/release-notice.ts
@@ -1,0 +1,141 @@
+export const RELEASE_NOTICE_TITLE_MAX_LENGTH = 80;
+
+const RELEASE_VERSION_MAX_LENGTH = 128;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
+const LINE_SEPARATOR_PATTERN = /[\r\n\u2028\u2029]/u;
+const SAFE_RELEASE_VERSION_PATTERN = /^[0-9A-Za-z.+-]+$/u;
+
+export interface ReleaseTitle {
+  version: string;
+  title: string;
+}
+
+export interface DesktopReleaseManifest {
+  version: string;
+  title: string | null;
+}
+
+export type ReleaseNotice = ReleaseTitle;
+
+export type InstalledReleaseManifestStatus = "pending" | "error" | "success";
+
+export function normalizeReleaseVersion(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  if (LINE_SEPARATOR_PATTERN.test(value)) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (
+    !normalized
+    || normalized.length > RELEASE_VERSION_MAX_LENGTH
+    || !SAFE_RELEASE_VERSION_PATTERN.test(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function normalizeReleaseTitle(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  if (LINE_SEPARATOR_PATTERN.test(value)) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (
+    !normalized
+    || CONTROL_CHARACTER_PATTERN.test(normalized)
+    || [...normalized].length > RELEASE_NOTICE_TITLE_MAX_LENGTH
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function normalizeReleaseTitlePair(value: unknown): ReleaseTitle | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const candidate = value as { version?: unknown; title?: unknown };
+  const version = normalizeReleaseVersion(candidate.version);
+  const title = normalizeReleaseTitle(candidate.title);
+  return version && title ? { version, title } : null;
+}
+
+export function parseDesktopReleaseManifest(
+  value: unknown,
+  requestedVersion: string,
+): DesktopReleaseManifest | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const expectedVersion = normalizeReleaseVersion(requestedVersion);
+  const candidate = value as { version?: unknown; notes?: unknown };
+  const version = normalizeReleaseVersion(candidate.version);
+  if (!expectedVersion || version !== expectedVersion) {
+    return null;
+  }
+
+  return {
+    version,
+    title: normalizeReleaseTitle(candidate.notes),
+  };
+}
+
+export function resolveInstalledReleaseTitle(input: {
+  currentVersion: unknown;
+  manifestStatus: InstalledReleaseManifestStatus;
+  manifest: DesktopReleaseManifest | null | undefined;
+  cachedRelease: unknown;
+}): ReleaseTitle | null {
+  const currentVersion = normalizeReleaseVersion(input.currentVersion);
+  if (!currentVersion) {
+    return null;
+  }
+
+  if (input.manifestStatus === "success") {
+    if (
+      input.manifest?.version !== currentVersion
+      || !input.manifest.title
+    ) {
+      return null;
+    }
+    return {
+      version: currentVersion,
+      title: input.manifest.title,
+    };
+  }
+
+  const cachedRelease = normalizeReleaseTitlePair(input.cachedRelease);
+  return cachedRelease?.version === currentVersion ? cachedRelease : null;
+}
+
+export function selectReleaseNotice(input: {
+  installedRelease: unknown;
+  acknowledgedReleaseVersion: unknown;
+}): ReleaseNotice | null {
+  const installedRelease = normalizeReleaseTitlePair(input.installedRelease);
+  const acknowledgedReleaseVersion = normalizeReleaseVersion(
+    input.acknowledgedReleaseVersion,
+  );
+
+  if (
+    installedRelease
+    && installedRelease.version !== acknowledgedReleaseVersion
+  ) {
+    return installedRelease;
+  }
+
+  return null;
+}

--- a/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
+++ b/apps/desktop/src/stores/preferences/user-preferences-store.test.ts
@@ -198,17 +198,23 @@ describe("user preference migration", () => {
       futurePreference: true,
       onboardingCompletedVersion: 1,
       onboardingPrimaryGoalId: "build",
+      dismissedAvailableVersion: "0.3.25",
+      acknowledgedAvailableVersion: "0.3.25",
     } as unknown as UserPreferences);
 
     await bootstrapUserPreferencesForTest();
     const state = useUserPreferencesStore.getState() as unknown as Record<string, unknown>;
     expect(state.onboardingCompletedVersion).toBeUndefined();
     expect(state.onboardingPrimaryGoalId).toBeUndefined();
+    expect(state.dismissedAvailableVersion).toBeUndefined();
+    expect(state.acknowledgedAvailableVersion).toBeUndefined();
 
     const persisted = storeMocks.values.get("user_preferences") as Record<string, unknown>;
     expect(persisted.futurePreference).toBe(true);
     expect(persisted.onboardingCompletedVersion).toBeUndefined();
     expect(persisted.onboardingPrimaryGoalId).toBeUndefined();
+    expect(persisted.dismissedAvailableVersion).toBeUndefined();
+    expect(persisted.acknowledgedAvailableVersion).toBeUndefined();
   });
 
   it("preserves unrelated unknown keys while marking model visibility defaults reset", async () => {

--- a/apps/desktop/src/stores/updater/updater-store.test.ts
+++ b/apps/desktop/src/stores/updater/updater-store.test.ts
@@ -42,6 +42,20 @@ describe("updater store", () => {
     expect(useUpdaterStore.getState().manualCheckCompletedAt).toBeNull();
   });
 
+  it("keeps the authored title with its available version", () => {
+    useUpdaterStore.getState().setAvailable(
+      "0.3.25",
+      {},
+      "Introducing Grok",
+    );
+
+    expect(useUpdaterStore.getState().availableVersion).toBe("0.3.25");
+    expect(useUpdaterStore.getState().availableTitle).toBe("Introducing Grok");
+
+    useUpdaterStore.getState().reset();
+    expect(useUpdaterStore.getState().availableTitle).toBeNull();
+  });
+
   it("arms and disarms restart-when-idle", () => {
     useUpdaterStore.getState().setRestartWhenIdle(true);
     expect(useUpdaterStore.getState().restartWhenIdle).toBe(true);

--- a/apps/desktop/src/stores/updater/updater-store.ts
+++ b/apps/desktop/src/stores/updater/updater-store.ts
@@ -15,6 +15,7 @@ export type UpdaterErrorSource = "check" | "download";
 interface UpdaterState {
   phase: UpdaterPhase;
   availableVersion: string | null;
+  availableTitle: string | null;
   lastCheckedAt: string | null;
   errorMessage: string | null;
   errorSource: UpdaterErrorSource | null;
@@ -27,7 +28,11 @@ interface UpdaterState {
   _updateHandle: unknown | null;
 
   setPhase: (phase: UpdaterPhase) => void;
-  setAvailable: (version: string, handle: unknown) => void;
+  setAvailable: (
+    version: string,
+    handle: unknown,
+    title?: string | null,
+  ) => void;
   setDownloadProgress: (progress: number) => void;
   setReady: () => void;
   setError: (message: string, source: UpdaterErrorSource) => void;
@@ -42,6 +47,7 @@ interface UpdaterState {
 export const useUpdaterStore = create<UpdaterState>((set) => ({
   phase: "idle",
   availableVersion: null,
+  availableTitle: null,
   lastCheckedAt: null,
   errorMessage: null,
   errorSource: null,
@@ -54,10 +60,11 @@ export const useUpdaterStore = create<UpdaterState>((set) => ({
   setPhase: (phase) =>
     set({ phase, errorMessage: null, errorSource: null, restartPromptOpen: false }),
 
-  setAvailable: (version, handle) =>
+  setAvailable: (version, handle, title = null) =>
     set({
       phase: "available",
       availableVersion: version,
+      availableTitle: title,
       _updateHandle: handle,
       errorMessage: null,
       errorSource: null,
@@ -94,6 +101,7 @@ export const useUpdaterStore = create<UpdaterState>((set) => ({
     set({
       phase: "idle",
       availableVersion: null,
+      availableTitle: null,
       errorMessage: null,
       errorSource: null,
       downloadProgress: null,

--- a/apps/packages/ui/src/primitives/Badge.tsx
+++ b/apps/packages/ui/src/primitives/Badge.tsx
@@ -1,7 +1,14 @@
 import { forwardRef, type HTMLAttributes } from "react";
 import { twMerge } from "../utils/tw-merge";
 
-export type BadgeTone = "neutral" | "accent" | "success" | "info" | "warning" | "destructive";
+export type BadgeTone =
+  | "neutral"
+  | "accent"
+  | "success"
+  | "info"
+  | "warning"
+  | "destructive"
+  | "sidebar";
 
 interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   tone?: BadgeTone;
@@ -14,6 +21,7 @@ const toneClasses: Record<BadgeTone, string> = {
   info: "border-info/25 bg-info/10 text-info",
   warning: "border-warning/30 bg-warning/10 text-warning",
   destructive: "border-destructive/30 bg-destructive/10 text-destructive",
+  sidebar: "border-sidebar-border bg-sidebar-accent text-sidebar-muted-foreground",
 };
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(

--- a/apps/packages/ui/src/primitives/Button.tsx
+++ b/apps/packages/ui/src/primitives/Button.tsx
@@ -2,7 +2,16 @@ import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { twMerge } from "../utils/tw-merge";
 import { Spinner } from "./Spinner";
 
-type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "destructive" | "inverted" | "unstyled";
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "ghost"
+  | "destructive"
+  | "inverted"
+  | "sidebar"
+  | "sidebar-link"
+  | "unstyled";
 type ButtonSize = "sm" | "md" | "pill" | "icon" | "icon-sm" | "unstyled";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -24,6 +33,10 @@ const variantClasses: Record<ButtonVariant, string> = {
     "bg-destructive text-destructive-foreground font-medium hover:bg-destructive/90",
   inverted:
     "bg-foreground text-background hover:bg-foreground/80",
+  sidebar:
+    "font-medium text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring",
+  "sidebar-link":
+    "text-ui font-medium text-sidebar-foreground underline decoration-sidebar-muted-foreground/60 underline-offset-2 hover:decoration-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring",
   unstyled: "",
 };
 

--- a/apps/packages/ui/src/primitives/IconButton.tsx
+++ b/apps/packages/ui/src/primitives/IconButton.tsx
@@ -21,7 +21,7 @@ interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const toneClasses: Record<IconButtonTone, string> = {
   default: "text-muted-foreground hover:bg-accent hover:text-foreground",
   sidebar:
-    "text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground",
+    "text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring",
 };
 
 const sizeClasses: Record<IconButtonSize, string> = {

--- a/scripts/ci-cd/generate-updater-manifest.test.mjs
+++ b/scripts/ci-cd/generate-updater-manifest.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const generator = path.join(repoRoot, "scripts/generate-updater-manifest.mjs");
+
+function writeArtifacts(root) {
+  const artifacts = path.join(root, "artifacts");
+  const fixtures = [
+    ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.app.tar.gz"],
+    ["desktop-x86_64-apple-darwin", "Proliferate_x64.app.tar.gz"],
+  ];
+
+  for (const [directory, artifact] of fixtures) {
+    const target = path.join(artifacts, directory);
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, artifact), "archive");
+    fs.writeFileSync(path.join(target, `${artifact}.sig`), `signature-${directory}\n`);
+  }
+
+  return artifacts;
+}
+
+function generateManifest(t, notes) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-updater-manifest-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const output = path.join(root, "latest.json");
+  const args = [
+    generator,
+    "--version",
+    "1.2.3",
+    "--artifacts-dir",
+    writeArtifacts(root),
+    "--base-url",
+    "https://downloads.proliferate.com/desktop/stable",
+    "--output",
+    output,
+  ];
+  if (notes !== undefined) args.push("--notes", notes);
+
+  const result = spawnSync(process.execPath, args, { encoding: "utf8" });
+  return { output, result };
+}
+
+test("writes a trimmed release title as top-level notes", (t) => {
+  const { output, result } = generateManifest(t, "  Introducing Grok  ");
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(manifest.version, "1.2.3");
+  assert.equal(manifest.notes, "Introducing Grok");
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("omits notes when the release title is absent or blank", (t) => {
+  for (const notes of [undefined, "   "]) {
+    const { output, result } = generateManifest(t, notes);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(Object.hasOwn(JSON.parse(fs.readFileSync(output, "utf8")), "notes"), false);
+  }
+});
+
+test("accepts an 80-character release title", (t) => {
+  const title = "a".repeat(80);
+  const { output, result } = generateManifest(t, title);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(fs.readFileSync(output, "utf8")).notes, title);
+});
+
+test("validates and previews a release title without build artifacts", () => {
+  const result = spawnSync(
+    process.execPath,
+    [generator, "--notes", "  Introducing Grok  ", "--validate-notes-only", "true"],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Release title: Introducing Grok$/m);
+});
+
+test("rejects multiline, control-character, and overlong release titles", (t) => {
+  const invalidTitles = [
+    ["Introducing\nGrok", /single line/],
+    ["Introducing\tGrok", /control characters/],
+    ["a".repeat(81), /at most 80 characters/],
+  ];
+
+  for (const [notes, expectedError] of invalidTitles) {
+    const { output, result } = generateManifest(t, notes);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, expectedError);
+    assert.equal(fs.existsSync(output), false);
+  }
+});

--- a/scripts/ci-cd/release-title-propagation.test.mjs
+++ b/scripts/ci-cd/release-title-propagation.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowRoot = new URL("../../.github/workflows/", import.meta.url);
+
+async function workflow(name) {
+  return readFile(new URL(name, workflowRoot), "utf8");
+}
+
+test("desktop release accepts and writes the optional release title", async () => {
+  const source = await workflow("release-desktop.yml");
+
+  assert.match(source, /workflow_dispatch:[\s\S]*?release_title:/);
+  assert.match(source, /workflow_call:[\s\S]*?release_title:/);
+  assert.match(source, /RELEASE_TITLE: \$\{\{ inputs\.release_title \|\| '' \}\}/);
+  assert.match(source, /--notes "\$RELEASE_TITLE"/);
+});
+
+test("same-version desktop release runs share one non-cancelling concurrency lock", async () => {
+  const source = await workflow("release-desktop.yml");
+  const jobs = source.indexOf("\njobs:");
+  const workflowConfiguration = source.slice(0, jobs);
+
+  assert.match(
+    workflowConfiguration,
+    /concurrency:\s+group: release-desktop-\$\{\{ inputs\.version && format\('desktop-v\{0\}', inputs\.version\) \|\| github\.ref_name \}\}\s+cancel-in-progress: false/,
+  );
+});
+
+test("release coordinators pass the title into the desktop release lane", async () => {
+  const [nightly, hotfix, promote, deployDesktop] = await Promise.all([
+    workflow("nightly-release-train.yml"),
+    workflow("hotfix-production.yml"),
+    workflow("promote-production.yml"),
+    workflow("_deploy-desktop.yml"),
+  ]);
+
+  for (const source of [nightly, hotfix, promote]) {
+    assert.match(source, /workflow_dispatch:[\s\S]*?release_title:/);
+    assert.match(
+      source,
+      /release_title: \$\{\{ github\.event\.inputs\.release_title \|\| '' \}\}/,
+    );
+  }
+
+  assert.match(deployDesktop, /workflow_call:[\s\S]*?release_title:/);
+  assert.match(deployDesktop, /release_title: \$\{\{ inputs\.release_title \}\}/);
+});
+
+test("desktop updater publication fails closed before overwriting a released version", async () => {
+  const [source, infra] = await Promise.all([
+    workflow("release-desktop.yml"),
+    readFile(new URL("../../apps/desktop/infra/main.tf", import.meta.url), "utf8"),
+  ]);
+
+  const preflight = source.indexOf("- name: Refuse an existing immutable updater manifest");
+  const assetUpload = source.indexOf("- name: Upload desktop assets to S3");
+  assert.ok(preflight >= 0 && preflight < assetUpload, "immutable preflight must run before asset upload");
+  assert.match(
+    source.slice(preflight, assetUpload),
+    /head-object[\s\S]*?if \[\[ "\$head_error" != \*"\(404\)"\* \]\]; then[\s\S]*?exit 1/,
+  );
+  assert.match(infra, /"s3:GetObject"/);
+});
+
+test("desktop updater creates the immutable manifest before changing the rolling feed", async () => {
+  const source = await workflow("release-desktop.yml");
+  const publish = source.slice(source.indexOf("- name: Upload manifest to S3"));
+  const immutableCreate = publish.indexOf("aws s3api put-object");
+  const rollingUpload = publish.indexOf('"s3://${BUCKET}/desktop/stable/latest.json"');
+
+  assert.ok(
+    immutableCreate >= 0 && immutableCreate < rollingUpload,
+    "immutable manifest creation must gate the rolling upload",
+  );
+  assert.match(
+    publish.slice(immutableCreate, rollingUpload),
+    /--body latest\.json[\s\S]*?--if-none-match "\*"[\s\S]*?then[\s\S]*?exit 1[\s\S]*?fi/,
+  );
+});

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -21,6 +21,6 @@ apps/desktop/src/App.tsx 418 top-level desktop app shell/router pending route-tr
 apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
 apps/desktop/src/components/workspace/git/GitPanel.tsx 429 git panel pending staged/unstaged section split
 apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx 404 git review file row pending action-cluster split
-apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 410 workspace sidebar item pending indicator/menu split
+apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 414 workspace sidebar item pending indicator/menu split
 apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-domain/src/chats/transcript/transcript-row-model.ts 940 transcript row model pending row-kind module split

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -34,9 +34,43 @@ const version = args.version;
 const artifactsDir = args["artifacts-dir"];
 const baseUrl = args["base-url"];
 const output = args.output;
+const rawNotes = args.notes;
+const validateNotesOnly = args["validate-notes-only"] === "true";
+
+const MAX_NOTES_LENGTH = 80;
+
+function normalizeNotes(value) {
+  if (value === undefined) return undefined;
+  if (/[\r\n\u2028\u2029]/u.test(value)) {
+    throw new Error("release title must be a single line");
+  }
+
+  const notes = value.trim();
+  if (!notes) return undefined;
+  if (/[\u0000-\u001F\u007F-\u009F]/u.test(notes)) {
+    throw new Error("release title must not contain control characters");
+  }
+  if (Array.from(notes).length > MAX_NOTES_LENGTH) {
+    throw new Error(`release title must be at most ${MAX_NOTES_LENGTH} characters`);
+  }
+  return notes;
+}
+
+let notes;
+try {
+  notes = normalizeNotes(rawNotes);
+} catch (error) {
+  console.error(`Invalid --notes: ${error.message}`);
+  process.exit(1);
+}
+
+if (validateNotesOnly) {
+  console.log(notes ? `Release title: ${notes}` : "Release title omitted");
+  process.exit(0);
+}
 
 if (!version || !artifactsDir || !baseUrl || !output) {
-  console.error("Usage: generate-updater-manifest.mjs --version <ver> --artifacts-dir <dir> --base-url <url> --output <file>");
+  console.error("Usage: generate-updater-manifest.mjs --version <ver> --artifacts-dir <dir> --base-url <url> --output <file> [--notes <title>] [--validate-notes-only true]");
   process.exit(1);
 }
 
@@ -64,6 +98,7 @@ const platforms = [
 
 const manifest = {
   version,
+  ...(notes ? { notes } : {}),
   pub_date: new Date().toISOString(),
   platforms: {},
 };

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -35,7 +35,7 @@ apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing des
 apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 900 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
-apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 631 existing desktop oversized test file
+apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 630 existing desktop oversized test file
 apps/web/src/hooks/chat/workflows/use-web-cloud-prompt-actions.ts 434 managed sandbox web prompt flow awaiting chat action split
 server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read path extends existing identity store
 server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_settings model added for catalog-driven per-harness settings

--- a/specs/codebase/features/README.md
+++ b/specs/codebase/features/README.md
@@ -29,6 +29,7 @@ low-level runtime contracts.
 | Support reporting | Desktop support report uploads, sanitization, diagnostics, and support-submitted issue handoff. | [support-reporting.md](support-reporting.md) |
 | Terminals | Workspace terminal pane UX, terminal record actions, and the creation grid contract for new terminals. | [terminals.md](terminals.md) |
 | Workspace migration | Workspace migration flows, user attestation, durability, queue state, and completion/error semantics. | [workspace-migration.md](workspace-migration.md) |
+| Desktop updates | Packaged updater metadata, version-aware sidebar release notices, acknowledgment, and post-install behavior. | [desktop-updates.md](desktop-updates.md) |
 
 ## Outline Coverage
 

--- a/specs/codebase/features/desktop-updates.md
+++ b/specs/codebase/features/desktop-updates.md
@@ -1,0 +1,150 @@
+# Desktop Updates And Release Notices
+
+Status: authoritative for the packaged Desktop updater, its sidebar release
+notice, and the version-specific metadata published on the Desktop downloads
+CDN.
+
+Read this spec with
+[`ci-cd.md`](../../developing/deploying/ci-cd.md) and
+[`desktop-update-testing.md`](../../developing/testing/desktop-update-testing.md).
+The CI/CD spec owns packaging, signing, publishing, and operator procedure; the
+testing spec owns the real N−1 to N updater mechanism; this feature spec owns
+user-visible update and release-notice behavior.
+
+## Product Contract
+
+The Desktop updater manifest is the release-notice source consumed by the app.
+It keeps the standard Tauri updater shape and may add one optional field:
+
+```json
+{
+  "version": "0.3.25",
+  "notes": "Introducing Grok",
+  "pub_date": "2026-07-12T00:00:00Z",
+  "platforms": {}
+}
+```
+
+- `version` is the exact Desktop version advertised or installed.
+- `notes`, when present, is the release-notice title. It is plain text, one
+  line, trimmed, and no longer than 80 characters.
+- The title does not contain Markdown or HTML and is never rendered as either.
+- The notice destination is always
+  `https://proliferate.com/changelog`; the manifest does not provide a URL.
+- A manifest without a valid `notes` title remains a valid updater manifest
+  and produces no release-notice card.
+
+The downloads CDN publishes the same manifest at two identities:
+
+- `desktop/stable/latest.json` is the rolling updater feed.
+- `desktop/stable/<version>/latest.json` is the immutable installed-version
+  record.
+
+The rolling feed answers which version is available. The immutable record
+answers which titled release is currently installed, including after an
+in-app upgrade, a manual DMG upgrade, or a fresh install.
+
+## Notice Selection
+
+The sidebar derives notices from the running version only:
+
+1. Resolve the exact installed app version.
+2. Read `desktop/stable/<installed-version>/latest.json`.
+3. Show its valid title unless that installed version was acknowledged.
+4. Otherwise, show no release notice.
+
+The rolling updater feed exposes its valid `notes` value through updater state.
+The morphing update toast uses `UPDATE` plus that authored headline throughout
+available, downloading, and ready phases while its operational status and
+Download/progress/Restart controls change. An untitled manifest retains the
+generic updater copy. An available target never produces a sidebar
+release-notice card; the updater toast is its single announcement surface.
+
+Installed versions are compared as exact strings after transport
+normalization. A response fetched from a versioned manifest path is rejected
+when its `version` does not match the requested version.
+
+Release-notice persistence stores `acknowledgedReleaseVersion` for the
+currently installed release. Closing the installed card or successfully
+opening its changelog records that exact version. Update checking, downloading,
+installation, restart, and available-target changes do not modify this
+acknowledgment, so an acknowledged installed notice cannot be resurrected by
+later updater activity.
+
+The app caches the current valid version/title pair as an offline fallback.
+Transport failure, malformed JSON, a mismatched version, or a missing title
+must fail quiet and must never block update checking, installation, relaunch,
+or the rest of the sidebar.
+
+## Updater UX Boundary
+
+The packaged Desktop updater remains a user-gated flow:
+
+- Settings → Desktop updates starts an explicit update check.
+- The compact update pill remains an operational indicator.
+- The update toast owns the pre-install announcement: a valid authored title
+  stays visible while its download action, progress, and restart action morph.
+  It also owns recoverable update errors.
+- The existing restart dialog owns completion of an installed update.
+- The release-notice card appears only after a titled version is running. It
+  supplies changelog context and never duplicates availability, download,
+  progress, restart, or error controls.
+
+The headless T4 scenario proves manifest selection, signature verification,
+and bundle replacement. Focused renderer tests and a packaged-WebView smoke
+prove the user-visible notice states and interactions.
+
+## Sidebar Presentation
+
+The release-notice card renders immediately above the sidebar account footer.
+
+- The installed-version notice uses the eyebrow `NEW`.
+- The authored title is the card headline.
+- The sole content action is `Changelog →` and opens the fixed external URL.
+- A close affordance is keyboard accessible and has an explicit accessible
+  label.
+
+The card uses sidebar semantic tokens, tolerates an 80-character title without
+overflow, and is absent when the sidebar is collapsed.
+
+## Release Operation
+
+`release_title` is an optional Desktop release input. Named launches provide
+it; unattended and routine releases may omit it. Manifest generation validates
+the title before any updater asset is published. The same generated JSON is
+then uploaded to both rolling and immutable manifest keys.
+
+The rolling and immutable records for a version must carry the same authored
+title. The packaged WebView must be able to fetch the immutable record from the
+public downloads CDN. Direct tag-push releases without an authored input remain
+valid and publish without `notes`. Atomic publication order, collision handling,
+same-version reruns, CORS configuration, and partial-publish recovery are owned
+by [`ci-cd.md`](../../developing/deploying/ci-cd.md).
+
+## Acceptance Matrix
+
+| Scenario | Required result |
+| --- | --- |
+| Titled update is available | Update toast shows `UPDATE` and the authored title with Download; the sidebar shows no notice for that target. |
+| Titled update is downloading or ready | The toast keeps the authored title visible while showing progress or Restart. |
+| Update installs and app relaunches | Sidebar shows `NEW` and the installed title. |
+| Installed card is closed | That installed version does not reappear. |
+| Changelog is opened | Fixed changelog URL opens and that version is acknowledged. |
+| Installed release was acknowledged before newer targets | Updater activity does not resurrect the installed notice. |
+| Fresh install has titled versioned manifest | Sidebar shows `NEW` once the normal app shell is available. |
+| Manifest omits `notes` | Existing updater UI works and no release card renders. |
+| Versioned response version mismatches | Response is ignored and cached valid data may be used. |
+| CDN is unavailable | App and updater remain usable; cached valid title may render. |
+| N-1 to N packaged upgrade | No target sidebar card appears before install; the installed title appears once after relaunch. |
+
+## Implementation Ownership
+
+- Release manifest generation and CDN publication:
+  `scripts/generate-updater-manifest.mjs`,
+  `.github/workflows/release-desktop.yml`, and `apps/desktop/infra/main.tf`.
+- Raw Tauri and downloads access: `apps/desktop/src/lib/access/**`.
+- React Query ownership for immutable manifests:
+  `apps/desktop/src/hooks/access/**`.
+- Pure selection and normalization: `apps/desktop/src/lib/domain/updates/**`.
+- Persistence and UI-facing orchestration: `apps/desktop/src/hooks/updates/**`.
+- Presentation: `apps/desktop/src/components/workspace/shell/sidebar/**`.

--- a/specs/codebase/features/settings-admin-ia.md
+++ b/specs/codebase/features/settings-admin-ia.md
@@ -290,6 +290,10 @@ Settings / User         Archived chats
 
 Support and Desktop updates are not `tbr`.
 
+This spec owns the placement and naming of the Desktop updates settings action.
+[`desktop-updates.md`](./desktop-updates.md) owns what that action does and the
+rest of the packaged updater and release-notice experience.
+
 ## 5. Target Model
 
 ### 5.0 Organization control center map

--- a/specs/codebase/structures/desktop-native/README.md
+++ b/specs/codebase/structures/desktop-native/README.md
@@ -40,6 +40,7 @@ apps/desktop/src-tauri/
 | --- | --- |
 | `specs/codebase/structures/desktop-native/specs/anyharness-sidecar.md` | How packaged Desktop bundles, finds, launches, monitors, and restarts the local AnyHarness runtime. |
 | `specs/codebase/structures/desktop-native/specs/agent-seeds.md` | How bundled agent seeds are built, packaged, hydrated, tracked, repaired, and distinguished from downloaded artifacts. |
+| `specs/codebase/features/desktop-updates.md` and `specs/developing/deploying/ci-cd.md` | Product behavior and release mechanics to read together when changing `tauri.conf.json` updater configuration, updater manifests, or packaged update behavior. |
 
 ## Rules
 

--- a/specs/developing/deploying/ci-cd.md
+++ b/specs/developing/deploying/ci-cd.md
@@ -402,10 +402,15 @@ apps/desktop/
   infra/main.tf              # updater bucket, CloudFront, GitHub OIDC release role
   src-tauri/tauri.conf.json  # updater endpoint, public key, bundle config
   src/lib/access/tauri/updater.ts
+  src/lib/access/downloads/desktop-release-manifest.ts
   src/hooks/access/tauri/use-updater.ts
+  src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts
+  src/hooks/updates/facade/use-release-notice.ts
   src/stores/updater/updater-store.ts
-  src/components/settings/UpdateSettings.tsx
-  src/components/feedback/UpdateBanner.tsx
+  src/components/feedback/UpdateToastPresenter.tsx
+  src/components/feedback/UpdateRestartDialog.tsx
+  src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
+  src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx
 server/
   infra/main.tf              # ECR, ECS, RDS, and server runtime infra
   deploy/                    # self-hosted production compose + update scripts
@@ -654,11 +659,13 @@ Flow:
    - normalizes macOS updater archive names to stable arch-specific filenames
    - creates a draft GitHub release with generated release notes
 8. The updater publish job then:
-   - generates `latest.json`
+   - generates `latest.json`, including the optional validated one-line
+     `release_title` as standard Tauri `notes`
    - generates `installers.json`
    - uploads signed updater artifacts and public DMG installers to
      `s3://.../desktop/stable/`
-   - uploads `latest.json` and `installers.json`
+   - atomically creates the immutable versioned `latest.json`, then uploads the
+     same file to rolling `latest.json` and publishes `installers.json`
    - invalidates the CloudFront cache for both manifests
 
 Note:
@@ -669,6 +676,24 @@ Note:
 - `latest.json` is reserved for Tauri updater clients and intentionally points
   at `.app.tar.gz` archives plus signatures. Public download pages should use
   `installers.json`, which points at the user-facing DMG installers.
+- Named Desktop releases may provide `release_title` (plain text, one line,
+  80 characters maximum). An omitted title remains a valid release and omits
+  `notes`; direct tag-push releases have no title input and use that fallback.
+- The publisher refuses an existing immutable
+  `desktop/stable/<version>/latest.json` before changing updater assets. After
+  asset upload it creates that key atomically with `If-None-Match: *`; only a
+  successful create permits the same generated file to replace rolling
+  `latest.json`. Any authorization, precondition, or write failure stops before
+  the rolling feed changes. Release runs serialize on a normalized
+  `desktop-v<version>` concurrency key without cancelling the active run, so a
+  queued same-version run reaches the immutable preflight only after the first
+  publisher finishes. A partial first publish that creates the immutable key
+  but fails before rolling publication requires explicit operator inspection
+  and removal of the immutable object before rerunning.
+- The downloads CloudFront distribution attaches public CORS response headers
+  for `GET`, `HEAD`, and preflight requests. Updater archive signatures remain
+  the installation trust boundary; release-notice copy is rendered only as
+  inert text.
 - Agent seeds are target-specific Tauri resources under
   `apps/desktop/src-tauri/agent-seeds/`. The seed builder cleans previous generated
   seed files before writing the current target archive, and the workflow asserts
@@ -742,28 +767,45 @@ make release-desktop-draft DESKTOP_RELEASE_TAG=desktop-v0.1.28
 
 Source of truth:
 
+- `specs/codebase/features/desktop-updates.md`
 - `apps/desktop/src-tauri/tauri.conf.json`
 - `apps/desktop/src/lib/access/tauri/updater.ts`
+- `apps/desktop/src/lib/access/downloads/desktop-release-manifest.ts`
+- `apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts`
 - `apps/desktop/src/hooks/access/tauri/use-updater.ts`
+- `apps/desktop/src/hooks/updates/facade/use-release-notice.ts`
 - `apps/desktop/src/stores/updater/updater-store.ts`
-- `apps/desktop/src/components/settings/UpdateSettings.tsx`
-- `apps/desktop/src/components/feedback/UpdateBanner.tsx`
+- `apps/desktop/src/components/feedback/UpdateToastPresenter.tsx`
+- `apps/desktop/src/components/feedback/UpdateRestartDialog.tsx`
+- `apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx`
+- `apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx`
 
 Flow:
 
 1. Tauri reads the updater endpoint from `apps/desktop/src-tauri/tauri.conf.json`.
 2. The packaged app checks `https://downloads.proliferate.com/desktop/stable/latest.json`.
 3. `apps/desktop/src/lib/access/tauri/updater.ts` is the only frontend wrapper around
-   `@tauri-apps/plugin-updater` and relaunch behavior.
+   `@tauri-apps/plugin-updater` and relaunch behavior. It preserves the target
+   version and optional Tauri `body` (`notes`) returned by the update check.
 4. `apps/desktop/src/hooks/access/tauri/use-updater.ts` owns the UI-facing updater flow:
    - initial delayed check
-   - six-hour polling
+   - 30-minute polling
    - download progress
    - install and relaunch
    - telemetry/error capture
-5. `apps/desktop/src/stores/updater/updater-store.ts` owns local updater UI state and
-   the persisted `lastCheckedAt` timestamp.
-6. `UpdateSettings.tsx` and `UpdateBanner.tsx` are the user-facing entrypoints.
+5. `apps/desktop/src/stores/updater/updater-store.ts` owns live updater UI state;
+   the access hook persists the last-check timestamp through the preferences
+   access boundary.
+6. The installed app fetches its immutable versioned manifest from the same
+   downloads CDN. The sidebar selects only that running version's unacknowledged
+   title and uses an exact-version cached title only when the CDN lookup is
+   pending or unavailable.
+7. `UpdateToastPresenter` owns the pre-install announcement and its authored
+   `UPDATE` title alongside Download, progress, restart, and recoverable-error
+   states. Available targets have no separate sidebar dismissal state.
+8. The sidebar release card appears only for an installed titled version. It
+   owns the `NEW` title presentation, installed-version acknowledgment, and the
+   fixed `https://proliferate.com/changelog` action.
 
 ### Runtime and SDK Release
 
@@ -1213,7 +1255,7 @@ Known failure signatures and what they mean:
 | Frontend updater platform wrapper | `apps/desktop/src/lib/access/tauri/updater.ts` |
 | Frontend updater orchestration | `apps/desktop/src/hooks/access/tauri/use-updater.ts` |
 | Frontend updater local state | `apps/desktop/src/stores/updater/updater-store.ts` |
-| Frontend updater UI surfaces | `apps/desktop/src/components/settings/UpdateSettings.tsx`, `apps/desktop/src/components/feedback/UpdateBanner.tsx` |
+| Frontend updater UI surfaces | `apps/desktop/src/components/feedback/UpdateToastPresenter.tsx`, `apps/desktop/src/components/feedback/UpdateRestartDialog.tsx`, `apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx`, `apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx` |
 | Desktop updater infra and publish permissions | `apps/desktop/infra/main.tf` |
 | Cloud API infra | `server/infra/main.tf` |
 | Self-hosted production deploy | `server/deploy/**` |

--- a/specs/developing/testing/desktop-update-testing.md
+++ b/specs/developing/testing/desktop-update-testing.md
@@ -5,6 +5,13 @@ artifact there, and watch the real Tauri auto-updater converge. This is the
 tier-4 "Desktop app" mechanism from the [testing README](./README.md); read that
 first for the tier model.
 
+Read the product and UI acceptance contract in
+[`desktop-updates.md`](../../codebase/features/desktop-updates.md) alongside
+this mechanism. T4-DESKTOP-1 proves manifest fetch, semver selection, signature
+verification, and the real bundle swap headlessly. It does not render the
+packaged WebView: release-notice presentation and interaction are covered by
+focused renderer tests plus a packaged-WebView smoke when preparing a release.
+
 The shipped app is not touched. `apps/desktop/src-tauri/tauri.conf.json` keeps
 its production endpoint (`https://downloads.proliferate.com/desktop/stable/latest.json`)
 and production pubkey. A test build overrides only those two values (plus a

--- a/specs/spec-catalog.md
+++ b/specs/spec-catalog.md
@@ -186,6 +186,7 @@ Most billing already shipped. Spec 09 closes: wire `authorize_sandbox_start` to 
 | `cloud-dispatch.md` (spec 08) | Web/Mobile/Desktop dispatch UX — live hooks, exposure-aware listing, Continue remotely, Open in web, deep links |
 | `cowork-artifacts.md` | Cowork artifact creation and delegation |
 | `delegated-work.md` | Delegated work flows |
+| `desktop-updates.md` | Packaged Desktop updater UX, version-aware release notices, and release-title metadata |
 | `mobile-cloud-client.md` | Mobile Cloud SDK cutover from fixture data |
 | `onboarding.md` | Signed-out to product-ready account handoff, readiness gates, and first workspace transition |
 | `pending-workspace-shell.md` | Shell shown while workspace is pending |
@@ -407,6 +408,7 @@ analytics systems, local dev, and deploying.
 | MCP / skills / plugins runtime config | `primitives/mcp-skills.md` + `primitives/mcp-runtime.md` |
 | Product MCP tool (add/change) | `features/agent-features/servers.md` + `definitions/README.md` |
 | Onboarding / first-run readiness | `features/onboarding.md` + `features/product-auth.md` |
+| Desktop updater / release notices | `features/desktop-updates.md` + `developing/deploying/ci-cd.md` |
 | Workspace archive / prune / lifecycle | `primitives/workspace-lifecycle.md` |
 | Billing / wake gate | `primitives/billing.md` + `primitives/cloud-commands.md` |
 | Claiming | `primitives/claiming.md` |


### PR DESCRIPTION
## Summary

- publish an optional validated one-line Desktop release title through standard Tauri notes, plus immutable per-version manifests with fail-closed atomic publication and CDN CORS
- show the authored title in the pre-install updater toast, then show the installed release as a persistent NEW sidebar card linking to https://proliferate.com/changelog until acknowledged
- add version-scoped acknowledgment/cache state, real playground states, focused tests, and the updater behavior/release contract

## Verification

- focused Desktop updater/release-notice suite: 13 files, 101 tests passed
- Desktop TypeScript: passed
- shared UI typecheck: passed
- release scripts: 49 tests passed
- changed workflows: actionlint passed
- git diff --check: passed

## Baseline note

pnpm --dir apps/desktop pretest completes the package builds, then the design-system checker reports existing origin/main arbitrary-type utility violations in harness settings, file search/tree, diff UI, and product-ui. None of those files are changed here.
