### PR TITLE
feat(desktop): add Subagents UX playground

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -108,6 +108,14 @@ const AgentsPlaygroundPage = import.meta.env.DEV
     )
   : null
 
+const SubagentsUxPlaygroundPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("@/pages/SubagentsUxPlaygroundPage").then((m) => ({
+        default: m.SubagentsUxPlaygroundPage,
+      })),
+    )
+  : null
+
 function isTauriDesktop(): boolean {
   return typeof window !== "undefined"
     && "__TAURI_INTERNALS__" in (window as unknown as Record<string, unknown>)
@@ -370,6 +378,16 @@ function AppRuntime() {
                 element={
                   <Suspense fallback={null}>
                     <AgentsPlaygroundPage />
+                  </Suspense>
+                }
+              />
+            )}
+            {import.meta.env.DEV && SubagentsUxPlaygroundPage && (
+              <Route
+                path="/playground/subagents"
+                element={
+                  <Suspense fallback={null}>
+                    <SubagentsUxPlaygroundPage />
                   </Suspense>
                 }
               />

--- a/apps/desktop/src/components/playground/subagents-ux/SubagentsUxPlayground.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/SubagentsUxPlayground.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { SegmentedControl } from "@proliferate/ui/primitives/SegmentedControl";
+import { FullFlowPrototype } from "./full-flow/FullFlowPrototype";
+import { IdentityReceiptsPrototype } from "./identity-receipts/IdentityReceiptsPrototype";
+import { NavigationClosePrototype } from "./navigation-close/NavigationClosePrototype";
+import { PopoverPanePrototype } from "./popover-pane/PopoverPanePrototype";
+
+type PrototypeView = "full-flow" | "identity" | "popover-pane" | "navigation-close";
+
+const PROTOTYPE_VIEWS = [
+  { id: "full-flow", label: "Full flow" },
+  { id: "identity", label: "Identity + receipt" },
+  { id: "popover-pane", label: "Popover + pane" },
+  { id: "navigation-close", label: "Tabs + close" },
+] as const satisfies readonly { id: PrototypeView; label: string }[];
+
+/**
+ * Dev-only interactive lab. "Full flow" is the coherent default walkthrough
+ * of the whole delegated-work model; the other lanes stay as focused
+ * comparison surfaces. These remain fixture surfaces until a direction is
+ * selected and promoted into the production Subagents components.
+ */
+export function SubagentsUxPlayground() {
+  const [view, setView] = useState<PrototypeView>("full-flow");
+
+  return (
+    <div
+      className="flex h-screen min-h-0 w-full flex-col overflow-hidden bg-background text-foreground"
+      data-subagents-ux-lab
+    >
+      <header className="flex shrink-0 flex-wrap items-center gap-4 border-b border-border px-5 py-3">
+        <div className="min-w-0 flex-1">
+          <h1 className="text-base font-semibold">Subagents UX lab</h1>
+          <p className="truncate text-ui-sm text-muted-foreground">
+            Interactive Fable drafts · fixture data only · no production session mutations
+          </p>
+        </div>
+        <SegmentedControl
+          items={PROTOTYPE_VIEWS}
+          value={view}
+          onChange={setView}
+          ariaLabel="Subagents prototype view"
+        />
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {view === "full-flow" ? <FullFlowPrototype /> : null}
+        {view === "identity" ? (
+          <div className="h-full overflow-y-auto p-6">
+            <div className="mx-auto max-w-4xl">
+              <IdentityReceiptsPrototype />
+            </div>
+          </div>
+        ) : null}
+        {view === "popover-pane" ? <PopoverPanePrototype /> : null}
+        {view === "navigation-close" ? (
+          <div className="h-full min-h-0 p-4">
+            <NavigationClosePrototype />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowFixtures.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowFixtures.tsx
@@ -1,0 +1,364 @@
+// Fixture data for the coherent default "full flow" lane: several parent
+// sessions with runtime-observable subagent rosters, immutable creation
+// receipts embedded in the parent transcripts, and an archive of closed
+// child sessions whose transcripts stay reopenable after the relationship
+// is deleted. Prototype-local on purpose, matching the other lanes.
+
+import type {
+  PrototypeAgentStatus,
+  PrototypeGit,
+} from "../popover-pane/PopoverPaneFixtures";
+import type { SubagentReceiptModel } from "../identity-receipts/SubagentCreationReceipt";
+
+export interface FullFlowMessage {
+  speaker: "user" | "agent" | "tool";
+  text: string;
+}
+
+export type FullFlowTranscriptItem =
+  | { kind: "message"; message: FullFlowMessage }
+  | { kind: "receipt"; receipt: SubagentReceiptModel };
+
+export interface FullFlowChild {
+  id: string;
+  /** Agent-supplied task label — the primary identity everywhere. */
+  label: string;
+  harness: string;
+  status: PrototypeAgentStatus;
+  /** Metadata, never a roster state. */
+  wakeScheduled: boolean;
+  /** Composed status line ("Working · 4m"); last-turn metadata for Done/Idle. */
+  detail: string;
+  transcript: FullFlowMessage[];
+}
+
+export interface FullFlowParent {
+  id: string;
+  title: string;
+  git: PrototypeGit;
+  transcript: FullFlowTranscriptItem[];
+  children: FullFlowChild[];
+}
+
+export interface FullFlowArchivedSession {
+  id: string;
+  label: string;
+  parentTitle: string;
+  /** "Closed · Yesterday" — archive listing line. */
+  closedDetail: string;
+  transcript: FullFlowMessage[];
+}
+
+export interface FullFlowWorkspace {
+  parents: FullFlowParent[];
+  archived: FullFlowArchivedSession[];
+}
+
+const SHIP_GIT: PrototypeGit = {
+  branch: "feat/workspace-activity",
+  changedFiles: 6,
+  stagedFiles: 2,
+  ahead: 2,
+  behind: 0,
+  conflictedFiles: 0,
+  pullRequestLabel: "PR #1042 · Open · Checks passing",
+};
+
+const AUTH_GIT: PrototypeGit = {
+  branch: "feat/auth-hardening",
+  changedFiles: 3,
+  stagedFiles: 0,
+  ahead: 0,
+  behind: 1,
+  conflictedFiles: 0,
+  pullRequestLabel: null,
+};
+
+export function buildFullFlowWorkspace(): FullFlowWorkspace {
+  return {
+    parents: [
+      {
+        id: "ff-parent-workspace-activity",
+        title: "Ship workspace activity",
+        git: { ...SHIP_GIT },
+        transcript: [
+          {
+            kind: "message",
+            message: {
+              speaker: "user",
+              text: "Land the workspace activity card. Delegate the checks that can run in parallel.",
+            },
+          },
+          {
+            kind: "message",
+            message: {
+              speaker: "agent",
+              text: "I split out four bounded checks and delegated them. I'll keep integrating here and read their results as they finish.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_api-surface-check",
+              title: "API Surface Check",
+              harnessLabel: "Claude",
+              wakeScheduled: true,
+              timestamp: "2026-07-11 14:02",
+              prompt: "Inspect the public API surface for contract mismatches against the SDK.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_sdk-types-sync",
+              title: "SDK Types Sync",
+              harnessLabel: "Codex",
+              wakeScheduled: false,
+              timestamp: "2026-07-11 14:02",
+              prompt: "Regenerate SDK types and flag any drift from the contract crate.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_flaky-test-hunt",
+              title: "Flaky Test Hunt",
+              harnessLabel: "Codex",
+              wakeScheduled: false,
+              timestamp: "2026-07-11 14:05",
+              prompt: "Re-run the desktop vitest suite 10x and isolate any flaky specs.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_changelog-draft",
+              title: "Changelog Draft",
+              harnessLabel: "Claude",
+              wakeScheduled: true,
+              timestamp: "2026-07-11 14:08",
+              prompt: "Draft changelog entries for the workspace activity card from the merged PRs.",
+            },
+          },
+          {
+            kind: "message",
+            message: {
+              speaker: "agent",
+              text: "Changelog Draft finished — its summary is in the pane. The flaky test hunt hit a tool error; I'll read its last turn before retrying.",
+            },
+          },
+        ],
+        children: [
+          {
+            id: "subagent_ff_api-surface-check",
+            label: "API Surface Check",
+            harness: "Claude",
+            status: "running",
+            wakeScheduled: true,
+            detail: "Working · 4m",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "Diffing the exported contract types against the generated SDK surface.",
+              },
+              {
+                speaker: "tool",
+                text: "read anyharness-contract/src/v1/sessions.rs (412 lines)",
+              },
+              {
+                speaker: "agent",
+                text: "Found one candidate mismatch in create_subagent; verifying against the TS client before reporting.",
+              },
+            ],
+          },
+          {
+            id: "subagent_ff_sdk-types-sync",
+            label: "SDK Types Sync",
+            harness: "Codex",
+            status: "running",
+            wakeScheduled: false,
+            detail: "Working · 2m",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "Regenerating SDK types from the contract crate.",
+              },
+              {
+                speaker: "tool",
+                text: "pnpm --filter @anyharness/sdk generate → OK",
+              },
+            ],
+          },
+          {
+            id: "subagent_ff_flaky-test-hunt",
+            label: "Flaky Test Hunt",
+            harness: "Codex",
+            status: "errored",
+            wakeScheduled: false,
+            detail: "Failed · tool error",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "Running the desktop vitest suite in a loop to surface order-dependent failures.",
+              },
+              {
+                speaker: "tool",
+                text: "vitest run --repeat 10 → exited 1 (sandbox connection lost on pass 4)",
+              },
+            ],
+          },
+          {
+            id: "subagent_ff_changelog-draft",
+            label: "Changelog Draft",
+            harness: "Claude",
+            status: "completed",
+            wakeScheduled: false,
+            detail: "Done · Drafted 8 entries",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "Collected the merged PRs behind the activity card and drafted entries for each.",
+              },
+              {
+                speaker: "tool",
+                text: "wrote docs/changelog/workspace-activity.md (8 entries)",
+              },
+              {
+                speaker: "agent",
+                text: "Done. Eight entries drafted; two flagged for a human tone pass.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "ff-parent-auth-hardening",
+        title: "Harden auth session handling",
+        git: { ...AUTH_GIT },
+        transcript: [
+          {
+            kind: "message",
+            message: {
+              speaker: "user",
+              text: "Harden session handling: key rotation and bulk revocation.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_session-key-rotation",
+              title: "Session Key Rotation",
+              harnessLabel: "Claude",
+              wakeScheduled: true,
+              timestamp: "2026-07-11 11:40",
+              prompt: "Implement session key rotation on privilege change plus a 24h schedule.",
+            },
+          },
+          {
+            kind: "receipt",
+            receipt: {
+              subagentId: "subagent_ff_bulk-revocation",
+              title: "Bulk Revocation Endpoint",
+              harnessLabel: "Codex",
+              wakeScheduled: false,
+              timestamp: "2026-07-11 11:41",
+              prompt: "Add a bulk session revocation endpoint with per-user and global scopes.",
+            },
+          },
+          {
+            kind: "message",
+            message: {
+              speaker: "agent",
+              text: "Revocation is done. Rotation finished its last turn and is idle waiting on my review of the rotation triggers.",
+            },
+          },
+        ],
+        children: [
+          {
+            id: "subagent_ff_session-key-rotation",
+            label: "Session Key Rotation",
+            harness: "Claude",
+            status: "idle",
+            wakeScheduled: true,
+            detail: "Idle · Completed turn",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "Rotation now triggers on privilege change and on a 24-hour schedule.",
+              },
+              {
+                speaker: "tool",
+                text: "9 files changed · tests passing",
+              },
+            ],
+          },
+          {
+            id: "subagent_ff_bulk-revocation",
+            label: "Bulk Revocation Endpoint",
+            harness: "Codex",
+            status: "completed",
+            wakeScheduled: false,
+            detail: "Done · Endpoint + audit events",
+            transcript: [
+              {
+                speaker: "agent",
+                text: "POST /sessions/revoke supports per-user and global scopes, one audit event per batch.",
+              },
+              {
+                speaker: "agent",
+                text: "Done. Endpoint merged behind the existing auth middleware.",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    archived: [
+      {
+        id: "subagent_ff_repo-shape-audit",
+        label: "Repo Shape Audit",
+        parentTitle: "Ship workspace activity",
+        closedDetail: "Closed · Yesterday",
+        transcript: [
+          {
+            speaker: "agent",
+            text: "Audited the repo-shape rules against the new activity components.",
+          },
+          {
+            speaker: "tool",
+            text: "3 violations found · report written to specs/notes/repo-shape-audit.md",
+          },
+          {
+            speaker: "tool",
+            text: "Deleted by you. The session transcript stays available here.",
+          },
+        ],
+      },
+      {
+        id: "subagent_ff_legacy-cookie-spike",
+        label: "Spike: Legacy Cookie Migration",
+        parentTitle: "Harden auth session handling",
+        closedDetail: "Closed · 2 days ago",
+        transcript: [
+          {
+            speaker: "agent",
+            text: "Mapped which clients still send the legacy cookie.",
+          },
+          {
+            speaker: "tool",
+            text: "Deleted by you after finishing its turn — the legacy path is being removed instead.",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export const FULL_FLOW_STATUS_LABELS: Record<PrototypeAgentStatus, string> = {
+  starting: "Starting",
+  running: "Working",
+  idle: "Idle",
+  completed: "Done",
+  errored: "Failed",
+  closed: "Closed",
+};

--- a/apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowPrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowPrototype.tsx
@@ -1,0 +1,718 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
+import { Archive, X } from "@proliferate/ui/icons";
+import { SubagentIdentityGlyph } from "../identity-receipts/SubagentIdentityGlyph";
+import { SubagentCreationReceipt } from "../identity-receipts/SubagentCreationReceipt";
+import { AgentGlyph } from "../popover-pane/AgentGlyph";
+import { ActivityAggregatePopover } from "../popover-pane/ActivityAggregatePopover";
+import { PrototypeComposerSurface } from "../popover-pane/PopoverPanePrototype";
+import {
+  GlobalAgentsPanePrototype,
+  type GlobalAgentsParentFixture,
+} from "../popover-pane/GlobalAgentsPanePrototype";
+import type { PrototypeAgent } from "../popover-pane/PopoverPaneFixtures";
+import {
+  buildFullFlowWorkspace,
+  FULL_FLOW_STATUS_LABELS,
+  type FullFlowArchivedSession,
+  type FullFlowChild,
+  type FullFlowMessage,
+  type FullFlowParent,
+} from "./FullFlowFixtures";
+
+/**
+ * The coherent default lane: one app-like surface that walks the whole model
+ * end to end — immutable creation receipts in the parent transcript, the
+ * aggregate activity cap above the inert composer, the global navigation-only
+ * Agents pane (overview → parent drill → child open), child sessions as
+ * normal full-chat tabs clustered right of their parent, tab close (hide
+ * only, control on the left) vs relationship delete (confirm drain for
+ * active, immediate for completed), and archive reopen after delete.
+ */
+
+type TabDescriptor =
+  | { kind: "parent"; parentId: string }
+  | { kind: "child"; parentId: string; childId: string }
+  | { kind: "archived"; archivedId: string };
+
+function tabKey(tab: TabDescriptor): string {
+  switch (tab.kind) {
+    case "parent":
+      return `parent:${tab.parentId}`;
+    case "child":
+      return `child:${tab.childId}`;
+    case "archived":
+      return `archived:${tab.archivedId}`;
+  }
+}
+
+type PaneView = { mode: "overview" } | { mode: "parent"; parentId: string };
+
+function childToPaneAgent(child: FullFlowChild): PrototypeAgent {
+  return {
+    id: child.id,
+    label: child.label,
+    harness: child.harness,
+    status: child.status,
+    wakeScheduled: child.wakeScheduled,
+    detail: child.detail,
+  };
+}
+
+export function FullFlowPrototype() {
+  const [workspace, setWorkspace] = useState(buildFullFlowWorkspace);
+  const [openTabs, setOpenTabs] = useState<TabDescriptor[]>(() => (
+    buildFullFlowWorkspace().parents.map((parent) => ({
+      kind: "parent" as const,
+      parentId: parent.id,
+    }))
+  ));
+  const [activeTabKey, setActiveTabKey] = useState<string>(() => (
+    `parent:${buildFullFlowWorkspace().parents[0]?.id ?? ""}`
+  ));
+  const [paneOpen, setPaneOpen] = useState(true);
+  const [paneView, setPaneView] = useState<PaneView>({ mode: "overview" });
+  const [deleteCandidateId, setDeleteCandidateId] = useState<string | null>(null);
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+
+  const reset = useCallback(() => {
+    const fresh = buildFullFlowWorkspace();
+    setWorkspace(fresh);
+    setOpenTabs(fresh.parents.map((parent) => ({ kind: "parent", parentId: parent.id })));
+    setActiveTabKey(`parent:${fresh.parents[0]?.id ?? ""}`);
+    setPaneOpen(true);
+    setPaneView({ mode: "overview" });
+    setDeleteCandidateId(null);
+  }, []);
+
+  const parentById = useCallback(
+    (parentId: string) => workspace.parents.find((parent) => parent.id === parentId),
+    [workspace],
+  );
+  const childById = useCallback(
+    (childId: string) => {
+      for (const parent of workspace.parents) {
+        const child = parent.children.find((candidate) => candidate.id === childId);
+        if (child) return { parent, child };
+      }
+      return undefined;
+    },
+    [workspace],
+  );
+
+  // Create-or-focus: a child owns at most one tab, inserted or moved into the
+  // contiguous child-agent run immediately to the right of its parent tab.
+  const openChildTab = useCallback((parentId: string, childId: string) => {
+    setOpenTabs((tabs) => {
+      const existing = tabs.find((tab) => tab.kind === "child" && tab.childId === childId);
+      const without = existing ? tabs.filter((tab) => tab !== existing) : tabs;
+      const parentIndex = without.findIndex(
+        (tab) => tab.kind === "parent" && tab.parentId === parentId,
+      );
+      if (parentIndex === -1) {
+        return [...without, { kind: "child", parentId, childId }];
+      }
+      let insertAt = parentIndex + 1;
+      while (insertAt < without.length) {
+        const candidate = without[insertAt];
+        if (!candidate || candidate.kind !== "child" || candidate.parentId !== parentId) break;
+        insertAt += 1;
+      }
+      const next = [...without];
+      next.splice(insertAt, 0, { kind: "child", parentId, childId });
+      return next;
+    });
+    setActiveTabKey(`child:${childId}`);
+  }, []);
+
+  const openArchivedTab = useCallback((archivedId: string) => {
+    setOpenTabs((tabs) => (
+      tabs.some((tab) => tab.kind === "archived" && tab.archivedId === archivedId)
+        ? tabs
+        : [...tabs, { kind: "archived", archivedId }]
+    ));
+    setActiveTabKey(`archived:${archivedId}`);
+  }, []);
+
+  // Closing a tab only hides the tab. The relationship — and the session —
+  // are untouched; the roster row in the Agents pane keeps working.
+  const closeTab = useCallback((key: string) => {
+    setOpenTabs((tabs) => {
+      const index = tabs.findIndex((tab) => tabKey(tab) === key);
+      const next = tabs.filter((tab) => tabKey(tab) !== key);
+      setActiveTabKey((active) => (
+        active === key
+          ? tabKey(next[Math.max(0, index - 1)] ?? next[0] ?? { kind: "parent", parentId: "" })
+          : active
+      ));
+      return next;
+    });
+  }, []);
+
+  // Relationship delete: the link leaves the parent's active roster and the
+  // child session moves to the archive, where its transcript stays
+  // reopenable. Any open tab for the child is removed.
+  const deleteChild = useCallback((childId: string, activeWorkEnded: boolean) => {
+    setWorkspace((prev) => {
+      let removed: { parent: FullFlowParent; child: FullFlowChild } | undefined;
+      const parents = prev.parents.map((parent) => {
+        const child = parent.children.find((candidate) => candidate.id === childId);
+        if (!child) return parent;
+        removed = { parent, child };
+        return {
+          ...parent,
+          children: parent.children.filter((candidate) => candidate.id !== childId),
+        };
+      });
+      if (!removed) return prev;
+      const archivedSession: FullFlowArchivedSession = {
+        id: removed.child.id,
+        label: removed.child.label,
+        parentTitle: removed.parent.title,
+        closedDetail: "Closed · Just now",
+        transcript: [
+          ...removed.child.transcript,
+          {
+            speaker: "tool",
+            text: activeWorkEnded
+              ? "Deleted by you. Active work was ended; the session transcript stays available here."
+              : "Deleted by you. The session transcript stays available here.",
+          },
+        ],
+      };
+      return { parents, archived: [archivedSession, ...prev.archived] };
+    });
+    closeTab(`child:${childId}`);
+  }, [closeTab]);
+
+  // Confirm only when active work would be ended (starting/running);
+  // idle/completed/failed relationships delete immediately.
+  const requestDelete = useCallback((childId: string) => {
+    const found = childById(childId);
+    if (!found) return;
+    const isActive = found.child.status === "starting"
+      || found.child.status === "running";
+    if (isActive) {
+      setDeleteCandidateId(childId);
+    } else {
+      deleteChild(childId, false);
+    }
+  }, [childById, deleteChild]);
+
+  // Roving focus on the tab strip: only the active tab is in the tab order;
+  // arrows move DOM focus, Home/End jump, Enter/Space selects.
+  const onTablistKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+    if (!keys.includes(event.key)) return;
+    const tabButtons = Array.from(
+      tablistRef.current?.querySelectorAll<HTMLButtonElement>("[role='tab']") ?? [],
+    );
+    if (tabButtons.length === 0) return;
+    const currentIndex = tabButtons.findIndex((button) => button === document.activeElement);
+    let nextIndex: number;
+    switch (event.key) {
+      case "ArrowLeft":
+        nextIndex = currentIndex <= 0 ? tabButtons.length - 1 : currentIndex - 1;
+        break;
+      case "ArrowRight":
+        nextIndex = currentIndex === -1 || currentIndex === tabButtons.length - 1
+          ? 0
+          : currentIndex + 1;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      default:
+        nextIndex = tabButtons.length - 1;
+    }
+    event.preventDefault();
+    tabButtons[nextIndex]?.focus();
+  }, []);
+
+  const paneParents: GlobalAgentsParentFixture[] = useMemo(
+    () => workspace.parents
+      .filter((parent) => parent.children.length > 0)
+      .map((parent) => ({
+        id: parent.id,
+        title: parent.title,
+        agents: parent.children.map(childToPaneAgent),
+      })),
+    [workspace],
+  );
+
+  const activeTab = openTabs.find((tab) => tabKey(tab) === activeTabKey)
+    ?? openTabs[0];
+  const deleteCandidate = deleteCandidateId ? childById(deleteCandidateId) : undefined;
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background text-foreground">
+      <header className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 border-b border-border px-4 py-2">
+        <div className="min-w-0 flex-1">
+          <h1 className="text-sm font-semibold">Full flow</h1>
+          <p className="truncate text-xs text-muted-foreground">
+            Receipt → cap → global pane → parent drill → child tab → close vs delete → archive reopen
+          </p>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={reset}>
+          Reset
+        </Button>
+        <Button
+          type="button"
+          variant={paneOpen ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={paneOpen}
+          onClick={() => setPaneOpen((open) => !open)}
+        >
+          Agents pane
+        </Button>
+      </header>
+
+      {/* Tab strip: parent anchors, child tabs clustered to their right with
+          the close control on the LEFT, delegated bubbles on the parent's right. */}
+      <div
+        ref={tablistRef}
+        role="tablist"
+        aria-label="Sessions"
+        onKeyDown={onTablistKeyDown}
+        className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border px-2 py-1.5"
+      >
+        {openTabs.map((tab) => {
+          const key = tabKey(tab);
+          const selected = key === activeTabKey;
+          if (tab.kind === "parent") {
+            const parent = parentById(tab.parentId);
+            if (!parent) return null;
+            return (
+              <ParentTab
+                key={key}
+                parent={parent}
+                selected={selected}
+                onSelect={() => setActiveTabKey(key)}
+                onOpenCluster={() => {
+                  setPaneOpen(true);
+                  setPaneView({ mode: "parent", parentId: parent.id });
+                }}
+              />
+            );
+          }
+          if (tab.kind === "child") {
+            const found = childById(tab.childId);
+            if (!found) return null;
+            return (
+              <ChildTab
+                key={key}
+                child={found.child}
+                selected={selected}
+                onSelect={() => setActiveTabKey(key)}
+                onCloseTab={() => closeTab(key)}
+              />
+            );
+          }
+          const archived = workspace.archived.find(
+            (session) => session.id === tab.archivedId,
+          );
+          if (!archived) return null;
+          return (
+            <ArchivedTab
+              key={key}
+              session={archived}
+              selected={selected}
+              onSelect={() => setActiveTabKey(key)}
+              onCloseTab={() => closeTab(key)}
+            />
+          );
+        })}
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Main area: the normal Chat view — transcript plus inert composer.
+            Never a transcript browser inside the Agents pane. */}
+        <main
+          role="tabpanel"
+          id="full-flow-chat"
+          aria-labelledby={activeTab ? `full-flow-tab-${tabKey(activeTab)}` : undefined}
+          className="flex min-w-0 flex-1 flex-col overflow-hidden"
+        >
+          {activeTab?.kind === "parent" ? (
+            <ParentChatView
+              parent={parentById(activeTab.parentId)}
+              onOpenChild={(childId) => {
+                if (activeTab.kind !== "parent") return;
+                // Receipts are immutable history: if the relationship was
+                // deleted since creation, the receipt reopens the archived
+                // session instead of a live child tab.
+                if (childById(childId)) {
+                  openChildTab(activeTab.parentId, childId);
+                } else if (workspace.archived.some((session) => session.id === childId)) {
+                  openArchivedTab(childId);
+                }
+              }}
+              onOpenAgentsPane={() => {
+                setPaneOpen(true);
+                setPaneView(
+                  activeTab.kind === "parent"
+                    ? { mode: "parent", parentId: activeTab.parentId }
+                    : { mode: "overview" },
+                );
+              }}
+            />
+          ) : null}
+          {activeTab?.kind === "child" ? (
+            <ChildChatView found={childById(activeTab.childId)} />
+          ) : null}
+          {activeTab?.kind === "archived" ? (
+            <ArchivedChatView
+              session={workspace.archived.find((s) => s.id === activeTab.archivedId)}
+            />
+          ) : null}
+          {!activeTab ? (
+            <div className="flex flex-1 items-center justify-center">
+              <p className="text-sm text-muted-foreground">No open sessions.</p>
+            </div>
+          ) : null}
+        </main>
+
+        {/* Global Agents pane: navigation only. */}
+        {paneOpen ? (
+          <aside className="w-72 shrink-0 border-l border-sidebar-border">
+            <GlobalAgentsPanePrototype
+              parents={paneParents}
+              archived={workspace.archived.map((session) => ({
+                id: session.id,
+                label: session.label,
+                parentTitle: session.parentTitle,
+                closedDetail: session.closedDetail,
+              }))}
+              selectedParentId={paneView.mode === "parent" ? paneView.parentId : null}
+              activeAgentId={activeTab?.kind === "child" ? activeTab.childId : null}
+              onSelectParent={(parentId) => setPaneView({ mode: "parent", parentId })}
+              onBack={() => setPaneView({ mode: "overview" })}
+              onOpenAgent={openChildTab}
+              onDeleteAgent={(_parentId, agentId) => requestDelete(agentId)}
+              onOpenArchived={openArchivedTab}
+            />
+          </aside>
+        ) : null}
+      </div>
+
+      <ConfirmationDialog
+        open={deleteCandidate != null}
+        title={deleteCandidate ? `Delete "${deleteCandidate.child.label}"?` : ""}
+        description="This agent still has active work. Deleting ends that work, then removes the agent from this chat. Its session transcript moves to the archive and stays readable. This can't be undone."
+        confirmLabel="End work and delete"
+        confirmVariant="destructive"
+        onClose={() => setDeleteCandidateId(null)}
+        onConfirm={() => {
+          if (deleteCandidateId) {
+            deleteChild(deleteCandidateId, true);
+            setDeleteCandidateId(null);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+const TAB_SHELL_CLASS = "group/tab flex max-w-[240px] shrink-0 items-center rounded-md border";
+
+function tabToneClass(selected: boolean): string {
+  return selected
+    ? "border-border bg-accent text-foreground"
+    : "border-transparent text-muted-foreground hover:bg-accent/60";
+}
+
+function TabCloseButton({ label, onClose }: { label: string; onClose: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      aria-label={`Close tab for ${label} (keeps the session)`}
+      title="Close tab — hides the tab only"
+      onClick={onClose}
+      className="ml-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover/tab:opacity-100 focus-visible:opacity-100"
+    >
+      <X className="size-3" aria-hidden="true" />
+    </Button>
+  );
+}
+
+function ParentTab({
+  parent,
+  selected,
+  onSelect,
+  onOpenCluster,
+}: {
+  parent: FullFlowParent;
+  selected: boolean;
+  onSelect: () => void;
+  onOpenCluster: () => void;
+}) {
+  const bubbleChildren = parent.children.slice(0, 3);
+  const overflow = parent.children.length - bubbleChildren.length;
+  return (
+    <div className={`${TAB_SHELL_CLASS} ${tabToneClass(selected)}`}>
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        role="tab"
+        id={`full-flow-tab-parent:${parent.id}`}
+        aria-selected={selected}
+        aria-controls="full-flow-chat"
+        tabIndex={selected ? 0 : -1}
+        title={parent.title}
+        onClick={onSelect}
+        className="flex min-w-0 items-center gap-1.5 px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
+      >
+        <span className="truncate text-ui font-medium">{parent.title}</span>
+      </Button>
+      {parent.children.length > 0 ? (
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          aria-label={`${parent.children.length} delegated ${parent.children.length === 1 ? "agent" : "agents"} for ${parent.title} — open Agents pane`}
+          title="Delegated agents — open Agents pane"
+          onClick={onOpenCluster}
+          className="mr-1 flex shrink-0 items-center rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+        >
+          <span className="flex items-center -space-x-1.5">
+            {bubbleChildren.map((child) => (
+              <span
+                key={child.id}
+                className="flex size-[16px] items-center justify-center rounded-full bg-background ring-1 ring-border"
+              >
+                <AgentGlyph id={child.id} size={10} />
+              </span>
+            ))}
+          </span>
+          {overflow > 0 ? (
+            <span className="ml-0.5 font-mono text-xs text-muted-foreground">
+              +{overflow}
+            </span>
+          ) : null}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function ChildTab({
+  child,
+  selected,
+  onSelect,
+  onCloseTab,
+}: {
+  child: FullFlowChild;
+  selected: boolean;
+  onSelect: () => void;
+  onCloseTab: () => void;
+}) {
+  return (
+    <div className={`${TAB_SHELL_CLASS} ${tabToneClass(selected)}`}>
+      <TabCloseButton label={child.label} onClose={onCloseTab} />
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        role="tab"
+        id={`full-flow-tab-child:${child.id}`}
+        aria-selected={selected}
+        aria-controls="full-flow-chat"
+        tabIndex={selected ? 0 : -1}
+        title={child.label}
+        onClick={onSelect}
+        className="flex min-w-0 items-center gap-1.5 py-1 pl-1 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
+      >
+        <SubagentIdentityGlyph
+          seed={child.id}
+          size={13}
+          label={`Identity mark for ${child.label}`}
+        />
+        <span className="truncate text-ui font-medium">{child.label}</span>
+      </Button>
+    </div>
+  );
+}
+
+function ArchivedTab({
+  session,
+  selected,
+  onSelect,
+  onCloseTab,
+}: {
+  session: FullFlowArchivedSession;
+  selected: boolean;
+  onSelect: () => void;
+  onCloseTab: () => void;
+}) {
+  return (
+    <div className={`${TAB_SHELL_CLASS} ${tabToneClass(selected)}`}>
+      <TabCloseButton label={session.label} onClose={onCloseTab} />
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        role="tab"
+        id={`full-flow-tab-archived:${session.id}`}
+        aria-selected={selected}
+        aria-controls="full-flow-chat"
+        tabIndex={selected ? 0 : -1}
+        title={`${session.label} (archived)`}
+        onClick={onSelect}
+        className="flex min-w-0 items-center gap-1.5 py-1 pl-1 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
+      >
+        <SubagentIdentityGlyph
+          seed={session.id}
+          size={13}
+          dimmed
+          label={`Identity mark for ${session.label}`}
+        />
+        <span className="truncate text-ui font-medium text-muted-foreground">
+          {session.label}
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+function TranscriptMessage({ message }: { message: FullFlowMessage }) {
+  return (
+    <div className="mb-3 last:mb-0">
+      <p className="text-ui-sm text-muted-foreground">
+        {message.speaker === "user" ? "You" : message.speaker === "agent" ? "Agent" : "System"}
+      </p>
+      <p className={`text-ui leading-5 ${message.speaker === "tool" ? "text-muted-foreground" : "text-foreground"}`}>
+        {message.text}
+      </p>
+    </div>
+  );
+}
+
+function ParentChatView({
+  parent,
+  onOpenChild,
+  onOpenAgentsPane,
+}: {
+  parent: FullFlowParent | undefined;
+  onOpenChild: (childId: string) => void;
+  onOpenAgentsPane: () => void;
+}) {
+  if (!parent) return null;
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl px-10 py-4">
+          {parent.transcript.map((item, index) => (
+            item.kind === "message" ? (
+              <TranscriptMessage key={index} message={item.message} />
+            ) : (
+              // Quiet immutable historical event: the receipt records the
+              // creation as it happened. Live status stays in the pane/tab.
+              <div key={index} className="mb-3 last:mb-0">
+                <SubagentCreationReceipt
+                  model={item.receipt}
+                  density="compact"
+                  onOpenSession={(subagentId) => onOpenChild(subagentId)}
+                />
+              </div>
+            )
+          ))}
+        </div>
+      </div>
+      <div className="mx-auto flex w-full max-w-2xl flex-col px-5 pb-6">
+        <div className="px-5">
+          <ActivityAggregatePopover
+            git={parent.git}
+            agents={parent.children.map(childToPaneAgent)}
+            onOpenSubagentsPane={onOpenAgentsPane}
+          />
+        </div>
+        <PrototypeComposerSurface />
+      </div>
+    </div>
+  );
+}
+
+function ChildChatView({
+  found,
+}: {
+  found: { parent: FullFlowParent; child: FullFlowChild } | undefined;
+}) {
+  if (!found) return null;
+  const { parent, child } = found;
+  // `detail` is already composed from the runtime status ("Working · 4m");
+  // wakeScheduled is metadata appended after it, never a roster state.
+  const statusLine = [
+    child.detail || FULL_FLOW_STATUS_LABELS[child.status],
+    child.wakeScheduled ? "Wake scheduled" : null,
+  ].filter((part): part is string => part !== null).join(" · ");
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+        <SubagentIdentityGlyph
+          seed={child.id}
+          size={18}
+          label={`Identity mark for ${child.label}`}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-ui font-medium">{child.label}</p>
+          <p className="truncate text-ui-sm text-muted-foreground">
+            {statusLine} · Delegated by {parent.title}
+          </p>
+        </div>
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">{child.harness}</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl px-10 py-4">
+          {child.transcript.map((message, index) => (
+            <TranscriptMessage key={index} message={message} />
+          ))}
+        </div>
+      </div>
+      <div className="mx-auto flex w-full max-w-2xl flex-col px-5 pb-6">
+        <PrototypeComposerSurface />
+      </div>
+    </div>
+  );
+}
+
+function ArchivedChatView({ session }: { session: FullFlowArchivedSession | undefined }) {
+  if (!session) return null;
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+        <SubagentIdentityGlyph
+          seed={session.id}
+          size={18}
+          dimmed
+          label={`Identity mark for ${session.label}`}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-ui font-medium">{session.label}</p>
+          <p className="truncate text-ui-sm text-muted-foreground">
+            {session.closedDetail} · Was delegated by {session.parentTitle}
+          </p>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl px-10 py-4">
+          {session.transcript.map((message, index) => (
+            <TranscriptMessage key={index} message={message} />
+          ))}
+        </div>
+      </div>
+      {/* Terminal session: no composer, no writable affordance — just a quiet
+          read-only footer stating the session is closed. */}
+      <footer className="mx-auto w-full max-w-2xl px-5 pb-6">
+        <div className="flex items-center gap-2 rounded-md border border-border/60 bg-foreground/5 px-3 py-2 text-ui-sm text-muted-foreground">
+          <Archive className="size-3.5 shrink-0" aria-hidden="true" />
+          <span>This session is closed. The transcript is read-only; no new prompts can be sent.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/identity-receipts/IdentityReceiptsPrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/identity-receipts/IdentityReceiptsPrototype.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from "react";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
+import { SegmentedControl } from "@proliferate/ui/primitives/SegmentedControl";
+import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
+import { shortDelegatedWorkId } from "@/lib/domain/delegated-work/identity";
+import { SubagentIdentityGlyph } from "./SubagentIdentityGlyph";
+import {
+  SubagentCreationReceipt,
+  type ReceiptDensity,
+  type SubagentReceiptModel,
+} from "./SubagentCreationReceipt";
+
+type GroupingMode = "single" | "grouped";
+type WakeMode = "scheduled" | "none";
+
+const WAKE_ITEMS = [
+  { id: "scheduled", label: "Wake scheduled" },
+  { id: "none", label: "No wake" },
+] as const satisfies readonly { id: WakeMode; label: string }[];
+
+const DENSITY_ITEMS = [
+  { id: "compact", label: "Compact" },
+  { id: "comfortable", label: "Comfortable" },
+] as const satisfies readonly { id: ReceiptDensity; label: string }[];
+
+const MODE_ITEMS = [
+  { id: "single", label: "Single" },
+  { id: "grouped", label: "Grouped" },
+] as const satisfies readonly { id: GroupingMode; label: string }[];
+
+// Task-derived titles mirroring the labels agents actually mint (slug-style
+// tasks, display-cased for UI).
+const GROUP_FIXTURES: { idSuffix: string; title: string; wake: boolean; prompt: string }[] = [
+  { idSuffix: "api-surface", title: "API Surface Check", wake: true, prompt: "Check the public API for contract drift." },
+  { idSuffix: "session-lifecycle", title: "Session Lifecycle Audit", wake: false, prompt: "Audit create, wake, and close behavior." },
+  { idSuffix: "cloud-auth", title: "Cloud Auth Review", wake: false, prompt: "Review cloud authentication boundaries." },
+  { idSuffix: "mcp-catalog", title: "MCP Catalog Probe", wake: false, prompt: "Compare advertised MCP tools with handlers." },
+  { idSuffix: "ci-cd", title: "CI Pipeline Cleanup", wake: false, prompt: "Find redundant CI jobs and dependencies." },
+];
+
+export function IdentityReceiptsPrototype() {
+  const [seed, setSeed] = useState("subagent_abc123");
+  const [wakeMode, setWakeMode] = useState<WakeMode>("scheduled");
+  const [density, setDensity] = useState<ReceiptDensity>("comfortable");
+  const [mode, setMode] = useState<GroupingMode>("single");
+  const [lastAction, setLastAction] = useState<string | null>(null);
+
+  const normalizedSeed = seed.trim() || "subagent_abc123";
+
+  const singleModel: SubagentReceiptModel = useMemo(
+    () => ({
+      subagentId: normalizedSeed,
+      title: "API Surface Check",
+      harnessLabel: "Claude",
+      wakeScheduled: wakeMode === "scheduled",
+      timestamp: "2026-07-11 14:02",
+      prompt: "Inspect the public API surface for contract mismatches.",
+    }),
+    [normalizedSeed, wakeMode],
+  );
+
+  const groupedModels: SubagentReceiptModel[] = useMemo(
+    () =>
+      GROUP_FIXTURES.map((fixture) => ({
+        subagentId: `${normalizedSeed}-${fixture.idSuffix}`,
+        title: fixture.title,
+        harnessLabel: "Claude",
+        wakeScheduled: fixture.wake,
+        timestamp: "2026-07-11 14:02",
+        prompt: fixture.prompt,
+      })),
+    [normalizedSeed],
+  );
+
+  const neighborSeeds = useMemo(
+    () => Array.from({ length: 12 }, (_, index) => `${normalizedSeed}-${index}`),
+    [normalizedSeed],
+  );
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-6">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          Identity + creation receipts
+        </h2>
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="w-56">
+            <Label htmlFor="identity-seed-input">Identity seed (subagent ID)</Label>
+            <Input
+              id="identity-seed-input"
+              value={seed}
+              placeholder="subagent_abc123"
+              onChange={(event) => setSeed(event.target.value)}
+            />
+          </div>
+          <div>
+            <Label>Launch receipt</Label>
+            <SegmentedControl
+              items={WAKE_ITEMS}
+              value={wakeMode}
+              onChange={setWakeMode}
+              ariaLabel="Wake scheduling recorded by the receipt"
+            />
+          </div>
+        </div>
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <Label>Density</Label>
+            <SegmentedControl
+              items={DENSITY_ITEMS}
+              value={density}
+              onChange={setDensity}
+              ariaLabel="Receipt density"
+            />
+          </div>
+          <div>
+            <Label>Mode</Label>
+            <SegmentedControl
+              items={MODE_ITEMS}
+              value={mode}
+              onChange={setMode}
+              ariaLabel="Single or grouped receipts"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section aria-label="Creation receipts" className="flex flex-col gap-2">
+        {mode === "single" ? (
+          <SubagentCreationReceipt
+            model={singleModel}
+            density={density}
+            onOpenSession={(id) => setLastAction(`Open agent session: ${id}`)}
+          />
+        ) : (
+          <div className={density === "compact" ? "flex flex-col gap-1" : "flex flex-col gap-1.5"}>
+            {groupedModels.map((model) => (
+              <SubagentCreationReceipt
+                key={model.subagentId}
+                model={model}
+                density={density}
+                onOpenSession={(id) => setLastAction(`Open agent session: ${id}`)}
+              />
+            ))}
+          </div>
+        )}
+        <p aria-live="polite" className="min-h-4 text-xs text-faint">
+          {lastAction ?? "Receipt actions land here."}
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold text-muted-foreground">
+          Determinism check — glyphs for adjacent seeds
+        </h3>
+        <div className="flex flex-wrap items-center gap-2">
+          {neighborSeeds.map((neighborSeed) => (
+            <Tooltip
+              key={neighborSeed}
+              content={shortDelegatedWorkId(neighborSeed)}
+              singleLine
+            >
+              <span className="flex size-8 items-center justify-center rounded-md bg-foreground/5">
+                <SubagentIdentityGlyph seed={neighborSeed} size={20} />
+              </span>
+            </Tooltip>
+          ))}
+        </div>
+        <p className="text-xs text-faint">
+          Same seed always yields the same mark; the short ID stays hover-only.
+          The agent-authored task label is the only human-readable name.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx
@@ -1,0 +1,135 @@
+import { useId, useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ChevronDown, ChevronRight } from "@proliferate/ui/icons";
+import { shortDelegatedWorkId } from "@/lib/domain/delegated-work/identity";
+import { SubagentIdentityGlyph } from "./SubagentIdentityGlyph";
+
+export type ReceiptDensity = "compact" | "comfortable";
+
+export interface SubagentReceiptModel {
+  subagentId: string;
+  title: string;
+  harnessLabel: string;
+  wakeScheduled: boolean;
+  timestamp: string;
+  prompt?: string;
+}
+
+export function SubagentCreationReceipt({
+  model,
+  density,
+  onOpenSession,
+}: {
+  model: SubagentReceiptModel;
+  density: ReceiptDensity;
+  onOpenSession?: (subagentId: string) => void;
+}) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const detailsId = useId();
+  // The agent-authored task label is the sole human-readable name; the short
+  // ID surfaces only in the disclosure details.
+  const shortId = shortDelegatedWorkId(model.subagentId);
+  const launchFragments = [
+    model.harnessLabel,
+    model.wakeScheduled ? "Wake scheduled" : null,
+  ].filter((value): value is string => !!value);
+  const compact = density === "compact";
+
+  return (
+    <div
+      role="group"
+      aria-label={`${model.title} subagent created`}
+      className="flex min-w-0 flex-col items-start"
+    >
+      {/* Codex-style inline chip row: pill with glyph + authored task label,
+          then a quiet verb. The chip itself is the disclosure trigger. */}
+      <div className={`flex min-w-0 max-w-full items-center ${compact ? "gap-1.5" : "gap-2"}`}>
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          aria-expanded={detailsOpen}
+          aria-controls={detailsId}
+          aria-label={detailsOpen ? `Hide details for ${model.title}` : `Show details for ${model.title}`}
+          onClick={() => setDetailsOpen((open) => !open)}
+          className={`group/receipt inline-flex min-w-0 max-w-64 items-center rounded-full border border-border/60 bg-foreground/5 hover:border-border hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border ${
+            compact ? "h-6 gap-1 pl-1.5 pr-2" : "h-7 gap-1.5 pl-2 pr-2.5"
+          }`}
+        >
+          <SubagentIdentityGlyph
+            seed={model.subagentId}
+            size={compact ? 13 : 15}
+            label={`Identity mark for ${model.title}`}
+          />
+          <span
+            className={`truncate font-medium text-foreground ${compact ? "text-xs" : "text-sm"}`}
+            title={model.title}
+          >
+            {model.title}
+          </span>
+          {detailsOpen
+            ? <ChevronDown className="size-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+            : (
+              <ChevronRight
+                className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/receipt:opacity-100 group-focus-visible/receipt:opacity-100"
+                aria-hidden="true"
+              />
+            )}
+        </Button>
+        <span className={`shrink-0 text-muted-foreground ${compact ? "text-xs" : "text-sm"}`}>
+          created
+        </span>
+        {!compact && launchFragments.length > 0 ? (
+          <span className="hidden min-w-0 truncate font-mono text-xs text-faint sm:inline">
+            {launchFragments.join(" · ")}
+          </span>
+        ) : null}
+      </div>
+      {detailsOpen && (
+        <div
+          id={detailsId}
+          className={`mt-1 flex w-fit max-w-full flex-col gap-1 rounded-md border border-border/60 bg-foreground/5 text-xs text-muted-foreground ${
+            compact ? "px-2.5 py-1.5" : "px-3 py-2"
+          }`}
+        >
+          <DetailRow label="ID" value={shortId} mono />
+          <DetailRow label="Launch" value={launchFragments.join(" · ")} />
+          <DetailRow label="Created" value={model.timestamp} />
+          {model.prompt ? <DetailRow label="Prompt" value={model.prompt} /> : null}
+          {onOpenSession ? (
+            <div className="mt-1 flex items-center gap-1.5">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-6 px-2"
+                onClick={() => onOpenSession(model.subagentId)}
+              >
+                Open agent session
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="w-14 shrink-0 text-faint">{label}</span>
+      <span className={`min-w-0 truncate text-foreground/80 ${mono ? "font-mono" : ""}`}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentIdentityGlyph.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentIdentityGlyph.tsx
@@ -1,0 +1,126 @@
+import { delegatedWorkVisualIdentity } from "@/lib/domain/delegated-work/identity";
+
+/**
+ * Deterministic compact geometric identity mark for a subagent, keyed by the
+ * subagent ID. Color reuses the delegated-agent token assignment so the glyph
+ * always agrees with tab bubbles and receipt name tinting; the geometry
+ * (outer frame, inner motif, rotation, orbit dots) is derived from independent
+ * bit ranges of the same seed hash so nearby IDs diverge visually.
+ */
+
+interface GlyphGeometry {
+  outer: "circle" | "square" | "hexagon" | "octagon";
+  inner: "diamond" | "dot" | "bars" | "triangle";
+  rotation: number;
+  orbitCount: number;
+  orbitPhase: number;
+}
+
+const OUTER_SHAPES: GlyphGeometry["outer"][] = ["circle", "square", "hexagon", "octagon"];
+const INNER_MOTIFS: GlyphGeometry["inner"][] = ["diamond", "dot", "bars", "triangle"];
+
+export function subagentGlyphGeometry(seed: string): GlyphGeometry {
+  const hash = mixHash(stableHash(seed));
+  return {
+    outer: OUTER_SHAPES[hash & 3] ?? "circle",
+    inner: INNER_MOTIFS[(hash >>> 2) & 3] ?? "diamond",
+    rotation: ((hash >>> 4) & 3) * 45,
+    orbitCount: (hash >>> 6) & 3,
+    orbitPhase: ((hash >>> 8) % 12) * 30,
+  };
+}
+
+const HEXAGON_POINTS = "21,12 16.5,19.79 7.5,19.79 3,12 7.5,4.21 16.5,4.21";
+const OCTAGON_POINTS =
+  "20.69,8.4 20.69,15.6 15.6,20.69 8.4,20.69 3.31,15.6 3.31,8.4 8.4,3.31 15.6,3.31";
+
+export function SubagentIdentityGlyph({
+  seed,
+  size = 20,
+  dimmed = false,
+  className = "",
+  label,
+}: {
+  seed: string;
+  size?: number;
+  dimmed?: boolean;
+  className?: string;
+  label?: string;
+}) {
+  const visual = delegatedWorkVisualIdentity(seed);
+  const geometry = subagentGlyphGeometry(seed);
+  const shapeOpacity = dimmed ? 0.45 : 1;
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      role={label ? "img" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      className={`shrink-0 ${visual.textColorClassName} ${className}`.trim()}
+    >
+      <g opacity={shapeOpacity}>
+        <g stroke="currentColor" strokeWidth={1.5} fill="currentColor" fillOpacity={0.14}>
+          {geometry.outer === "circle" && <circle cx={12} cy={12} r={9} />}
+          {geometry.outer === "square" && (
+            <rect x={3.5} y={3.5} width={17} height={17} rx={4.5} />
+          )}
+          {geometry.outer === "hexagon" && <polygon points={HEXAGON_POINTS} />}
+          {geometry.outer === "octagon" && <polygon points={OCTAGON_POINTS} />}
+        </g>
+        <g fill="currentColor" transform={`rotate(${geometry.rotation} 12 12)`}>
+          {geometry.inner === "diamond" && (
+            <polygon points="12,7.2 16.8,12 12,16.8 7.2,12" />
+          )}
+          {geometry.inner === "dot" && <circle cx={12} cy={12} r={3.1} />}
+          {geometry.inner === "bars" && (
+            <>
+              <rect x={8.9} y={8} width={2.3} height={8} rx={1.1} />
+              <rect x={12.8} y={8} width={2.3} height={8} rx={1.1} />
+            </>
+          )}
+          {geometry.inner === "triangle" && (
+            <polygon points="12,7.4 16.2,15.2 7.8,15.2" />
+          )}
+        </g>
+        <g fill="currentColor" fillOpacity={0.75}>
+          {Array.from({ length: geometry.orbitCount }, (_, index) => {
+            const angle = ((geometry.orbitPhase + index * 120) * Math.PI) / 180;
+            return (
+              <circle
+                key={index}
+                cx={round(12 + 6.6 * Math.cos(angle))}
+                cy={round(12 + 6.6 * Math.sin(angle))}
+                r={1.1}
+              />
+            );
+          })}
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function stableHash(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+// Same avalanche mix used by the delegated-work color assignment: geometry
+// consumes different bit ranges than the name/color indices, so glyph shape
+// stays decorrelated from glyph color across sequential IDs.
+function mixHash(hash: number): number {
+  let value = hash >>> 0;
+  value = Math.imul(value ^ (value >>> 16), 0x7feb352d) >>> 0;
+  value = Math.imul(value ^ (value >>> 15), 0x846ca68b) >>> 0;
+  return (value ^ (value >>> 16)) >>> 0;
+}

--- a/apps/desktop/src/components/playground/subagents-ux/navigation-close/NavigationClosePrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/navigation-close/NavigationClosePrototype.tsx
@@ -1,0 +1,673 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
+import { X } from "@proliferate/ui/icons";
+import { SubagentIdentityGlyph } from "@/components/playground/subagents-ux/identity-receipts/SubagentIdentityGlyph";
+
+/**
+ * Interactive prototype for parent↔child navigation plus close/delete
+ * semantics. Encodes the reference-derived rules:
+ * - visible names are task-derived titles; identity is a persistent glyph
+ * - status is text/time/structure, never pills
+ * - the right pane is parent-scoped (Working / Done) and never changes when
+ *   the focused tab changes; closed relationships are archived elsewhere
+ * - opening a child creates or focuses exactly one tab, inserted immediately
+ *   to the right of the parent tab
+ * - closing a tab only removes the tab; the relationship survives
+ * - deleting an *active* relationship confirms and honestly records the end
+ *   request while runtime status remains running; deleting completed work is
+ *   immediate
+ * - no fake undo anywhere
+ */
+
+type ChildStatus = "running" | "completed" | "closed";
+
+interface TranscriptEntry {
+  speaker: "user" | "agent" | "tool";
+  text: string;
+}
+
+interface ChildAgent {
+  id: string;
+  title: string;
+  status: ChildStatus;
+  /** Seconds the child had already been running when the scenario loaded. */
+  startedOffsetSec: number;
+  stepIndex: number;
+  stepCount: number;
+  completionSummary?: string;
+  closedNote?: string;
+  /** Local command metadata, never a lifecycle state. */
+  endRequested?: boolean;
+  transcript: TranscriptEntry[];
+}
+
+interface Scenario {
+  id: string;
+  label: string;
+  parentTitle: string;
+  parentTranscript: TranscriptEntry[];
+  children: ChildAgent[];
+}
+
+const PARENT_TAB_ID = "__parent__";
+
+function buildScenarios(): Scenario[] {
+  return [
+    {
+      id: "mid-flight",
+      label: "Mid-flight refactor",
+      parentTitle: "Refactor payment retry pipeline",
+      parentTranscript: [
+        { speaker: "user", text: "Refactor the payment retry pipeline so retries are idempotent and observable." },
+        { speaker: "agent", text: "I split this into four tracks and delegated three of them. I'm coordinating and reviewing results here." },
+        { speaker: "tool", text: "Delegated: Migrate retry schema · Backfill retry metrics · Update retry integration tests" },
+        { speaker: "agent", text: "Schema migration finished — see the Done section. The metrics backfill and test update are still running." },
+      ],
+      children: [
+        {
+          id: "nav-close/backfill-retry-metrics",
+          title: "Backfill retry metrics",
+          status: "running",
+          startedOffsetSec: 252,
+          stepIndex: 3,
+          stepCount: 5,
+          transcript: [
+            { speaker: "agent", text: "Scanning the last 30 days of retry events to reconstruct metric points." },
+            { speaker: "tool", text: "query events --topic payment.retry --since 30d → 48,112 rows" },
+            { speaker: "agent", text: "Writing backfill batches. Two of five partitions are committed so far." },
+          ],
+        },
+        {
+          id: "nav-close/update-retry-tests",
+          title: "Update retry integration tests",
+          status: "running",
+          startedOffsetSec: 98,
+          stepIndex: 1,
+          stepCount: 4,
+          transcript: [
+            { speaker: "agent", text: "Reading the existing retry integration suite to map which cases assume at-most-once delivery." },
+            { speaker: "tool", text: "read tests/payments/retry_integration.spec.ts (612 lines)" },
+          ],
+        },
+        {
+          id: "nav-close/migrate-retry-schema",
+          title: "Migrate retry schema",
+          status: "completed",
+          startedOffsetSec: 1240,
+          stepIndex: 6,
+          stepCount: 6,
+          completionSummary: "Added idempotency_key column, backfilled 3 tables, migration applied cleanly",
+          transcript: [
+            { speaker: "agent", text: "Adding an idempotency_key column to retry_attempts and the two audit tables." },
+            { speaker: "tool", text: "migrate apply 20260711_retry_idempotency → OK (3 tables)" },
+            { speaker: "agent", text: "Done. Migration applied cleanly; backfill verified against a sampled 1% of rows." },
+          ],
+        },
+        {
+          id: "nav-close/spike-retry-dlq",
+          title: "Spike: dead-letter queue sizing",
+          status: "closed",
+          startedOffsetSec: 2900,
+          stepIndex: 2,
+          stepCount: 5,
+          closedNote: "Closed after finishing its turn — spike superseded by the metrics backfill",
+          transcript: [
+            { speaker: "agent", text: "Estimating DLQ volume under the proposed retry caps." },
+            { speaker: "tool", text: "Closed by you. The agent finished its in-progress turn, then stopped." },
+          ],
+        },
+      ],
+    },
+    {
+      id: "fresh",
+      label: "Fresh delegation",
+      parentTitle: "Add CSV export to reports",
+      parentTranscript: [
+        { speaker: "user", text: "Add CSV export to the reports page." },
+        { speaker: "agent", text: "I delegated the serializer work and will wire the UI here once it lands." },
+      ],
+      children: [
+        {
+          id: "nav-close/report-csv-serializer",
+          title: "Build report CSV serializer",
+          status: "running",
+          startedOffsetSec: 14,
+          stepIndex: 1,
+          stepCount: 3,
+          transcript: [
+            { speaker: "agent", text: "Starting on the serializer. Reading the report row model first." },
+          ],
+        },
+      ],
+    },
+    {
+      id: "wrap-up",
+      label: "Wrap-up review",
+      parentTitle: "Harden auth session handling",
+      parentTranscript: [
+        { speaker: "user", text: "Harden session handling: rotation, revocation, and audit coverage." },
+        { speaker: "agent", text: "All delegated tracks have finished. Review each result below, then delete the ones you've accepted." },
+      ],
+      children: [
+        {
+          id: "nav-close/session-rotation",
+          title: "Implement session key rotation",
+          status: "completed",
+          startedOffsetSec: 3600,
+          stepIndex: 5,
+          stepCount: 5,
+          completionSummary: "Rotation on privilege change + 24h schedule, 9 files changed",
+          transcript: [
+            { speaker: "agent", text: "Rotation triggers on privilege change and on a 24-hour schedule." },
+            { speaker: "tool", text: "9 files changed · tests passing" },
+          ],
+        },
+        {
+          id: "nav-close/revocation-endpoint",
+          title: "Add bulk revocation endpoint",
+          status: "completed",
+          startedOffsetSec: 3400,
+          stepIndex: 4,
+          stepCount: 4,
+          completionSummary: "POST /sessions/revoke with per-user and global scopes",
+          transcript: [
+            { speaker: "agent", text: "Endpoint supports per-user and global revocation with an audit event per batch." },
+          ],
+        },
+        {
+          id: "nav-close/audit-log-events",
+          title: "Emit session audit events",
+          status: "completed",
+          startedOffsetSec: 2100,
+          stepIndex: 3,
+          stepCount: 3,
+          completionSummary: "Create/refresh/revoke events wired to the audit sink",
+          transcript: [
+            { speaker: "agent", text: "All three lifecycle events now flow to the audit sink with actor attribution." },
+          ],
+        },
+        {
+          id: "nav-close/legacy-cookie-spike",
+          title: "Spike: legacy cookie migration",
+          status: "closed",
+          startedOffsetSec: 5000,
+          stepIndex: 1,
+          stepCount: 4,
+          closedNote: "Closed after finishing its turn — legacy path is being removed instead",
+          transcript: [
+            { speaker: "agent", text: "Mapping which clients still send the legacy cookie." },
+            { speaker: "tool", text: "Closed by you. The agent finished its in-progress turn, then stopped." },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+function formatElapsed(totalSec: number): string {
+  const sec = Math.max(0, Math.floor(totalSec));
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ${String(sec % 60).padStart(2, "0")}s`;
+  return `${Math.floor(sec / 3600)}h ${String(Math.floor((sec % 3600) / 60)).padStart(2, "0")}m`;
+}
+
+function childStatusLine(child: ChildAgent, elapsedSec: number): string {
+  switch (child.status) {
+    case "running":
+      return child.endRequested
+        ? "Working · end requested"
+        : `Working · ${formatElapsed(elapsedSec)} · step ${child.stepIndex} of ${child.stepCount}`;
+    case "completed":
+      return `Done in ${formatElapsed(child.startedOffsetSec)} · ${child.completionSummary ?? ""}`;
+    case "closed":
+      return child.closedNote ?? "Closed";
+  }
+}
+
+export function NavigationClosePrototype() {
+  const scenarios = useMemo(buildScenarios, []);
+  const [scenarioId, setScenarioId] = useState(scenarios[0]?.id ?? "mid-flight");
+  const [resetCount, setResetCount] = useState(0);
+  const scenario = scenarios.find((s) => s.id === scenarioId) ?? scenarios[0]!;
+
+  const [children, setChildren] = useState<ChildAgent[]>(() => scenario.children);
+  const [openTabIds, setOpenTabIds] = useState<string[]>([PARENT_TAB_ID]);
+  const [activeTabId, setActiveTabId] = useState<string>(PARENT_TAB_ID);
+  const [closeCandidateId, setCloseCandidateId] = useState<string | null>(null);
+  const [loadedAt, setLoadedAt] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const finishTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+
+  // Roving focus: arrows/Home/End move DOM focus across [role=tab] buttons.
+  const onTablistKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+    const tabButtons = Array.from(
+      tablistRef.current?.querySelectorAll<HTMLButtonElement>("[role='tab']") ?? [],
+    );
+    if (tabButtons.length === 0) return;
+    const currentIndex = tabButtons.findIndex((button) => button === document.activeElement);
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? tabButtons.length - 1
+        : event.key === "ArrowLeft"
+          ? (currentIndex <= 0 ? tabButtons.length - 1 : currentIndex - 1)
+          : (currentIndex === -1 || currentIndex === tabButtons.length - 1 ? 0 : currentIndex + 1);
+    event.preventDefault();
+    tabButtons[nextIndex]?.focus();
+  }, []);
+
+  const clearFinishTimers = useCallback(() => {
+    for (const timer of finishTimersRef.current.values()) clearTimeout(timer);
+    finishTimersRef.current.clear();
+  }, []);
+
+  // Reset all interactive state whenever the scenario changes or Reset is hit.
+  useEffect(() => {
+    clearFinishTimers();
+    setChildren(scenario.children.map((child) => ({ ...child })));
+    setOpenTabIds([PARENT_TAB_ID]);
+    setActiveTabId(PARENT_TAB_ID);
+    setCloseCandidateId(null);
+    setLoadedAt(Date.now());
+  }, [scenario, resetCount, clearFinishTimers]);
+
+  useEffect(() => clearFinishTimers, [clearFinishTimers]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const elapsedFor = useCallback(
+    (child: ChildAgent) => child.startedOffsetSec + (nowMs - loadedAt) / 1000,
+    [nowMs, loadedAt],
+  );
+
+  const childById = useCallback(
+    (id: string) => children.find((child) => child.id === id),
+    [children],
+  );
+
+  // Create-or-focus: a child owns at most one tab, inserted immediately to
+  // the right of the parent tab.
+  const openChild = useCallback((childId: string) => {
+    setOpenTabIds((tabs) => (
+      tabs.includes(childId) ? tabs : [PARENT_TAB_ID, childId, ...tabs.slice(1)]
+    ));
+    setActiveTabId(childId);
+  }, []);
+
+  // Closing a tab only removes the tab; the relationship is untouched.
+  const closeTab = useCallback((tabId: string) => {
+    setOpenTabIds((tabs) => {
+      const index = tabs.indexOf(tabId);
+      const next = tabs.filter((id) => id !== tabId);
+      setActiveTabId((active) => (
+        active === tabId ? (next[Math.max(0, index - 1)] ?? PARENT_TAB_ID) : active
+      ));
+      return next;
+    });
+  }, []);
+
+  // Confirmed deletion of an active relationship: status remains the
+  // runtime-observable `running` while the explicit end request is pending.
+  // The fixture then moves the relationship out of the active roster.
+  const confirmDeleteActive = useCallback((childId: string) => {
+    setCloseCandidateId(null);
+    setChildren((prev) => prev.map((child) => (
+      child.id === childId ? { ...child, endRequested: true } : child
+    )));
+    const timer = setTimeout(() => {
+      finishTimersRef.current.delete(childId);
+      setChildren((prev) => prev.map((child) => (
+        child.id === childId
+          ? {
+              ...child,
+              status: "closed" as const,
+              endRequested: false,
+              closedNote: "Closed after finishing its turn",
+              transcript: [
+                ...child.transcript,
+                { speaker: "tool" as const, text: "Closed by you. The agent finished its in-progress turn, then stopped." },
+              ],
+            }
+          : child
+      )));
+      closeTab(childId);
+    }, 2600);
+    finishTimersRef.current.set(childId, timer);
+  }, [closeTab]);
+
+  // Deleting a completed relationship is immediate. The relationship leaves
+  // the active roster while its transcript remains retained as closed history.
+  const deleteCompleted = useCallback((childId: string) => {
+    setChildren((prev) => prev.map((child) => (
+      child.id === childId
+        ? {
+            ...child,
+            status: "closed" as const,
+            closedNote: "Deleted after completion",
+            transcript: [
+              ...child.transcript,
+              { speaker: "tool" as const, text: "Deleted by you. The archived transcript remains available." },
+            ],
+          }
+        : child
+    )));
+    closeTab(childId);
+  }, [closeTab]);
+
+  const activeChildren = children.filter((child) => child.status === "running");
+  const doneChildren = children.filter((child) => child.status === "completed");
+  const closeCandidate = closeCandidateId ? childById(closeCandidateId) : undefined;
+  const activeChild = activeTabId === PARENT_TAB_ID ? undefined : childById(activeTabId);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-background text-foreground">
+      {/* Scenario / reset controls */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <label htmlFor="nav-close-scenario" className="text-ui-sm text-muted-foreground">
+          Scenario
+        </label>
+        <select
+          id="nav-close-scenario"
+          value={scenarioId}
+          onChange={(event) => setScenarioId(event.target.value)}
+          className="h-7 rounded-md border border-border bg-background px-2 text-ui text-foreground"
+        >
+          {scenarios.map((option) => (
+            <option key={option.id} value={option.id}>{option.label}</option>
+          ))}
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setResetCount((count) => count + 1)}
+          className="h-7 px-2"
+        >
+          Reset
+        </Button>
+        <p className="ml-auto truncate text-ui-sm text-muted-foreground">
+          Tabs close freely; relationships only end via the pane.
+        </p>
+      </div>
+
+      {/* Tab strip: parent first, child tabs inserted immediately to its
+          right. Roving tabindex: only the active tab participates in the tab
+          order; arrows/Home/End move focus between tabs. */}
+      <div
+        ref={tablistRef}
+        role="tablist"
+        aria-label="Parent and child sessions"
+        onKeyDown={onTablistKeyDown}
+        className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border px-2 py-1.5"
+      >
+        {openTabIds.map((tabId) => {
+          const isParent = tabId === PARENT_TAB_ID;
+          const child = isParent ? undefined : childById(tabId);
+          if (!isParent && !child) return null;
+          const selected = activeTabId === tabId;
+          const title = isParent ? scenario.parentTitle : child!.title;
+          return (
+            <div
+              key={tabId}
+              className={`group/tab flex max-w-[220px] shrink-0 items-center rounded-md border ${
+                selected
+                  ? "border-border bg-accent text-foreground"
+                  : "border-transparent text-muted-foreground hover:bg-accent/60"
+              }`}
+            >
+              {!isParent ? (
+                <Button
+                  type="button"
+                  variant="unstyled"
+                  size="unstyled"
+                  aria-label={`Close tab for ${title} (keeps the agent running)`}
+                  title="Close tab — the agent keeps running"
+                  onClick={() => closeTab(tabId)}
+                  className="ml-1 rounded p-0.5 text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground group-hover/tab:opacity-100 focus-visible:opacity-100"
+                >
+                  <X className="size-3" aria-hidden="true" />
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="unstyled"
+                size="unstyled"
+                role="tab"
+                id={`nav-close-tab-${tabId}`}
+                aria-selected={selected}
+                aria-controls="nav-close-transcript"
+                tabIndex={selected ? 0 : -1}
+                title={title}
+                onClick={() => setActiveTabId(tabId)}
+                className={`flex min-w-0 items-center gap-1.5 py-1 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border ${isParent ? "pl-2" : "pl-1"}`}
+              >
+                {child ? (
+                  <SubagentIdentityGlyph
+                    seed={child.id}
+                    size={14}
+                    dimmed={child.status === "closed"}
+                    label={`Identity mark for ${child.title}`}
+                  />
+                ) : null}
+                <span className="truncate text-ui font-medium">{title}</span>
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Main mock transcript — driven only by the focused tab */}
+        <div
+          role="tabpanel"
+          id="nav-close-transcript"
+          aria-labelledby={`nav-close-tab-${activeTabId}`}
+          className="flex min-w-0 flex-1 flex-col overflow-hidden"
+        >
+          <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+            {activeChild ? (
+              <SubagentIdentityGlyph
+                seed={activeChild.id}
+                size={18}
+                dimmed={activeChild.status === "closed"}
+                label={`Identity mark for ${activeChild.title}`}
+              />
+            ) : null}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-ui font-medium">
+                {activeChild ? activeChild.title : scenario.parentTitle}
+              </p>
+              <p className="truncate text-ui-sm text-muted-foreground">
+                {activeChild
+                  ? childStatusLine(activeChild, elapsedFor(activeChild))
+                  : `Parent session · ${activeChildren.length} working · ${doneChildren.length} done`}
+              </p>
+            </div>
+            {activeChild?.status === "running" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={activeChild.endRequested}
+                onClick={() => setCloseCandidateId(activeChild.id)}
+                className="h-7 shrink-0 px-2 text-muted-foreground hover:text-destructive"
+              >
+                {activeChild.endRequested ? "End requested…" : "Delete agent"}
+              </Button>
+            ) : null}
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+            {(activeChild ? activeChild.transcript : scenario.parentTranscript).map((entry, index) => (
+              <div key={index} className="mb-3 last:mb-0">
+                <p className="text-ui-sm text-muted-foreground">
+                  {entry.speaker === "user" ? "You" : entry.speaker === "agent" ? "Agent" : "System"}
+                </p>
+                <p className={`text-ui leading-5 ${entry.speaker === "tool" ? "text-muted-foreground" : "text-foreground"}`}>
+                  {entry.text}
+                </p>
+              </div>
+            ))}
+            {activeChild?.status === "running" && activeChild.endRequested ? (
+              <div className="mb-3">
+                <p className="text-ui-sm text-muted-foreground">System</p>
+                <p className="text-ui leading-5 text-muted-foreground">
+                  End requested. Runtime still reports this session as working; no new work will start.
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Parent-scoped right pane: sibling scope never changes with tab focus */}
+        <div className="flex w-72 shrink-0 flex-col overflow-hidden border-l border-sidebar-border bg-sidebar-background text-sidebar-foreground">
+          <div className="border-b border-sidebar-border px-4 py-3">
+            <p className="truncate text-ui font-medium">{scenario.parentTitle}</p>
+            <p className="mt-0.5 truncate text-ui-sm text-sidebar-muted-foreground">
+              {activeChildren.length === 0 && doneChildren.length === 0
+                ? "No delegated work"
+                : `${activeChildren.length} working · ${doneChildren.length} done`}
+            </p>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+            {activeChildren.length > 0 ? (
+              <section className="mb-4">
+                <h2 className="mb-1.5 px-1 text-ui-sm font-normal text-sidebar-muted-foreground">
+                  Working
+                </h2>
+                <div className="flex flex-col gap-0.5">
+                  {activeChildren.map((child) => (
+                    <PaneRow
+                      key={child.id}
+                      child={child}
+                      isFocused={activeTabId === child.id}
+                      statusLine={childStatusLine(child, elapsedFor(child))}
+                      onOpen={() => openChild(child.id)}
+                      action={
+                        !child.endRequested
+                          ? { label: "Delete", onClick: () => setCloseCandidateId(child.id) }
+                          : undefined
+                      }
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+            {doneChildren.length > 0 ? (
+              <section className="mb-4">
+                <h2 className="mb-1.5 px-1 text-ui-sm font-normal text-sidebar-muted-foreground">
+                  Done
+                </h2>
+                <div className="flex flex-col gap-0.5">
+                  {doneChildren.map((child) => (
+                    <PaneRow
+                      key={child.id}
+                      child={child}
+                      isFocused={activeTabId === child.id}
+                      statusLine={childStatusLine(child, elapsedFor(child))}
+                      onOpen={() => openChild(child.id)}
+                      action={{
+                        label: "Delete",
+                        title: "Delete immediately — this can't be undone",
+                        onClick: () => deleteCompleted(child.id),
+                      }}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+            {activeChildren.length === 0 && doneChildren.length === 0 ? (
+              <p className="px-1 pt-2 text-ui-sm text-sidebar-muted-foreground">
+                Delegated work for this chat will appear here.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmationDialog
+        open={closeCandidate != null}
+        title={closeCandidate ? `Delete "${closeCandidate.title}"?` : ""}
+        description="This agent has active work. Deleting requests that work to end and removes the relationship from this chat. Its session transcript remains available in the archive."
+        confirmLabel="End work and delete"
+        confirmVariant="destructive"
+        onClose={() => setCloseCandidateId(null)}
+        onConfirm={() => {
+          if (closeCandidateId) confirmDeleteActive(closeCandidateId);
+        }}
+      />
+    </div>
+  );
+}
+
+function PaneRow({
+  child,
+  isFocused,
+  statusLine,
+  onOpen,
+  action,
+  dimmed = false,
+}: {
+  child: ChildAgent;
+  isFocused: boolean;
+  statusLine: string;
+  onOpen: () => void;
+  action?: { label: string; onClick: () => void; title?: string };
+  dimmed?: boolean;
+}) {
+  return (
+    <div
+      className={`group/pane-row flex min-h-11 items-center rounded-lg hover:bg-sidebar-accent ${isFocused ? "bg-sidebar-accent" : ""}`}
+    >
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        aria-current={isFocused ? "true" : undefined}
+        title={child.title}
+        onClick={onOpen}
+        className="flex min-w-0 flex-1 items-center justify-start gap-2 px-2 py-1.5 text-left text-sidebar-foreground"
+      >
+        <SubagentIdentityGlyph
+          seed={child.id}
+          size={18}
+          dimmed={dimmed}
+          label={`Identity mark for ${child.title}`}
+        />
+        <span className="min-w-0 flex-1">
+          <span className={`block truncate text-ui font-medium ${dimmed ? "text-sidebar-muted-foreground" : ""}`}>
+            {child.title}
+          </span>
+          <span className="block truncate text-ui-sm font-normal text-sidebar-muted-foreground">
+            {statusLine}
+          </span>
+        </span>
+      </Button>
+      {action ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`${action.label} ${child.title}`}
+          title={action.title}
+          onClick={action.onClick}
+          className="mr-1 h-7 shrink-0 px-2 text-sidebar-muted-foreground opacity-0 hover:bg-sidebar-accent hover:text-destructive group-hover/pane-row:opacity-100 focus-visible:opacity-100"
+        >
+          {action.label}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/ActivityAggregatePopover.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/ActivityAggregatePopover.tsx
@@ -1,0 +1,255 @@
+import type { ReactNode } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { PopoverButton } from "@proliferate/ui/primitives/PopoverButton";
+import {
+  ArrowUp,
+  ChevronRight,
+  CircleAlert,
+  GitBranch,
+  GitCommit,
+  GitPullRequest,
+  StackedFiles,
+} from "@proliferate/ui/icons";
+import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
+import { AgentGlyphStack } from "./AgentGlyph";
+import {
+  buildActivityFacts,
+  buildSubagentAggregate,
+  subagentCountsLine,
+  type ActivityFact,
+  type PrototypeAgent,
+  type PrototypeGit,
+} from "./PopoverPaneFixtures";
+
+export type PrototypeSourceControlAction =
+  | "review"
+  | "commit"
+  | "publish"
+  | "pull-request";
+
+/**
+ * Compact attached activity cap + click-open aggregate popover.
+ * The popover is aggregate-only: source-control facts plus a subagent avatar
+ * stack with counts. The full roster lives in the right pane, opened from here.
+ */
+export function ActivityAggregatePopover({
+  git,
+  agents,
+  onOpenSubagentsPane,
+  onSourceControlAction,
+}: {
+  git: PrototypeGit;
+  agents: readonly PrototypeAgent[];
+  onOpenSubagentsPane: () => void;
+  onSourceControlAction?: (action: PrototypeSourceControlAction) => void;
+}) {
+  const aggregate = buildSubagentAggregate(agents);
+  const facts = buildActivityFacts(git, aggregate).slice(0, 3);
+  const countsLine = subagentCountsLine(aggregate);
+  const stagingLabel = git.stagedFiles > 0 ? `${git.stagedFiles} staged` : null;
+  const syncLabel = [
+    git.ahead > 0 ? `${git.ahead} ahead` : null,
+    git.behind > 0 ? `${git.behind} behind` : null,
+  ].filter((part): part is string => part !== null).join(" · ") || null;
+
+  return (
+    <PopoverButton
+      trigger={(
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          // Same cap treatment as the production activity card: cancel the
+          // dock's px-5 inset so the cap shares the composer's outer edges.
+          className="-mx-5 flex h-9 w-[calc(100%+2.5rem)] min-w-0 items-center justify-start rounded-t-[var(--radius-composer,1rem)] border-x-[0.5px] border-t-[0.5px] border-[var(--color-composer-border)] bg-[var(--color-composer-background)] px-3 text-left text-ui-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
+          aria-label={`Workspace activity: ${facts.map((fact) => fact.label).join(", ")}`}
+        >
+          <span className="flex min-w-0 flex-1 items-center overflow-hidden">
+            {facts.map((fact, index) => (
+              <TriggerFact key={fact.key} fact={fact} withSeparator={index > 0} />
+            ))}
+          </span>
+        </Button>
+      )}
+      side="top"
+      align="start"
+      offset={8}
+      className="w-auto border-0 bg-transparent p-0 shadow-none"
+    >
+      {(close) => (
+        <ComposerPopoverSurface
+          variant="summary"
+          className="w-[min(300px,calc(100vw-1rem))] overflow-hidden"
+        >
+          <PopoverSection title="Source control" flush={aggregate.total === 0}>
+            <PopoverFactRow icon={<GitBranch className="size-4" />} label={git.branch} />
+            <PopoverFactRow
+              icon={<StackedFiles className="size-4" />}
+              label={git.changedFiles === 0
+                ? "No changes"
+                : `${git.changedFiles} ${git.changedFiles === 1 ? "change" : "changes"}`}
+              meta={stagingLabel}
+            />
+            {git.conflictedFiles > 0 ? (
+              <PopoverFactRow
+                icon={<CircleAlert className="size-4 text-destructive" />}
+                label={`${git.conflictedFiles} ${git.conflictedFiles === 1 ? "conflict" : "conflicts"}`}
+              />
+            ) : null}
+            {syncLabel ? (
+              <PopoverFactRow icon={<ArrowUp className="size-4" />} label={syncLabel} />
+            ) : null}
+            {git.pullRequestLabel ? (
+              <PopoverFactRow
+                icon={<GitPullRequest className="size-4" />}
+                label={git.pullRequestLabel}
+              />
+            ) : null}
+            <div className="mt-1 flex flex-col gap-0.5 border-t border-border/60 pt-1">
+              {git.changedFiles > 0 ? (
+                <PopoverActionRow
+                  icon={<StackedFiles className="size-4" />}
+                  label="Review changes"
+                  onClick={() => {
+                    onSourceControlAction?.("review");
+                    close();
+                  }}
+                />
+              ) : null}
+              {git.changedFiles > 0 ? (
+                <PopoverActionRow
+                  icon={<GitCommit className="size-4" />}
+                  label="Commit…"
+                  onClick={() => {
+                    onSourceControlAction?.("commit");
+                    close();
+                  }}
+                />
+              ) : null}
+              <PopoverActionRow
+                icon={<ArrowUp className="size-4" />}
+                label={git.ahead > 0 ? "Push changes" : "Publish branch"}
+                onClick={() => {
+                  onSourceControlAction?.("publish");
+                  close();
+                }}
+              />
+              <PopoverActionRow
+                icon={<GitPullRequest className="size-4" />}
+                label={git.pullRequestLabel ? "Open pull request" : "Create pull request"}
+                onClick={() => {
+                  onSourceControlAction?.("pull-request");
+                  close();
+                }}
+              />
+            </div>
+          </PopoverSection>
+          {aggregate.total > 0 ? (
+            <PopoverSection title="Subagents" flush>
+              <Button
+                type="button"
+                variant="unstyled"
+                size="unstyled"
+                onClick={() => {
+                  onOpenSubagentsPane();
+                  close();
+                }}
+                className="relative isolate flex min-h-8 w-full min-w-0 items-center justify-start gap-2 py-1 text-left text-ui-sm text-foreground before:absolute before:inset-y-0 before:-inset-x-2 before:-z-10 before:rounded-sm before:content-[''] hover:before:bg-list-hover focus-visible:outline-none focus-visible:before:bg-list-hover"
+                aria-label={`Open subagents pane: ${aggregate.total} ${aggregate.total === 1 ? "subagent" : "subagents"}`}
+              >
+                <AgentGlyphStack ids={agents.map((agent) => agent.id)} />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate">
+                    {aggregate.total} {aggregate.total === 1 ? "subagent" : "subagents"}
+                  </span>
+                  {countsLine ? (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {countsLine}
+                    </span>
+                  ) : null}
+                </span>
+                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+              </Button>
+            </PopoverSection>
+          ) : null}
+        </ComposerPopoverSurface>
+      )}
+    </PopoverButton>
+  );
+}
+
+function PopoverActionRow({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      onClick={onClick}
+      className="relative isolate flex min-h-8 w-full min-w-0 items-center justify-start gap-2 py-1 text-left text-ui-sm text-foreground before:absolute before:inset-y-0 before:-inset-x-2 before:-z-10 before:rounded-sm before:content-[''] hover:before:bg-list-hover focus-visible:outline-none focus-visible:before:bg-list-hover"
+    >
+      <span className="flex w-[18px] shrink-0 items-center justify-start text-muted-foreground">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </Button>
+  );
+}
+
+function TriggerFact({ fact, withSeparator }: { fact: ActivityFact; withSeparator: boolean }) {
+  const toneClass = fact.tone === "destructive"
+    ? "text-destructive"
+    : fact.tone === "attention"
+      ? "text-warning-foreground"
+      : "text-current";
+  return (
+    <>
+      {withSeparator ? <span className="mx-1.5 shrink-0 text-border-heavy">·</span> : null}
+      <span className={`min-w-0 truncate ${toneClass}`}>{fact.label}</span>
+    </>
+  );
+}
+
+function PopoverSection({
+  title,
+  flush = false,
+  children,
+}: {
+  title: string;
+  flush?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`relative flex flex-col ${flush ? "pb-0.5" : "pb-3 after:absolute after:inset-x-3.5 after:bottom-0 after:h-px after:scale-y-50 after:bg-border after:content-['']"}`}>
+      <header className="flex h-7 min-w-0 items-center px-3.5 pb-0.5 text-ui-sm text-muted-foreground">
+        <span className="shrink-0">{title}</span>
+      </header>
+      <div className="flex flex-col gap-0.5 px-3.5">{children}</div>
+    </section>
+  );
+}
+
+function PopoverFactRow({
+  icon,
+  label,
+  meta,
+}: {
+  icon: ReactNode;
+  label: string;
+  meta?: string | null;
+}) {
+  return (
+    <div className="flex min-h-7 min-w-0 items-center gap-2 py-1 text-ui-sm text-muted-foreground">
+      <span className="flex w-[18px] shrink-0 items-center justify-start">{icon}</span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {meta ? <span className="shrink-0 text-xs text-faint">{meta}</span> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/AgentGlyph.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/AgentGlyph.tsx
@@ -1,0 +1,46 @@
+import { SubagentIdentityGlyph } from "../identity-receipts/SubagentIdentityGlyph";
+
+export function AgentGlyph({
+  id,
+  size = 16,
+  dimmed = false,
+}: {
+  id: string;
+  size?: number;
+  dimmed?: boolean;
+}) {
+  return <SubagentIdentityGlyph seed={id} size={size} dimmed={dimmed} />;
+}
+
+/**
+ * Overlapping avatar stack for the aggregate popover: up to `max` glyphs on a
+ * popover-colored keyline, then a mono "+N" overflow count. Aggregate-only —
+ * no names, no per-agent affordances.
+ */
+export function AgentGlyphStack({
+  ids,
+  max = 4,
+}: {
+  ids: readonly string[];
+  max?: number;
+}) {
+  const shown = ids.slice(0, max);
+  const overflow = ids.length - shown.length;
+  return (
+    <span className="flex items-center">
+      <span className="flex items-center -space-x-1.5">
+        {shown.map((id) => (
+          <span
+            key={id}
+            className="flex size-[18px] items-center justify-center rounded-full bg-popover ring-1 ring-popover-ring"
+          >
+            <AgentGlyph id={id} size={11} />
+          </span>
+        ))}
+      </span>
+      {overflow > 0 ? (
+        <span className="ml-1 font-mono text-xs text-muted-foreground">+{overflow}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/GlobalAgentsPanePrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/GlobalAgentsPanePrototype.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ArrowLeft, ChevronDown, ChevronRight } from "@proliferate/ui/icons";
+import { AgentGlyph, AgentGlyphStack } from "./AgentGlyph";
+import {
+  buildSubagentAggregate,
+  subagentCountsLine,
+  type PrototypeAgent,
+} from "./PopoverPaneFixtures";
+import { SubagentsPanePrototype } from "./SubagentsPanePrototype";
+
+export interface GlobalAgentsParentFixture {
+  id: string;
+  title: string;
+  agents: readonly PrototypeAgent[];
+}
+
+export interface GlobalAgentsArchivedFixture {
+  id: string;
+  label: string;
+  parentTitle: string;
+  closedDetail: string;
+}
+
+/**
+ * Navigation-only Agents pane. Overview lists every parent session with
+ * visible subagents plus a collapsed archive of closed child sessions;
+ * selecting a parent drills into its direct-child roster with Back. Child
+ * selection is delegated to the host so the normal Chat view/tab owns the
+ * transcript and composer — the pane never renders transcript content.
+ */
+export function GlobalAgentsPanePrototype({
+  parents,
+  archived = [],
+  selectedParentId,
+  activeAgentId,
+  onSelectParent,
+  onBack,
+  onOpenAgent,
+  onDeleteAgent,
+  onOpenArchived,
+}: {
+  parents: readonly GlobalAgentsParentFixture[];
+  archived?: readonly GlobalAgentsArchivedFixture[];
+  selectedParentId: string | null;
+  activeAgentId: string | null;
+  onSelectParent: (parentId: string) => void;
+  onBack: () => void;
+  onOpenAgent: (parentId: string, agentId: string) => void;
+  onDeleteAgent?: (parentId: string, agentId: string) => void;
+  onOpenArchived?: (archivedId: string) => void;
+}) {
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const selectedParent = parents.find((parent) => parent.id === selectedParentId) ?? null;
+
+  if (selectedParent) {
+    const aggregate = buildSubagentAggregate(selectedParent.agents);
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-sidebar-background text-sidebar-foreground">
+        <div className="flex shrink-0 items-center gap-2 border-b border-sidebar-border px-3 py-2.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Back to all parent sessions"
+            title="Back to Agents overview"
+            onClick={onBack}
+            className="shrink-0 text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+          </Button>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-ui font-medium text-sidebar-foreground">
+              {selectedParent.title}
+            </p>
+            <p className="truncate text-ui-sm text-sidebar-muted-foreground">
+              {subagentCountsLine(aggregate) ?? `${aggregate.total} subagents`}
+            </p>
+          </div>
+        </div>
+        <div className="min-h-0 flex-1">
+          <SubagentsPanePrototype
+            parentTitle={selectedParent.title}
+            agents={selectedParent.agents}
+            selectedAgentId={activeAgentId}
+            onSelectAgent={(agentId) => onOpenAgent(selectedParent.id, agentId)}
+            onDeleteAgent={onDeleteAgent
+              ? (agentId) => onDeleteAgent(selectedParent.id, agentId)
+              : undefined}
+            showHeader={false}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-sidebar-background text-sidebar-foreground">
+      <div className="shrink-0 border-b border-sidebar-border px-4 py-3">
+        <p className="text-ui font-medium text-sidebar-foreground">Agents</p>
+        <p className="mt-0.5 text-ui-sm text-sidebar-muted-foreground">
+          {parents.length} {parents.length === 1 ? "parent session" : "parent sessions"}
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        <div role="list" aria-label="Parent sessions with subagents">
+          {parents.map((parent) => {
+            const aggregate = buildSubagentAggregate(parent.agents);
+            return (
+              <div key={parent.id} role="listitem">
+                <Button
+                  type="button"
+                  variant="unstyled"
+                  size="unstyled"
+                  onClick={() => onSelectParent(parent.id)}
+                  className="flex min-h-12 w-full min-w-0 items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left text-sidebar-foreground hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-sidebar-border"
+                >
+                  <AgentGlyphStack ids={parent.agents.map((agent) => agent.id)} max={3} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-ui font-medium">{parent.title}</span>
+                    <span className="block truncate text-ui-sm text-sidebar-muted-foreground">
+                      {subagentCountsLine(aggregate) ?? `${aggregate.total} subagents`}
+                    </span>
+                  </span>
+                  <ChevronRight className="size-3.5 shrink-0 text-sidebar-muted-foreground" aria-hidden="true" />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+        {parents.length === 0 ? (
+          <p className="px-2 pt-2 text-ui-sm text-sidebar-muted-foreground">
+            No parent sessions have active subagents.
+          </p>
+        ) : null}
+        {archived.length > 0 && onOpenArchived ? (
+          <section className="mt-4 border-t border-sidebar-border pt-3">
+            <Button
+              type="button"
+              variant="unstyled"
+              size="unstyled"
+              aria-expanded={archiveOpen}
+              onClick={() => setArchiveOpen((open) => !open)}
+              className="mb-1 flex w-full items-center gap-1 px-2 text-left text-ui-sm text-sidebar-muted-foreground hover:text-sidebar-foreground focus-visible:outline-none focus-visible:text-sidebar-foreground"
+            >
+              {archiveOpen
+                ? <ChevronDown className="size-3.5 shrink-0" aria-hidden="true" />
+                : <ChevronRight className="size-3.5 shrink-0" aria-hidden="true" />}
+              Archive ({archived.length})
+            </Button>
+            {archiveOpen ? (
+              <div role="list" aria-label="Archived agent sessions" className="flex flex-col gap-0.5">
+                {archived.map((session) => (
+                  <div key={session.id} role="listitem">
+                    <Button
+                      type="button"
+                      variant="unstyled"
+                      size="unstyled"
+                      title={`${session.label} · ${session.parentTitle}`}
+                      onClick={() => onOpenArchived(session.id)}
+                      className="flex min-h-11 w-full min-w-0 items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left text-sidebar-foreground hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-sidebar-border"
+                    >
+                      <AgentGlyph id={session.id} dimmed />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-ui font-medium text-sidebar-muted-foreground">
+                          {session.label}
+                        </span>
+                        <span className="block truncate text-ui-sm text-sidebar-muted-foreground">
+                          {session.closedDetail} · {session.parentTitle}
+                        </span>
+                      </span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPaneFixtures.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPaneFixtures.tsx
@@ -1,0 +1,411 @@
+// Fixture data + pure aggregate helpers for the popover/pane prototype lane.
+// Prototype-local on purpose: this lane must not touch the shared playground
+// fixture tree while the visual direction is still being explored.
+
+export type PopoverPaneScenarioKey =
+  | "no-agents"
+  | "multiple-running"
+  | "mixed-states"
+  | "failures"
+  | "overflow";
+
+export type PrototypeAgentStatus =
+  | "starting"
+  | "running"
+  | "idle"
+  | "completed"
+  | "errored"
+  | "closed";
+
+export interface PrototypeAgent {
+  id: string;
+  /** Task-named label — the serious name in the pane. */
+  label: string;
+  harness: string;
+  status: PrototypeAgentStatus;
+  wakeScheduled: boolean;
+  /** Secondary status line, already composed ("Working · 4m"). */
+  detail: string;
+}
+
+export interface PrototypeGit {
+  branch: string;
+  changedFiles: number;
+  stagedFiles: number;
+  ahead: number;
+  behind: number;
+  conflictedFiles: number;
+  pullRequestLabel: string | null;
+}
+
+export interface PopoverPaneScenario {
+  key: PopoverPaneScenarioKey;
+  label: string;
+  parentTitle: string;
+  git: PrototypeGit;
+  agents: PrototypeAgent[];
+  closedAgents: PrototypeAgent[];
+}
+
+const BASE_GIT: PrototypeGit = {
+  branch: "feat/workspace-activity",
+  changedFiles: 6,
+  stagedFiles: 2,
+  ahead: 2,
+  behind: 0,
+  conflictedFiles: 0,
+  pullRequestLabel: "PR #1042 · Open · Checks passing",
+};
+
+const OVERFLOW_TASKS = [
+  "API Surface Check",
+  "SDK Types Sync",
+  "Migration Dry Run",
+  "Flaky Test Hunt",
+  "Changelog Draft",
+  "Perf Trace Sweep",
+  "Docs Truth Pass",
+  "Repo Shape Audit",
+  "Fixture Backfill",
+  "Telemetry Mask Review",
+  "Catalog Probe",
+  "Release Notes Draft",
+  "Contract Diff Check",
+  "Query Key Census",
+] as const;
+
+function overflowAgents(): PrototypeAgent[] {
+  return OVERFLOW_TASKS.map((label, index) => {
+    const status: PrototypeAgentStatus = index === 3
+      ? "errored"
+      : index === 9
+        ? "starting"
+        : index % 3 === 0
+          ? "running"
+          : index % 3 === 1
+            ? "idle"
+            : "completed";
+    return {
+      id: `overflow-${index}-${label.toLowerCase().replace(/\s+/gu, "-")}`,
+      label,
+      harness: index % 2 === 0 ? "Claude" : "Codex",
+      status,
+      wakeScheduled: index % 4 === 1,
+      detail: status === "errored"
+        ? "Failed · tool error"
+        : status === "starting"
+          ? "Starting"
+          : status === "running"
+            ? `Working · ${3 + index}m`
+            : status === "idle"
+              ? "Idle · Completed turn"
+              : "Done · Completed turn",
+    };
+  });
+}
+
+export const POPOVER_PANE_SCENARIOS: readonly PopoverPaneScenario[] = [
+  {
+    key: "no-agents",
+    label: "No agents",
+    parentTitle: "Ship workspace activity",
+    git: { ...BASE_GIT, changedFiles: 0, stagedFiles: 0, ahead: 0, pullRequestLabel: null },
+    agents: [],
+    closedAgents: [],
+  },
+  {
+    key: "multiple-running",
+    label: "Multiple running",
+    parentTitle: "Ship workspace activity",
+    git: BASE_GIT,
+    agents: [
+      {
+        id: "run-api-surface",
+        label: "API Surface Check",
+        harness: "Claude",
+        status: "running",
+        wakeScheduled: false,
+        detail: "Working · 4m",
+      },
+      {
+        id: "run-sdk-types",
+        label: "SDK Types Sync",
+        harness: "Codex",
+        status: "running",
+        wakeScheduled: false,
+        detail: "Working · 2m",
+      },
+      {
+        id: "run-migration-dry",
+        label: "Migration Dry Run",
+        harness: "Claude",
+        status: "running",
+        wakeScheduled: true,
+        detail: "Working · Wake scheduled",
+      },
+      {
+        id: "run-perf-trace",
+        label: "Perf Trace Sweep",
+        harness: "Codex",
+        status: "starting",
+        wakeScheduled: false,
+        detail: "Starting",
+      },
+    ],
+    closedAgents: [],
+  },
+  {
+    key: "mixed-states",
+    label: "Mixed states",
+    parentTitle: "Ship workspace activity",
+    git: BASE_GIT,
+    agents: [
+      {
+        id: "mix-api-surface",
+        label: "API Surface Check",
+        harness: "Claude",
+        status: "starting",
+        wakeScheduled: false,
+        detail: "Starting",
+      },
+      {
+        id: "mix-flaky-tests",
+        label: "Flaky Test Hunt",
+        harness: "Codex",
+        status: "errored",
+        wakeScheduled: false,
+        detail: "Failed · tool error",
+      },
+      {
+        id: "mix-sdk-types",
+        label: "SDK Types Sync",
+        harness: "Claude",
+        status: "running",
+        wakeScheduled: false,
+        detail: "Working · 6m",
+      },
+      {
+        id: "mix-migration-dry",
+        label: "Migration Dry Run",
+        harness: "Codex",
+        status: "idle",
+        wakeScheduled: true,
+        detail: "Idle · Wake scheduled",
+      },
+      {
+        id: "mix-changelog",
+        label: "Changelog Draft",
+        harness: "Claude",
+        status: "completed",
+        wakeScheduled: false,
+        detail: "Done · Completed turn",
+      },
+      {
+        id: "mix-docs-pass",
+        label: "Docs Truth Pass",
+        harness: "Codex",
+        status: "completed",
+        wakeScheduled: false,
+        detail: "Done · Completed turn",
+      },
+    ],
+    closedAgents: [
+      {
+        id: "mix-closed-repo-shape",
+        label: "Repo Shape Audit",
+        harness: "Claude",
+        status: "closed",
+        wakeScheduled: false,
+        detail: "Closed · Yesterday",
+      },
+      {
+        id: "mix-closed-fixture",
+        label: "Fixture Backfill",
+        harness: "Codex",
+        status: "closed",
+        wakeScheduled: false,
+        detail: "Closed · 2 days ago",
+      },
+    ],
+  },
+  {
+    key: "failures",
+    label: "Failures",
+    parentTitle: "Ship workspace activity",
+    git: { ...BASE_GIT, conflictedFiles: 1 },
+    agents: [
+      {
+        id: "fail-flaky-tests",
+        label: "Flaky Test Hunt",
+        harness: "Codex",
+        status: "errored",
+        wakeScheduled: false,
+        detail: "Failed · exit 1",
+      },
+      {
+        id: "fail-catalog-probe",
+        label: "Catalog Probe",
+        harness: "Claude",
+        status: "errored",
+        wakeScheduled: false,
+        detail: "Failed · sandbox lost",
+      },
+      {
+        id: "fail-api-surface",
+        label: "API Surface Check",
+        harness: "Claude",
+        status: "starting",
+        wakeScheduled: false,
+        detail: "Starting",
+      },
+      {
+        id: "fail-sdk-types",
+        label: "SDK Types Sync",
+        harness: "Codex",
+        status: "running",
+        wakeScheduled: false,
+        detail: "Working · 1m",
+      },
+    ],
+    closedAgents: [],
+  },
+  {
+    key: "overflow",
+    label: "Overflow",
+    parentTitle: "Ship workspace activity",
+    git: BASE_GIT,
+    agents: overflowAgents(),
+    closedAgents: [
+      {
+        id: "overflow-closed-release",
+        label: "Release Dry Run",
+        harness: "Claude",
+        status: "closed",
+        wakeScheduled: false,
+        detail: "Closed · Yesterday",
+      },
+      {
+        id: "overflow-closed-seed",
+        label: "Seed Script Repair",
+        harness: "Codex",
+        status: "closed",
+        wakeScheduled: false,
+        detail: "Closed · 3 days ago",
+      },
+      {
+        id: "overflow-closed-lint",
+        label: "Lint Debt Sweep",
+        harness: "Claude",
+        status: "closed",
+        wakeScheduled: false,
+        detail: "Closed · Last week",
+      },
+    ],
+  },
+];
+
+export function resolvePopoverPaneScenario(key: PopoverPaneScenarioKey): PopoverPaneScenario {
+  return POPOVER_PANE_SCENARIOS.find((scenario) => scenario.key === key)
+    ?? POPOVER_PANE_SCENARIOS[0];
+}
+
+export interface SubagentAggregate {
+  total: number;
+  working: number;
+  idle: number;
+  wakeScheduled: number;
+  failed: number;
+  done: number;
+}
+
+export function buildSubagentAggregate(agents: readonly PrototypeAgent[]): SubagentAggregate {
+  return {
+    total: agents.length,
+    working: agents.filter((agent) => agent.status === "running" || agent.status === "starting").length,
+    idle: agents.filter((agent) => agent.status === "idle").length,
+    wakeScheduled: agents.filter((agent) => agent.wakeScheduled).length,
+    failed: agents.filter((agent) => agent.status === "errored").length,
+    done: agents.filter((agent) => agent.status === "completed").length,
+  };
+}
+
+export type ActivityFactTone = "default" | "attention" | "destructive";
+
+export interface ActivityFact {
+  key: string;
+  label: string;
+  tone: ActivityFactTone;
+}
+
+// Fact ordering mirrors buildSummaryFacts in
+// lib/domain/workspaces/activity/composer-workspace-activity.ts: attention
+// first, then active agents, actionable git state, then the healthy fallback.
+export function buildActivityFacts(
+  git: PrototypeGit,
+  aggregate: SubagentAggregate,
+): ActivityFact[] {
+  const facts: ActivityFact[] = [];
+  if (git.conflictedFiles > 0) {
+    facts.push({
+      key: "conflicts",
+      label: `${git.conflictedFiles} ${git.conflictedFiles === 1 ? "conflict" : "conflicts"}`,
+      tone: "destructive",
+    });
+  }
+  if (aggregate.failed > 0) {
+    facts.push({
+      key: "agents-failed",
+      label: `${aggregate.failed} ${aggregate.failed === 1 ? "agent failed" : "agents failed"}`,
+      tone: "destructive",
+    });
+  }
+  const workingCount = aggregate.working;
+  if (workingCount > 0) {
+    facts.push({
+      key: "agents-working",
+      label: `${workingCount} ${workingCount === 1 ? "agent working" : "agents working"}`,
+      tone: "default",
+    });
+  }
+  if (git.ahead > 0 || git.behind > 0) {
+    const parts = [
+      git.ahead > 0 ? `${git.ahead} ahead` : null,
+      git.behind > 0 ? `${git.behind} behind` : null,
+    ].filter((part): part is string => part !== null);
+    facts.push({ key: "sync", label: parts.join(" · "), tone: "default" });
+  }
+  if (git.changedFiles > 0) {
+    facts.push({
+      key: "changes",
+      label: `${git.changedFiles} ${git.changedFiles === 1 ? "change" : "changes"}`,
+      tone: "default",
+    });
+  }
+  if (git.pullRequestLabel) {
+    facts.push({ key: "pull-request", label: pullRequestSummary(git.pullRequestLabel), tone: "default" });
+  }
+  if (facts.length === 0) {
+    facts.push({ key: "branch", label: git.branch, tone: "default" });
+    facts.push({ key: "clean", label: "No changes", tone: "default" });
+  }
+  return facts;
+}
+
+export function subagentCountsLine(aggregate: SubagentAggregate): string | null {
+  const parts = [
+    aggregate.failed > 0 ? `${aggregate.failed} failed` : null,
+    aggregate.working > 0 ? `${aggregate.working} working` : null,
+    aggregate.idle > 0 ? `${aggregate.idle} idle` : null,
+    aggregate.done > 0 ? `${aggregate.done} done` : null,
+  ].filter((part): part is string => part !== null);
+  return parts.slice(0, 3).join(" · ") || null;
+}
+
+function pullRequestSummary(label: string): string {
+  const parts = label.split("·").map((part) => part.trim()).filter(Boolean);
+  const identity = parts[0] ?? label;
+  const checks = parts.find((part) => /^checks\s+/iu.test(part));
+  return checks
+    ? `${identity} ${checks.replace(/^checks\s+/iu, "").toLowerCase()}`
+    : identity;
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPanePrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPanePrototype.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Textarea } from "@proliferate/ui/primitives/Textarea";
+import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
+import { ArrowUp, ChevronDown } from "@proliferate/ui/icons";
+import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
+import {
+  ActivityAggregatePopover,
+  type PrototypeSourceControlAction,
+} from "./ActivityAggregatePopover";
+import { GlobalAgentsPanePrototype } from "./GlobalAgentsPanePrototype";
+import {
+  POPOVER_PANE_SCENARIOS,
+  resolvePopoverPaneScenario,
+  type PopoverPaneScenarioKey,
+} from "./PopoverPaneFixtures";
+
+/**
+ * Visual prototyping lane for the aggregate activity popover + the global
+ * Agents right pane. Fixture-only, no live session wiring: an app-like
+ * composer with the compact attached activity cap on the left, the pane
+ * beside it, and scenario controls across the top. The popover's Subagents
+ * entry opens the pane drilled into the current parent.
+ */
+export function PopoverPanePrototype() {
+  const [scenarioKey, setScenarioKey] = useState<PopoverPaneScenarioKey>("mixed-states");
+  const [paneOpen, setPaneOpen] = useState(true);
+  const [paneParentId, setPaneParentId] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const scenario = resolvePopoverPaneScenario(scenarioKey);
+  const paneParentFixtureId = `scenario-parent-${scenario.key}`;
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background text-foreground">
+      <header className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border px-4 py-2.5">
+        <div className="flex flex-col">
+          <h1 className="text-sm font-semibold">Aggregate popover + Subagents pane</h1>
+          <p className="text-xs text-muted-foreground">
+            Click the cap above the composer for the aggregate popover; rows in the pane select.
+          </p>
+        </div>
+        <div role="group" aria-label="Scenario" className="ml-auto flex items-center gap-1">
+          {POPOVER_PANE_SCENARIOS.map((candidate) => (
+            <Button
+              key={candidate.key}
+              type="button"
+              variant={candidate.key === scenarioKey ? "secondary" : "ghost"}
+              size="sm"
+              aria-pressed={candidate.key === scenarioKey}
+              onClick={() => {
+                setScenarioKey(candidate.key);
+                setSelectedAgentId(null);
+                setPaneParentId(null);
+              }}
+            >
+              {candidate.label}
+            </Button>
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant={paneOpen ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={paneOpen}
+          onClick={() => setPaneOpen((open) => !open)}
+        >
+          Right pane
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <main className="relative flex min-w-0 flex-1 flex-col justify-end">
+          <div className="mx-auto flex w-full max-w-2xl flex-col px-5 pb-6">
+            <div className="px-5">
+              <ActivityAggregatePopover
+                key={scenario.key}
+                git={scenario.git}
+                agents={scenario.agents}
+                onOpenSubagentsPane={() => {
+                  setPaneOpen(true);
+                  setPaneParentId(paneParentFixtureId);
+                }}
+                onSourceControlAction={(action) => setLastAction(
+                  sourceControlActionLabel(action),
+                )}
+              />
+            </div>
+            <PrototypeComposerSurface />
+          </div>
+        </main>
+        {paneOpen ? (
+          <aside className="w-72 shrink-0 border-l border-sidebar-border">
+            <GlobalAgentsPanePrototype
+              parents={scenario.agents.length > 0
+                ? [{
+                    id: paneParentFixtureId,
+                    title: scenario.parentTitle,
+                    agents: scenario.agents,
+                  }]
+                : []}
+              archived={scenario.closedAgents.map((agent) => ({
+                id: agent.id,
+                label: agent.label,
+                parentTitle: scenario.parentTitle,
+                closedDetail: agent.detail,
+              }))}
+              selectedParentId={paneParentId}
+              activeAgentId={selectedAgentId}
+              onSelectParent={(parentId) => setPaneParentId(parentId)}
+              onBack={() => setPaneParentId(null)}
+              onOpenAgent={(_parentId, agentId) => setSelectedAgentId(agentId)}
+              onOpenArchived={(archivedId) => setLastAction(
+                `Reopen archived session ${archivedId} in a chat tab (prototype only).`,
+              )}
+            />
+          </aside>
+        ) : null}
+      </div>
+      <p aria-live="polite" className="sr-only">
+        {lastAction}
+      </p>
+    </div>
+  );
+}
+
+// Read-only app-like composer surface. The activity cap paints before this so
+// the composer's own top outline stays visible at the seam (chat-composer.md §4.1).
+export function PrototypeComposerSurface() {
+  return (
+    <ChatComposerSurface>
+      <div className="relative flex flex-col">
+        <div
+          className="mb-2 flex-grow select-text overflow-y-auto px-5 pt-3.5"
+          style={{ minHeight: "3.5rem" }}
+        >
+          <Textarea
+            variant="ghost"
+            rows={2}
+            placeholder="Ask for a follow-up"
+            spellCheck={false}
+            readOnly
+            className="min-h-0 px-0 py-0 text-base leading-relaxed text-foreground placeholder:text-muted-foreground/70"
+          />
+        </div>
+        <div className="flex items-center gap-1 px-3 pb-2">
+          <ComposerControlButton
+            label="Claude"
+            detail="Sonnet"
+            trailing={<ChevronDown className="size-3" />}
+            aria-label="Model (prototype, inert)"
+          />
+          <ComposerControlButton label="Default" aria-label="Mode (prototype, inert)" />
+          <Button
+            type="button"
+            variant="inverted"
+            size="icon-sm"
+            aria-label="Send (prototype, inert)"
+            className="ml-auto"
+          >
+            <ArrowUp className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </ChatComposerSurface>
+  );
+}
+
+function sourceControlActionLabel(action: PrototypeSourceControlAction): string {
+  switch (action) {
+    case "review":
+      return "Review changes selected (prototype only).";
+    case "commit":
+      return "Commit selected (prototype only).";
+    case "publish":
+      return "Publish or push selected (prototype only).";
+    case "pull-request":
+      return "Pull request selected (prototype only).";
+  }
+}

--- a/apps/desktop/src/components/playground/subagents-ux/popover-pane/SubagentsPanePrototype.tsx
+++ b/apps/desktop/src/components/playground/subagents-ux/popover-pane/SubagentsPanePrototype.tsx
@@ -1,0 +1,186 @@
+import { Button } from "@proliferate/ui/primitives/Button";
+import { AgentGlyph } from "./AgentGlyph";
+import type { PrototypeAgent } from "./PopoverPaneFixtures";
+
+/**
+ * Parent-scoped Subagents right pane using only roster-observable session
+ * states. Rows are task-named, clickable, and visibly selected. When
+ * `onDeleteAgent` is provided, rows expose a hover Delete action — the
+ * relationship-ending affordance, distinct from closing a tab.
+ */
+export function SubagentsPanePrototype({
+  parentTitle,
+  agents,
+  selectedAgentId,
+  onSelectAgent,
+  onDeleteAgent,
+  showHeader = true,
+}: {
+  parentTitle: string;
+  agents: readonly PrototypeAgent[];
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string) => void;
+  onDeleteAgent?: (agentId: string) => void;
+  showHeader?: boolean;
+}) {
+  const failed = agents.filter((agent) => agent.status === "errored");
+  const active = agents.filter((agent) => (
+    agent.status === "running" || agent.status === "starting"
+  ));
+  const idle = agents.filter((agent) => agent.status === "idle");
+  const done = agents.filter((agent) => agent.status === "completed");
+  const summary = [
+    failed.length > 0 ? `${failed.length} failed` : null,
+    active.length > 0 ? `${active.length} working` : null,
+    idle.length > 0 ? `${idle.length} idle` : null,
+    done.length > 0 ? `${done.length} done` : null,
+  ].filter((part): part is string => part !== null).join(" · ") || "No subagents";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-sidebar-background text-sidebar-foreground">
+      {showHeader ? (
+        <div className="border-b border-sidebar-border px-4 py-3">
+          <p className="truncate text-ui font-medium text-sidebar-foreground">{parentTitle}</p>
+          <p className="mt-0.5 truncate text-ui-sm text-sidebar-muted-foreground">{summary}</p>
+        </div>
+      ) : null}
+      {agents.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center">
+          <p className="max-w-xs text-sm leading-5 text-sidebar-muted-foreground">
+            No subagents for this chat.
+          </p>
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3" role="list" aria-label="Subagents">
+          {failed.length > 0 ? (
+            <PaneSection
+              title="Failed"
+              agents={failed}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={onSelectAgent}
+              onDeleteAgent={onDeleteAgent}
+            />
+          ) : null}
+          {active.length > 0 ? (
+            <PaneSection
+              title="Working"
+              agents={active}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={onSelectAgent}
+              onDeleteAgent={onDeleteAgent}
+            />
+          ) : null}
+          {idle.length > 0 ? (
+            <PaneSection
+              title="Idle"
+              agents={idle}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={onSelectAgent}
+              onDeleteAgent={onDeleteAgent}
+            />
+          ) : null}
+          {done.length > 0 ? (
+            <PaneSection
+              title="Done"
+              agents={done}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={onSelectAgent}
+              onDeleteAgent={onDeleteAgent}
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PaneSection({
+  title,
+  agents,
+  selectedAgentId,
+  onSelectAgent,
+  onDeleteAgent,
+}: {
+  title: string;
+  agents: readonly PrototypeAgent[];
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string) => void;
+  onDeleteAgent?: (agentId: string) => void;
+}) {
+  return (
+    <section className="mb-4 last:mb-0">
+      <h2 className="mb-1.5 px-1 text-ui-sm font-normal text-sidebar-muted-foreground">{title}</h2>
+      <div className="flex flex-col gap-0.5">
+        {agents.map((agent) => (
+          <PaneRow
+            key={agent.id}
+            agent={agent}
+            selected={selectedAgentId === agent.id}
+            onSelect={() => onSelectAgent(agent.id)}
+            onDelete={onDeleteAgent ? () => onDeleteAgent(agent.id) : undefined}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PaneRow({
+  agent,
+  selected,
+  onSelect,
+  onDelete,
+}: {
+  agent: PrototypeAgent;
+  selected: boolean;
+  onSelect: () => void;
+  onDelete?: () => void;
+}) {
+  const detailToneClass = agent.status === "errored"
+    ? "text-destructive"
+    : "text-sidebar-muted-foreground";
+  return (
+    <div
+      role="listitem"
+      className={`group/pane-row flex min-h-11 min-w-0 items-center rounded-lg hover:bg-sidebar-accent ${selected ? "bg-sidebar-accent" : ""}`}
+    >
+      <Button
+        type="button"
+        variant="unstyled"
+        size="unstyled"
+        aria-current={selected ? "true" : undefined}
+        title={`${agent.label} · ${agent.harness} · ${agent.detail}`}
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-center justify-start gap-2 rounded-lg px-2 py-1.5 text-left text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-sidebar-border"
+      >
+        <AgentGlyph id={agent.id} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-ui font-medium">
+            {agent.label}
+          </span>
+          <span className={`block truncate text-ui-sm font-normal ${detailToneClass}`}>
+            {agent.detail}
+          </span>
+        </span>
+        <span className="shrink-0 font-mono text-xs text-sidebar-muted-foreground">
+          {agent.harness}
+        </span>
+      </Button>
+      {onDelete ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`Delete ${agent.label}`}
+          title={agent.status === "running" || agent.status === "starting"
+            ? "Delete agent — active work will be ended"
+            : "Delete agent"}
+          onClick={onDelete}
+          className="mr-1 h-7 shrink-0 px-2 text-sidebar-muted-foreground opacity-0 hover:bg-sidebar-accent hover:text-destructive group-hover/pane-row:opacity-100 focus-visible:opacity-100"
+        >
+          Delete
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/pages/SubagentsUxPlaygroundPage.tsx
+++ b/apps/desktop/src/pages/SubagentsUxPlaygroundPage.tsx
@@ -1,0 +1,5 @@
+import { SubagentsUxPlayground } from "@/components/playground/subagents-ux/SubagentsUxPlayground";
+
+export function SubagentsUxPlaygroundPage() {
+  return <SubagentsUxPlayground />;
+}

--- a/specs/codebase/features/chat-composer.md
+++ b/specs/codebase/features/chat-composer.md
@@ -455,6 +455,10 @@ Scenarios (selectable via `?s=<key>`):
 
 The playground is **dev-only**. It is lazy-loaded via `React.lazy()` gated on `import.meta.env.DEV` in `App.tsx`, so neither the page nor its fixtures land in production bundles.
 
+`/playground/subagents` is a separate fixture-only UX lab for Subagents receipts,
+navigation, panes, transcripts, and close/archive behavior. It is DEV-gated and
+does not read or mutate production sessions.
+
 When you change any composer-area component, **load the playground and verify every scenario still looks right** before opening a PR. The playground exists to catch drift — if it stops looking like the real app, either fix the real app or fix the playground (and add a regression scenario).
 
 ### Playground structure


### PR DESCRIPTION
## What changed

- Add a DEV-gated, fixture-only Subagents UX lab.
- Cover creation receipts, parent and global agent panes, child transcript tabs, close/delete behavior, and archived read-only transcripts.
- Keep authored task labels as the only human-readable agent identity.
- Keep all production Subagents hooks, stores, and session mutations out of this branch.

## Validation

- Desktop TypeScript check.
- Production Vite build; the DEV route is absent from the bundle.
- Frontend boundary and diff checks.
- Live browser smoke on /playground/subagents, including archived read-only transcript behavior and clean console logs.