### PR TITLE
feat(support): private completed-report feed with immutable client release (P1)

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -292,6 +292,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/github-app/connected": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Github App Connected Page Endpoint */
+        get: operations["github_app_connected_page_endpoint_auth_github_app_connected_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/integrations/github/callback": {
         parameters: {
             query?: never;
@@ -1681,6 +1698,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/runtime/download/{target}/{asset}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime Artifact Download Endpoint
+         * @description 302 to the pinned AnyHarness binary (or its ``.sha256``) on the downloads CDN.
+         *
+         *     Unauthenticated by design, like the worker artifact redirect: the sandbox
+         *     worker fetches the runtime binary over a public CDN URL behind this 302, so
+         *     the sandbox never needs GitHub egress or credentials.
+         */
+        get: operations["runtime_artifact_download_endpoint_v1_cloud_runtime_download__target___asset__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/integration-gateway/mcp": {
         parameters: {
             query?: never;
@@ -2017,6 +2058,23 @@ export interface paths {
         put?: never;
         /** Complete Support Report Upload Endpoint */
         post: operations["complete_support_report_upload_endpoint_v1_support_reports__report_id__complete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/internal/support/reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Support Report Feed */
+        get: operations["list_support_report_feed_internal_support_reports_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -4070,6 +4128,22 @@ export interface components {
             /** Path */
             path: string;
         };
+        /**
+         * DeploymentIdentity
+         * @description How this control plane identifies itself.
+         *
+         *     ``mode`` mirrors the desktop telemetry runtime modes. ``displayName`` is the
+         *     operator's instance name; empty means "use the connected origin" so the
+         *     desktop never mislabels a self-managed server as the vendor product.
+         */
+        DeploymentIdentity: {
+            /** Mode */
+            mode: string;
+            /** Displayname */
+            displayName: string;
+            /** Logourl */
+            logoUrl: string | null;
+        };
         /** DesktopWorkerEnrollmentRequest */
         DesktopWorkerEnrollmentRequest: {
             /** Desktopinstallid */
@@ -4420,6 +4494,7 @@ export interface components {
             workerVersion: string;
             /** Mindesktopversion */
             minDesktopVersion: string;
+            capabilities: components["schemas"]["ServerCapabilities"];
         };
         /** OAuthAvailabilityResponse */
         OAuthAvailabilityResponse: {
@@ -5004,6 +5079,16 @@ export interface components {
             proBillingEnabled: boolean;
         };
         /**
+         * PricingCapability
+         * @description Whether a vendor pricing page is meaningful for this deployment.
+         */
+        PricingCapability: {
+            /** Available */
+            available: boolean;
+            /** Url */
+            url: string | null;
+        };
+        /**
          * ProfileUpdateRequest
          * @description Editable fields on the authenticated user's own profile.
          *
@@ -5154,6 +5239,30 @@ export interface components {
              */
             runCommand: string;
         };
+        /**
+         * ServerCapabilities
+         * @description Versioned, conservative declaration of what this deployment offers.
+         *
+         *     Defaults are disabled: a capability is true only when the operator
+         *     configured the underlying feature. The desktop treats an absent contract
+         *     (older servers) as all-off + self-managed.
+         */
+        ServerCapabilities: {
+            /** Contractversion */
+            contractVersion: number;
+            deployment: components["schemas"]["DeploymentIdentity"];
+            /** Billing */
+            billing: boolean;
+            /** Usagemetering */
+            usageMetering: boolean;
+            /** Cloudworkspaces */
+            cloudWorkspaces: boolean;
+            /** Agentgateway */
+            agentGateway: boolean;
+            webApp: components["schemas"]["WebAppCapability"];
+            support: components["schemas"]["SupportCapability"];
+            pricing: components["schemas"]["PricingCapability"];
+        };
         /** SetIntegrationEnabledRequest */
         SetIntegrationEnabledRequest: {
             /** Enabled */
@@ -5287,6 +5396,77 @@ export interface components {
             /** Livemode */
             livemode?: boolean | null;
         };
+        /**
+         * SupportCapability
+         * @description Where a user of this deployment should go for support.
+         *
+         *     ``vendor`` is the hosted product's own support; ``operator`` is a
+         *     self-managed operator's configured destination; ``none`` means the desktop
+         *     offers no support-email affordance for this server.
+         */
+        SupportCapability: {
+            /** Kind */
+            kind: string;
+            /** Email */
+            email: string | null;
+            /** Url */
+            url: string | null;
+        };
+        /** SupportFeedItem */
+        SupportFeedItem: {
+            /** Reportid */
+            reportId: string;
+            /**
+             * Submittedat
+             * Format: date-time
+             */
+            submittedAt: string;
+            /**
+             * Completedat
+             * Format: date-time
+             */
+            completedAt: string;
+            /** Owneruserid */
+            ownerUserId: string;
+            /** Kind */
+            kind: string;
+            /** Summary */
+            summary?: string | null;
+            /** Releaseid */
+            releaseId?: string | null;
+            /** Releasewarning */
+            releaseWarning?: string | null;
+            /** Notifyme */
+            notifyMe: boolean;
+            /** Creditconsent */
+            creditConsent: boolean;
+            /** Creditname */
+            creditName?: string | null;
+            /** Outreachoverride */
+            outreachOverride?: string | null;
+            /** Privatecasereference */
+            privateCaseReference: string;
+            /** Sentryevents */
+            sentryEvents?: components["schemas"]["SupportFeedSentryEvent"][];
+            /** Cursor */
+            cursor: string;
+        };
+        /** SupportFeedPage */
+        SupportFeedPage: {
+            /** Items */
+            items: components["schemas"]["SupportFeedItem"][];
+            /** Nextcursor */
+            nextCursor?: string | null;
+            /** Hasmore */
+            hasMore: boolean;
+        };
+        /** SupportFeedSentryEvent */
+        SupportFeedSentryEvent: {
+            /** Project */
+            project: string;
+            /** Eventid */
+            eventId: string;
+        };
         /** SupportMessageContext */
         SupportMessageContext: {
             /**
@@ -5408,6 +5588,8 @@ export interface components {
             creditConsent: boolean;
             /** Creditname */
             creditName?: string | null;
+            /** Clientreleaseid */
+            clientReleaseId?: string | null;
             /**
              * Urgent
              * @default false
@@ -5485,6 +5667,8 @@ export interface components {
             posthogDistinctId?: string | null;
             /** Posthogsessionid */
             posthogSessionId?: string | null;
+            /** Sentryevents */
+            sentryEvents?: components["schemas"]["SupportSentryEventReference"][];
             /** Sentryeventids */
             sentryEventIds?: string[];
         };
@@ -5531,6 +5715,9 @@ export interface components {
             creditConsent: boolean;
             /** Creditname */
             creditName?: string | null;
+            /** Clientreleaseid */
+            clientReleaseId?: string | null;
+            telemetryRefs?: components["schemas"]["SupportReportTelemetryReferences"] | null;
         };
         /** SupportReportUploadResponse */
         SupportReportUploadResponse: {
@@ -5603,6 +5790,13 @@ export interface components {
             kind: "most_recent_workspace" | "choose_workspace" | "app_only";
             /** Workspaceids */
             workspaceIds?: string[];
+        };
+        /** SupportSentryEventReference */
+        SupportSentryEventReference: {
+            /** Project */
+            project: string;
+            /** Eventid */
+            eventId: string;
         };
         /** TeamCheckoutIntentResponse */
         TeamCheckoutIntentResponse: {
@@ -5732,10 +5926,7 @@ export interface components {
              * Format: uuid
              */
             id: string;
-            /**
-             * Email
-             * Format: email
-             */
+            /** Email */
             email: string;
             /**
              * Is Active
@@ -5782,6 +5973,19 @@ export interface components {
             ctx?: Record<string, never>;
         };
         /**
+         * WebAppCapability
+         * @description Whether a hosted web app exists for this deployment, and where it lives.
+         *
+         *     Self-managed deployments have no hosted web app (users connect the signed
+         *     desktop app), so ``available`` is false and the desktop hides web handoffs.
+         */
+        WebAppCapability: {
+            /** Available */
+            available: boolean;
+            /** Baseurl */
+            baseUrl: string | null;
+        };
+        /**
          * WorkerDesiredVersions
          * @description The component versions this server pins; workers converge onto these.
          */
@@ -5789,7 +5993,7 @@ export interface components {
             /** Worker */
             worker?: string | null;
             /** Anyharness */
-            anyharness: string;
+            anyharness?: string | null;
             /** Catalogversion */
             catalogVersion?: string | null;
         };
@@ -6610,10 +6814,10 @@ export interface operations {
     };
     github_app_installation_callback_endpoint_auth_github_app_installation_callback_get: {
         parameters: {
-            query: {
+            query?: {
                 installation_id?: string | null;
                 setup_action?: string | null;
-                state: string;
+                state?: string | null;
             };
             header?: never;
             path?: never;
@@ -6641,12 +6845,32 @@ export interface operations {
             };
         };
     };
+    github_app_connected_page_endpoint_auth_github_app_connected_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+        };
+    };
     github_app_setup_callback_endpoint_integrations_github_callback_get: {
         parameters: {
-            query: {
+            query?: {
                 installation_id?: string | null;
                 setup_action?: string | null;
-                state: string;
+                state?: string | null;
             };
             header?: never;
             path?: never;
@@ -9603,6 +9827,38 @@ export interface operations {
             };
         };
     };
+    runtime_artifact_download_endpoint_v1_cloud_runtime_download__target___asset__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target: string;
+                asset: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     integration_gateway_mcp_get_v1_cloud_integration_gateway_mcp_get: {
         parameters: {
             query?: never;
@@ -10301,6 +10557,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SupportReportCompleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_support_report_feed_internal_support_reports_get: {
+        parameters: {
+            query?: {
+                cursor?: string | null;
+                limit?: number;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupportFeedPage"];
                 };
             };
             /** @description Validation Error */

--- a/server/alembic/versions/b3c4d5e6f7a9_support_report_client_release_and_summary.py
+++ b/server/alembic/versions/b3c4d5e6f7a9_support_report_client_release_and_summary.py
@@ -1,0 +1,61 @@
+"""support_report client_release_id and tracker_summary
+
+Adds the immutable client release identifier and the server-produced scrubbed
+tracker summary to ``support_report``. Both are forward-only, nullable, and
+back-compatible: legacy rows keep NULL values and remain feedable with a
+visible warning through the private completed-report feed.
+
+Revision ID: b3c4d5e6f7a9
+Revises: a2b3c4d5e6f8
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3c4d5e6f7a9"
+down_revision: str | Sequence[str] | None = "a2b3c4d5e6f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    if not _has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    }
+
+
+def upgrade() -> None:
+    if not _has_table("support_report"):
+        return
+    if not _has_column("support_report", "client_release_id"):
+        op.add_column(
+            "support_report",
+            sa.Column("client_release_id", sa.String(length=255), nullable=True),
+        )
+    if not _has_column("support_report", "tracker_summary"):
+        op.add_column(
+            "support_report",
+            sa.Column("tracker_summary", sa.String(length=240), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if not _has_table("support_report"):
+        return
+    if _has_column("support_report", "tracker_summary"):
+        op.drop_column("support_report", "tracker_summary")
+    if _has_column("support_report", "client_release_id"):
+        op.drop_column("support_report", "client_release_id")

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -305,6 +305,14 @@ class Settings(BaseSettings):
     support_report_attachment_max_bytes: int = 25 * 1024 * 1024
     support_report_total_attachment_max_bytes: int = 100 * 1024 * 1024
     support_report_internal_base_url: str = ""
+    # Dedicated Bearer key for the private completed-report feed
+    # (GET /internal/support/reports). Empty disables the feed (every request is
+    # rejected); the route still exists so the feed is dark-deployable.
+    support_feed_bearer_token: str = ""
+    # When true, production report completion rejects a missing/malformed
+    # canonical client release ID. Defaults off so the capability deploys dark
+    # until clients emit their canonical release IDs.
+    support_report_require_client_release: bool = False
     signups_slack_webhook_url: str = ""
     billing_positive_slack_webhook_url: str = ""
     billing_negative_slack_webhook_url: str = ""

--- a/server/proliferate/db/models/support.py
+++ b/server/proliferate/db/models/support.py
@@ -98,6 +98,13 @@ class SupportReport(Base):
     kind: Mapped[str] = mapped_column(String(32), server_default="bug", default="bug")
     credit_consent: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     credit_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Immutable canonical client release ID (<component>@<semver>+<12-char-sha>)
+    # captured with the report intent. NULL for legacy/malformed values, which
+    # remain feedable with a visible warning.
+    client_release_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Server-produced, scrubbed, bounded (<=240 char) summary derived from the
+    # report message. It never substitutes for the private report body.
+    tracker_summary: Mapped[str | None] = mapped_column(String(240), nullable=True)
     urgent: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     notify_me: Mapped[bool] = mapped_column(Boolean, server_default="false", default=False)
     request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)

--- a/server/proliferate/db/store/support_reports.py
+++ b/server/proliferate/db/store/support_reports.py
@@ -7,11 +7,34 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.db.models.auth import User
 from proliferate.db.models.support import SupportReport
 from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class SupportFeedReportRow:
+    """Privacy-safe projection of a completed report for the internal feed.
+
+    Only fields the feed may expose are read. The account email is never
+    selected; ``owner_outreach_email`` is the explicit outreach override only.
+    """
+
+    id: str
+    owner_user_id: UUID
+    kind: str
+    tracker_summary: str | None
+    client_release_id: str | None
+    notify_me: bool
+    credit_consent: bool
+    credit_name: str | None
+    owner_outreach_email: str | None
+    telemetry_refs: dict[str, object]
+    created_at: datetime
+    completed_at: datetime
 
 
 @dataclass(frozen=True)
@@ -35,6 +58,8 @@ class SupportReportSnapshot:
     kind: str
     credit_consent: bool
     credit_name: str | None
+    client_release_id: str | None
+    tracker_summary: str | None
     urgent: bool
     notify_me: bool
     request_id: str | None
@@ -117,6 +142,8 @@ async def create_report(
     kind: str,
     credit_consent: bool,
     credit_name: str | None = None,
+    client_release_id: str | None = None,
+    tracker_summary: str | None = None,
     urgent: bool = False,
     notify_me: bool = False,
     request_id: str | None = None,
@@ -143,6 +170,8 @@ async def create_report(
         kind=kind,
         credit_consent=credit_consent,
         credit_name=credit_name,
+        client_release_id=client_release_id,
+        tracker_summary=tracker_summary,
         urgent=urgent,
         notify_me=notify_me,
         request_id=request_id,
@@ -381,6 +410,56 @@ async def mark_tracker_slack_notified(
     return _snapshot(row)
 
 
+async def list_completed_reports_for_feed(
+    db: AsyncSession,
+    *,
+    after_completed_at: datetime | None,
+    after_id: str | None,
+    limit: int,
+) -> list[SupportFeedReportRow]:
+    """Return completed reports ordered by ``(completed_at, id)``.
+
+    An empty cursor (both bounds ``None``) starts from the oldest completion.
+    The caller reads ``limit + 1`` to determine ``hasMore``.
+    """
+
+    query = (
+        select(SupportReport, User.outreach_email)
+        .join(User, User.id == SupportReport.owner_user_id)
+        .where(
+            SupportReport.status == "completed",
+            SupportReport.completed_at.is_not(None),
+        )
+        .order_by(SupportReport.completed_at.asc(), SupportReport.id.asc())
+        .limit(limit)
+    )
+    if after_completed_at is not None and after_id is not None:
+        query = query.where(
+            tuple_(SupportReport.completed_at, SupportReport.id)
+            > (after_completed_at, after_id)
+        )
+    rows = (await db.execute(query)).all()
+    return [_feed_row(report, outreach_email) for report, outreach_email in rows]
+
+
+def _feed_row(row: SupportReport, owner_outreach_email: str | None) -> SupportFeedReportRow:
+    assert row.completed_at is not None
+    return SupportFeedReportRow(
+        id=row.id,
+        owner_user_id=row.owner_user_id,
+        kind=row.kind,
+        tracker_summary=row.tracker_summary,
+        client_release_id=row.client_release_id,
+        notify_me=row.notify_me,
+        credit_consent=row.credit_consent,
+        credit_name=row.credit_name,
+        owner_outreach_email=owner_outreach_email,
+        telemetry_refs=_dict_json(row.telemetry_refs_json),
+        created_at=row.created_at,
+        completed_at=row.completed_at,
+    )
+
+
 async def _require_report_row(db: AsyncSession, report_id: str) -> SupportReport:
     row = await db.get(SupportReport, report_id)
     if row is None:
@@ -415,6 +494,8 @@ def _snapshot(row: SupportReport) -> SupportReportSnapshot:
         kind=row.kind,
         credit_consent=row.credit_consent,
         credit_name=row.credit_name,
+        client_release_id=row.client_release_id,
+        tracker_summary=row.tracker_summary,
         urgent=row.urgent,
         notify_me=row.notify_me,
         request_id=row.request_id,

--- a/server/proliferate/db/store/support_reports.py
+++ b/server/proliferate/db/store/support_reports.py
@@ -435,8 +435,7 @@ async def list_completed_reports_for_feed(
     )
     if after_completed_at is not None and after_id is not None:
         query = query.where(
-            tuple_(SupportReport.completed_at, SupportReport.id)
-            > (after_completed_at, after_id)
+            tuple_(SupportReport.completed_at, SupportReport.id) > (after_completed_at, after_id)
         )
     rows = (await db.execute(query)).all()
     return [_feed_row(report, outreach_email) for report, outreach_email in rows]

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -77,6 +77,7 @@ from proliferate.server.organizations.usage.api import router as organization_us
 from proliferate.server.setup.api import router as first_run_setup_router
 from proliferate.server.setup.lifecycle import ensure_first_run_setup_token
 from proliferate.server.support.api import router as support_router
+from proliferate.server.support.feed.api import router as support_feed_router
 from proliferate.server.version import server_version
 from proliferate.utils.logging import configure_server_logging
 
@@ -288,6 +289,10 @@ def create_app() -> FastAPI:
     app.include_router(catalogs_router, prefix=f"{api_prefix}/v1", tags=["catalogs"])
     app.include_router(ai_magic_router, prefix=f"{api_prefix}/v1", tags=["ai_magic"])
     app.include_router(support_router, prefix=f"{api_prefix}/v1", tags=["support"])
+    # Private completed-report feed. Logical route /internal/support/reports
+    # (externally /api/internal/support/reports); dark-deployable behind a
+    # dedicated Bearer key.
+    app.include_router(support_feed_router, prefix=api_prefix, tags=["support-feed"])
     app.include_router(billing_router, prefix=f"{api_prefix}/v1", tags=["billing"])
     app.include_router(organizations_router, prefix=f"{api_prefix}/v1", tags=["organizations"])
     app.include_router(

--- a/server/proliferate/server/support/domain/report_records.py
+++ b/server/proliferate/server/support/domain/report_records.py
@@ -30,6 +30,9 @@ class SupportReportLike(Protocol):
     object_manifest: dict[str, object]
     expected_uploads: dict[str, object]
     public_content_consent: bool
+    kind: str
+    credit_consent: bool
+    credit_name: str | None
     urgent: bool
     notify_me: bool
 
@@ -241,6 +244,9 @@ def support_request_record(
         },
         "message": message.strip(),
         "publicContentConsent": report.public_content_consent,
+        "kind": report.kind,
+        "creditConsent": report.credit_consent,
+        "creditName": report.credit_name,
         "urgent": report.urgent,
         "notifyMe": report.notify_me,
         "context": report.source_context,

--- a/server/proliferate/server/support/domain/tracker_intent.py
+++ b/server/proliferate/server/support/domain/tracker_intent.py
@@ -1,0 +1,153 @@
+"""Pure server-produced support tracker intent derivations.
+
+These helpers derive the tracker-facing projection of a support report from the
+private report intent: the canonical client release ID, the normalized Sentry
+references, and the scrubbed bounded summary. They never expose the raw report
+body; the summary is a redacted, length-capped derivative.
+"""
+
+from __future__ import annotations
+
+import re
+
+from proliferate.server.support.redaction import redact_support_text
+
+# Canonical release components. The release ID always identifies the process
+# that emitted the report intent. Sentry project names are routing names, not
+# release components.
+RELEASE_COMPONENTS: frozenset[str] = frozenset(
+    {
+        "proliferate-server",
+        "proliferate-litellm",
+        "proliferate-web",
+        "proliferate-mobile",
+        "proliferate-desktop",
+        "proliferate-desktop-native",
+        "anyharness",
+        "proliferate-worker",
+        "proliferate-supervisor",
+    }
+)
+
+TRACKER_SUMMARY_MAX_CHARS = 240
+
+# <component>@<semver>+<12-char-sha>. Semver core is X.Y.Z with an optional
+# dot-separated pre-release suffix; the build SHA is exactly 12 lowercase hex.
+_RELEASE_ID_RE = re.compile(
+    r"^(?P<component>[a-z0-9][a-z0-9-]*)"
+    r"@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)"
+    r"\+(?P<sha>[0-9a-f]{12})$"
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def parse_client_release_id(value: str | None) -> str | None:
+    """Return the canonical release ID when valid, otherwise ``None``.
+
+    A malformed value is treated as absent so it stores as NULL and the report
+    stays feedable with a visible warning. The component must be one of the
+    fixed release components; project names are never release components.
+    """
+
+    if not value:
+        return None
+    candidate = value.strip()
+    match = _RELEASE_ID_RE.match(candidate)
+    if match is None:
+        return None
+    if match.group("component") not in RELEASE_COMPONENTS:
+        return None
+    return candidate
+
+
+def build_tracker_summary(message: str | None) -> str | None:
+    """Build the scrubbed, whitespace-collapsed, <=240 char tracker summary.
+
+    Secrets, bearer tokens, signed-URL query params, and long opaque strings are
+    redacted before truncation. The summary is an internal safe projection; it
+    is never a substitute for the private report body.
+    """
+
+    if not message:
+        return None
+    scrubbed = redact_support_text(message, max_chars=TRACKER_SUMMARY_MAX_CHARS * 4)
+    collapsed = _WHITESPACE_RE.sub(" ", scrubbed).strip()
+    if not collapsed:
+        return None
+    if len(collapsed) <= TRACKER_SUMMARY_MAX_CHARS:
+        return collapsed
+    # Reserve one character for the ellipsis so the stored value never exceeds
+    # the column bound.
+    return collapsed[: TRACKER_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
+
+
+def normalize_telemetry_refs(raw: dict[str, object] | None) -> dict[str, object]:
+    """Normalize telemetry references into the stored canonical shape.
+
+    Sentry references become ``{"sentryEvents": [{"project", "eventId"}]}``.
+    Structured ``{project, eventId}`` pairs are retained. Bare
+    ``sentryEventIds`` without a project are insufficient to form a pair; they
+    are preserved under ``sentryEventIds`` for later bounded backfill but are
+    never guessed into a project.
+    """
+
+    normalized: dict[str, object] = {}
+    if not isinstance(raw, dict):
+        return {}
+
+    for key in ("posthogDistinctId", "posthogSessionId"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            normalized[key] = value
+
+    pairs = _normalize_sentry_events(raw.get("sentryEvents"))
+    seen_event_ids = {pair["eventId"] for pair in pairs}
+    if pairs:
+        normalized["sentryEvents"] = pairs
+
+    unresolved = _project_less_event_ids(raw.get("sentryEventIds"), seen_event_ids)
+    if unresolved:
+        normalized["sentryEventIds"] = unresolved
+
+    return normalized
+
+
+def _normalize_sentry_events(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    pairs: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        project = item.get("project")
+        event_id = item.get("eventId")
+        if not isinstance(project, str) or not isinstance(event_id, str):
+            continue
+        project = project.strip()
+        event_id = event_id.strip()
+        if not project or not event_id:
+            continue
+        dedupe_key = (project, event_id)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        pairs.append({"project": project, "eventId": event_id})
+    return pairs
+
+
+def _project_less_event_ids(value: object, already_paired: set[str]) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    unresolved: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        event_id = item.strip()
+        if not event_id or event_id in already_paired or event_id in seen:
+            continue
+        seen.add(event_id)
+        unresolved.append(event_id)
+    return unresolved

--- a/server/proliferate/server/support/feed/access.py
+++ b/server/proliferate/server/support/feed/access.py
@@ -1,0 +1,36 @@
+"""Support feed access dependency.
+
+The feed uses a dedicated Bearer key, separate from employee/web/agent auth.
+The key is compared in constant time. An unset key rejects every request so the
+route is dark-deployable: it exists but is unusable until the key is provisioned.
+"""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import Header
+
+from proliferate.config import settings
+from proliferate.server.support.feed.errors import SupportFeedUnauthorized
+
+_BEARER_PREFIX = "Bearer "
+
+
+async def require_support_feed_key(
+    authorization: str | None = Header(default=None),
+) -> None:
+    configured = settings.support_feed_bearer_token.strip()
+    presented = _extract_bearer(authorization)
+    # Constant-time comparison; an unset configured key never authenticates.
+    if not configured or presented is None:
+        raise SupportFeedUnauthorized()
+    if not hmac.compare_digest(presented, configured):
+        raise SupportFeedUnauthorized()
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    if not authorization or not authorization.startswith(_BEARER_PREFIX):
+        return None
+    token = authorization[len(_BEARER_PREFIX) :].strip()
+    return token or None

--- a/server/proliferate/server/support/feed/api.py
+++ b/server/proliferate/server/support/feed/api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import get_async_session
+from proliferate.server.support.feed.access import require_support_feed_key
+from proliferate.server.support.feed.models import SupportFeedPage
+from proliferate.server.support.feed.service import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    MIN_LIMIT,
+    get_support_report_feed,
+)
+
+# Logical private route. The hosted product mounts server routes beneath /api,
+# so this is reached externally as /api/internal/support/reports. It is not a
+# public /v1 route and must not be replaced by /v1/support/reports/poll.
+router = APIRouter(prefix="/internal/support", tags=["support-feed"])
+
+
+@router.get(
+    "/reports",
+    response_model=SupportFeedPage,
+    dependencies=[Depends(require_support_feed_key)],
+)
+async def list_support_report_feed(
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=DEFAULT_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT),
+    db: AsyncSession = Depends(get_async_session),
+) -> SupportFeedPage:
+    return await get_support_report_feed(db=db, cursor=cursor, limit=limit)

--- a/server/proliferate/server/support/feed/domain/cursor.py
+++ b/server/proliferate/server/support/feed/domain/cursor.py
@@ -1,0 +1,78 @@
+"""Versioned authenticated opaque cursor for the support feed.
+
+The cursor wraps the ``(completed_at, id)`` order tuple and is authenticated
+with an HMAC so a tampered or forged cursor is rejected. It is pure: the signing
+secret is passed in by the caller. Decoding raises :class:`ValueError` on any
+malformed, mis-versioned, or tampered value; the service translates that into a
+product error.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime
+
+_CURSOR_VERSION = "v1"
+
+
+def encode_cursor(*, secret: str, completed_at: datetime, report_id: str) -> str:
+    payload = {
+        "v": _CURSOR_VERSION,
+        "c": _to_iso(completed_at),
+        "i": report_id,
+    }
+    body = _b64encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signature = _b64encode(_sign(secret, body))
+    return f"{_CURSOR_VERSION}.{body}.{signature}"
+
+
+def decode_cursor(*, secret: str, cursor: str) -> tuple[datetime, str]:
+    parts = cursor.split(".")
+    if len(parts) != 3:
+        raise ValueError("Malformed support feed cursor.")
+    version, body, signature = parts
+    if version != _CURSOR_VERSION:
+        raise ValueError("Unsupported support feed cursor version.")
+    expected_signature = _b64encode(_sign(secret, body))
+    if not hmac.compare_digest(signature, expected_signature):
+        raise ValueError("Support feed cursor signature mismatch.")
+    try:
+        payload = json.loads(_b64decode(body))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Corrupt support feed cursor payload.") from exc
+    if not isinstance(payload, dict) or payload.get("v") != _CURSOR_VERSION:
+        raise ValueError("Corrupt support feed cursor payload.")
+    completed_raw = payload.get("c")
+    report_id = payload.get("i")
+    if not isinstance(completed_raw, str) or not isinstance(report_id, str):
+        raise ValueError("Corrupt support feed cursor payload.")
+    return _from_iso(completed_raw), report_id
+
+
+def _sign(secret: str, body: str) -> bytes:
+    return hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _to_iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed

--- a/server/proliferate/server/support/feed/errors.py
+++ b/server/proliferate/server/support/feed/errors.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from proliferate.errors import InvalidRequest, ProliferateError
+
+
+class SupportFeedUnauthorized(ProliferateError):
+    code = "support_feed_unauthorized"
+    status_code = 401
+    headers: ClassVar[dict[str, str]] = {"WWW-Authenticate": "Bearer"}
+
+    def __init__(self) -> None:
+        super().__init__("A valid support feed bearer key is required.")
+
+
+class SupportFeedInvalidCursor(InvalidRequest):
+    code = "support_feed_invalid_cursor"
+
+    def __init__(self) -> None:
+        super().__init__("The support feed cursor is invalid.")

--- a/server/proliferate/server/support/feed/models.py
+++ b/server/proliferate/server/support/feed/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SupportFeedSentryEvent(BaseModel):
+    project: str
+    event_id: str = Field(alias="eventId")
+
+
+class SupportFeedItem(BaseModel):
+    report_id: str = Field(alias="reportId")
+    submitted_at: datetime = Field(alias="submittedAt")
+    completed_at: datetime = Field(alias="completedAt")
+    owner_user_id: str = Field(alias="ownerUserId")
+    kind: str
+    summary: str | None = None
+    release_id: str | None = Field(default=None, alias="releaseId")
+    # Machine-readable warning surfaced when the release is missing/malformed.
+    release_warning: str | None = Field(default=None, alias="releaseWarning")
+    notify_me: bool = Field(alias="notifyMe")
+    credit_consent: bool = Field(alias="creditConsent")
+    credit_name: str | None = Field(default=None, alias="creditName")
+    outreach_override: str | None = Field(default=None, alias="outreachOverride")
+    private_case_reference: str = Field(alias="privateCaseReference")
+    sentry_events: list[SupportFeedSentryEvent] = Field(
+        default_factory=list, alias="sentryEvents"
+    )
+    cursor: str
+
+    model_config = {"populate_by_name": True}
+
+
+class SupportFeedPage(BaseModel):
+    items: list[SupportFeedItem]
+    next_cursor: str | None = Field(default=None, alias="nextCursor")
+    has_more: bool = Field(alias="hasMore")
+
+    model_config = {"populate_by_name": True}

--- a/server/proliferate/server/support/feed/models.py
+++ b/server/proliferate/server/support/feed/models.py
@@ -25,9 +25,7 @@ class SupportFeedItem(BaseModel):
     credit_name: str | None = Field(default=None, alias="creditName")
     outreach_override: str | None = Field(default=None, alias="outreachOverride")
     private_case_reference: str = Field(alias="privateCaseReference")
-    sentry_events: list[SupportFeedSentryEvent] = Field(
-        default_factory=list, alias="sentryEvents"
-    )
+    sentry_events: list[SupportFeedSentryEvent] = Field(default_factory=list, alias="sentryEvents")
     cursor: str
 
     model_config = {"populate_by_name": True}

--- a/server/proliferate/server/support/feed/service.py
+++ b/server/proliferate/server/support/feed/service.py
@@ -1,0 +1,107 @@
+"""Private completed-report feed service.
+
+Exposes only completed reports, ordered by ``(completed_at, id)``, through a
+versioned authenticated opaque cursor. It never exposes the report message,
+diagnostics, attachments, object keys, signed URLs, account email, or log
+bodies. Private case evidence is fetched later through an audited support
+boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.store import support_reports
+from proliferate.db.store.support_reports import SupportFeedReportRow
+from proliferate.server.support.feed.domain.cursor import decode_cursor, encode_cursor
+from proliferate.server.support.feed.errors import SupportFeedInvalidCursor
+from proliferate.server.support.feed.models import (
+    SupportFeedItem,
+    SupportFeedPage,
+    SupportFeedSentryEvent,
+)
+
+DEFAULT_LIMIT = 50
+MIN_LIMIT = 1
+MAX_LIMIT = 100
+
+_RELEASE_MISSING_WARNING = "client_release_missing"
+
+
+async def get_support_report_feed(
+    *,
+    db: AsyncSession,
+    cursor: str | None,
+    limit: int,
+) -> SupportFeedPage:
+    bounded_limit = max(MIN_LIMIT, min(MAX_LIMIT, limit))
+    secret = _cursor_secret()
+
+    after_completed_at = None
+    after_id = None
+    if cursor:
+        try:
+            after_completed_at, after_id = decode_cursor(secret=secret, cursor=cursor)
+        except ValueError as exc:
+            raise SupportFeedInvalidCursor() from exc
+
+    # Read one extra row to determine hasMore without a second query.
+    rows = await support_reports.list_completed_reports_for_feed(
+        db,
+        after_completed_at=after_completed_at,
+        after_id=after_id,
+        limit=bounded_limit + 1,
+    )
+    has_more = len(rows) > bounded_limit
+    page_rows = rows[:bounded_limit]
+
+    items = [_feed_item(row, secret=secret) for row in page_rows]
+    next_cursor = items[-1].cursor if (has_more and items) else None
+    return SupportFeedPage(items=items, next_cursor=next_cursor, has_more=has_more)
+
+
+def _feed_item(row: SupportFeedReportRow, *, secret: str) -> SupportFeedItem:
+    item_cursor = encode_cursor(
+        secret=secret,
+        completed_at=row.completed_at,
+        report_id=row.id,
+    )
+    return SupportFeedItem(
+        reportId=row.id,
+        submittedAt=row.created_at,
+        completedAt=row.completed_at,
+        ownerUserId=str(row.owner_user_id),
+        kind=row.kind,
+        summary=row.tracker_summary,
+        releaseId=row.client_release_id,
+        releaseWarning=None if row.client_release_id else _RELEASE_MISSING_WARNING,
+        notifyMe=row.notify_me,
+        creditConsent=row.credit_consent,
+        creditName=row.credit_name if row.credit_consent else None,
+        outreachOverride=row.owner_outreach_email,
+        privateCaseReference=f"support-report:{row.id}",
+        sentryEvents=_sentry_events(row.telemetry_refs),
+        cursor=item_cursor,
+    )
+
+
+def _sentry_events(telemetry_refs: dict[str, object]) -> list[SupportFeedSentryEvent]:
+    raw = telemetry_refs.get("sentryEvents")
+    if not isinstance(raw, list):
+        return []
+    events: list[SupportFeedSentryEvent] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        project = entry.get("project")
+        event_id = entry.get("eventId")
+        if isinstance(project, str) and isinstance(event_id, str) and project and event_id:
+            events.append(SupportFeedSentryEvent(project=project, eventId=event_id))
+    return events
+
+
+def _cursor_secret() -> str:
+    # The cursor is authenticated with a stable server secret so it survives
+    # restarts. jwt_secret is always configured in production.
+    return settings.jwt_secret

--- a/server/proliferate/server/support/models.py
+++ b/server/proliferate/server/support/models.py
@@ -129,9 +129,7 @@ class SupportReportCreateRequest(BaseModel):
     credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
     # Canonical client release ID (<component>@<semver>+<12-char-sha>) captured
     # with the immutable report intent. Malformed/absent values store as NULL.
-    client_release_id: str | None = Field(
-        default=None, alias="clientReleaseId", max_length=255
-    )
+    client_release_id: str | None = Field(default=None, alias="clientReleaseId", max_length=255)
     urgent: bool = Field(default=False, alias="urgent")
     notify_me: bool = Field(default=False, alias="notifyMe")
 
@@ -188,9 +186,7 @@ class SupportReportUploadRequest(BaseModel):
     kind: Literal["bug", "feature"] = Field(default="bug")
     credit_consent: bool = Field(default=False, alias="creditConsent")
     credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
-    client_release_id: str | None = Field(
-        default=None, alias="clientReleaseId", max_length=255
-    )
+    client_release_id: str | None = Field(default=None, alias="clientReleaseId", max_length=255)
     telemetry_refs: SupportReportTelemetryReferences | None = Field(
         default=None,
         alias="telemetryRefs",

--- a/server/proliferate/server/support/models.py
+++ b/server/proliferate/server/support/models.py
@@ -68,6 +68,11 @@ class SupportReportWorkspaceReference(BaseModel):
     sandbox_type: str | None = Field(default=None, alias="sandboxType", max_length=128)
 
 
+class SupportSentryEventReference(BaseModel):
+    project: str = Field(min_length=1, max_length=128)
+    event_id: str = Field(alias="eventId", min_length=1, max_length=128)
+
+
 class SupportReportTelemetryReferences(BaseModel):
     posthog_distinct_id: str | None = Field(
         default=None,
@@ -79,6 +84,13 @@ class SupportReportTelemetryReferences(BaseModel):
         alias="posthogSessionId",
         max_length=255,
     )
+    # Canonical {project, eventId} Sentry references. Clients should send these
+    # so the tracker can resolve the exact Sentry issue.
+    sentry_events: list[SupportSentryEventReference] = Field(
+        default_factory=list, alias="sentryEvents", max_length=20
+    )
+    # Legacy project-less event IDs. Insufficient to form a pair; retained for
+    # later bounded backfill and never guessed into a project.
     sentry_event_ids: list[str] = Field(
         default_factory=list, alias="sentryEventIds", max_length=20
     )
@@ -115,6 +127,11 @@ class SupportReportCreateRequest(BaseModel):
     kind: Literal["bug", "feature"] = Field(default="bug")
     credit_consent: bool = Field(default=False, alias="creditConsent")
     credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
+    # Canonical client release ID (<component>@<semver>+<12-char-sha>) captured
+    # with the immutable report intent. Malformed/absent values store as NULL.
+    client_release_id: str | None = Field(
+        default=None, alias="clientReleaseId", max_length=255
+    )
     urgent: bool = Field(default=False, alias="urgent")
     notify_me: bool = Field(default=False, alias="notifyMe")
 
@@ -171,6 +188,13 @@ class SupportReportUploadRequest(BaseModel):
     kind: Literal["bug", "feature"] = Field(default="bug")
     credit_consent: bool = Field(default=False, alias="creditConsent")
     credit_name: str | None = Field(default=None, alias="creditName", max_length=200)
+    client_release_id: str | None = Field(
+        default=None, alias="clientReleaseId", max_length=255
+    )
+    telemetry_refs: SupportReportTelemetryReferences | None = Field(
+        default=None,
+        alias="telemetryRefs",
+    )
 
 
 class SupportReportUploadTargetsRequest(BaseModel):

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.config import settings
 from proliferate.db.store import support_reports
 from proliferate.integrations.aws import (
     AwsIntegrationError,
@@ -18,13 +19,7 @@ from proliferate.middleware.request_context import (
     set_resource_tenant_context,
     set_support_report_context,
 )
-from proliferate.config import settings
 from proliferate.server.support.domain.message import normalize_support_message
-from proliferate.server.support.domain.tracker_intent import (
-    build_tracker_summary,
-    normalize_telemetry_refs,
-    parse_client_release_id,
-)
 from proliferate.server.support.domain.report_records import (
     expected_manifest_entries,
     expected_manifest_keys,
@@ -37,6 +32,11 @@ from proliferate.server.support.domain.report_records import (
     tenant_context_for_report,
     trusted_workspace_refs_for_report,
     workspace_refs_for_create,
+)
+from proliferate.server.support.domain.tracker_intent import (
+    build_tracker_summary,
+    normalize_telemetry_refs,
+    parse_client_release_id,
 )
 from proliferate.server.support.errors import (
     SupportMessageEmpty,

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -18,7 +18,13 @@ from proliferate.middleware.request_context import (
     set_resource_tenant_context,
     set_support_report_context,
 )
+from proliferate.config import settings
 from proliferate.server.support.domain.message import normalize_support_message
+from proliferate.server.support.domain.tracker_intent import (
+    build_tracker_summary,
+    normalize_telemetry_refs,
+    parse_client_release_id,
+)
 from proliferate.server.support.domain.report_records import (
     expected_manifest_entries,
     expected_manifest_keys,
@@ -168,10 +174,10 @@ async def create_support_report(
             source_surface=body.source_surface,
             source_context=support_context_record(body.context),
             workspace_refs=trusted_workspace_refs,
-            telemetry_refs=(
+            telemetry_refs=normalize_telemetry_refs(
                 body.telemetry_refs.model_dump(by_alias=True, exclude_none=True)
                 if body.telemetry_refs
-                else {}
+                else None
             ),
             expected_uploads=body.expected_client_uploads.model_dump(by_alias=True),
             public_content_consent=False,
@@ -180,6 +186,10 @@ async def create_support_report(
             # Credit consent is available on both the bug and prompt modals
             # (previously prompt-only); gate on consent alone.
             credit_name=(body.credit_name if body.credit_consent else None),
+            # Immutable canonical release ID and scrubbed summary are produced
+            # server-side at capture; a malformed release stores as NULL.
+            client_release_id=parse_client_release_id(body.client_release_id),
+            tracker_summary=build_tracker_summary(body.message),
             urgent=body.urgent,
             notify_me=body.notify_me,
             request_id=get_request_id(),
@@ -303,6 +313,9 @@ async def create_support_report_upload(
             publicContentConsent=False,
             kind=body.kind,
             creditConsent=body.credit_consent,
+            creditName=body.credit_name,
+            clientReleaseId=body.client_release_id,
+            telemetryRefs=body.telemetry_refs,
         ),
     )
     return await create_support_report_upload_targets(
@@ -358,6 +371,15 @@ async def _complete_db_backed_report(
         raise SupportReportUploadInvalid("Support report upload belongs to another user.")
     if report.status == "completed":
         return SupportReportCompleteResponse(reportId=report.id)
+
+    # New production reports must carry a canonical client release ID before
+    # completion. Dark by default: legacy rows (created before the column, or
+    # with a malformed release) store NULL and stay feedable with a visible
+    # warning. P2 flips this on once every client emits its canonical release.
+    if settings.support_report_require_client_release and report.client_release_id is None:
+        raise SupportReportUploadInvalid(
+            "Support report is missing a canonical client release ID."
+        )
 
     _install_report_correlation(report)
     manifest = report.object_manifest

--- a/server/tests/integration/test_support_feed.py
+++ b/server/tests/integration/test_support_feed.py
@@ -1,0 +1,296 @@
+"""Integration tests for the private completed-report support feed."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.models.auth import User
+from proliferate.db.models.support import SupportReport
+
+_FEED_PATH = "/internal/support/reports"
+_FEED_TOKEN = "test-support-feed-token"
+_ACCOUNT_EMAIL_SENTINEL = "private-account@example.com"
+
+
+@pytest.fixture(autouse=True)
+def _configure_feed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "support_feed_bearer_token", _FEED_TOKEN)
+    monkeypatch.setattr(settings, "jwt_secret", "feed-cursor-secret")
+
+
+async def _make_user(db: AsyncSession, *, outreach_email: str | None = None) -> User:
+    user = User(
+        id=uuid4(),
+        email=f"{uuid4().hex}-{_ACCOUNT_EMAIL_SENTINEL}",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        outreach_email=outreach_email,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_completed_report(
+    db: AsyncSession,
+    *,
+    owner: User,
+    completed_at: datetime,
+    report_id: str | None = None,
+    kind: str = "bug",
+    tracker_summary: str | None = "Prod is down.",
+    client_release_id: str | None = "proliferate-web@0.3.26+9affc0f0d489",
+    notify_me: bool = False,
+    credit_consent: bool = False,
+    credit_name: str | None = None,
+    telemetry_refs: dict[str, object] | None = None,
+) -> str:
+    rid = report_id or uuid4().hex
+    db.add(
+        SupportReport(
+            id=rid,
+            client_job_id=uuid4().hex,
+            owner_user_id=owner.id,
+            primary_tenant_id=f"user:{owner.id}",
+            status="completed",
+            s3_bucket="private-support-bucket",
+            s3_prefix=f"support/reports/{rid}",
+            kind=kind,
+            notify_me=notify_me,
+            credit_consent=credit_consent,
+            credit_name=credit_name,
+            client_release_id=client_release_id,
+            tracker_summary=tracker_summary,
+            telemetry_refs_json=json.dumps(telemetry_refs or {}),
+            created_at=completed_at - timedelta(minutes=5),
+            updated_at=completed_at,
+            completed_at=completed_at,
+        )
+    )
+    await db.flush()
+    return rid
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_FEED_TOKEN}"}
+
+
+async def test_feed_rejects_missing_and_wrong_key(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner = await _make_user(db_session)
+    await _make_completed_report(
+        db_session, owner=owner, completed_at=datetime(2026, 7, 1, tzinfo=UTC)
+    )
+    await db_session.commit()
+
+    assert (await client.get(_FEED_PATH)).status_code == 401
+    assert (
+        await client.get(_FEED_PATH, headers={"Authorization": "Bearer wrong"})
+    ).status_code == 401
+    assert (await client.get(_FEED_PATH, headers=_auth())).status_code == 200
+
+
+async def test_feed_unset_key_rejects_every_request(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "support_feed_bearer_token", "")
+    # Even the empty string presented as a token must not authenticate.
+    assert (await client.get(_FEED_PATH, headers={"Authorization": "Bearer "})).status_code == 401
+    assert (await client.get(_FEED_PATH, headers=_auth())).status_code == 401
+
+
+async def test_feed_item_is_privacy_safe(client: AsyncClient, db_session: AsyncSession) -> None:
+    owner = await _make_user(db_session, outreach_email="override@example.com")
+    rid = await _make_completed_report(
+        db_session,
+        owner=owner,
+        completed_at=datetime(2026, 7, 2, 9, 0, tzinfo=UTC),
+        kind="feature",
+        tracker_summary="App crashed on launch.",
+        notify_me=True,
+        credit_consent=True,
+        credit_name="Ada Lovelace",
+        telemetry_refs={
+            "sentryEvents": [{"project": "proliferate-web", "eventId": "evt_1"}],
+            "sentryEventIds": ["bare_id"],
+            "posthogDistinctId": "distinct_1",
+        },
+    )
+    await db_session.commit()
+
+    response = await client.get(_FEED_PATH, headers=_auth())
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["hasMore"] is False
+    (item,) = payload["items"]
+
+    assert item["reportId"] == rid
+    assert item["kind"] == "feature"
+    assert item["summary"] == "App crashed on launch."
+    assert item["releaseId"] == "proliferate-web@0.3.26+9affc0f0d489"
+    assert item["releaseWarning"] is None
+    assert item["notifyMe"] is True
+    assert item["creditConsent"] is True
+    assert item["creditName"] == "Ada Lovelace"
+    assert item["outreachOverride"] == "override@example.com"
+    assert item["privateCaseReference"] == f"support-report:{rid}"
+    assert item["sentryEvents"] == [{"project": "proliferate-web", "eventId": "evt_1"}]
+    assert isinstance(item["cursor"], str) and item["cursor"]
+
+    # Nothing private may leak anywhere in the serialized payload.
+    raw = response.text
+    for forbidden in (
+        _ACCOUNT_EMAIL_SENTINEL,
+        owner.email,
+        "private-support-bucket",
+        "support/reports/",
+        "distinct_1",
+        "bare_id",
+        "hashed_password",
+        "request.json",
+    ):
+        assert forbidden not in raw, forbidden
+
+
+async def test_feed_legacy_null_release_has_warning(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner = await _make_user(db_session)
+    await _make_completed_report(
+        db_session,
+        owner=owner,
+        completed_at=datetime(2026, 7, 3, tzinfo=UTC),
+        client_release_id=None,
+    )
+    await db_session.commit()
+
+    payload = (await client.get(_FEED_PATH, headers=_auth())).json()
+    (item,) = payload["items"]
+    assert item["releaseId"] is None
+    assert item["releaseWarning"] == "client_release_missing"
+
+
+async def test_feed_same_timestamp_pagination_no_skip_or_dupe(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner = await _make_user(db_session)
+    shared = datetime(2026, 7, 4, 12, 0, 0, tzinfo=UTC)
+    ids = sorted(uuid4().hex for _ in range(5))
+    for rid in ids:
+        await _make_completed_report(db_session, owner=owner, completed_at=shared, report_id=rid)
+    await db_session.commit()
+
+    collected: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):
+        params = {"limit": "2"}
+        if cursor:
+            params["cursor"] = cursor
+        payload = (await client.get(_FEED_PATH, headers=_auth(), params=params)).json()
+        collected.extend(entry["reportId"] for entry in payload["items"])
+        if not payload["hasMore"]:
+            break
+        cursor = payload["nextCursor"]
+        assert cursor is not None
+
+    assert collected == ids  # ordered by id under the shared timestamp; no gaps/dupes
+
+
+async def test_feed_full_pagination_count_parity(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner = await _make_user(db_session)
+    base = datetime(2026, 7, 5, tzinfo=UTC)
+    expected = set()
+    for offset in range(7):
+        expected.add(
+            await _make_completed_report(
+                db_session, owner=owner, completed_at=base + timedelta(minutes=offset)
+            )
+        )
+    # A non-completed report must never appear in the feed.
+    db_session.add(
+        SupportReport(
+            id="uploading_report",
+            client_job_id=uuid4().hex,
+            owner_user_id=owner.id,
+            primary_tenant_id=f"user:{owner.id}",
+            status="uploading",
+            s3_bucket="b",
+            s3_prefix="p",
+        )
+    )
+    await db_session.commit()
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(20):
+        params = {"limit": "3"}
+        if cursor:
+            params["cursor"] = cursor
+        payload = (await client.get(_FEED_PATH, headers=_auth(), params=params)).json()
+        seen.extend(entry["reportId"] for entry in payload["items"])
+        if not payload["hasMore"]:
+            break
+        cursor = payload["nextCursor"]
+
+    assert set(seen) == expected
+    assert len(seen) == len(expected)
+    assert "uploading_report" not in seen
+
+
+async def test_feed_cursor_replay_is_deterministic(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    owner = await _make_user(db_session)
+    base = datetime(2026, 7, 6, tzinfo=UTC)
+    for offset in range(4):
+        await _make_completed_report(
+            db_session, owner=owner, completed_at=base + timedelta(minutes=offset)
+        )
+    await db_session.commit()
+
+    first = (await client.get(_FEED_PATH, headers=_auth(), params={"limit": "2"})).json()
+    cursor = first["items"][-1]["cursor"]
+
+    a = await client.get(_FEED_PATH, headers=_auth(), params={"cursor": cursor, "limit": "2"})
+    b = await client.get(_FEED_PATH, headers=_auth(), params={"cursor": cursor, "limit": "2"})
+    assert a.status_code == 200 and b.status_code == 200
+    assert a.text == b.text
+
+
+async def test_feed_rejects_tampered_cursor(client: AsyncClient, db_session: AsyncSession) -> None:
+    owner = await _make_user(db_session)
+    await _make_completed_report(
+        db_session, owner=owner, completed_at=datetime(2026, 7, 7, tzinfo=UTC)
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        _FEED_PATH, headers=_auth(), params={"cursor": "v1.tampered.signature"}
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "support_feed_invalid_cursor"
+
+
+async def test_feed_limit_bounds_enforced(client: AsyncClient, db_session: AsyncSession) -> None:
+    owner = await _make_user(db_session)
+    await _make_completed_report(
+        db_session, owner=owner, completed_at=datetime(2026, 7, 8, tzinfo=UTC)
+    )
+    await db_session.commit()
+
+    too_low = await client.get(_FEED_PATH, headers=_auth(), params={"limit": "0"})
+    too_high = await client.get(_FEED_PATH, headers=_auth(), params={"limit": "101"})
+    assert too_low.status_code == 422
+    assert too_high.status_code == 422

--- a/server/tests/integration/test_support_report_capture.py
+++ b/server/tests/integration/test_support_report_capture.py
@@ -1,0 +1,147 @@
+"""Capture-time behavior for client release, summary, and telemetry refs."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.models.auth import User
+from proliferate.db.store import support_reports
+from proliferate.server.support import service
+from proliferate.server.support.errors import SupportReportUploadInvalid
+from proliferate.server.support.models import (
+    SupportReportCompleteRequest,
+    SupportReportCreateRequest,
+)
+
+
+@pytest.fixture(autouse=True)
+def _storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "support_report_s3_bucket", "private-support-bucket")
+    monkeypatch.setattr(settings, "support_report_s3_region", "")
+
+    async def _fake_put_json_object(**_: object) -> None:
+        return None
+
+    monkeypatch.setattr(service, "put_json_object", _fake_put_json_object)
+
+
+async def _user(db: AsyncSession) -> User:
+    user = User(
+        id=uuid4(),
+        email=f"{uuid4().hex}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def _create_body(**overrides: object) -> SupportReportCreateRequest:
+    payload: dict[str, object] = {
+        "clientJobId": uuid4().hex,
+        "message": "Login  broke.  token=super-secret",
+        "sourceSurface": "web",
+        "scope": {"kind": "app_only", "workspaceIds": []},
+        "expectedClientUploads": {"diagnostics": False, "attachmentCount": 0},
+    }
+    payload.update(overrides)
+    return SupportReportCreateRequest.model_validate(payload)
+
+
+async def test_create_stores_canonical_release_summary_and_refs(
+    db_session: AsyncSession,
+) -> None:
+    user = await _user(db_session)
+    response = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(
+            clientReleaseId="proliferate-web@0.3.26+9affc0f0d489",
+            telemetryRefs={
+                "sentryEvents": [{"project": "proliferate-web", "eventId": "e1"}],
+                "sentryEventIds": ["e1", "e2"],
+            },
+        ),
+    )
+
+    stored = await support_reports.get_report_by_id(db_session, response.report_id)
+    assert stored is not None
+    assert stored.client_release_id == "proliferate-web@0.3.26+9affc0f0d489"
+    assert stored.tracker_summary is not None
+    assert "super-secret" not in stored.tracker_summary
+    assert stored.telemetry_refs["sentryEvents"] == [
+        {"project": "proliferate-web", "eventId": "e1"}
+    ]
+    assert stored.telemetry_refs["sentryEventIds"] == ["e2"]
+
+
+async def test_create_nulls_malformed_release(db_session: AsyncSession) -> None:
+    user = await _user(db_session)
+    response = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(clientReleaseId="proliferate-cloud@bogus"),
+    )
+    stored = await support_reports.get_report_by_id(db_session, response.report_id)
+    assert stored is not None
+    assert stored.client_release_id is None
+
+
+async def test_completion_enforcement_rejects_missing_release_when_enabled(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "support_report_require_client_release", True)
+    user = await _user(db_session)
+    response = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(),  # no clientReleaseId
+    )
+    with pytest.raises(SupportReportUploadInvalid):
+        await service.complete_support_report_upload(
+            db=db_session,
+            sender_user_id=user.id,
+            sender_email=user.email,
+            sender_display_name=None,
+            report_id=response.report_id,
+            body=SupportReportCompleteRequest(),
+        )
+
+
+async def test_completion_allows_missing_release_when_disabled(
+    db_session: AsyncSession,
+) -> None:
+    # Dark by default: a legacy/absent release still completes.
+    user = await _user(db_session)
+    response = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(),
+    )
+    result = await service.complete_support_report_upload(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        report_id=response.report_id,
+        body=SupportReportCompleteRequest(),
+    )
+    assert result.report_id == response.report_id
+    stored = await support_reports.get_report_by_id(db_session, response.report_id)
+    assert stored is not None
+    assert stored.status == "completed"

--- a/server/tests/unit/test_support_feed_cursor.py
+++ b/server/tests/unit/test_support_feed_cursor.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from proliferate.server.support.feed.domain.cursor import decode_cursor, encode_cursor
+
+_SECRET = "cursor-signing-secret"
+
+
+def test_cursor_round_trip_preserves_tuple() -> None:
+    completed_at = datetime(2026, 7, 13, 12, 34, 56, tzinfo=UTC)
+    cursor = encode_cursor(secret=_SECRET, completed_at=completed_at, report_id="report_1")
+    decoded_at, decoded_id = decode_cursor(secret=_SECRET, cursor=cursor)
+    assert decoded_at == completed_at
+    assert decoded_id == "report_1"
+
+
+def test_cursor_is_deterministic() -> None:
+    completed_at = datetime(2026, 7, 13, tzinfo=UTC)
+    a = encode_cursor(secret=_SECRET, completed_at=completed_at, report_id="r")
+    b = encode_cursor(secret=_SECRET, completed_at=completed_at, report_id="r")
+    assert a == b
+
+
+def test_cursor_rejects_tampered_payload() -> None:
+    cursor = encode_cursor(
+        secret=_SECRET,
+        completed_at=datetime(2026, 7, 13, tzinfo=UTC),
+        report_id="r",
+    )
+    version, body, signature = cursor.split(".")
+    tampered = f"{version}.{body}x.{signature}"
+    with pytest.raises(ValueError):
+        decode_cursor(secret=_SECRET, cursor=tampered)
+
+
+def test_cursor_rejects_wrong_secret() -> None:
+    cursor = encode_cursor(
+        secret=_SECRET,
+        completed_at=datetime(2026, 7, 13, tzinfo=UTC),
+        report_id="r",
+    )
+    with pytest.raises(ValueError):
+        decode_cursor(secret="different-secret", cursor=cursor)
+
+
+def test_cursor_rejects_wrong_version() -> None:
+    cursor = encode_cursor(
+        secret=_SECRET,
+        completed_at=datetime(2026, 7, 13, tzinfo=UTC),
+        report_id="r",
+    )
+    _, body, signature = cursor.split(".")
+    with pytest.raises(ValueError):
+        decode_cursor(secret=_SECRET, cursor=f"v2.{body}.{signature}")
+
+
+def test_cursor_rejects_garbage() -> None:
+    with pytest.raises(ValueError):
+        decode_cursor(secret=_SECRET, cursor="not-a-cursor")

--- a/server/tests/unit/test_support_report_records.py
+++ b/server/tests/unit/test_support_report_records.py
@@ -6,7 +6,14 @@ from types import SimpleNamespace
 from proliferate.server.support.domain.report_records import support_request_record
 
 
-def _fake_report(*, urgent: bool, notify_me: bool) -> SimpleNamespace:
+def _fake_report(
+    *,
+    urgent: bool,
+    notify_me: bool,
+    kind: str = "bug",
+    credit_consent: bool = False,
+    credit_name: str | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         id="report_abc",
         client_job_id="job_abc",
@@ -18,6 +25,9 @@ def _fake_report(*, urgent: bool, notify_me: bool) -> SimpleNamespace:
         object_manifest={},
         expected_uploads={"diagnostics": True, "attachmentCount": 0},
         public_content_consent=False,
+        kind=kind,
+        credit_consent=credit_consent,
+        credit_name=credit_name,
         urgent=urgent,
         notify_me=notify_me,
     )
@@ -36,6 +46,27 @@ def test_support_request_record_includes_urgent_and_notify_me() -> None:
     assert record["urgent"] is True
     assert record["notifyMe"] is True
     assert record["message"] == "Prod is down."
+
+
+def test_support_request_record_includes_kind_and_credit_fields() -> None:
+    record = support_request_record(
+        report=_fake_report(
+            urgent=False,
+            notify_me=False,
+            kind="feature",
+            credit_consent=True,
+            credit_name="Ada Lovelace",
+        ),
+        sender_email="support@example.com",
+        sender_display_name="Support Tester",
+        message="Please add this.",
+        scope={"kind": "app_only", "workspaceIds": []},
+        correlation={"reportId": "report_abc"},
+    )
+
+    assert record["kind"] == "feature"
+    assert record["creditConsent"] is True
+    assert record["creditName"] == "Ada Lovelace"
 
 
 def test_support_request_record_defaults_capture_flags_false() -> None:

--- a/server/tests/unit/test_support_tracker_intent.py
+++ b/server/tests/unit/test_support_tracker_intent.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from proliferate.server.support.domain.tracker_intent import (
+    TRACKER_SUMMARY_MAX_CHARS,
+    build_tracker_summary,
+    normalize_telemetry_refs,
+    parse_client_release_id,
+)
+
+
+def test_parse_client_release_id_accepts_canonical_value() -> None:
+    value = "proliferate-desktop@0.3.26+9affc0f0d489"
+    assert parse_client_release_id(value) == value
+
+
+def test_parse_client_release_id_accepts_all_canonical_components() -> None:
+    for component in (
+        "proliferate-server",
+        "proliferate-litellm",
+        "proliferate-web",
+        "proliferate-mobile",
+        "proliferate-desktop",
+        "proliferate-desktop-native",
+        "anyharness",
+        "proliferate-worker",
+        "proliferate-supervisor",
+    ):
+        value = f"{component}@1.2.3+0123456789ab"
+        assert parse_client_release_id(value) == value
+
+
+def test_parse_client_release_id_rejects_unknown_component() -> None:
+    # Sentry project names are routing names, not release components.
+    assert parse_client_release_id("proliferate-cloud@0.3.26+9affc0f0d489") is None
+    assert parse_client_release_id("proliferate-target@0.3.26+9affc0f0d489") is None
+
+
+def test_parse_client_release_id_rejects_malformed_version_and_sha() -> None:
+    assert parse_client_release_id("proliferate-web@1.2+9affc0f0d489") is None
+    assert parse_client_release_id("proliferate-web@1.2.3+SHORT") is None
+    assert parse_client_release_id("proliferate-web@1.2.3+0123456789abcdef") is None
+    assert parse_client_release_id("proliferate-web@1.2.3+0123456789AB") is None
+    assert parse_client_release_id("0.3.26+9affc0f0d489") is None
+    assert parse_client_release_id(None) is None
+    assert parse_client_release_id("") is None
+
+
+def test_build_tracker_summary_scrubs_and_bounds() -> None:
+    message = "Login broke. token=super-secret-value contact me at a@b.com " + "x" * 400
+    summary = build_tracker_summary(message)
+    assert summary is not None
+    assert len(summary) <= TRACKER_SUMMARY_MAX_CHARS
+    assert "super-secret-value" not in summary
+
+
+def test_build_tracker_summary_collapses_whitespace() -> None:
+    summary = build_tracker_summary("  Prod   is\n\ndown  ")
+    assert summary == "Prod is down"
+
+
+def test_build_tracker_summary_empty_is_none() -> None:
+    assert build_tracker_summary("") is None
+    assert build_tracker_summary("    ") is None
+    assert build_tracker_summary(None) is None
+
+
+def test_normalize_telemetry_refs_keeps_pairs_and_dedupes() -> None:
+    normalized = normalize_telemetry_refs(
+        {
+            "sentryEvents": [
+                {"project": "proliferate-web", "eventId": "e1"},
+                {"project": "proliferate-web", "eventId": "e1"},
+                {"project": "proliferate-desktop", "eventId": "e2"},
+            ],
+            "sentryEventIds": ["e1", "e3"],
+            "posthogDistinctId": "d1",
+        }
+    )
+    assert normalized["sentryEvents"] == [
+        {"project": "proliferate-web", "eventId": "e1"},
+        {"project": "proliferate-desktop", "eventId": "e2"},
+    ]
+    # e1 already resolved to a pair; only the genuinely project-less id remains.
+    assert normalized["sentryEventIds"] == ["e3"]
+    assert normalized["posthogDistinctId"] == "d1"
+
+
+def test_normalize_telemetry_refs_never_guesses_project() -> None:
+    normalized = normalize_telemetry_refs({"sentryEventIds": ["e1", "e2"]})
+    assert "sentryEvents" not in normalized
+    assert normalized["sentryEventIds"] == ["e1", "e2"]
+
+
+def test_normalize_telemetry_refs_empty() -> None:
+    assert normalize_telemetry_refs(None) == {}
+    assert normalize_telemetry_refs({}) == {}

--- a/specs/codebase/features/support-reporting.md
+++ b/specs/codebase/features/support-reporting.md
@@ -192,9 +192,19 @@ POST /v1/support/reports/{reportId}/upload-targets
 POST /v1/support/reports/{reportId}/complete
 POST /v1/support/report-uploads                 legacy compatibility wrapper
 POST /v1/support/messages                       zero-upload compatibility shim
+GET  /internal/support/reports                   private completed-report feed
 ```
 
 There is no active `/tracker` endpoint.
+
+`GET /internal/support/reports` is a private machine route (externally
+`/api/internal/support/reports`), separate from user/web auth. It requires a
+dedicated `SUPPORT_FEED_BEARER_TOKEN` compared in constant time; an unset token
+rejects every request so the feed is dark-deployable. It returns only completed
+reports ordered by `(completed_at, id)` behind a versioned authenticated opaque
+cursor, and never exposes the message, diagnostics, attachments, object keys,
+signed URLs, account email, or log bodies. The downstream contract lives in
+[`support-system.md`](support-system.md).
 
 ### Create
 
@@ -261,6 +271,17 @@ include owner/client identity, lifecycle, S3 location, source/scope/reference
 JSON, expected and actual object manifests, kind/credit/urgent/notify intent,
 request IDs, timestamps, and Slack receipt state.
 
+Two immutable capture columns feed the downstream tracker projection:
+
+- `client_release_id` — the canonical `<component>@<semver>+<12-char-sha>`
+  release the client was running. A missing or malformed value stores NULL; the
+  row stays feedable with a visible warning. `telemetry_refs_json` normalizes
+  Sentry references to `{"sentryEvents": [{"project", "eventId"}]}`; project-less
+  event IDs are insufficient to form a pair and are never guessed.
+- `tracker_summary` — a server-produced, redacted, whitespace-collapsed summary
+  capped at 240 characters. It is a safe internal projection and never a
+  substitute for the private report body.
+
 Default object layout:
 
 ```text
@@ -316,6 +337,7 @@ cloud/sdk/src/client/support.ts
 cloud/sdk-react/src/hooks/support.ts
 
 server/proliferate/server/support/**
+server/proliferate/server/support/feed/**
 server/proliferate/db/models/support.py
 server/proliferate/db/store/support_reports.py
 

--- a/specs/codebase/features/support-system.md
+++ b/specs/codebase/features/support-system.md
@@ -835,7 +835,8 @@ The following are known implementation differences, not alternate contracts:
 - all six currently provisioned Grafana rules lack the required UID/component
   labels; none has the log-enrichment annotations, and no webhook health canary
   exists;
-- the support feed endpoint/key do not exist and production sync is disabled;
+- the private support feed endpoint and its dedicated key exist and are
+  dark-deployable, but tracker-side production sync is still disabled;
 - release identity is not deterministic on every component: server release is
   reused for target processes, mobile can fall back, supervisor has no runtime
   build stamp, and structured logs do not consistently emit `release_id`;

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -943,6 +943,18 @@
   description: Internal support-report viewer URL prefix; Slack, GitHub, and Linear receive only this report URL or report ID, never S3 keys
   tags: [production]
 
+- name: SUPPORT_FEED_BEARER_TOKEN
+  secret: true
+  default: ""
+  description: Dedicated Bearer key for the private completed-report feed (GET /internal/support/reports); empty rejects every request so the route is dark-deployable
+  tags: [production]
+
+- name: SUPPORT_REPORT_REQUIRE_CLIENT_RELEASE
+  secret: false
+  default: "false"
+  description: When true, report completion rejects a missing or malformed canonical client release ID; off by default until clients emit their release IDs
+  tags: [production]
+
 - name: SUPPORT_TRACKER_ENABLED
   secret: false
   default: "false"


### PR DESCRIPTION
P1 of the support-system program, implementing the "Support feed" contract in `support-system.md`.

- `support_report` gains immutable `client_release_id` (validated `<component>@<semver>+<12-char-sha>` against the 9-component allowlist; malformed → NULL, never guessed) and a scrubbed 240-char `tracker_summary` (migration `b3c4d5e6f7a9`, nullable adds only)
- `telemetry_refs_json` normalizes Sentry references to `{project, eventId}` pairs; project-less legacy IDs retained separately and never emitted
- Private feed `GET /internal/support/reports` (externally `/api/internal/support/reports`): dedicated Bearer key (`SUPPORT_FEED_BEARER_TOKEN`, constant-time compare, dark-deployable — empty key rejects everything), completed-only, `(completed_at, id)` order, limit 1–100, versioned HMAC opaque cursors per item + page `nextCursor`/`hasMore`
- Never exposes message, diagnostics, attachments, object keys, signed URLs, account email, or logs (snapshot-tested); `outreachOverride` is the explicit `outreach_email` override only
- Completion enforcement of canonical release behind `SUPPORT_REPORT_REQUIRE_CLIENT_RELEASE` (default off — flips on with P2 producers)
- SDK/OpenAPI regenerated; 1109 server tests pass incl. same-timestamp pagination, cursor replay/tamper, key rejection, privacy snapshots, historical count parity

Adversarially reviewed (privacy/auth/pagination/migration/release-validation): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)