### PR TITLE
ci(release): enforce PR title and label contract (R1)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@
 - Title format: `<type>(<scope>): <plain-English change>`
 - Required: exactly one `release:*` label
 - Required: at least one `area:*` label
+- Apply every affected `area:*` label. Do not infer areas from the component
+  name alone.
 
 Release labels:
 `release:large-feature`, `release:minor-feature`, `release:performance`,
@@ -15,6 +17,13 @@ Release labels:
 Area labels:
 `area:desktop`, `area:anyharness`, `area:sdk`, `area:server`, `area:cloud`,
 `area:docs`, `area:website`, `area:release`, `area:product`
+
+## Support and attribution (optional)
+
+- Tracker issue IDs linked through the tracker API:
+- Do not include report bodies, emails, internal IDs, or telemetry identities
+  here. The tracker is the source of truth for consented attribution and posts
+  the safe projection comment after linking.
 
 ## Verification
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
           node --check scripts/ci-cd/detect-deploy-surfaces.mjs
           node --check scripts/ci-cd/prepare-artifact-release.mjs
           node --check scripts/ci-cd/publish-product-release.mjs
+          node --check scripts/ci-cd/pr-metadata.mjs
           node --check scripts/ci-cd/resolve-deploy-base.mjs
+          node --check scripts/ci-cd/validate-pr-metadata.mjs
           node --check scripts/agent-catalog/build-catalog.mjs
           node --check scripts/agent-catalog/check-version-discipline.mjs
           node --check scripts/agent-catalog/resolve-pins.mjs

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -23,92 +23,37 @@ jobs:
     name: Validate PR title and labels
     runs-on: ubuntu-latest
     steps:
-      - name: Validate metadata
+      # pull_request_target runs with write-capable secrets, so only trusted
+      # base-revision code is checked out and executed. The untrusted PR head is
+      # never checked out; changed paths come from the GitHub API instead.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Collect changed paths
         uses: actions/github-script@v9
         with:
           script: |
-            const pr = context.payload.pull_request;
-            if (!pr) {
-              core.setFailed("This workflow must run on a pull request event.");
-              return;
-            }
-
-            if (pr.draft) {
-              core.notice("Draft PR: metadata enforcement starts when the PR is ready for review.");
-              return;
-            }
-
-            const allowedTitleTypes = [
-              "feat",
-              "fix",
-              "perf",
-              "docs",
-              "refactor",
-              "chore",
-              "ci",
-              "test",
-              "build",
-              "release",
-            ];
-            const titlePattern = new RegExp(
-              `^(${allowedTitleTypes.join("|")})\\([a-z0-9][a-z0-9/-]*\\): .+`,
+            const fs = require("node:fs");
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            fs.writeFileSync(
+              "changed-files.json",
+              JSON.stringify(files.map((file) => file.filename)),
             );
+            core.info(`Collected ${files.length} changed path(s).`);
 
-            const allowedReleaseLabels = new Set([
-              "release:large-feature",
-              "release:minor-feature",
-              "release:performance",
-              "release:fix",
-              "release:docs",
-              "release:maintenance",
-              "release:skip",
-            ]);
-            const allowedAreaLabels = new Set([
-              "area:desktop",
-              "area:anyharness",
-              "area:sdk",
-              "area:server",
-              "area:cloud",
-              "area:docs",
-              "area:website",
-              "area:release",
-              "area:product",
-            ]);
-
-            const labels = pr.labels.map((label) => label.name);
-            const releaseLabels = labels.filter((label) => label.startsWith("release:"));
-            const areaLabels = labels.filter((label) => label.startsWith("area:"));
-            const invalidReleaseLabels = releaseLabels.filter(
-              (label) => !allowedReleaseLabels.has(label),
-            );
-            const invalidAreaLabels = areaLabels.filter(
-              (label) => !allowedAreaLabels.has(label),
-            );
-
-            const errors = [];
-            if (!titlePattern.test(pr.title)) {
-              errors.push(
-                `PR title must match <type>(<scope>): <change>. Allowed types: ${allowedTitleTypes.join(", ")}.`,
-              );
-            }
-            if (releaseLabels.length !== 1) {
-              errors.push(
-                `PR must have exactly one release:* label. Found ${releaseLabels.length}: ${releaseLabels.join(", ") || "none"}.`,
-              );
-            }
-            if (areaLabels.length < 1) {
-              errors.push("PR must have at least one area:* label.");
-            }
-            if (invalidReleaseLabels.length > 0) {
-              errors.push(`Unknown release label(s): ${invalidReleaseLabels.join(", ")}.`);
-            }
-            if (invalidAreaLabels.length > 0) {
-              errors.push(`Unknown area label(s): ${invalidAreaLabels.join(", ")}.`);
-            }
-
-            if (errors.length > 0) {
-              core.setFailed(errors.join("\n"));
-              return;
-            }
-
-            core.notice("PR metadata looks good.");
+      - name: Validate metadata
+        run: >-
+          node scripts/ci-cd/validate-pr-metadata.mjs
+          --event "$GITHUB_EVENT_PATH"
+          --changed-files-json changed-files.json

--- a/scripts/ci-cd/detect-deploy-surfaces.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.mjs
@@ -96,7 +96,7 @@ function changedFiles(base, head) {
     .filter(Boolean);
 }
 
-function matches(path, prefixes) {
+export function matches(path, prefixes) {
   return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 }
 

--- a/scripts/ci-cd/pr-metadata.mjs
+++ b/scripts/ci-cd/pr-metadata.mjs
@@ -1,0 +1,185 @@
+import { matches } from "./detect-deploy-surfaces.mjs";
+
+export const ALLOWED_TITLE_TYPES = Object.freeze([
+  "feat",
+  "fix",
+  "perf",
+  "docs",
+  "refactor",
+  "chore",
+  "ci",
+  "test",
+  "build",
+  "release",
+]);
+
+export const ALLOWED_RELEASE_LABELS = Object.freeze([
+  "release:large-feature",
+  "release:minor-feature",
+  "release:performance",
+  "release:fix",
+  "release:docs",
+  "release:maintenance",
+  "release:skip",
+]);
+
+export const ALLOWED_AREA_LABELS = Object.freeze([
+  "area:desktop",
+  "area:anyharness",
+  "area:sdk",
+  "area:server",
+  "area:cloud",
+  "area:docs",
+  "area:website",
+  "area:release",
+  "area:product",
+]);
+
+const TITLE_PATTERN = new RegExp(
+  `^(${ALLOWED_TITLE_TYPES.join("|")})\\([a-z0-9][a-z0-9/-]*\\): [^\\r\\n]+$`,
+);
+
+// Area detection reuses the deploy-surface detector's `matches(path, prefixes)`
+// convention (see detect-deploy-surfaces.mjs). It is a distinct projection: the
+// area:* taxonomy is not the deploy-surface taxonomy, so this classifier maps
+// changed paths onto area labels directly rather than translating surfaces.
+//
+// Each rule contributes candidate area label(s) for a changed path:
+// - a path that resolves to exactly one candidate is a REQUIRED area;
+// - a path that resolves to two or more candidates is AMBIGUOUS and, unless the
+//   PR already applies one of those candidates, blocks for a human choice;
+// - a path that resolves to no candidate is neutral and contributes nothing.
+//
+// Deliberate gaps (reported, not guessed): apps/mobile has no area:* label in
+// the fixed taxonomy, so mobile-only paths stay neutral and rely on the
+// "at least one area" rule plus explicit author choice. Component identity is
+// never guessed into an area label.
+const AREA_RULES = Object.freeze([
+  // Release/CI/deploy plumbing owns area:release.
+  { area: "area:release", test: (p) => p.startsWith(".github/") || matches(p, ["scripts/ci-cd"]) },
+  // SDK packages take precedence over the web/runtime prefixes they nest under.
+  { area: "area:sdk", test: (p) => matches(p, ["anyharness/sdk", "anyharness/sdk-react", "cloud/sdk"]) },
+  {
+    area: "area:anyharness",
+    test: (p) =>
+      matches(p, ["anyharness/crates", "anyharness/tests", "catalogs"]),
+  },
+  { area: "area:desktop", test: (p) => matches(p, ["apps/desktop"]) },
+  { area: "area:website", test: (p) => matches(p, ["apps/web"]) },
+  { area: "area:server", test: (p) => matches(p, ["server"]) },
+  { area: "area:cloud", test: (p) => matches(p, ["cloud"]) },
+  {
+    area: "area:docs",
+    test: (p) => matches(p, ["specs", "docs"]) || (!p.includes("/") && p.endsWith(".md")),
+  },
+  // Shared product surfaces are cross-cutting by definition.
+  { area: "area:product", test: (p) => matches(p, ["apps/packages"]) },
+]);
+
+function candidateAreasForPath(path) {
+  const areas = new Set();
+  for (const rule of AREA_RULES) {
+    if (rule.test(path)) {
+      areas.add(rule.area);
+    }
+  }
+  return areas;
+}
+
+/**
+ * Derive area-label expectations from a PR's changed paths.
+ *
+ * Returns:
+ * - `required`: areas that every applied label set must include;
+ * - `ambiguous`: `{ path, candidates }` entries whose area could not be
+ *   determined uniquely and which need an explicit human choice.
+ */
+export function deriveAreaExpectation(changedFiles = []) {
+  const required = new Set();
+  const ambiguous = [];
+  for (const file of changedFiles) {
+    const path = typeof file === "string" ? file : file?.filename;
+    if (!path) {
+      continue;
+    }
+    const candidates = candidateAreasForPath(path);
+    if (candidates.size === 1) {
+      required.add([...candidates][0]);
+    } else if (candidates.size > 1) {
+      ambiguous.push({ path, candidates: [...candidates].sort() });
+    }
+  }
+  return { required: [...required].sort(), ambiguous };
+}
+
+function labelNames(labels) {
+  return labels
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter((label) => typeof label === "string" && label.length > 0);
+}
+
+/**
+ * Validate the PR metadata contract used by both contributors and release
+ * tooling. The returned errors are intentionally plain strings so callers can
+ * render them in Actions, tests, or local tooling without GitHub dependencies.
+ *
+ * When `changedFiles` is provided, area labels are additionally checked against
+ * the areas derived from the actual changed paths: every clearly-implied area
+ * must be applied, and an ambiguous path-to-area result blocks for a human
+ * choice rather than guessing a label.
+ */
+export function validatePullRequestMetadata({ title, labels = [], changedFiles = null }) {
+  const names = labelNames(labels);
+  const releaseLabels = names.filter((label) => label.startsWith("release:"));
+  const areaLabels = names.filter((label) => label.startsWith("area:"));
+  const appliedAreas = new Set(areaLabels);
+  const allowedReleaseLabels = new Set(ALLOWED_RELEASE_LABELS);
+  const allowedAreaLabels = new Set(ALLOWED_AREA_LABELS);
+  const errors = [];
+
+  if (!TITLE_PATTERN.test(title || "")) {
+    errors.push(
+      `PR title must match <type>(<scope>): <change>. Allowed types: ${ALLOWED_TITLE_TYPES.join(", ")}.`,
+    );
+  }
+  if (releaseLabels.length !== 1) {
+    errors.push(
+      `PR must have exactly one release:* label. Found ${releaseLabels.length}: ${releaseLabels.join(", ") || "none"}.`,
+    );
+  }
+  if (areaLabels.length < 1) {
+    errors.push("PR must have at least one area:* label.");
+  }
+
+  const invalidReleaseLabels = releaseLabels.filter((label) => !allowedReleaseLabels.has(label));
+  if (invalidReleaseLabels.length > 0) {
+    errors.push(`Unknown release label(s): ${invalidReleaseLabels.join(", ")}.`);
+  }
+  const invalidAreaLabels = areaLabels.filter((label) => !allowedAreaLabels.has(label));
+  if (invalidAreaLabels.length > 0) {
+    errors.push(`Unknown area label(s): ${invalidAreaLabels.join(", ")}.`);
+  }
+
+  if (Array.isArray(changedFiles)) {
+    const { required, ambiguous } = deriveAreaExpectation(changedFiles);
+    const missing = required.filter((area) => !appliedAreas.has(area));
+    if (missing.length > 0) {
+      errors.push(
+        `Changed paths require area label(s): ${missing.join(", ")}. Apply every area affected by the diff.`,
+      );
+    }
+    const unresolved = ambiguous.filter(
+      ({ candidates }) => !candidates.some((area) => appliedAreas.has(area)),
+    );
+    if (unresolved.length > 0) {
+      const detail = unresolved
+        .map(({ path, candidates }) => `${path} -> ${candidates.join(" | ")}`)
+        .join("; ");
+      errors.push(
+        `Changed paths map to more than one area and none is applied; choose the correct area:* label(s) explicitly: ${detail}.`,
+      );
+    }
+  }
+
+  return errors;
+}

--- a/scripts/ci-cd/validate-pr-metadata.mjs
+++ b/scripts/ci-cd/validate-pr-metadata.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+import { validatePullRequestMetadata } from "./pr-metadata.mjs";
+
+function parseArgs(argv) {
+  const parsed = {
+    event: "",
+    title: "",
+    labelsJson: "",
+    changedFilesJson: "",
+    draft: false,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--event":
+        parsed.event = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--title":
+        parsed.title = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--labels-json":
+        parsed.labelsJson = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--changed-files-json":
+        parsed.changedFilesJson = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--draft":
+        parsed.draft = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function usage() {
+  console.log(`Validate a pull request title and release/area labels.
+
+Usage:
+  node scripts/ci-cd/validate-pr-metadata.mjs --event <github-event.json> [--changed-files-json <files.json>]
+  node scripts/ci-cd/validate-pr-metadata.mjs --title <title> --labels-json <json> [--changed-files-json <files.json>]
+
+--changed-files-json points at a JSON array of changed paths (strings) or
+GitHub file objects ({"filename": "..."}). When provided, area labels are also
+checked against the areas implied by the changed paths.
+`);
+}
+
+function loadChangedFiles(parsed) {
+  if (!parsed.changedFilesJson) {
+    return null;
+  }
+  const raw = JSON.parse(fs.readFileSync(parsed.changedFilesJson, "utf8"));
+  if (!Array.isArray(raw)) {
+    throw new Error("--changed-files-json must contain a JSON array.");
+  }
+  return raw;
+}
+
+function loadInput(parsed) {
+  const changedFiles = loadChangedFiles(parsed);
+  if (parsed.event) {
+    const event = JSON.parse(fs.readFileSync(parsed.event, "utf8"));
+    const pr = event.pull_request;
+    if (!pr) {
+      throw new Error("--event must contain a pull_request payload.");
+    }
+    return {
+      title: pr.title,
+      labels: pr.labels || [],
+      draft: Boolean(pr.draft),
+      changedFiles,
+    };
+  }
+  if (!parsed.title || !parsed.labelsJson) {
+    throw new Error("Provide --event, or both --title and --labels-json.");
+  }
+  const labels = JSON.parse(parsed.labelsJson);
+  if (!Array.isArray(labels)) {
+    throw new Error("--labels-json must be a JSON array.");
+  }
+  return { title: parsed.title, labels, draft: parsed.draft, changedFiles };
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    usage();
+    return;
+  }
+  const input = loadInput(parsed);
+  if (input.draft) {
+    console.log("Draft PR: metadata enforcement starts when the PR is ready for review.");
+    return;
+  }
+  const errors = validatePullRequestMetadata(input);
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+  console.log("PR metadata looks good.");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/ci-cd/validate-pr-metadata.test.mjs
+++ b/scripts/ci-cd/validate-pr-metadata.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveAreaExpectation,
+  validatePullRequestMetadata,
+} from "./pr-metadata.mjs";
+
+const valid = {
+  title: "fix(server): preserve support report identity",
+  labels: ["release:fix", "area:server"],
+};
+
+test("accepts the release metadata contract", () => {
+  assert.deepEqual(validatePullRequestMetadata(valid), []);
+});
+
+test("requires a conventional title, one release label, and an area", () => {
+  const errors = validatePullRequestMetadata({
+    title: "Fix support identity",
+    labels: ["release:fix", "release:docs"],
+  });
+
+  assert.equal(errors.length, 3);
+  assert.match(errors[0], /title must match/);
+  assert.match(errors[1], /exactly one release/);
+  assert.match(errors[2], /at least one area/);
+});
+
+test("rejects unknown release and area labels", () => {
+  const errors = validatePullRequestMetadata({
+    title: valid.title,
+    labels: ["release:experimental", "area:unknown"],
+  });
+
+  assert.equal(errors.length, 2);
+  assert.match(errors[0], /Unknown release label/);
+  assert.match(errors[1], /Unknown area label/);
+});
+
+test("derives required areas from changed paths", () => {
+  const { required, ambiguous } = deriveAreaExpectation([
+    "apps/desktop/src/main.ts",
+    "server/proliferate/api/support.py",
+    ".github/workflows/pr-metadata.yml",
+    "anyharness/sdk/src/index.ts",
+    "anyharness/crates/anyharness/src/lib.rs",
+    "specs/README.md",
+  ]);
+
+  assert.deepEqual(required, [
+    "area:anyharness",
+    "area:desktop",
+    "area:docs",
+    "area:release",
+    "area:sdk",
+    "area:server",
+  ]);
+  assert.deepEqual(ambiguous, []);
+});
+
+test("mobile-only and unrecognized paths are neutral, not guessed", () => {
+  const { required, ambiguous } = deriveAreaExpectation([
+    "apps/mobile/app/index.tsx",
+    "Makefile",
+    "install/setup.sh",
+  ]);
+
+  assert.deepEqual(required, []);
+  assert.deepEqual(ambiguous, []);
+});
+
+test("blocks when a required area derived from paths is missing", () => {
+  const errors = validatePullRequestMetadata({
+    title: "fix(desktop): repair updater",
+    labels: ["release:fix", "area:server"],
+    changedFiles: ["apps/desktop/src/updater.ts"],
+  });
+
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /require area label\(s\): area:desktop/);
+});
+
+test("passes when applied areas cover every derived area", () => {
+  const errors = validatePullRequestMetadata({
+    title: "feat(desktop): bundle seed",
+    labels: ["release:minor-feature", "area:desktop", "area:release"],
+    changedFiles: [
+      "apps/desktop/src-tauri/tauri.conf.json",
+      ".github/workflows/release-desktop.yml",
+    ],
+  });
+
+  assert.deepEqual(errors, []);
+});
+
+test("ambiguous path-to-area result blocks for a human choice", () => {
+  const errors = validatePullRequestMetadata({
+    title: "chore(deps): bump shared deps",
+    labels: ["release:maintenance", "area:release"],
+    changedFiles: ["cloud/sdk/package.json"],
+  });
+
+  // cloud/sdk/... matches both area:sdk and area:cloud.
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /map to more than one area/);
+  assert.match(errors[0], /cloud\/sdk\/package\.json -> area:cloud \| area:sdk/);
+});
+
+test("ambiguity is resolved once one candidate area is applied", () => {
+  const errors = validatePullRequestMetadata({
+    title: "chore(sdk): bump cloud sdk deps",
+    labels: ["release:maintenance", "area:sdk"],
+    changedFiles: ["cloud/sdk/package.json"],
+  });
+
+  assert.deepEqual(errors, []);
+});


### PR DESCRIPTION
R1 of the support-system program: finish and enforce the PR metadata contract from `ci-cd.md`.

- `scripts/ci-cd/pr-metadata.mjs` — title format, exactly one `release:*`, at least one `area:*`, and path-derived area expectations reusing the deploy-surface detector's `matches()` primitive (no forked logic)
- Ambiguity blocks with an actionable message naming the path and candidate areas instead of guessing
- `pr-metadata.yml` runs as a trusted `pull_request_target` job: base-SHA checkout only, changed files collected via the GitHub API, single required-check-friendly job on open/edit/synchronize/label/reopen/ready
- `ci.yml` gains `node --check` for the new scripts; existing `node --test scripts/ci-cd` gate covers the 10 new tests (58 pass total)
- PR template notes the apply-every-area rule and optional support attribution

Ported from reviewed donor WIP; `_deploy-server.yml` Slack-webhook hunks (product lane) and `publish-landing-changelog.yml` (R3 seed) deliberately excluded.

Known taxonomy gap flagged for follow-up: `apps/mobile` paths have no `area:*` label; treated as neutral rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)