### PR TITLE
docs(contributing): document USE_EXISTING_POSTGRES/USE_EXISTING_REDIS and Windows/WSL2 local dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,34 @@ make dev-list
 make run PROFILE=main
 ```
 
+### Using existing Postgres/Redis (no Docker)
+
+`make setup` and `make run` start Postgres and Redis via Docker by default. If
+you already run them natively, skip Docker with:
+
+```bash
+make setup PROFILE=main USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1
+make run PROFILE=main USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1
+```
+
+The existing-Postgres path expects a `proliferate` role to exist; create it
+once before setup:
+
+```sql
+CREATE ROLE proliferate LOGIN PASSWORD 'localdev' SUPERUSER;
+CREATE DATABASE proliferate OWNER proliferate;
+```
+
+Setup then creates its per-profile database (e.g. `proliferate_dev_main`)
+itself.
+
+### Windows
+
+The toolchain targets macOS and Linux; on Windows, develop inside WSL2. Clone
+the repo into the WSL filesystem (e.g. `~/proliferate`) — Rust builds on a
+mounted Windows drive (`/mnt/...`) are an order of magnitude slower. Dev-server
+ports are forwarded to Windows automatically.
+
 ## Pull Requests
 
 Keep PRs focused and leave unrelated files alone.


### PR DESCRIPTION
## Summary

Ports the documentation half of #978 into the `## Local Development` section of
CONTRIBUTING.md, per the maintainer guidance when closing that PR that it should be ported into the current authoritative local-development docs. The cleanup half returns separately as its own focused PR.

- Document the existing `USE_EXISTING_POSTGRES=1` / `USE_EXISTING_REDIS=1` Makefile flags — today `make setup` requires Docker even when Postgres/Redis run natively, and the escape hatches are only discoverable by reading the Makefile.
- Document the `proliferate`/`localdev` role the existing-Postgres path expects (the current first failure is a raw connection error).
- Add a Windows/WSL2 note: develop inside WSL2 and clone into the WSL filesystem (Rust builds on `/mnt/...` are an order of magnitude slower).

## Verification

Re-verified against current `main` (release-2026-07-12), not the state at the time of #978:

- Flags exist and gate Docker startup: `Makefile:13,16` (+ usage at 492, 690)
- Role/password defaults are `proliferate`/`localdev`: `scripts/dev.mjs:676-677`, `Makefile:10-11`
- Per-profile database naming `proliferate_dev_<profile>`: `scripts/dev.mjs:192`
- Originally exercised end-to-end from a clean clone on WSL2 Ubuntu with native Postgres/Redis: `make setup PROFILE=bench USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1`, `make build`, `make run`, including agent sessions.

Intended labels (maintainer-applied; fork PRs cannot set labels): `release:docs`, `area:docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)