### PR TITLE
fix(sdk): isolate AnyHarness cache and runtime queries

### DIFF
--- a/anyharness/sdk-react/src/context/AnyHarnessRuntime.tsx
+++ b/anyharness/sdk-react/src/context/AnyHarnessRuntime.tsx
@@ -4,6 +4,12 @@ import type { AnyHarnessClientConnection } from "../lib/client-cache.js";
 export interface AnyHarnessRuntimeContextValue {
   runtimeUrl: string | null;
   authToken?: string | null;
+  /**
+   * Stable identity boundary for cached AnyHarness data, such as an API
+   * deployment and authenticated actor. Falls back to runtimeUrl while
+   * callers migrate to an explicit scope.
+   */
+  cacheScopeKey?: string | null;
 }
 
 const AnyHarnessRuntimeContext = createContext<AnyHarnessRuntimeContextValue | null>(null);
@@ -11,13 +17,20 @@ const AnyHarnessRuntimeContext = createContext<AnyHarnessRuntimeContextValue | n
 export function AnyHarnessRuntime({
   runtimeUrl,
   authToken,
+  cacheScopeKey,
   children,
 }: AnyHarnessRuntimeContextValue & { children: ReactNode }) {
   return (
-    <AnyHarnessRuntimeContext.Provider value={{ runtimeUrl, authToken }}>
+    <AnyHarnessRuntimeContext.Provider value={{ runtimeUrl, authToken, cacheScopeKey }}>
       {children}
     </AnyHarnessRuntimeContext.Provider>
   );
+}
+
+export function resolveRuntimeCacheScopeKey(
+  context: AnyHarnessRuntimeContextValue,
+): string {
+  return context.cacheScopeKey?.trim() || context.runtimeUrl?.trim() || "";
 }
 
 export function useAnyHarnessRuntimeContext(): AnyHarnessRuntimeContextValue {
@@ -26,6 +39,10 @@ export function useAnyHarnessRuntimeContext(): AnyHarnessRuntimeContextValue {
     throw new Error("AnyHarnessRuntime provider is required.");
   }
   return context;
+}
+
+export function useAnyHarnessCacheScopeKey(): string {
+  return resolveRuntimeCacheScopeKey(useAnyHarnessRuntimeContext());
 }
 
 export function resolveRuntimeConnection(

--- a/anyharness/sdk-react/src/hooks/agent-gateway-catalog.ts
+++ b/anyharness/sdk-react/src/hooks/agent-gateway-catalog.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/rea
 import type { AnyHarnessClient } from "@anyharness/sdk";
 import {
   useAnyHarnessRuntimeContext,
+  resolveRuntimeCacheScopeKey,
   resolveRuntimeConnection,
   type AnyHarnessRuntimeContextValue,
 } from "../context/AnyHarnessRuntime.js";
@@ -22,10 +23,11 @@ function gatewayModelsQueryOptions(
   options?: RuntimeQueryOptions,
 ) {
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const trimmedKind = kind.trim();
 
   return {
-    queryKey: anyHarnessAgentGatewayModelsKey(runtimeUrl, trimmedKind),
+    queryKey: anyHarnessAgentGatewayModelsKey(runtimeUrl, trimmedKind, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0 && trimmedKind.length > 0,
     refetchInterval: options?.refetchInterval,
     queryFn: async ({ signal }: { signal: AbortSignal }) => {
@@ -73,6 +75,7 @@ export function useRefreshAgentGatewayModelsMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (kind: string) => {
@@ -85,7 +88,7 @@ export function useRefreshAgentGatewayModelsMutation() {
       // freshly-recorded probe. Invalidate so the next read re-enriches instead
       // of caching a sparse id-only list.
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentGatewayModelsKey(runtimeUrl, kind.trim()),
+        queryKey: anyHarnessAgentGatewayModelsKey(runtimeUrl, kind.trim(), cacheScopeKey),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/agents.ts
+++ b/anyharness/sdk-react/src/hooks/agents.ts
@@ -7,7 +7,11 @@ import type {
   InstallAgentRequest,
   ReconcileAgentsRequest,
 } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -25,9 +29,10 @@ interface RuntimeQueryOptions {
 export function useAgentsQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessAgentsKey(runtimeUrl),
+    queryKey: anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -41,10 +46,11 @@ export function useAgentLaunchOptionsQuery(options?: RuntimeQueryOptions & {
 }) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const workspaceId = options?.workspaceId ?? null;
 
   return useQuery({
-    queryKey: anyHarnessAgentLaunchOptionsKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessAgentLaunchOptionsKey(runtimeUrl, workspaceId, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -60,6 +66,7 @@ export function useInstallAgentMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (input: { kind: string; request?: InstallAgentRequest }) => {
@@ -67,7 +74,9 @@ export function useInstallAgentMutation() {
       return client.agents.install(input.kind, input.request ?? {});
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: anyHarnessAgentsKey(runtimeUrl) });
+      await queryClient.invalidateQueries({
+        queryKey: anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
+      });
     },
   });
 }
@@ -98,6 +107,7 @@ export function useCloseAgentLoginTerminalMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (terminalId: string) => {
@@ -105,9 +115,11 @@ export function useCloseAgentLoginTerminalMutation() {
       await client.agents.closeLoginTerminal(terminalId);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: anyHarnessAgentsKey(runtimeUrl) });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentLaunchOptionsPrefixKey(runtimeUrl),
+        queryKey: anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: anyHarnessAgentLaunchOptionsPrefixKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -122,10 +134,11 @@ export function useAgentReconcileStatusQuery(
 ) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const refetchWhileActive = options?.refetchWhileActive ?? true;
 
   return useQuery({
-    queryKey: anyHarnessAgentReconcileStatusKey(runtimeUrl),
+    queryKey: anyHarnessAgentReconcileStatusKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -146,16 +159,22 @@ export function useReconcileAgentsMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
-    mutationKey: anyHarnessReconcileAgentsMutationKey(runtimeUrl),
+    mutationKey: anyHarnessReconcileAgentsMutationKey(runtimeUrl, cacheScopeKey),
     mutationFn: async (request?: ReconcileAgentsRequest) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
       return client.agents.reconcile(request ?? {});
     },
     onSuccess: async (response) => {
-      queryClient.setQueryData(anyHarnessAgentReconcileStatusKey(runtimeUrl), response);
-      await queryClient.invalidateQueries({ queryKey: anyHarnessAgentsKey(runtimeUrl) });
+      queryClient.setQueryData(
+        anyHarnessAgentReconcileStatusKey(runtimeUrl, cacheScopeKey),
+        response,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
+      });
     },
   });
 }

--- a/anyharness/sdk-react/src/hooks/cowork.ts
+++ b/anyharness/sdk-react/src/hooks/cowork.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { CreateCoworkThreadRequest } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -20,9 +24,10 @@ interface RuntimeQueryOptions {
 export function useCoworkStatusQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessCoworkStatusKey(runtimeUrl),
+    queryKey: anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -34,9 +39,10 @@ export function useCoworkStatusQuery(options?: RuntimeQueryOptions) {
 export function useCoworkThreadsQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessCoworkThreadsKey(runtimeUrl),
+    queryKey: anyHarnessCoworkThreadsKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -51,9 +57,10 @@ export function useCoworkManagedWorkspacesQuery(
 ) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, sessionId),
+    queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, sessionId, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0 && !!sessionId,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -71,9 +78,10 @@ export function useCoworkArtifactManifestQuery(
 ) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessCoworkManifestKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessCoworkManifestKey(runtimeUrl, workspaceId, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0 && !!workspaceId,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -89,9 +97,15 @@ export function useCoworkArtifactQuery(
 ) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessCoworkArtifactKey(runtimeUrl, workspaceId, artifactId),
+    queryKey: anyHarnessCoworkArtifactKey(
+      runtimeUrl,
+      workspaceId,
+      artifactId,
+      cacheScopeKey,
+    ),
     enabled:
       (options?.enabled ?? true) &&
       runtimeUrl.length > 0 &&
@@ -111,6 +125,7 @@ export function useCoworkArtifactQuery(
 export function useEnableCoworkMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -120,9 +135,15 @@ export function useEnableCoworkMutation() {
     },
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessCoworkStatusKey(runtimeUrl) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessCoworkThreadsKey(runtimeUrl) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessRepoRootsKey(runtimeUrl) }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessCoworkThreadsKey(runtimeUrl, cacheScopeKey),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey),
+        }),
       ]);
     },
   });
@@ -131,6 +152,7 @@ export function useEnableCoworkMutation() {
 export function useCreateCoworkThreadMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -140,9 +162,15 @@ export function useCreateCoworkThreadMutation() {
     },
     onSuccess: () => {
       void Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessCoworkStatusKey(runtimeUrl) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessCoworkThreadsKey(runtimeUrl) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl) }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessCoworkThreadsKey(runtimeUrl, cacheScopeKey),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
+        }),
       ]).catch(() => undefined);
     },
   });

--- a/anyharness/sdk-react/src/hooks/files.ts
+++ b/anyharness/sdk-react/src/hooks/files.ts
@@ -31,17 +31,13 @@ import {
   anyHarnessWorkspaceFileTreeKey,
 } from "../lib/query-keys.js";
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useWorkspaceFilesQuery(options: {
   workspaceId?: string | null;
   path?: string;
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const path = options.path ?? "";
   const enabled = (options.enabled ?? true) && !!workspaceId;
@@ -75,7 +71,7 @@ export function useReadWorkspaceFileQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
   const queryKey = anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, options.path);
@@ -129,7 +125,7 @@ export function useSearchWorkspaceFilesQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const query = options.query ?? "";
   const limit = options.limit ?? 50;
@@ -166,7 +162,7 @@ export function useStatWorkspaceFileQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
   const queryKey = anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, options.path);
@@ -195,7 +191,7 @@ export function useStatWorkspaceFileQuery(options: {
 export function useWriteWorkspaceFileMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -241,7 +237,7 @@ export function useCreateWorkspaceDirectoryMutation(options?: { workspaceId?: st
 export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -297,7 +293,7 @@ export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string
 export function useDeleteWorkspaceEntryMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -346,7 +342,7 @@ function useCreateWorkspaceEntryMutation(
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({

--- a/anyharness/sdk-react/src/hooks/files.ts
+++ b/anyharness/sdk-react/src/hooks/files.ts
@@ -13,7 +13,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import {
   type AnyHarnessQueryTimingOptions,
@@ -31,9 +31,8 @@ import {
   anyHarnessWorkspaceFileTreeKey,
 } from "../lib/query-keys.js";
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useWorkspaceFilesQuery(options: {
@@ -42,11 +41,11 @@ export function useWorkspaceFilesQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const path = options.path ?? "";
   const enabled = (options.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, path);
+  const queryKey = anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, path);
   useReportAnyHarnessCacheDecision({
     category: "file.list",
     enabled,
@@ -76,10 +75,10 @@ export function useReadWorkspaceFileQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
-  const queryKey = anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, options.path);
+  const queryKey = anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, options.path);
   useReportAnyHarnessCacheDecision({
     category: "file.read",
     enabled,
@@ -130,12 +129,12 @@ export function useSearchWorkspaceFilesQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const query = options.query ?? "";
   const limit = options.limit ?? 50;
   const enabled = (options.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessWorkspaceFileSearchKey(runtimeUrl, workspaceId, query, limit);
+  const queryKey = anyHarnessWorkspaceFileSearchKey(cacheScopeKey, workspaceId, query, limit);
   useReportAnyHarnessCacheDecision({
     category: "file.search",
     enabled,
@@ -167,10 +166,10 @@ export function useStatWorkspaceFileQuery(options: {
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
-  const queryKey = anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, options.path);
+  const queryKey = anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, options.path);
   useReportAnyHarnessCacheDecision({
     category: "file.stat",
     enabled,
@@ -196,7 +195,7 @@ export function useStatWorkspaceFileQuery(options: {
 export function useWriteWorkspaceFileMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -209,22 +208,22 @@ export function useWriteWorkspaceFileMutation(options?: { workspaceId?: string |
       const parentPath = parentDirectoryPath(input.path);
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, parentPath),
+          queryKey: anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, parentPath),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
         }),
       ]);
     },
@@ -242,7 +241,7 @@ export function useCreateWorkspaceDirectoryMutation(options?: { workspaceId?: st
 export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -256,37 +255,37 @@ export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string
       const newParentPath = parentDirectoryPath(response.entry.path);
       const invalidations = [
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, oldParentPath),
+          queryKey: anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, oldParentPath),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, newParentPath),
+          queryKey: anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, newParentPath),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, response.entry.path),
+          queryKey: anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, response.entry.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, response.entry.path),
+          queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, response.entry.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
         }),
       ];
       if (response.entry.kind === "directory") {
         invalidations.push(
           queryClient.invalidateQueries({
-            queryKey: anyHarnessWorkspaceFilesScopeKey(runtimeUrl, workspaceId),
+            queryKey: anyHarnessWorkspaceFilesScopeKey(cacheScopeKey, workspaceId),
           }),
         );
       }
@@ -298,7 +297,7 @@ export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string
 export function useDeleteWorkspaceEntryMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -311,28 +310,28 @@ export function useDeleteWorkspaceEntryMutation(options?: { workspaceId?: string
       const parentPath = parentDirectoryPath(input.path);
       const invalidations = [
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, parentPath),
+          queryKey: anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, parentPath),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, input.path),
+          queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, input.path),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
         }),
       ];
       if (response.kind === "directory") {
         invalidations.push(
           queryClient.invalidateQueries({
-            queryKey: anyHarnessWorkspaceFilesScopeKey(runtimeUrl, workspaceId),
+            queryKey: anyHarnessWorkspaceFilesScopeKey(cacheScopeKey, workspaceId),
           }),
         );
       }
@@ -347,7 +346,7 @@ function useCreateWorkspaceEntryMutation(
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -364,30 +363,30 @@ function useCreateWorkspaceEntryMutation(
       const parentPath = parentDirectoryPath(input.path);
       if (kind === "file" && response.file) {
         queryClient.setQueryData(
-          anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, input.path),
+          anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, input.path),
           response.file satisfies ReadWorkspaceFileResponse,
         );
       }
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, workspaceId, parentPath),
+          queryKey: anyHarnessWorkspaceFileTreeKey(cacheScopeKey, workspaceId, parentPath),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
         }),
         kind === "file"
           ? queryClient.invalidateQueries({
-              queryKey: anyHarnessWorkspaceFileStatKey(runtimeUrl, workspaceId, input.path),
+              queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, input.path),
             })
           : Promise.resolve(),
         kind === "file"
           ? queryClient.invalidateQueries({
-              queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+              queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
             })
           : Promise.resolve(),
         kind === "file"
           ? queryClient.invalidateQueries({
-              queryKey: anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+              queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
             })
           : Promise.resolve(),
       ]);

--- a/anyharness/sdk-react/src/hooks/git.ts
+++ b/anyharness/sdk-react/src/hooks/git.ts
@@ -11,7 +11,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import {
   type AnyHarnessQueryTimingOptions,
@@ -56,38 +56,37 @@ type TimedBaseWorktreeDiffFilesQueryOptions =
   & ListBaseWorktreeDiffFilesOptions
   & AnyHarnessQueryTimingOptions;
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 async function invalidateWorkspaceGit(
   queryClient: ReturnType<typeof useQueryClient>,
-  runtimeUrl: string,
+  cacheScopeKey: string,
   workspaceId: string | null | undefined,
 ) {
   await Promise.all([
     queryClient.invalidateQueries({
-      queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
     }),
     queryClient.invalidateQueries({
-      queryKey: anyHarnessGitBranchesKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessGitBranchesKey(cacheScopeKey, workspaceId),
     }),
     queryClient.invalidateQueries({
-      queryKey: anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     }),
     queryClient.invalidateQueries({
-      queryKey: anyHarnessPullRequestKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessPullRequestKey(cacheScopeKey, workspaceId),
     }),
   ]);
 }
 
 export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessGitStatusKey(runtimeUrl, workspaceId);
+  const queryKey = anyHarnessGitStatusKey(cacheScopeKey, workspaceId);
   useReportAnyHarnessCacheDecision({
     category: "git.status",
     enabled,
@@ -113,11 +112,11 @@ export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
 
 export function useGitDiffQuery(options: TimedGitDiffQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
   const queryKey = anyHarnessGitDiffKey(
-    runtimeUrl,
+    cacheScopeKey,
     workspaceId,
     options.path,
     options.scope,
@@ -151,10 +150,10 @@ export function useGitBranchDiffFilesQuery(
   options?: TimedBranchDiffFilesQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessGitBranchDiffFilesKey(runtimeUrl, workspaceId, options?.baseRef);
+  const queryKey = anyHarnessGitBranchDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
   useReportAnyHarnessCacheDecision({
     category: "git.branch_diff_files",
     enabled,
@@ -182,10 +181,10 @@ export function useGitBaseWorktreeDiffFilesQuery(
   options?: TimedBaseWorktreeDiffFilesQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessGitBaseWorktreeDiffFilesKey(runtimeUrl, workspaceId, options?.baseRef);
+  const queryKey = anyHarnessGitBaseWorktreeDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
   useReportAnyHarnessCacheDecision({
     category: "git.base_worktree_diff_files",
     enabled,
@@ -211,11 +210,11 @@ export function useGitBaseWorktreeDiffFilesQuery(
 
 export function useGitBranchesQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessGitBranchesKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessGitBranchesKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -231,7 +230,7 @@ export function useGitBranchesQuery(options?: WorkspaceQueryOptions) {
 export function useStageGitPathsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -240,14 +239,14 @@ export function useStageGitPathsMutation(options?: { workspaceId?: string | null
       const client = getAnyHarnessClient(resolved.connection);
       await client.git.stagePaths(resolved.connection.anyharnessWorkspaceId, paths);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useUnstageGitPathsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -256,14 +255,14 @@ export function useUnstageGitPathsMutation(options?: { workspaceId?: string | nu
       const client = getAnyHarnessClient(resolved.connection);
       await client.git.unstagePaths(resolved.connection.anyharnessWorkspaceId, paths);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useStagePatchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -272,14 +271,14 @@ export function useStagePatchMutation(options?: { workspaceId?: string | null })
       const client = getAnyHarnessClient(resolved.connection);
       await client.git.stagePatch(resolved.connection.anyharnessWorkspaceId, patch);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useUnstagePatchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -288,14 +287,14 @@ export function useUnstagePatchMutation(options?: { workspaceId?: string | null 
       const client = getAnyHarnessClient(resolved.connection);
       await client.git.unstagePatch(resolved.connection.anyharnessWorkspaceId, patch);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useRevertGitPatchesMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -304,14 +303,14 @@ export function useRevertGitPatchesMutation(options?: { workspaceId?: string | n
       const client = getAnyHarnessClient(resolved.connection);
       return client.git.revertPatches(resolved.connection.anyharnessWorkspaceId, input);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useCommitGitMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -320,14 +319,14 @@ export function useCommitGitMutation(options?: { workspaceId?: string | null }) 
       const client = getAnyHarnessClient(resolved.connection);
       return client.git.commit(resolved.connection.anyharnessWorkspaceId, input);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function usePushGitMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -336,14 +335,14 @@ export function usePushGitMutation(options?: { workspaceId?: string | null }) {
       const client = getAnyHarnessClient(resolved.connection);
       return client.git.push(resolved.connection.anyharnessWorkspaceId, input ?? {});
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }
 
 export function useRenameGitBranchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -352,6 +351,6 @@ export function useRenameGitBranchMutation(options?: { workspaceId?: string | nu
       const client = getAnyHarnessClient(resolved.connection);
       return client.git.renameBranch(resolved.connection.anyharnessWorkspaceId, newName);
     },
-    onSuccess: async () => invalidateWorkspaceGit(queryClient, runtimeUrl, workspaceId),
+    onSuccess: async () => invalidateWorkspaceGit(queryClient, cacheScopeKey, workspaceId),
   });
 }

--- a/anyharness/sdk-react/src/hooks/git.ts
+++ b/anyharness/sdk-react/src/hooks/git.ts
@@ -56,10 +56,6 @@ type TimedBaseWorktreeDiffFilesQueryOptions =
   & ListBaseWorktreeDiffFilesOptions
   & AnyHarnessQueryTimingOptions;
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 async function invalidateWorkspaceGit(
   queryClient: ReturnType<typeof useQueryClient>,
   cacheScopeKey: string,
@@ -83,7 +79,7 @@ async function invalidateWorkspaceGit(
 
 export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
   const queryKey = anyHarnessGitStatusKey(cacheScopeKey, workspaceId);
@@ -112,7 +108,7 @@ export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
 
 export function useGitDiffQuery(options: TimedGitDiffQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
   const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
   const queryKey = anyHarnessGitDiffKey(
@@ -150,7 +146,7 @@ export function useGitBranchDiffFilesQuery(
   options?: TimedBranchDiffFilesQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
   const queryKey = anyHarnessGitBranchDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
@@ -181,7 +177,7 @@ export function useGitBaseWorktreeDiffFilesQuery(
   options?: TimedBaseWorktreeDiffFilesQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
   const queryKey = anyHarnessGitBaseWorktreeDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
@@ -210,7 +206,7 @@ export function useGitBaseWorktreeDiffFilesQuery(
 
 export function useGitBranchesQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -230,7 +226,7 @@ export function useGitBranchesQuery(options?: WorkspaceQueryOptions) {
 export function useStageGitPathsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -246,7 +242,7 @@ export function useStageGitPathsMutation(options?: { workspaceId?: string | null
 export function useUnstageGitPathsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -262,7 +258,7 @@ export function useUnstageGitPathsMutation(options?: { workspaceId?: string | nu
 export function useStagePatchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -278,7 +274,7 @@ export function useStagePatchMutation(options?: { workspaceId?: string | null })
 export function useUnstagePatchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -294,7 +290,7 @@ export function useUnstagePatchMutation(options?: { workspaceId?: string | null 
 export function useRevertGitPatchesMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -310,7 +306,7 @@ export function useRevertGitPatchesMutation(options?: { workspaceId?: string | n
 export function useCommitGitMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -326,7 +322,7 @@ export function useCommitGitMutation(options?: { workspaceId?: string | null }) 
 export function usePushGitMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -342,7 +338,7 @@ export function usePushGitMutation(options?: { workspaceId?: string | null }) {
 export function useRenameGitBranchMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({

--- a/anyharness/sdk-react/src/hooks/mobility.ts
+++ b/anyharness/sdk-react/src/hooks/mobility.ts
@@ -10,7 +10,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -24,18 +24,17 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useWorkspaceMobilityPreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessWorkspaceMobilityPreflightKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessWorkspaceMobilityPreflightKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -52,7 +51,7 @@ export function useUpdateWorkspaceMobilityRuntimeStateMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -78,10 +77,10 @@ export function useUpdateWorkspaceMobilityRuntimeStateMutation(
       const targetWorkspaceId = variables.workspaceId ?? workspaceId;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityPreflightKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityPreflightKey(cacheScopeKey, targetWorkspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(cacheScopeKey, targetWorkspaceId),
         }),
       ]);
     },
@@ -119,7 +118,7 @@ export function useInstallWorkspaceMobilityArchiveMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -150,13 +149,13 @@ export function useInstallWorkspaceMobilityArchiveMutation(
       const targetWorkspaceId = variables.workspaceId ?? workspaceId;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessSessionsKey(cacheScopeKey, targetWorkspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityPreflightKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityPreflightKey(cacheScopeKey, targetWorkspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(cacheScopeKey, targetWorkspaceId),
         }),
       ]);
     },
@@ -167,7 +166,7 @@ export function useDestroyWorkspaceMobilitySourceMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -193,13 +192,13 @@ export function useDestroyWorkspaceMobilitySourceMutation(
       const targetWorkspaceId = variables.workspaceId ?? workspaceId;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessSessionsKey(cacheScopeKey, targetWorkspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityPreflightKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityPreflightKey(cacheScopeKey, targetWorkspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(runtimeUrl, targetWorkspaceId),
+          queryKey: anyHarnessWorkspaceMobilityRuntimeStateKey(cacheScopeKey, targetWorkspaceId),
         }),
       ]);
     },

--- a/anyharness/sdk-react/src/hooks/mobility.ts
+++ b/anyharness/sdk-react/src/hooks/mobility.ts
@@ -24,13 +24,9 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useWorkspaceMobilityPreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -51,7 +47,7 @@ export function useUpdateWorkspaceMobilityRuntimeStateMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -118,7 +114,7 @@ export function useInstallWorkspaceMobilityArchiveMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -166,7 +162,7 @@ export function useDestroyWorkspaceMobilitySourceMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 

--- a/anyharness/sdk-react/src/hooks/plans.ts
+++ b/anyharness/sdk-react/src/hooks/plans.ts
@@ -4,7 +4,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -19,18 +19,17 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useWorkspacePlansQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -48,11 +47,11 @@ export function usePlanDetailQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, planId),
+    queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, planId),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!planId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -84,12 +83,12 @@ export function usePlanDetailsQueries(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQueries({
     queries: planIds.map((planId) => ({
-      queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, planId),
+      queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, planId),
       enabled: (options?.enabled ?? true) && !!workspaceId && !!planId,
       queryFn: async ({ signal }) => {
         const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -109,12 +108,12 @@ export function usePlanDocumentQuery(
   options?: WorkspaceQueryOptions & { materialize?: boolean },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const materialize = options?.materialize ?? false;
 
   return useQuery({
-    queryKey: anyHarnessPlanDocumentKey(runtimeUrl, workspaceId, planId, materialize),
+    queryKey: anyHarnessPlanDocumentKey(cacheScopeKey, workspaceId, planId, materialize),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!planId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -129,7 +128,7 @@ export function usePlanDocumentQuery(
 
 export function useMaterializePlanDocumentMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -143,7 +142,7 @@ export function useMaterializePlanDocumentMutation(options?: { workspaceId?: str
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessPlanDocumentKey(runtimeUrl, workspaceId, variables.planId, true),
+        queryKey: anyHarnessPlanDocumentKey(cacheScopeKey, workspaceId, variables.planId, true),
       });
     },
   });
@@ -151,7 +150,7 @@ export function useMaterializePlanDocumentMutation(options?: { workspaceId?: str
 
 export function useApprovePlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -166,14 +165,14 @@ export function useApprovePlanMutation(options?: { workspaceId?: string | null }
     onSuccess: async (response, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, variables.planId),
+          queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, variables.planId),
         }),
         queryClient.invalidateQueries({
           queryKey: anyHarnessSessionEventsKey(
-            runtimeUrl,
+            cacheScopeKey,
             workspaceId,
             response.plan.sessionId,
           ),
@@ -184,10 +183,10 @@ export function useApprovePlanMutation(options?: { workspaceId?: string | null }
       if (!isPlanDecisionVersionConflict(error)) return;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, variables.planId),
+          queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, variables.planId),
         }),
       ]);
     },
@@ -196,7 +195,7 @@ export function useApprovePlanMutation(options?: { workspaceId?: string | null }
 
 export function useRejectPlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -211,14 +210,14 @@ export function useRejectPlanMutation(options?: { workspaceId?: string | null })
     onSuccess: async (response, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, variables.planId),
+          queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, variables.planId),
         }),
         queryClient.invalidateQueries({
           queryKey: anyHarnessSessionEventsKey(
-            runtimeUrl,
+            cacheScopeKey,
             workspaceId,
             response.plan.sessionId,
           ),
@@ -229,10 +228,10 @@ export function useRejectPlanMutation(options?: { workspaceId?: string | null })
       if (!isPlanDecisionVersionConflict(error)) return;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, variables.planId),
+          queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, variables.planId),
         }),
       ]);
     },
@@ -241,7 +240,7 @@ export function useRejectPlanMutation(options?: { workspaceId?: string | null })
 
 export function useHandoffPlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -258,14 +257,14 @@ export function useHandoffPlanMutation(options?: { workspaceId?: string | null }
     onSuccess: async (response, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlansKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessPlansKey(cacheScopeKey, workspaceId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessPlanKey(runtimeUrl, workspaceId, variables.planId),
+          queryKey: anyHarnessPlanKey(cacheScopeKey, workspaceId, variables.planId),
         }),
         queryClient.invalidateQueries({
           queryKey: anyHarnessSessionEventsKey(
-            runtimeUrl,
+            cacheScopeKey,
             workspaceId,
             response.targetSessionId,
           ),

--- a/anyharness/sdk-react/src/hooks/plans.ts
+++ b/anyharness/sdk-react/src/hooks/plans.ts
@@ -19,13 +19,9 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useWorkspacePlansQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -47,7 +43,7 @@ export function usePlanDetailQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -83,7 +79,7 @@ export function usePlanDetailsQueries(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQueries({
@@ -108,7 +104,7 @@ export function usePlanDocumentQuery(
   options?: WorkspaceQueryOptions & { materialize?: boolean },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const materialize = options?.materialize ?? false;
 
@@ -128,7 +124,7 @@ export function usePlanDocumentQuery(
 
 export function useMaterializePlanDocumentMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -150,7 +146,7 @@ export function useMaterializePlanDocumentMutation(options?: { workspaceId?: str
 
 export function useApprovePlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -195,7 +191,7 @@ export function useApprovePlanMutation(options?: { workspaceId?: string | null }
 
 export function useRejectPlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -240,7 +236,7 @@ export function useRejectPlanMutation(options?: { workspaceId?: string | null })
 
 export function useHandoffPlanMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 

--- a/anyharness/sdk-react/src/hooks/pull-requests.ts
+++ b/anyharness/sdk-react/src/hooks/pull-requests.ts
@@ -6,6 +6,7 @@ import {
 } from "../context/AnyHarnessWorkspace.js";
 import {
   useAnyHarnessRuntimeContext,
+  useAnyHarnessCacheScopeKey,
   resolveRuntimeConnection,
 } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
@@ -20,18 +21,17 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useCurrentPullRequestQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessPullRequestKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessPullRequestKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     retry: false,
     queryFn: async ({ signal }) => {
@@ -54,10 +54,11 @@ export function useRepoPullRequestStatusesQuery(options: {
 }) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const repoRootId = options.repoRootId ?? null;
 
   return useQuery({
-    queryKey: anyHarnessRepoRootPullRequestsKey(runtimeUrl, repoRootId),
+    queryKey: anyHarnessRepoRootPullRequestsKey(runtimeUrl, repoRootId, cacheScopeKey),
     enabled: (options.enabled ?? true) && runtimeUrl.length > 0 && !!repoRootId,
     retry: false,
     staleTime: options.staleTime,
@@ -77,7 +78,7 @@ export function useRepoPullRequestStatusesQuery(options: {
 export function useCreatePullRequestMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -88,7 +89,7 @@ export function useCreatePullRequestMutation(options?: { workspaceId?: string | 
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessPullRequestKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessPullRequestKey(cacheScopeKey, workspaceId),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/pull-requests.ts
+++ b/anyharness/sdk-react/src/hooks/pull-requests.ts
@@ -21,13 +21,9 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useCurrentPullRequestQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -78,7 +74,7 @@ export function useRepoPullRequestStatusesQuery(options: {
 export function useCreatePullRequestMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({

--- a/anyharness/sdk-react/src/hooks/repo-roots.ts
+++ b/anyharness/sdk-react/src/hooks/repo-roots.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { PrepareRepoRootMobilityDestinationRequest } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -17,9 +21,10 @@ interface RuntimeQueryOptions {
 export function useRepoRootsQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessRepoRootsKey(runtimeUrl),
+    queryKey: anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -32,6 +37,7 @@ export function useResolveRepoRootFromPathMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (path: string) => {
@@ -40,7 +46,7 @@ export function useResolveRepoRootFromPathMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRepoRootsKey(runtimeUrl),
+        queryKey: anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -69,10 +75,11 @@ export function useRepoRootGitBranchesQuery(options: {
 }) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const repoRootId = options.repoRootId?.trim() ?? "";
 
   return useQuery({
-    queryKey: anyHarnessRepoRootGitBranchesKey(runtimeUrl, repoRootId),
+    queryKey: anyHarnessRepoRootGitBranchesKey(runtimeUrl, repoRootId, cacheScopeKey),
     enabled: (options.enabled ?? true) && repoRootId.length > 0 && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -87,10 +94,11 @@ export function useDetectRepoRootSetupQuery(options: {
 }) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   const repoRootId = options.repoRootId?.trim() ?? "";
 
   return useQuery({
-    queryKey: anyHarnessRepoRootDetectSetupKey(runtimeUrl, repoRootId),
+    queryKey: anyHarnessRepoRootDetectSetupKey(runtimeUrl, repoRootId, cacheScopeKey),
     enabled: (options.enabled ?? true) && repoRootId.length > 0 && runtimeUrl.length > 0,
     staleTime: Infinity,
     queryFn: async ({ signal }) => {
@@ -104,6 +112,7 @@ export function usePrepareRepoRootMobilityDestinationMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async ({
@@ -118,7 +127,7 @@ export function usePrepareRepoRootMobilityDestinationMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/reviews.ts
+++ b/anyharness/sdk-react/src/hooks/reviews.ts
@@ -9,7 +9,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -26,9 +26,8 @@ interface WorkspaceQueryOptions {
   refetchIntervalInBackground?: boolean;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 function useWorkspaceId(options?: { workspaceId?: string | null }) {
@@ -38,7 +37,7 @@ function useWorkspaceId(options?: { workspaceId?: string | null }) {
 
 async function invalidateSessionReviews(
   queryClient: ReturnType<typeof useQueryClient>,
-  runtimeUrl: string,
+  cacheScopeKey: string,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
 ) {
@@ -47,13 +46,13 @@ async function invalidateSessionReviews(
   // subagent summary query is the only linked-session hierarchy that changes.
   await Promise.all([
     queryClient.invalidateQueries({
-      queryKey: anyHarnessSessionReviewsKey(runtimeUrl, workspaceId, sessionId),
+      queryKey: anyHarnessSessionReviewsKey(cacheScopeKey, workspaceId, sessionId),
     }),
     queryClient.invalidateQueries({
-      queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, sessionId),
+      queryKey: anyHarnessSessionSubagentsKey(cacheScopeKey, workspaceId, sessionId),
     }),
     queryClient.invalidateQueries({
-      queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
     }),
   ]);
 }
@@ -63,11 +62,11 @@ export function useSessionReviewsQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
 
   return useQuery({
-    queryKey: anyHarnessSessionReviewsKey(runtimeUrl, workspaceId, sessionId),
+    queryKey: anyHarnessSessionReviewsKey(cacheScopeKey, workspaceId, sessionId),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!sessionId,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: options?.refetchIntervalInBackground,
@@ -88,12 +87,12 @@ export function useReviewAssignmentCritiqueQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
 
   return useQuery({
     queryKey: anyHarnessReviewAssignmentCritiqueKey(
-      runtimeUrl,
+      cacheScopeKey,
       workspaceId,
       reviewRunId,
       assignmentId,
@@ -119,7 +118,7 @@ export function useReviewAssignmentCritiqueQuery(
 
 export function useStartPlanReviewMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
   const queryClient = useQueryClient();
 
@@ -136,7 +135,7 @@ export function useStartPlanReviewMutation(options?: { workspaceId?: string | nu
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );
@@ -146,7 +145,7 @@ export function useStartPlanReviewMutation(options?: { workspaceId?: string | nu
 
 export function useStartCodeReviewMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
   const queryClient = useQueryClient();
 
@@ -162,7 +161,7 @@ export function useStartCodeReviewMutation(options?: { workspaceId?: string | nu
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );
@@ -172,7 +171,7 @@ export function useStartCodeReviewMutation(options?: { workspaceId?: string | nu
 
 export function useStopReviewMutation(options?: { workspaceId?: string | null }) {
   const workspaceId = useWorkspaceId(options);
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -185,7 +184,7 @@ export function useStopReviewMutation(options?: { workspaceId?: string | null })
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );
@@ -197,7 +196,7 @@ export function useRetryReviewAssignmentMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspaceId = useWorkspaceId(options);
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -220,7 +219,7 @@ export function useRetryReviewAssignmentMutation(
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );
@@ -230,7 +229,7 @@ export function useRetryReviewAssignmentMutation(
 
 export function useSendReviewFeedbackMutation(options?: { workspaceId?: string | null }) {
   const workspaceId = useWorkspaceId(options);
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -243,7 +242,7 @@ export function useSendReviewFeedbackMutation(options?: { workspaceId?: string |
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );
@@ -255,7 +254,7 @@ export function useMarkReviewRevisionReadyMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspaceId = useWorkspaceId(options);
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -270,7 +269,7 @@ export function useMarkReviewRevisionReadyMutation(
     onSuccess: async (response) => {
       await invalidateSessionReviews(
         queryClient,
-        runtimeUrl,
+        cacheScopeKey,
         workspaceId,
         response.run.parentSessionId,
       );

--- a/anyharness/sdk-react/src/hooks/reviews.ts
+++ b/anyharness/sdk-react/src/hooks/reviews.ts
@@ -26,10 +26,6 @@ interface WorkspaceQueryOptions {
   refetchIntervalInBackground?: boolean;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 function useWorkspaceId(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   return options?.workspaceId ?? workspace.workspaceId;
@@ -62,7 +58,7 @@ export function useSessionReviewsQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
 
   return useQuery({
@@ -87,7 +83,7 @@ export function useReviewAssignmentCritiqueQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
 
   return useQuery({
@@ -118,7 +114,7 @@ export function useReviewAssignmentCritiqueQuery(
 
 export function useStartPlanReviewMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
   const queryClient = useQueryClient();
 
@@ -145,7 +141,7 @@ export function useStartPlanReviewMutation(options?: { workspaceId?: string | nu
 
 export function useStartCodeReviewMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = useWorkspaceId(options);
   const queryClient = useQueryClient();
 
@@ -171,7 +167,7 @@ export function useStartCodeReviewMutation(options?: { workspaceId?: string | nu
 
 export function useStopReviewMutation(options?: { workspaceId?: string | null }) {
   const workspaceId = useWorkspaceId(options);
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -196,7 +192,7 @@ export function useRetryReviewAssignmentMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspaceId = useWorkspaceId(options);
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -229,7 +225,7 @@ export function useRetryReviewAssignmentMutation(
 
 export function useSendReviewFeedbackMutation(options?: { workspaceId?: string | null }) {
   const workspaceId = useWorkspaceId(options);
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 
@@ -254,7 +250,7 @@ export function useMarkReviewRevisionReadyMutation(
   options?: { workspaceId?: string | null },
 ) {
   const workspaceId = useWorkspaceId(options);
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspace = useAnyHarnessWorkspaceContext();
 

--- a/anyharness/sdk-react/src/hooks/runtime-gating.test.tsx
+++ b/anyharness/sdk-react/src/hooks/runtime-gating.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
+import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
+import { useAgentReconcileStatusQuery, useAgentsQuery } from "./agents.js";
+import { useRuntimeHealthQuery } from "./runtime.js";
+import { useRuntimeWorkspacesQuery, useWorkspaceQuery } from "./workspaces.js";
+
+const mocks = vi.hoisted(() => ({
+  getClient: vi.fn(),
+  getHealth: vi.fn(),
+  getReconcileStatus: vi.fn(),
+  getWorkspace: vi.fn(),
+  listAgents: vi.fn(),
+  listWorkspaces: vi.fn(),
+}));
+
+vi.mock("../lib/client-cache.js", () => ({
+  getAnyHarnessClient: (connection: unknown) => {
+    mocks.getClient(connection);
+    return {
+      runtime: { getHealth: mocks.getHealth },
+      agents: {
+        list: mocks.listAgents,
+        getReconcileStatus: mocks.getReconcileStatus,
+      },
+      workspaces: {
+        list: mocks.listWorkspaces,
+        get: mocks.getWorkspace,
+      },
+    };
+  },
+}));
+
+describe("runtime query gating", () => {
+  afterEach(() => {
+    cleanup();
+    mocks.getClient.mockReset();
+    mocks.getHealth.mockReset();
+    mocks.getReconcileStatus.mockReset();
+    mocks.getWorkspace.mockReset();
+    mocks.listAgents.mockReset();
+    mocks.listWorkspaces.mockReset();
+  });
+
+  it("keeps local runtime queries idle while a cloud workspace query resolves", async () => {
+    mocks.getWorkspace.mockResolvedValue({ id: "sandbox-workspace-1" });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => ({
+      agents: useAgentsQuery(),
+      health: useRuntimeHealthQuery(),
+      reconcile: useAgentReconcileStatusQuery(),
+      runtimeWorkspaces: useRuntimeWorkspacesQuery(),
+      workspace: useWorkspaceQuery({}),
+    }), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <AnyHarnessRuntime
+            runtimeUrl={null}
+            cacheScopeKey="https://api.test::user:user-1"
+          >
+            <AnyHarnessWorkspace
+              workspaceId="cloud:workspace-1"
+              resolveConnection={async () => ({
+                runtimeUrl: "https://api.test/v1/gateway/cloud-sandbox/anyharness",
+                authToken: "temporary-gateway-token",
+                anyharnessWorkspaceId: "sandbox-workspace-1",
+              })}
+            >
+              {children}
+            </AnyHarnessWorkspace>
+          </AnyHarnessRuntime>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.workspace.isSuccess).toBe(true));
+
+    expect(result.current.agents.fetchStatus).toBe("idle");
+    expect(result.current.health.fetchStatus).toBe("idle");
+    expect(result.current.reconcile.fetchStatus).toBe("idle");
+    expect(result.current.runtimeWorkspaces.fetchStatus).toBe("idle");
+    expect(mocks.listAgents).not.toHaveBeenCalled();
+    expect(mocks.getHealth).not.toHaveBeenCalled();
+    expect(mocks.getReconcileStatus).not.toHaveBeenCalled();
+    expect(mocks.listWorkspaces).not.toHaveBeenCalled();
+    expect(mocks.getClient).toHaveBeenCalledTimes(1);
+    expect(mocks.getClient).toHaveBeenCalledWith({
+      runtimeUrl: "https://api.test/v1/gateway/cloud-sandbox/anyharness",
+      authToken: "temporary-gateway-token",
+      anyharnessWorkspaceId: "sandbox-workspace-1",
+    });
+    expect(mocks.getWorkspace).toHaveBeenCalledWith(
+      "sandbox-workspace-1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});

--- a/anyharness/sdk-react/src/hooks/runtime.ts
+++ b/anyharness/sdk-react/src/hooks/runtime.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AnyHarnessRequestOptions } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { anyHarnessRuntimeHealthKey } from "../lib/query-keys.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
@@ -15,9 +19,10 @@ interface RuntimeQueryOptions {
 export function useRuntimeHealthQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessRuntimeHealthKey(runtimeUrl),
+    queryKey: anyHarnessRuntimeHealthKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));

--- a/anyharness/sdk-react/src/hooks/session-pending-prompts.ts
+++ b/anyharness/sdk-react/src/hooks/session-pending-prompts.ts
@@ -5,18 +5,17 @@ import {
   resolveWorkspaceConnectionFromContext,
   useAnyHarnessWorkspaceContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { anyHarnessSessionKey } from "../lib/query-keys.js";
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useEditPendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -33,7 +32,7 @@ export function useEditPendingPromptMutation(options?: { workspaceId?: string | 
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -41,7 +40,7 @@ export function useEditPendingPromptMutation(options?: { workspaceId?: string | 
 
 export function useDeletePendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -53,7 +52,7 @@ export function useDeletePendingPromptMutation(options?: { workspaceId?: string 
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -61,7 +60,7 @@ export function useDeletePendingPromptMutation(options?: { workspaceId?: string 
 
 export function useReorderPendingPromptsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -78,7 +77,7 @@ export function useReorderPendingPromptsMutation(options?: { workspaceId?: strin
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -86,7 +85,7 @@ export function useReorderPendingPromptsMutation(options?: { workspaceId?: strin
 
 export function useSteerPendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -98,7 +97,7 @@ export function useSteerPendingPromptMutation(options?: { workspaceId?: string |
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/session-pending-prompts.ts
+++ b/anyharness/sdk-react/src/hooks/session-pending-prompts.ts
@@ -9,13 +9,9 @@ import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { anyHarnessSessionKey } from "../lib/query-keys.js";
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useEditPendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -40,7 +36,7 @@ export function useEditPendingPromptMutation(options?: { workspaceId?: string | 
 
 export function useDeletePendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -60,7 +56,7 @@ export function useDeletePendingPromptMutation(options?: { workspaceId?: string 
 
 export function useReorderPendingPromptsMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -85,7 +81,7 @@ export function useReorderPendingPromptsMutation(options?: { workspaceId?: strin
 
 export function useSteerPendingPromptMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -16,7 +16,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import {
   type AnyHarnessQueryTimingOptions,
@@ -42,17 +42,16 @@ interface WorkspaceMutationInput {
 
 type TimedWorkspaceQueryOptions = WorkspaceQueryOptions & AnyHarnessQueryTimingOptions;
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useWorkspaceSessionsQuery(options?: TimedWorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessSessionsKey(runtimeUrl, workspaceId);
+  const queryKey = anyHarnessSessionsKey(cacheScopeKey, workspaceId);
   useReportAnyHarnessCacheDecision({
     category: "session.list",
     enabled,
@@ -79,11 +78,11 @@ export function useSessionQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId),
+    queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!sessionId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -115,11 +114,11 @@ export function useSessionLiveConfigQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessSessionLiveConfigKey(runtimeUrl, workspaceId, sessionId),
+    queryKey: anyHarnessSessionLiveConfigKey(cacheScopeKey, workspaceId, sessionId),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!sessionId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -137,7 +136,7 @@ export function useSessionEventsQuery(
   options?: TimedWorkspaceQueryOptions & { request?: ListSessionEventsOptions },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const afterSeq = options?.request?.afterSeq;
   const beforeSeq = options?.request?.beforeSeq;
@@ -145,7 +144,7 @@ export function useSessionEventsQuery(
   const turnLimit = options?.request?.turnLimit;
   const enabled = (options?.enabled ?? true) && !!workspaceId && !!sessionId;
   const queryKey = anyHarnessSessionEventsKey(
-    runtimeUrl,
+    cacheScopeKey,
     workspaceId,
     sessionId,
     afterSeq,
@@ -186,11 +185,11 @@ export function useSessionSubagentsQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, sessionId),
+    queryKey: anyHarnessSessionSubagentsKey(cacheScopeKey, workspaceId, sessionId),
     enabled: (options?.enabled ?? true) && !!workspaceId && !!sessionId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -205,7 +204,7 @@ export function useSessionSubagentsQuery(
 
 export function useScheduleSubagentWakeMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -218,10 +217,10 @@ export function useScheduleSubagentWakeMutation(options?: { workspaceId?: string
     onSuccess: async (_response, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, variables.sessionId),
+          queryKey: anyHarnessSessionSubagentsKey(cacheScopeKey, workspaceId, variables.sessionId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, variables.childSessionId),
+          queryKey: anyHarnessSessionSubagentsKey(cacheScopeKey, workspaceId, variables.childSessionId),
         }),
       ]);
     },
@@ -230,7 +229,7 @@ export function useScheduleSubagentWakeMutation(options?: { workspaceId?: string
 
 export function useCreateSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -262,7 +261,7 @@ export function useCreateSessionMutation(options?: { workspaceId?: string | null
         ? input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId
         : options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -270,7 +269,7 @@ export function useCreateSessionMutation(options?: { workspaceId?: string | null
 
 export function useSetSessionConfigOptionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -289,13 +288,13 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+          queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionLiveConfigKey(runtimeUrl, workspaceId, variables.sessionId),
+          queryKey: anyHarnessSessionLiveConfigKey(cacheScopeKey, workspaceId, variables.sessionId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
         }),
       ]);
     },
@@ -304,7 +303,7 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
 
 export function usePromptSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -323,7 +322,7 @@ export function usePromptSessionMutation(options?: { workspaceId?: string | null
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionEventsKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionEventsKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -331,7 +330,7 @@ export function usePromptSessionMutation(options?: { workspaceId?: string | null
 
 export function usePromptSessionTextMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -343,7 +342,7 @@ export function usePromptSessionTextMutation(options?: { workspaceId?: string | 
     },
     onSuccess: async (_response, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionEventsKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionEventsKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -351,7 +350,7 @@ export function usePromptSessionTextMutation(options?: { workspaceId?: string | 
 
 export function useForkSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -364,16 +363,16 @@ export function useForkSessionMutation(options?: { workspaceId?: string | null }
     onSuccess: async (response, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+          queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, response.session.id),
+          queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, response.session.id),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionEventsKey(runtimeUrl, workspaceId, response.session.id),
+          queryKey: anyHarnessSessionEventsKey(cacheScopeKey, workspaceId, response.session.id),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
         }),
       ]);
     },
@@ -382,7 +381,7 @@ export function useForkSessionMutation(options?: { workspaceId?: string | null }
 
 export function useResumeSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -399,8 +398,8 @@ export function useResumeSessionMutation(options?: { workspaceId?: string | null
     onSuccess: async (_response, input) => {
       const sessionId = typeof input === "string" ? input : input.sessionId;
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId) }),
       ]);
     },
   });
@@ -408,7 +407,7 @@ export function useResumeSessionMutation(options?: { workspaceId?: string | null
 
 export function useUpdateSessionTitleMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -428,10 +427,10 @@ export function useUpdateSessionTitleMutation(options?: { workspaceId?: string |
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+          queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId),
+          queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
         }),
       ]);
     },
@@ -440,7 +439,7 @@ export function useUpdateSessionTitleMutation(options?: { workspaceId?: string |
 
 export function useSetSessionGoalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -459,7 +458,7 @@ export function useSetSessionGoalMutation(options?: { workspaceId?: string | nul
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -467,7 +466,7 @@ export function useSetSessionGoalMutation(options?: { workspaceId?: string | nul
 
 export function useClearSessionGoalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -485,7 +484,7 @@ export function useClearSessionGoalMutation(options?: { workspaceId?: string | n
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -493,7 +492,7 @@ export function useClearSessionGoalMutation(options?: { workspaceId?: string | n
 
 export function useSetSessionLoopMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -521,7 +520,7 @@ export function useSetSessionLoopMutation(options?: { workspaceId?: string | nul
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -529,7 +528,7 @@ export function useSetSessionLoopMutation(options?: { workspaceId?: string | nul
 
 export function useClearSessionLoopMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -551,7 +550,7 @@ export function useClearSessionLoopMutation(options?: { workspaceId?: string | n
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, variables.sessionId),
+        queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
       });
     },
   });
@@ -559,7 +558,7 @@ export function useClearSessionLoopMutation(options?: { workspaceId?: string | n
 
 export function useCancelSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -578,8 +577,8 @@ export function useCancelSessionMutation(options?: { workspaceId?: string | null
         ? options?.workspaceId ?? workspace.workspaceId
         : input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId) }),
       ]);
     },
   });
@@ -587,7 +586,7 @@ export function useCancelSessionMutation(options?: { workspaceId?: string | null
 
 export function useDismissSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -606,8 +605,8 @@ export function useDismissSessionMutation(options?: { workspaceId?: string | nul
         ? options?.workspaceId ?? workspace.workspaceId
         : input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId) }),
       ]);
     },
   });
@@ -615,7 +614,7 @@ export function useDismissSessionMutation(options?: { workspaceId?: string | nul
 
 export function useCloseSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -634,8 +633,8 @@ export function useCloseSessionMutation(options?: { workspaceId?: string | null 
         ? options?.workspaceId ?? workspace.workspaceId
         : input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId) }),
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId) }),
       ]);
     },
   });
@@ -643,7 +642,7 @@ export function useCloseSessionMutation(options?: { workspaceId?: string | null 
 
 export function useRestoreDismissedSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -661,12 +660,12 @@ export function useRestoreDismissedSessionMutation(options?: { workspaceId?: str
     onSuccess: async (response, input) => {
       const workspaceId = input?.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       const invalidations = [
-        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(runtimeUrl, workspaceId) }),
+        queryClient.invalidateQueries({ queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId) }),
       ];
       if (response?.id) {
         invalidations.push(
           queryClient.invalidateQueries({
-            queryKey: anyHarnessSessionKey(runtimeUrl, workspaceId, response.id),
+            queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, response.id),
           }),
         );
       }

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -42,13 +42,9 @@ interface WorkspaceMutationInput {
 
 type TimedWorkspaceQueryOptions = WorkspaceQueryOptions & AnyHarnessQueryTimingOptions;
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useWorkspaceSessionsQuery(options?: TimedWorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
   const queryKey = anyHarnessSessionsKey(cacheScopeKey, workspaceId);
@@ -78,7 +74,7 @@ export function useSessionQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -114,7 +110,7 @@ export function useSessionLiveConfigQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -136,7 +132,7 @@ export function useSessionEventsQuery(
   options?: TimedWorkspaceQueryOptions & { request?: ListSessionEventsOptions },
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const afterSeq = options?.request?.afterSeq;
   const beforeSeq = options?.request?.beforeSeq;
@@ -185,7 +181,7 @@ export function useSessionSubagentsQuery(
   options?: WorkspaceQueryOptions,
 ) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -204,7 +200,7 @@ export function useSessionSubagentsQuery(
 
 export function useScheduleSubagentWakeMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -229,7 +225,7 @@ export function useScheduleSubagentWakeMutation(options?: { workspaceId?: string
 
 export function useCreateSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -269,7 +265,7 @@ export function useCreateSessionMutation(options?: { workspaceId?: string | null
 
 export function useSetSessionConfigOptionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -303,7 +299,7 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
 
 export function usePromptSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -330,7 +326,7 @@ export function usePromptSessionMutation(options?: { workspaceId?: string | null
 
 export function usePromptSessionTextMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -350,7 +346,7 @@ export function usePromptSessionTextMutation(options?: { workspaceId?: string | 
 
 export function useForkSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -381,7 +377,7 @@ export function useForkSessionMutation(options?: { workspaceId?: string | null }
 
 export function useResumeSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
@@ -407,7 +403,7 @@ export function useResumeSessionMutation(options?: { workspaceId?: string | null
 
 export function useUpdateSessionTitleMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -439,7 +435,7 @@ export function useUpdateSessionTitleMutation(options?: { workspaceId?: string |
 
 export function useSetSessionGoalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -466,7 +462,7 @@ export function useSetSessionGoalMutation(options?: { workspaceId?: string | nul
 
 export function useClearSessionGoalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -492,7 +488,7 @@ export function useClearSessionGoalMutation(options?: { workspaceId?: string | n
 
 export function useSetSessionLoopMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -528,7 +524,7 @@ export function useSetSessionLoopMutation(options?: { workspaceId?: string | nul
 
 export function useClearSessionLoopMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -558,7 +554,7 @@ export function useClearSessionLoopMutation(options?: { workspaceId?: string | n
 
 export function useCancelSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -586,7 +582,7 @@ export function useCancelSessionMutation(options?: { workspaceId?: string | null
 
 export function useDismissSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -614,7 +610,7 @@ export function useDismissSessionMutation(options?: { workspaceId?: string | nul
 
 export function useCloseSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -642,7 +638,7 @@ export function useCloseSessionMutation(options?: { workspaceId?: string | null 
 
 export function useRestoreDismissedSessionMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/anyharness/sdk-react/src/hooks/terminals.ts
+++ b/anyharness/sdk-react/src/hooks/terminals.ts
@@ -9,7 +9,7 @@ import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
 } from "../context/AnyHarnessWorkspace.js";
-import { useAnyHarnessRuntimeContext } from "../context/AnyHarnessRuntime.js";
+import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { anyHarnessTerminalsKey } from "../lib/query-keys.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
@@ -19,18 +19,17 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useTerminalsQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -46,7 +45,7 @@ export function useTerminalsQuery(options?: WorkspaceQueryOptions) {
 export function useCreateTerminalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
 
   return useMutation({
     mutationFn: async (
@@ -65,7 +64,7 @@ export function useCreateTerminalMutation(options?: { workspaceId?: string | nul
         ? input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId
         : options?.workspaceId ?? workspace.workspaceId;
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -100,7 +99,7 @@ export function useResizeTerminalMutation() {
 export function useUpdateTerminalTitleMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -114,7 +113,7 @@ export function useUpdateTerminalTitleMutation(options?: { workspaceId?: string 
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -123,7 +122,7 @@ export function useUpdateTerminalTitleMutation(options?: { workspaceId?: string 
 export function useCloseTerminalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -136,7 +135,7 @@ export function useCloseTerminalMutation(options?: { workspaceId?: string | null
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -145,7 +144,7 @@ export function useCloseTerminalMutation(options?: { workspaceId?: string | null
 export function useRunTerminalCommandMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -159,7 +158,7 @@ export function useRunTerminalCommandMutation(options?: { workspaceId?: string |
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/terminals.ts
+++ b/anyharness/sdk-react/src/hooks/terminals.ts
@@ -19,13 +19,9 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useTerminalsQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -45,7 +41,7 @@ export function useTerminalsQuery(options?: WorkspaceQueryOptions) {
 export function useCreateTerminalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   return useMutation({
     mutationFn: async (
@@ -99,7 +95,7 @@ export function useResizeTerminalMutation() {
 export function useUpdateTerminalTitleMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -122,7 +118,7 @@ export function useUpdateTerminalTitleMutation(options?: { workspaceId?: string 
 export function useCloseTerminalMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({
@@ -144,7 +140,7 @@ export function useCloseTerminalMutation(options?: { workspaceId?: string | null
 export function useRunTerminalCommandMutation(options?: { workspaceId?: string | null }) {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useMutation({

--- a/anyharness/sdk-react/src/hooks/workspaces.test.tsx
+++ b/anyharness/sdk-react/src/hooks/workspaces.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
 import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
 import {
+  anyHarnessWorkspaceDetailKey,
   anyHarnessWorkspacePurgePreflightKey,
   anyHarnessWorkspaceQueryKeyRoots,
   anyHarnessWorkspaceRetirePreflightKey,
@@ -19,15 +20,19 @@ import {
 const mocks = vi.hoisted(() => ({
   listWorkspaces: vi.fn(),
   getWorkspace: vi.fn(),
+  clientConnection: vi.fn(),
 }));
 
 vi.mock("../lib/client-cache.js", () => ({
-  getAnyHarnessClient: () => ({
-    workspaces: {
-      list: mocks.listWorkspaces,
-      get: mocks.getWorkspace,
-    },
-  }),
+  getAnyHarnessClient: (connection: unknown) => {
+    mocks.clientConnection(connection);
+    return {
+      workspaces: {
+        list: mocks.listWorkspaces,
+        get: mocks.getWorkspace,
+      },
+    };
+  },
 }));
 
 describe("sdk-react workspace query request options", () => {
@@ -35,6 +40,7 @@ describe("sdk-react workspace query request options", () => {
     cleanup();
     mocks.listWorkspaces.mockReset();
     mocks.getWorkspace.mockReset();
+    mocks.clientConnection.mockReset();
   });
 
   it("passes query signals to runtime workspace list without adding them to query keys", async () => {
@@ -91,6 +97,77 @@ describe("sdk-react workspace query request options", () => {
       anyHarnessWorkspacePurgePreflightKey("http://runtime.test", "workspace-1"),
     ));
   });
+
+  it("keeps a cloud workspace key stable and free of resolved gateway credentials", async () => {
+    mocks.getWorkspace.mockResolvedValue({ id: "anyharness-workspace-1" });
+    const queryClient = createQueryClient();
+    let credentialGeneration = 1;
+    const resolveConnection = vi.fn().mockImplementation(async () => ({
+      runtimeUrl: `https://gateway.test/temporary-route-${credentialGeneration}`,
+      authToken: `temporary-token-${credentialGeneration}`,
+      anyharnessWorkspaceId: "anyharness-workspace-1",
+    }));
+
+    const { result } = renderHook(() => useWorkspaceQuery({}), {
+      wrapper: createWrapper(queryClient, null, {
+        cacheScopeKey: "https://api.test:user-1",
+        resolveConnection,
+      }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    credentialGeneration = 2;
+    await result.current.refetch();
+
+    expect(resolveConnection).toHaveBeenCalledTimes(2);
+    expect(resolveConnection).toHaveBeenCalledWith("workspace-1");
+    expect(mocks.clientConnection).toHaveBeenCalledWith(expect.objectContaining({
+      runtimeUrl: "https://gateway.test/temporary-route-1",
+      authToken: "temporary-token-1",
+    }));
+    expect(mocks.clientConnection).toHaveBeenCalledWith(expect.objectContaining({
+      runtimeUrl: "https://gateway.test/temporary-route-2",
+      authToken: "temporary-token-2",
+    }));
+    expect(queryClient.getQueryCache().getAll().map((query) => query.queryKey)).toContainEqual(
+      anyHarnessWorkspaceDetailKey("https://api.test:user-1", "workspace-1"),
+    );
+    const serializedKeys = JSON.stringify(
+      queryClient.getQueryCache().getAll().map((query) => query.queryKey),
+    );
+    expect(serializedKeys).not.toContain("temporary-route");
+    expect(serializedKeys).not.toContain("temporary-token");
+  });
+
+  it("isolates the same logical workspace across actor cache scopes", async () => {
+    mocks.getWorkspace
+      .mockResolvedValueOnce({ id: "anyharness-workspace-1", actor: "user-1" })
+      .mockResolvedValueOnce({ id: "anyharness-workspace-1", actor: "user-2" });
+    const queryClient = createQueryClient();
+
+    const first = renderHook(() => useWorkspaceQuery({}), {
+      wrapper: createWrapper(queryClient, null, {
+        cacheScopeKey: "https://api.test:user-1",
+      }),
+    });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    first.unmount();
+
+    const second = renderHook(() => useWorkspaceQuery({}), {
+      wrapper: createWrapper(queryClient, null, {
+        cacheScopeKey: "https://api.test:user-2",
+      }),
+    });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData(
+      anyHarnessWorkspaceDetailKey("https://api.test:user-1", "workspace-1"),
+    )).toMatchObject({ actor: "user-1" });
+    expect(queryClient.getQueryData(
+      anyHarnessWorkspaceDetailKey("https://api.test:user-2", "workspace-1"),
+    )).toMatchObject({ actor: "user-2" });
+  });
 });
 
 function createQueryClient(): QueryClient {
@@ -103,17 +180,31 @@ function createQueryClient(): QueryClient {
   });
 }
 
-function createWrapper(queryClient: QueryClient, runtimeUrl: string) {
+function createWrapper(
+  queryClient: QueryClient,
+  runtimeUrl: string | null,
+  options?: {
+    cacheScopeKey?: string;
+    resolveConnection?: () => Promise<{
+      runtimeUrl: string;
+      authToken?: string;
+      anyharnessWorkspaceId: string;
+    }>;
+  },
+) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <AnyHarnessRuntime runtimeUrl={runtimeUrl}>
+        <AnyHarnessRuntime
+          runtimeUrl={runtimeUrl}
+          cacheScopeKey={options?.cacheScopeKey}
+        >
           <AnyHarnessWorkspace
             workspaceId="workspace-1"
-            resolveConnection={async () => ({
-              runtimeUrl,
+            resolveConnection={options?.resolveConnection ?? (async () => ({
+              runtimeUrl: runtimeUrl ?? "https://gateway.test",
               anyharnessWorkspaceId: "anyharness-workspace-1",
-            })}
+            }))}
           >
             {children}
           </AnyHarnessWorkspace>

--- a/anyharness/sdk-react/src/hooks/workspaces.ts
+++ b/anyharness/sdk-react/src/hooks/workspaces.ts
@@ -43,10 +43,6 @@ interface WorkspaceQueryOptions {
   requestOptions?: AnyHarnessRequestOptions;
 }
 
-function useWorkspaceCacheScopeKey() {
-  return useAnyHarnessCacheScopeKey();
-}
-
 export function useRuntimeWorkspacesQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
@@ -64,7 +60,7 @@ export function useRuntimeWorkspacesQuery(options?: RuntimeQueryOptions) {
 
 export function useWorkspaceQuery(options: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -184,7 +180,7 @@ export function useUpdateWorkspaceDisplayNameMutation() {
 
 export function useRetireWorkspacePreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -204,7 +200,7 @@ export function useRetireWorkspacePreflightQuery(options?: WorkspaceQueryOptions
 
 export function usePurgeWorkspacePreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -330,7 +326,7 @@ export function useRetryPurgeWorkspaceMutation() {
 
 export function useDetectProjectSetupQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
@@ -350,7 +346,7 @@ export function useDetectProjectSetupQuery(options?: WorkspaceQueryOptions) {
 
 export function useSetupStatusQuery(options?: WorkspaceQueryOptions & { refetchWhileRunning?: boolean }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const cacheScopeKey = useWorkspaceCacheScopeKey();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const refetchWhileRunning = options?.refetchWhileRunning ?? true;
 

--- a/anyharness/sdk-react/src/hooks/workspaces.ts
+++ b/anyharness/sdk-react/src/hooks/workspaces.ts
@@ -6,7 +6,12 @@ import type {
   StartWorkspaceSetupRequest,
   UpdateWorkspaceDisplayNameRequest,
 } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessCacheScopeKey,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import {
   useAnyHarnessWorkspaceContext,
   resolveWorkspaceConnectionFromContext,
@@ -17,9 +22,10 @@ import {
 import {
   anyHarnessRepoRootsKey,
   anyHarnessRuntimeWorkspacesKey,
-  anyHarnessWorkspaceQueryKeyRoots,
+  anyHarnessWorkspaceKey,
   anyHarnessWorktreesInventoryKey,
   anyHarnessWorkspacePurgePreflightKey,
+  anyHarnessWorkspaceDetailKey,
   anyHarnessWorkspaceDetectSetupKey,
   anyHarnessWorkspaceRetirePreflightKey,
   anyHarnessWorkspaceSetupStatusKey,
@@ -37,17 +43,17 @@ interface WorkspaceQueryOptions {
   requestOptions?: AnyHarnessRequestOptions;
 }
 
-function useWorkspaceRuntimeUrl() {
-  const runtime = useAnyHarnessRuntimeContext();
-  return runtime.runtimeUrl?.trim() ?? "";
+function useWorkspaceCacheScopeKey() {
+  return useAnyHarnessCacheScopeKey();
 }
 
 export function useRuntimeWorkspacesQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+    queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -58,11 +64,11 @@ export function useRuntimeWorkspacesQuery(options?: RuntimeQueryOptions) {
 
 export function useWorkspaceQuery(options: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: [...anyHarnessWorkspaceQueryKeyRoots(runtimeUrl, workspaceId), "detail"] as const,
+    queryKey: anyHarnessWorkspaceDetailKey(cacheScopeKey, workspaceId),
     enabled: (options.enabled ?? true) && !!workspaceId,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
@@ -79,6 +85,7 @@ export function useResolveWorkspaceFromPathMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (path: string) => {
@@ -87,10 +94,10 @@ export function useResolveWorkspaceFromPathMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRepoRootsKey(runtimeUrl),
+        queryKey: anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -100,6 +107,7 @@ export function useCreateWorkspaceMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (input: CreateWorkspaceRequest) => {
@@ -108,10 +116,10 @@ export function useCreateWorkspaceMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRepoRootsKey(runtimeUrl),
+        queryKey: anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -121,6 +129,7 @@ export function useCreateWorktreeWorkspaceMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (input: CreateWorktreeWorkspaceRequest) => {
@@ -129,7 +138,7 @@ export function useCreateWorktreeWorkspaceMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -140,6 +149,7 @@ export function useUpdateWorkspaceDisplayNameMutation() {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async ({
@@ -162,10 +172,10 @@ export function useUpdateWorkspaceDisplayNameMutation() {
     onSuccess: async (_data, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+          queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
         }),
         queryClient.invalidateQueries({
-          queryKey: anyHarnessWorkspaceQueryKeyRoots(runtimeUrl, variables.workspaceId),
+          queryKey: anyHarnessWorkspaceKey(cacheScopeKey, variables.workspaceId),
         }),
       ]);
     },
@@ -174,11 +184,11 @@ export function useUpdateWorkspaceDisplayNameMutation() {
 
 export function useRetireWorkspacePreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessWorkspaceRetirePreflightKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     staleTime: 60_000,
     queryFn: async ({ signal }) => {
@@ -194,11 +204,11 @@ export function useRetireWorkspacePreflightQuery(options?: WorkspaceQueryOptions
 
 export function usePurgeWorkspacePreflightQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessWorkspacePurgePreflightKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessWorkspacePurgePreflightKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     staleTime: 60_000,
     queryFn: async ({ signal }) => {
@@ -217,6 +227,7 @@ export function useRetireWorkspaceMutation() {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (workspaceId: string) => {
@@ -226,10 +237,10 @@ export function useRetireWorkspaceMutation() {
     },
     onSuccess: async (_data, workspaceId) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspaceRetirePreflightKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -240,6 +251,7 @@ export function useRetryRetireCleanupMutation() {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (workspaceId: string) => {
@@ -251,10 +263,10 @@ export function useRetryRetireCleanupMutation() {
     },
     onSuccess: async (_data, workspaceId) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspaceRetirePreflightKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -265,6 +277,7 @@ export function usePurgeWorkspaceMutation() {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (workspaceId: string) => {
@@ -274,13 +287,13 @@ export function usePurgeWorkspaceMutation() {
     },
     onSuccess: async (_data, workspaceId) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspacePurgePreflightKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspacePurgePreflightKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -291,6 +304,7 @@ export function useRetryPurgeWorkspaceMutation() {
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (workspaceId: string) => {
@@ -302,13 +316,13 @@ export function useRetryPurgeWorkspaceMutation() {
     },
     onSuccess: async (_data, workspaceId) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspacePurgePreflightKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspacePurgePreflightKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -316,11 +330,11 @@ export function useRetryPurgeWorkspaceMutation() {
 
 export function useDetectProjectSetupQuery(options?: WorkspaceQueryOptions) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
 
   return useQuery({
-    queryKey: anyHarnessWorkspaceDetectSetupKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessWorkspaceDetectSetupKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     staleTime: Infinity,
     queryFn: async ({ signal }) => {
@@ -336,12 +350,12 @@ export function useDetectProjectSetupQuery(options?: WorkspaceQueryOptions) {
 
 export function useSetupStatusQuery(options?: WorkspaceQueryOptions & { refetchWhileRunning?: boolean }) {
   const workspace = useAnyHarnessWorkspaceContext();
-  const runtimeUrl = useWorkspaceRuntimeUrl();
+  const cacheScopeKey = useWorkspaceCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const refetchWhileRunning = options?.refetchWhileRunning ?? true;
 
   return useQuery({
-    queryKey: anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
+    queryKey: anyHarnessWorkspaceSetupStatusKey(cacheScopeKey, workspaceId),
     enabled: (options?.enabled ?? true) && !!workspaceId,
     // Don't retry on 404 (no setup job exists for this workspace)
     retry: (failureCount, error) => {
@@ -370,7 +384,7 @@ export function useRerunSetupMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (workspaceId: string) => {
@@ -382,7 +396,7 @@ export function useRerunSetupMutation() {
     },
     onSuccess: async (_data, workspaceId) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspaceSetupStatusKey(cacheScopeKey, workspaceId),
       });
     },
   });
@@ -392,7 +406,7 @@ export function useStartSetupMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const workspace = useAnyHarnessWorkspaceContext();
   const queryClient = useQueryClient();
-  const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async ({
@@ -411,7 +425,7 @@ export function useStartSetupMutation() {
     },
     onSuccess: async (_data, variables) => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceSetupStatusKey(runtimeUrl, variables.workspaceId),
+        queryKey: anyHarnessWorkspaceSetupStatusKey(cacheScopeKey, variables.workspaceId),
       });
     },
   });

--- a/anyharness/sdk-react/src/hooks/worktrees.ts
+++ b/anyharness/sdk-react/src/hooks/worktrees.ts
@@ -3,7 +3,11 @@ import type {
   PruneOrphanWorktreeRequest,
   UpdateWorktreeRetentionPolicyRequest,
 } from "@anyharness/sdk";
-import { useAnyHarnessRuntimeContext, resolveRuntimeConnection } from "../context/AnyHarnessRuntime.js";
+import {
+  resolveRuntimeCacheScopeKey,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
@@ -19,9 +23,10 @@ interface RuntimeQueryOptions {
 export function useWorktreeInventoryQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+    queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -34,6 +39,7 @@ export function usePruneOrphanWorktreeMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (input: PruneOrphanWorktreeRequest) => {
@@ -42,10 +48,10 @@ export function usePruneOrphanWorktreeMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -54,9 +60,10 @@ export function usePruneOrphanWorktreeMutation() {
 export function useWorktreeRetentionPolicyQuery(options?: RuntimeQueryOptions) {
   const runtime = useAnyHarnessRuntimeContext();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useQuery({
-    queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl),
+    queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl, cacheScopeKey),
     enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
     queryFn: async ({ signal }) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
@@ -69,6 +76,7 @@ export function useUpdateWorktreeRetentionPolicyMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async (input: UpdateWorktreeRetentionPolicyRequest) => {
@@ -77,10 +85,10 @@ export function useUpdateWorktreeRetentionPolicyMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
       });
     },
   });
@@ -90,6 +98,7 @@ export function useRunWorktreeRetentionMutation() {
   const runtime = useAnyHarnessRuntimeContext();
   const queryClient = useQueryClient();
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
 
   return useMutation({
     mutationFn: async () => {
@@ -98,13 +107,13 @@ export function useRunWorktreeRetentionMutation() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl),
+        queryKey: anyHarnessWorktreesRetentionPolicyKey(runtimeUrl, cacheScopeKey),
       });
       await queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(runtimeUrl, cacheScopeKey),
       });
     },
   });

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -1,6 +1,8 @@
 export {
   AnyHarnessRuntime,
+  resolveRuntimeCacheScopeKey,
   resolveRuntimeConnection,
+  useAnyHarnessCacheScopeKey,
   useAnyHarnessRuntimeContext,
 } from "./context/AnyHarnessRuntime.js";
 export {
@@ -8,6 +10,9 @@ export {
   resolveWorkspaceConnectionFromContext,
   useAnyHarnessWorkspaceContext,
 } from "./context/AnyHarnessWorkspace.js";
+export type {
+  AnyHarnessRuntimeContextValue,
+} from "./context/AnyHarnessRuntime.js";
 export type {
   AnyHarnessResolvedConnection,
   AnyHarnessWorkspaceContextValue,
@@ -21,7 +26,9 @@ export type {
 } from "./lib/timing-options.js";
 
 export {
+  anyHarnessCacheScopeKey,
   anyHarnessRuntimeKey,
+  anyHarnessWorkspaceKey,
   anyHarnessRuntimeHealthKey,
   anyHarnessAgentsKey,
   anyHarnessAgentLaunchOptionsKey,
@@ -32,6 +39,7 @@ export {
   anyHarnessRuntimeWorkspacesKey,
   anyHarnessWorkspaceRetirePreflightKey,
   anyHarnessWorkspacePurgePreflightKey,
+  anyHarnessWorkspaceDetailKey,
   anyHarnessWorktreesInventoryKey,
   anyHarnessWorktreesRetentionPolicyKey,
   anyHarnessRepoRootsKey,

--- a/anyharness/sdk-react/src/lib/query-keys.test.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   anyHarnessGitBaseWorktreeDiffFilesKey,
   anyHarnessGitDiffKey,
+  anyHarnessRuntimeHealthKey,
   anyHarnessSessionEventsKey,
+  anyHarnessSessionsKey,
 } from "./query-keys.js";
 
 describe("sdk-react query keys", () => {
@@ -14,8 +16,9 @@ describe("sdk-react query keys", () => {
     ).toEqual([
       "anyharness",
       "http://runtime.test",
-      "session",
+      "workspace",
       "workspace-1",
+      "session",
       "session-1",
       "events",
     ]);
@@ -35,8 +38,9 @@ describe("sdk-react query keys", () => {
     ).toEqual([
       "anyharness",
       "http://runtime.test",
-      "session",
+      "workspace",
       "workspace-1",
+      "session",
       "session-1",
       "events",
       {
@@ -54,8 +58,9 @@ describe("sdk-react query keys", () => {
     ).toEqual([
       "anyharness",
       "http://runtime.test",
-      "git-diff",
+      "workspace",
       "workspace-1",
+      "git-diff",
       "base-worktree-files",
       "origin/main",
     ]);
@@ -71,12 +76,37 @@ describe("sdk-react query keys", () => {
     ).toEqual([
       "anyharness",
       "http://runtime.test",
-      "git-diff",
+      "workspace",
       "workspace-1",
+      "git-diff",
       "base_worktree",
       "origin/main",
       "src/old-app.ts",
       "src/app.ts",
+    ]);
+  });
+
+  it("separates runtime transport identity from the stable cache scope", () => {
+    expect(anyHarnessRuntimeHealthKey("http://runtime-a.test", "api:user-1"))
+      .toEqual([
+        "anyharness",
+        "api:user-1",
+        "runtime",
+        "http://runtime-a.test",
+        "health",
+      ]);
+    expect(anyHarnessRuntimeHealthKey("http://runtime-b.test", "api:user-1"))
+      .not
+      .toEqual(anyHarnessRuntimeHealthKey("http://runtime-a.test", "api:user-1"));
+  });
+
+  it("keeps logical workspace keys independent of resolved gateway credentials", () => {
+    expect(anyHarnessSessionsKey("api:user-1", "workspace-1")).toEqual([
+      "anyharness",
+      "api:user-1",
+      "workspace",
+      "workspace-1",
+      "sessions",
     ]);
   });
 });

--- a/anyharness/sdk-react/src/lib/query-keys.test.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.test.ts
@@ -100,6 +100,16 @@ describe("sdk-react query keys", () => {
       .toEqual(anyHarnessRuntimeHealthKey("http://runtime-a.test", "api:user-1"));
   });
 
+  it("does not silently fall back to runtime identity when an explicit scope is empty", () => {
+    expect(anyHarnessRuntimeHealthKey("http://runtime.test", "")).toEqual([
+      "anyharness",
+      "",
+      "runtime",
+      "http://runtime.test",
+      "health",
+    ]);
+  });
+
   it("keeps logical workspace keys independent of resolved gateway credentials", () => {
     expect(anyHarnessSessionsKey("api:user-1", "workspace-1")).toEqual([
       "anyharness",

--- a/anyharness/sdk-react/src/lib/query-keys.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.ts
@@ -4,11 +4,11 @@ export function anyHarnessCacheScopeKey(cacheScopeKey: string | null | undefined
 
 export function anyHarnessRuntimeKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   const normalizedRuntimeUrl = runtimeUrl?.trim() ?? "";
   return [
-    ...anyHarnessCacheScopeKey(cacheScopeKey?.trim() || normalizedRuntimeUrl),
+    ...anyHarnessCacheScopeKey(cacheScopeKey?.trim() ?? ""),
     "runtime",
     normalizedRuntimeUrl,
   ] as const;
@@ -27,22 +27,22 @@ export function anyHarnessWorkspaceKey(
 
 export function anyHarnessRuntimeHealthKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "health"] as const;
 }
 
 export function anyHarnessAgentsKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "agents"] as const;
 }
 
 export function anyHarnessAgentLaunchOptionsKey(
   runtimeUrl: string | null | undefined,
-  workspaceId?: string | null,
-  cacheScopeKey?: string | null,
+  workspaceId: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [
     ...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
@@ -53,14 +53,14 @@ export function anyHarnessAgentLaunchOptionsKey(
 
 export function anyHarnessAgentLaunchOptionsPrefixKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "launch-options"] as const;
 }
 
 export function anyHarnessAgentReconcileStatusKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "reconcile-status"] as const;
 }
@@ -68,21 +68,21 @@ export function anyHarnessAgentReconcileStatusKey(
 export function anyHarnessAgentGatewayModelsKey(
   runtimeUrl: string | null | undefined,
   kind: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "gateway-models", kind ?? null] as const;
 }
 
 export function anyHarnessReconcileAgentsMutationKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "reconcile"] as const;
 }
 
 export function anyHarnessRuntimeWorkspacesKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "workspaces"] as const;
 }
@@ -103,21 +103,21 @@ export function anyHarnessWorkspacePurgePreflightKey(
 
 export function anyHarnessWorktreesInventoryKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "worktrees", "inventory"] as const;
 }
 
 export function anyHarnessWorktreesRetentionPolicyKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "worktrees", "retention-policy"] as const;
 }
 
 export function anyHarnessRepoRootsKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "repo-roots"] as const;
 }
@@ -125,7 +125,7 @@ export function anyHarnessRepoRootsKey(
 export function anyHarnessRepoRootPullRequestsKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "pull-requests"] as const;
 }
@@ -133,7 +133,7 @@ export function anyHarnessRepoRootPullRequestsKey(
 export function anyHarnessRepoRootGitBranchesKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "git-branches"] as const;
 }
@@ -141,7 +141,7 @@ export function anyHarnessRepoRootGitBranchesKey(
 export function anyHarnessRepoRootDetectSetupKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "detect-setup"] as const;
 }
@@ -169,14 +169,14 @@ export function anyHarnessWorkspaceMobilityRuntimeStateKey(
 
 export function anyHarnessCoworkStatusKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "cowork", "status"] as const;
 }
 
 export function anyHarnessCoworkThreadsKey(
   runtimeUrl: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "cowork", "threads"] as const;
 }
@@ -184,7 +184,7 @@ export function anyHarnessCoworkThreadsKey(
 export function anyHarnessCoworkManagedWorkspacesKey(
   runtimeUrl: string | null | undefined,
   sessionId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [
     ...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey),
@@ -198,7 +198,7 @@ export function anyHarnessCoworkManagedWorkspacesKey(
 export function anyHarnessCoworkManifestKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [
     ...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey),
@@ -211,7 +211,7 @@ export function anyHarnessCoworkManifestKey(
 export function anyHarnessCoworkArtifactScopeKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [...anyHarnessCoworkManifestKey(runtimeUrl, workspaceId, cacheScopeKey), "artifact"] as const;
 }
@@ -220,7 +220,7 @@ export function anyHarnessCoworkArtifactKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
   artifactId: string | null | undefined,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ) {
   return [
     ...anyHarnessCoworkArtifactScopeKey(runtimeUrl, workspaceId, cacheScopeKey),

--- a/anyharness/sdk-react/src/lib/query-keys.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.ts
@@ -1,188 +1,272 @@
-export function anyHarnessRuntimeKey(runtimeUrl: string | null | undefined) {
-  return ["anyharness", runtimeUrl?.trim() ?? ""] as const;
+export function anyHarnessCacheScopeKey(cacheScopeKey: string | null | undefined) {
+  return ["anyharness", cacheScopeKey?.trim() ?? ""] as const;
 }
 
-export function anyHarnessRuntimeHealthKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "health"] as const;
+export function anyHarnessRuntimeKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  const normalizedRuntimeUrl = runtimeUrl?.trim() ?? "";
+  return [
+    ...anyHarnessCacheScopeKey(cacheScopeKey?.trim() || normalizedRuntimeUrl),
+    "runtime",
+    normalizedRuntimeUrl,
+  ] as const;
 }
 
-export function anyHarnessAgentsKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "agents"] as const;
+export function anyHarnessWorkspaceKey(
+  cacheScopeKey: string | null | undefined,
+  workspaceId: string | null | undefined,
+) {
+  return [
+    ...anyHarnessCacheScopeKey(cacheScopeKey),
+    "workspace",
+    workspaceId ?? null,
+  ] as const;
+}
+
+export function anyHarnessRuntimeHealthKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "health"] as const;
+}
+
+export function anyHarnessAgentsKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "agents"] as const;
 }
 
 export function anyHarnessAgentLaunchOptionsKey(
   runtimeUrl: string | null | undefined,
   workspaceId?: string | null,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessAgentsKey(runtimeUrl), "launch-options", workspaceId ?? null] as const;
+  return [
+    ...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey),
+    "launch-options",
+    workspaceId ?? null,
+  ] as const;
 }
 
 export function anyHarnessAgentLaunchOptionsPrefixKey(
   runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessAgentsKey(runtimeUrl), "launch-options"] as const;
+  return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "launch-options"] as const;
 }
 
 export function anyHarnessAgentReconcileStatusKey(
   runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessAgentsKey(runtimeUrl), "reconcile-status"] as const;
+  return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "reconcile-status"] as const;
 }
 
 export function anyHarnessAgentGatewayModelsKey(
   runtimeUrl: string | null | undefined,
   kind: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessAgentsKey(runtimeUrl), "gateway-models", kind ?? null] as const;
+  return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "gateway-models", kind ?? null] as const;
 }
 
 export function anyHarnessReconcileAgentsMutationKey(
   runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessAgentsKey(runtimeUrl), "reconcile"] as const;
+  return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "reconcile"] as const;
 }
 
-export function anyHarnessRuntimeWorkspacesKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "workspaces"] as const;
+export function anyHarnessRuntimeWorkspacesKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "workspaces"] as const;
 }
 
 export function anyHarnessWorkspaceRetirePreflightKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeWorkspacesKey(runtimeUrl), workspaceId ?? null, "retire", "preflight"] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "retire", "preflight"] as const;
 }
 
 export function anyHarnessWorkspacePurgePreflightKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeWorkspacesKey(runtimeUrl), workspaceId ?? null, "purge", "preflight"] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "purge", "preflight"] as const;
 }
 
-export function anyHarnessWorktreesInventoryKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "worktrees", "inventory"] as const;
+export function anyHarnessWorktreesInventoryKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "worktrees", "inventory"] as const;
 }
 
-export function anyHarnessWorktreesRetentionPolicyKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "worktrees", "retention-policy"] as const;
+export function anyHarnessWorktreesRetentionPolicyKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "worktrees", "retention-policy"] as const;
 }
 
-export function anyHarnessRepoRootsKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "repo-roots"] as const;
+export function anyHarnessRepoRootsKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "repo-roots"] as const;
 }
 
 export function anyHarnessRepoRootPullRequestsKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessRepoRootsKey(runtimeUrl), repoRootId ?? null, "pull-requests"] as const;
+  return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "pull-requests"] as const;
 }
 
 export function anyHarnessRepoRootGitBranchesKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessRepoRootsKey(runtimeUrl), repoRootId ?? null, "git-branches"] as const;
+  return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "git-branches"] as const;
 }
 
 export function anyHarnessRepoRootDetectSetupKey(
   runtimeUrl: string | null | undefined,
   repoRootId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessRepoRootsKey(runtimeUrl), repoRootId ?? null, "detect-setup"] as const;
+  return [...anyHarnessRepoRootsKey(runtimeUrl, cacheScopeKey), repoRootId ?? null, "detect-setup"] as const;
 }
 
 export function anyHarnessWorkspaceMobilityKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "mobility", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "mobility"] as const;
 }
 
 export function anyHarnessWorkspaceMobilityPreflightKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessWorkspaceMobilityKey(runtimeUrl, workspaceId), "preflight"] as const;
+  return [...anyHarnessWorkspaceMobilityKey(cacheScopeKey, workspaceId), "preflight"] as const;
 }
 
 export function anyHarnessWorkspaceMobilityRuntimeStateKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessWorkspaceMobilityKey(runtimeUrl, workspaceId), "runtime-state"] as const;
+  return [...anyHarnessWorkspaceMobilityKey(cacheScopeKey, workspaceId), "runtime-state"] as const;
 }
 
-export function anyHarnessCoworkStatusKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "cowork", "status"] as const;
+export function anyHarnessCoworkStatusKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "cowork", "status"] as const;
 }
 
-export function anyHarnessCoworkThreadsKey(runtimeUrl: string | null | undefined) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "cowork", "threads"] as const;
+export function anyHarnessCoworkThreadsKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey?: string | null,
+) {
+  return [...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey), "cowork", "threads"] as const;
 }
 
 export function anyHarnessCoworkManagedWorkspacesKey(
   runtimeUrl: string | null | undefined,
   sessionId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "cowork", "sessions", sessionId ?? null, "managed-workspaces"] as const;
+  return [
+    ...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey),
+    "cowork",
+    "sessions",
+    sessionId ?? null,
+    "managed-workspaces",
+  ] as const;
 }
 
 export function anyHarnessCoworkManifestKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "cowork", workspaceId ?? null, "manifest"] as const;
+  return [
+    ...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey),
+    "cowork",
+    workspaceId ?? null,
+    "manifest",
+  ] as const;
 }
 
 export function anyHarnessCoworkArtifactScopeKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessCoworkManifestKey(runtimeUrl, workspaceId), "artifact"] as const;
+  return [...anyHarnessCoworkManifestKey(runtimeUrl, workspaceId, cacheScopeKey), "artifact"] as const;
 }
 
 export function anyHarnessCoworkArtifactKey(
   runtimeUrl: string | null | undefined,
   workspaceId: string | null | undefined,
   artifactId: string | null | undefined,
+  cacheScopeKey?: string | null,
 ) {
-  return [...anyHarnessCoworkArtifactScopeKey(runtimeUrl, workspaceId), artifactId ?? null] as const;
+  return [
+    ...anyHarnessCoworkArtifactScopeKey(runtimeUrl, workspaceId, cacheScopeKey),
+    artifactId ?? null,
+  ] as const;
+}
+
+export function anyHarnessWorkspaceDetailKey(
+  cacheScopeKey: string | null | undefined,
+  workspaceId: string | null | undefined,
+) {
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "detail"] as const;
 }
 
 export function anyHarnessSessionsKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "sessions", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "sessions"] as const;
 }
 
 export function anyHarnessSessionKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "session", workspaceId ?? null, sessionId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "session", sessionId ?? null] as const;
 }
 
 export function anyHarnessSessionScopeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "session", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "session"] as const;
 }
 
 export function anyHarnessSessionLiveConfigKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
 ) {
-  return [...anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId), "live-config"] as const;
+  return [...anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId), "live-config"] as const;
 }
 
 export function anyHarnessSessionEventsKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
   afterSeq?: number,
@@ -191,7 +275,7 @@ export function anyHarnessSessionEventsKey(
   turnLimit?: number,
 ) {
   const scopeKey = [
-    ...anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId),
+    ...anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId),
     "events",
   ] as const;
   if (
@@ -214,69 +298,68 @@ export function anyHarnessSessionEventsKey(
 }
 
 export function anyHarnessSessionSubagentsKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
 ) {
-  return [...anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId), "subagents"] as const;
+  return [...anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId), "subagents"] as const;
 }
 
 export function anyHarnessSessionReviewsKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   sessionId: string | null | undefined,
 ) {
-  return [...anyHarnessSessionKey(runtimeUrl, workspaceId, sessionId), "reviews"] as const;
+  return [...anyHarnessSessionKey(cacheScopeKey, workspaceId, sessionId), "reviews"] as const;
 }
 
 export function anyHarnessReviewAssignmentCritiqueKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   reviewRunId: string | null | undefined,
   assignmentId: string | null | undefined,
 ) {
   return [
-    ...anyHarnessRuntimeKey(runtimeUrl),
+    ...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId),
     "review-critique",
-    workspaceId ?? null,
     reviewRunId ?? null,
     assignmentId ?? null,
   ] as const;
 }
 
 export function anyHarnessPlansKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "plans", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "plans"] as const;
 }
 
 export function anyHarnessPlanKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   planId: string | null | undefined,
 ) {
-  return [...anyHarnessPlansKey(runtimeUrl, workspaceId), planId ?? null] as const;
+  return [...anyHarnessPlansKey(cacheScopeKey, workspaceId), planId ?? null] as const;
 }
 
 export function anyHarnessPlanDocumentKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   planId: string | null | undefined,
   materialize = false,
 ) {
-  return [...anyHarnessPlanKey(runtimeUrl, workspaceId, planId), "document", materialize] as const;
+  return [...anyHarnessPlanKey(cacheScopeKey, workspaceId, planId), "document", materialize] as const;
 }
 
 export function anyHarnessGitStatusKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "git-status", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "git-status"] as const;
 }
 
 export function anyHarnessGitDiffKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   path: string | null | undefined,
   scope: string | null | undefined = "working_tree",
@@ -284,7 +367,7 @@ export function anyHarnessGitDiffKey(
   oldPath: string | null | undefined = null,
 ) {
   return [
-    ...anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+    ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     normalizeGitDiffScope(scope),
     normalizeNullableGitArg(baseRef),
     normalizeNullableGitArg(oldPath),
@@ -293,31 +376,31 @@ export function anyHarnessGitDiffKey(
 }
 
 export function anyHarnessGitDiffScopeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "git-diff", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "git-diff"] as const;
 }
 
 export function anyHarnessGitBranchDiffFilesKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   baseRef: string | null | undefined = null,
 ) {
   return [
-    ...anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+    ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     "branch-files",
     normalizeNullableGitArg(baseRef),
   ] as const;
 }
 
 export function anyHarnessGitBaseWorktreeDiffFilesKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   baseRef: string | null | undefined = null,
 ) {
   return [
-    ...anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
+    ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     "base-worktree-files",
     normalizeNullableGitArg(baseRef),
   ] as const;
@@ -333,116 +416,115 @@ function normalizeNullableGitArg(value: string | null | undefined) {
 }
 
 export function anyHarnessGitBranchesKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "git-branches", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "git-branches"] as const;
 }
 
 export function anyHarnessPullRequestKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "pull-request", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "pull-request"] as const;
 }
 
 export function anyHarnessWorkspaceSetupStatusKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "workspace-setup-status", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "setup-status"] as const;
 }
 
 export function anyHarnessWorkspaceDetectSetupKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "workspace-detect-setup", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "detect-setup"] as const;
 }
 
 export function anyHarnessWorkspaceFileTreeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   path: string,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "files", workspaceId ?? null, path] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "files", path] as const;
 }
 
 export function anyHarnessWorkspaceFilesScopeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "files", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "files"] as const;
 }
 
 export function anyHarnessWorkspaceFileSearchScopeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "file-search", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "file-search"] as const;
 }
 
 export function anyHarnessWorkspaceFileSearchKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   query: string,
   limit: number,
 ) {
-  return [...anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId), query, limit] as const;
+  return [...anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId), query, limit] as const;
 }
 
 export function anyHarnessWorkspaceFileKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   path: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "file", workspaceId ?? null, path ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "file", path ?? null] as const;
 }
 
 export function anyHarnessWorkspaceFileScopeKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "file", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "file"] as const;
 }
 
 export function anyHarnessWorkspaceFileStatKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   path: string | null | undefined,
 ) {
-  return [...anyHarnessWorkspaceFileKey(runtimeUrl, workspaceId, path), "stat"] as const;
+  return [...anyHarnessWorkspaceFileKey(cacheScopeKey, workspaceId, path), "stat"] as const;
 }
 
 export function anyHarnessTerminalsKey(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
-  return [...anyHarnessRuntimeKey(runtimeUrl), "terminals", workspaceId ?? null] as const;
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "terminals"] as const;
 }
 
 export function anyHarnessWorkspaceQueryKeyRoots(
-  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
 ) {
   return [
-    anyHarnessWorkspaceMobilityKey(runtimeUrl, workspaceId),
-    anyHarnessCoworkManifestKey(runtimeUrl, workspaceId),
-    anyHarnessCoworkArtifactScopeKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspacePurgePreflightKey(runtimeUrl, workspaceId),
-    anyHarnessSessionsKey(runtimeUrl, workspaceId),
-    anyHarnessSessionScopeKey(runtimeUrl, workspaceId),
-    anyHarnessPlansKey(runtimeUrl, workspaceId),
-    anyHarnessGitStatusKey(runtimeUrl, workspaceId),
-    anyHarnessGitDiffScopeKey(runtimeUrl, workspaceId),
-    anyHarnessGitBranchesKey(runtimeUrl, workspaceId),
-    anyHarnessPullRequestKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceDetectSetupKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceFilesScopeKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
-    anyHarnessWorkspaceFileScopeKey(runtimeUrl, workspaceId),
-    anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+    anyHarnessWorkspaceKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceMobilityKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceRetirePreflightKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspacePurgePreflightKey(cacheScopeKey, workspaceId),
+    anyHarnessSessionsKey(cacheScopeKey, workspaceId),
+    anyHarnessSessionScopeKey(cacheScopeKey, workspaceId),
+    anyHarnessPlansKey(cacheScopeKey, workspaceId),
+    anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
+    anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
+    anyHarnessGitBranchesKey(cacheScopeKey, workspaceId),
+    anyHarnessPullRequestKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceSetupStatusKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceDetectSetupKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceFilesScopeKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
+    anyHarnessWorkspaceFileScopeKey(cacheScopeKey, workspaceId),
+    anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
   ] as const;
 }

--- a/apps/desktop/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts
@@ -2,12 +2,14 @@ import {
   anyHarnessAgentLaunchOptionsPrefixKey,
   anyHarnessAgentReconcileStatusKey,
   anyHarnessAgentsKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 export function useAgentResourcesCache() {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const invalidateAgentListResources = useCallback(async (runtimeUrl: string) => {
     const normalizedRuntimeUrl = runtimeUrl.trim();
@@ -17,10 +19,10 @@ export function useAgentResourcesCache() {
 
     await Promise.all([
       queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentsKey(normalizedRuntimeUrl),
+        queryKey: anyHarnessAgentsKey(normalizedRuntimeUrl, cacheScopeKey),
       }),
     ]);
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const invalidateAgentSetupResources = useCallback(async (runtimeUrl: string) => {
     const normalizedRuntimeUrl = runtimeUrl.trim();
@@ -30,13 +32,13 @@ export function useAgentResourcesCache() {
 
     await Promise.all([
       queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentsKey(normalizedRuntimeUrl),
+        queryKey: anyHarnessAgentsKey(normalizedRuntimeUrl, cacheScopeKey),
       }),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentReconcileStatusKey(normalizedRuntimeUrl),
+        queryKey: anyHarnessAgentReconcileStatusKey(normalizedRuntimeUrl, cacheScopeKey),
       }),
     ]);
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const invalidateAgentLaunchReadinessResources = useCallback(async (
     runtimeUrl: string,
@@ -49,10 +51,13 @@ export function useAgentResourcesCache() {
     await Promise.all([
       invalidateAgentSetupResources(normalizedRuntimeUrl),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessAgentLaunchOptionsPrefixKey(normalizedRuntimeUrl),
+        queryKey: anyHarnessAgentLaunchOptionsPrefixKey(
+          normalizedRuntimeUrl,
+          cacheScopeKey,
+        ),
       }),
     ]);
-  }, [invalidateAgentSetupResources, queryClient]);
+  }, [cacheScopeKey, invalidateAgentSetupResources, queryClient]);
 
   return {
     invalidateAgentLaunchReadinessResources,

--- a/apps/desktop/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
+++ b/apps/desktop/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
@@ -2,6 +2,7 @@ import type { AgentLaunchOptionsResponse } from "@anyharness/sdk";
 import {
   anyHarnessAgentLaunchOptionsKey,
   useAgentLaunchOptionsQuery,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { getAgentLaunchOptions } from "@/lib/access/anyharness/agents";
@@ -15,6 +16,7 @@ export function useWorkspaceAgentLaunchOptionsQuery({
   workspaceId: string | null;
   cloudConnectionInfo?: CloudConnectionInfo | null;
 }): UseQueryResult<AgentLaunchOptionsResponse> {
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const localQuery = useAgentLaunchOptionsQuery({
     workspaceId,
     enabled: !cloudConnectionInfo,
@@ -25,6 +27,7 @@ export function useWorkspaceAgentLaunchOptionsQuery({
     queryKey: anyHarnessAgentLaunchOptionsKey(
       gatewayRuntimeUrl,
       gatewayWorkspaceId,
+      cacheScopeKey,
     ),
     enabled: Boolean(cloudConnectionInfo && gatewayRuntimeUrl && gatewayWorkspaceId),
     queryFn: async ({ signal }) => {

--- a/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-cache.ts
@@ -4,6 +4,7 @@ import {
   anyHarnessCoworkManifestKey,
   anyHarnessCoworkStatusKey,
   anyHarnessCoworkThreadsKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -12,39 +13,49 @@ import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-
 export function useCoworkCache() {
   const queryClient = useQueryClient();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const invalidateCoworkThreads = useCallback(async () => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkThreadsKey(runtimeUrl),
+      queryKey: anyHarnessCoworkThreadsKey(runtimeUrl, cacheScopeKey),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 
   const invalidateCoworkStatus = useCallback(async () => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkStatusKey(runtimeUrl),
+      queryKey: anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 
   const invalidateCoworkManagedWorkspaces = useCallback(async (parentSessionId: string) => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, parentSessionId),
+      queryKey: anyHarnessCoworkManagedWorkspacesKey(
+        runtimeUrl,
+        parentSessionId,
+        cacheScopeKey,
+      ),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 
   const invalidateCoworkArtifactManifest = useCallback(async (workspaceId: string) => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkManifestKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessCoworkManifestKey(runtimeUrl, workspaceId, cacheScopeKey),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 
   const invalidateCoworkArtifact = useCallback(async (
     workspaceId: string,
     artifactId: string,
   ) => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessCoworkArtifactKey(runtimeUrl, workspaceId, artifactId),
+      queryKey: anyHarnessCoworkArtifactKey(
+        runtimeUrl,
+        workspaceId,
+        artifactId,
+        cacheScopeKey,
+      ),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 
   return {
     invalidateCoworkArtifact,

--- a/apps/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts
@@ -5,6 +5,7 @@ import {
   anyHarnessWorkspaceFileSearchScopeKey,
   anyHarnessWorkspaceFileTreeKey,
   anyHarnessWorkspaceFilesScopeKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useCallback } from "react";
 import {
@@ -31,23 +32,22 @@ interface WorkspaceFileCacheTarget {
 
 export function useWorkspaceFilesCache() {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const invalidateWorkspaceFiles = useCallback(async ({
-    runtimeUrl,
     workspaceId,
   }: {
-    runtimeUrl: string;
     workspaceId: string;
   }) => {
     await Promise.all([
       queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceFilesScopeKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspaceFilesScopeKey(cacheScopeKey, workspaceId),
       }),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessWorkspaceFileSearchScopeKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessWorkspaceFileSearchScopeKey(cacheScopeKey, workspaceId),
       }),
     ]);
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const prefetchWorkspaceDirectory = useCallback(async ({
     materializedWorkspaceId,
@@ -59,7 +59,11 @@ export function useWorkspaceFilesCache() {
     dirPath: string;
   }) => {
     await queryClient.prefetchQuery({
-      queryKey: anyHarnessWorkspaceFileTreeKey(runtimeUrl, materializedWorkspaceId, dirPath),
+      queryKey: anyHarnessWorkspaceFileTreeKey(
+        cacheScopeKey,
+        materializedWorkspaceId,
+        dirPath,
+      ),
       queryFn: async ({ signal }) => {
         return listWorkspaceFiles(
           buildConnection(runtimeUrl, authToken),
@@ -69,7 +73,7 @@ export function useWorkspaceFilesCache() {
         );
       },
     });
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const reloadWorkspaceFile = useCallback(async ({
     materializedWorkspaceId,
@@ -80,7 +84,11 @@ export function useWorkspaceFilesCache() {
   }: WorkspaceFileCacheTarget & {
     filePath: string;
   }) => {
-    const queryKey = anyHarnessWorkspaceFileKey(runtimeUrl, materializedWorkspaceId, filePath);
+    const queryKey = anyHarnessWorkspaceFileKey(
+      cacheScopeKey,
+      materializedWorkspaceId,
+      filePath,
+    );
     await queryClient.invalidateQueries({ queryKey, exact: true });
     return queryClient.fetchQuery({
       queryKey,
@@ -94,7 +102,7 @@ export function useWorkspaceFilesCache() {
       },
       staleTime: 0,
     });
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   return {
     invalidateWorkspaceFiles,

--- a/apps/desktop/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts
@@ -2,10 +2,10 @@ import type { Session } from "@anyharness/sdk";
 import {
   anyHarnessSessionKey,
   anyHarnessSessionsKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 export type WorkspaceSession = Session & { workspaceId: string };
 
@@ -13,10 +13,6 @@ export interface WorkspaceSessionCacheSnapshot {
   sessions: WorkspaceSession[] | undefined;
   dataUpdatedAt: number;
   isInvalidated: boolean;
-}
-
-interface WorkspaceSessionCacheOptions {
-  runtimeUrl?: string;
 }
 
 function upsertWorkspaceSession(
@@ -37,60 +33,56 @@ function removeWorkspaceSession(
 
 export function useWorkspaceSessionCache() {
   const queryClient = useQueryClient();
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const getWorkspaceSessionCacheSnapshot = useCallback((
     workspaceId: string,
-    options?: WorkspaceSessionCacheOptions,
   ): WorkspaceSessionCacheSnapshot => {
-    const queryKey = anyHarnessSessionsKey(options?.runtimeUrl ?? runtimeUrl, workspaceId);
+    const queryKey = anyHarnessSessionsKey(cacheScopeKey, workspaceId);
     const queryState = queryClient.getQueryState(queryKey);
     return {
       sessions: queryClient.getQueryData<WorkspaceSession[]>(queryKey),
       dataUpdatedAt: queryState?.dataUpdatedAt ?? 0,
       isInvalidated: queryState?.isInvalidated ?? false,
     };
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   const setWorkspaceSessions = useCallback((
     workspaceId: string,
     updater: (sessions: WorkspaceSession[] | undefined) => WorkspaceSession[],
-    options?: WorkspaceSessionCacheOptions,
   ) => {
     queryClient.setQueryData<WorkspaceSession[]>(
-      anyHarnessSessionsKey(options?.runtimeUrl ?? runtimeUrl, workspaceId),
+      anyHarnessSessionsKey(cacheScopeKey, workspaceId),
       updater,
     );
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   const upsertWorkspaceSessionRecord = useCallback((
     workspaceId: string,
     session: Session,
-    options?: WorkspaceSessionCacheOptions,
   ) => {
-    const targetRuntimeUrl = options?.runtimeUrl ?? runtimeUrl;
     queryClient.setQueryData(
-      anyHarnessSessionKey(targetRuntimeUrl, workspaceId, session.id),
+      anyHarnessSessionKey(cacheScopeKey, workspaceId, session.id),
       session,
     );
     queryClient.setQueryData<WorkspaceSession[]>(
-      anyHarnessSessionsKey(targetRuntimeUrl, workspaceId),
+      anyHarnessSessionsKey(cacheScopeKey, workspaceId),
       (sessions) => upsertWorkspaceSession(sessions, {
         ...session,
         workspaceId,
       }),
     );
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   const removeWorkspaceSessionRecord = useCallback((
     workspaceId: string,
     sessionId: string,
   ) => {
     queryClient.setQueryData<WorkspaceSession[]>(
-      anyHarnessSessionsKey(runtimeUrl, workspaceId),
+      anyHarnessSessionsKey(cacheScopeKey, workspaceId),
       (sessions) => removeWorkspaceSession(sessions, sessionId),
     );
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   return {
     getWorkspaceSessionCacheSnapshot,

--- a/apps/desktop/src/hooks/access/anyharness/terminals/use-terminal-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/terminals/use-terminal-cache.ts
@@ -1,25 +1,27 @@
 import type { TerminalRecord } from "@anyharness/sdk";
-import { anyHarnessTerminalsKey } from "@anyharness/sdk-react";
+import {
+  anyHarnessTerminalsKey,
+  useAnyHarnessCacheScopeKey,
+} from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 export function useTerminalCache() {
   const queryClient = useQueryClient();
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const invalidateWorkspaceTerminals = useCallback(async (workspaceId: string) => {
     await queryClient.invalidateQueries({
-      queryKey: anyHarnessTerminalsKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessTerminalsKey(cacheScopeKey, workspaceId),
     });
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   const setWorkspaceTerminalRecords = useCallback((
     workspaceId: string,
     records: TerminalRecord[],
   ) => {
-    queryClient.setQueryData(anyHarnessTerminalsKey(runtimeUrl, workspaceId), records);
-  }, [queryClient, runtimeUrl]);
+    queryClient.setQueryData(anyHarnessTerminalsKey(cacheScopeKey, workspaceId), records);
+  }, [cacheScopeKey, queryClient]);
 
   return {
     invalidateWorkspaceTerminals,

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
@@ -3,7 +3,10 @@
 import { createElement, type ReactNode } from "react";
 import { renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { anyHarnessSessionsKey } from "@anyharness/sdk-react";
+import {
+  AnyHarnessRuntime,
+  anyHarnessSessionsKey,
+} from "@anyharness/sdk-react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   commitReplacedSessionTombstone,
@@ -25,6 +28,8 @@ const mocks = vi.hoisted(() => ({
   listWorkspaceSessions: vi.fn(),
   writeSessionReplacementTombstones: vi.fn(() => true),
 }));
+
+const CACHE_SCOPE_KEY = "desktop:test-user";
 
 vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
   readSessionReplacementTombstones: () => ({}),
@@ -85,20 +90,15 @@ describe("replacement tombstone reconciliation", () => {
       defaultOptions: { queries: { retry: false } },
     });
     const runtimeUrl = "http://runtime.test";
-    queryClient.setQueryData(anyHarnessSessionsKey(runtimeUrl, "workspace-1"), [
+    queryClient.setQueryData(anyHarnessSessionsKey(CACHE_SCOPE_KEY, "workspace-1"), [
       { id: "runtime-old", workspaceId: "workspace-1" },
       { id: "runtime-new", workspaceId: "workspace-1" },
     ]);
     stageReplacedSessionTombstone("workspace-1", "runtime-old", ["client-old"]);
-    const wrapper = ({ children }: { children: ReactNode }) => createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children,
-    );
+    const wrapper = createWrapper(queryClient, runtimeUrl);
     const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
 
     const sessions = await result.current.loadWorkspaceSessions({
-      runtimeUrl,
       workspaceConnection: {} as never,
       workspaceId: "workspace-1",
     });
@@ -114,11 +114,7 @@ describe("replacement tombstone reconciliation", () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    const wrapper = ({ children }: { children: ReactNode }) => createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children,
-    );
+    const wrapper = createWrapper(queryClient, "http://runtime.test");
     const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
     const firstList = result.current.fetchWorkspaceSessions({
       workspaceConnection: {} as never,
@@ -141,6 +137,17 @@ describe("replacement tombstone reconciliation", () => {
     expect(committedReplacedSessionTombstonesForWorkspace("workspace-1")).toEqual([]);
   });
 });
+
+function createWrapper(queryClient: QueryClient, runtimeUrl: string) {
+  return ({ children }: { children: ReactNode }) => createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    createElement(
+      AnyHarnessRuntime,
+      { runtimeUrl, cacheScopeKey: CACHE_SCOPE_KEY, children },
+    ),
+  );
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
@@ -2,6 +2,7 @@ import type { AnyHarnessRequestOptions } from "@anyharness/sdk";
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import {
   anyHarnessSessionsKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -23,7 +24,6 @@ import {
 export type CacheDecision = "hit" | "stale" | "miss";
 
 interface LoadWorkspaceSessionsInput {
-  runtimeUrl: string;
   workspaceConnection: AnyHarnessResolvedConnection;
   workspaceId: string;
   requestOptions?: AnyHarnessRequestOptions;
@@ -138,17 +138,17 @@ export function reconcileReplacedSessionTombstones(
 // Owns AnyHarness React Query cache shape needed during workspace activation.
 export function useWorkspaceBootstrapCache() {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const getWorkspaceSessionsCacheDecision = useCallback((
-    runtimeUrl: string,
     workspaceId: string,
   ): CacheDecision => {
-    const queryKey = anyHarnessSessionsKey(runtimeUrl, workspaceId);
+    const queryKey = anyHarnessSessionsKey(cacheScopeKey, workspaceId);
     const cacheState = queryClient.getQueryState(queryKey);
     return cacheState?.dataUpdatedAt
       ? cacheState.isInvalidated ? "stale" : "hit"
       : "miss";
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const fetchWorkspaceSessions = useCallback((
     input: FetchWorkspaceSessionsInput,
@@ -157,7 +157,7 @@ export function useWorkspaceBootstrapCache() {
   const loadWorkspaceSessions = useCallback(async (
     input: LoadWorkspaceSessionsInput,
   ): Promise<WorkspaceSession[]> => {
-    const queryKey = anyHarnessSessionsKey(input.runtimeUrl, input.workspaceId);
+    const queryKey = anyHarnessSessionsKey(cacheScopeKey, input.workspaceId);
     const cacheState = queryClient.getQueryState(queryKey);
     const cachedSessions = queryClient.getQueryData<WorkspaceSession[]>(queryKey);
     if (
@@ -183,7 +183,7 @@ export function useWorkspaceBootstrapCache() {
     });
     queryClient.setQueryData(queryKey, sessions);
     return sessions;
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   return {
     fetchWorkspaceSessions,

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceRetirePreflightResponse } from "@anyharness/sdk";
 import {
   anyHarnessWorkspaceRetirePreflightKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueries, type UseQueryResult } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
@@ -19,11 +20,12 @@ export function useWorkspaceRetirePreflightQueries(
   workspaceIds: string[],
 ): WorkspaceRetirePreflightQuery[] {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const enabledWorkspaceIds = useBatchedRetirePreflightWorkspaceIds(workspaceIds);
 
   return useQueries({
     queries: workspaceIds.map((workspaceId) => ({
-      queryKey: anyHarnessWorkspaceRetirePreflightKey(runtimeUrl, workspaceId),
+      queryKey: anyHarnessWorkspaceRetirePreflightKey(cacheScopeKey, workspaceId),
       enabled: runtimeUrl.trim().length > 0 && enabledWorkspaceIds.has(workspaceId),
       staleTime: 60_000,
       retry: false,

--- a/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts
+++ b/apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts
@@ -1,23 +1,25 @@
 import type { GetSetupStatusResponse } from "@anyharness/sdk";
-import { anyHarnessWorkspaceSetupStatusKey } from "@anyharness/sdk-react";
+import {
+  anyHarnessWorkspaceSetupStatusKey,
+  useAnyHarnessCacheScopeKey,
+} from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 export type CachedWorkspaceSetupStatus = GetSetupStatusResponse["status"] | null;
 
 // Owns cached AnyHarness workspace setup-status reads for product workflows.
 export function useWorkspaceSetupStatusCache() {
   const queryClient = useQueryClient();
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const getCachedWorkspaceSetupStatus = useCallback((
     workspaceId: string,
   ): CachedWorkspaceSetupStatus => {
     return queryClient.getQueryData<GetSetupStatusResponse>(
-      anyHarnessWorkspaceSetupStatusKey(runtimeUrl, workspaceId),
+      anyHarnessWorkspaceSetupStatusKey(cacheScopeKey, workspaceId),
     )?.status ?? null;
-  }, [queryClient, runtimeUrl]);
+  }, [cacheScopeKey, queryClient]);
 
   return {
     getCachedWorkspaceSetupStatus,

--- a/apps/desktop/src/hooks/plans/cache/use-proposed-plan-cache.ts
+++ b/apps/desktop/src/hooks/plans/cache/use-proposed-plan-cache.ts
@@ -7,6 +7,7 @@ import type {
 import {
   anyHarnessPlanKey,
   anyHarnessPlansKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { patchProposedPlanDecisionInTranscript } from "@/lib/domain/plans/proposed-plan-transcript";
 import {
@@ -15,29 +16,28 @@ import {
 } from "@/stores/sessions/session-records";
 
 interface ProposedPlanCacheOptions {
-  runtimeUrl: string;
   selectedWorkspaceId: string | null;
 }
 
 // Owns cache writes needed by proposed-plan card actions, including transcript projections.
 export function useProposedPlanCache({
-  runtimeUrl,
   selectedWorkspaceId,
 }: ProposedPlanCacheOptions) {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   const patchPlanDecisionQueries = useCallback((plan: ProposedPlanDetail) => {
     queryClient.setQueryData(
-      anyHarnessPlanKey(runtimeUrl, selectedWorkspaceId, plan.id),
+      anyHarnessPlanKey(cacheScopeKey, selectedWorkspaceId, plan.id),
       plan,
     );
     queryClient.setQueryData<ProposedPlanSummary[]>(
-      anyHarnessPlansKey(runtimeUrl, selectedWorkspaceId),
+      anyHarnessPlansKey(cacheScopeKey, selectedWorkspaceId),
       (plans) => plans?.map((cachedPlan) => (
         cachedPlan.id === plan.id ? { ...cachedPlan, ...plan } : cachedPlan
       )),
     );
-  }, [queryClient, runtimeUrl, selectedWorkspaceId]);
+  }, [cacheScopeKey, queryClient, selectedWorkspaceId]);
 
   const applyPlanDecisionToCache = useCallback((plan: ProposedPlanDetail) => {
     patchPlanDecisionQueries(plan);

--- a/apps/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
+++ b/apps/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts
@@ -34,7 +34,6 @@ import {
 } from "@/lib/infra/measurement/latency-flow";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import { completeChatPromptSubmitSideEffects } from "@/lib/workflows/chat/complete-chat-prompt-submit-side-effects";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { getSessionRecords } from "@/stores/sessions/session-records";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useToastStore } from "@/stores/toast/toast-store";
@@ -92,7 +91,6 @@ export function useProposedPlanActions() {
 // Owns approve/reject actions and decision-conflict refresh behavior.
 function useProposedPlanDecisionActions() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const showToast = useToastStore((state) => state.show);
   const approveMutation = useApprovePlanMutation({ workspaceId: selectedWorkspaceId });
   const rejectMutation = useRejectPlanMutation({ workspaceId: selectedWorkspaceId });
@@ -102,7 +100,6 @@ function useProposedPlanDecisionActions() {
   const {
     applyPlanDecisionToCache,
   } = useProposedPlanCache({
-    runtimeUrl,
     selectedWorkspaceId,
   });
 

--- a/apps/desktop/src/hooks/sessions/cache/use-session-stream-cache.ts
+++ b/apps/desktop/src/hooks/sessions/cache/use-session-stream-cache.ts
@@ -4,6 +4,7 @@ import {
   anyHarnessGitStatusKey,
   anyHarnessSessionReviewsKey,
   anyHarnessSessionSubagentsKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
@@ -17,7 +18,6 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 export interface SessionStreamCache {
   invalidateWorkspaceCollections(runtimeUrl: string): void;
   invalidateSessionSubagents(input: {
-    runtimeUrl: string;
     workspaceId: string | null;
     sessionId: string;
   }): void;
@@ -26,12 +26,10 @@ export interface SessionStreamCache {
     sessionId: string;
   }): void;
   invalidateSessionReviews(input: {
-    runtimeUrl: string;
     workspaceId: string | null;
     parentSessionId: string;
   }): void;
   invalidateGitStatus(input: {
-    runtimeUrl: string;
     workspaceId: string;
   }): void;
   refreshPrStatuses(input: {
@@ -44,6 +42,7 @@ export interface SessionStreamCache {
 // Does not interpret stream envelopes or mutate session stores.
 export function useSessionStreamCache(): SessionStreamCache {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   return useMemo<SessionStreamCache>(() => ({
     invalidateWorkspaceCollections(runtimeUrl) {
@@ -51,27 +50,39 @@ export function useSessionStreamCache(): SessionStreamCache {
         queryKey: workspaceCollectionsScopeKey(runtimeUrl),
       });
     },
-    invalidateSessionSubagents({ runtimeUrl, workspaceId, sessionId }) {
+    invalidateSessionSubagents({ workspaceId, sessionId }) {
       void queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, workspaceId, sessionId),
+        queryKey: anyHarnessSessionSubagentsKey(cacheScopeKey, workspaceId, sessionId),
       });
     },
     invalidateCoworkManagedWorkspaces({ runtimeUrl, sessionId }) {
       void queryClient.invalidateQueries({
-        queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, sessionId),
+        queryKey: anyHarnessCoworkManagedWorkspacesKey(
+          runtimeUrl,
+          sessionId,
+          cacheScopeKey,
+        ),
       });
       void queryClient.invalidateQueries({
-        queryKey: [...anyHarnessRuntimeKey(runtimeUrl), "cowork", "sessions"],
+        queryKey: [
+          ...anyHarnessRuntimeKey(runtimeUrl, cacheScopeKey),
+          "cowork",
+          "sessions",
+        ],
       });
     },
-    invalidateSessionReviews({ runtimeUrl, workspaceId, parentSessionId }) {
+    invalidateSessionReviews({ workspaceId, parentSessionId }) {
       void queryClient.invalidateQueries({
-        queryKey: anyHarnessSessionReviewsKey(runtimeUrl, workspaceId, parentSessionId),
+        queryKey: anyHarnessSessionReviewsKey(
+          cacheScopeKey,
+          workspaceId,
+          parentSessionId,
+        ),
       });
     },
-    invalidateGitStatus({ runtimeUrl, workspaceId }) {
+    invalidateGitStatus({ workspaceId }) {
       void queryClient.invalidateQueries({
-        queryKey: anyHarnessGitStatusKey(runtimeUrl, workspaceId),
+        queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
       });
     },
     refreshPrStatuses({ runtimeUrl, workspaceId }) {
@@ -89,7 +100,12 @@ export function useSessionStreamCache(): SessionStreamCache {
       if (!repoRootId) {
         return;
       }
-      scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl, repoRootId });
+      scheduleRepoPrStatusRefresh({
+        queryClient,
+        runtimeUrl,
+        repoRootId,
+        cacheScopeKey,
+      });
     },
-  }), [queryClient]);
+  }), [cacheScopeKey, queryClient]);
 }

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -33,7 +33,6 @@ export interface ConfigIntentDispatchDeps {
   upsertWorkspaceSessionRecord: (
     workspaceId: string,
     session: Session,
-    options?: { runtimeUrl?: string },
   ) => void;
 }
 
@@ -51,7 +50,7 @@ export async function dispatchConfigIntent(
     dispatchedAt: new Date().toISOString(),
   });
   try {
-    const { connection, workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(
+    const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(
       intent.clientSessionId,
     );
     useSessionIntentStore.getState().bindMaterializedSession(
@@ -64,9 +63,7 @@ export async function dispatchConfigIntent(
       request: { configId: intent.configId, value: intent.value },
     });
     if (workspaceId) {
-      deps.upsertWorkspaceSessionRecord(workspaceId, response.session, {
-        runtimeUrl: connection.runtimeUrl,
-      });
+      deps.upsertWorkspaceSessionRecord(workspaceId, response.session);
     }
     const latestSlot = getSessionRecord(intent.clientSessionId);
     const responseLiveConfig = response.liveConfig ?? response.session.liveConfig ?? null;

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts
@@ -64,7 +64,6 @@ export interface PromptIntentDispatchDeps {
   upsertWorkspaceSessionRecord: (
     workspaceId: string,
     session: Session,
-    options?: { runtimeUrl?: string },
   ) => void;
 }
 
@@ -124,7 +123,6 @@ export async function dispatchPromptIntent(
       return;
     }
     const {
-      connection,
       workspaceId,
       materializedSessionId: resolvedSessionId,
     } = await getSessionClientAndWorkspace(entry.clientSessionId);
@@ -153,9 +151,7 @@ export async function dispatchPromptIntent(
     }
 
     deps.applySessionSummary(entry.clientSessionId, response.session, workspaceId);
-    deps.upsertWorkspaceSessionRecord(workspaceId, response.session, {
-      runtimeUrl: connection.runtimeUrl,
-    });
+    deps.upsertWorkspaceSessionRecord(workspaceId, response.session);
     useSessionIntentStore.getState().patchIntent(entry.intentId, {
       status: "accepted",
       deliveryState: response.status === "queued" ? "accepted_queued" : "accepted_running",

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.test.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.test.ts
@@ -122,7 +122,6 @@ describe("applyBatchedStreamSideEffects", () => {
     expect(sessionStreamCache.invalidateWorkspaceCollections)
       .toHaveBeenCalledWith("http://runtime.test");
     expect(sessionStreamCache.invalidateGitStatus).toHaveBeenCalledWith({
-      runtimeUrl: "http://runtime.test",
       workspaceId: "workspace-1",
     });
   });

--- a/apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.ts
+++ b/apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.ts
@@ -145,7 +145,6 @@ export function applyBatchedStreamSideEffects(input: {
   }
   if (plan.invalidateSessionSubagents) {
     input.sessionStreamCache.invalidateSessionSubagents({
-      runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
     });
@@ -158,14 +157,12 @@ export function applyBatchedStreamSideEffects(input: {
   }
   for (const parentSessionId of plan.reviewParentSessionIds) {
     input.sessionStreamCache.invalidateSessionReviews({
-      runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
       parentSessionId,
     });
   }
   if (plan.invalidateGitStatus && input.workspaceId) {
     input.sessionStreamCache.invalidateGitStatus({
-      runtimeUrl: input.runtimeUrl,
       workspaceId: input.workspaceId,
     });
   }

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
@@ -153,7 +153,6 @@ describe("created runtime cleanup", () => {
     expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
       "workspace-1",
       expect.objectContaining({ id: "runtime-retained" }),
-      { runtimeUrl: "http://runtime.test" },
     );
     removeSessionRecord(pendingSessionId);
   });
@@ -211,7 +210,6 @@ describe("created runtime cleanup", () => {
     expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
       "workspace-1",
       expect.objectContaining({ id: "runtime-superseded-retained" }),
-      { runtimeUrl: "http://runtime.test" },
     );
     expect(mocks.applySessionLaunchDefaults).not.toHaveBeenCalled();
     unregister();

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
@@ -29,7 +29,6 @@ export function materializeExistingSession({
   launchIntentId,
   pendingSessionId,
   resolvedModeId,
-  runtimeUrl,
   upsertWorkspaceSessionRecord,
   workspaceId,
 }: {
@@ -43,9 +42,7 @@ export function materializeExistingSession({
   upsertWorkspaceSessionRecord: (
     workspaceId: string,
     session: Session,
-    options?: { runtimeUrl?: string },
   ) => void;
-  runtimeUrl?: string;
   workspaceId: string;
 }): string {
   annotateLatencyFlow(latencyFlowId, {
@@ -73,7 +70,7 @@ export function materializeExistingSession({
   if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
     rememberLastViewedSession(workspaceId, existingSession.id);
   }
-  upsertWorkspaceSessionRecord(workspaceId, existingSession, { runtimeUrl });
+  upsertWorkspaceSessionRecord(workspaceId, existingSession);
   if (launchIntentId) {
     useChatLaunchIntentStore.getState().markMaterializedIfActive(
       launchIntentId,

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -66,7 +66,6 @@ interface MaterializeSessionCreationInput {
   upsertWorkspaceSessionRecord: (
     workspaceId: string,
     session: Session,
-    options?: { runtimeUrl?: string },
   ) => void;
   workspaceId: string;
 }
@@ -169,7 +168,6 @@ async function runSessionCreationMaterialization({
         latencyFlowId: options.latencyFlowId,
         pendingSessionId,
         resolvedModeId,
-        runtimeUrl: target.baseUrl,
         upsertWorkspaceSessionRecord,
         workspaceId,
         launchIntentId: options.launchIntentId,
@@ -220,7 +218,6 @@ async function runSessionCreationMaterialization({
       launchIntentId: options.launchIntentId,
       pendingSessionId,
       resolvedModeId,
-      runtimeUrl: target.baseUrl,
       upsertWorkspaceSessionRecord,
       workspaceId,
     });
@@ -335,9 +332,7 @@ async function runSessionCreationMaterialization({
   if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
     rememberLastViewedSession(workspaceId, launchedSession.id);
   }
-  upsertWorkspaceSessionRecord(workspaceId, launchedSession, {
-    runtimeUrl: target.baseUrl,
-  });
+  upsertWorkspaceSessionRecord(workspaceId, launchedSession);
   trackProductEvent("chat_session_created", {
     workspace_kind: cloudWorkspaceId ? "cloud" : "local",
     agent_kind: options.agentKind,

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-model-fallback-action.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-model-fallback-action.ts
@@ -14,7 +14,7 @@ export function useSessionModelFallbackAction() {
   const setSessionConfigOptionMutation = useSetSessionConfigOptionMutation();
 
   return useCallback(async (sessionId: string, fallbackModelId: string) => {
-    const { connection, workspaceId, materializedSessionId } =
+    const { workspaceId, materializedSessionId } =
       await getSessionClientAndWorkspace(sessionId);
     const response = await setSessionConfigOptionMutation.mutateAsync({
       workspaceId,
@@ -25,9 +25,7 @@ export function useSessionModelFallbackAction() {
       },
     });
 
-    upsertWorkspaceSessionRecord(workspaceId, response.session, {
-      runtimeUrl: connection.runtimeUrl,
-    });
+    upsertWorkspaceSessionRecord(workspaceId, response.session);
 
     const latestSlot = getSessionRecord(sessionId);
     if (!latestSlot) {

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
@@ -122,7 +122,6 @@ describe("useSessionRestoreActions", () => {
     expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
       "workspace-1",
       restored,
-      { runtimeUrl: "http://runtime.test" },
     );
   });
 
@@ -168,7 +167,6 @@ describe("useSessionRestoreActions", () => {
     expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
       "workspace-1",
       restored,
-      { runtimeUrl: "http://runtime.test" },
     );
   });
 

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
@@ -123,9 +123,7 @@ export function useSessionRestoreActions() {
           throw new Error("Could not save restored session state. Try again.");
         }
         cancelQueuedReplacementDismissal(workspaceId, restoredSession.id);
-        upsertWorkspaceSessionRecord(workspaceId, restoredSession, {
-          runtimeUrl: target.baseUrl,
-        });
+        upsertWorkspaceSessionRecord(workspaceId, restoredSession);
         return restoredSession;
       });
       logLatency("session.restore.request_completed", {

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-title-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-title-actions.ts
@@ -43,7 +43,7 @@ export function useSessionTitleActions() {
       throw new Error("Chat title cannot be empty.");
     }
 
-    const { connection, workspaceId, materializedSessionId } =
+    const { workspaceId, materializedSessionId } =
       await getSessionClientAndWorkspace(sessionId);
     const operationId = startMeasurementOperation({
       kind: "session_rename",
@@ -62,9 +62,7 @@ export function useSessionTitleActions() {
 
     const storeStartedAt = performance.now();
     applySessionSummary(sessionId, session, workspaceId);
-    upsertWorkspaceSessionRecord(workspaceId, session, {
-      runtimeUrl: connection.runtimeUrl,
-    });
+    upsertWorkspaceSessionRecord(workspaceId, session);
     if (operationId) {
       recordMeasurementMetric({
         type: "store",

--- a/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
@@ -36,7 +36,7 @@ export function useWorkspaceSessionLoader() {
       ? useHarnessConnectionStore.getState().runtimeUrl
       : await ensureRuntimeReadyForSessions();
     const requestHeaders = getLatencyFlowRequestHeaders(options?.latencyFlowId);
-    const cacheSnapshot = getWorkspaceSessionCacheSnapshot(workspaceId, { runtimeUrl });
+    const cacheSnapshot = getWorkspaceSessionCacheSnapshot(workspaceId);
     if (options?.measurementOperationId) {
       recordMeasurementMetric({
         type: "cache",
@@ -77,7 +77,7 @@ export function useWorkspaceSessionLoader() {
       workspaceId,
       loadedSessions,
     ) ?? [];
-    setWorkspaceSessions(workspaceId, () => sessions, { runtimeUrl });
+    setWorkspaceSessions(workspaceId, () => sessions);
     return sessions;
   }, [
     getWorkspaceRuntimeBlockReason,

--- a/apps/desktop/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx
+++ b/apps/desktop/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx
@@ -50,12 +50,13 @@ vi.mock("@anyharness/sdk", () => ({
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
-  anyHarnessTerminalsKey: (runtimeUrl: string, workspaceId: string) => [
+  anyHarnessTerminalsKey: (cacheScopeKey: string, workspaceId: string) => [
     "terminals",
-    runtimeUrl,
+    cacheScopeKey,
     workspaceId,
   ],
   getAnyHarnessClient: vi.fn(),
+  useAnyHarnessCacheScopeKey: () => "test-cache-scope",
 }));
 
 vi.mock("@/hooks/access/cloud/query-keys", () => ({

--- a/apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.test.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.test.ts
@@ -1,0 +1,233 @@
+import {
+  anyHarnessAgentLaunchOptionsKey,
+  anyHarnessGitStatusKey,
+  anyHarnessSessionsKey,
+  anyHarnessWorkspaceFileTreeKey,
+  anyHarnessWorkspaceKey,
+} from "@anyharness/sdk-react";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCloudWorkspaceMaterializationCacheTracker,
+} from "./cloud-workspace-materialization-cache";
+
+const CACHE_SCOPE_KEY = "https://api.test::user:user-1";
+const CLOUD_WORKSPACE_ID = "cloud-workspace-1";
+const LOGICAL_WORKSPACE_ID = `cloud:${CLOUD_WORKSPACE_ID}`;
+
+function connection(input: {
+  anyharnessWorkspaceId?: string;
+  runtimeGeneration?: number;
+  accessToken?: string;
+}) {
+  return {
+    runtimeUrl: "https://gateway.test/v1/anyharness",
+    accessToken: input.accessToken ?? "token-1",
+    anyharnessWorkspaceId: input.anyharnessWorkspaceId ?? "runtime-workspace-1",
+    runtimeGeneration: input.runtimeGeneration ?? 1,
+    allowedAgentKinds: [],
+    readyAgentKinds: [],
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function seedWorkspaceCache(queryClient: QueryClient) {
+  queryClient.setQueryData(
+    anyHarnessWorkspaceKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    { id: "workspace" },
+  );
+  queryClient.setQueryData(
+    anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    [{ id: "session-1" }],
+  );
+  queryClient.setQueryData(
+    anyHarnessGitStatusKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    { currentBranch: "main" },
+  );
+  queryClient.setQueryData(
+    anyHarnessWorkspaceFileTreeKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID, "."),
+    [{ path: "README.md" }],
+  );
+  queryClient.setQueryData(
+    anyHarnessAgentLaunchOptionsKey(
+      "https://gateway.test/v1/anyharness",
+      "runtime-workspace-1",
+      CACHE_SCOPE_KEY,
+    ),
+    { agents: [] },
+  );
+}
+
+describe("cloud workspace materialization cache", () => {
+  it("keeps workspace cache through a gateway token refresh", async () => {
+    const queryClient = createQueryClient();
+    const tracker = createCloudWorkspaceMaterializationCacheTracker({
+      queryClient,
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
+    seedWorkspaceCache(queryClient);
+
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({
+      accessToken: "token-1",
+    }) });
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({
+      accessToken: "token-2",
+    }) });
+
+    expect(queryClient.getQueryData(
+      anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    )).toEqual([{ id: "session-1" }]);
+  });
+
+  it.each([
+    ["AnyHarness workspace replacement", connection({ anyharnessWorkspaceId: "runtime-workspace-2" })],
+    ["runtime generation change", connection({ runtimeGeneration: 2 })],
+  ])("clears every workspace descendant after %s", async (_label, replacement) => {
+    const queryClient = createQueryClient();
+    const tracker = createCloudWorkspaceMaterializationCacheTracker({
+      queryClient,
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
+    seedWorkspaceCache(queryClient);
+
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({}) });
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: replacement });
+
+    expect(queryClient.getQueryData(
+      anyHarnessWorkspaceKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    )).toBeUndefined();
+    expect(queryClient.getQueryData(
+      anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    )).toBeUndefined();
+    expect(queryClient.getQueryData(
+      anyHarnessGitStatusKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    )).toBeUndefined();
+    expect(queryClient.getQueryData(
+      anyHarnessWorkspaceFileTreeKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID, "."),
+    )).toBeUndefined();
+    expect(queryClient.getQueryData(
+      anyHarnessAgentLaunchOptionsKey(
+        "https://gateway.test/v1/anyharness",
+        "runtime-workspace-1",
+        CACHE_SCOPE_KEY,
+      ),
+    )).toBeUndefined();
+  });
+
+  it("cancels an old materialization request before it can repopulate the cache", async () => {
+    const queryClient = createQueryClient();
+    const tracker = createCloudWorkspaceMaterializationCacheTracker({
+      queryClient,
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
+    let aborted = false;
+    const request = queryClient.fetchQuery({
+      queryKey: anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+      queryFn: ({ signal }) => new Promise<never>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          aborted = true;
+          reject(signal.reason);
+        });
+      }),
+    });
+
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({}) });
+    await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({
+      anyharnessWorkspaceId: "runtime-workspace-2",
+    }) });
+
+    await expect(request).rejects.toBeDefined();
+    expect(aborted).toBe(true);
+    expect(queryClient.getQueryData(
+      anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID),
+    )).toBeUndefined();
+  });
+
+  it("clears and refetches active workspace and launch-option queries", async () => {
+    const queryClient = createQueryClient();
+    const tracker = createCloudWorkspaceMaterializationCacheTracker({
+      queryClient,
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
+    const sessionsKey = anyHarnessSessionsKey(CACHE_SCOPE_KEY, LOGICAL_WORKSPACE_ID);
+    const launchOptionsKey = anyHarnessAgentLaunchOptionsKey(
+      "https://gateway.test/v1/anyharness",
+      "runtime-workspace-1",
+      CACHE_SCOPE_KEY,
+    );
+    queryClient.setQueryData(sessionsKey, [{ id: "stale-session" }]);
+    queryClient.setQueryData(launchOptionsKey, { source: "stale" });
+
+    let resolveFreshSessions: (sessions: { id: string }[]) => void = () => {
+      throw new Error("Expected the active query to refetch.");
+    };
+    const freshSessions = new Promise<{ id: string }[]>((resolve) => {
+      resolveFreshSessions = resolve;
+    });
+    let resolveFreshLaunchOptions: (options: { source: string }) => void = () => {
+      throw new Error("Expected the active launch-options query to refetch.");
+    };
+    const freshLaunchOptions = new Promise<{ source: string }>((resolve) => {
+      resolveFreshLaunchOptions = resolve;
+    });
+    let sessionsFetchCount = 0;
+    let launchOptionsFetchCount = 0;
+    const sessionsObserver = new QueryObserver(queryClient, {
+      queryKey: sessionsKey,
+      queryFn: () => {
+        sessionsFetchCount += 1;
+        return freshSessions;
+      },
+      staleTime: Infinity,
+    });
+    const launchOptionsObserver = new QueryObserver(queryClient, {
+      queryKey: launchOptionsKey,
+      queryFn: () => {
+        launchOptionsFetchCount += 1;
+        return freshLaunchOptions;
+      },
+      staleTime: Infinity,
+    });
+    const unsubscribeSessions = sessionsObserver.subscribe(() => {});
+    const unsubscribeLaunchOptions = launchOptionsObserver.subscribe(() => {});
+
+    try {
+      expect(sessionsObserver.getCurrentResult().data).toEqual([{ id: "stale-session" }]);
+      expect(launchOptionsObserver.getCurrentResult().data).toEqual({ source: "stale" });
+      expect(sessionsFetchCount).toBe(0);
+      expect(launchOptionsFetchCount).toBe(0);
+
+      await tracker.observe({ cloudWorkspaceId: CLOUD_WORKSPACE_ID, connection: connection({}) });
+      const transition = tracker.observe({
+        cloudWorkspaceId: CLOUD_WORKSPACE_ID,
+        connection: connection({ runtimeGeneration: 2 }),
+      });
+
+      await vi.waitFor(() => {
+        expect(sessionsFetchCount).toBe(1);
+        expect(launchOptionsFetchCount).toBe(1);
+      });
+      expect(sessionsObserver.getCurrentResult().data).toBeUndefined();
+      expect(launchOptionsObserver.getCurrentResult().data).toBeUndefined();
+
+      resolveFreshSessions([{ id: "fresh-session" }]);
+      resolveFreshLaunchOptions({ source: "fresh" });
+      await transition;
+
+      expect(sessionsObserver.getCurrentResult().data).toEqual([{ id: "fresh-session" }]);
+      expect(launchOptionsObserver.getCurrentResult().data).toEqual({ source: "fresh" });
+      expect(queryClient.getQueryData(sessionsKey)).toEqual([{ id: "fresh-session" }]);
+      expect(queryClient.getQueryData(launchOptionsKey)).toEqual({ source: "fresh" });
+    } finally {
+      unsubscribeSessions();
+      unsubscribeLaunchOptions();
+    }
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.ts
@@ -1,0 +1,154 @@
+import {
+  anyHarnessAgentLaunchOptionsKey,
+  anyHarnessWorkspaceKey,
+} from "@anyharness/sdk-react";
+import type { QueryClient } from "@tanstack/react-query";
+import type { CloudConnectionInfo } from "@/lib/access/cloud/client";
+import { cloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+
+export interface CloudWorkspaceMaterializationIdentity {
+  anyharnessWorkspaceId: string;
+  runtimeGeneration: number;
+}
+
+function normalizeWorkspaceId(value: string | null | undefined): string | null {
+  const normalized = value?.trim() ?? "";
+  return normalized || null;
+}
+
+/**
+ * Excludes short-lived gateway credentials so a token refresh retains the
+ * workspace cache, while a replacement runtime/workspace clears it.
+ */
+export function cloudWorkspaceMaterializationIdentity(
+  connection: CloudConnectionInfo,
+): CloudWorkspaceMaterializationIdentity | null {
+  const anyharnessWorkspaceId = normalizeWorkspaceId(connection.anyharnessWorkspaceId);
+  if (!anyharnessWorkspaceId) {
+    return null;
+  }
+
+  return {
+    anyharnessWorkspaceId,
+    runtimeGeneration: connection.runtimeGeneration ?? 0,
+  };
+}
+
+export function sameCloudWorkspaceMaterialization(
+  left: CloudWorkspaceMaterializationIdentity,
+  right: CloudWorkspaceMaterializationIdentity,
+): boolean {
+  return left.anyharnessWorkspaceId === right.anyharnessWorkspaceId
+    && left.runtimeGeneration === right.runtimeGeneration;
+}
+
+export interface CloudWorkspaceMaterializationCacheTracker {
+  observe(input: {
+    cloudWorkspaceId: string;
+    connection: CloudConnectionInfo;
+  }): Promise<void>;
+}
+
+interface CloudWorkspaceMaterializationObservation {
+  identity: CloudWorkspaceMaterializationIdentity;
+  runtimeUrl: string;
+}
+
+interface MaterializationCacheQueryFilters {
+  queryKey: readonly unknown[];
+  exact: boolean;
+}
+
+async function clearMaterializationQueries(
+  queryClient: QueryClient,
+  filters: MaterializationCacheQueryFilters[],
+): Promise<void> {
+  await Promise.all(filters.map((queryFilters) => queryClient.cancelQueries(queryFilters)));
+
+  for (const queryFilters of filters) {
+    queryClient.removeQueries({
+      ...queryFilters,
+      type: "inactive",
+    });
+  }
+
+  await Promise.all(filters.map((queryFilters) => queryClient.resetQueries({
+    ...queryFilters,
+    type: "active",
+  })));
+}
+
+async function clearMaterializationTransitionCaches(input: {
+  queryClient: QueryClient;
+  cacheScopeKey: string;
+  cloudWorkspaceId: string;
+  previous: CloudWorkspaceMaterializationObservation;
+  next: CloudWorkspaceMaterializationObservation;
+}): Promise<void> {
+  const workspaceFilters = {
+    queryKey: anyHarnessWorkspaceKey(
+      input.cacheScopeKey,
+      cloudWorkspaceSyntheticId(input.cloudWorkspaceId),
+    ),
+    exact: false as const,
+  };
+  const launchOptionObservations = (
+    input.previous.runtimeUrl === input.next.runtimeUrl
+    && input.previous.identity.anyharnessWorkspaceId
+      === input.next.identity.anyharnessWorkspaceId
+  )
+    ? [input.previous]
+    : [input.previous, input.next];
+  const launchOptionFilters = launchOptionObservations.map((observation) => ({
+    queryKey: anyHarnessAgentLaunchOptionsKey(
+      observation.runtimeUrl,
+      observation.identity.anyharnessWorkspaceId,
+      input.cacheScopeKey,
+    ),
+    exact: true as const,
+  }));
+
+  await clearMaterializationQueries(input.queryClient, [
+    workspaceFilters,
+    ...launchOptionFilters,
+  ]);
+}
+
+/**
+ * Owns the transition from a stable Cloud workspace identity to the current
+ * AnyHarness materialization. The initial observation establishes a baseline;
+ * later runtime/workspace replacements discard every descendant workspace key.
+ */
+export function createCloudWorkspaceMaterializationCacheTracker(input: {
+  queryClient: QueryClient;
+  cacheScopeKey: string;
+}): CloudWorkspaceMaterializationCacheTracker {
+  const observations = new Map<string, CloudWorkspaceMaterializationObservation>();
+
+  return {
+    async observe({ cloudWorkspaceId, connection }) {
+      const identity = cloudWorkspaceMaterializationIdentity(connection);
+      if (!identity) {
+        return;
+      }
+
+      const next = {
+        identity,
+        runtimeUrl: connection.runtimeUrl.trim(),
+      };
+      const previous = observations.get(cloudWorkspaceId);
+      observations.set(cloudWorkspaceId, next);
+      if (!previous || sameCloudWorkspaceMaterialization(previous.identity, identity)) {
+        return;
+      }
+
+      await clearMaterializationTransitionCaches({
+        queryClient: input.queryClient,
+        cacheScopeKey: input.cacheScopeKey,
+        cloudWorkspaceId,
+        previous,
+        next,
+      });
+    },
+  };
+}

--- a/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts
@@ -6,6 +6,7 @@ import {
   anyHarnessSessionReviewsKey,
   anyHarnessSessionSubagentsKey,
   resolveWorkspaceConnectionFromContext,
+  useAnyHarnessCacheScopeKey,
   useAnyHarnessWorkspaceContext,
 } from "@anyharness/sdk-react";
 import type {
@@ -51,6 +52,7 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
   sessionIds: string[];
 }): WorkspaceHeaderSubagentHierarchy {
   const workspace = useAnyHarnessWorkspaceContext();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const recordSessionRelationshipHint = useSessionDirectoryStore(
     (state) => state.recordRelationshipHint,
@@ -83,7 +85,11 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     queries: uniqueSessionIds.map((sessionId, index) => {
       const materializedSessionId = materializedSessionIds[index];
       return {
-        queryKey: anyHarnessSessionSubagentsKey(runtimeUrl, args.workspaceId, sessionId),
+        queryKey: anyHarnessSessionSubagentsKey(
+          cacheScopeKey,
+          args.workspaceId,
+          sessionId,
+        ),
         enabled: shouldEnableHeaderSessionScopedQuery({
           workspaceId: args.workspaceId,
           sessionId,
@@ -109,7 +115,11 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     queries: uniqueSessionIds.map((sessionId, index) => {
       const materializedSessionId = materializedSessionIds[index];
       return {
-        queryKey: anyHarnessSessionReviewsKey(runtimeUrl, args.workspaceId, sessionId),
+        queryKey: anyHarnessSessionReviewsKey(
+          cacheScopeKey,
+          args.workspaceId,
+          sessionId,
+        ),
         enabled: shouldEnableHeaderSessionScopedQuery({
           workspaceId: args.workspaceId,
           sessionId,
@@ -135,7 +145,11 @@ export function useWorkspaceHeaderSubagentHierarchy(args: {
     queries: uniqueSessionIds.map((sessionId, index) => {
       const materializedSessionId = materializedSessionIds[index];
       return {
-        queryKey: anyHarnessCoworkManagedWorkspacesKey(runtimeUrl, materializedSessionId),
+        queryKey: anyHarnessCoworkManagedWorkspacesKey(
+          runtimeUrl,
+          materializedSessionId,
+          cacheScopeKey,
+        ),
         enabled: shouldEnableHeaderSessionScopedQuery({
           workspaceId: args.workspaceId,
           sessionId,

--- a/apps/desktop/src/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary.ts
@@ -25,7 +25,7 @@ function isCloudConnectionInfo(value: unknown): value is CloudConnectionInfo {
     && typeof (value as { runtimeGeneration?: unknown }).runtimeGeneration === "number";
 }
 
-// Observes every Cloud connection update, including background refetches, so
+// Observes each Cloud connection update, including background refetches, so
 // a stable product workspace cannot reuse data from a replaced materialization.
 export function useCloudWorkspaceMaterializationCacheBoundary() {
   const queryClient = useQueryClient();

--- a/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx
@@ -132,8 +132,18 @@ describe("scheduleRepoPrStatusRefresh", () => {
   it("skips scheduling without a runtime url or repo root id", async () => {
     const queryClient = new QueryClient();
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: " ", repoRootId: "root-a" });
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "" });
+    scheduleRepoPrStatusRefresh({
+      queryClient,
+      runtimeUrl: " ",
+      repoRootId: "root-a",
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
+    scheduleRepoPrStatusRefresh({
+      queryClient,
+      runtimeUrl: RUNTIME_URL,
+      repoRootId: "",
+      cacheScopeKey: CACHE_SCOPE_KEY,
+    });
     await vi.advanceTimersByTimeAsync(300);
 
     expect(mocks.listRepoRootPullRequestStatuses).not.toHaveBeenCalled();

--- a/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx
@@ -21,7 +21,21 @@ vi.mock("@/lib/access/anyharness/pull-requests", () => ({
 }));
 
 const RUNTIME_URL = "http://runtime.test";
-const KEY = anyHarnessRepoRootPullRequestsKey(RUNTIME_URL, "root-a");
+const CACHE_SCOPE_KEY = "desktop:test-user";
+const KEY = anyHarnessRepoRootPullRequestsKey(
+  RUNTIME_URL,
+  "root-a",
+  CACHE_SCOPE_KEY,
+);
+
+function scheduleRefresh(queryClient: QueryClient): void {
+  scheduleRepoPrStatusRefresh({
+    queryClient,
+    runtimeUrl: RUNTIME_URL,
+    repoRootId: "root-a",
+    cacheScopeKey: CACHE_SCOPE_KEY,
+  });
+}
 
 function okResult(fetchedAt: string, headBranch = "feature"): RepoPullRequestStatusesResult {
   return {
@@ -46,9 +60,9 @@ describe("scheduleRepoPrStatusRefresh", () => {
     mocks.listRepoRootPullRequestStatuses.mockResolvedValue(okResult("2026-07-01T12:00:00.000Z"));
     const queryClient = new QueryClient();
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
+    scheduleRefresh(queryClient);
+    scheduleRefresh(queryClient);
+    scheduleRefresh(queryClient);
 
     expect(mocks.listRepoRootPullRequestStatuses).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(300);
@@ -68,7 +82,7 @@ describe("scheduleRepoPrStatusRefresh", () => {
     queryClient.setQueryData(KEY, newer);
     mocks.listRepoRootPullRequestStatuses.mockResolvedValue(okResult("2026-07-01T12:00:00.000Z"));
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
+    scheduleRefresh(queryClient);
     await vi.advanceTimersByTimeAsync(300);
 
     expect(queryClient.getQueryData(KEY)).toEqual(newer);
@@ -80,7 +94,7 @@ describe("scheduleRepoPrStatusRefresh", () => {
     const fresher = okResult("2026-07-01T13:00:00.000Z", "fresher");
     mocks.listRepoRootPullRequestStatuses.mockResolvedValue(fresher);
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
+    scheduleRefresh(queryClient);
     await vi.advanceTimersByTimeAsync(300);
 
     expect(queryClient.getQueryData(KEY)).toEqual(fresher);
@@ -96,7 +110,7 @@ describe("scheduleRepoPrStatusRefresh", () => {
       fetchedAt: null,
     });
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
+    scheduleRefresh(queryClient);
     await vi.advanceTimersByTimeAsync(300);
 
     expect(queryClient.getQueryData(KEY)).toEqual(good);
@@ -107,11 +121,11 @@ describe("scheduleRepoPrStatusRefresh", () => {
     const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     mocks.listRepoRootPullRequestStatuses.mockResolvedValue(okResult("2026-07-01T12:00:00.000Z"));
 
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl: RUNTIME_URL, repoRootId: "root-a" });
+    scheduleRefresh(queryClient);
     await vi.advanceTimersByTimeAsync(300);
 
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: anyHarnessWorktreesInventoryKey(RUNTIME_URL),
+      queryKey: anyHarnessWorktreesInventoryKey(RUNTIME_URL, CACHE_SCOPE_KEY),
     });
   });
 

--- a/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.ts
@@ -1,6 +1,7 @@
 import {
   anyHarnessRepoRootPullRequestsKey,
   anyHarnessWorktreesInventoryKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -17,8 +18,12 @@ const PR_STATUS_REFRESH_DEBOUNCE_MS = 250;
 
 const pendingRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function refreshTimerKey(runtimeUrl: string, repoRootId: string): string {
-  return `${runtimeUrl}::${repoRootId}`;
+function refreshTimerKey(
+  runtimeUrl: string,
+  repoRootId: string,
+  cacheScopeKey?: string | null,
+): string {
+  return `${cacheScopeKey?.trim() || runtimeUrl}::${runtimeUrl}::${repoRootId}`;
 }
 
 // Monotonic guard: never replace cached data whose fetchedAt is newer, and
@@ -43,21 +48,22 @@ async function runRepoPrStatusRefresh(input: {
   queryClient: QueryClient;
   runtimeUrl: string;
   repoRootId: string;
+  cacheScopeKey?: string | null;
 }): Promise<void> {
-  const { queryClient, runtimeUrl, repoRootId } = input;
+  const { cacheScopeKey, queryClient, runtimeUrl, repoRootId } = input;
   const result = await listRepoRootPullRequestStatuses(
     { runtimeUrl },
     repoRootId,
     { refresh: true },
   );
   queryClient.setQueryData<RepoPullRequestStatusesResult>(
-    anyHarnessRepoRootPullRequestsKey(runtimeUrl, repoRootId),
+    anyHarnessRepoRootPullRequestsKey(runtimeUrl, repoRootId, cacheScopeKey),
     (previous) => mergeRefreshedPrStatuses(previous, result),
   );
   // Layer 0 (ahead/behind/dirty) refreshes on the same triggers: the worktree
   // inventory query has no other desktop refetch trigger.
   await queryClient.invalidateQueries({
-    queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl),
+    queryKey: anyHarnessWorktreesInventoryKey(runtimeUrl, cacheScopeKey),
   });
 }
 
@@ -65,13 +71,15 @@ export function scheduleRepoPrStatusRefresh(input: {
   queryClient: QueryClient;
   runtimeUrl: string;
   repoRootId: string;
+  cacheScopeKey?: string | null;
 }): void {
   const runtimeUrl = input.runtimeUrl.trim();
   const repoRootId = input.repoRootId.trim();
   if (!runtimeUrl || !repoRootId) {
     return;
   }
-  const key = refreshTimerKey(runtimeUrl, repoRootId);
+  const cacheScopeKey = input.cacheScopeKey?.trim() || undefined;
+  const key = refreshTimerKey(runtimeUrl, repoRootId, cacheScopeKey);
   const existing = pendingRefreshTimers.get(key);
   if (existing !== undefined) {
     clearTimeout(existing);
@@ -82,6 +90,7 @@ export function scheduleRepoPrStatusRefresh(input: {
       queryClient: input.queryClient,
       runtimeUrl,
       repoRootId,
+      cacheScopeKey,
     });
   }, PR_STATUS_REFRESH_DEBOUNCE_MS));
 }
@@ -96,9 +105,10 @@ export function resetPrStatusRefreshForTests(): void {
 // The only writer of the repo-root PR status keys.
 export function useRefreshPrStatuses() {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
 
   return useCallback((repoRootId: string) => {
-    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl, repoRootId });
-  }, [queryClient, runtimeUrl]);
+    scheduleRepoPrStatusRefresh({ queryClient, runtimeUrl, repoRootId, cacheScopeKey });
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
 }

--- a/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.ts
@@ -21,9 +21,9 @@ const pendingRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 function refreshTimerKey(
   runtimeUrl: string,
   repoRootId: string,
-  cacheScopeKey?: string | null,
+  cacheScopeKey: string | null | undefined,
 ): string {
-  return `${cacheScopeKey?.trim() || runtimeUrl}::${runtimeUrl}::${repoRootId}`;
+  return `${cacheScopeKey?.trim() ?? ""}::${runtimeUrl}::${repoRootId}`;
 }
 
 // Monotonic guard: never replace cached data whose fetchedAt is newer, and
@@ -48,7 +48,7 @@ async function runRepoPrStatusRefresh(input: {
   queryClient: QueryClient;
   runtimeUrl: string;
   repoRootId: string;
-  cacheScopeKey?: string | null;
+  cacheScopeKey: string | null | undefined;
 }): Promise<void> {
   const { cacheScopeKey, queryClient, runtimeUrl, repoRootId } = input;
   const result = await listRepoRootPullRequestStatuses(
@@ -71,14 +71,14 @@ export function scheduleRepoPrStatusRefresh(input: {
   queryClient: QueryClient;
   runtimeUrl: string;
   repoRootId: string;
-  cacheScopeKey?: string | null;
+  cacheScopeKey: string | null | undefined;
 }): void {
   const runtimeUrl = input.runtimeUrl.trim();
   const repoRootId = input.repoRootId.trim();
   if (!runtimeUrl || !repoRootId) {
     return;
   }
-  const cacheScopeKey = input.cacheScopeKey?.trim() || undefined;
+  const cacheScopeKey = input.cacheScopeKey?.trim() ?? "";
   const key = refreshTimerKey(runtimeUrl, repoRootId, cacheScopeKey);
   const existing = pendingRefreshTimers.get(key);
   if (existing !== undefined) {

--- a/apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
 import { AnyHarnessError } from "@anyharness/sdk";
-import { anyHarnessRepoRootPullRequestsKey } from "@anyharness/sdk-react";
+import {
+  AnyHarnessRuntime,
+  anyHarnessRepoRootPullRequestsKey,
+} from "@anyharness/sdk-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
@@ -24,6 +27,7 @@ vi.mock("@anyharness/sdk-react", async (importOriginal) => {
 });
 
 const RUNTIME_URL = "http://runtime.test";
+const CACHE_SCOPE_KEY = "desktop:test-user";
 
 function makeQueryClient(): QueryClient {
   return new QueryClient({
@@ -39,7 +43,9 @@ function renderRepoPrStatuses(queryClient: QueryClient, repoRootIds: string[]) {
   function Wrapper({ children }: PropsWithChildren) {
     return (
       <QueryClientProvider client={queryClient}>
-        {children}
+        <AnyHarnessRuntime runtimeUrl={RUNTIME_URL} cacheScopeKey={CACHE_SCOPE_KEY}>
+          {children}
+        </AnyHarnessRuntime>
       </QueryClientProvider>
     );
   }
@@ -85,7 +91,7 @@ describe("useRepoPrStatuses", () => {
     expect(result.current.fetchedAtByRepoRootId["root-a"]).toBe("2026-07-01T12:00:00.000Z");
 
     expect(queryClient.getQueryData(
-      anyHarnessRepoRootPullRequestsKey(RUNTIME_URL, "root-a"),
+      anyHarnessRepoRootPullRequestsKey(RUNTIME_URL, "root-a", CACHE_SCOPE_KEY),
     )).toEqual({
       availability: "ok",
       entries: [{ headBranch: "feature", pullRequest: null }],

--- a/apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.ts
@@ -1,5 +1,8 @@
 import type { BranchPullRequestStatus } from "@anyharness/sdk";
-import { anyHarnessRepoRootPullRequestsKey } from "@anyharness/sdk-react";
+import {
+  anyHarnessRepoRootPullRequestsKey,
+  useAnyHarnessCacheScopeKey,
+} from "@anyharness/sdk-react";
 import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
@@ -22,6 +25,7 @@ export interface RepoPrStatusesState {
 // hooks. Reads only — the sole writer of these keys is use-pr-status-refresh.
 export function useRepoPrStatuses(repoRootIds: string[]): RepoPrStatusesState {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const trimmedRuntimeUrl = runtimeUrl.trim();
 
   const ids = useMemo(
@@ -31,7 +35,11 @@ export function useRepoPrStatuses(repoRootIds: string[]): RepoPrStatusesState {
 
   return useQueries({
     queries: ids.map((repoRootId) => ({
-      queryKey: anyHarnessRepoRootPullRequestsKey(trimmedRuntimeUrl, repoRootId),
+      queryKey: anyHarnessRepoRootPullRequestsKey(
+        trimmedRuntimeUrl,
+        repoRootId,
+        cacheScopeKey,
+      ),
       enabled: trimmedRuntimeUrl.length > 0,
       staleTime: PR_STATUS_STALE_MS,
       // No interval/focus polling (owner decision 2026-07-02): PR status

--- a/apps/desktop/src/hooks/workspaces/cache/use-workspace-selection-cache.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-workspace-selection-cache.ts
@@ -1,7 +1,10 @@
 import type { CoworkStatus } from "@anyharness/sdk";
 import {
+  anyHarnessCoworkArtifactScopeKey,
+  anyHarnessCoworkManifestKey,
   anyHarnessCoworkStatusKey,
   anyHarnessWorkspaceQueryKeyRoots,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -29,6 +32,7 @@ interface CancelPreviousWorkspaceDisplayQueriesInput {
 // Owns query-cache reads and invalidation needed by workspace selection/bootstrap flows.
 export function useWorkspaceSelectionCache() {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const authStatus = useAuthStore((state) => state.status);
   const authUserId = useAuthStore((state) => state.user?.id ?? null);
 
@@ -44,9 +48,9 @@ export function useWorkspaceSelectionCache() {
       cloudMobilityWorkspacesKey(),
     ),
     coworkStatus: queryClient.getQueryData<CoworkStatus>(
-      anyHarnessCoworkStatusKey(runtimeUrl),
+      anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
     ),
-  }), [authStatus, authUserId, queryClient]);
+  }), [authStatus, authUserId, cacheScopeKey, queryClient]);
 
   const cancelPreviousWorkspaceDisplayQueries = useCallback((
     input: CancelPreviousWorkspaceDisplayQueriesInput,
@@ -61,7 +65,12 @@ export function useWorkspaceSelectionCache() {
       if (!workspaceId || nextIds.has(workspaceId)) {
         continue;
       }
-      for (const root of anyHarnessWorkspaceQueryKeyRoots(input.runtimeUrl, workspaceId)) {
+      const workspaceRoots = [
+        ...anyHarnessWorkspaceQueryKeyRoots(cacheScopeKey, workspaceId),
+        anyHarnessCoworkManifestKey(input.runtimeUrl, workspaceId, cacheScopeKey),
+        anyHarnessCoworkArtifactScopeKey(input.runtimeUrl, workspaceId, cacheScopeKey),
+      ];
+      for (const root of workspaceRoots) {
         roots.add(JSON.stringify(root));
       }
     }
@@ -70,7 +79,7 @@ export function useWorkspaceSelectionCache() {
       const queryKey = JSON.parse(serializedRoot) as readonly unknown[];
       void queryClient.cancelQueries({ queryKey, exact: false });
     }
-  }, [queryClient]);
+  }, [cacheScopeKey, queryClient]);
 
   const invalidateCloudWorkspaceStartState = useCallback(async (runtimeUrl: string) => {
     await Promise.all([

--- a/apps/desktop/src/hooks/workspaces/cache/use-workspaces.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/cache/use-workspaces.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
 import { buildWorkspaceCollections } from "@/lib/domain/workspaces/cloud/collections";
 import { buildLogicalWorkspaces } from "@/lib/domain/workspaces/cloud/logical-workspaces";
+import type { CloudWorkspaceSummary } from "@/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { workspaceCollectionsKey } from "./query-keys";
 import { useWorkspaces } from "./use-workspaces";
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => {
   const listCloudWorkspaces = vi.fn();
 
   return {
+    cloudActive: false,
     listCloudWorkspaces,
     repoRootsList,
     workspacesList,
@@ -30,7 +32,7 @@ vi.mock("@/lib/access/anyharness/workspaces", () => ({
 
 vi.mock("@/hooks/cloud/derived/use-cloud-availability-state", () => ({
   useCloudAvailabilityState: () => ({
-    cloudActive: false,
+    cloudActive: mocks.cloudActive,
   }),
 }));
 
@@ -41,6 +43,7 @@ vi.mock("@proliferate/cloud-sdk/client/workspaces", () => ({
 describe("useWorkspaces", () => {
 
   beforeEach(() => {
+    mocks.cloudActive = false;
     useHarnessConnectionStore.setState({
       runtimeUrl: "http://runtime.test",
       connectionState: "healthy",
@@ -50,7 +53,9 @@ describe("useWorkspaces", () => {
 
   afterEach(() => {
     cleanup();
-    vi.clearAllMocks();
+    mocks.listCloudWorkspaces.mockReset();
+    mocks.repoRootsList.mockReset();
+    mocks.workspacesList.mockReset();
     useHarnessConnectionStore.getState().resetConnectionState();
   });
 
@@ -118,6 +123,58 @@ describe("useWorkspaces", () => {
       "/Users/pablo/proliferate",
     ]);
   });
+
+  it("does not attempt local inventory requests when only cloud is available", async () => {
+    mocks.cloudActive = true;
+    useHarnessConnectionStore.setState({
+      runtimeUrl: "",
+      connectionState: "connecting",
+      error: null,
+    });
+
+    const { result } = renderUseWorkspaces();
+
+    expect(mocks.workspacesList).not.toHaveBeenCalled();
+    expect(mocks.repoRootsList).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it("keeps seeded cloud workspace data available without a local runtime", () => {
+    mocks.cloudActive = true;
+    useHarnessConnectionStore.setState({
+      runtimeUrl: "",
+      connectionState: "connecting",
+      error: null,
+    });
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      workspaceCollectionsKey("", true, null),
+      buildWorkspaceCollections([], [], [makeCloudWorkspace()]),
+    );
+
+    const { result } = renderUseWorkspaces(queryClient);
+
+    expect(mocks.workspacesList).not.toHaveBeenCalled();
+    expect(mocks.repoRootsList).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data?.cloudWorkspaces.map((workspace) => workspace.id)).toEqual([
+      "cloud-1",
+    ]);
+  });
+
+  it("continues loading local inventory when cloud is also active", async () => {
+    mocks.cloudActive = true;
+    mocks.workspacesList.mockResolvedValueOnce([]);
+    mocks.repoRootsList.mockResolvedValueOnce([]);
+
+    const { result } = renderUseWorkspaces();
+
+    await waitFor(() => expect(mocks.workspacesList).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.repoRootsList).toHaveBeenCalledOnce());
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.isSuccess).toBe(true);
+  });
 });
 
 function createQueryClient() {
@@ -166,5 +223,41 @@ function makeRepoRoot(): RepoRoot {
     remoteUrl: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function makeCloudWorkspace(): CloudWorkspaceSummary {
+  return {
+    id: "cloud-1",
+    displayName: "Cloud workspace",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "main",
+      baseBranch: "main",
+    },
+    status: "ready",
+    workspaceStatus: "ready",
+    runtime: {
+      environmentId: "runtime-1",
+      status: "running",
+      generation: 1,
+      actionBlockKind: null,
+      actionBlockReason: null,
+    },
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    actionBlockKind: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    readyAt: "2026-01-01T00:00:00.000Z",
+    postReadyPhase: "complete",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    visibility: "private",
   };
 }

--- a/apps/desktop/src/hooks/workspaces/cache/use-workspaces.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-workspaces.ts
@@ -93,11 +93,10 @@ async function preservePreviousOnNonAbort<T>(
 
 export function useWorkspaces(options?: UseWorkspacesOptions) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const hasLocalRuntime = runtimeUrl.trim().length > 0;
   const authUserId = useAuthStore((state) => state.user?.id ?? null);
   const { cloudActive } = useCloudAvailabilityState();
-  const canQuery = (options?.enabled ?? true) && (
-    runtimeUrl.trim().length > 0 || cloudActive
-  );
+  const canQuery = (options?.enabled ?? true) && hasLocalRuntime;
   const {
     getWorkspaceCollectionsCacheState,
     queryKey,
@@ -106,6 +105,9 @@ export function useWorkspaces(options?: UseWorkspacesOptions) {
   return useQuery<WorkspaceCollections>({
     queryKey,
     queryFn: async ({ signal }) => {
+      if (!hasLocalRuntime) {
+        throw new Error("A local AnyHarness runtime is required to refresh local workspace inventory.");
+      }
       const startedAt = startLatencyTimer();
       const operationId = startMeasurementOperation({
         kind: "workspace_collections_refresh",
@@ -188,7 +190,7 @@ export function useWorkspaces(options?: UseWorkspacesOptions) {
         const collections = buildWorkspaceCollections(
           localWorkspaces,
           repoRoots,
-          [],
+          cachedCollections?.cloudWorkspaces ?? [],
         );
         recordMeasurementWorkflowStep({
           operationId,
@@ -198,6 +200,7 @@ export function useWorkspaces(options?: UseWorkspacesOptions) {
         });
         logLatency("workspace.collections.fetch.success", {
           runtimeUrl,
+          hasLocalRuntime,
           cloudActive,
           localCount: collections.localWorkspaces.length,
           cloudCount: collections.cloudWorkspaces.length,

--- a/apps/desktop/src/hooks/workspaces/cache/use-worktree-settings-target-cache.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-worktree-settings-target-cache.ts
@@ -2,6 +2,7 @@ import {
   anyHarnessRuntimeWorkspacesKey,
   anyHarnessWorktreesInventoryKey,
   anyHarnessWorktreesRetentionPolicyKey,
+  useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
@@ -15,6 +16,7 @@ import type { WorktreeSettingsTarget } from "@/lib/domain/workspaces/worktrees/w
 // Owns cache invalidation for the product-composed Worktree Settings target view.
 export function useWorktreeSettingsTargetCache(workspaceCollectionsRuntimeUrl: string | null) {
   const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
   return useCallback(async (target: WorktreeSettingsTarget) => {
     await Promise.all([
@@ -25,17 +27,17 @@ export function useWorktreeSettingsTargetCache(workspaceCollectionsRuntimeUrl: s
         queryKey: worktreeSettingsTargetRetentionPolicyKey(target),
       }),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesInventoryKey(target.runtimeUrl),
+        queryKey: anyHarnessWorktreesInventoryKey(target.runtimeUrl, cacheScopeKey),
       }),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessWorktreesRetentionPolicyKey(target.runtimeUrl),
+        queryKey: anyHarnessWorktreesRetentionPolicyKey(target.runtimeUrl, cacheScopeKey),
       }),
       queryClient.invalidateQueries({
-        queryKey: anyHarnessRuntimeWorkspacesKey(target.runtimeUrl),
+        queryKey: anyHarnessRuntimeWorkspacesKey(target.runtimeUrl, cacheScopeKey),
       }),
       queryClient.invalidateQueries({
         queryKey: workspaceCollectionsScopeKey(workspaceCollectionsRuntimeUrl ?? target.runtimeUrl),
       }),
     ]);
-  }, [queryClient, workspaceCollectionsRuntimeUrl]);
+  }, [cacheScopeKey, queryClient, workspaceCollectionsRuntimeUrl]);
 }

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-cloud-workspace-materialization-cache-boundary.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-cloud-workspace-materialization-cache-boundary.ts
@@ -1,0 +1,67 @@
+import { useAnyHarnessCacheScopeKey } from "@anyharness/sdk-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import type { CloudConnectionInfo } from "@/lib/access/cloud/client";
+import { isCloudWorkspaceConnectionQueryKey } from "@/hooks/access/cloud/query-keys";
+import { createCloudWorkspaceMaterializationCacheTracker } from "@/hooks/workspaces/cache/cloud-workspace-materialization-cache";
+
+function cloudWorkspaceIdFromConnectionQueryKey(
+  queryKey: readonly unknown[],
+): string | null {
+  if (!isCloudWorkspaceConnectionQueryKey(queryKey)) {
+    return null;
+  }
+
+  return typeof queryKey[2] === "string" && queryKey[2].trim()
+    ? queryKey[2]
+    : null;
+}
+
+function isCloudConnectionInfo(value: unknown): value is CloudConnectionInfo {
+  return !!value
+    && typeof value === "object"
+    && typeof (value as { runtimeUrl?: unknown }).runtimeUrl === "string"
+    && typeof (value as { anyharnessWorkspaceId?: unknown }).anyharnessWorkspaceId === "string"
+    && typeof (value as { runtimeGeneration?: unknown }).runtimeGeneration === "number";
+}
+
+// Observes every Cloud connection update, including background refetches, so
+// a stable product workspace cannot reuse data from a replaced materialization.
+export function useCloudWorkspaceMaterializationCacheBoundary() {
+  const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+
+  useEffect(() => {
+    const tracker = createCloudWorkspaceMaterializationCacheTracker({
+      queryClient,
+      cacheScopeKey,
+    });
+
+    const observeConnectionQuery = (query: {
+      queryKey: readonly unknown[];
+      state: { data: unknown };
+    }) => {
+      const cloudWorkspaceId = cloudWorkspaceIdFromConnectionQueryKey(query.queryKey);
+      if (!cloudWorkspaceId || !isCloudConnectionInfo(query.state.data)) {
+        return;
+      }
+
+      void tracker.observe({
+        cloudWorkspaceId,
+        connection: query.state.data,
+      });
+    };
+
+    for (const query of queryClient.getQueryCache().getAll()) {
+      observeConnectionQuery(query);
+    }
+
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (event.type !== "updated" || event.action.type !== "success") {
+        return;
+      }
+
+      observeConnectionQuery(event.query);
+    });
+  }, [cacheScopeKey, queryClient]);
+}

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
@@ -94,7 +94,6 @@ export function useSelectedCloudRuntimeRehydration(
         await bootstrapWorkspace({
           workspaceId,
           logicalWorkspaceId: selectedLogicalWorkspaceId ?? workspaceId,
-          runtimeUrl,
           workspaceConnection: {
             runtimeUrl: freshConnectionInfo.runtimeUrl,
             authToken: freshConnectionInfo.accessToken,

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
@@ -229,7 +229,6 @@ async function reconcileAfterHotPaint(input: {
   const result = await deps.reconcileHotWorkspace({
     workspaceId: connectionResult.materializedWorkspaceId ?? resolvedWorkspaceId,
     logicalWorkspaceId,
-    runtimeUrl: connectionResult.runtimeUrl,
     workspaceConnection: connectionResult.workspaceConnection,
     sessionId,
     selectionNonce: nonce,

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
@@ -123,7 +123,6 @@ export async function runWorkspaceSelection(
       const bootstrapResult = await deps.bootstrapWorkspace({
         workspaceId: connectionResult.materializedWorkspaceId ?? context.workspaceId,
         logicalWorkspaceId: context.logicalWorkspaceId,
-        runtimeUrl: connectionResult.runtimeUrl,
         workspaceConnection: connectionResult.workspaceConnection,
         startedAt: context.selectionStartedAt,
         latencyFlowId: request.options?.latencyFlowId,
@@ -211,7 +210,6 @@ export async function runWorkspaceSelection(
       const bootstrapResult = await deps.bootstrapWorkspace({
         workspaceId: connectionResult.materializedWorkspaceId ?? context.workspaceId,
         logicalWorkspaceId: context.logicalWorkspaceId,
-        runtimeUrl: connectionResult.runtimeUrl,
         workspaceConnection: connectionResult.workspaceConnection,
         startedAt: context.selectionStartedAt,
         latencyFlowId: request.options?.latencyFlowId,
@@ -344,7 +342,6 @@ export async function runWorkspaceSelection(
   const bootstrapResult = await deps.bootstrapWorkspace({
     workspaceId: connectionResult.materializedWorkspaceId ?? context.workspaceId,
     logicalWorkspaceId: context.logicalWorkspaceId,
-    runtimeUrl: connectionResult.runtimeUrl,
     workspaceConnection: connectionResult.workspaceConnection,
     startedAt: context.selectionStartedAt,
     latencyFlowId: request.options?.latencyFlowId,

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
@@ -50,7 +50,6 @@ export interface WorkspaceSelectionDeps {
   bootstrapWorkspace: (input: {
     workspaceId: string;
     logicalWorkspaceId: string;
-    runtimeUrl: string;
     workspaceConnection: AnyHarnessResolvedConnection;
     startedAt: number;
     latencyFlowId?: string | null;
@@ -59,7 +58,6 @@ export interface WorkspaceSelectionDeps {
   reconcileHotWorkspace: (input: {
     workspaceId: string;
     logicalWorkspaceId: string;
-    runtimeUrl: string;
     workspaceConnection: AnyHarnessResolvedConnection;
     sessionId: string;
     selectionNonce: number;

--- a/apps/desktop/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
@@ -35,7 +35,6 @@ const WORKSPACE_RECONCILE_SESSION_LIST_TIMEOUT_MS = 3_000;
 interface ReconcileHotWorkspaceInput {
   workspaceId: string;
   logicalWorkspaceId: string;
-  runtimeUrl: string;
   workspaceConnection: AnyHarnessResolvedConnection;
   sessionId: string;
   selectionNonce: number;
@@ -55,7 +54,6 @@ interface WorkspaceFileAccessInput {
 interface UseHotWorkspaceReconcileActionInput {
   cancelDeferredFileTreePrefetch: () => void;
   loadWorkspaceSessions: (input: {
-    runtimeUrl: string;
     workspaceConnection: AnyHarnessResolvedConnection;
     workspaceId: string;
     requestOptions?: AnyHarnessRequestOptions;
@@ -90,7 +88,6 @@ export function useHotWorkspaceReconcileAction({
   return useCallback(async ({
     workspaceId,
     logicalWorkspaceId,
-    runtimeUrl,
     workspaceConnection,
     sessionId,
     latencyFlowId,
@@ -152,7 +149,6 @@ export function useHotWorkspaceReconcileAction({
       });
       const sessionsStartedAt = startLatencyTimer();
       const sessions = await loadWorkspaceSessions({
-        runtimeUrl,
         workspaceConnection,
         workspaceId,
         requestOptions: sessionRequestOptions ?? undefined,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -60,7 +60,6 @@ import {
 interface BootstrapWorkspaceInput {
   workspaceId: string;
   logicalWorkspaceId: string;
-  runtimeUrl: string;
   workspaceConnection: AnyHarnessResolvedConnection;
   startedAt: number;
   latencyFlowId?: string | null;
@@ -113,7 +112,6 @@ export function useWorkspaceBootstrapActions() {
   const bootstrapWorkspace = useCallback(async ({
     workspaceId,
     logicalWorkspaceId,
-    runtimeUrl,
     workspaceConnection,
     startedAt,
     latencyFlowId,
@@ -195,7 +193,7 @@ export function useWorkspaceBootstrapActions() {
           type: "cache",
           category: "session.list",
           operationId: measurementOperationId,
-          decision: getWorkspaceSessionsCacheDecision(runtimeUrl, workspaceId),
+          decision: getWorkspaceSessionsCacheDecision(workspaceId),
           source: "react_query",
         });
       }
@@ -206,7 +204,6 @@ export function useWorkspaceBootstrapActions() {
         headers: requestHeaders,
       });
       const sessions = await loadWorkspaceSessions({
-        runtimeUrl,
         workspaceConnection,
         workspaceId,
         requestOptions: sessionRequestOptions ?? undefined,

--- a/apps/desktop/src/lib/domain/auth/anyharness-cache-scope.test.ts
+++ b/apps/desktop/src/lib/domain/auth/anyharness-cache-scope.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildAnyHarnessCacheScopeKey } from "./anyharness-cache-scope";
+
+describe("buildAnyHarnessCacheScopeKey", () => {
+  it("isolates authenticated actors on the same deployment", () => {
+    const first = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://api.proliferate.com",
+      authStatus: "authenticated",
+      authUserId: "user-1",
+    });
+    const second = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://api.proliferate.com",
+      authStatus: "authenticated",
+      authUserId: "user-2",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("isolates the same actor across deployments", () => {
+    const hosted = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://api.proliferate.com",
+      authStatus: "authenticated",
+      authUserId: "user-1",
+    });
+    const selfHosted = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://proliferate.example.com",
+      authStatus: "authenticated",
+      authUserId: "user-1",
+    });
+
+    expect(hosted).not.toBe(selfHosted);
+  });
+
+  it("isolates path-based deployments on the same origin", () => {
+    const first = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://proliferate.example.com/instance-a",
+      authStatus: "authenticated",
+      authUserId: "user-1",
+    });
+    const second = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://proliferate.example.com/instance-b",
+      authStatus: "authenticated",
+      authUserId: "user-1",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("keeps anonymous and bootstrapping caches separate", () => {
+    const anonymous = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://api.proliferate.com",
+      authStatus: "anonymous",
+      authUserId: null,
+    });
+    const bootstrapping = buildAnyHarnessCacheScopeKey({
+      apiBaseUrl: "https://api.proliferate.com",
+      authStatus: "bootstrapping",
+      authUserId: null,
+    });
+
+    expect(anonymous).not.toBe(bootstrapping);
+  });
+});

--- a/apps/desktop/src/lib/domain/auth/anyharness-cache-scope.ts
+++ b/apps/desktop/src/lib/domain/auth/anyharness-cache-scope.ts
@@ -1,0 +1,20 @@
+import type { AuthClientStatus } from "./auth-state-mapping";
+
+interface AnyHarnessCacheScopeInput {
+  apiBaseUrl: string;
+  authStatus: AuthClientStatus;
+  authUserId: string | null;
+}
+
+export function buildAnyHarnessCacheScopeKey(
+  input: AnyHarnessCacheScopeInput,
+): string {
+  const apiBaseUrl = input.apiBaseUrl.trim() || "unknown-deployment";
+  const authUserId = input.authUserId?.trim() ?? "";
+
+  if (input.authStatus === "authenticated" && authUserId) {
+    return `${apiBaseUrl}::user:${authUserId}`;
+  }
+
+  return `${apiBaseUrl}::${input.authStatus}`;
+}

--- a/apps/desktop/src/lib/workflows/cowork/create-cowork-thread.ts
+++ b/apps/desktop/src/lib/workflows/cowork/create-cowork-thread.ts
@@ -60,7 +60,6 @@ export interface CreateCoworkThreadWorkflowDeps {
   upsertWorkspaceSessionRecord(
     workspaceId: string,
     session: Session,
-    options?: { runtimeUrl?: string },
   ): void;
   recordCreatedSession(input: {
     projectedSessionId: string | null;
@@ -194,9 +193,7 @@ export async function createCoworkThreadWorkflow(
     }
 
     deps.upsertLocalWorkspace(result.workspace);
-    deps.upsertWorkspaceSessionRecord(result.workspace.id, launchedSession, {
-      runtimeUrl: input.runtimeUrl,
-    });
+    deps.upsertWorkspaceSessionRecord(result.workspace.id, launchedSession);
     const activeSessionId = projectedSessionId ?? launchedSession.id;
     deps.recordCreatedSession({
       projectedSessionId,

--- a/apps/desktop/src/providers/AppProviders.tsx
+++ b/apps/desktop/src/providers/AppProviders.tsx
@@ -35,7 +35,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { buildAnyHarnessCacheScopeKey } from "@/lib/domain/auth/anyharness-cache-scope";
 import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
 import { withFreshCloudSandboxGatewayAccessToken } from "@/lib/access/cloud/cloud-sandbox-gateway";
-import { useCloudWorkspaceMaterializationCacheBoundary } from "@/hooks/workspaces/lifecycle/use-cloud-workspace-materialization-cache-boundary";
+import { useCloudWorkspaceMaterializationCacheBoundary } from "@/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary";
 import { TelemetryProvider } from "./TelemetryProvider";
 
 async function resolveWorkspaceConnectionWithCache(

--- a/apps/desktop/src/providers/AppProviders.tsx
+++ b/apps/desktop/src/providers/AppProviders.tsx
@@ -35,6 +35,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { buildAnyHarnessCacheScopeKey } from "@/lib/domain/auth/anyharness-cache-scope";
 import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
 import { withFreshCloudSandboxGatewayAccessToken } from "@/lib/access/cloud/cloud-sandbox-gateway";
+import { useCloudWorkspaceMaterializationCacheBoundary } from "@/hooks/workspaces/lifecycle/use-cloud-workspace-materialization-cache-boundary";
 import { TelemetryProvider } from "./TelemetryProvider";
 
 async function resolveWorkspaceConnectionWithCache(
@@ -175,12 +176,19 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
 
   return (
     <AnyHarnessRuntime runtimeUrl={runtimeUrl} cacheScopeKey={cacheScopeKey}>
-      <AnyHarnessWorkspace
-        workspaceId={providerWorkspaceId}
-        resolveConnection={resolveConnection}
-      >
-        {children}
-      </AnyHarnessWorkspace>
+      <CloudWorkspaceMaterializationCacheBoundary>
+        <AnyHarnessWorkspace
+          workspaceId={providerWorkspaceId}
+          resolveConnection={resolveConnection}
+        >
+          {children}
+        </AnyHarnessWorkspace>
+      </CloudWorkspaceMaterializationCacheBoundary>
     </AnyHarnessRuntime>
   );
+}
+
+function CloudWorkspaceMaterializationCacheBoundary({ children }: { children: ReactNode }) {
+  useCloudWorkspaceMaterializationCacheBoundary();
+  return children;
 }

--- a/apps/desktop/src/providers/AppProviders.tsx
+++ b/apps/desktop/src/providers/AppProviders.tsx
@@ -32,6 +32,8 @@ import { getWorkspaceCollectionsFromCache } from "@/hooks/workspaces/cache/query
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "@/stores/sessions/session-selection-store";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { buildAnyHarnessCacheScopeKey } from "@/lib/domain/auth/anyharness-cache-scope";
+import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
 import { withFreshCloudSandboxGatewayAccessToken } from "@/lib/access/cloud/cloud-sandbox-gateway";
 import { TelemetryProvider } from "./TelemetryProvider";
 
@@ -78,6 +80,11 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const authStatus = useAuthStore((state) => state.status);
   const authUserId = useAuthStore((state) => state.user?.id ?? null);
+  const cacheScopeKey = useMemo(() => buildAnyHarnessCacheScopeKey({
+    apiBaseUrl: getProliferateApiBaseUrl(),
+    authStatus,
+    authUserId,
+  }), [authStatus, authUserId]);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore((state) => state.selectedLogicalWorkspaceId);
   const providerWorkspaceId = resolveRouteScopedWorkspaceProviderId({
@@ -96,7 +103,7 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
         cloudMobilityWorkspacesKey(),
       );
       const coworkStatus = appQueryClient.getQueryData<CoworkStatus>(
-        anyHarnessCoworkStatusKey(runtimeUrl),
+        anyHarnessCoworkStatusKey(runtimeUrl, cacheScopeKey),
       );
       const standardProjection = workspaceCollections
         ? buildStandardRepoProjection({
@@ -163,11 +170,11 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
 
       return resolveWorkspaceConnectionWithCache(runtimeUrl, workspaceId);
     },
-    [authStatus, authUserId, runtimeUrl, selectedWorkspaceId],
+    [authStatus, authUserId, cacheScopeKey, runtimeUrl, selectedWorkspaceId],
   );
 
   return (
-    <AnyHarnessRuntime runtimeUrl={runtimeUrl}>
+    <AnyHarnessRuntime runtimeUrl={runtimeUrl} cacheScopeKey={cacheScopeKey}>
       <AnyHarnessWorkspace
         workspaceId={providerWorkspaceId}
         resolveConnection={resolveConnection}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -25,7 +25,7 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
-anyharness/sdk-react/src/hooks/sessions.ts 728 existing SDK React oversized file
+anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 773 existing generated cloud SDK type surface (+billing budget-limit/usage types)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file


### PR DESCRIPTION
## What changed

- Added an explicit AnyHarness cache scope derived from the API deployment and authenticated actor.
- Split runtime-scoped query identity from logical workspace-scoped identity across SDK React and Desktop cache consumers.
- Kept workspace cache identity stable across temporary cloud gateway token and URL refreshes.
- Disabled local AnyHarness inventory queries when a host has no local runtime, while preserving cloud workspace routing.
- Added regression coverage for actor/deployment isolation, gateway credential rotation, Web-style null-runtime routing, and Desktop workspace caching.

## Why

Workspace requests could use a cloud gateway while their React Query keys were rooted in the Desktop local runtime. That made the shared Desktop/Web boundary vulnerable to stale or cross-deployment cache reuse. The Desktop workspace inventory hook could also attempt local runtime calls when only cloud access was available.

## Impact

This establishes the cache and routing boundary needed before moving the Desktop product surface into the shared Web/Desktop client. Cloud queries no longer depend on a fake local runtime, user and self-host deployments are isolated, and dynamic local runtime queries retain transport identity.

## Validation

- make build
- pnpm --filter @anyharness/sdk-react test (22 passing)
- Desktop TypeScript typecheck
- Focused Desktop cache, routing, session, terminal, and workspace workflow tests
- Fresh query-scope profile: API, AnyHarness, Desktop renderer, and hosted Web all returned HTTP 200; the native Desktop app opened and successfully exercised workspace, repo-root, auth, and health requests
- Profile stopped cleanly after the smoke

## Known baseline

The repository-wide Desktop test entrypoint currently stops on existing design-system violations, and direct full Vitest has unrelated failures reproducible on main. All tests affected by this diff pass.
