### PR TITLE
fix(anyharness): resolve Cursor model variants

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/apply.rs
@@ -5,6 +5,7 @@ use anyharness_contract::v1::{ConfigApplyState, SessionLiveConfigSnapshot};
 use tokio::sync::Mutex;
 
 use crate::live::sessions::actor::command::SetConfigOptionCommandError;
+use crate::live::sessions::actor::config::diagnostics;
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, persist_requested_config_value_if_changed, persisted_control_values,
 };
@@ -12,7 +13,7 @@ use crate::live::sessions::actor::config::queue::config_request_matches_current_
 use crate::live::sessions::actor::config::selection::{
     current_select_value, find_select_option_by_purpose, find_select_option_for_request,
     find_select_option_for_value, is_mode_config_request, is_model_config_request,
-    option_matches_purpose, select_option_contains_value,
+    option_matches_purpose, resolve_model_variant_value, select_option_contains_value,
 };
 use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose, PersistedSessionConfigState,
@@ -134,6 +135,10 @@ pub(in crate::live::sessions::actor) async fn apply_select_config_option_with_po
         return Ok(ConfigApplyOutcome::NotApplied);
     };
 
+    let resolved_value = resolve_model_variant_value(option, desired_value);
+    diagnostics::trace_native_variant(native_session_id, config_id, desired_value, &resolved_value);
+    let desired_value = resolved_value.as_str();
+
     if !select_option_contains_value(option, desired_value) && !allow_foreign_value {
         return Ok(ConfigApplyOutcome::NotApplied);
     }
@@ -179,6 +184,14 @@ pub(in crate::live::sessions::actor) async fn apply_specific_config_option(
     let is_mode_request = is_mode_config_request(config_id, option);
     let tracked_purpose = tracked_config_purpose(config_id, option);
     let model_value_authorized = is_model_request && catalog_authorized_model;
+
+    // Resolve before validation so validation, ACP, and persistence agree.
+    let resolved_value = option.map_or_else(
+        || desired_value.to_string(),
+        |option| resolve_model_variant_value(option, desired_value),
+    );
+    diagnostics::trace_session_variant(session_id, config_id, desired_value, &resolved_value);
+    let desired_value = resolved_value.as_str();
 
     if option.is_none() && !is_model_request && !is_mode_request {
         return Err(SetConfigOptionCommandError::Rejected(format!(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/diagnostics.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/diagnostics.rs
@@ -1,0 +1,37 @@
+pub(in crate::live::sessions::actor) fn trace_native_variant(
+    native_session_id: &str,
+    config_id: &str,
+    requested: &str,
+    resolved: &str,
+) {
+    if requested == resolved {
+        return;
+    }
+
+    tracing::debug!(
+        native_session_id,
+        config_id,
+        requested,
+        resolved,
+        "[model-switch] resolved bare model variant from live ACP config"
+    );
+}
+
+pub(in crate::live::sessions::actor) fn trace_session_variant(
+    session_id: &str,
+    config_id: &str,
+    requested: &str,
+    resolved: &str,
+) {
+    if requested == resolved {
+        return;
+    }
+
+    tracing::debug!(
+        session_id,
+        config_id,
+        requested,
+        resolved,
+        "[model-switch] resolved bare model variant from live ACP config"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -123,8 +123,7 @@ impl SessionActor {
         catalog_authorized_model: bool,
     ) -> Result<ConfigApplyState, crate::live::sessions::actor::command::SetConfigOptionCommandError>
     {
-        let option = find_select_option_for_request(&self.startup_state.config_options, config_id);
-        queue_pending_config_change(
+        let resolved_value = queue_pending_config_change(
             self.caps.state.as_ref(),
             &self.session_id,
             &self.startup_state,
@@ -132,6 +131,7 @@ impl SessionActor {
             value,
             catalog_authorized_model,
         )?;
+        let option = find_select_option_for_request(&self.startup_state.config_options, config_id);
 
         if let Err(error) = persist_requested_config_value_if_changed(
             self.caps.state.as_ref(),
@@ -139,7 +139,7 @@ impl SessionActor {
             &self.session_id,
             &mut self.persisted_config_state,
             tracked_config_purpose(config_id, option),
-            value,
+            &resolved_value,
             chrono::Utc::now().to_rfc3339(),
         )
         .await

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply;
+pub mod diagnostics;
 pub mod handle;
 pub mod persist;
 pub mod queue;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/queue.rs
@@ -10,7 +10,8 @@ use crate::live::sessions::actor::config::apply::{
 };
 use crate::live::sessions::actor::config::selection::{
     current_select_value, find_select_option_for_request, is_mode_config_request,
-    is_model_config_request, pending_config_rank, select_option_contains_value,
+    is_model_config_request, pending_config_rank, resolve_model_variant_value,
+    select_option_contains_value,
 };
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::state::SessionStartupState;
@@ -23,11 +24,25 @@ pub(in crate::live::sessions::actor) fn queue_pending_config_change(
     config_id: &str,
     value: &str,
     catalog_authorized_model: bool,
-) -> Result<(), SetConfigOptionCommandError> {
+) -> Result<String, SetConfigOptionCommandError> {
     let option = find_select_option_for_request(&startup_state.config_options, config_id);
     let is_model_request = is_model_config_request(config_id, option);
     let is_mode_request = is_mode_config_request(config_id, option);
     let model_value_authorized = is_model_request && catalog_authorized_model;
+    let resolved_value = option.map_or_else(
+        || value.to_string(),
+        |option| resolve_model_variant_value(option, value),
+    );
+    if resolved_value != value {
+        tracing::debug!(
+            session_id,
+            config_id,
+            requested = value,
+            resolved = %resolved_value,
+            "[model-switch] resolved queued bare model variant from live ACP config"
+        );
+    }
+    let value = resolved_value.as_str();
 
     if option.is_none() && !is_model_request && !is_mode_request {
         return Err(SetConfigOptionCommandError::Rejected(format!(
@@ -70,7 +85,9 @@ pub(in crate::live::sessions::actor) fn queue_pending_config_change(
             value: value.to_string(),
             queued_at,
         })
-        .map_err(|error| SetConfigOptionCommandError::Rejected(error.to_string()))
+        .map_err(|error| SetConfigOptionCommandError::Rejected(error.to_string()))?;
+
+    Ok(resolved_value)
 }
 
 pub(in crate::live::sessions::actor) fn config_request_matches_current_state(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/selection.rs
@@ -236,3 +236,78 @@ pub(in crate::live::sessions::actor) fn select_option_values(
         _ => Vec::new(),
     }
 }
+
+fn model_variant_base(value: &str) -> &str {
+    value.split_once('[').map_or(value, |(base, _)| base)
+}
+
+/// A bracket-params value is a model base followed by either `[]` or a
+/// comma-separated parameter list. Context-window tags such as `[1m]` are
+/// distinct model ids and deliberately do not match this grammar.
+fn is_bracket_params_variant(value: &str) -> bool {
+    let Some((base, suffix)) = value.split_once('[') else {
+        return false;
+    };
+    let Some(params) = suffix.strip_suffix(']') else {
+        return false;
+    };
+
+    !base.is_empty()
+        && (params.is_empty()
+            || params
+                .split(',')
+                .all(|pair| !pair.is_empty() && pair.contains('=')))
+}
+
+/// A non-empty or malformed bracket suffix is an explicit caller choice. The
+/// resolver may fill in a bare/empty variant, but must never replace params a
+/// caller supplied.
+fn has_explicit_variant_params(value: &str) -> bool {
+    let Some((_, suffix)) = value.split_once('[') else {
+        return false;
+    };
+
+    suffix
+        .strip_suffix(']')
+        .map_or(true, |params| !params.is_empty())
+}
+
+/// Resolve a model request to the exact composed value advertised by the live
+/// ACP session.
+///
+/// Cursor's bracket-params model control accepts values such as
+/// `composer-2.5[fast=true]`, while product selection can request the bare
+/// catalog id `composer-2.5` (or `composer-2.5[]`). The live option is the
+/// active-session authority for those provider-chosen defaults. Resolution is
+/// intentionally conservative: it only substitutes when exactly one distinct
+/// advertised bracket-params value shares the requested base.
+pub(in crate::live::sessions::actor) fn resolve_model_variant_value(
+    option: &acp::schema::SessionConfigOption,
+    desired_value: &str,
+) -> String {
+    if has_explicit_variant_params(desired_value)
+        || select_option_contains_value(option, desired_value)
+        || !option_matches_purpose(option, ConfigPurpose::Model)
+    {
+        return desired_value.to_string();
+    }
+
+    let requested_base = model_variant_base(desired_value);
+    let mut resolved: Option<String> = None;
+
+    for candidate in select_option_values(option) {
+        if model_variant_base(&candidate) != requested_base
+            || !is_bracket_params_variant(&candidate)
+        {
+            continue;
+        }
+
+        match resolved.as_deref() {
+            None => resolved = Some(candidate),
+            Some(existing) if existing == candidate => {}
+            Some(_) => return desired_value.to_string(),
+        }
+    }
+
+    resolved.unwrap_or_else(|| desired_value.to_string())
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_variants.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_variants.rs
@@ -1,0 +1,162 @@
+use super::*;
+use crate::app::test_support;
+
+#[test]
+fn resolves_missing_params_to_unique_live_composed_value() {
+    let mut option = model_option(&[
+        ("kimi-k2.5[]", "Kimi K2.5"),
+        ("composer-2.5[fast=true]", "Composer 2.5"),
+    ]);
+    set_current_value(&mut option, "kimi-k2.5[]");
+
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5"),
+        "composer-2.5[fast=true]"
+    );
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5[]"),
+        "composer-2.5[fast=true]"
+    );
+    assert_eq!(
+        resolve_model_variant_value(&option, "kimi-k2.5[]"),
+        "kimi-k2.5[]"
+    );
+    assert_eq!(
+        resolve_model_variant_value(&option, "unknown-model"),
+        "unknown-model"
+    );
+}
+
+#[test]
+fn preserves_explicit_params_and_ambiguous_bases() {
+    let option = model_option(&[
+        ("composer-2.5[fast=true]", "Composer Fast"),
+        ("composer-2.5[fast=false]", "Composer Standard"),
+    ]);
+
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5[fast=false]"),
+        "composer-2.5[fast=false]"
+    );
+    assert_eq!(
+        resolve_model_variant_value(&option, "composer-2.5"),
+        "composer-2.5"
+    );
+}
+
+#[test]
+fn does_not_collapse_context_tags_or_non_model_controls() {
+    let model_option = model_option(&[("sonnet[1m]", "Sonnet (1M context)")]);
+    assert_eq!(
+        resolve_model_variant_value(&model_option, "sonnet"),
+        "sonnet"
+    );
+
+    let mut mode_option = acp::schema::SessionConfigOption::select(
+        "mode",
+        "Mode",
+        "agent",
+        vec![acp::schema::SessionConfigSelectOption::new(
+            "agent[fast=true]",
+            "Agent",
+        )],
+    );
+    mode_option.category = Some(acp::schema::SessionConfigOptionCategory::Mode);
+    assert_eq!(resolve_model_variant_value(&mode_option, "agent"), "agent");
+}
+
+#[test]
+fn busy_queue_persists_resolved_live_model_variant() {
+    let db = Db::open_in_memory().expect("open db");
+    test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace");
+    let store = SessionStore::new(db);
+    store
+        .insert(&SessionRecord {
+            id: "session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            agent_kind: AgentKind::Cursor.as_str().to_string(),
+            native_session_id: Some("native-1".to_string()),
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "busy".to_string(),
+            created_at: "2026-03-25T00:00:00Z".to_string(),
+            updated_at: "2026-03-25T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy:
+                crate::domains::sessions::model::SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        })
+        .expect("insert session");
+
+    let mut option = model_option(&[
+        ("kimi-k2.5[]", "Kimi K2.5"),
+        ("composer-2.5[fast=true]", "Composer 2.5"),
+    ]);
+    set_current_value(&mut option, "kimi-k2.5[]");
+    let startup_state = SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: vec![option],
+        current_model_id: Some("kimi-k2.5[]".to_string()),
+        available_models: Vec::new(),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    };
+
+    let resolved = queue_pending_config_change(
+        &store,
+        "session-1",
+        &startup_state,
+        "model",
+        "composer-2.5",
+        false,
+    )
+    .expect("queue live-advertised model variant");
+
+    assert_eq!(resolved, "composer-2.5[fast=true]");
+    let pending = store
+        .list_pending_config_changes("session-1")
+        .expect("list pending config");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].value, "composer-2.5[fast=true]");
+}
+
+fn model_option(values: &[(&str, &str)]) -> acp::schema::SessionConfigOption {
+    let mut option = acp::schema::SessionConfigOption::select(
+        "model",
+        "Model",
+        values
+            .first()
+            .map_or_else(String::new, |(value, _)| (*value).to_string()),
+        values
+            .iter()
+            .map(|(value, name)| {
+                acp::schema::SessionConfigSelectOption::new(
+                    (*value).to_string(),
+                    (*name).to_string(),
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Model);
+    option
+}
+
+fn set_current_value(option: &mut acp::schema::SessionConfigOption, value: &str) {
+    let acp::schema::SessionConfigKind::Select(select) = &mut option.kind else {
+        panic!("test model option must be select");
+    };
+    select.current_value = value.to_string().into();
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -11,7 +11,7 @@ use super::config::persist::{load_startup_restore_snapshot, persisted_control_va
 use super::config::queue::queue_pending_config_change;
 use super::config::selection::{
     find_select_option_for_request, is_mode_config_request, is_model_config_request,
-    pending_config_rank, select_option_values,
+    pending_config_rank, resolve_model_variant_value, select_option_values,
 };
 use super::config::types::{tracked_config_purpose, PersistedSessionConfigState};
 use super::interactions::cleanup::resolve_pending_interactions;
@@ -48,6 +48,7 @@ use anyharness_contract::v1::{
 use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
 
 mod config;
+mod config_variants;
 mod domain_ops;
 mod notifications;
 mod prompt;


### PR DESCRIPTION
## Summary

Fresh-port the still-relevant Cursor model-switch correctness fix from #724 onto current `main`:

- resolve a bare/empty-bracket model request to the one distinct composed bracket-params value advertised by the live ACP session
- preserve explicit parameter choices, ambiguous variants, and context tags such as `[1m]`
- use the same resolved value for validation, ACP apply, busy queueing, and persistence
- cover idle, startup/restore, and busy paths, with requested→resolved debug diagnostics

## Verification

- actor config suite: 18/18
- broader AnyHarness config suite: 38/38
- `cargo check -p anyharness-lib`
- AnyHarness boundaries, old-path check, Rust formatting, and diff check
- full AnyHarness library run: 986 passed, 1 ignored; the sole failure is the independently reproduced stale schema snapshot already present on current `main` and being fixed separately

Supersedes #724.