### PR TITLE
fix(desktop): surface dispatch worker startup failures

### DIFF
--- a/apps/desktop/src-tauri/src/commands/cloud_worker.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::OpenOptions,
-    io,
+    io::{self, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -23,6 +23,8 @@ use crate::{
 mod launcher;
 
 use launcher::find_proliferate_worker_launcher;
+
+const WORKER_LOG_TAIL_MAX_BYTES: u64 = 64 * 1024;
 
 #[derive(Default)]
 pub struct CloudWorkerState {
@@ -197,22 +199,19 @@ pub async fn ensure_desktop_dispatch_worker(
     };
     if let Some(status) = startup_exit {
         let log_tail = read_worker_log_tail(&paths.log, 12);
+        let scrubbed_log_path = scrub_diagnostic_text(&paths.log.to_string_lossy());
         tracing::error!(
             launcher = %launcher,
             %status,
-            log_path = %paths.log.display(),
+            log_path = %scrubbed_log_path,
             log_tail = %log_tail,
             "Proliferate Worker exited during startup"
         );
-        let mut message = format!(
-            "Proliferate Worker exited during startup with {status}. See {} for output.",
-            paths.log.display()
-        );
-        if !log_tail.is_empty() {
-            message.push_str("\n\nLast worker log lines:\n");
-            message.push_str(&log_tail);
-        }
-        return Err(message);
+        return Err(worker_startup_failure_message(
+            &status.to_string(),
+            &paths.log,
+            &log_tail,
+        ));
     }
 
     let result = EnsureDesktopDispatchWorkerResult {
@@ -459,13 +458,38 @@ fn startup_watch_window(fresh_enrollment: bool) -> Duration {
     }
 }
 
+fn worker_startup_failure_message(status: &str, log_path: &Path, log_tail: &str) -> String {
+    let scrubbed_log_path = scrub_diagnostic_text(&log_path.to_string_lossy());
+    let mut message = format!(
+        "Proliferate Worker exited during startup with {status}. See {scrubbed_log_path} for output."
+    );
+    if !log_tail.is_empty() {
+        message.push_str("\n\nLast worker log lines:\n");
+        message.push_str(log_tail);
+    }
+    message
+}
+
 /// Best-effort context for a startup error returned to the renderer. The
-/// worker log is truncated for every launch, so reading it here remains
-/// bounded to the failed startup attempt.
+/// worker log is truncated for every launch. Read only a fixed suffix so this
+/// error path cannot allocate or block in proportion to total log volume.
 fn read_worker_log_tail(path: &Path, max_lines: usize) -> String {
-    let Ok(contents) = std::fs::read_to_string(path) else {
+    let Ok(mut file) = std::fs::File::open(path) else {
         return String::new();
     };
+    let Ok(file_len) = file.metadata().map(|metadata| metadata.len()) else {
+        return String::new();
+    };
+    let read_len = file_len.min(WORKER_LOG_TAIL_MAX_BYTES) as usize;
+    let start = file_len.saturating_sub(read_len as u64);
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return String::new();
+    }
+    let mut bytes = vec![0; read_len];
+    if file.read_exact(&mut bytes).is_err() {
+        return String::new();
+    }
+    let contents = String::from_utf8_lossy(&bytes);
     let lines = contents.lines().collect::<Vec<_>>();
     let start = lines.len().saturating_sub(max_lines);
     scrub_diagnostic_text(&lines[start..].join("\n"))

--- a/apps/desktop/src-tauri/src/commands/cloud_worker.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker.rs
@@ -11,11 +11,12 @@ use tauri::State;
 use tokio::{
     process::Child,
     sync::Mutex,
-    time::{sleep, Duration},
+    time::{sleep, Duration, Instant},
 };
 
 use crate::{
     app_config,
+    diagnostics::scrub_diagnostic_text,
     sidecar::{resolve_shell_path, SharedSidecar},
 };
 
@@ -181,21 +182,37 @@ pub async fn ensure_desktop_dispatch_worker(
         pid = child.id(),
         "Proliferate Worker spawned"
     );
-    sleep(Duration::from_millis(150)).await;
-    if let Some(status) = child
-        .try_wait()
-        .map_err(|error| format!("Failed to inspect Proliferate Worker startup: {error}"))?
-    {
+    let startup_deadline = Instant::now() + startup_watch_window(enrollment_token.is_some());
+    let startup_exit = loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("Failed to inspect Proliferate Worker startup: {error}"))?
+        {
+            break Some(status);
+        }
+        if Instant::now() >= startup_deadline {
+            break None;
+        }
+        sleep(Duration::from_millis(100)).await;
+    };
+    if let Some(status) = startup_exit {
+        let log_tail = read_worker_log_tail(&paths.log, 12);
         tracing::error!(
             launcher = %launcher,
             %status,
             log_path = %paths.log.display(),
+            log_tail = %log_tail,
             "Proliferate Worker exited during startup"
         );
-        return Err(format!(
+        let mut message = format!(
             "Proliferate Worker exited during startup with {status}. See {} for output.",
             paths.log.display()
-        ));
+        );
+        if !log_tail.is_empty() {
+            message.push_str("\n\nLast worker log lines:\n");
+            message.push_str(&log_tail);
+        }
+        return Err(message);
     }
 
     let result = EnsureDesktopDispatchWorkerResult {
@@ -430,6 +447,28 @@ fn open_worker_log(path: &Path) -> Result<(std::fs::File, std::fs::File), String
         .try_clone()
         .map_err(|error| format!("Failed to open worker log at {}: {error}", path.display()))?;
     Ok((file, clone))
+}
+
+fn startup_watch_window(fresh_enrollment: bool) -> Duration {
+    if fresh_enrollment {
+        // A fresh enrollment must survive its first control-plane roundtrip.
+        // This catches contract mismatches that exit after the old 150ms watch.
+        Duration::from_secs(3)
+    } else {
+        Duration::from_millis(500)
+    }
+}
+
+/// Best-effort context for a startup error returned to the renderer. The
+/// worker log is truncated for every launch, so reading it here remains
+/// bounded to the failed startup attempt.
+fn read_worker_log_tail(path: &Path, max_lines: usize) -> String {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return String::new();
+    };
+    let lines = contents.lines().collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(max_lines);
+    scrub_diagnostic_text(&lines[start..].join("\n"))
 }
 
 fn toml_string(value: &str) -> String {

--- a/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
@@ -63,12 +63,39 @@ impl fmt::Display for WorkerLauncher {
 }
 
 pub(super) fn find_proliferate_worker_launcher() -> Option<WorkerLauncher> {
-    if let Ok(value) = std::env::var("PROLIFERATE_WORKER_BIN") {
-        if let Some(path) = usable_worker_binary(&PathBuf::from(value)) {
-            return Some(WorkerLauncher::Binary(path));
-        }
-    }
+    let explicit = std::env::var("PROLIFERATE_WORKER_BIN")
+        .ok()
+        .and_then(|value| usable_worker_binary(&PathBuf::from(value)))
+        .map(WorkerLauncher::Binary);
 
+    let debug_cargo = if cfg!(debug_assertions) {
+        match (which::which("cargo").ok(), workspace_root()) {
+            (Some(cargo), Some(workspace_root)) => Some(WorkerLauncher::CargoRun {
+                cargo,
+                workspace_root,
+            }),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    select_worker_launcher(explicit, debug_cargo, find_scanned_worker_launcher)
+}
+
+/// Preserves an explicit developer override while ensuring debug builds run the
+/// worker from the current checkout instead of silently selecting a stale
+/// target/debug or PATH binary. Release builds pass no cargo launcher and keep
+/// the packaged/scanned binary behavior.
+fn select_worker_launcher(
+    explicit: Option<WorkerLauncher>,
+    debug_cargo: Option<WorkerLauncher>,
+    scan: impl FnOnce() -> Option<WorkerLauncher>,
+) -> Option<WorkerLauncher> {
+    explicit.or(debug_cargo).or_else(scan)
+}
+
+fn find_scanned_worker_launcher() -> Option<WorkerLauncher> {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
             let target = current_target_triple();
@@ -92,16 +119,6 @@ pub(super) fn find_proliferate_worker_launcher() -> Option<WorkerLauncher> {
     if let Ok(path) = which::which("proliferate-worker") {
         if let Some(path) = usable_worker_binary(&path) {
             return Some(WorkerLauncher::Binary(path));
-        }
-    }
-
-    if cfg!(debug_assertions) {
-        if let (Some(cargo), Some(workspace_root)) = (which::which("cargo").ok(), workspace_root())
-        {
-            return Some(WorkerLauncher::CargoRun {
-                cargo,
-                workspace_root,
-            });
         }
     }
 
@@ -172,4 +189,57 @@ fn is_placeholder_sidecar(path: &Path) -> bool {
     };
     let text = String::from_utf8_lossy(&bytes);
     text.contains("sidecar is not available") || text.contains("unsupported target placeholder")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, path::PathBuf};
+
+    use super::{select_worker_launcher, WorkerLauncher};
+
+    fn binary(path: &str) -> WorkerLauncher {
+        WorkerLauncher::Binary(PathBuf::from(path))
+    }
+
+    fn cargo_run() -> WorkerLauncher {
+        WorkerLauncher::CargoRun {
+            cargo: PathBuf::from("/toolchain/cargo"),
+            workspace_root: PathBuf::from("/workspace"),
+        }
+    }
+
+    #[test]
+    fn explicit_binary_wins_without_scanning() {
+        let scanned = Cell::new(false);
+        let launcher = select_worker_launcher(Some(binary("/explicit")), Some(cargo_run()), || {
+            scanned.set(true);
+            Some(binary("/scanned"))
+        });
+
+        assert!(
+            matches!(launcher, Some(WorkerLauncher::Binary(path)) if path == PathBuf::from("/explicit"))
+        );
+        assert!(!scanned.get());
+    }
+
+    #[test]
+    fn debug_cargo_wins_over_scanned_binaries() {
+        let scanned = Cell::new(false);
+        let launcher = select_worker_launcher(None, Some(cargo_run()), || {
+            scanned.set(true);
+            Some(binary("/stale-target-debug"))
+        });
+
+        assert!(matches!(launcher, Some(WorkerLauncher::CargoRun { .. })));
+        assert!(!scanned.get());
+    }
+
+    #[test]
+    fn scanned_binary_is_used_when_cargo_run_is_unavailable() {
+        let launcher = select_worker_launcher(None, None, || Some(binary("/packaged")));
+
+        assert!(
+            matches!(launcher, Some(WorkerLauncher::Binary(path)) if path == PathBuf::from("/packaged"))
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
@@ -1,6 +1,6 @@
-use std::{env, fs};
+use std::{env, fs, time::Duration};
 
-use super::write_worker_config;
+use super::{read_worker_log_tail, startup_watch_window, write_worker_config};
 
 #[test]
 fn worker_config_uses_the_desktop_sidecar_url() {
@@ -25,4 +25,70 @@ fn worker_config_uses_the_desktop_sidecar_url() {
     let contents = fs::read_to_string(config_path).expect("read worker config");
     assert!(contents.contains("runtime_base_url = \"http://127.0.0.1:50746\""));
     fs::remove_dir_all(root).expect("remove temporary worker config root");
+}
+
+#[test]
+fn fresh_enrollment_gets_the_longer_startup_watch() {
+    assert_eq!(startup_watch_window(true), Duration::from_secs(3));
+    assert_eq!(startup_watch_window(false), Duration::from_millis(500));
+}
+
+#[test]
+fn worker_log_tail_returns_only_the_requested_final_lines() {
+    let root = env::temp_dir().join(format!(
+        "proliferate-worker-log-tail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::create_dir_all(&root).expect("create temporary worker log root");
+    let log_path = root.join("worker.log");
+    let contents = (1..=20)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&log_path, contents).expect("write worker log");
+
+    assert_eq!(
+        read_worker_log_tail(&log_path, 3),
+        "line 18\nline 19\nline 20"
+    );
+    fs::remove_dir_all(root).expect("remove temporary worker log root");
+}
+
+#[test]
+fn missing_worker_log_has_no_tail() {
+    let missing = env::temp_dir().join(format!(
+        "proliferate-worker-missing-log-{}",
+        uuid::Uuid::new_v4()
+    ));
+
+    assert_eq!(read_worker_log_tail(&missing, 12), "");
+}
+
+#[test]
+fn worker_log_tail_scrubs_secrets_and_user_paths() {
+    let root = env::temp_dir().join(format!(
+        "proliferate-worker-scrubbed-log-tail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::create_dir_all(&root).expect("create temporary worker log root");
+    let log_path = root.join("worker.log");
+    let home = crate::app_config::home_dir().expect("resolve user home");
+    let private_path = home.join("projects/private-repository");
+    fs::write(
+        &log_path,
+        format!(
+            "Authorization: Bearer auth-secret-value\nPROLIFERATE_TOKEN=env-secret-value\nworkspace={}",
+            private_path.display()
+        ),
+    )
+    .expect("write worker log");
+
+    let tail = read_worker_log_tail(&log_path, 12);
+
+    assert!(!tail.contains("auth-secret-value"));
+    assert!(!tail.contains("env-secret-value"));
+    assert!(!tail.contains(&home.to_string_lossy().to_string()));
+    assert!(tail.contains("[REDACTED]"));
+    assert!(tail.contains("~/projects/private-repository"));
+    fs::remove_dir_all(root).expect("remove temporary worker log root");
 }

--- a/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/tests.rs
@@ -1,6 +1,9 @@
 use std::{env, fs, time::Duration};
 
-use super::{read_worker_log_tail, startup_watch_window, write_worker_config};
+use super::{
+    read_worker_log_tail, startup_watch_window, worker_startup_failure_message,
+    write_worker_config, WORKER_LOG_TAIL_MAX_BYTES,
+};
 
 #[test]
 fn worker_config_uses_the_desktop_sidecar_url() {
@@ -90,5 +93,41 @@ fn worker_log_tail_scrubs_secrets_and_user_paths() {
     assert!(!tail.contains(&home.to_string_lossy().to_string()));
     assert!(tail.contains("[REDACTED]"));
     assert!(tail.contains("~/projects/private-repository"));
+    fs::remove_dir_all(root).expect("remove temporary worker log root");
+}
+
+#[test]
+fn startup_failure_message_scrubs_the_worker_log_path() {
+    let home = crate::app_config::home_dir().expect("resolve user home");
+    let log_path = home.join(".proliferate-local/dev/profiles/private/cloud-worker/worker.log");
+
+    let message = worker_startup_failure_message("exit status: 1", &log_path, "safe tail");
+
+    assert!(!message.contains(&home.to_string_lossy().to_string()));
+    assert!(message.contains("See ~/"));
+    assert!(message.contains("safe tail"));
+}
+
+#[test]
+fn worker_log_tail_reads_only_the_bounded_suffix() {
+    let root = env::temp_dir().join(format!(
+        "proliferate-worker-bounded-log-tail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::create_dir_all(&root).expect("create temporary worker log root");
+    let log_path = root.join("worker.log");
+    let old_prefix = "old-prefix-that-must-not-be-read";
+    let oversized_middle = "x".repeat(WORKER_LOG_TAIL_MAX_BYTES as usize + 1024);
+    fs::write(
+        &log_path,
+        format!("{old_prefix}\n{oversized_middle}\nrecent line one\nrecent line two\n"),
+    )
+    .expect("write oversized worker log");
+
+    let tail = read_worker_log_tail(&log_path, 3);
+
+    assert!(!tail.contains(old_prefix));
+    assert!(tail.contains("recent line one"));
+    assert!(tail.contains("recent line two"));
     fs::remove_dir_all(root).expect("remove temporary worker log root");
 }

--- a/apps/desktop/src/copy/cloud/desktop-worker-copy.ts
+++ b/apps/desktop/src/copy/cloud/desktop-worker-copy.ts
@@ -1,0 +1,5 @@
+export function desktopWorkerStartupFailureCopy(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error ?? "");
+  const normalizedDetail = detail.trim().length > 0 ? detail.trim() : "Unknown error";
+  return `Cloud integrations worker failed to start: ${normalizedDetail}`;
+}

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -252,4 +252,33 @@ describe("useDesktopWorkerEnrollment", () => {
       ]);
     });
   });
+
+  it("does not show a stale failure after sign-out cancels enrollment", async () => {
+    let failOldEnrollment: (() => void) | null = null;
+    workflowMocks.ensureDesktopWorker.mockImplementationOnce(
+      (_organizationId, deps) =>
+        new Promise<boolean>((resolve) => {
+          failOldEnrollment = () => {
+            deps.onFailure("old identity failed after sign-out");
+            resolve(false);
+          };
+        }),
+    );
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(failOldEnrollment).not.toBeNull();
+    });
+    harness.signOut();
+    await waitFor(() => {
+      expect(workflowMocks.teardownDesktopWorker).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      failOldEnrollment?.();
+      await flushEffects();
+    });
+    expect(harness.getToasts()).toEqual([]);
+  });
 });

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -5,7 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthUser } from "@/lib/domain/auth/auth-user";
 
 const workflowMocks = vi.hoisted(() => ({
-  ensureDesktopWorker: vi.fn<(organizationId: string | null) => Promise<boolean>>(),
+  ensureDesktopWorker: vi.fn<
+    (
+      organizationId: string | null,
+      deps: { onFailure: (error: unknown) => void },
+    ) => Promise<boolean>
+  >(),
   teardownDesktopWorker: vi.fn<() => Promise<void>>(),
 }));
 
@@ -24,6 +29,7 @@ async function loadEnrollmentHarness() {
   vi.resetModules();
   const { useAuthStore } = await import("@/stores/auth/auth-store");
   const { useOrganizationStore } = await import("@/stores/organizations/organization-store");
+  const { useToastStore } = await import("@/stores/toast/toast-store");
   const { useDesktopWorkerEnrollment } = await import("./use-desktop-worker-enrollment");
   useAuthStore.setState({
     status: "bootstrapping",
@@ -35,6 +41,7 @@ async function loadEnrollmentHarness() {
     activeOrganizationId: null,
     activeOrganizationValidated: false,
   });
+  useToastStore.setState({ toasts: [] });
   const rendered = renderHook(() => useDesktopWorkerEnrollment());
   return {
     ...rendered,
@@ -45,6 +52,7 @@ async function loadEnrollmentHarness() {
       useOrganizationStore.getState().setActiveOrganizationId(organizationId, {
         validated: true,
       }),
+    getToasts: () => useToastStore.getState().toasts,
     nudgeRender: () => useAuthStore.setState({ error: "nudge a re-render" }),
   };
 }
@@ -135,7 +143,10 @@ describe("useDesktopWorkerEnrollment", () => {
     await waitFor(() => {
       expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
     });
-    expect(workflowMocks.ensureDesktopWorker).toHaveBeenLastCalledWith("org-2");
+    expect(workflowMocks.ensureDesktopWorker).toHaveBeenLastCalledWith(
+      "org-2",
+      expect.objectContaining({ onFailure: expect.any(Function) }),
+    );
     expect(workflowMocks.teardownDesktopWorker).not.toHaveBeenCalled();
   });
 
@@ -221,5 +232,24 @@ describe("useDesktopWorkerEnrollment", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("shows the native startup failure to the user", async () => {
+    workflowMocks.ensureDesktopWorker.mockImplementationOnce(async (_organizationId, deps) => {
+      deps.onFailure("worker exited: enrollment contract mismatch");
+      return false;
+    });
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(harness.getToasts()).toEqual([
+        expect.objectContaining({
+          message:
+            "Cloud integrations worker failed to start: worker exited: enrollment contract mismatch",
+          type: "error",
+        }),
+      ]);
+    });
   });
 });

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
+import { desktopWorkerStartupFailureCopy } from "@/copy/cloud/desktop-worker-copy";
 import {
   ensureDesktopWorker,
   teardownDesktopWorker,
 } from "@/lib/workflows/cloud/ensure-desktop-worker";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useOrganizationStore } from "@/stores/organizations/organization-store";
+import { useToastStore } from "@/stores/toast/toast-store";
 
 // (user, org) key the desktop worker is currently enrolled for. Module-level
 // so remounts (or StrictMode double-effects) don't re-enroll for the same
@@ -48,6 +50,7 @@ export function useDesktopWorkerEnrollment(): void {
   const activeOrganizationId = useOrganizationStore(
     (state) => state.activeOrganizationId,
   );
+  const showToast = useToastStore((state) => state.show);
   const [retryNonce, setRetryNonce] = useState(0);
   useEffect(() => {
     if (authStatus === "bootstrapping") {
@@ -74,7 +77,11 @@ export function useDesktopWorkerEnrollment(): void {
     enrolledIdentityKey = nextIdentityKey;
     let cancelled = false;
     let retryTimer: number | null = null;
-    void ensureDesktopWorker(activeOrganizationId).then((enrolled) => {
+    void ensureDesktopWorker(activeOrganizationId, {
+      onFailure: (error) => {
+        showToast(desktopWorkerStartupFailureCopy(error), "error");
+      },
+    }).then((enrolled) => {
       if (enrolled || enrolledIdentityKey !== nextIdentityKey) {
         return;
       }
@@ -95,5 +102,5 @@ export function useDesktopWorkerEnrollment(): void {
         window.clearTimeout(retryTimer);
       }
     };
-  }, [authStatus, authUserId, activeOrganizationId, retryNonce]);
+  }, [authStatus, authUserId, activeOrganizationId, retryNonce, showToast]);
 }

--- a/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -79,6 +79,9 @@ export function useDesktopWorkerEnrollment(): void {
     let retryTimer: number | null = null;
     void ensureDesktopWorker(activeOrganizationId, {
       onFailure: (error) => {
+        if (cancelled || enrolledIdentityKey !== nextIdentityKey) {
+          return;
+        }
         showToast(desktopWorkerStartupFailureCopy(error), "error");
       },
     }).then((enrolled) => {

--- a/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
+++ b/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
@@ -39,7 +39,9 @@ describe("ensureDesktopWorker", () => {
   });
 
   it("enrolls with the caller-supplied organization id", async () => {
-    await expect(ensureDesktopWorker("org-1")).resolves.toBe(true);
+    await expect(
+      ensureDesktopWorker("org-1", { onFailure: vi.fn() }),
+    ).resolves.toBe(true);
 
     expect(sdkMocks.enrollDesktopWorker).toHaveBeenCalledWith("install-1", "org-1");
     expect(tauriMocks.ensureDesktopDispatchWorker).toHaveBeenCalledWith({
@@ -49,16 +51,33 @@ describe("ensureDesktopWorker", () => {
   });
 
   it("enrolls org-less users with a null organization id", async () => {
-    await expect(ensureDesktopWorker(null)).resolves.toBe(true);
+    await expect(
+      ensureDesktopWorker(null, { onFailure: vi.fn() }),
+    ).resolves.toBe(true);
 
     expect(sdkMocks.enrollDesktopWorker).toHaveBeenCalledWith("install-1", null);
   });
 
   it("resolves false when enrollment fails so the guard can retry", async () => {
-    sdkMocks.enrollDesktopWorker.mockRejectedValue(new Error("offline"));
+    const error = new Error("offline");
+    const onFailure = vi.fn();
+    sdkMocks.enrollDesktopWorker.mockRejectedValue(error);
 
-    await expect(ensureDesktopWorker(null)).resolves.toBe(false);
+    await expect(ensureDesktopWorker(null, { onFailure })).resolves.toBe(false);
 
     expect(tauriMocks.ensureDesktopDispatchWorker).not.toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledWith(error);
+  });
+
+  it("still resolves false when the failure reporter throws", async () => {
+    sdkMocks.enrollDesktopWorker.mockRejectedValue(new Error("offline"));
+
+    await expect(
+      ensureDesktopWorker(null, {
+        onFailure: () => {
+          throw new Error("toast unavailable");
+        },
+      }),
+    ).resolves.toBe(false);
   });
 });

--- a/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
+++ b/apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts
@@ -13,6 +13,10 @@ import { captureTelemetryException } from "@/lib/integrations/telemetry/client";
 // versa). Tasks swallow their own errors, so the chain never rejects.
 let workerLifecycleChain: Promise<unknown> = Promise.resolve();
 
+export interface EnsureDesktopWorkerDeps {
+  onFailure: (error: unknown) => void;
+}
+
 function enqueueWorkerLifecycleTask<T>(task: () => Promise<T>): Promise<T> {
   const run = workerLifecycleChain.then(task, task);
   workerLifecycleChain = run;
@@ -27,7 +31,10 @@ function enqueueWorkerLifecycleTask<T>(task: () => Promise<T>): Promise<T> {
 // active organization changes mid-flight.
 // Runs opportunistically on login; never blocks or throws on failure.
 // Resolves false when enrollment failed so the guard can retry.
-export function ensureDesktopWorker(organizationId: string | null): Promise<boolean> {
+export function ensureDesktopWorker(
+  organizationId: string | null,
+  deps: EnsureDesktopWorkerDeps,
+): Promise<boolean> {
   return enqueueWorkerLifecycleTask(async () => {
     try {
       const desktopInstallId = await getDesktopInstallId();
@@ -47,6 +54,16 @@ export function ensureDesktopWorker(organizationId: string | null): Promise<bool
           domain: "cloud",
         },
       });
+      try {
+        deps.onFailure(error);
+      } catch (notificationError) {
+        captureTelemetryException(notificationError, {
+          tags: {
+            action: "notify-desktop-worker-failure",
+            domain: "cloud",
+          },
+        });
+      }
       return false;
     }
   });


### PR DESCRIPTION
## Summary

Fresh-port the still-relevant behavior from #922 onto current `main`:

- prefer the checked-out worker via `cargo run` in debug builds while preserving `PROLIFERATE_WORKER_BIN` precedence
- watch fresh enrollment startup long enough to catch contract/runtime crashes
- surface a bounded, scrubbed worker log tail to the user instead of silently failing
- keep renderer notifications at the lifecycle-hook boundary
- redact credentials and user paths before the tail reaches tracing, telemetry, or UI

## Review hardening

All three actionable review findings are addressed:

- cancelled or stale identity enrollments cannot show a failure toast
- returned and traced worker-log paths are scrubbed
- tail reads are bounded to the final 64 KiB before selecting recent lines

## Verification

- Rust desktop-worker tests: 10/10
- renderer worker/enrollment tests: 15/15
- full Desktop package build, TypeScript, and Vite build
- frontend boundaries, max-lines/full strict repo shape, Rust formatting, and diff checks

Supersedes #922.