### PR TITLE
docs(specs): promote web/desktop unification contract and rollout ledger

### DIFF
--- a/specs/codebase/features/README.md
+++ b/specs/codebase/features/README.md
@@ -31,6 +31,7 @@ low-level runtime contracts.
 | Terminals | Workspace terminal pane UX, terminal record actions, and the creation grid contract for new terminals. | [terminals.md](terminals.md) |
 | Workspace migration | Workspace migration flows, user attestation, durability, queue state, and completion/error semantics. | [workspace-migration.md](workspace-migration.md) |
 | Desktop updates | Packaged updater metadata, version-aware sidebar release notices, acknowledgment, and post-install behavior. | [desktop-updates.md](desktop-updates.md) |
+| Web/Desktop client unification | Shared `@proliferate/product-client` ownership boundary, thin Desktop/Web hosts, the composite host contract, product scope/authority isolation, capability policy, and the cutover's migration governance and definition of done. | [web-desktop-client-unification.md](web-desktop-client-unification.md) |
 
 ## Outline Coverage
 

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -802,8 +802,10 @@ with the exact PRODUCTION `only_surfaces` and
 failure, non-success, or unverifiable outcome enters a finally-style cleanup:
 restore EVERY gate to its recorded prior value or prior absence, read the
 restoration back and verify it, then release the landing hold and halt —
-except that an unexpected Deploy Staging run keeps the hold longer, per the
-rule below. The cleanup covers a partial override write or read-back failure,
+except as the terminality rule below requires the hold to be kept longer
+(any cancellation-requested run and any abnormal or unverifiable staging
+execution, not only an unexpected Deploy Staging run). The cleanup covers a
+partial override write or read-back failure,
 a failed merge, a merge-SHA tree mismatch, an exact-landing-SHA main CI
 failure/cancellation/timeout, an automatic staging
 failure/cancellation/timeout, an unexpected lane execution, an unexpected
@@ -815,21 +817,27 @@ failure is escalated — the hold is never released over unrestored gates. Only
 verified automatic staging success plus verified gate restoration may proceed
 to production promotion.
 
-**Unexpected-run cancellation is not terminal proof.** A cancellation request
-does not prove a run stopped, and a cancelled Deploy Staging run may already
-have partially deployed. For any unexpected Deploy Staging run after the
-first override mutation: request cancellation and restore/read back the gate
-state promptly, but KEEP the landing hold until the run is confirmed terminal
-AND its per-lane/deploy-summary/log evidence proves it produced no side
-effects — or until every possibly affected staging surface is restored to its
-recorded pre-landing staging baseline with artifact/health/routes
-re-verified. If terminality, the side-effect assessment, or that recovery
-cannot be proven, the hold remains and production stays hard-stopped and
-escalated. Only after confirmed terminality, absent-or-recovered effects, and
-verified gate restoration may the hold release — still halted for review,
-never proceeding to promotion. The failure and recovery evidence is recorded
-per the standing failure-evidence requirements (Phase V / incident record).
-The full mechanics live in the rollout ledger.
+**Terminality rule: cancellation is not terminal proof, and the hold outlives
+unproven runs.** A cancellation request does not prove a run stopped, and a
+cancelled run may already have acted. Once overrides are armed, gate
+restoration (with read-back verification) remains prompt in every case, but
+the landing hold may release only after ALL of the following are proven:
+every cancellation-requested run — a source main-CI run or any deploy run —
+is confirmed terminal; every cancelled source main-CI run is proven, across a
+bounded event-propagation barrier, to have emitted no downstream Deploy
+Staging run (if one appears, it is handled under this rule like any other
+staging execution); and every abnormal, failed, cancelled, timed-out, or
+unverifiable staging execution — including the expected exact-landing-SHA
+staging run executing unexpected lanes — is confirmed terminal AND its
+per-lane/deploy-summary/log evidence proves it produced no side effects, or
+every possibly affected staging surface is restored to its recorded
+pre-landing staging baseline with artifact/health/routes re-verified. Any
+unproven terminality, downstream-emission absence, side-effect assessment, or
+recovery retains the hold and hard-stops production with escalation. A fully
+proven failure path releases the hold only into halted-for-review, never into
+promotion. The failure and recovery evidence is recorded per the standing
+failure-evidence requirements (Phase V / incident record). The full mechanics
+live in the rollout ledger.
 
 **External configuration is mutated only after the landing merges, every
 PRODUCTION surface deploys at the exact merge SHA, and old + canonical routes

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -711,10 +711,12 @@ collapse the stack to main.
 
 Reviewed states are preserved as plainly named evidence branches under
 `refs/heads/wdu-evidence/**` (fetchable with ordinary `git fetch origin`,
-never force-pushed, deleted only per the final verification PR's branch
-index), with commit SHA, tree SHA, and stable patch hash recorded in the PR
-body/ledger. Consumers fetch and assert existence + recorded-hash equality
-before comparing. Committed ledgers contain no secret values — secrets are
+never force-pushed). Evidence branches are deleted only AFTER the docs-only
+post-cutover verification PR (Phase V) has merged, and only according to the
+branch index committed in its release record — never earlier at any
+intermediate checkpoint. Commit SHA, tree SHA, and stable patch hash are
+recorded in the PR body/ledger. Consumers fetch and assert existence +
+recorded-hash equality before comparing. Committed ledgers contain no secret values — secrets are
 referenced by name/location only.
 
 ### 10.3 Intake and freeze gates
@@ -767,11 +769,15 @@ staging/production deploy bases:
   promote workflow.
 
 Every DETECTED surface is explicitly dispositioned: PRODUCTION; reviewed
-staging-only (ungated lanes — Server, Web, E2B, LiteLLM — cannot be suppressed
-on the automatic path, so an ungated exclusion is reviewed staging-only or the
-chain stops); gate-suppressed (only actually gated lanes); or a separate
-reviewed artifact-release disposition (a detected Runtime surface has no
-hosted deploy lane). If Desktop is included, the release-prep version bump
+staging-only (ungated lanes — Server, Web, and E2B — cannot be suppressed on
+the automatic path, so an ungated exclusion is reviewed staging-only or the
+chain stops); gate-suppressed (only actually gated lanes: Mobile build via
+`MOBILE_DEPLOY_ENABLED`, Desktop via `DESKTOP_DEPLOY_ENABLED`, Workers via
+`WORKERS_DEPLOY_ENABLED`, and LiteLLM via `LITELLM_DEPLOY_ENABLED` in
+`.github/workflows/_deploy-litellm.yml`; gate lists are verified against the
+actual workflow files, never assumed); or a separate reviewed
+artifact-release disposition (a detected Runtime surface has no hosted deploy
+lane). If Desktop is included, the release-prep version bump
 (covering every canonical owning coordinate) is a distinct reviewed commit
 inside the replay list, with the exact-SHA tag and a new draft release created
 and published only at production promotion per the canonical desktop release
@@ -782,11 +788,23 @@ landing hold before the reviewed staging environment-gate overrides are set
 and read back; the merge happens only then; merge-SHA tree equality plus green
 main CI gates the automatic staging path; the automatic staging run is
 verified to have executed exactly EFFECTIVE_STAGING; gates are restored to
-their recorded prior state; and only then is the exact landing merge SHA
-promoted to production with the exact PRODUCTION `only_surfaces` and
-`require_staging_success=true`. No failure path leaves temporary overrides
-active. The full mechanics, including the failure-handling invariant, live in
-the rollout ledger.
+their recorded prior state with the restoration read back and verified; and
+only then is the exact landing merge SHA promoted to production with the exact
+PRODUCTION `only_surfaces` and `require_staging_success=true`.
+
+**Override cleanup invariant.** From the first override mutation onward, every
+failure, non-success, or unverifiable outcome enters a finally-style cleanup:
+restore EVERY gate to its recorded prior value or prior absence, read the
+restoration back and verify it, then release the landing hold and halt. This
+covers a partial override write or read-back failure, a failed merge, a
+merge-SHA tree mismatch, an exact-landing-SHA main CI failure/cancellation/
+timeout, an automatic staging failure/cancellation/timeout, an unexpected lane
+execution, and any state that cannot be verified. If restoration itself fails,
+production promotion is hard-stopped and the landing hold remains in place
+while the failure is escalated — the hold is never released over unrestored
+gates. Only verified automatic staging success plus verified gate restoration
+may proceed to production promotion. The full mechanics live in the rollout
+ledger.
 
 **External configuration is mutated only after the landing merges, every
 PRODUCTION surface deploys at the exact merge SHA, and old + canonical routes
@@ -795,18 +813,60 @@ classified, and recorded only. After deploy verification, items are applied
 one producer at a time: source change → activation (redeploy/restart/rebuild
 at the same landing SHA per the item's recorded mechanism) → secret-safe
 live-consumption proof → that producer's smoke. A source edit without
-activation is never an update. A failed smoke triggers immediate source
-restore, re-activation, live rollback proof, a recovery smoke, and a halt.
-Every item — changed or unchanged — closes only with live proof plus a
-successful mapped smoke. The per-item schema is defined in the rollout ledger.
+activation is never an update. **Any failure after a producer's
+source-of-truth mutation** — a failed or unverifiable activation, a failed or
+unverifiable live-consumption proof, or a failed smoke — triggers immediate
+source restore, re-activation at the same landing SHA, live rollback proof,
+the item's mapped recovery smoke, recorded evidence of both the failure and
+the recovery, and a halt. If the recovery itself cannot be proven, the
+sequence remains halted until it is. Every item — changed or unchanged —
+closes only with live proof plus a successful mapped smoke. The per-item
+schema is defined in the rollout ledger.
 
-The migration completes only when a docs-only post-cutover verification PR
-commits the immutable release record at
+### 10.6 Release-surface closure and the Phase V release record
+
+Before the accepted PR 4 head freezes, Phase H inventories and explicitly
+dispositions every required user-facing release surface: the landing page,
+public docs, changelog/release notes, in-app release notes/copy,
+install/download surfaces, support/runbook surfaces, and any further release
+surface the sweep discovers. Each disposition is exactly one of
+update-in-this-landing (the change enters the replay list),
+update-post-landing (with a named owner and deadline), or no-change-needed
+(with the reason recorded). These dispositions and their evidence carry into
+the landing's release plan and the Phase V record.
+
+The migration completes only when the docs-only post-cutover verification PR
+(Phase V) commits the immutable release record at
 `specs/developing/deploying/web-desktop-unification-release-record.md` and
-merges. There is no recovered-stable completion path: a halted external
-sequence blocks verification, evidence-branch cleanup, and completion.
+merges. That record seals, at minimum:
 
-### 10.6 Rollback
+- the exact landing merge SHA and per-surface deployed SHAs, with the reviewed
+  DETECTED / EFFECTIVE_STAGING / PRODUCTION sets and per-surface dispositions;
+- the landing-ordering evidence: quiescence proof, prior gate state, override
+  set/read-back, merge-SHA tree-equality + main-CI proof, EFFECTIVE_STAGING
+  per-lane execution proof, verified gate restoration, and the production
+  promotion record (`only_surfaces`, `require_staging_success=true`,
+  non-dry-run deploy-summary `headSha` evidence per surface);
+- per-surface artifact/health verification and old + canonical inbound route
+  verification;
+- each release-surface disposition and its outcome/evidence (if Desktop
+  shipped: the released version and exact SHA, the exact-SHA tag, the
+  published GitHub Release, and stable updater-manifest verification at that
+  version/SHA);
+- the complete external-item table: every item, changed or unchanged, with
+  activation mechanism used, secret-safe live-consumption proof, and mapped
+  smoke evidence (secrets redacted by name/location);
+- all failure and recovery evidence (source restores, re-activations, live
+  rollback proofs, recovery smokes, resolutions);
+- the requirement-by-requirement audit against this spec's definition of done;
+- the `wdu-evidence/**` branch index (names + recorded hashes) authorizing
+  their cleanup.
+
+No evidence branch is deleted before Phase V merges. There is no
+recovered-stable completion path: a halted external sequence blocks
+verification, evidence-branch cleanup, and completion.
+
+### 10.7 Rollback
 
 PR 0b, PR 0c, the docs/intake phases, PR 1, the browser removal, and PR 2 are
 each independently reversible merged units at their boundary. PR 3/PR 4 never

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -823,19 +823,23 @@ cancelled run may already have acted. Once overrides are armed, gate
 restoration (with read-back verification) remains prompt in every case, but
 the landing hold may release only after ALL of the following are proven:
 every cancellation-requested run — a source main-CI run or any deploy run —
-is confirmed terminal; EVERY cancellation-requested source main-CI run —
+is confirmed terminal; for EVERY cancellation-requested source main-CI run —
 regardless of its terminal conclusion, including one that wins the race and
-completes SUCCESS despite the cancellation request — is proven, across a
-bounded event-propagation barrier, to have emitted no downstream Deploy
-Staging run (any run it emitted routes through the abnormal-staging clause of
-this rule); and every abnormal, failed, cancelled, timed-out, or
+completes SUCCESS despite the cancellation request — every downstream Deploy
+Staging run it emitted is enumerated and accounted for across a bounded
+event-propagation barrier (zero emissions is acceptable; each emitted run
+routes through the abnormal-staging clause of this rule and must be fully
+handled), with the barrier proving that no late or otherwise unaccounted
+downstream emission remains before hold release; and every abnormal, failed,
+cancelled, timed-out, or
 unverifiable staging execution — including the expected exact-landing-SHA
 staging run executing unexpected lanes — is confirmed terminal AND its
 per-lane/deploy-summary/log evidence proves it produced no side effects, or
 every possibly affected staging surface is restored to its recorded
 pre-landing staging baseline with artifact/health/routes re-verified. Any
-unproven terminality, downstream-emission absence, side-effect assessment, or
-recovery retains the hold and hard-stops production with escalation. A fully
+unproven terminality, any unaccounted, late, or unhandled downstream
+emission, and any unproven side-effect assessment or recovery retains the
+hold and hard-stops production with escalation. A fully
 proven failure path releases the hold only into halted-for-review, never into
 promotion. The failure and recovery evidence is recorded per the standing
 failure-evidence requirements (Phase V / incident record). The full mechanics

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -823,10 +823,12 @@ cancelled run may already have acted. Once overrides are armed, gate
 restoration (with read-back verification) remains prompt in every case, but
 the landing hold may release only after ALL of the following are proven:
 every cancellation-requested run — a source main-CI run or any deploy run —
-is confirmed terminal; every cancelled source main-CI run is proven, across a
+is confirmed terminal; EVERY cancellation-requested source main-CI run —
+regardless of its terminal conclusion, including one that wins the race and
+completes SUCCESS despite the cancellation request — is proven, across a
 bounded event-propagation barrier, to have emitted no downstream Deploy
-Staging run (if one appears, it is handled under this rule like any other
-staging execution); and every abnormal, failed, cancelled, timed-out, or
+Staging run (any run it emitted routes through the abnormal-staging clause of
+this rule); and every abnormal, failed, cancelled, timed-out, or
 unverifiable staging execution — including the expected exact-landing-SHA
 staging run executing unexpected lanes — is confirmed terminal AND its
 per-lane/deploy-summary/log evidence proves it produced no side effects, or

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -783,14 +783,20 @@ inside the replay list, with the exact-SHA tag and a new draft release created
 and published only at production promotion per the canonical desktop release
 procedure.
 
-The landing order is binding: pre-override quiescence is proven under a
-landing hold before the reviewed staging environment-gate overrides are set
-and read back; the merge happens only then; merge-SHA tree equality plus green
-main CI gates the automatic staging path; the automatic staging run is
-verified to have executed exactly EFFECTIVE_STAGING; gates are restored to
-their recorded prior state with the restoration read back and verified; and
-only then is the exact landing merge SHA promoted to production with the exact
-PRODUCTION `only_surfaces` and `require_staging_success=true`.
+The landing order is binding: a landing hold explicitly blocks other main
+merges, main-CI reruns/manual dispatches, AND manual `deploy-staging.yml`
+`workflow_dispatch` runs (the workflow exposes an independent dispatch
+trigger); pre-override quiescence is proven under that hold — draining every
+queued/running Deploy Staging run regardless of trigger source as well as
+qualifying main-CI runs and their source correlations across a bounded
+propagation barrier — before the reviewed staging environment-gate overrides
+are set and read back; the merge happens only then; merge-SHA tree equality
+plus green main CI gates the automatic staging path; the automatic staging
+run is verified to have executed exactly EFFECTIVE_STAGING; gates are
+restored to their recorded prior state with the restoration read back and
+verified; and only then is the exact landing merge SHA promoted to production
+with the exact PRODUCTION `only_surfaces` and
+`require_staging_success=true`.
 
 **Override cleanup invariant.** From the first override mutation onward, every
 failure, non-success, or unverifiable outcome enters a finally-style cleanup:
@@ -799,7 +805,10 @@ restoration back and verify it, then release the landing hold and halt. This
 covers a partial override write or read-back failure, a failed merge, a
 merge-SHA tree mismatch, an exact-landing-SHA main CI failure/cancellation/
 timeout, an automatic staging failure/cancellation/timeout, an unexpected lane
-execution, and any state that cannot be verified. If restoration itself fails,
+execution, an unexpected Deploy Staging run from any trigger source — a manual
+`workflow_dispatch` or any run other than the expected exact-landing-SHA
+automatic run is cancelled immediately and enters this cleanup — and any state
+that cannot be verified. If restoration itself fails,
 production promotion is hard-stopped and the landing hold remains in place
 while the failure is escalated — the hold is never released over unrestored
 gates. Only verified automatic staging success plus verified gate restoration
@@ -819,9 +828,13 @@ unverifiable live-consumption proof, or a failed smoke — triggers immediate
 source restore, re-activation at the same landing SHA, live rollback proof,
 the item's mapped recovery smoke, recorded evidence of both the failure and
 the recovery, and a halt. If the recovery itself cannot be proven, the
-sequence remains halted until it is. Every item — changed or unchanged —
-closes only with live proof plus a successful mapped smoke. The per-item
-schema is defined in the rollout ledger.
+sequence remains halted until it is. An uncertain source-write outcome — a
+write that fails, times out, or returns an unverifiable result — is treated
+as a possible mutation: re-read the source of truth; if it provably still
+holds the prior value, record that evidence and halt before continuing; if it
+changed or its state cannot be verified, run the full recovery above. Every
+item — changed or unchanged — closes only with live proof plus a successful
+mapped smoke. The per-item schema is defined in the rollout ledger.
 
 ### 10.6 Release-surface closure and the Phase V release record
 
@@ -846,16 +859,21 @@ merges. That record seals, at minimum:
   set/read-back, merge-SHA tree-equality + main-CI proof, EFFECTIVE_STAGING
   per-lane execution proof, verified gate restoration, and the production
   promotion record (`only_surfaces`, `require_staging_success=true`,
-  non-dry-run deploy-summary `headSha` evidence per surface);
+  non-dry-run deploy-summary `headSha` evidence per surface, and the
+  deploy-run links for every staging and production run cited);
 - per-surface artifact/health verification and old + canonical inbound route
   verification;
 - each release-surface disposition and its outcome/evidence (if Desktop
   shipped: the released version and exact SHA, the exact-SHA tag, the
   published GitHub Release, and stable updater-manifest verification at that
   version/SHA);
-- the complete external-item table: every item, changed or unchanged, with
-  activation mechanism used, secret-safe live-consumption proof, and mapped
-  smoke evidence (secrets redacted by name/location);
+- the complete external-item table: for every item, changed or unchanged, its
+  secret-safe source location, actual before value, actual after value
+  (secrets redacted by name/location, never by value), required-change
+  classification, activation mechanism used, secret-safe live-consumption
+  proof, and who applied the change and when — plus, for every mapped smoke,
+  the flow run, its result, and its timestamp (explicit item→smoke mapping
+  wherever a shared smoke covers multiple items);
 - all failure and recovery evidence (source restores, re-activations, live
   rollback proofs, recovery smokes, resolutions);
 - the requirement-by-requirement audit against this spec's definition of done;

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -801,19 +801,35 @@ with the exact PRODUCTION `only_surfaces` and
 **Override cleanup invariant.** From the first override mutation onward, every
 failure, non-success, or unverifiable outcome enters a finally-style cleanup:
 restore EVERY gate to its recorded prior value or prior absence, read the
-restoration back and verify it, then release the landing hold and halt. This
-covers a partial override write or read-back failure, a failed merge, a
-merge-SHA tree mismatch, an exact-landing-SHA main CI failure/cancellation/
-timeout, an automatic staging failure/cancellation/timeout, an unexpected lane
-execution, an unexpected Deploy Staging run from any trigger source — a manual
-`workflow_dispatch` or any run other than the expected exact-landing-SHA
-automatic run is cancelled immediately and enters this cleanup — and any state
-that cannot be verified. If restoration itself fails,
-production promotion is hard-stopped and the landing hold remains in place
-while the failure is escalated — the hold is never released over unrestored
-gates. Only verified automatic staging success plus verified gate restoration
-may proceed to production promotion. The full mechanics live in the rollout
-ledger.
+restoration back and verify it, then release the landing hold and halt —
+except that an unexpected Deploy Staging run keeps the hold longer, per the
+rule below. The cleanup covers a partial override write or read-back failure,
+a failed merge, a merge-SHA tree mismatch, an exact-landing-SHA main CI
+failure/cancellation/timeout, an automatic staging
+failure/cancellation/timeout, an unexpected lane execution, an unexpected
+Deploy Staging run from any trigger source (a manual `workflow_dispatch` or
+any run other than the expected exact-landing-SHA automatic run), and any
+state that cannot be verified. If restoration itself fails, production
+promotion is hard-stopped and the landing hold remains in place while the
+failure is escalated — the hold is never released over unrestored gates. Only
+verified automatic staging success plus verified gate restoration may proceed
+to production promotion.
+
+**Unexpected-run cancellation is not terminal proof.** A cancellation request
+does not prove a run stopped, and a cancelled Deploy Staging run may already
+have partially deployed. For any unexpected Deploy Staging run after the
+first override mutation: request cancellation and restore/read back the gate
+state promptly, but KEEP the landing hold until the run is confirmed terminal
+AND its per-lane/deploy-summary/log evidence proves it produced no side
+effects — or until every possibly affected staging surface is restored to its
+recorded pre-landing staging baseline with artifact/health/routes
+re-verified. If terminality, the side-effect assessment, or that recovery
+cannot be proven, the hold remains and production stays hard-stopped and
+escalated. Only after confirmed terminality, absent-or-recovered effects, and
+verified gate restoration may the hold release — still halted for review,
+never proceeding to promotion. The failure and recovery evidence is recorded
+per the standing failure-evidence requirements (Phase V / incident record).
+The full mechanics live in the rollout ledger.
 
 **External configuration is mutated only after the landing merges, every
 PRODUCTION surface deploys at the exact merge SHA, and old + canonical routes
@@ -830,11 +846,15 @@ the item's mapped recovery smoke, recorded evidence of both the failure and
 the recovery, and a halt. If the recovery itself cannot be proven, the
 sequence remains halted until it is. An uncertain source-write outcome — a
 write that fails, times out, or returns an unverifiable result — is treated
-as a possible mutation: re-read the source of truth; if it provably still
-holds the prior value, record that evidence and halt before continuing; if it
-changed or its state cannot be verified, run the full recovery above. Every
-item — changed or unchanged — closes only with live proof plus a successful
-mapped smoke. The per-item schema is defined in the rollout ledger.
+as a possible mutation, and a single re-read cannot rule out a late
+asynchronous apply. Proven-unchanged requires either an authoritative
+terminal status for the write operation PLUS a confirming read, or a bounded
+settling barrier with repeated authoritative reads proving the prior value
+remained stable throughout; with that proof, record the evidence and halt
+before continuing. Without it, treat the item as changed/unverifiable and run
+the full recovery above while halted. Every item — changed or unchanged —
+closes only with live proof plus a successful mapped smoke. The per-item
+schema is defined in the rollout ledger.
 
 ### 10.6 Release-surface closure and the Phase V release record
 

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -1,0 +1,923 @@
+# Web/Desktop Client Unification
+
+Status: authoritative contract for the shared Desktop/Web connected DOM
+product (`@proliferate/product-client`), its two thin hosts, the product
+scope/authority isolation model, the capability policy, and the governance
+rules under which the migration lands.
+
+This spec is the settled contract promoted from the decision-complete
+migration plan. On any conflict, this file wins over
+[`../../tbd/web-desktop-unification-migration.md`](../../tbd/web-desktop-unification-migration.md)
+(non-authoritative rollout history/execution detail) and
+[`../../tbd/web-desktop-unification-intake-ledger.md`](../../tbd/web-desktop-unification-intake-ledger.md)
+(historical intake snapshot). Binding execution state — chain state, intake
+snapshots, the freeze ledger, and the external-configuration item schema —
+lives in
+[`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md),
+never under `specs/tbd/`.
+
+This contract does not redefine feature behavior. Auth, onboarding, settings,
+chat, transcript, workspace, billing, workflow, and other product behavior
+remain owned by their focused feature and primitive specs. This file decides
+which layer owns cross-client behavior, what the host boundary is, and what
+must be true at each migration checkpoint.
+
+Scope: the DOM product in `apps/desktop`, `apps/web`, and `apps/packages/**`,
+plus the narrow authority/lifecycle corrections in `anyharness/sdk-react` and
+`cloud/sdk-react`. Mobile product behavior is outside this contract and must
+remain green while shared SDK providers are corrected.
+
+## 1. Outcome
+
+Desktop and Web render one connected product implementation:
+`@proliferate/product-client`.
+
+Desktop is the visual, behavioral, and state-management source of truth. The
+old Web product implementation is not a second source to reconcile: it is
+deleted in the Web cutover landing and replaced by the Desktop-derived product
+client in the same mainline landing.
+
+```text
+Desktop native host ----\
+                         +--> one ProductClient --> Cloud SDK React
+Web browser host --------/                      \--> AnyHarness SDK React
+```
+
+At completion:
+
+- the same components, pages, hooks, stores, product workflows, Cloud SDK
+  wiring, and AnyHarness SDK wiring implement the product on Desktop and Web;
+- `apps/desktop` is a thin native bootstrap and transport host;
+- `apps/web` is a thin browser bootstrap and transport host;
+- product differences are caused by real capabilities, not by two product
+  implementations drifting apart;
+- Desktop keeps its current experience and native capabilities;
+- Web gets that experience for managed-cloud work, without pretending it can
+  access a user's local machine;
+- the old Web chat client, polling loop, stores, pages, and controllers no
+  longer exist;
+- `@proliferate/product-surfaces` is absorbed by and replaced with
+  `product-client`; there are not two connected shared-product packages.
+
+Hosts answer "how do I authenticate here?", "can this device access a local
+runtime?", and "how do I open this link?" They do not reimplement product
+behavior.
+
+## 2. Closed decisions
+
+1. **Desktop is the baseline.** Preserve its UI, interaction model, stores,
+   warm workspace shell, and product workflows. Extraction and host cutover,
+   not redesign.
+2. **The package is `@proliferate/product-client`.** It absorbs
+   `product-surfaces`; neither both packages nor the old name survives.
+3. **The connected product is shared.** The package owns React pages, product
+   routes, connected hooks, scoped stores, lifecycle orchestration, Cloud SDK
+   React wiring, and AnyHarness SDK React wiring.
+4. **One composite host contract.** One typed host object with nested
+   capability groups; no separate auth-host/runtime-host provider trees.
+5. **Product routes are shared.** Each app creates its browser router and owns
+   raw transport callback entrypoints; `ProductClient` owns the authenticated
+   product route tree and the ordinary login/join product screens.
+6. **Desktop owns raw Tauri access.** `product-client` never imports Tauri or
+   exposes a generic `invoke`. Shared product code calls a typed optional
+   Desktop bridge.
+7. **Web commands managed-cloud runtimes only.** It never discovers or
+   directly connects to a local sidecar, SSH target, or Desktop-exposed local
+   runtime. Server-visible local metadata may be shown read-only with an
+   "Open in Desktop" action.
+8. **Cloud AnyHarness behavior is identical.** Both hosts use the same shared
+   gateway resolver and the same AnyHarness React provider/hooks for managed
+   cloud workspaces.
+9. **Authentication transport remains host-owned.** Product auth state and UI
+   are normalized; cookies/CSRF/PKCE on Web and native vault/protocol handling
+   on Desktop are not normalized away.
+10. **No old Web product compatibility requirement.** Old Web presentation,
+    stores, controllers, and ordinary product aliases are deleted. A bounded
+    one-release redirect set exists only to order external/deployed URL
+    producers safely; it is not a second product or a feature flag.
+11. **Self-hosted Desktop remains supported.** Self-hosted Web is a named
+    follow-up: the contract must allow one, but it is not an acceptance
+    criterion for this cutover.
+12. **Mobile is not involved.** Mobile continues to consume only its allowed
+    SDKs, `product-domain`, and the native design layer, and stays DOM-free.
+13. **The embedded Tauri browser is not preserved.** A separately reviewable
+    removal lands before the mechanical move and deletes the live workspace
+    browser panel, tab/actions, raw webview access, and their callers. It is
+    not bridged or moved into product-client.
+14. **The cache-scope correction lands first.** PR 0a (commit `bdd11aa5a`)
+    landed the SDK/query-key foundation; PR 0b adds same-principal session
+    authority generation plus credential-mutation ordering; PR 0c removes the
+    credential-keyed global AnyHarness client map and adds target
+    generation/client/stream lifecycle ownership. Product-client copies
+    neither global cache pattern into a shared package.
+15. **Host seams are separated from file movement.** Desktop adopts the host,
+    bridge, and scoped-provider model while source paths remain stable (PR 1);
+    only then does a freeze-gated PR mechanically move product source (PR 2).
+16. **Each host marks its surface before rendering.** Both hosts set
+    `data-proliferate-client="desktop|web"`. Shared Tailwind variants may use
+    that marker for presentation; capability logic remains structural and is
+    never implemented as CSS hiding.
+17. **AnyHarness clients are scope-owned.** The SDK React module-global client
+    map keyed by raw bearer token is removed before source movement. Product
+    authority owns a bounded client registry; target-generation changes use a
+    credential-free connection identity and a generic transition boundary for
+    Cloud, local, and SSH runtimes.
+
+## 3. Package ownership and build contract
+
+### 3.1 Ownership boundary
+
+```text
+apps/packages/product-client/   # the shared connected product
+  src/
+    ProductClient.tsx              # lightweight auth/product gate (from PR 2)
+    AuthenticatedProductClient.tsx # route-lazy connected product (from PR 2)
+    app/ pages/ components/ hooks/ stores/ providers/ config/ copy/ assets/
+    lib/{domain,workflows,infra}/
+    host/                          # product-host types + ProductHostProvider
+
+apps/desktop/src/                # thin native host: bootstrap, native auth
+                                 # transport, telemetry install, raw Tauri
+                                 # access, native lifecycle, host CSS
+apps/web/src/                    # thin browser host: bootstrap, env config,
+                                 # browser auth/PKCE transport, telemetry
+                                 # install, host CSS
+```
+
+This is an ownership map, not a rename mandate: the mechanical move preserves
+Desktop's existing domain/responsibility taxonomy where it is already valid.
+
+### 3.2 Dependency direction
+
+```text
+apps/desktop ----\
+                  +--> product-client --> product-ui --> ui --> design/dom
+apps/web --------/             |
+                               +--> product-domain
+                               +--> cloud-sdk / cloud-sdk-react
+                               +--> anyharness/sdk / anyharness/sdk-react
+
+apps/mobile --> product-domain + design/react-native + SDKs
+```
+
+- `product-client` imports neither app, no Tauri package or Desktop raw-access
+  file, and no browser auth-cookie, PKCE, or vendor telemetry implementation.
+- Apps import only public product-client entrypoints, never its internal
+  stores and hooks.
+- `product-ui` remains props-in/callbacks-out presentation; `product-domain`
+  remains React-free and Mobile-safe; `ui` and `design` stay separate lower
+  layers.
+- No app-local copy of a product-client store or controller exists after its
+  cutover; imports remain direct with no convenience barrel files.
+
+### 3.3 Import-path rule
+
+Package-private product-client imports use Node package imports:
+
+```json
+{ "imports": { "#product/*": "./src/*" } }
+```
+
+- Moved product-client internals rewrite `@/...` specifiers to `#product/...`
+  with an AST module-specifier codemod (never blind text replacement — the
+  repo contains unrelated `@@/` regex text);
+- retained Desktop host files keep `@/...`;
+- hosts import only public `@proliferate/product-client/<entrypoint>` exports;
+- no app-level Vite alias or TypeScript `paths` for `#product`; `#/*` is an
+  invalid Node package-import name and is not used;
+- TypeScript, Vite, and Vitest all prove the mapping in PR 1, before the
+  mechanical move;
+- post-move scans reject `@/` inside product-client, `#product/` in either
+  app, and unresolved `#product/` text in final bundles.
+
+### 3.4 Package build contract and staged export map
+
+`product-client` is private application source, not a published UI library. It
+is a source-consumed workspace package: both host Vite builds compile the same
+source; the package `build`/`typecheck` typechecks the source; Vitest runs
+against the source. React, React DOM, React Router, and React Query are peer
+dependencies (plus dev dependencies for package tests) resolved and deduped to
+each host's single workspace version.
+
+**The export map is staged.** This is binding scope resolution:
+
+- **PR 1** creates the package skeleton exporting **host, provider, scope, and
+  package-resolution primitives only** — `ProductHost` types,
+  `ProductHostProvider`, `ProductScopeBoundary`, `ProductAuthorityHandle`
+  types, the entry-intent coordinator contract, and the proven `#product/*`
+  mapping. There is **no `ProductClient` export in PR 1**.
+- The candidate root split — a lightweight `ProductClient` gate plus a lazy
+  `AuthenticatedProductClient` — is built **in place at stable Desktop-owned
+  paths** during PR 1, consuming those primitives. The §8 performance fixture
+  measures this in-place candidate.
+- PR 1's `desktop: null` proof tests **host/provider/capability composition**,
+  not a package-owned product mount.
+- **PR 2** mechanically moves the proven candidate root into the package and
+  only then adds the real `ProductClient`/`AuthenticatedProductClient`
+  exports.
+
+The mechanical asset move is part of PR 2: product SVG/PNG/JPEG/MP3 assets and
+`assets.d.ts` move under product-client; genuinely native window/application
+resources stay in Desktop; Vite `?raw` behavior is preserved for file icons
+and the bundled agent catalog; `provider-registry.generated.json` moves to
+product-client with `scripts/vendor-provider-registry.mjs` generating at the
+new owning path; `catalogs/agents/catalog.json` stays the repo-level generated
+source of truth and is imported, never copied; a build test bundles
+representative `?raw`, image, audio, JSON, and repo-level catalog imports in
+both Desktop and Web.
+
+## 4. The one host contract
+
+The host is one value in one provider (an authority sketch, not mandated
+property names):
+
+```ts
+interface ProductHost {
+  surface: "desktop" | "web";
+  deployment: ProductDeploymentHost;
+  auth: ProductAuthHost;
+  cloud: ProductCloudHost;
+  persistence: ProductPersistenceHost;
+  links: ProductLinksHost;
+  telemetry: ProductTelemetryHost;
+  desktop: DesktopBridge | null;
+}
+```
+
+One `ProductHostProvider`; nested groups document authority without many React
+contexts; the object is not a service locator. `surface` is descriptive —
+product behavior checks a real capability (`desktop !== null`, a server
+capability, or a workspace capability), not `surface === "web"` scattered
+through components. The host supplies no page/settings/chat/composer/workspace
+render slots; the only UI wholly outside product-client is genuine host chrome
+or transport entry UI (native window controls, a browser OAuth callback
+spinner).
+
+### 4.1 Deployment authority
+
+Supplies the normalized API origin/configuration, the current deployment/cache
+key, deployment-change observation, Desktop's optional connect/switch/reset
+operation, and Web's fixed configured deployment. It does not hardcode server
+capabilities — billing, SSO, gateway, hosted-mode, and other capabilities come
+from server truth. No persistent deployment-UUID protocol exists; the
+credential-free deployment key derives from the normalized API configuration.
+
+### 4.2 Auth authority
+
+```ts
+type ProductAuthStatus =
+  | "bootstrapping" | "anonymous" | "authenticated" | "unreachable";
+
+type ProductAuthorityIdentity = Readonly<{
+  deploymentKey: string;
+  actor: { kind: "anonymous" } | { kind: "user"; id: string };
+  generation: number;
+}>;
+```
+
+`ProductAuthHost` exposes normalized status, principal, `authGeneration`,
+`bindAuthority(expected)` returning a `ProductAuthorityHandle` (or `null` on
+mismatch), `startSignIn`, and CAS `signOut(expected)`. The handle provides one
+atomic fresh access-token + `credentialRevision` snapshot, atomic
+register-and-replay `observeCredentialRevision`, and
+`invalidateIfCurrent({credentialRevision, reason})`.
+
+Binding constraints:
+
+- product code never reads cookies, PKCE state, native vault entries, or raw
+  refresh credentials; host bootstrap owns restoration and publishes `status`;
+- `unreachable` is the normalized state for a transiently unavailable
+  authenticated deployment: it retains the resolved principal and generation
+  underneath and never participates in cache identity;
+- long-lived Cloud/AnyHarness operations request one atomic token + credential
+  revision snapshot through the bound handle — never separate reads or a
+  token captured at connection creation;
+- `credentialRevision` is a monotonic, non-secret transport refresh signal
+  that advances when the access token is replaced without replacing the
+  authority; it is never scope/query-key identity;
+- a late operation from authority N can neither obtain N+1's token nor let an
+  N-era rejection invalidate N+1, even for the same principal; a request also
+  passes the `credentialRevision` it actually used, so a late 401 from token A
+  cannot invalidate newer token B within the same authority;
+- **one host-owned auth coordinator** serializes and compare-and-swaps every
+  credential-changing bootstrap, sign-in, callback commit, refresh
+  replacement, 401 invalidation, and sign-out against the applicable
+  authority, credential revision, or sign-in transaction id. It is the only
+  path to stored-credential writes/clears; raw Cloud middleware and stream
+  code never mutate storage behind the auth store;
+- `startSignIn` creates a credential-free transaction id bound to the expected
+  deployment and starting authority; callback credential commit succeeds only
+  while that transaction is current;
+- `signOut(expected)` CASes against the expected authority; a late
+  generation-N clear cannot erase generation N+1. Web additionally serializes
+  cookie-changing responses so a late logout `Set-Cookie` cannot clear a newer
+  login;
+- only a commit that replaces session authority advances `authGeneration`;
+  ordinary refresh keeps the generation and advances only
+  `credentialRevision`; stale callback/logout/refresh results are discarded
+  without storage or state mutation;
+- Desktop's semantic deployment connect/switch/reset lives in the deployment
+  group; Web omits those methods; the Desktop bridge does not own a duplicate
+  deployment API.
+
+### 4.3 Cloud transport authority
+
+The host owns credential transport and exposes exactly one scoped Cloud SDK
+client factory (`createScopedClient({deployment, authority})` returning a
+disposable client handle). The product client owns Cloud queries, mutations,
+workspace classification, gateway lookup, managed-cloud connection resolution,
+product orchestration, and query keys. A host must not own a parallel
+managed-cloud workspace resolver or a module-global Cloud client.
+`ProductScopeBoundary` creates the client for the current authority and
+disposes it on scope teardown; a client cannot outlive its ProductScope.
+
+Organization identity is operation input, not mutable transport ambient
+state: every owner-sensitive query/mutation captures one immutable
+`CloudOwnerContext` (`personal` or `organization` + id) before creating its
+query key and request, and passes that same value explicitly to header
+construction. Middleware never consults a live organization getter; an
+organization switch cannot turn an A-keyed operation into a request against B.
+
+The Cloud SDK React provider never publishes its resolved client into the SDK
+process-global singleton, and `useCloudClient()` fails closed when no provider
+is mounted (both removed in PR 1). A legacy global API may remain for
+out-of-scope non-React consumers during the migration, but ProductClient,
+Desktop, and Web neither populate nor read it for authenticated product work.
+
+### 4.4 Persistence authority
+
+Typed read/write/remove for non-secret, device-local product state only. The
+key set is typed and owned by product-client; arbitrary string access is not
+part of the interface. Web uses browser persistence; Desktop's typed adapter
+dispatches each key to its existing owner (Tauri Store or WebView
+`localStorage`). No key silently moves between backends or is renamed: any
+backend/key migration requires an explicit read-old/write-new transition,
+idempotency and rollback tests, and a declared old-value retirement point. The
+adapter stores no bearer tokens, refresh credentials, PKCE verifiers, native
+credential material, or provider API keys.
+
+### 4.5 Link/navigation authority and entry intents
+
+Internal product navigation is shared React Router behavior. The links group
+owns only host-differing actions: open an external URL, semantic
+open-in-Desktop handoff, shareable-link generation for the current deployment,
+system-browser open from Desktop, and host-decoded inbound deep links.
+
+Inbound transport state crosses the boundary as a normalized, validated,
+credential-free, one-shot `ProductEntryIntent` (SSO login intent, organization
+invitation, workspace/workflow location, completed billing return). Rules:
+
+- host callback/deep-link code validates and persists the intent into a
+  durable FIFO of unacknowledged intents before publishing; a later arrival
+  never overwrites an earlier one;
+- `observePending` is one atomic replaying subscription: an intent published
+  during subscription is delivered by replay or live event, never dropped
+  between restore and subscribe; delivery is at-least-once;
+- exactly one ProductEntryIntent coordinator lives above replaceable
+  ProductScopes; it is the sole consumer, processes serially, and deduplicates
+  by `intentId`; the owning workflow accepts idempotently by `intentId`
+  before the coordinator acknowledges and removes the entry; unacknowledged
+  work replays after scope replacement or process restart;
+- Desktop ingress registers the live URL listener before draining the initial
+  `getCurrent()` value, persists before notifying, and deduplicates overlap;
+- every intent carries a normalized credential-free target deployment key; the
+  coordinator dispatches only while that deployment is current; a
+  foreign-deployment head item never starves later valid work — hosted Web
+  acknowledges it as `handed-off` after a successful Desktop handoff or moves
+  it to durable, user-recoverable quarantine;
+- raw callback URLs, OAuth state, credentials, and arbitrary navigation
+  strings never enter the product intent.
+
+### 4.6 Telemetry authority
+
+Product-client emits typed product events and errors. The host installs
+Sentry/PostHog/native diagnostics, supplies release/runtime identity, and owns
+vendor lifecycle; product state has no direct vendor SDK access. The telemetry
+group supplies one narrow route-instrumentation component compatible with
+React Router's `<Routes>` contract — the sole infrastructure render adapter —
+so hosts wrap shared routes with their Sentry router instrumentation without
+importing Sentry into product-client. Existing replay-masking and payload
+restrictions continue to apply; moving a component authorizes no new payload
+fields.
+
+### 4.7 Desktop bridge
+
+`desktop` is `null` or one typed bridge grouping actual native capabilities:
+local runtime readiness/connection; repository/folder selection and worktree
+actions; open/reveal path, editor, terminal, shell; local agent/provider
+credential operations (product-user authentication credentials remain
+exclusively `ProductAuthHost`-owned); native context/application menus, dock,
+window operations; updater/version/relaunch; desktop worker and local
+automation execution; SSH target/tunnel operations; scratch-file persistence;
+diagnostics and support-attachment collection.
+
+The bridge is demand-driven — a typed method is added only when moved product
+code needs it — and never exposes generic Tauri `invoke`, raw command names,
+or a filesystem primitive broad enough to bypass product policy. Desktop-only
+product orchestration may live in product-client and call the bridge; raw
+execution remains in `apps/desktop`.
+
+## 5. Product scope and provider composition
+
+### 5.1 Scope identity
+
+Remote caches and live streams are scoped at least by **deployment +
+authenticated principal (or explicit anonymous) + in-memory `authGeneration`**.
+That tuple is exact: `bootstrapping` and `unreachable` never participate in a
+cache key; a transiently unreachable authenticated authority retains principal
+and generation; an unreachable client with no resolved authority mounts no
+authenticated remote providers.
+
+`authGeneration` is a process-local, monotonic **session authority epoch** —
+not deployment identity or token version. It advances when anonymous becomes
+authenticated (or the reverse), the principal changes, or logout/revocation/a
+replacement login invalidates the prior session authority. It does not advance
+on ordinary token refresh; routine Web token rotation updates transport
+credentials without remounting the QueryClient or tearing down active
+AnyHarness streams.
+
+`cacheScopeKey` is never overloaded with workspace or materialization
+identity; credentials and expiring gateway URLs never participate in semantic
+cache identity.
+
+### 5.2 Provider order
+
+```text
+Host bootstrap and auth transport
+  -> ProductHostProvider
+    -> ProductEntryIntentCoordinator (durable FIFO; survives scope replacement)
+      -> lightweight ProductClient auth/readiness gate
+        -> when authority is resolved:
+          ProductScopeBoundary (deployment + principal/anonymous + auth generation)
+            -> scope-owned QueryClientProvider
+              -> scope-owned CloudClientProvider
+                -> anonymous: shared login/join content
+                -> authenticated: scope-owned AnyHarness client registry
+                  -> shared AnyHarness runtime/workspace providers
+                    -> lazy AuthenticatedProductClient
+```
+
+Mandatory properties: no module-global QueryClient in Desktop, Web, or
+product-client; no Cloud React provider write to (or hook fallback through)
+the Cloud SDK process-global client; no module-global AnyHarness client
+registry or credential-bearing client cache; presentation states cannot churn
+a retained authority's scope key; a scope change cancels or makes unreachable
+old queries, streams, and connection completions; Cloud and AnyHarness
+consumers see the same scope; providers are not copied per host; Web does not
+mount the Desktop local-runtime subtree; teardown runs once and removes every
+listener, timer, subscription, and stream owned by the prior scope.
+
+### 5.3 Product state classes
+
+| State | Owner | Lifetime |
+| --- | --- | --- |
+| Server entities and remote results | Query cache / owning SDK | Product scope |
+| Active AnyHarness connection/stream | AnyHarness SDK React + scoped target/stream transition owner | Target slot + generation + product authority |
+| Actor-sensitive selection, drafts, pending prompts, tabs | Product-client scoped store factories | Product authority; reset before replacement authority renders |
+| Organization-sensitive client state | Product-client organization-scoped stores | Deployment + principal + organization |
+| Workspace-local UI state | Product-client stores keyed by logical workspace id | Workspace within product authority |
+| Non-sensitive device preferences | Product-client store + host persistence | Device |
+| Auth secrets and pending OAuth state | Host auth transport | Host security rules |
+| Native runtime/process state | Desktop host/bridge | Desktop process |
+| Pure product decisions | `product-domain` or product-client `lib/domain` | Stateless |
+
+Actor-sensitive stores are scope-owned factories instantiated under
+`ProductScopeBoundary`; organization-sensitive stores are factories under a
+nested organization boundary; workspace-sensitive stores are keyed/factored so
+a delayed writer reaches only the old instance. A reset module-global
+singleton is not sufficient — an old Promise can retain its setter and write
+after rollover. Every asynchronous writer captures/checks its owning authority
+epoch before emitting external side effects. Persisted device-global keys keep
+Desktop's existing backend/key/schema through the mechanical move; actor-,
+organization-, and workspace-sensitive persisted values are credential-free,
+namespaced by declared lifetime, and removed/ignored on rollover. Old Web
+stores receive no compatibility migration.
+
+## 6. Routing, callbacks, and capability policy
+
+### 6.1 Route ownership
+
+One `BrowserRouter` per app; one shared product route tree. Hosts own routes
+that terminate a transport protocol (Web OAuth/PKCE callback and auth error,
+Web SSO-slug and invitation entry decoders, Stripe/billing return decoders,
+Desktop protocol/deep-link ingress, development-only host diagnostics).
+`ProductClient` owns the canonical shared routes:
+
+```text
+/login  /  /workflows  /workflows/:workflowId
+/workspaces  /workspaces/:workspaceId  /settings?section=<sectionId>
+```
+
+This preserves Desktop's URL/state semantics: workspace selection reconciles
+from `/workspaces/:workspaceId`, active sessions remain tab/store-owned, and
+Settings sections remain query-string state overlaying the warm
+`MainScreen`/workspace shell (a performance and stream-continuity invariant —
+the shell stays mounted across authenticated route changes). Desktop's
+host/legacy entrypoints (`/index.html`, `/setup`, `/settings/cloud` +
+`/settings/billing` billing decoders, `/automations{,/:workflowId}` thin
+redirects through the Web R+1 window, DEV-only `/playground/**`) are preserved
+explicitly through the mechanical move.
+
+Web permanently retains `/auth/callback`, `/auth/error`,
+`/join/:organizationId`, and the `/settings/cloud` billing-return decoder
+(handling `returnSurface=desktop` before navigating browser returns to shared
+`/settings?section=billing`), so browser OAuth, SSO, invitations, and Desktop
+checkout/portal returns need no flag day. Cutover release R adds a bounded
+Vercel 307 redirect set before the SPA catch-all (`/settings/cloud` bypasses
+it); the exact array and per-route dispositions are rollout detail in the
+migration plan §10.3–10.4. Redirects are retained through R+1 and at least
+seven days, then removed only after the producer ledger is rechecked. Every
+inbound-URL producer (OAuth redirect configuration, Stripe return URLs, GitHub
+App returns, invitation links, server-generated Web links, Desktop handoff
+URLs) is audited against the producer ledger; external/deployed configuration
+changes follow the rollout ledger's external-item sequencing (§10 below).
+
+### 6.2 AnyHarness resolution
+
+Normal product code never constructs `AnyHarnessClient`; it uses the shared
+SDK React providers and hooks. The product client owns logical workspace
+classification, materialization selection, Cloud workspace records, and shared
+provider composition. Both hosts use one product-client gateway resolver for
+managed cloud; Desktop additionally supplies local/SSH connection authority
+through its bridge.
+
+Credential-free connection identity is **target slot + target generation**:
+
+```text
+slot:  cloud:<deployment-key>:<logical-cloud-workspace-id>
+       local:<desktop-runtime-slot-id>          # stable, never a PID
+       ssh:<deployment-key>:<ssh-target-id>
+gen:   cloud:<anyharness-workspace-id>:<runtime-generation>
+       local:<process-generation>
+       ssh:<tunnel-generation>
+```
+
+Runtime-tier SDK query keys use authority scope + slot + generation — never
+`runtimeUrl`, token, or connection revision; workspace keys keep logical
+workspace ids. A slot-owned connection-material coordinator shares normal
+in-flight resolution, supersedes older attempts on forced refresh, and
+CAS-installs on both connection-resolution revision and the observed
+`credentialRevision` (delayed A is discarded and its waiters adopt B; a failed
+latest attempt retries rather than installing older A). Managed connection
+material remembers its `credentialRevision`; a revision advance marks material
+stale and forces slot-owned refresh on the next operation/reconnect without
+tearing down healthy streams. A generic transition boundary serializes
+generation changes with atomic `register(authority, slot, generation,
+resource)` — late old-generation registrations are rejected and closed; a
+local-process or SSH-tunnel generation transition fans out to every workspace
+attached to that slot and leaves unrelated slots alone. Clients carry
+operation leases: same-generation material rotation retires the old client
+(no new work, in-flight settles, released at zero leases); authority or
+generation teardown force-closes every lease. Query/client eviction is never
+accepted as stream teardown.
+
+Web negative guarantees (test assertions, not hidden controls): `desktop` is
+`null`; no local runtime bootstrap executes; no global local
+workspace/repo/cowork inventory query executes; no local AnyHarness URL is
+constructed; no direct SSH connection is attempted; no raw AnyHarness client
+is created at a page or workflow callsite; selecting a server-visible local
+record renders an honest Desktop handoff.
+
+### 6.3 Capability policy
+
+Capability checks derive from three sources — host/device (bridge present),
+deployment/server (API-advertised capabilities), and the selected resource —
+never one manually synchronized boolean object. Managed-cloud
+create/open/resume, chat/transcript/config, files/changes/terminal/subagents,
+cloud secrets/integrations/org policy, cloud workflow create/edit/run, and
+billing/usage/plan settings are the same shared product on both hosts.
+Local/SSH creation, local runtime inventory, native file/editor/terminal
+actions, local agent credentials, native updater, and self-host deployment
+switch are Desktop-only; Web hides them or offers a truthful Desktop handoff
+(read-only server-visible summaries where the matrix allows). Controls are
+functional or absent — no dead disabled controls for layout parity. Context
+menus share product content; Desktop renders natively, Web renders a DOM menu
+with native-only actions omitted.
+
+## 7. Styling and assets
+
+Desktop's rendered product is the visual source of truth.
+
+- `apps/packages/design/src/css/product.css` is the shared Desktop-derived
+  product stylesheet (created in PR 2 from `desktop.css`'s product selectors);
+  `desktop.css` reduces to importing `product.css` plus genuinely native
+  window-chrome overrides. One defined cascade, no duplicate import: Desktop
+  `index.css` → `design/desktop.css` → `product.css` + native overrides; Web
+  `index.css` → `design/product.css` + browser-host CSS.
+- Both hosts set `document.documentElement.dataset.proliferateClient` before
+  rendering; `product.css` may expose `desktop:`/`web:` variants from that
+  marker for genuine visual differences only — never to hide controls whose
+  hooks/queries would still execute.
+- The Tailwind `@source "../../../product-client/src"` line is added **in
+  PR 1** together with a fail-closed assertion; without it, classes in moved
+  JSX are silently omitted from both production bundles.
+- The `product.css` export-map entry and copier proof, appearance
+  initialization (synchronous pre-render initializer called by both host
+  mains; CSS default equals product default), fonts/assets ownership, and
+  durable shared test IDs move with product-client per the rollout detail.
+- No Web-specific restyling during cutover; Tauri window chrome and macOS
+  safe-area elements remain Desktop host UI.
+
+## 8. Hosted Web performance budget
+
+PR 1 includes a feasibility build before the PR 2 freeze: the in-place
+candidate root (lightweight gate + lazy authenticated root, at Desktop-owned
+paths) is mounted in a deterministic browser-safe host and measured at
+`/login` and authenticated `/`, using `data-product-ready="login"` and
+`data-product-ready="authenticated-home"` markers, Vite manifest generation,
+and a deterministic route-asset measurement (fresh-cache Playwright, gzip
+level 9 for JS/CSS, emitted bytes for fonts/images/audio, only assets
+requested before readiness).
+
+Acceptance targets for that build: login JS 525,000 B; login CSS 45,000 B;
+login fonts/images 100,000 B; login total 670,000 B; authenticated `/` total
+1,750,000 B; Web host overhead ≤5% over the PR 2 ProductClient home fixture.
+The byte targets must be proven, or an evidence-backed replacement budget must
+be committed under explicit spec review, before PR 2 is authorized — never a
+silent ratchet. Independently of exact numbers, login/callback entries exclude
+authenticated product roots, Monaco, Shiki grammars/themes, xterm, editors,
+and non-entry routes. PR 2 commits the moved fixture's measured asset ledger;
+PR 4 enforces the committed budgets against the real Web host.
+
+## 9. Lifecycle ownership
+
+Every root effect has an assigned owner:
+
+- **Host bootstrap/process lifecycles** stay app-owned: API/deployment
+  configuration bootstrap, Web cookie/PKCE transport, Desktop vault/protocol
+  transport, vendor telemetry installation, startup diagnostics, Tauri
+  reload/context-menu policies, sidecar process bootstrap and raw health
+  transport, window/process listeners.
+- **Shared product lifecycles** move with product-client: entry-intent queue
+  coordination above ProductScope, organization selection, session/workspace
+  selection and intent dispatch, query/stream-connected behavior, preference
+  hydration/persistence orchestration, home deferred launches, support UI
+  state, command/shortcut interpretation, Cloud workspace and workflow
+  orchestration.
+- **Desktop-capability product lifecycles** live in product-client and call
+  the optional bridge (not mounted when the bridge is absent): local agent
+  reconcile/auth sync, local automation execution, worker enrollment tied to
+  auth transitions, updater presentation, product-aware native menu dispatch,
+  worktree preference sync, native support/diagnostic collection.
+
+Invariants preserved from the current Desktop root: auth bootstrap completes
+its initial decision before runtime-dependent work assumes a principal;
+runtime bootstrap starts only after auth leaves `bootstrapping`; worker
+enrollment observes the authenticated→anonymous transition; preference
+hydration completes before default-sync effects write; updater/menu/deep-link
+/global dispatch listeners mount once; every timer/listener/stream has
+deterministic cleanup; the workspace shell stays warm across routes;
+provider/scope teardown cannot let a stale completion mutate the next actor.
+
+## 10. Migration governance
+
+The migration executes as a serialized chain with binding governance. The
+live chain state, ledgers, and templates are in the
+[rollout ledger](../../developing/deploying/web-desktop-unification-rollout.md);
+step-by-step execution recipes remain rollout detail in the TBD migration
+plan. The governance rules themselves are contract:
+
+### 10.1 Checkpoint sequence
+
+| Checkpoint | Outcome |
+| --- | --- |
+| PR 0 | Cache/runtime authority fencing: 0a landed (`bdd11aa5a`); 0b adds same-user auth generation + credential-mutation CAS; 0c owns AnyHarness clients, streams, and target replacement. |
+| PR 1 | Desktop consumes the new host/scope seams in place; primitives-only package skeleton; candidate root split at Desktop-owned paths; enforcement generalized; ledgers committed. |
+| Pre-PR-2 cleanup | Embedded Tauri browser feature and callers removed (separately reviewable). |
+| PR 2 | Freeze-gated mechanical move of Desktop product source into product-client; Desktop mounts the package `ProductClient`. |
+| PR 3 | Delete the old Web product; retain a buildable thin browser host. Review-only. |
+| PR 4 | Web host adapters + mount the same `ProductClient`. Review-only. |
+| Landing | One cutover landing merges the reviewed PR 3 + PR 4 work; docs-only post-cutover verification seals completion. |
+| Follow-up | Self-hosted Web against the same host contract (explicitly unplanned here). |
+
+PR 1 is behavioral boundary work without path churn; PR 2 is path churn
+without behavior work; PR 3/PR 4 are separate review units that ship as one
+Web deploy unit.
+
+### 10.2 Sliding two-PR stack and review/merge ownership
+
+The chain runs as a sliding two-PR stack: at most two PRs with active writers
+exist at any time; one writer per phase; the orchestrator — never an
+implementer — review-accepts, merges, and marks ready. A child phase forks
+from its parent's immutable review-accepted head with `PARENT_AT_FORK`
+recorded durably (orchestrator log + child PR body) and asserted at fork.
+After the parent squash-merges, the child restacks with
+`git rebase --onto <target> $PARENT_AT_FORK`, proves equivalence (identical
+base trees ⇒ pre/post child tree equality; changed base ⇒ `git range-diff`
+against the accepted evidence branch with independently reviewed conflict
+resolutions and pre/post patch hashes), force-with-lease pushes, reruns CI,
+and is independently re-reviewed. Docs gates and the freeze gate deliberately
+collapse the stack to main.
+
+Reviewed states are preserved as plainly named evidence branches under
+`refs/heads/wdu-evidence/**` (fetchable with ordinary `git fetch origin`,
+never force-pushed, deleted only per the final verification PR's branch
+index), with commit SHA, tree SHA, and stable patch hash recorded in the PR
+body/ledger. Consumers fetch and assert existence + recorded-hash equality
+before comparing. Committed ledgers contain no secret values — secrets are
+referenced by name/location only.
+
+### 10.3 Intake and freeze gates
+
+The PR-1 and PR-2 intake gates are committed docs-only ledger phases
+(`wdu/intake-pr1`, `wdu/intake-pr2-freeze`) appending binding snapshots to the
+rollout ledger — never to `specs/tbd/`. The PR-1 snapshot records the
+then-current main SHA, the accepted PR 0c head (the PR 1 code baseline), and a
+disposition for every live conflicting branch/worktree/PR. The PR 2 freeze
+requires **both** an explicit dated user signal and the merged freeze ledger
+(timestamp, base SHA, freeze owner, planned duration, disposition/retargeting
+for every conflicting Desktop branch/worktree). Freeze validity is revalidated
+three times — at PR 2 launch, immediately before its review-acceptance, and
+immediately before its merge — each time re-running the live conflict
+inventory; any expiry or new undispositioned conflict hard-stops until a
+renewed signal plus a committed ledger amendment lands and the PR is
+re-reviewed. PR 1 and PR 2 verify the committed ledger evidence on main, not
+transcripts.
+
+### 10.4 Web cutover landing
+
+PR 3 (`delete legacy Web`) and PR 4 (`Web ProductClient`) are permanently
+review-only PRs that are **never merged**. The landing branch
+(`wdu/web-cutover-landing`) is created from fresh main and **cherry-picks
+exactly the recorded ordered commit list `G_BASE..H_HEAD`** (immutable
+accepted heads preserved as evidence branches) — never an unspecified merge of
+heads. Equivalence is proven before merge: exact tree equality when the
+landing base equals the PR 3 base; otherwise recorded stable patch hashes plus
+a `range-diff` manifest with independent review of every non-identical hunk
+and conflict resolution. Drift, a newly detected surface, or a
+release-coordinate issue returns the work to the PR 4 writer, whose
+re-accepted head lands on a new versioned evidence branch and forces the
+landing to be rebuilt and re-proven. The landing runs combined CI, the full
+PR 4 gate battery, and a pre-merge completeness battery (Mobile DOM-boundary +
+typecheck; all affected SDK/package builds and tests) before its single merge;
+PR 3/PR 4 then close as review-only records.
+
+### 10.5 Deployment selection and external-configuration ordering
+
+Deployment selection is modeled as **three reviewed sets**, produced during
+PR 4 review and re-asserted at landing time from the real last-successful
+staging/production deploy bases:
+
+- **DETECTED** — the deploy-surface detector's output over the real bases
+  (plan-job outputs prove this set only, never lane execution);
+- **EFFECTIVE_STAGING** — the automatic staging lanes actually expected to
+  execute after environment gates (proven only by per-lane enabled/skipped
+  evidence);
+- **PRODUCTION** — the exact explicit `only_surfaces` set for the canonical
+  promote workflow.
+
+Every DETECTED surface is explicitly dispositioned: PRODUCTION; reviewed
+staging-only (ungated lanes — Server, Web, E2B, LiteLLM — cannot be suppressed
+on the automatic path, so an ungated exclusion is reviewed staging-only or the
+chain stops); gate-suppressed (only actually gated lanes); or a separate
+reviewed artifact-release disposition (a detected Runtime surface has no
+hosted deploy lane). If Desktop is included, the release-prep version bump
+(covering every canonical owning coordinate) is a distinct reviewed commit
+inside the replay list, with the exact-SHA tag and a new draft release created
+and published only at production promotion per the canonical desktop release
+procedure.
+
+The landing order is binding: pre-override quiescence is proven under a
+landing hold before the reviewed staging environment-gate overrides are set
+and read back; the merge happens only then; merge-SHA tree equality plus green
+main CI gates the automatic staging path; the automatic staging run is
+verified to have executed exactly EFFECTIVE_STAGING; gates are restored to
+their recorded prior state; and only then is the exact landing merge SHA
+promoted to production with the exact PRODUCTION `only_surfaces` and
+`require_staging_success=true`. No failure path leaves temporary overrides
+active. The full mechanics, including the failure-handling invariant, live in
+the rollout ledger.
+
+**External configuration is mutated only after the landing merges, every
+PRODUCTION surface deploys at the exact merge SHA, and old + canonical routes
+verify.** Before the merge, external items are inventoried, verified,
+classified, and recorded only. After deploy verification, items are applied
+one producer at a time: source change → activation (redeploy/restart/rebuild
+at the same landing SHA per the item's recorded mechanism) → secret-safe
+live-consumption proof → that producer's smoke. A source edit without
+activation is never an update. A failed smoke triggers immediate source
+restore, re-activation, live rollback proof, a recovery smoke, and a halt.
+Every item — changed or unchanged — closes only with live proof plus a
+successful mapped smoke. The per-item schema is defined in the rollout ledger.
+
+The migration completes only when a docs-only post-cutover verification PR
+commits the immutable release record at
+`specs/developing/deploying/web-desktop-unification-release-record.md` and
+merges. There is no recovered-stable completion path: a halted external
+sequence blocks verification, evidence-branch cleanup, and completion.
+
+### 10.6 Rollback
+
+PR 0b, PR 0c, the docs/intake phases, PR 1, the browser removal, and PR 2 are
+each independently reversible merged units at their boundary. PR 3/PR 4 never
+merge (nothing to roll back on main). The cutover landing is the single
+functional Web-cutover rollback unit on main — but only until external
+mutations begin; after any external item changes, rollback must also restore
+each changed item's recorded previous value (with re-activation), or
+intentionally retain the compatibility redirects until every changed producer
+is rolled back. No permanent old/new runtime flag exists as rollback
+infrastructure. If a Desktop behavior cannot be preserved through the bridge,
+stop and model the missing narrow capability — never move raw Tauri access
+into product-client. If Web cannot execute an action, show a truthful
+absence/handoff — never a Web-specific imitation with a second product owner.
+
+## 11. Enforcement and verification
+
+Both frontend enforcement scripts (`scripts/report_frontend_structure.py`,
+`scripts/check_frontend_boundaries.py`) are generalized in PR 1 from
+Desktop-only traversal/predicates to an explicit ownership-root/rule table
+covering Desktop and product-client (and Web where a rule applies), with
+plant-a-violation tests per root/rule pair and deliberately migrated
+allowlists. The Tailwind source assertion and the ProductClient
+performance-fixture check fail loudly at the same boundary.
+
+The move gate includes these literal scans (all empty), plus both scripts'
+AST/path checks:
+
+```bash
+rg -F '"@/' apps/packages/product-client/src
+rg -F '"#product/' apps/desktop/src apps/web/src
+rg -F '#product/' apps/desktop/dist apps/web/dist
+rg -F '@proliferate/product-surfaces' apps package.json pnpm-lock.yaml
+```
+
+Verification tiers: shared Playwright journeys run one journey body under
+Desktop web-renderer and hosted-Web fixtures (host fixtures own only
+bootstrap/auth and unavailable-capability expectations); a native Desktop lane
+remains required for Tauri-only operations; isolated Desktop profiles are
+exercised at PR 0b, PR 0c, PR 1, and PR 2 (the PR 2 profile includes
+self-host server reconnect, relaunch, and keychain credential preservation);
+PR 2 carries a CSS/Tailwind visual baseline proving unchanged Desktop
+rendering; CI rejects a production Web artifact without the ProductClient
+mount. The focused unit/component test matrix and tier ownership are rollout
+detail in the migration plan §18; the canonical release-test inventory remains
+owned by `specs/developing/testing/`.
+
+## 12. Definition of done
+
+Ownership: `@proliferate/product-client` is the only connected shared DOM
+product; Desktop and Web import and mount the same `ProductClient`;
+`product-surfaces` no longer exists; each app contains only host ownership;
+Mobile imports remain unchanged and DOM-free.
+
+Behavior: Desktop's visual/behavioral baseline is preserved, including local,
+direct SSH, managed-cloud, native settings, updater, and self-host connection
+paths; Web exposes the same managed-cloud product experience, never attempts
+local runtime discovery, and truthfully hands off unsupported actions; cloud
+chat/transcript/config/files/terminal behavior has one SDK React owner; the
+warm workspace shell and route continuity remain intact.
+
+Security and state isolation: auth secrets remain host-owned; Web bearer
+tokens are memory-only in production; connection code requests fresh tokens
+through an authority-bound handle; delayed old-authority work cannot read,
+overwrite, clear, or invalidate a replacement authority for the same
+principal; no cache, stream, draft, prompt, tab, or selection crosses
+deployment/actor/authority-generation scope; organization-sensitive state is
+keyed/reset by organization; credentials are absent from query/cache identity;
+runtime query identity uses target slot/generation; no module-global
+QueryClient, process-global Cloud client publication/fallback, or
+bearer-keyed AnyHarness client map remains.
+
+Deletion: old Web polling/raw AnyHarness client, product
+stores/controllers/pages, duplicate Desktop copies, the embedded Tauri
+browser, any generic Tauri bridge, and every permanent compatibility
+flag/wrapper/duplicate mutation owner are gone.
+
+Verification: both apps build and typecheck; moved tests pass under
+product-client; Desktop's full relevant suite passes; shared Playwright
+journeys pass in both host lanes; native smoke covers Tauri-only boundaries;
+isolated profiles were exercised at the required checkpoints; Web login/home
+stay within the committed evidence-backed budgets with ≤5% host overhead; the
+chain's ledgers (host-dependency, store-lifetime, move-manifest, producer,
+restack, replay, release record) are durable and zero-unclassified; the
+post-cutover verification PR is merged.
+
+## 13. Migration exceptions and current state
+
+- PR 0a is landed (`bdd11aa5a`, PR #1144); PR #1143 (workflows authoring V1)
+  is merged. Every other checkpoint is pending; the code on main does not yet
+  implement this contract's host boundary, scope ownership, or package. The
+  rollout ledger's chain-state section is the live record.
+- [`web-cloud-local-parity.md`](web-cloud-local-parity.md) still describes the
+  superseded separate-controller model for some surfaces; PR 1 (and the PR 2
+  move) reconcile it and the frontend structure guides listed in the migration
+  plan §20. Until then, this spec wins on any conflict about connected-product
+  ownership.
+- The old Web product under `apps/web/src` and `product-surfaces` remain live
+  until their checkpoints delete/absorb them; no new product behavior may be
+  built in the old Web controllers, and any feature adding a genuinely
+  host-specific operation extends the one host contract narrowly with both
+  positive and negative host tests.
+
+## Related docs
+
+- Binding execution/freeze ledger:
+  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md)
+- Rollout history/execution recipes (non-authoritative):
+  [`../../tbd/web-desktop-unification-migration.md`](../../tbd/web-desktop-unification-migration.md),
+  [`../../tbd/web-desktop-unification-intake-ledger.md`](../../tbd/web-desktop-unification-intake-ledger.md)
+- Frontend structure: [`../structures/frontend/README.md`](../structures/frontend/README.md),
+  [`../structures/frontend/packages/README.md`](../structures/frontend/packages/README.md)
+- SDK ownership: [`../structures/sdk/README.md`](../structures/sdk/README.md)
+- CI/CD and release: [`../../developing/deploying/ci-cd.md`](../../developing/deploying/ci-cd.md)
+- Testing standard: [`../../developing/testing/README.md`](../../developing/testing/README.md)

--- a/specs/developing/deploying/README.md
+++ b/specs/developing/deploying/README.md
@@ -18,6 +18,12 @@ configuration, and self-hosted deployment. Local development belongs under
   image sources.
 - [self-hosted-aws.md](self-hosted-aws.md): one-click AWS CloudFormation launch
   stack that bootstraps the canonical self-hosted deployment.
+- [web-desktop-unification-rollout.md](web-desktop-unification-rollout.md):
+  binding execution and freeze ledger for the Web/Desktop client unification
+  chain — chain state, PR-1 intake snapshots, the PR-2 freeze ledger, and the
+  deployment-selection/external-configuration item schema. The contract itself
+  is canonical at
+  [`../../codebase/features/web-desktop-client-unification.md`](../../codebase/features/web-desktop-client-unification.md).
 
 ## Process Map
 

--- a/specs/developing/deploying/ci-cd.md
+++ b/specs/developing/deploying/ci-cd.md
@@ -53,7 +53,8 @@ Configuration and secret locations:
 - GitHub environment variables hold non-secret lane config and gates, including
   `AWS_REGION`, `AWS_DEPLOY_ROLE_ARN`, `VERCEL_*`, `WEB_URL`, `API_*`,
   `MOBILE_DEPLOY_ENABLED`, `EAS_*`, `DESKTOP_DEPLOY_ENABLED`,
-  `DESKTOP_DOWNLOADS_BASE_URL`, `WORKERS_DEPLOY_ENABLED`, E2B template refs,
+  `DESKTOP_DOWNLOADS_BASE_URL`, `WORKERS_DEPLOY_ENABLED`,
+  `LITELLM_DEPLOY_ENABLED`, E2B template refs,
   and non-secret support SSM parameter names plus legacy tracker
   ids/labels/limits retained during cleanup.
 - GitHub environment secrets hold deploy credentials used directly by Actions,
@@ -117,6 +118,7 @@ Before deploying:
    - `EAS_SUBMIT_ENABLED`
    - `DESKTOP_DEPLOY_ENABLED`
    - `WORKERS_DEPLOY_ENABLED`
+   - `LITELLM_DEPLOY_ENABLED`
 5. For user-facing releases, confirm whether the landing page, public docs,
    changelog/release notes, in-app copy, install docs, or support docs need to
    change with the release. Update them before deployment when they are part of
@@ -301,7 +303,9 @@ only_surfaces=all       # deploy every lane that is enabled by env gates
 
 If the intent is "only web" but the diff also detects mobile, server, E2B, or
 desktop, use `only_surfaces=web`.
-Only mobile, desktop, and workers currently have environment gates. Setting
+Only mobile, desktop, workers, and LiteLLM currently have environment gates
+(`MOBILE_DEPLOY_ENABLED`, `DESKTOP_DEPLOY_ENABLED`, `WORKERS_DEPLOY_ENABLED`,
+`LITELLM_DEPLOY_ENABLED` — each defaults to `false` when unset). Setting
 `EAS_SUBMIT_ENABLED=false` skips TestFlight submission only; the mobile build
 can still run when `MOBILE_DEPLOY_ENABLED=true`. Server, web, and E2B do not
 have skip gates, so use `only_surfaces` when those detected lanes must not run.
@@ -389,6 +393,7 @@ and any remaining owner.
   _deploy-server.yml         # reusable ECR/ECS/Alembic/server-health lane
   _deploy-workers.yml        # reusable hosted worker lane, gated until workers are enabled
   _deploy-web.yml            # reusable Vercel deploy/alias/smoke lane
+  _deploy-litellm.yml        # reusable LiteLLM ECR/ECS lane, gated by LITELLM_DEPLOY_ENABLED
   _deploy-mobile.yml         # reusable EAS/TestFlight lane, gated until app identity is ready
   _deploy-desktop.yml        # reusable desktop release lane, gated until beta/stable channel split
   cloud-tests.yml            # real-provider cloud lifecycle + cloud-backed runtime suites
@@ -1015,13 +1020,17 @@ Deploy graph:
      promoted SHA, and no static `DESKTOP_RELEASE_REF` is used
    - workers are intentionally gated until the hosted worker ECS command/service
      is canonical
+   - LiteLLM deploys ECR/ECS when `LITELLM_DEPLOY_ENABLED=true` for the target
+     environment and skips otherwise
 4. Upload a deploy summary artifact.
 
 Important: `force_surfaces` is additive. It forces listed surfaces to deploy in
 addition to any surfaces detected from the diff. Use `only_surfaces` when the
-intent is exact, such as `only_surfaces=web` for a web-only hotfix. Only mobile,
-desktop, and workers currently have environment gates. Setting `only_surfaces`
-is the supported way to keep detected server/web/E2B lanes from running.
+intent is exact, such as `only_surfaces=web` for a web-only hotfix. Only
+mobile, desktop, workers, and LiteLLM currently have environment gates
+(`MOBILE_DEPLOY_ENABLED`, `DESKTOP_DEPLOY_ENABLED`, `WORKERS_DEPLOY_ENABLED`,
+`LITELLM_DEPLOY_ENABLED`). Setting `only_surfaces` is the supported way to
+keep detected server/web/E2B lanes from running.
 
 Required GitHub environment vars/secrets:
 
@@ -1116,6 +1125,17 @@ APPLE_API_ISSUER
 APPLE_API_KEY
 APPLE_API_KEY_PATH
 KEYCHAIN_PASSWORD
+
+# litellm, when enabled
+LITELLM_DEPLOY_ENABLED
+ECR_LITELLM_REPOSITORY
+ECS_LITELLM_SERVICE
+ECS_LITELLM_CONTAINER_NAME
+LITELLM_DATABASE_URL      # secret
+LITELLM_MASTER_KEY        # secret
+AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY # secret
+AGENT_GATEWAY_MANAGED_OPENAI_API_KEY    # secret
+AGENT_GATEWAY_MANAGED_XAI_API_KEY       # secret
 ```
 
 For staging, the canonical values are expected to point at staging resources
@@ -1192,6 +1212,7 @@ EAS_SUBMIT_PROFILE=staging
 EAS_SUBMIT_ENABLED=true
 WORKERS_DEPLOY_ENABLED=false
 DESKTOP_DEPLOY_ENABLED=<unset; defaults to false>
+LITELLM_DEPLOY_ENABLED=true
 ```
 
 Current hosted production inventory:

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -275,15 +275,35 @@ override write/read-back failure, failed merge, merge-SHA tree mismatch,
 exact-landing-SHA main CI failure/cancellation/timeout, automatic staging
 failure/cancellation/timeout, unexpected lane execution, an unexpected Deploy
 Staging run from ANY trigger source (a manual `workflow_dispatch` or any run
-other than the expected exact-landing-SHA automatic run — cancel it
-immediately, then enter cleanup), or any state that cannot be verified —
-restore EVERY gate to its recorded prior value or prior absence, read the
-restoration back and verify it, then release the landing hold and halt. No
-failure path may leave the temporary overrides active or
-permit a later source CI completion to emit staging. If restoration itself
-fails or cannot be verified, production promotion is hard-stopped and the
-landing hold REMAINS in place while the failure is escalated; the hold is
-never released over unrestored or unverified gates.
+other than the expected exact-landing-SHA automatic run — request its
+cancellation immediately, then enter cleanup under the unexpected-run rule
+below), or any state that cannot be verified — restore EVERY gate to its
+recorded prior value or prior absence, read the restoration back and verify
+it, then release the landing hold and halt; for an unexpected Deploy Staging
+run, the hold is released only per the unexpected-run rule below. No failure
+path may leave the temporary overrides active or permit a later source CI
+completion to emit staging. If restoration itself fails or cannot be
+verified, production promotion is hard-stopped and the landing hold REMAINS
+in place while the failure is escalated; the hold is never released over
+unrestored or unverified gates.
+
+**Unexpected-run rule (cancellation is not terminal proof):** a cancellation
+request does not prove the run stopped, and a cancelled Deploy Staging run
+may already have partially deployed. On any unexpected Deploy Staging run
+after the first override mutation: request cancellation and restore/read back
+the gate state promptly, but KEEP the landing hold until BOTH (a) the run is
+confirmed terminal, and (b) its per-lane enabled/skipped evidence,
+deploy-summary artifacts, and logs prove it produced no side effects — or,
+where side effects occurred or cannot be ruled out, every possibly affected
+staging surface is restored to its recorded pre-landing staging baseline and
+its artifact/health/routes are re-verified. If terminality, the side-effect
+assessment, or that recovery cannot be proven, the hold remains and
+production stays hard-stopped and escalated. Only after confirmed
+terminality, absent-or-recovered side effects, and verified gate restoration
+may the hold release — the chain is still halted for review and never
+proceeds directly to promotion. The failure and recovery evidence is retained
+per the standing failure-evidence requirements (§5.2 item 6 / a
+non-completing incident record).
 
 ### 4.3 External-configuration item schema
 
@@ -326,12 +346,16 @@ Application rules (binding):
   sequence remains halted until it is.
 - **An uncertain source-write outcome is treated as a possible mutation.** A
   source-of-truth write that fails, times out, or returns an unverifiable
-  result may nevertheless have applied. RE-READ the source of truth. If it
-  provably still holds the prior value, record that evidence and halt before
-  continuing the sequence. If it changed — or its state cannot be verified —
-  run the full recovery: restore the recorded prior value, re-activate at the
-  same landing SHA, prove the live rollback, run the item's mapped recovery
-  smoke, record everything, halt. A failed recovery remains halted.
+  result may nevertheless have applied — and a single re-read cannot rule out
+  a late asynchronous apply. Proven-unchanged requires either (a) an
+  authoritative terminal status for the write operation PLUS a confirming
+  authoritative read, or (b) a bounded settling barrier with repeated
+  authoritative reads proving the prior value remained stable throughout.
+  With that proof, record the evidence and halt before continuing the
+  sequence. Without it, treat the item as changed/unverifiable and run the
+  full recovery while halted: restore the recorded prior value, re-activate
+  at the same landing SHA, prove the live rollback, run the item's mapped
+  recovery smoke, record everything, halt. A failed recovery remains halted.
 - **Unchanged items are not exempt:** each closes as verified-correct only
   with secret-safe live proof plus its mapped smoke executed.
 - The sequence completes only when every item is verified-correct-with-proof

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -1,0 +1,292 @@
+# Web/Desktop Unification Rollout Ledger
+
+Status: binding execution and freeze ledger for the Web/Desktop client
+unification chain.
+
+This document is the readiness authority for the migration defined by
+[`../../codebase/features/web-desktop-client-unification.md`](../../codebase/features/web-desktop-client-unification.md)
+(the canonical contract; it wins any conflict). The intake phases append their
+binding snapshots **here** — never under `specs/tbd/` — and the PR 1 and PR 2
+writers verify readiness against the committed sections of this file, not
+against transcripts. The docs-only post-cutover verification phase commits the
+final immutable release record at
+`specs/developing/deploying/web-desktop-unification-release-record.md`.
+
+Non-authoritative history: the original migration plan and the 2026-07-13
+intake sweep remain under `specs/tbd/` as execution detail and sweep input
+only.
+
+Ledger rules (binding):
+
+- **No secrets in git.** Every entry records identifiers, URLs, and non-secret
+  configuration values only; secret values are referenced by name/location
+  (for example "SSM parameter X", "Stripe restricted key <name>"), never by
+  value.
+- **Durable evidence.** Reviewed states are preserved as evidence branches
+  under `refs/heads/wdu-evidence/**` (pushed with
+  `git push origin <sha>:refs/heads/wdu-evidence/<label>`, never
+  force-pushed, deleted only per the verification phase's branch index), with
+  commit SHA, tree SHA (`git rev-parse <ref>^{tree}`), and stable patch hash
+  (`git diff --binary --full-index A...B | git patch-id --stable`) recorded in
+  the PR body or this ledger. Any consumer first runs `git fetch origin`,
+  asserts the branch exists, and asserts its hashes equal the recorded values
+  before comparing.
+- **Facts only.** Snapshot sections record live state at their timestamp; they
+  do not invent dispositions for items whose owner is unknown — those are
+  marked `needs-owner-decision` and block the gated phase until resolved.
+
+## 1. Chain state
+
+The chain executes as a sliding two-PR stack: at most two PRs with active
+writers at any time; one writer per phase; the orchestrator alone
+review-accepts, merges, and marks ready. Children fork from immutable
+review-accepted parent heads with `PARENT_AT_FORK` recorded and asserted;
+restacks use `git rebase --onto <target> $PARENT_AT_FORK` with an equivalence
+proof (identical base trees ⇒ child tree equality; changed base ⇒ range-diff
+against the accepted evidence branch plus independently reviewed conflict
+resolutions). Docs gates and the freeze gate collapse the stack to main.
+
+| # | Phase | Branch | Base → target | Merge disposition | Status |
+| --- | --- | --- | --- | --- | --- |
+| A | Workflows V1 merge-readiness | `codex/workflows-v1-pr1` (PR #1143) | main | Merged by orchestrator | **Merged 2026-07-13** (`5e86a7faf`) |
+| A2 | Docs promotion + this ledger | `wdu/docs-migration-plan` | main | Merges (docs-only) | In review |
+| B | PR 0b auth generation | `wdu/pr0b-auth-generation` | main | Merges after C is accepted | Pending |
+| C | PR 0c runtime lifecycle | `wdu/pr0c-runtime-lifecycle` | accepted B head → B, restacks to main | Merges after I1 is reviewed | Pending |
+| I1 | PR-1 intake snapshot (docs-only) | `wdu/intake-pr1` | accepted restacked C head → C, restacks to main | Merges; appends §2 here | Pending |
+| D | PR 1 Desktop host boundary | `wdu/pr1-desktop-host-boundary` | post-I1 main | Merges after E is accepted | Pending |
+| E | Embedded-browser removal | `wdu/embedded-browser-removal` | accepted D head → D, restacks to main | Merges to main | Pending |
+| — | **Freeze gate** | — | — | Explicit dated user signal required | Closed |
+| I2 | PR-2 freeze ledger (docs-only) | `wdu/intake-pr2-freeze` | main | Merges; appends §3 here | Pending |
+| F | PR 2 product-client extraction | `wdu/pr2-product-client-extraction` | post-I2 main | Merges to main before G exists | Pending |
+| G | PR 3 delete legacy Web | `wdu/pr3-delete-legacy-web` | fresh post-F main → main | **Review-only; never merges** | Pending |
+| H | PR 4 Web ProductClient | `wdu/pr4-web-product-client` | G_HEAD → G | **Review-only; never merges** | Pending |
+| L | Web cutover landing | `wdu/web-cutover-landing` | fresh main | The only merged Web-cutover PR | Pending |
+| V | Post-cutover verification | `wdu/post-cutover-verification` | fresh post-L main | Merges (docs-only); the completion gate | Pending |
+| I | Self-hosted Web | — | — | Follow-up; explicitly unplanned | — |
+
+Recorded chain facts (append per event; each entry dated, with SHAs):
+
+- 2026-07-13 — PR #1143 merged to main as `5e86a7faf`. Chain baseline for A2
+  is `origin/main@5e86a7faf`.
+
+Stop conditions that halt the chain: a gate the writer cannot make green; a
+conflict with a protected branch lacking a recorded disposition; the PR 2
+freeze signal absent; the committed intake-ledger evidence missing at PR 1 or
+PR 2 launch; anything that would require a second writer on a live phase
+branch.
+
+### 1.1 Web cutover landing mechanics (G/H/L summary)
+
+G branches only from post-F main; `G_BASE` and, at acceptance, `G_HEAD` are
+preserved as `wdu-evidence/landing-g-base` / `landing-g-head`. H branches from
+`G_HEAD`; at acceptance `H_HEAD` is preserved as
+`wdu-evidence/landing-h-head` and the exact ordered commit list
+`git rev-list --reverse G_BASE..H_HEAD` is recorded here. L is created from
+fresh main (`L_BASE` preserved as `wdu-evidence/landing-l-base`) and
+cherry-picks exactly that list. Equivalence proof before merge: if
+`L_BASE == G_BASE`, exact tree equality between `landing-h-head` and the L
+head; otherwise recorded stable patch hashes of both ranges plus a
+`git range-diff G_BASE..H_HEAD L_BASE..<L>` manifest with independent review
+of every non-identical hunk and conflict resolution. Accepted evidence heads
+are never mutated: any return-to-H produces a new versioned evidence branch
+(`landing-h-head-v2`, …), a recomputed commit list, and a mandatory L
+rebuild/re-proof. Before any deployment from the merge commit, the merge-SHA
+evidence rule applies: for the automatic staging path, merged-main tree
+equality with the reviewed L head **plus** fully green main CI on that exact
+SHA is required; on tree-equality failure the exact-L main CI run is cancelled
+before it can complete, any created staging run is cancelled, gates are
+restored, and the chain halts.
+
+## 2. PR-1 intake snapshot (Phase I1 appends here)
+
+Phase I1 appends a dated section below using this template. PR 1 may launch
+only when the committed snapshot exists on main with zero
+`needs-owner-decision` items.
+
+```markdown
+### PR-1 intake snapshot — <YYYY-MM-DD>
+
+- Snapshot timestamp: <ISO-8601>
+- origin/main SHA at snapshot: <sha> (docs baseline)
+- Accepted wdu/pr0c-runtime-lifecycle head: <sha> (PR 1 code baseline)
+- PR #1143: merged (<sha>); PR #1142: recorded superseded by <owning program>
+- Competing structure-alignment migrations live: none / <list>
+
+| Item (branch/worktree/PR) | Owner | Head SHA | Touched slice | Disposition |
+| --- | --- | --- | --- | --- |
+| <item> | <owner> | <sha> | Desktop root / auth / telemetry / Cloud access / native access | land-before-PR1 \| retarget \| park \| no-conflict \| needs-owner-decision |
+```
+
+Sweep inputs: `gh pr list`, `git branch -r`, and the protected set in the
+historical intake ledger (`specs/tbd/web-desktop-unification-intake-ledger.md`
+§4). Unknown-owner items are marked `needs-owner-decision` and listed
+prominently; they block PR 1.
+
+## 3. PR-2 freeze ledger (Phase I2 appends here)
+
+The PR 2 freeze gate requires **both** an explicit dated user signal (quoted
+verbatim below) and this merged ledger section. Freeze validity is revalidated
+three times — at PR 2 launch, immediately before PR 2 review-acceptance, and
+immediately before PR 2 merges — each time comparing timestamp + planned
+duration against the current time and re-running the live Desktop conflict
+inventory against the dispositions below. Any expiry or new undispositioned
+conflict hard-stops PR 2 until a renewed user signal plus a committed
+amendment to this section lands and the PR is re-reviewed.
+
+```markdown
+### PR-2 freeze ledger — <YYYY-MM-DD>
+
+- Freeze timestamp: <ISO-8601>
+- User signal (verbatim quote + date): "<quote>"
+- Base SHA: <origin/main sha>
+- Freeze owner: <who>
+- Planned duration: <e.g. 48h, ending <ISO-8601>>
+
+| Item (branch/worktree/PR) | Owner | Head SHA | Slice | Disposition |
+| --- | --- | --- | --- | --- |
+| <item> | <owner> | <sha> | <slice> | merged \| parked \| retargeted-to-product-client \| cancelled \| needs-owner-decision |
+
+Amendments: <dated renewals/redispositions>
+```
+
+The sweep covers, at minimum, the historical intake ledger's §4.4 protected
+dirty set, the subagent runtime program, `whale`, and every open Desktop UI
+PR. `needs-owner-decision` items block PR 2.
+
+## 4. Deployment selection and external-configuration items
+
+### 4.1 Three reviewed selection sets
+
+Automatic staging (`deploy-staging.yml` firing on main-CI success) has no
+`only_surfaces`; detection plus GitHub `staging` environment gates decide what
+executes. Selection for the cutover landing is therefore modeled as three
+reviewed sets, produced during Phase H from the real last-successful staging
+and production deploy-summary `headSha` bases (resolved per
+[`ci-cd.md`](ci-cd.md)) and re-asserted by Phase L pre-merge:
+
+| Set | Meaning | Proof |
+| --- | --- | --- |
+| DETECTED | `scripts/ci-cd/detect-deploy-surfaces.mjs` output over the real bases through the reviewed head | Plan-job `selection_mode`/`selected_surfaces` outputs (proves detection only, never lane execution) |
+| EFFECTIVE_STAGING | Automatic lanes actually expected to execute after gates | Per-lane enabled/skipped evidence from the automatic run |
+| PRODUCTION | Exact explicit `only_surfaces` set for the canonical promote workflow | The promote invocation + non-dry-run deploy-summary `headSha` evidence per surface |
+
+Every DETECTED surface receives exactly one disposition, recorded here:
+
+- **PRODUCTION** (therefore also EFFECTIVE_STAGING);
+- **reviewed staging-only** — Server, Web, E2B, and LiteLLM lanes are UNGATED
+  and cannot be suppressed on the automatic path; an ungated detected surface
+  excluded from PRODUCTION is explicitly reviewed as staging-only or the chain
+  stops until an automatic exact-selection mechanism lands;
+- **gate-suppressed** — only actually gated lanes: Mobile build
+  (`MOBILE_DEPLOY_ENABLED`), Desktop (`DESKTOP_DEPLOY_ENABLED`), Workers
+  (`WORKERS_DEPLOY_ENABLED`). `EAS_SUBMIT_ENABLED` gates TestFlight submission
+  inside an enabled Mobile lane, not the Mobile build itself;
+- **separate artifact-release disposition** — a detected Runtime surface has
+  no hosted deploy lane in `deploy-staging.yml`; it goes through the canonical
+  runtime release procedure or the chain hard-stops.
+
+Gate values are not assumed verified live: the accessible environment scope
+exposes only `DESKTOP_CHANNEL=beta`; other gate values may be inherited
+org-level variables. Phase H either audits inheritance with sufficient read
+access or plans explicit staging environment-level overrides regardless,
+recording per gate whether an environment-level value previously existed
+(restore by value) or not (restore prior absence by deletion). If Desktop is
+in PRODUCTION, the ≥0.3.28 version bump covering every canonical owning
+coordinate is a distinct reviewed release-prep commit inside the replay list;
+the exact-SHA tag and a NEW draft GitHub Release are created and published
+only at production promotion per the canonical desktop release procedure (the
+pre-existing `desktop-v0.3.27` tag/feed/draft is not the migration release).
+
+### 4.2 Landing order: quiescence, overrides, restore-before-promote
+
+The landing ordering is binding and executes under an orchestrator-held
+landing hold that explicitly blocks other main merges AND main-CI
+reruns/manual dispatches:
+
+1. **Pre-override quiescence is proven first.** A `deploy-staging`-idle check
+   alone is insufficient: an already queued/running/re-run qualifying main CI
+   run can complete after the overrides are set and emit an older
+   `workflow_run` that consumes them. Therefore: drain every queued/running
+   qualifying main CI run; for each run that completes successfully during the
+   drain, wait for its corresponding Deploy Staging `workflow_run` to
+   materialize AND complete; recheck both the source main-CI runs and the
+   deploy-staging runs across a bounded event-propagation barrier until
+   quiescence is proven. Unprovable correlation or quiescence ⇒ stop.
+2. Record the prior staging gate state secret-safe (including whether each
+   variable existed at the environment level at all); set the explicit
+   reviewed staging environment-level overrides; read every override back and
+   verify it.
+3. Merge the landing PR. If the merge fails after overrides are set, restore
+   the gates before releasing the hold.
+4. Immediately verify the merge-SHA rule: merged-main tree SHA equals the
+   reviewed landing head's tree SHA, plus fully green main CI on the exact
+   merge SHA (the automatic path cannot wait for a full post-merge battery).
+   Tree-equality failure ⇒ immediately cancel the exact-landing-SHA main CI
+   run before it can complete, cancel any already-created staging run, restore
+   the gates, halt. Exact-landing main CI failed/cancelled/timed out ⇒ restore
+   the gates, halt.
+5. Main CI success triggers the automatic staging run under the already-set
+   gates. Capture proof it executed exactly EFFECTIVE_STAGING (plan-job
+   outputs prove DETECTED; per-lane enabled/skipped evidence proves
+   execution). Any other execution ⇒ stop, restore gates, return to review.
+6. **Verify the automatic staging run, THEN restore the gates per the recorded
+   restore steps (restoring prior absence by deletion), and ONLY THEN promote
+   the exact landing merge SHA to production** with the exact PRODUCTION
+   `only_surfaces` and `require_staging_success=true`. Record non-dry-run
+   staging and production deploy-summary `headSha` evidence per surface;
+   verify each surface's artifact/health; verify old and canonical inbound
+   routes — all before any external mutation begins.
+
+**Failure-handling invariant:** no failure path — failed merge, failed tree
+equality, failed/cancelled/timed-out exact-landing main CI — may leave the
+temporary overrides active or permit a later source CI completion to emit
+staging.
+
+### 4.3 External-configuration item schema
+
+Phase H inventories every deployed configuration value the producers touch —
+Stripe dashboard settings and `STRIPE_CHECKOUT_*`/portal return URLs wherever
+they are deployed (GitHub environments, SSM/ECS task config, Vercel env, per
+the deployment docs), OAuth registrations, `FRONTEND_BASE_URL`/front-end
+origins, and every other discovered producer. Phase L completes and verifies
+the schema pre-merge. Each item records:
+
+| Field | Meaning |
+| --- | --- |
+| Item id | Stable identifier for the configuration value |
+| Source-of-truth location | Secret-safe: where the deployed value lives (GitHub environment X, SSM parameter name, Vercel project env, Stripe dashboard setting, OAuth app registration) |
+| Affected surface/process | Which deployed surface or process consumes it |
+| Current / required value | Non-secret values verbatim; secrets by name/location only |
+| Activation mechanism | redeploy \| service restart \| rebuild \| task-definition rollout — what makes the running artifact consume the new value |
+| Live-proof method | How consumption is proven from the running artifact/task without exposing secret values |
+| Smoke procedure | The end-to-end flow that exercises this producer (mapped explicitly; a shared smoke covers multiple items only via a recorded item→smoke mapping) |
+| Rollback source restore | Exact steps to restore the previous value |
+| Rollback activation | Re-activation steps at the same landing SHA |
+| Recovery smoke | The flow that proves the rollback restored the old behavior |
+
+Application rules (binding):
+
+- **Before the landing merges:** inventory, verify current live values,
+  classify, and record only. Mutate nothing that depends on new production
+  routes.
+- **After the landing merges, the PRODUCTION surfaces deploy at the exact
+  merge SHA, and routes verify:** apply items one producer at a time — source
+  change → activation → live-consumption proof → smoke. A source edit without
+  activation is never an update.
+- **Failed smoke ⇒ immediate recovery:** restore the source of truth,
+  re-activate at the same landing SHA, prove the live rollback, run a recovery
+  smoke, record both, halt — nothing further until resolved.
+- **Unchanged items are not exempt:** each closes as verified-correct only
+  with secret-safe live proof plus its mapped smoke executed.
+- The sequence completes only when every item is verified-correct-with-proof
+  +smoke or updated+activated+proved+smoked. There is no recovered-stable
+  completion: a halt blocks the verification phase, evidence-branch cleanup,
+  and migration completion until resolved (incident evidence may live in a
+  non-completing docs incident record, which does not substitute).
+
+### 4.4 Item table (Phase H creates; Phase L completes; Phase V seals)
+
+*Empty until Phase H. Entries follow the §4.3 schema; outcomes are recorded
+per item as `verified-correct+proved+smoked`,
+`updated+activated+proved+smoked`, or `failed+recovered+halted` with evidence
+links.*

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -282,8 +282,9 @@ recorded prior value or prior absence, read the restoration back and verify
 it, then release the landing hold and halt; wherever a cancellation-requested
 run or an abnormal/unverifiable staging execution is involved, the hold is
 released only per the terminality rule below. No failure path may leave the
-temporary overrides active or permit a later source CI completion to emit
-staging. If restoration itself fails or cannot be verified, production
+temporary overrides active, and no failure path may release the hold while
+any downstream Deploy Staging emission remains unenumerated, non-terminal, or
+unhandled. If restoration itself fails or cannot be verified, production
 promotion is hard-stopped and the landing hold REMAINS in place while the
 failure is escalated; the hold is never released over unrestored or
 unverified gates.

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -276,34 +276,44 @@ exact-landing-SHA main CI failure/cancellation/timeout, automatic staging
 failure/cancellation/timeout, unexpected lane execution, an unexpected Deploy
 Staging run from ANY trigger source (a manual `workflow_dispatch` or any run
 other than the expected exact-landing-SHA automatic run — request its
-cancellation immediately, then enter cleanup under the unexpected-run rule
+cancellation immediately, then enter cleanup under the terminality rule
 below), or any state that cannot be verified — restore EVERY gate to its
 recorded prior value or prior absence, read the restoration back and verify
-it, then release the landing hold and halt; for an unexpected Deploy Staging
-run, the hold is released only per the unexpected-run rule below. No failure
-path may leave the temporary overrides active or permit a later source CI
-completion to emit staging. If restoration itself fails or cannot be
-verified, production promotion is hard-stopped and the landing hold REMAINS
-in place while the failure is escalated; the hold is never released over
-unrestored or unverified gates.
+it, then release the landing hold and halt; wherever a cancellation-requested
+run or an abnormal/unverifiable staging execution is involved, the hold is
+released only per the terminality rule below. No failure path may leave the
+temporary overrides active or permit a later source CI completion to emit
+staging. If restoration itself fails or cannot be verified, production
+promotion is hard-stopped and the landing hold REMAINS in place while the
+failure is escalated; the hold is never released over unrestored or
+unverified gates.
 
-**Unexpected-run rule (cancellation is not terminal proof):** a cancellation
-request does not prove the run stopped, and a cancelled Deploy Staging run
-may already have partially deployed. On any unexpected Deploy Staging run
-after the first override mutation: request cancellation and restore/read back
-the gate state promptly, but KEEP the landing hold until BOTH (a) the run is
-confirmed terminal, and (b) its per-lane enabled/skipped evidence,
-deploy-summary artifacts, and logs prove it produced no side effects — or,
-where side effects occurred or cannot be ruled out, every possibly affected
-staging surface is restored to its recorded pre-landing staging baseline and
-its artifact/health/routes are re-verified. If terminality, the side-effect
-assessment, or that recovery cannot be proven, the hold remains and
-production stays hard-stopped and escalated. Only after confirmed
-terminality, absent-or-recovered side effects, and verified gate restoration
-may the hold release — the chain is still halted for review and never
-proceeds directly to promotion. The failure and recovery evidence is retained
-per the standing failure-evidence requirements (§5.2 item 6 / a
-non-completing incident record).
+**Terminality rule (cancellation is not terminal proof; the hold outlives
+unproven runs):** a cancellation request does not prove a run stopped, and a
+cancelled run may already have acted. Once overrides are armed, gate
+restoration (with read-back verification) remains prompt in every case, but
+the landing hold may release only after ALL of the following are proven:
+
+- every cancellation-requested run — a source main-CI run or any deploy run —
+  is confirmed terminal;
+- every cancelled source main-CI run is proven, across a bounded
+  event-propagation barrier, to have emitted NO downstream Deploy Staging
+  run; if one appears, it is handled under the next bullet like any other
+  staging execution;
+- every abnormal, failed, cancelled, timed-out, or unverifiable staging
+  execution — including the expected exact-landing-SHA staging run executing
+  unexpected lanes — is confirmed terminal AND its per-lane enabled/skipped
+  evidence, deploy-summary artifacts, and logs prove it produced no side
+  effects, OR every possibly affected staging surface is restored to its
+  recorded pre-landing staging baseline and its artifact/health/routes are
+  re-verified.
+
+Any unproven terminality, downstream-emission absence, side-effect
+assessment, or recovery retains the hold and hard-stops production with
+escalation. A fully proven failure path releases the hold only into
+halted-for-review — never directly into promotion. The failure and recovery
+evidence is retained per the standing failure-evidence requirements (§5.2
+item 6 / a non-completing incident record).
 
 ### 4.3 External-configuration item schema
 

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -296,12 +296,14 @@ the landing hold may release only after ALL of the following are proven:
 
 - every cancellation-requested run — a source main-CI run or any deploy run —
   is confirmed terminal;
-- EVERY cancellation-requested source main-CI run — regardless of its
+- for EVERY cancellation-requested source main-CI run — regardless of its
   terminal conclusion, including a run that wins the race and completes
-  SUCCESS despite the cancellation request — is proven, across a bounded
-  event-propagation barrier, to have emitted NO downstream Deploy Staging
-  run; any run it emitted is handled under the next bullet like any other
-  staging execution;
+  SUCCESS despite the cancellation request — every downstream Deploy Staging
+  run it emitted is enumerated and accounted for across a bounded
+  event-propagation barrier: zero emissions is acceptable; each emitted run
+  is handled under the next bullet like any other staging execution and must
+  be fully handled; the barrier must prove that no late or otherwise
+  unaccounted downstream emission remains before hold release;
 - every abnormal, failed, cancelled, timed-out, or unverifiable staging
   execution — including the expected exact-landing-SHA staging run executing
   unexpected lanes — is confirmed terminal AND its per-lane enabled/skipped
@@ -310,10 +312,11 @@ the landing hold may release only after ALL of the following are proven:
   recorded pre-landing staging baseline and its artifact/health/routes are
   re-verified.
 
-Any unproven terminality, downstream-emission absence, side-effect
-assessment, or recovery retains the hold and hard-stops production with
-escalation. A fully proven failure path releases the hold only into
-halted-for-review — never directly into promotion. The failure and recovery
+Any unproven terminality, any unaccounted, late, or unhandled downstream
+emission, and any unproven side-effect assessment or recovery retains the
+hold and hard-stops production with escalation. A fully proven failure path
+releases the hold only into halted-for-review — never directly into
+promotion. The failure and recovery
 evidence is retained per the standing failure-evidence requirements (§5.2
 item 6 / a non-completing incident record).
 

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -296,9 +296,11 @@ the landing hold may release only after ALL of the following are proven:
 
 - every cancellation-requested run — a source main-CI run or any deploy run —
   is confirmed terminal;
-- every cancelled source main-CI run is proven, across a bounded
+- EVERY cancellation-requested source main-CI run — regardless of its
+  terminal conclusion, including a run that wins the race and completes
+  SUCCESS despite the cancellation request — is proven, across a bounded
   event-propagation barrier, to have emitted NO downstream Deploy Staging
-  run; if one appears, it is handled under the next bullet like any other
+  run; any run it emitted is handled under the next bullet like any other
   staging execution;
 - every abnormal, failed, cancelled, timed-out, or unverifiable staging
   execution — including the expected exact-landing-SHA staging run executing

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -25,10 +25,14 @@ Ledger rules (binding):
 - **Durable evidence.** Reviewed states are preserved as evidence branches
   under `refs/heads/wdu-evidence/**` (pushed with
   `git push origin <sha>:refs/heads/wdu-evidence/<label>`, never
-  force-pushed, deleted only per the verification phase's branch index), with
-  commit SHA, tree SHA (`git rev-parse <ref>^{tree}`), and stable patch hash
-  (`git diff --binary --full-index A...B | git patch-id --stable`) recorded in
-  the PR body or this ledger. Any consumer first runs `git fetch origin`,
+  force-pushed). Evidence branches are deleted only AFTER the Phase V
+  docs-only post-cutover verification PR has merged, and only according to
+  the branch index committed in its release record — never earlier. Each
+  branch's commit SHA, tree SHA (`git rev-parse <ref>^{tree}`), and stable
+  patch hash
+  (`git diff --binary --full-index A...B | git patch-id --stable`) are
+  recorded in the PR body or this ledger. Any consumer first runs
+  `git fetch origin`,
   asserts the branch exists, and asserts its hashes equal the recorded values
   before comparing.
 - **Facts only.** Snapshot sections record live state at their timestamp; they
@@ -173,24 +177,34 @@ and production deploy-summary `headSha` bases (resolved per
 Every DETECTED surface receives exactly one disposition, recorded here:
 
 - **PRODUCTION** (therefore also EFFECTIVE_STAGING);
-- **reviewed staging-only** — Server, Web, E2B, and LiteLLM lanes are UNGATED
-  and cannot be suppressed on the automatic path; an ungated detected surface
+- **reviewed staging-only** — Server, Web, and E2B lanes are UNGATED and
+  cannot be suppressed on the automatic path; an ungated detected surface
   excluded from PRODUCTION is explicitly reviewed as staging-only or the chain
   stops until an automatic exact-selection mechanism lands;
 - **gate-suppressed** — only actually gated lanes: Mobile build
   (`MOBILE_DEPLOY_ENABLED`), Desktop (`DESKTOP_DEPLOY_ENABLED`), Workers
-  (`WORKERS_DEPLOY_ENABLED`). `EAS_SUBMIT_ENABLED` gates TestFlight submission
-  inside an enabled Mobile lane, not the Mobile build itself;
+  (`WORKERS_DEPLOY_ENABLED`), and LiteLLM (`LITELLM_DEPLOY_ENABLED`, checked
+  in `.github/workflows/_deploy-litellm.yml`; default `false` when unset).
+  `EAS_SUBMIT_ENABLED` gates TestFlight submission inside an enabled Mobile
+  lane, not the Mobile build itself. Gate lists are verified against the
+  actual workflow files at each use, never assumed;
 - **separate artifact-release disposition** — a detected Runtime surface has
   no hosted deploy lane in `deploy-staging.yml`; it goes through the canonical
   runtime release procedure or the chain hard-stops.
 
-Gate values are not assumed verified live: the accessible environment scope
-exposes only `DESKTOP_CHANNEL=beta`; other gate values may be inherited
-org-level variables. Phase H either audits inheritance with sufficient read
-access or plans explicit staging environment-level overrides regardless,
-recording per gate whether an environment-level value previously existed
-(restore by value) or not (restore prior absence by deletion). If Desktop is
+Gate values are point-in-time and must be re-audited live at Phase H and
+re-verified at Phase L; recorded observations never substitute for a fresh
+read. A 2026-07-13 read-only audit of the GitHub environments showed
+environment-level values on `staging` of `LITELLM_DEPLOY_ENABLED=true`,
+`MOBILE_DEPLOY_ENABLED=true`, `EAS_SUBMIT_ENABLED=true`, and
+`DESKTOP_CHANNEL=beta`, with no environment-level `DESKTOP_DEPLOY_ENABLED` or
+`WORKERS_DEPLOY_ENABLED` (both default `false` when unset); `Production`
+carries environment-level `DESKTOP_DEPLOY_ENABLED`, `LITELLM_DEPLOY_ENABLED`,
+and `MOBILE_DEPLOY_ENABLED`. Phase H audits the then-current state (including
+any org-level inheritance) with sufficient read access or plans explicit
+staging environment-level overrides regardless, recording per gate whether an
+environment-level value previously existed (restore by value) or not (restore
+prior absence by deletion). If Desktop is
 in PRODUCTION, the ≥0.3.28 version bump covering every canonical owning
 coordinate is a distinct reviewed release-prep commit inside the replay list;
 the exact-SHA tag and a NEW draft GitHub Release are created and published
@@ -215,32 +229,45 @@ reruns/manual dispatches:
 2. Record the prior staging gate state secret-safe (including whether each
    variable existed at the environment level at all); set the explicit
    reviewed staging environment-level overrides; read every override back and
-   verify it.
-3. Merge the landing PR. If the merge fails after overrides are set, restore
-   the gates before releasing the hold.
+   verify it. From the FIRST override mutation onward, the cleanup invariant
+   below is armed — a partial override write or a failed read-back is itself a
+   failure that enters cleanup.
+3. Merge the landing PR. A failed merge enters cleanup.
 4. Immediately verify the merge-SHA rule: merged-main tree SHA equals the
    reviewed landing head's tree SHA, plus fully green main CI on the exact
    merge SHA (the automatic path cannot wait for a full post-merge battery).
    Tree-equality failure ⇒ immediately cancel the exact-landing-SHA main CI
-   run before it can complete, cancel any already-created staging run, restore
-   the gates, halt. Exact-landing main CI failed/cancelled/timed out ⇒ restore
-   the gates, halt.
+   run before it can complete and cancel any already-created staging run, then
+   enter cleanup. Exact-landing main CI failed/cancelled/timed out ⇒ enter
+   cleanup.
 5. Main CI success triggers the automatic staging run under the already-set
    gates. Capture proof it executed exactly EFFECTIVE_STAGING (plan-job
    outputs prove DETECTED; per-lane enabled/skipped evidence proves
-   execution). Any other execution ⇒ stop, restore gates, return to review.
+   execution). Automatic staging failure/cancellation/timeout, an unexpected
+   lane execution, or inability to verify what executed ⇒ enter cleanup and
+   return to review.
 6. **Verify the automatic staging run, THEN restore the gates per the recorded
-   restore steps (restoring prior absence by deletion), and ONLY THEN promote
-   the exact landing merge SHA to production** with the exact PRODUCTION
-   `only_surfaces` and `require_staging_success=true`. Record non-dry-run
-   staging and production deploy-summary `headSha` evidence per surface;
-   verify each surface's artifact/health; verify old and canonical inbound
-   routes — all before any external mutation begins.
+   restore steps (restoring prior absence by deletion) and read the
+   restoration back to verify it, and ONLY THEN promote the exact landing
+   merge SHA to production** with the exact PRODUCTION `only_surfaces` and
+   `require_staging_success=true`. Only verified automatic staging success
+   plus verified gate restoration may proceed to production. Record
+   non-dry-run staging and production deploy-summary `headSha` evidence per
+   surface; verify each surface's artifact/health; verify old and canonical
+   inbound routes — all before any external mutation begins.
 
-**Failure-handling invariant:** no failure path — failed merge, failed tree
-equality, failed/cancelled/timed-out exact-landing main CI — may leave the
-temporary overrides active or permit a later source CI completion to emit
-staging.
+**Override cleanup invariant (finally-style, armed at the first override
+mutation):** on every failure, non-success, or unverifiable outcome — partial
+override write/read-back failure, failed merge, merge-SHA tree mismatch,
+exact-landing-SHA main CI failure/cancellation/timeout, automatic staging
+failure/cancellation/timeout, unexpected lane execution, or any state that
+cannot be verified — restore EVERY gate to its recorded prior value or prior
+absence, read the restoration back and verify it, then release the landing
+hold and halt. No failure path may leave the temporary overrides active or
+permit a later source CI completion to emit staging. If restoration itself
+fails or cannot be verified, production promotion is hard-stopped and the
+landing hold REMAINS in place while the failure is escalated; the hold is
+never released over unrestored or unverified gates.
 
 ### 4.3 External-configuration item schema
 
@@ -273,9 +300,14 @@ Application rules (binding):
   merge SHA, and routes verify:** apply items one producer at a time — source
   change → activation → live-consumption proof → smoke. A source edit without
   activation is never an update.
-- **Failed smoke ⇒ immediate recovery:** restore the source of truth,
-  re-activate at the same landing SHA, prove the live rollback, run a recovery
-  smoke, record both, halt — nothing further until resolved.
+- **Any failure after a source-of-truth mutation ⇒ immediate recovery.** Not
+  only a failed smoke: a failed or unverifiable activation and a failed or
+  unverifiable live-consumption proof trigger the same recovery. Restore the
+  source of truth, re-activate at the same landing SHA, prove the live
+  rollback, run the item's mapped recovery smoke, record both the failure and
+  the recovery, halt — nothing further until resolved. If the recovery itself
+  cannot be proven (rollback activation or live rollback proof fails), the
+  sequence remains halted until it is.
 - **Unchanged items are not exempt:** each closes as verified-correct only
   with secret-safe live proof plus its mapped smoke executed.
 - The sequence completes only when every item is verified-correct-with-proof
@@ -290,3 +322,58 @@ Application rules (binding):
 per item as `verified-correct+proved+smoked`,
 `updated+activated+proved+smoked`, or `failed+recovered+halted` with evidence
 links.*
+
+## 5. Release-surface closure and Phase V release record
+
+### 5.1 Release-surface closure (Phase H produces; carried into L and V)
+
+Before the accepted PR 4 head freezes, Phase H inventories and dispositions
+EVERY required user-facing release surface — the landing page, public docs,
+changelog/release notes, in-app release notes/copy, install/download
+surfaces, support/runbook surfaces, and any further release surface the sweep
+discovers — each into exactly one of:
+
+| Disposition | Meaning |
+| --- | --- |
+| update-in-this-landing | The change enters the exact replay list |
+| update-post-landing | Named owner + deadline recorded |
+| no-change-needed | Reason recorded |
+
+If Desktop ships, closure additionally covers creation/review/publication of
+the exact-SHA tag and the NEW draft GitHub Release at production promotion per
+the canonical desktop release procedure, and explicit stable updater-manifest
+verification at the exact released version/SHA.
+
+### 5.2 Phase V release record (the completion gate)
+
+Phase V launches only after the §4.3 external sequence fully completes. It
+commits the immutable release record at
+`specs/developing/deploying/web-desktop-unification-release-record.md`
+(indexed in [`README.md`](README.md)), sealing at least:
+
+1. the exact landing merge SHA and per-surface deployed SHAs, with the
+   reviewed DETECTED / EFFECTIVE_STAGING / PRODUCTION sets and per-surface
+   dispositions (reviewed staging-only surfaces recorded as such);
+2. the landing-ordering evidence: quiescence proof, recorded prior gate
+   state, override set/read-back, merge-SHA tree-equality + green-main-CI
+   proof, EFFECTIVE_STAGING per-lane execution proof, verified gate
+   restoration, and the production promotion record with non-dry-run staging
+   and production deploy-summary `headSha` evidence per surface;
+3. per-surface artifact/health verification and old + canonical inbound route
+   verification;
+4. each release-surface disposition and its outcome/evidence (if Desktop
+   shipped: released version, exact SHA, exact-SHA tag, published GitHub
+   Release, and stable updater-manifest verification);
+5. the complete external-item table per §4.3 — every item, changed or
+   unchanged, with activation mechanism used, secret-safe live-consumption
+   proof, and mapped smoke evidence (secrets redacted by name/location);
+6. all failure and recovery evidence: what failed, the source restore, the
+   re-activation at the same landing SHA, the live rollback proof, the
+   recovery smoke, and the resolution;
+7. the requirement-by-requirement audit against the canonical spec's
+   definition of done, each with an evidence pointer;
+8. the index of every `wdu-evidence/**` branch (name + recorded commit/tree/
+   patch hashes) authorizing their cleanup.
+
+No `wdu-evidence/**` branch is deleted before Phase V merges; deletion follows
+only the committed branch index. Completion requires Phase V merged.

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -194,17 +194,24 @@ Every DETECTED surface receives exactly one disposition, recorded here:
 
 Gate values are point-in-time and must be re-audited live at Phase H and
 re-verified at Phase L; recorded observations never substitute for a fresh
-read. A 2026-07-13 read-only audit of the GitHub environments showed
-environment-level values on `staging` of `LITELLM_DEPLOY_ENABLED=true`,
-`MOBILE_DEPLOY_ENABLED=true`, `EAS_SUBMIT_ENABLED=true`, and
-`DESKTOP_CHANNEL=beta`, with no environment-level `DESKTOP_DEPLOY_ENABLED` or
-`WORKERS_DEPLOY_ENABLED` (both default `false` when unset); `Production`
-carries environment-level `DESKTOP_DEPLOY_ENABLED`, `LITELLM_DEPLOY_ENABLED`,
-and `MOBILE_DEPLOY_ENABLED`. Phase H audits the then-current state (including
-any org-level inheritance) with sufficient read access or plans explicit
-staging environment-level overrides regardless, recording per gate whether an
-environment-level value previously existed (restore by value) or not (restore
-prior absence by deletion). If Desktop is
+read. A 2026-07-13 read-only audit (`gh variable list --env <env>`) showed
+these environment-level gate values — `staging`:
+`MOBILE_DEPLOY_ENABLED=true`, `EAS_SUBMIT_ENABLED=true`,
+`LITELLM_DEPLOY_ENABLED=true`, `WORKERS_DEPLOY_ENABLED=false`, and
+`DESKTOP_CHANNEL=beta`, with NO environment-level `DESKTOP_DEPLOY_ENABLED`
+(defaults `false` when unset); `Production`: `MOBILE_DEPLOY_ENABLED=true`,
+`EAS_SUBMIT_ENABLED=true`, `LITELLM_DEPLOY_ENABLED=true`,
+`WORKERS_DEPLOY_ENABLED=false`, and `DESKTOP_DEPLOY_ENABLED=true`. Restore
+semantics follow prior existence: a gate that previously existed at the
+environment level is restored BY VALUE (per this audit, staging
+`WORKERS_DEPLOY_ENABLED` restores to `false`, not by deletion); only a gate
+that previously did not exist at the environment level (per this audit, only
+staging `DESKTOP_DEPLOY_ENABLED`) has its prior absence restored by deletion.
+Phase H audits the then-current state (including any org-level inheritance)
+with sufficient read access or plans explicit staging environment-level
+overrides regardless, recording per gate whether an environment-level value
+previously existed (restore by value) or not (restore prior absence by
+deletion). If Desktop is
 in PRODUCTION, the ≥0.3.28 version bump covering every canonical owning
 coordinate is a distinct reviewed release-prep commit inside the replay list;
 the exact-SHA tag and a NEW draft GitHub Release are created and published
@@ -214,18 +221,24 @@ pre-existing `desktop-v0.3.27` tag/feed/draft is not the migration release).
 ### 4.2 Landing order: quiescence, overrides, restore-before-promote
 
 The landing ordering is binding and executes under an orchestrator-held
-landing hold that explicitly blocks other main merges AND main-CI
-reruns/manual dispatches:
+landing hold that explicitly blocks other main merges, main-CI reruns/manual
+dispatches, AND manual `deploy-staging.yml` `workflow_dispatch` runs — the
+workflow exposes an independent `workflow_dispatch` trigger in addition to
+its `workflow_run` path, so blocking main CI alone is insufficient:
 
 1. **Pre-override quiescence is proven first.** A `deploy-staging`-idle check
    alone is insufficient: an already queued/running/re-run qualifying main CI
    run can complete after the overrides are set and emit an older
-   `workflow_run` that consumes them. Therefore: drain every queued/running
-   qualifying main CI run; for each run that completes successfully during the
-   drain, wait for its corresponding Deploy Staging `workflow_run` to
-   materialize AND complete; recheck both the source main-CI runs and the
-   deploy-staging runs across a bounded event-propagation barrier until
-   quiescence is proven. Unprovable correlation or quiescence ⇒ stop.
+   `workflow_run` that consumes them, and a manual dispatch can start a Deploy
+   Staging run with no main-CI source at all. Therefore: drain every
+   queued/running Deploy Staging run REGARDLESS of trigger source (automatic
+   `workflow_run` or manual `workflow_dispatch`); drain every queued/running
+   qualifying main CI run; for each main-CI run that completes successfully
+   during the drain, wait for its corresponding Deploy Staging `workflow_run`
+   to materialize AND complete; recheck the source main-CI runs and ALL
+   deploy-staging runs (both trigger sources) across a bounded
+   event-propagation barrier until quiescence is proven. Unprovable
+   correlation or quiescence ⇒ stop.
 2. Record the prior staging gate state secret-safe (including whether each
    variable existed at the environment level at all); set the explicit
    reviewed staging environment-level overrides; read every override back and
@@ -260,10 +273,13 @@ reruns/manual dispatches:
 mutation):** on every failure, non-success, or unverifiable outcome — partial
 override write/read-back failure, failed merge, merge-SHA tree mismatch,
 exact-landing-SHA main CI failure/cancellation/timeout, automatic staging
-failure/cancellation/timeout, unexpected lane execution, or any state that
-cannot be verified — restore EVERY gate to its recorded prior value or prior
-absence, read the restoration back and verify it, then release the landing
-hold and halt. No failure path may leave the temporary overrides active or
+failure/cancellation/timeout, unexpected lane execution, an unexpected Deploy
+Staging run from ANY trigger source (a manual `workflow_dispatch` or any run
+other than the expected exact-landing-SHA automatic run — cancel it
+immediately, then enter cleanup), or any state that cannot be verified —
+restore EVERY gate to its recorded prior value or prior absence, read the
+restoration back and verify it, then release the landing hold and halt. No
+failure path may leave the temporary overrides active or
 permit a later source CI completion to emit staging. If restoration itself
 fails or cannot be verified, production promotion is hard-stopped and the
 landing hold REMAINS in place while the failure is escalated; the hold is
@@ -308,6 +324,14 @@ Application rules (binding):
   the recovery, halt — nothing further until resolved. If the recovery itself
   cannot be proven (rollback activation or live rollback proof fails), the
   sequence remains halted until it is.
+- **An uncertain source-write outcome is treated as a possible mutation.** A
+  source-of-truth write that fails, times out, or returns an unverifiable
+  result may nevertheless have applied. RE-READ the source of truth. If it
+  provably still holds the prior value, record that evidence and halt before
+  continuing the sequence. If it changed — or its state cannot be verified —
+  run the full recovery: restore the recorded prior value, re-activate at the
+  same landing SHA, prove the live rollback, run the item's mapped recovery
+  smoke, record everything, halt. A failed recovery remains halted.
 - **Unchanged items are not exempt:** each closes as verified-correct only
   with secret-safe live proof plus its mapped smoke executed.
 - The sequence completes only when every item is verified-correct-with-proof
@@ -358,15 +382,21 @@ commits the immutable release record at
    state, override set/read-back, merge-SHA tree-equality + green-main-CI
    proof, EFFECTIVE_STAGING per-lane execution proof, verified gate
    restoration, and the production promotion record with non-dry-run staging
-   and production deploy-summary `headSha` evidence per surface;
+   and production deploy-summary `headSha` evidence per surface AND the
+   deploy-run links for every staging and production run cited;
 3. per-surface artifact/health verification and old + canonical inbound route
    verification;
 4. each release-surface disposition and its outcome/evidence (if Desktop
    shipped: released version, exact SHA, exact-SHA tag, published GitHub
    Release, and stable updater-manifest verification);
-5. the complete external-item table per §4.3 — every item, changed or
-   unchanged, with activation mechanism used, secret-safe live-consumption
-   proof, and mapped smoke evidence (secrets redacted by name/location);
+5. the complete external-item table per §4.3 — for EVERY item, changed or
+   unchanged: its secret-safe source-of-truth location, the actual before
+   value, the actual after value (secrets redacted by name/location, never by
+   value), the required-change classification, the activation mechanism used,
+   the secret-safe live-consumption proof, and who applied the change and
+   when; plus, for every mapped smoke: the flow that was run, the result, and
+   the timestamp (with the explicit item→smoke mapping wherever a shared
+   smoke covers multiple items);
 6. all failure and recovery evidence: what failed, the source restore, the
    re-activation at the same landing SHA, the live rollback proof, the
    recovery smoke, and the resolution;

--- a/specs/tbd/README.md
+++ b/specs/tbd/README.md
@@ -19,6 +19,8 @@ They are not operating law until they are promoted into `specs/codebase/**` or
 | [support-system-alignment.md](support-system-alignment.md) | Historical live-system audit and superseded planning record. See the [accepted support-system contract](../codebase/features/support-system.md). |
 | [support-system-end-to-end-handoff.md](support-system-end-to-end-handoff.md) | Execution-grade worktree, implementation, AWS cutover, canary, rollback, and definition-of-done handoff for the accepted support-system contract. |
 | [structure-alignment-coordinator-model.md](structure-alignment-coordinator-model.md) | Coordinator model for structure-alignment planning. |
+| [web-desktop-unification-migration.md](web-desktop-unification-migration.md) | Non-authoritative rollout history and execution detail for the Web/Desktop product-client unification. The promoted contract is [web-desktop-client-unification.md](../codebase/features/web-desktop-client-unification.md); the binding execution/freeze ledger is [web-desktop-unification-rollout.md](../developing/deploying/web-desktop-unification-rollout.md). |
+| [web-desktop-unification-intake-ledger.md](web-desktop-unification-intake-ledger.md) | Historical 2026-07-13 intake snapshot of open PRs, worktrees, and migration conflicts. Binding intake/freeze snapshots live in the [rollout ledger](../developing/deploying/web-desktop-unification-rollout.md); this file is sweep input only. |
 | [workspace-migration-git-durability-plan.md](workspace-migration-git-durability-plan.md) | Workspace migration git durability planning. |
 
 ## Promotion Rules

--- a/specs/tbd/web-desktop-unification-intake-ledger.md
+++ b/specs/tbd/web-desktop-unification-intake-ledger.md
@@ -1,0 +1,380 @@
+# Web/Desktop Unification Intake Ledger
+
+Status: historical execution snapshot, non-authoritative.
+
+This ledger is history and sweep input only. The **binding** intake and freeze
+snapshots for the migration are appended to the rollout ledger at
+[`../developing/deploying/web-desktop-unification-rollout.md`](../developing/deploying/web-desktop-unification-rollout.md)
+by the committed docs-only intake phases; the promoted contract is
+[`../codebase/features/web-desktop-client-unification.md`](../codebase/features/web-desktop-client-unification.md).
+Do not cite this file for code review or release readiness.
+
+Snapshot: 2026-07-13, `main@bdd11aa5a7`. This ledger records the live intake
+required by Section 17 of
+[web-desktop-unification-migration.md](web-desktop-unification-migration.md).
+It is a point-in-time execution aid, not a permanent claim that a PR or
+worktree remains open. Items may already be resolved — for example, PR #1143
+merged to `main` as `5e86a7faf` on 2026-07-13, satisfying its "merge before
+PR 1" disposition below.
+
+## 1. Outcome
+
+The repository does not need a broad merge freeze before PR 0b/0c or the
+in-place PR 1. It needs four concrete actions:
+
+1. Fix the repository-shape failures in PR #1143, rebase it onto current
+   `main`, and merge it before PR 1.
+2. Do not merge PR #1142. Continue the clean test-only replacement on the
+   `test-foundation/v2-*` branch family, selectively absorb the useful six
+   commits from `codex/test-foundation-combined` and the test-only tail of
+   #1142, then close #1142.
+3. Protect the current uncommitted planning work, the detached support work,
+   and the dirty UI/runtime programs named below. Each must land, be
+   explicitly cancelled, or be retargeted before the mechanical PR 2 move.
+4. Close the stale PR/worktree swarms instead of carrying them into the
+   migration. Their still-valid guarantees belong in the test specification or
+   a fresh implementation, not in old integration branches.
+
+The only current product PR that blocks starting PR 1 is #1143. Resolving
+#1142 means choosing and recording its replacement; the replacement test work
+may continue alongside PR 0b/0c and PR 1 because those PRs do not move product
+paths.
+
+## 2. Disposition vocabulary
+
+| Disposition | Meaning |
+| --- | --- |
+| Merge | Make the branch reviewable and land it before the named checkpoint. |
+| Fresh-port | Move only reviewed behavior onto current `main`; never merge the old stack wholesale. |
+| Protect | Preserve dirty or unique work until its owner explicitly lands, retargets, or cancels it. |
+| Retarget | Continue the feature against the new canonical branch/path. |
+| Supersede | Close the PR/branch because current code, specs, or a newer program replaces it. |
+| Cleanup | Remove the local worktree only after confirming it is clean or contains disposable generated noise. |
+
+No cleanup disposition authorizes discarding uncommitted work. A dirty
+worktree remains protected until its diff is reviewed.
+
+## 3. Open GitHub PRs
+
+There were 46 open PRs at the snapshot. Every one is accounted for below.
+
+### 3.1 Migration-path decisions
+
+| PR | Owner / head | Touched slice | Disposition |
+| --- | --- | --- | --- |
+| [#1143](https://github.com/proliferate-ai/proliferate/pull/1143) Workflow definition authoring V1 | `pablonyx`; `codex/workflows-v1-pr1@d24fb7348f` | Server 18, shared packages 12, Cloud SDK 9, Desktop 6, Web 4, specs 4 | **Merge before PR 1.** Fix one forbidden raw Cloud SDK import and two over-limit files, rebase, run its gates, and merge. |
+| [#1142](https://github.com/proliferate-ai/proliferate/pull/1142) strict core-flow qualification | `pablonyx`; `codex/test-foundation-integration@f8aecfe260` | 589 files / about 105k additions across old Workflow V1, server, runtime, Desktop, packages, tests, CI, and specs | **Supersede.** It is conflicting and not a test-only PR. Port only reviewed test/runtime pieces to the V2 test foundation after #1143, then close it. |
+
+### 3.2 Independent current work
+
+These do not block PR 0b/0c or PR 1. They should be resolved before the PR 2
+freeze so the mechanical move starts from a quiet `main`.
+
+| PR | Owner / head | Disposition |
+| --- | --- | --- |
+| [#1141](https://github.com/proliferate-ai/proliferate/pull/1141) dead server config | `Rahul-Ganesan`; `838a474129` | Add required labels, resolve metadata/Vercel noise, and merge independently. |
+| [#1140](https://github.com/proliferate-ai/proliferate/pull/1140) local-development docs | `Rahul-Ganesan`; `adbc7da2c3` | Add required labels, resolve metadata/Vercel noise, and merge independently. |
+| [#1114](https://github.com/proliferate-ai/proliferate/pull/1114) GitHub Actions dependencies | Dependabot; `3a2fa152f2` | Merge as part of the dependency batch, then rebase the V2 test foundation's CI changes. |
+| [#1104](https://github.com/proliferate-ai/proliferate/pull/1104) Cargo dependencies | Dependabot; `1e839a48a9` | Merge as part of the dependency batch. |
+| [#807](https://github.com/proliferate-ai/proliferate/pull/807) Python dependencies | Dependabot; `b6a7a64eab` | Merge as part of the dependency batch after #1141. |
+| [#1105](https://github.com/proliferate-ai/proliferate/pull/1105) README product layout | `pablonyx`; `a1f914afa0` | Product-review the clean draft and either merge it or close it; it supersedes #839. |
+
+### 3.3 Explicit product decisions
+
+| PR | Owner / head | Disposition |
+| --- | --- | --- |
+| [#825](https://github.com/proliferate-ai/proliferate/pull/825) LiteLLM agent-auth spec | `pablonyx`; `6afcad9e1d` | It correctly removes Bifrost but predates the finalized free/paid per-seat billing policy. Reconcile useful architecture into current specs, then close or replace it; do not adopt it verbatim. |
+| [#772](https://github.com/proliferate-ai/proliferate/pull/772) native Linux Desktop | `VAIBHAVSING`; `2c646df2e1` | Decide whether Linux is in the supported Tier 4 matrix. If yes, reimplement/rebase as an independent current PR; otherwise close and retain a named backlog item. |
+
+### 3.4 Supersede or close
+
+The five-day rule applies here: old work is not merged because it happens to
+exist. A valid guarantee is retained in current specs/tests and the behavior is
+reimplemented from current `main` only if qualification proves it missing.
+
+| PRs | Reason |
+| --- | --- |
+| #1055 | Broad npm batch currently fails Desktop; close and let Dependabot regenerate after the structural migration. |
+| #998 | Current authoritative spec work supersedes the old architecture-doc consolidation. |
+| #964, #965 | Stale pre-Workflow automation branches; rederive any still-visible behavior after the current Workflow stack lands. |
+| #941, #952 | Old repository-shape fixes target superseded file layouts. |
+| #890, #943, #945, #946, #947, #948, #949, #950 | Preserve first-run, wake/resume, revoke cleanup, fail-closed auth, pre-clone, stalled materialization, recovery, and destroy guarantees in Tier 3 tests; close the stale implementations. |
+| #942 | Current catalog probing and gateway tests, not the old open-model branch, define routing behavior. |
+| #944 | Obsolete shared-sandbox profile direction conflicts with the user-per-sandbox model. |
+| #938, #939 | Current self-host/Tier 3–4 contracts supersede the old installer and optional BYO-certificate drafts. |
+| #892 | Targets an intermediate Mobile layout and Mobile is outside this migration. |
+| #881, #882, #883, #884, #885, #886 | Close the entire obsolete agent-auth stack; PR 0b/0c rederive only the accepted authority and lifecycle contracts. |
+| #847, #850 | Superseded subagent visual stack; current subagent work is tracked as one local program below. |
+| #839 | Superseded by the newer #1105 README choice. |
+| #802 | Stale integration-catalog gateway stack; Tier 3 integration qualification defines current missing work. |
+| #800 | Defer the local skills marketplace as fresh post-migration work. |
+| #791 | Reimplement native plan decisions only if current harness qualification shows the behavior is absent. |
+| #769 | Conflicts with the canonical profile-based Make workflow. |
+| #662, #745, #746 | Superseded by the current chat continuity/composer baseline. |
+| #729 | Abandoned isolated plugin/eval work; reopen fresh if it becomes a current priority. |
+
+This table accounts for 36 supersede/close PRs; together with the ten PRs in
+Sections 3.1–3.3, it accounts for all 46 open PRs.
+
+## 4. Local worktree programs
+
+The live repository had 158 worktrees: 45 dirty, five detached, and 125 whose
+heads were not ancestors of `main`. Most are duplicated swarm snapshots. The
+following program ledger is the controlling classification; PR-attached
+worktrees inherit their PR's disposition above.
+
+### 4.1 Canonical testing line
+
+| Work | Owner / head | Touched slice | Disposition |
+| --- | --- | --- | --- |
+| Current primary worktree | current session; `main@bdd11aa5a7`; 34 dirty/untracked entries at final snapshot | Testing specs/manifests plus this migration plan | **Protect.** The same intended spec set is committed on the V2 foundation branch; do not lose either copy while reconciling. |
+| `test-foundation/v2-{contracts,artifacts,runner,local,cloud,selfhost,t4-cloud,t4-desktop,tier2}` | active test-foundation agents; all at `2dbe4f302` | Two current commits: shared contracts and the authoritative testing/migration spec pack | **Canonical active line.** Continue sharded implementation here, integrate through one reviewed branch, and rebase after #1143. |
+| `codex/test-foundation-combined@6594a7d463` | prior test-foundation agent | Six cohesive fail-closed Tier 2/local/self-host/dual-host commits; nine dirty spec files | **Fresh-port source.** Preserve the unique self-update status correction, prefer the newer V2 specs, and port the six reviewed behaviors into V2. Do not create a competing final PR. |
+| `codex/test-foundation-integration@f8aecfe260` | PR #1142 | Entire obsolete Workflow integration plus test tail | **Supersede.** Salvage only test-only evidence missing from V2, notably Tier 4 cloud evidence, dependency-contract checks, and current Workflow scenario adaptations. |
+| `codex/{wdu-harness-foundation,test-dual-host-mainline,test-foundation-mainline}` | historical test agents | Earlier versions of the dual-host/foundation work | **Supersede/cleanup** after V2 contains the accepted tests. |
+| `codex/t3-{local-runner,ci-wiring}` and `codex/recover-{test-hardening,billing-release,desktop-tier1}` | old Workflow/test swarm | Tier 2/3/release runner source material on the obsolete integration base | **Reference only.** Port a missing test deliberately; never merge these stacks. |
+
+### 4.2 WDU prerequisite branches
+
+| Work | Owner / head | Disposition |
+| --- | --- | --- |
+| `codex/anyharness-query-scope@c3690a787a` | historical WDU agent | **Cleanup.** Its committed tree is exactly represented by merged PR #1144 / `bdd11aa5a`; only generated `Cargo.lock` drift remains locally. |
+| `codex/wdu0-contract-ledger@f0a1da3f97` | historical WDU agent | **Supersede.** The final migration plan replaces its old host/deployment model. Retain only any guarantee not already present in the final plan. |
+| `codex/wdu2-scope-contract@6d68b472fa` | historical WDU agent | **Supersede and rewrite in PR 0b.** Its persistent deployment UUID, `dpk1_`, and old epoch model are rejected. Tests may inform the current normalized deployment + host-owned `authGeneration` design. |
+| `codex/wdu2-server-identity@ea99ef3e9d` | historical WDU agent | **Cancel.** The new deployment UUID and `/meta` protocol are explicitly outside the aligned design. |
+| `codex/wdu2-native-vault@ba761189b9` | historical WDU agent | **Fresh-port selected security ideas only.** Reuse atomic file, private-permission, symlink, corruption, and temp-directory tests under the current PR 0b credential design; do not port `dpk1_`. |
+| `codex/wdu2-desktop-query-scope@46c36ff395` | historical WDU agent | **Fresh-port tests only.** PR #1144 supersedes most code; PR 0b/0c still needs same-user re-login and live-resource teardown fencing. |
+
+### 4.3 Workflow and subagent programs
+
+| Program | Owner / heads | Dirty/unique state | Disposition |
+| --- | --- | --- | --- |
+| Workflow V1 authoring | `codex/workflows-v1-pr1@d24fb7348f`; PR #1143 | Clean | Merge before PR 1. |
+| Workflow V1 PR 2 design | `codex/workflows-v1-pr2-design@d24fb7348f` | Two dirty design specs | Protect; continue after #1143. |
+| Workflow execution reference | `codex/workflows-simple-integration@dbd34ac39c` | Clean, seven commits over current base but 339 files | Do not merge wholesale. Split the accepted execution work into the post-#1143 Workflow PR sequence. |
+| Old Workflow/recovery swarm | `codex/recover-*`, `codex/workflows-*`, `workflows/completion-*`, `workflows/feat-*`, `workflows/ux-mocks` | About 30 overlapping heads from July 9–11 | Reference only, then supersede after a commit/parity check against the sequential Workflow stack. |
+| Dirty Workflow shards | `codex/workflows-v1-foundations-integration`, `codex/workflows-wf-poll-net-fable`, `codex/workflows-wf-outbox`, `codex/workflows-v1-integration-recovery` | Respectively 99, 21, 6, and 5 dirty entries at snapshot | Protect until the unique AnyHarness, network, outbox, and spec diffs are extracted or explicitly cancelled. |
+| Subagent runtime program | `codex/subagents-{close-api,mcp-contract,runtime-recovery,turn-context}` plus `codex/workspace-activity-snapshot` | `close-api` has 40 dirty entries; siblings are clean overlapping stacks | Treat as one program. Port accepted slices onto current `main`; do not merge the shared obsolete stack. Resolve before PR 2 or retarget once to `product-client`. |
+| Old combined chat baseline | `codex/chat-baseline-integration@4c8d1ae154` | Clean but 204 commits over an obsolete integration base | Cancel; current chat PRs and the protected UI diffs below are the only sources to review. |
+
+### 4.4 Protected dirty product work
+
+These branches do not prevent in-place PR 1. They must receive a named owner
+and a land/cancel/retarget decision before PR 2 moves Desktop paths.
+
+| Work | Head / dirty state | Touched slice | Required decision |
+| --- | --- | --- | --- |
+| Detached support work at `.codex/worktrees/385e/proliferate` | `bdd11aa5a7`; 36 dirty entries at final snapshot | Support reporting, PR metadata, CI, server infrastructure, Desktop and shared packages | Create a named branch. Land a focused PR before PR 2 or explicitly retarget it. |
+| `whale` | ancestor `af5b002d00`; 63 dirty entries | Transcript/tool-call polish, Desktop, product UI/domain, CSS, specs | Compare visually with the current chat baseline; extract a focused PR or cancel explicitly. |
+| `codex/composer-agent-ux` | ancestor `23d63162b5`; 89 dirty entries | Composer/agent settings plus mixed billing, GitHub auth, catalog, CI, and server changes | Audit by feature. Never merge as one unit; separately preserve any real billing/auth fixes. |
+| `codex/subagents-close-api` | `c502b22bc4`; 40 dirty entries | AnyHarness, Desktop, shared packages | Resolve as part of the one subagent runtime program above. |
+| `codex/transactional-empty-chat-switch-source` | `2be625e68b`; 125 dirty entries | Mixed scratch state after PR #1128 merged | Treat as protected scratch until its owner confirms no unique diff remains. |
+| `feat/pr-clarity` and `worktree-git-status-panel` | ancestor heads; 45 and 38 dirty entries | Git status / PR clarity UI | Presumed superseded by current Git-status UI under the five-day rule; perform one targeted visual comparison before cancellation. |
+| `tests/intent-sso` | `0fd0c3060b`; 263 dirty entries | Old intent/SSO test integration | Protect long enough to extract any unique fixture or scenario into V2, then supersede. |
+| `worktree-v1` | `5c13d0a55b`; 41 dirty entries | Very old server/auth work | Stale, but do not delete until the uncommitted diff is explicitly reviewed. |
+
+### 4.5 Detached and stale local state
+
+The five detached worktrees were:
+
+- `.codex/worktrees/385e/proliferate@bdd11aa5a7` — protected above;
+- `.codex/worktrees/9314/proliferate@53e761e00f` — old runtime-config
+  work with two dirty entries; review, then supersede;
+- `.claude/worktrees/wf_bb868f20-e6e-10@2f3efc43f4` — obsolete
+  repo-shape work; supersede;
+- `.claude/worktrees/wf_bb868f20-e6e-12@08023596e6` — obsolete
+  gateway-open-model work; supersede;
+- `.claude/worktrees/wf_c2e8588c-e8e-11@c413cd16e0` — obsolete auth
+  cleanup work; preserve the guarantee in tests, then supersede.
+
+Other stale local stacks—`agent-auth/*`, old self-hosting branches,
+`repo-environment-flows-*`, `goals*`, `catalog-fence-*`, old integration
+branches, and open-PR worktrees from Section 3—inherit the corresponding
+supersede/fresh-port decision. Merged bug-fix branches
+`fix/{billing-reconciler,org-compute-budget-attribution,invitations-admin-only,
+sandbox-proxy-product-gate,seat-adjustment-multisub}` are cleanup candidates;
+their PRs are already on `main` and their remaining dirt is generated noise.
+
+Clean duplicate animal-agent worktrees whose heads are already ancestors of
+`main` are cleanup candidates, except dirty `whale`. Clean worktrees for merged
+PRs #1128, #1130, #1131, #1133, #1136–#1139, and #1144 are also cleanup
+candidates. Actual removal is a separate housekeeping action after this ledger
+is accepted.
+
+## 5. Execution order
+
+1. Fix/rebase/merge #1143.
+2. Resolve the small independent merge batch (#1140, #1141, #807, #1104,
+   #1114, and the #1105 product decision).
+3. Keep `test-foundation/v2-*` as the only active test-foundation line. Port
+   accepted behavior from `test-foundation-combined` and the test-only tail of
+   #1142, validate it, open a clean PR, and close #1142.
+4. Implement PR 0b/0c and in-place PR 1. Fresh-port only the accepted WDU
+   security/lifecycle tests; do not merge the obsolete WDU branches.
+5. In parallel, split current Workflow work into reviewable slices and audit
+   the protected dirty product work.
+6. Immediately before PR 2, refresh this ledger, require every hot-surface
+   item to be merged/cancelled/retargeted, remove the embedded browser, and
+   begin the one-to-two-day Desktop path freeze.
+
+## 6. Gate to start PR 1
+
+PR 1 may start when:
+
+- #1143 is merged;
+- #1142 is recorded as superseded and V2 is the single canonical test line;
+- PR 0b/0c owners do not use the rejected WDU deployment-UUID design;
+- all dirty worktrees in Section 4 are protected from cleanup; and
+- queued structure-alignment work that assumes app-owned product pages or a
+  separate Web product is cancelled or retargeted.
+
+The dirty product programs do not all need to land before PR 1 because PR 1
+does not move their files. They do need final dispositions before PR 2.
+
+## 7. Raw active-worktree snapshot
+
+This appendix makes the grouped ledger auditable. It includes every worktree
+that was dirty, detached, or ahead of `main` at the snapshot. Repeated swarm
+heads are intentionally visible here. “Protect” means no destructive cleanup;
+it does not mean the old branch should ultimately merge.
+
+<details>
+<summary>133 dirty, detached, or unmerged worktree entries</summary>
+
+| Branch / head | Owner | State | Slice | Disposition | Path |
+| --- | --- | --- | --- | --- | --- |
+| `main@bdd11aa5a7` | Pablo/local | 2026-07-12; −0/+0; dirty 34 | Testing/migration specs | Protect current planning work | `~/proliferate` |
+| `codex/clean-sidebar-icons@8fda102145` | Codex session | 2026-07-11; −15/+1; dirty 0 | Merged product PR | Cleanup | `~/.codex/worktrees/255b/proliferate` |
+| `DETACHED@bdd11aa5a7` | Codex session | 2026-07-12; −0/+0; dirty 36; detached | Support/CI/product | Protect; name branch before PR 2 | `~/.codex/worktrees/385e/proliferate` |
+| `codex/repo-environment-flows-parked-4dd6@1cd8696762` | Codex session | 2026-06-29; −298/+44; dirty 9 | Historical product stack | Review dirt, then supersede | `~/.codex/worktrees/4dd6/proliferate` |
+| `codex/transactional-empty-chat-switch-source@2be625e68b` | Codex session | 2026-07-11; −18/+1; dirty 125 | Chat scratch | Protect pending owner confirmation | `~/.codex/worktrees/4df1/proliferate` |
+| `DETACHED@53e761e00f` | Codex session | 2026-06-28; −298/+43; dirty 2; detached | Historical detached work | Review dirt, then supersede | `~/.codex/worktrees/9314/proliferate` |
+| `codex/composer-agent-ux@23d63162b5` | Codex session | 2026-07-11; −18/+0; dirty 89 | Composer/agent/billing | Protect; split by feature | `~/.codex/worktrees/composer-agent-ux/proliferate` |
+| `codex/desktop-release-notices@2c788deab9` | Codex session | 2026-07-11; −13/+2; dirty 0 | Merged product PR | Cleanup | `~/.codex/worktrees/desktop-release-notices` |
+| `codex/transactional-empty-chat-switch@b2ce0606f0` | Codex session | 2026-07-11; −16/+1; dirty 0 | Merged product PR | Cleanup | `~/.codex/worktrees/empty-chat-switch-pr/proliferate` |
+| `codex/remove-runtime-config@53e761e00f` | Codex session | 2026-06-28; −298/+43; dirty 0 | Historical product stack | Supersede | `~/.codex/worktrees/f746/proliferate` |
+| `codex/repo-environment-flows-hardcut@0b6f2fff4c` | Codex session | 2026-06-30; −298/+48; dirty 0 | Historical product stack | Supersede | `~/.codex/worktrees/repo-env-flow-hardcut/proliferate` |
+| `codex/subagents-close-api@c502b22bc4` | Codex session | 2026-07-11; −20/+159; dirty 40 | Subagent runtime | Protect unique dirt; port as one program | `~/.codex/worktrees/subagents-close-api/proliferate` |
+| `codex/subagents-mcp-contract@d13da01522` | Codex session | 2026-07-11; −20/+161; dirty 0 | Subagent runtime | Reference within one current program | `~/.codex/worktrees/subagents-mcp-contract/proliferate` |
+| `codex/subagents-runtime-recovery@7b831e5ed4` | Codex session | 2026-07-11; −20/+159; dirty 0 | Subagent runtime | Reference within one current program | `~/.codex/worktrees/subagents-runtime-recovery/proliferate` |
+| `codex/subagents-turn-context@65b0702f43` | Codex session | 2026-07-11; −20/+158; dirty 0 | Subagent runtime | Reference within one current program | `~/.codex/worktrees/subagents-turn-context/proliferate` |
+| `codex/subagents-ux-mocks@abb56e3bb5` | Codex session | 2026-07-11; −13/+1; dirty 0 | Subagent runtime | Reference within one current program | `~/.codex/worktrees/subagents-ux-mocks/proliferate` |
+| `codex/wdu-harness-foundation@14e005756e` | Codex session | 2026-07-11; −11/+1; dirty 0 | Test foundation | Supersede after V2 parity | `~/.codex/worktrees/wdu-harness-foundation` |
+| `codex/workflows-v1-pr1@d24fb7348f` | Codex session | 2026-07-12; −1/+3; dirty 0 | PR-attached | Merge PR #1143 before PR 1 | `~/.codex/worktrees/workflows-v1-pr1/proliferate` |
+| `codex/workflows-v1-pr2-design@d24fb7348f` | Codex session | 2026-07-12; −1/+3; dirty 2 | Workflow | Protect design; continue after #1143 | `~/.codex/worktrees/workflows-v1-pr2-design/proliferate` |
+| `codex/workspace-activity-snapshot@a2e8599e61` | Codex session | 2026-07-11; −20/+158; dirty 0 | Subagent runtime | Reference within one current program | `~/.codex/worktrees/workspace-activity/proliferate` |
+| `agent-auth/00-spec@c0d6b57c0e` | local agent | 2026-07-01; −291/+2; dirty 0 | PR-attached | Reconcile then close/replace PR #825 | `~/.proliferate/worktrees/proliferate/agent-auth-00-spec` |
+| `agent-auth/16-catalog-probe@da0890709e` | local agent | 2026-07-02; −279/+9; dirty 0 | Old agent-auth | Supersede; PR 0b/0c owns accepted model | `~/.proliferate/worktrees/proliferate/agent-auth-16-catalog-probe` |
+| `agent-auth/full-integration@8ab0a6bde2` | local agent | 2026-07-01; −282/+17; dirty 1 | Old agent-auth | Supersede; PR 0b/0c owns accepted model | `~/.proliferate/worktrees/proliferate/agent-auth-full` |
+| `agent-auth/fix-missing-selection-native@6c5457df83` | local agent | 2026-07-02; −199/+1; dirty 1 | Old agent-auth | Supersede; PR 0b/0c owns accepted model | `~/.proliferate/worktrees/proliferate/agent-auth-hotfix` |
+| `fennec@60016bc392` | local agent | 2026-07-04; −158/+1; dirty 0 | PR-attached | Supersede with PR #998 | `~/.proliferate/worktrees/proliferate/fennec` |
+| `whale@af5b002d00` | local agent | 2026-07-09; −32/+0; dirty 63 | Chat/transcript UI | Protect; visual audit before PR 2 | `~/.proliferate/worktrees/proliferate/whale` |
+| `feat/composer-queue@2549dd9747` | Pablo/local | 2026-07-07; −129/+6; dirty 0 | Closed PR #1003 | Cleanup; superseded | `~/proliferate-composerq` |
+| `cursor-model-variant-switch@4098104337` | Pablo/local | 2026-06-16; −355/+3; dirty 0 | Cursor variants | Cleanup; superseded by #1137 | `~/proliferate-cursor-model-switch` |
+| `ux/wave-1-settings-system@61b4ff6ecf` | Pablo/local | 2026-07-01; −291/+6; dirty 4 | Older local program | Protect until targeted review | `~/proliferate-ds-chat-restyle` |
+| `codex/integration-catalog-gateway@7d6ecbb57b` | Pablo/local | 2026-06-30; −293/+8; dirty 0 | PR-attached | Supersede with PR #802 | `~/proliferate-integration-catalog-gateway` |
+| `feat/pr-clarity@acf162fe9d` | Pablo/local | 2026-07-07; −129/+0; dirty 45 | Git-status UI | Visual audit, then likely supersede | `~/proliferate-prstatus` |
+| `codex/workflow-positioning-readme@a1f914afa0` | Pablo/local | 2026-07-09; −46/+5; dirty 0 | PR-attached | Review/merge-or-close PR #1105 | `~/proliferate-readme-workflows` |
+| `seed/remove-cloudflare-docs@12fc4e22d4` | Pablo/local | 2026-07-07; −129/+1; dirty 3 | Older local program | Protect until targeted review | `~/proliferate-seedclean` |
+| `ui/combined-preview@80dee15f94` | Pablo/local | 2026-07-03; −189/+27; dirty 0 | Older local program | Review, then supersede | `~/proliferate-ui-combined` |
+| `fix/billing-reconciler@b5942f73bf` | Pablo/local | 2026-07-08; −108/+7; dirty 1 | Merged bug fix | Cleanup after generated dirt check | `~/proliferate-worktrees/reconciler-port` |
+| `workflows/ux-mocks@0e44f558c9` | Pablo/local | 2026-07-08; −189/+89; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-worktrees/workflows-ux` |
+| `codex/anyharness-query-scope@c3690a787a` | test/workflow agent | 2026-07-12; −1/+4; dirty 1 | WDU prerequisite | Cleanup; merged as #1144 | `~/proliferate-wt/anyharness-query-scope` |
+| `ux/environments-settings@b6997f2c02` | test/workflow agent | 2026-07-01; −279/+3; dirty 5 | Older local program | Protect until targeted review | `~/proliferate-wt/env-settings` |
+| `codex/cloud-worker-integrations-full@b88a3e8bfb` | test/workflow agent | 2026-07-02; −275/+18; dirty 3 | Older local program | Protect until targeted review | `~/proliferate-wt/full` |
+| `integration/agents-plus-convergence@6d4deca55d` | test/workflow agent | 2026-07-06; −145/+31; dirty 2 | Older local program | Protect until targeted review | `~/proliferate-wt/integration` |
+| `readme-revamp@76e3d95fcb` | test/workflow agent | 2026-07-01; −290/+6; dirty 0 | PR-attached | Supersede with PR #839 | `~/proliferate-wt/readme-revamp` |
+| `codex/recover-alerting@0344180153` | test/workflow agent | 2026-07-11; −20/+167; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-alerting` |
+| `codex/recover-billing-release@31afee08d3` | test/workflow agent | 2026-07-11; −20/+161; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-billing-release` |
+| `codex/recover-desktop-tier1@815b72b081` | test/workflow agent | 2026-07-11; −20/+161; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-desktop-tier1` |
+| `codex/recover-pending-prompts@7f3ba92ddc` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-pending-prompts` |
+| `codex/recover-platform-architecture-docs@1086aa4c3d` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-platform-architecture-docs` |
+| `codex/recover-test-hardening@1e792d1f34` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-test-hardening` |
+| `codex/recover-transcript-ui@4b4139a2c8` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-transcript-ui` |
+| `codex/recover-workflow-run-args-ui@3a11429003` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-workflow-run-args-ui` |
+| `codex/recover-workflow-structure@007278e20b` | test/workflow agent | 2026-07-11; −20/+160; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/recover-workflow-structure` |
+| `self-hosting/v1@82677b12b8` | test/workflow agent | 2026-07-02; −212/+0; dirty 2 | Old self-host | Supersede after V2 scenario parity | `~/proliferate-wt/self-hosting` |
+| `self-hosting/integration@71ad361904` | test/workflow agent | 2026-07-02; −280/+27; dirty 0 | Old self-host | Supersede after V2 scenario parity | `~/proliferate-wt/sh-integration` |
+| `codex/t3-ci-wiring@ac0a437403` | test/workflow agent | 2026-07-11; −11/+175; dirty 0 | Test foundation | Reference only; port missing CI behavior into V2 | `~/proliferate-wt/t3-ci-wiring` |
+| `codex/t3-local-runner@fd83ea9c7c` | test/workflow agent | 2026-07-11; −11/+176; dirty 1 | Test foundation | Review dirt, then port missing local-runner behavior into V2 | `~/proliferate-wt/t3-local-runner` |
+| `codex/test-dual-host-mainline@f0ff35c053` | test/workflow agent | 2026-07-11; −2/+1; dirty 0 | Test foundation | Supersede after V2 parity | `~/proliferate-wt/test-dual-host-mainline` |
+| `codex/test-foundation-combined@6594a7d463` | test/workflow agent | 2026-07-12; −2/+6; dirty 9 | Test foundation | Fresh-port source into V2 | `~/proliferate-wt/test-foundation-combined` |
+| `codex/test-foundation-integration@f8aecfe260` | test/workflow agent | 2026-07-11; −11/+186; dirty 0 | PR-attached | Supersede PR #1142 | `~/proliferate-wt/test-foundation-integration` |
+| `codex/test-foundation-mainline@6a4ec858f4` | test/workflow agent | 2026-07-11; −2/+1; dirty 0 | Test foundation | Supersede after V2 parity | `~/proliferate-wt/test-foundation-mainline` |
+| `test-foundation/v2-artifacts@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-artifacts` |
+| `test-foundation/v2-cloud@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-cloud` |
+| `test-foundation/v2-contracts@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-foundation` |
+| `test-foundation/v2-local@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-local` |
+| `test-foundation/v2-runner@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 2 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-runner` |
+| `test-foundation/v2-selfhost@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-selfhost` |
+| `test-foundation/v2-t4-cloud@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-t4-cloud` |
+| `test-foundation/v2-t4-desktop@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-t4-desktop` |
+| `test-foundation/v2-tier2@2dbe4f3021` | test/workflow agent | 2026-07-13; −0/+2; dirty 0 | Test foundation | Canonical V2 shard | `~/proliferate-wt/tf-tier2` |
+| `codex/composer-ultra-alignment@5444091fa1` | test/workflow agent | 2026-07-11; −7/+4; dirty 0 | Chat/transcript UI | Compare with the current chat baseline; merge or supersede before PR 2 | `~/proliferate-wt/transcript-continuity` |
+| `codex/wdu0-contract-ledger@f0a1da3f97` | test/workflow agent | 2026-07-12; −2/+3; dirty 0 | WDU prerequisite | Supersede with final plan | `~/proliferate-wt/wdu0-contract-ledger` |
+| `codex/wdu2-desktop-query-scope@46c36ff395` | test/workflow agent | 2026-07-12; −2/+5; dirty 0 | WDU prerequisite | Port missing lifecycle tests | `~/proliferate-wt/wdu2-desktop-query-scope` |
+| `codex/wdu2-native-vault@ba761189b9` | test/workflow agent | 2026-07-12; −2/+6; dirty 0 | WDU prerequisite | Port selected security tests | `~/proliferate-wt/wdu2-native-vault` |
+| `codex/wdu2-scope-contract@6d68b472fa` | test/workflow agent | 2026-07-12; −2/+4; dirty 0 | WDU prerequisite | Rewrite current design in PR 0b | `~/proliferate-wt/wdu2-scope-contract` |
+| `codex/wdu2-server-identity@ea99ef3e9d` | test/workflow agent | 2026-07-12; −2/+5; dirty 0 | WDU prerequisite | Cancel rejected UUID protocol | `~/proliferate-wt/wdu2-server-identity` |
+| `workflows/feat-2a-desktop-executor@f54c854114` | test/workflow agent | 2026-07-09; −189/+94; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wf-2a` |
+| `workflows/feat-3a-parallel-lanes@cd26a69fa8` | test/workflow agent | 2026-07-10; −189/+96; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wf-3a` |
+| `codex/workflows-broker-iso@0651b82b8b` | test/workflow agent | 2026-07-11; −17/+168; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/workflows-broker-iso` |
+| `codex/workflows-v1-foundations-integration@ed877352d9` | test/workflow agent | 2026-07-11; −17/+179; dirty 99 | Workflow | Protect unique dirt, then port/cancel | `~/proliferate-wt/workflows-foundations-integration` |
+| `codex/workflows-wf-outbox@32c97186d1` | test/workflow agent | 2026-07-11; −17/+176; dirty 6 | Workflow | Protect unique dirt, then port/cancel | `~/proliferate-wt/workflows-outbox` |
+| `codex/workflows-wf-poll-net-fable@ff5fb6060c` | test/workflow agent | 2026-07-11; −17/+177; dirty 21 | Workflow | Protect unique dirt, then port/cancel | `~/proliferate-wt/workflows-poll-net` |
+| `codex/workflows-simple-integration@dbd34ac39c` | test/workflow agent | 2026-07-12; −2/+7; dirty 0 | Workflow | Reference; split into current PRs | `~/proliferate-wt/workflows-simple-integration` |
+| `codex/workflows-v1-clean-integration@0826992477` | test/workflow agent | 2026-07-11; −11/+177; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/workflows-v1-clean-integration` |
+| `codex/workflows-v1-integration-recovery@32c97186d1` | test/workflow agent | 2026-07-11; −17/+176; dirty 5 | Workflow | Protect unique dirt, then port/cancel | `~/proliferate-wt/workflows-v1-integration-recovery` |
+| `codex/workflows-wf-id@46777561fd` | test/workflow agent | 2026-07-11; −17/+167; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/workflows-wf-id` |
+| `workflows/completion-delivery@979724a704` | test/workflow agent | 2026-07-10; −20/+153; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wsc-ws2c` |
+| `workflows/completion-audiences@4b64e26922` | test/workflow agent | 2026-07-10; −20/+151; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wsc-ws3b` |
+| `workflows/completion-receipts@ba57b40697` | test/workflow agent | 2026-07-11; −20/+154; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wsc-ws3c` |
+| `workflows/completion-background@9687cc59fc` | test/workflow agent | 2026-07-10; −20/+152; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wsc-ws4a` |
+| `workflows/completion-polling@7b3fe6106b` | test/workflow agent | 2026-07-11; −20/+154; dirty 0 | Workflow | Reference only; supersede after parity | `~/proliferate-wt/wsc-ws4b` |
+| `worktree-agent-a07e0f65663d7ac44@bbf580db3a` | Claude session | 2026-07-04; −158/+4; dirty 0 | Historical agent swarm | Supersede | `repo/.claude/worktrees/agent-a07e0f65663d7ac44` |
+| `goals-loops/anyharness@c2b029e41b` | Claude session | 2026-07-02; −201/+0; dirty 36 | Historical swarm | Review dirt, then supersede | `repo/.claude/worktrees/agent-a5305e54cf3d9f20e` |
+| `fix/org-compute-budget-attribution@ad866c12ca` | Claude session | 2026-07-08; −107/+1; dirty 1 | Merged bug fix | Cleanup after generated dirt check | `repo/.claude/worktrees/agent-a7628b8ebba7f5276` |
+| `fix/invitations-admin-only@772e976568` | Claude session | 2026-07-08; −107/+1; dirty 1 | Merged bug fix | Cleanup after generated dirt check | `repo/.claude/worktrees/agent-a8d4b5fb96440225b` |
+| `goals-loops/desktop-ui@6e72ef9e5a` | Claude session | 2026-07-02; −204/+4; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/agent-a9d643ae673c8ae82` |
+| `agents/opencode-gateway-native-union@9cb3fe6806` | Claude session | 2026-07-04; −158/+7; dirty 1 | Historical agent swarm | Review dirt, then supersede | `repo/.claude/worktrees/agent-ad6e0cb4c0f780257` |
+| `catalog-fence-seam2@84e42cc5f9` | Claude session | 2026-06-16; −355/+6; dirty 3 | Historical swarm | Review dirt, then supersede | `repo/.claude/worktrees/catalog-lockfile-pins` |
+| `worktree-chat-snappiness@cd46168483` | Claude session | 2026-06-13; −398/+1; dirty 1 | PR-attached | Supersede with PR #662 | `repo/.claude/worktrees/chat-snappiness` |
+| `worktree-cloud-sandbox-model-spec@d342edbf42` | Claude session | 2026-07-02; −259/+2; dirty 0 | PR-attached | Supersede with PR #890 | `repo/.claude/worktrees/cloud-sandbox-model-spec` |
+| `worktree-git-status-panel@2803dfbb4d` | Claude session | 2026-07-03; −175/+0; dirty 38 | Git-status UI | Visual audit, then likely supersede | `repo/.claude/worktrees/git-status-panel` |
+| `worktree-pr809-cleanup@fc11feb273` | Claude session | 2026-07-01; −292/+30; dirty 1 | Older local program | Protect until targeted review | `repo/.claude/worktrees/pr809-cleanup` |
+| `agent-auth/21-direct-runtime-ui@739157349e` | Claude session | 2026-07-05; −204/+15; dirty 0 | PR-attached | Supersede auth stack #886 | `repo/.claude/worktrees/ssh-direct-stack` |
+| `worktree-transcript-scroll-fix@480376452a` | Claude session | 2026-06-13; −398/+1; dirty 1 | Old transcript UI | Supersede after confirming the dirty entry is disposable noise | `repo/.claude/worktrees/transcript-scroll-fix` |
+| `automations/archive@656366d1f2` | Claude session | 2026-07-05; −158/+1; dirty 0 | PR-attached | Supersede with PR #965 | `repo/.claude/worktrees/wf_020c8caf-6ff-1` |
+| `automations/editor-config-dedupe@7ab0d7232a` | Claude session | 2026-07-05; −158/+1; dirty 0 | PR-attached | Supersede with PR #964 | `repo/.claude/worktrees/wf_020c8caf-6ff-2` |
+| `overnight/fix-preclone-typeerror@75bb7f7b1c` | Claude session | 2026-07-04; −165/+1; dirty 0 | PR-attached | Supersede; retain scenario from #948 | `repo/.claude/worktrees/wf_0c9796e3-528-1` |
+| `overnight/fix-orphan-materializing@e707ac3df6` | Claude session | 2026-07-04; −165/+1; dirty 0 | PR-attached | Supersede; retain scenario from #949 | `repo/.claude/worktrees/wf_0c9796e3-528-2` |
+| `overnight/fix-sandbox-wedge@93bb46f9b5` | Claude session | 2026-07-04; −165/+1; dirty 0 | PR-attached | Supersede; retain scenario from #950 | `repo/.claude/worktrees/wf_0c9796e3-528-3` |
+| `worktree-wf_22541b0f-ba4-1@9cb3fe6806` | Claude session | 2026-07-04; −158/+7; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/wf_22541b0f-ba4-1` |
+| `worktree-wf_25798819-f44-2@125ae77731` | Claude session | 2026-07-04; −158/+3; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/wf_25798819-f44-2` |
+| `goals/anyharness@bc33ed759a` | Claude session | 2026-07-02; −192/+1; dirty 1 | Historical swarm | Review dirt, then supersede | `repo/.claude/worktrees/wf_6136a8d3-4fd-3` |
+| `goals/ui@5943929ed2` | Claude session | 2026-07-02; −192/+1; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/wf_6136a8d3-4fd-4` |
+| `overnight/gateway-open-models@08023596e6` | Claude session | 2026-07-04; −167/+1; dirty 0 | PR-attached | Supersede with PR #942 | `repo/.claude/worktrees/wf_bb868f20-e6e-1` |
+| `DETACHED@2f3efc43f4` | Claude session | 2026-07-04; −167/+1; dirty 1; detached | Historical detached work | Review dirt, then supersede | `repo/.claude/worktrees/wf_bb868f20-e6e-10` |
+| `DETACHED@08023596e6` | Claude session | 2026-07-04; −167/+1; dirty 1; detached | Historical detached work | Review dirt, then supersede | `repo/.claude/worktrees/wf_bb868f20-e6e-12` |
+| `overnight/repo-shape-render-tests@2f3efc43f4` | Claude session | 2026-07-04; −167/+1; dirty 1 | PR-attached | Supersede with PR #941 | `repo/.claude/worktrees/wf_bb868f20-e6e-2` |
+| `overnight/b7-installer@aed7677a6f` | Claude session | 2026-07-04; −167/+1; dirty 0 | PR-attached | Supersede with PR #938 | `repo/.claude/worktrees/wf_bb868f20-e6e-3` |
+| `overnight/b8-byo-cert@0fd8565072` | Claude session | 2026-07-04; −167/+1; dirty 0 | PR-attached | Supersede with PR #939 | `repo/.claude/worktrees/wf_bb868f20-e6e-4` |
+| `overnight/org-profiles-v0@d374d15dbb` | Claude session | 2026-07-04; −167/+1; dirty 0 | PR-attached | Cancel obsolete direction from #944 | `repo/.claude/worktrees/wf_bb868f20-e6e-6` |
+| `DETACHED@c413cd16e0` | Claude session | 2026-07-04; −166/+1; dirty 1; detached | Historical detached work | Review dirt, then supersede | `repo/.claude/worktrees/wf_c2e8588c-e8e-11` |
+| `overnight/fix-desktop-first-run@e39f7181cb` | Claude session | 2026-07-04; −166/+1; dirty 0 | PR-attached | Supersede; retain scenario from #943 | `repo/.claude/worktrees/wf_c2e8588c-e8e-6` |
+| `overnight/fix-cleanup-on-revoke@c413cd16e0` | Claude session | 2026-07-04; −166/+1; dirty 0 | PR-attached | Supersede; retain scenario from #946 | `repo/.claude/worktrees/wf_c2e8588c-e8e-7` |
+| `overnight/fix-scoped-auth-chain@338bb6a959` | Claude session | 2026-07-04; −166/+1; dirty 0 | PR-attached | Supersede; retain guarantee from #947 | `repo/.claude/worktrees/wf_c2e8588c-e8e-8` |
+| `worktree-wf_d29beb68-9d0-1@0072cac041` | Claude session | 2026-07-04; −158/+2; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/wf_d29beb68-9d0-1` |
+| `worktree-wf_d29beb68-9d0-2@f6fbace9a1` | Claude session | 2026-07-04; −158/+3; dirty 0 | Historical swarm | Supersede | `repo/.claude/worktrees/wf_d29beb68-9d0-2` |
+| `codex/chat-baseline-integration@4c8d1ae154` | Codex session | 2026-07-11; −11/+204; dirty 0 | Chat | Cancel obsolete combined baseline | `repo/.codex/worktrees/chat-baseline-integration` |
+| `codex/fix-main-schema-snapshot@d83b365b3d` | Codex session | 2026-07-11; −7/+1; dirty 0 | Recent recovery port | Verify merged-equivalence, then cleanup | `repo/.codex/worktrees/fix-main-schema-snapshot` |
+| `codex/fix-main-shape-baseline@226e7bb521` | Codex session | 2026-07-11; −5/+1; dirty 0 | Recent recovery port | Verify merged-equivalence, then cleanup | `repo/.codex/worktrees/fix-main-shape-baseline` |
+| `codex/fresh-port-cursor-variants@8c890a1f5d` | Codex session | 2026-07-11; −4/+1; dirty 0 | Recent recovery port | Verify merged-equivalence, then cleanup | `repo/.codex/worktrees/fresh-port-cursor-variants` |
+| `codex/fresh-port-desktop-worker@78be06b589` | Codex session | 2026-07-11; −3/+2; dirty 0 | Recent recovery port | Verify merged-equivalence, then cleanup | `repo/.codex/worktrees/fresh-port-desktop-worker` |
+| `worktree-v1@5c13d0a55b` | Pablo/local | 2026-06-04; −556/+18; dirty 41 | Legacy server/auth | Protect dirty diff; then supersede | `~/worktree-v1` |
+| `fix/email-validation-mismatch@b3d13259dc` | Pablo/local | 2026-07-07; −112/+1; dirty 1 | Server bug fix | Manual compare with current main | `~/worktrees/fix-email-tld` |
+| `fix/sandbox-proxy-product-gate@1e8901e33c` | Pablo/local | 2026-07-09; −104/+1; dirty 1 | Merged bug fix | Cleanup after generated dirt check | `~/worktrees/fix-proxy-gates` |
+| `fix/seat-adjustment-multisub@86aff0dfeb` | Pablo/local | 2026-07-09; −106/+1; dirty 1 | Merged bug fix | Cleanup after generated dirt check | `~/worktrees/fix-seat-adjustment` |
+| `tests/intent-sso@0fd0c3060b` | Pablo/local | 2026-07-09; −77/+6; dirty 263 | Intent/SSO tests | Protect fixture salvage into V2 | `~/worktrees/tier2-sso` |
+
+</details>

--- a/specs/tbd/web-desktop-unification-intake-ledger.md
+++ b/specs/tbd/web-desktop-unification-intake-ledger.md
@@ -17,28 +17,31 @@ worktree remains open. Items may already be resolved — for example, PR #1143
 merged to `main` as `5e86a7faf` on 2026-07-13, satisfying its "merge before
 PR 1" disposition below.
 
-## 1. Outcome
+## 1. Outcome (as assessed at the 2026-07-13 snapshot)
 
-The repository does not need a broad merge freeze before PR 0b/0c or the
-in-place PR 1. It needs four concrete actions:
+At the snapshot, the repository did not need a broad merge freeze before
+PR 0b/0c or the in-place PR 1. It needed four concrete actions, recorded here
+as the point-in-time assessment:
 
 1. Fix the repository-shape failures in PR #1143, rebase it onto current
-   `main`, and merge it before PR 1.
-2. Do not merge PR #1142. Continue the clean test-only replacement on the
+   `main`, and merge it before PR 1. (Since completed: #1143 merged to `main`
+   as `5e86a7faf` on 2026-07-13.)
+2. Do not merge PR #1142; continue the clean test-only replacement on the
    `test-foundation/v2-*` branch family, selectively absorb the useful six
    commits from `codex/test-foundation-combined` and the test-only tail of
    #1142, then close #1142.
-3. Protect the current uncommitted planning work, the detached support work,
-   and the dirty UI/runtime programs named below. Each must land, be
+3. Protect the then-current uncommitted planning work, the detached support
+   work, and the dirty UI/runtime programs named below, each to land, be
    explicitly cancelled, or be retargeted before the mechanical PR 2 move.
 4. Close the stale PR/worktree swarms instead of carrying them into the
-   migration. Their still-valid guarantees belong in the test specification or
-   a fresh implementation, not in old integration branches.
+   migration, with still-valid guarantees preserved in the test specification
+   or a fresh implementation, not in old integration branches.
 
-The only current product PR that blocks starting PR 1 is #1143. Resolving
-#1142 means choosing and recording its replacement; the replacement test work
-may continue alongside PR 0b/0c and PR 1 because those PRs do not move product
-paths.
+At the snapshot, the only product PR blocking the start of PR 1 was #1143
+(now merged). Resolving #1142 meant choosing and recording its replacement;
+the replacement test work could continue alongside PR 0b/0c and PR 1 because
+those PRs do not move product paths. Current readiness state lives exclusively
+in the binding rollout ledger, not here.
 
 ## 2. Disposition vocabulary
 
@@ -54,6 +57,12 @@ paths.
 No cleanup disposition authorizes discarding uncommitted work. A dirty
 worktree remains protected until its diff is reviewed.
 
+The disposition cells in every table below are the snapshot's recorded
+decisions, written in the imperative voice of the time. They are historical
+record, not current instructions: the binding, current dispositions for any
+item are made only in the rollout ledger's PR-1 intake snapshot and PR-2
+freeze ledger.
+
 ## 3. Open GitHub PRs
 
 There were 46 open PRs at the snapshot. Every one is accounted for below.
@@ -67,8 +76,10 @@ There were 46 open PRs at the snapshot. Every one is accounted for below.
 
 ### 3.2 Independent current work
 
-These do not block PR 0b/0c or PR 1. They should be resolved before the PR 2
-freeze so the mechanical move starts from a quiet `main`.
+At the snapshot, these did not block PR 0b/0c or PR 1 and were assessed as
+work to resolve before the PR 2 freeze so the mechanical move would start
+from a quiet `main`. Their live status is tracked, if at all, in the binding
+rollout ledger's snapshots — not here.
 
 | PR | Owner / head | Disposition |
 | --- | --- | --- |
@@ -159,8 +170,11 @@ worktrees inherit their PR's disposition above.
 
 ### 4.4 Protected dirty product work
 
-These branches do not prevent in-place PR 1. They must receive a named owner
-and a land/cancel/retarget decision before PR 2 moves Desktop paths.
+At the snapshot, these branches did not prevent in-place PR 1 but were each
+assessed as needing a named owner and a land/cancel/retarget decision before
+PR 2 moves Desktop paths. The binding dispositions are made in the rollout
+ledger's PR-1 intake snapshot and PR-2 freeze ledger, which use this table as
+sweep input.
 
 | Work | Head / dirty state | Touched slice | Required decision |
 | --- | --- | --- | --- |
@@ -201,35 +215,43 @@ PRs #1128, #1130, #1131, #1133, #1136–#1139, and #1144 are also cleanup
 candidates. Actual removal is a separate housekeeping action after this ledger
 is accepted.
 
-## 5. Execution order
+## 5. Execution order (as recorded at the snapshot)
 
-1. Fix/rebase/merge #1143.
+This was the execution order recommended at the 2026-07-13 snapshot. It is
+history: the live chain order, gates, and readiness checks are owned
+exclusively by the binding rollout ledger.
+
+1. Fix/rebase/merge #1143. (Since completed: merged as `5e86a7faf` on
+   2026-07-13.)
 2. Resolve the small independent merge batch (#1140, #1141, #807, #1104,
    #1114, and the #1105 product decision).
-3. Keep `test-foundation/v2-*` as the only active test-foundation line. Port
-   accepted behavior from `test-foundation-combined` and the test-only tail of
-   #1142, validate it, open a clean PR, and close #1142.
-4. Implement PR 0b/0c and in-place PR 1. Fresh-port only the accepted WDU
-   security/lifecycle tests; do not merge the obsolete WDU branches.
-5. In parallel, split current Workflow work into reviewable slices and audit
-   the protected dirty product work.
-6. Immediately before PR 2, refresh this ledger, require every hot-surface
-   item to be merged/cancelled/retargeted, remove the embedded browser, and
-   begin the one-to-two-day Desktop path freeze.
+3. Keep `test-foundation/v2-*` as the only active test-foundation line,
+   porting accepted behavior from `test-foundation-combined` and the test-only
+   tail of #1142, validating it, opening a clean PR, and closing #1142.
+4. Implement PR 0b/0c and in-place PR 1, fresh-porting only the accepted WDU
+   security/lifecycle tests and never merging the obsolete WDU branches.
+5. In parallel, split then-current Workflow work into reviewable slices and
+   audit the protected dirty product work.
+6. Immediately before PR 2, re-inventory every hot-surface item as
+   merged/cancelled/retargeted, remove the embedded browser, and begin the
+   one-to-two-day Desktop path freeze. (That re-inventory is now the rollout
+   ledger's PR-2 freeze section — this tbd file is never refreshed.)
 
-## 6. Gate to start PR 1
+## 6. Gate to start PR 1 (as recorded at the snapshot)
 
-PR 1 may start when:
+At the snapshot, the assessed preconditions for starting PR 1 were:
 
-- #1143 is merged;
-- #1142 is recorded as superseded and V2 is the single canonical test line;
-- PR 0b/0c owners do not use the rejected WDU deployment-UUID design;
-- all dirty worktrees in Section 4 are protected from cleanup; and
-- queued structure-alignment work that assumes app-owned product pages or a
-  separate Web product is cancelled or retargeted.
+- #1143 merged (since satisfied: `5e86a7faf`);
+- #1142 recorded as superseded and V2 the single canonical test line;
+- PR 0b/0c owners not using the rejected WDU deployment-UUID design;
+- all dirty worktrees in Section 4 protected from cleanup; and
+- queued structure-alignment work that assumed app-owned product pages or a
+  separate Web product cancelled or retargeted.
 
-The dirty product programs do not all need to land before PR 1 because PR 1
-does not move their files. They do need final dispositions before PR 2.
+The dirty product programs did not all need to land before PR 1 because PR 1
+does not move their files; they needed final dispositions before PR 2. The
+BINDING readiness check for PR 1 is the committed PR-1 intake snapshot in the
+rollout ledger — not this section.
 
 ## 7. Raw active-worktree snapshot
 

--- a/specs/tbd/web-desktop-unification-migration.md
+++ b/specs/tbd/web-desktop-unification-migration.md
@@ -1,0 +1,2425 @@
+# Web/Desktop Product Client Unification
+
+Status: non-authoritative rollout history and execution detail. The settled
+contract has been promoted to
+[`../codebase/features/web-desktop-client-unification.md`](../codebase/features/web-desktop-client-unification.md)
+(canonical; it wins any conflict with this file), and the binding
+execution/freeze ledger lives at
+[`../developing/deploying/web-desktop-unification-rollout.md`](../developing/deploying/web-desktop-unification-rollout.md).
+This file retains the migration's execution recipes, inventories, and tables
+as rollout detail only. Do not cite it as the source of truth for code review
+or release readiness.
+
+Scope: the DOM product in `apps/desktop`, `apps/web`, and
+`apps/packages/**`, plus the narrow authority/lifecycle corrections required in
+`anyharness/sdk-react` and `cloud/sdk-react`. Mobile product behavior is
+explicitly outside this migration and must remain green while shared SDK
+providers are corrected.
+
+## 1. Outcome
+
+Desktop and Web will render one connected product implementation:
+`@proliferate/product-client`.
+
+Desktop is the visual, behavioral, and state-management source of truth. The
+current Web product implementation is not a second source to reconcile. It is
+deleted in the Web cutover stack and replaced by the Desktop-derived product
+client in the same combined mainline landing.
+
+At the end:
+
+- the same components, pages, hooks, stores, product workflows, Cloud SDK
+  wiring, and AnyHarness SDK wiring implement the product on Desktop and Web;
+- `apps/desktop` is a thin native bootstrap and transport host;
+- `apps/web` is a thin browser bootstrap and transport host;
+- product differences are caused by real capabilities, not by two product
+  implementations drifting apart;
+- Desktop keeps its current experience and native capabilities;
+- Web gets that experience for managed-cloud work, without pretending it can
+  access a user's local machine;
+- the old Web chat client, polling loop, stores, pages, and controllers no
+  longer exist;
+- the existing `product-surfaces` package is absorbed by and replaced with
+  `product-client`; there are not two connected shared-product packages.
+
+The concise mental model is:
+
+```text
+Desktop native host ----\
+                         +--> one ProductClient --> Cloud SDK React
+Web browser host --------/                      \--> AnyHarness SDK React
+```
+
+The hosts answer questions such as "how do I authenticate here?", "can this
+device access a local runtime?", and "how do I open this link?" They do not
+reimplement product behavior.
+
+### 1.1 Cutover in one screen
+
+| Checkpoint | Outcome |
+| --- | --- |
+| PR 0 | Finish cache/runtime authority fencing (`0a` landed; `0b` adds same-user auth generation and credential-mutation CAS; `0c` owns AnyHarness clients, streams, and target replacement). |
+| PR 1 | Make the current Desktop product consume the new host/scope seams while its files stay in place. |
+| Pre-PR-2 cleanup | Remove the live embedded Tauri browser feature and its callers; it is intentionally not bridged or moved. |
+| PR 2 | Mechanically move Desktop product source into `product-client`; Desktop mounts the package completely. |
+| PR 3 | Delete the old Web product implementation while retaining a buildable thin browser/auth host. |
+| PR 4 | Implement that Web host's adapters and mount the same `ProductClient` completely. |
+| Follow-up | Specify and ship self-hosted Web against the same host contract. |
+
+PR 1 contains behavioral boundary work without path churn. PR 2 contains path
+churn without product behavior work. PR 3 and PR 4 remain separate review
+units but ship as one Web deploy unit.
+
+## 2. Decisions
+
+These choices are closed for this migration.
+
+1. **Desktop is the baseline.** Preserve its UI, interaction model, stores,
+   warm workspace shell, and product workflows. This is an extraction and
+   host cutover, not a redesign.
+2. **The package is `@proliferate/product-client`.** Rename/absorb
+   `@proliferate/product-surfaces`; do not expand `product-surfaces` under its
+   old meaning and do not keep both packages permanently.
+3. **The connected product is shared.** The package owns React pages,
+   product routes, connected hooks, scoped stores, lifecycle orchestration,
+   Cloud SDK React wiring, and AnyHarness SDK React wiring.
+4. **There is one composite host contract.** There will not be separate
+   `auth-host`, `runtime-host`, `updater-host`, and similar provider trees.
+   The one host object has a few typed, nested capability groups.
+5. **Product routes are shared.** Each app creates its browser router and owns
+   raw transport callback entrypoints. `ProductClient` owns the authenticated
+   product route tree and the ordinary login/join product screens.
+6. **Desktop owns raw Tauri access.** `product-client` never imports Tauri or
+   exposes a generic `invoke`. Shared product code calls a typed optional
+   Desktop bridge.
+7. **Web commands managed-cloud runtimes only.** It never discovers or
+   directly connects to a local sidecar, SSH target, or Desktop-exposed local
+   runtime. Server-visible local metadata may be shown read-only with an
+   "Open in Desktop" action.
+8. **Cloud AnyHarness behavior is identical.** Both hosts use the same shared
+   gateway resolver and the same AnyHarness React provider/hooks for managed
+   cloud workspaces.
+9. **Authentication transport remains host-owned.** Product auth state and UI
+   are normalized; cookies/CSRF/PKCE on Web and native vault/protocol handling
+   on Desktop are not normalized away.
+10. **No old Web product compatibility requirement.** Old Web presentation,
+    stores, controllers, and ordinary product aliases may be deleted. A small
+    one-release redirect set exists only to order external/deployed URL
+    producers safely; it is not a second product or feature flag.
+11. **Self-hosted Desktop remains supported.** A self-hosted Web distribution
+    is a follow-up. The contract must allow one, but it is not an acceptance
+    criterion for this cutover.
+12. **Mobile is not involved.** Mobile continues to consume only its allowed
+    SDKs, `product-domain`, and native design layer.
+13. **The embedded Tauri browser is not preserved.** A named cleanup lands
+    before PR 2 and removes the live workspace browser panel, tab/actions, raw
+    webview access, and their callers. It is not added to the Desktop bridge or
+    moved into product-client.
+14. **The cache-scope correction lands first.** Commit `bdd11aa5a` landed the
+    SDK/query-key foundation. A follow-up adds same-principal session authority
+    generation plus credential-mutation ordering; an SDK/Desktop follow-up
+    removes the credential-keyed global AnyHarness client map and adds
+    target-generation/client/stream lifecycle ownership. The
+    in-place Desktop restructuring then adds the full ProductScopeBoundary
+    before source moves. Product-client does not copy either global cache
+    pattern into a shared package.
+15. **Host seams are separated from file movement.** Desktop adopts the host,
+    bridge, and scoped-provider model while source paths remain stable. Only
+    then does a quiet-window PR mechanically move product source.
+16. **Each host marks its surface before rendering.** Both hosts set
+    `data-proliferate-client="desktop|web"`. Shared Tailwind variants may use
+    that marker for presentation, while capability logic remains structural
+    and may not be implemented as CSS hiding.
+17. **AnyHarness clients are scope-owned.** The SDK React module-global client
+    map keyed by raw bearer token is removed before source movement. Product
+    authority owns a bounded client registry; target-generation changes use a
+    credential-free connection identity and a generic transition boundary for
+    Cloud, local, and SSH runtimes.
+
+## 3. Non-goals
+
+This migration does not:
+
+- redesign Desktop;
+- preserve the current Web UI or its URLs;
+- make Mobile render DOM product code;
+- build self-hosted Web deployment/configuration;
+- invent a new deployment identity protocol or `/meta` handshake;
+- redesign every persistence schema;
+- duplicate or redefine the canonical Tier 2/3/4 release-test inventory owned
+  by `specs/developing/testing/`;
+- replace the Cloud or AnyHarness SDKs;
+- build a generic plugin system for host behavior;
+- carry old and new product paths behind a permanent feature flag;
+- split every large Desktop module merely because it is being moved.
+
+The migration preserves ownership-correct lower packages. In
+particular, `product-ui`, `product-domain`, `ui`, and `design` stay separate.
+They can be consolidated later only for a concrete reason.
+
+## 4. Why the current model must change
+
+The repo currently has three connected DOM product implementations:
+
+- the full Desktop product under `apps/desktop/src/**`;
+- a much smaller, independent Web product under `apps/web/src/**`;
+- a narrow connected Cloud surface package under
+  `apps/packages/product-surfaces/src/**`.
+
+That shape creates duplicate owners. The duplication is already material:
+
+- Web chat constructs raw `AnyHarnessClient` instances and polls events rather
+  than using Desktop's SDK React streaming path;
+- Web has independent transcript, composer, optimistic-prompt, configuration,
+  and session stores;
+- Web and Desktop have separate route trees and product shell behavior;
+- Web's Cloud/auth provider owns a module-global QueryClient;
+- the existing Web workspace connection hook is not the path used by its chat
+  implementation;
+- Web behavior therefore cannot be made trustworthy by sharing a few visual
+  components.
+
+The old architectural formulation—shared presentation with separate Web and
+Desktop controllers—is explicitly superseded. Pure shared presentation is
+still useful, but it sits below a single shared connected product.
+
+This plan also supersedes the relevant ownership assumptions in the current
+`web-cloud-local-parity.md` draft: separate connected controllers, Web-specific
+product screens, Mobile participation, and Web URL compatibility are not part
+of this migration.
+
+## 5. Terms
+
+**Product client**
+: The connected DOM application: pages, shell, product routes, components,
+  hooks, product stores, product lifecycles, Cloud SDK React consumers, and
+  AnyHarness SDK React consumers.
+
+**Host**
+: The small Desktop or Web layer that owns bootstrap and access to external
+  systems that differ by deployment surface.
+
+**Deployment**
+: The Proliferate API/control-plane instance to which the client is currently
+  connected. Hosted Web has one configured deployment. Desktop may switch to a
+  self-hosted deployment.
+
+**Product scope**
+: The cache and lifecycle boundary for the current deployment, explicit actor
+  (authenticated principal or anonymous), and in-memory authority generation.
+  When any changes, old remote state and live work must not leak into the new
+  scope. Presentation/transport statuses such as `bootstrapping` and
+  `unreachable` are not scope identity.
+
+**Runtime target**
+: The AnyHarness process that owns a workspace materialization: Desktop local,
+  managed cloud, or direct SSH. A host's device capabilities determine which
+  target kinds it can command.
+
+**Server-visible local metadata**
+: Cloud/control-plane records describing work that runs on another user's
+  Desktop. Web may show these records, but that does not grant Web a route to
+  the local AnyHarness process.
+
+## 6. Target ownership
+
+### 6.1 Target tree
+
+The exact internal domain folders may continue to evolve under the frontend
+structure rules. The ownership boundary is fixed:
+
+```text
+apps/packages/product-client/
+  package.json
+  src/
+    ProductClient.tsx              # lightweight auth/product gate
+    AuthenticatedProductClient.tsx # route-lazy connected product
+    app/
+    pages/
+    components/
+    hooks/
+    stores/
+    providers/
+    config/
+    copy/
+    assets/
+    lib/
+      domain/
+      workflows/
+      infra/
+    host/
+      product-host.ts
+      ProductHostProvider.tsx
+
+apps/desktop/src/
+  main.tsx
+  App.tsx                       # host callbacks + ProductClient mount
+  host/
+    desktop-product-host.ts
+  bootstrap/
+  auth/                         # native auth transport and callback ingress
+  telemetry/                    # native vendor/runtime installation
+  lib/access/tauri/**           # raw Tauri boundary
+  native-lifecycle/             # process/window effects that do not own product state
+  index.css                     # host-only/native CSS
+
+apps/web/src/
+  main.tsx
+  App.tsx                       # browser callbacks + ProductClient mount
+  host/
+    web-product-host.ts
+  config/env.ts
+  auth/                         # browser session, PKCE, callback transport
+  telemetry/                    # browser vendor/runtime installation
+  index.css                     # host-only/browser CSS
+```
+
+This is an ownership map, not a demand to rename every file during the move.
+PR 2 must preserve Desktop's existing domain/responsibility taxonomy where
+it is already valid. Structural cleanup that is unrelated to the host boundary
+can happen afterward.
+
+### 6.2 Dependency direction
+
+```text
+apps/desktop ----\
+                  +--> product-client --> product-ui --> ui --> design/dom
+apps/web --------/             |
+                               +--> product-domain
+                               +--> cloud-sdk / cloud-sdk-react
+                               +--> anyharness/sdk / anyharness/sdk-react
+
+apps/mobile --> product-domain + design/react-native + SDKs
+```
+
+Rules:
+
+- `product-client` imports neither app.
+- `product-client` imports no Tauri package or Desktop raw-access file.
+- `product-client` imports no browser auth-cookie, PKCE, or vendor telemetry
+  implementation.
+- apps may import only public product-client entrypoints, not its internal
+  stores and hooks.
+- `product-ui` remains props-in/callbacks-out presentation.
+- `product-domain` remains React-free and Mobile-safe.
+- there is no app-local copy of a product-client store or controller after its
+  cutover.
+- imports remain direct; the migration does not create convenience barrel
+  files.
+
+### 6.3 Import-path rule during the move
+
+Desktop's `@/` alias currently means `apps/desktop/src`. Those imports cannot
+be moved unchanged into a package because `@/` is Desktop-owned and Web has no
+matching `@/` alias today.
+The decision is to use Node package imports inside product-client:
+
+```json
+{
+  "imports": {
+    "#product/*": "./src/*"
+  }
+}
+```
+
+Rules:
+
+- moved product-client internals rewrite `@/...` module specifiers to
+  `#product/...`;
+- retained Desktop host files keep `@/...`;
+- Desktop and Web import only public
+  `@proliferate/product-client/<entrypoint>` exports;
+- do not add app-level Vite aliases or TypeScript `paths` for `#product`;
+- `#/*` and `#/...` are invalid Node package-import names and must not be used;
+- use an AST/module-specifier codemod, not a blind text replacement (the repo
+  contains unrelated `@@/` regex text);
+- TypeScript, Vite, and Vitest must all resolve the package mapping in PR 1
+  before the mechanical move starts;
+- post-move scans reject `@/` in product-client, `#product/` in either app, and
+  unresolved `#product/` text in final bundles.
+
+### 6.4 Package build contract
+
+`product-client` is private application source, not a reusable published UI
+library. It contains code-split pages, CSS, and product assets (including the
+Desktop file/connector icon sets). The simplest target is therefore a
+source-consumed workspace package:
+
+- its public export map points at the small set of source entrypoints the hosts
+  need. The map is staged: in PR 1 it exposes host, provider, scope, and
+  package-resolution primitives plus their types only; the real
+  `ProductClient`/`AuthenticatedProductClient` exports are added in PR 2 when
+  the proven candidate root moves into the package;
+- Desktop and Web Vite compile the same source in their own bundles;
+- the package `build`/`typecheck` command typechecks the source; it does not
+  need to manufacture a separately publishable application bundle;
+- Vitest runs against the source;
+- React, React DOM, React Router, and React Query resolve to the host's one
+  workspace version, avoiding duplicate runtimes. They are peer dependencies
+  (and development dependencies for package tests), not package-owned runtime
+  dependencies; both host Vite configs verify/dedupe them;
+- package-private imports use the `#product/*` mapping proven in TypeScript,
+  Vite, and Vitest; they do not depend on either app's alias.
+
+Lower packages may keep their current `dist` build. If implementation evidence
+shows a built product-client package is materially safer, its build must also
+copy/emit CSS and assets and preserve dynamic imports; silently using plain
+`tsc` output without those resources is not a valid alternative.
+
+The mechanical asset move is part of PR 2:
+
+- move Desktop product SVG/PNG/JPEG/MP3 assets and `assets.d.ts` declarations
+  under product-client so both host bundles resolve the same imports;
+- keep genuinely native window/application resources in Desktop;
+- preserve Vite `?raw` behavior for file icons and the bundled agent catalog;
+- move `provider-registry.generated.json` to product-client and change
+  `scripts/vendor-provider-registry.mjs` to generate at the new owning path;
+- keep `catalogs/agents/catalog.json` as the repo-level generated source of
+  truth and import it from product-client (do not copy a second catalog);
+- add a build test that bundles representative `?raw`, image, audio, JSON, and
+  repo-level catalog imports in both Desktop and Web.
+
+## 7. The one host contract
+
+The host is one value in one provider. The following is an authority sketch,
+not a requirement to use these exact property names:
+
+```ts
+type ProductSurface = "desktop" | "web";
+
+interface ProductHost {
+  surface: ProductSurface;
+  deployment: ProductDeploymentHost;
+  auth: ProductAuthHost;
+  cloud: ProductCloudHost;
+  persistence: ProductPersistenceHost;
+  links: ProductLinksHost;
+  telemetry: ProductTelemetryHost;
+  desktop: DesktopBridge | null;
+}
+```
+
+It is intentionally composite:
+
+- there is one `ProductHostProvider`;
+- nested groups document authority without creating many React contexts;
+- feature hooks consume narrow methods from that one value;
+- the object is not a service locator and cannot return arbitrary app
+  internals;
+- `surface` is descriptive. Product behavior normally checks a real capability
+  (`desktop !== null`, a server capability, or a workspace capability), not
+  `surface === "web"` scattered through components.
+
+The host does not supply page, settings-pane, chat, composer, or workspace
+render slots. Product-client renders those surfaces itself. The only UI that
+stays wholly outside it is genuinely host chrome or transport entry UI, such
+as native macOS window controls or a browser OAuth callback spinner.
+
+### 7.1 Deployment authority
+
+The deployment group supplies:
+
+- the normalized API origin/configuration;
+- the current deployment/cache key;
+- a way to observe deployment changes;
+- Desktop's optional connect/switch/reset operation;
+- Web's fixed configured deployment.
+
+It does not hardcode server capabilities. Billing, SSO, gateway, hosted-mode,
+and other product capabilities continue to come from server truth (`/meta`,
+viewer, organization, or the owning SDK query).
+
+No new persistent deployment UUID protocol is required. For this migration,
+the cache-scope foundation may derive a credential-free deployment key from
+the normalized API configuration it already owns.
+
+### 7.2 Auth authority
+
+The auth group exposes normalized product state and semantic actions:
+
+```ts
+type ProductAuthStatus =
+  | "bootstrapping"
+  | "anonymous"
+  | "authenticated"
+  | "unreachable";
+
+type ProductAuthorityIdentity = Readonly<{
+  deploymentKey: string;
+  actor: { kind: "anonymous" } | { kind: "user"; id: string };
+  generation: number;
+}>;
+
+interface ProductAuthHost {
+  status: ProductAuthStatus;
+  principal: { id: string } | null;
+  authGeneration: number;
+  bindAuthority(expected: ProductAuthorityIdentity): ProductAuthorityHandle | null;
+  startSignIn(input: ProductSignInIntent): Promise<{ transactionId: string }>;
+  signOut(expected: ProductAuthorityIdentity): Promise<boolean>;
+}
+
+interface ProductAuthorityHandle {
+  readonly identity: ProductAuthorityIdentity;
+  getFreshCredentialSnapshot(): Promise<Readonly<{
+    accessToken: string | null;
+    credentialRevision: number;
+  }>>;
+  observeCredentialRevision(listener: (revision: number) => void): () => void;
+  invalidateIfCurrent(input: {
+    credentialRevision: number;
+    reason: AuthorityRejection;
+  }): Promise<boolean>;
+  dispose(): void;
+}
+```
+
+`unreachable` is the normalized target model for a transiently unavailable
+authenticated deployment. Desktop does not expose that auth status today; PR
+0b introduces it while retaining the resolved principal/authority underneath.
+
+The exact state shape may reuse existing Cloud SDK types. The important
+constraints are:
+
+- product code does not read cookies, PKCE state, native vault entries, or raw
+  refresh credentials;
+- host bootstrap owns restoration and publishes `status`; product code never
+  starts a second auth-bootstrap lifecycle;
+- `ProductScopeBoundary` binds one authority handle to its captured
+  `{deployment, principal-or-anonymous, authGeneration}` tuple. The handle
+  compares that tuple before returning a fresh token or invalidating auth. A
+  mismatched bind returns `null`; a disposed/stale handle fails token access
+  and makes `invalidateIfCurrent` a no-op;
+- long-lived Cloud/AnyHarness operations request one atomic token + credential
+  revision snapshot through that bound handle instead of reading them
+  separately or capturing a token at connection creation time;
+- each authority also owns a monotonic, non-secret `credentialRevision` that
+  advances when its access token is replaced without replacing the authority.
+  It is a transport refresh signal, never a ProductScope/query-key identity;
+- `observeCredentialRevision` atomically registers and replays the current
+  revision. Connection installation is serialized with those observations and
+  compare-and-swaps both its connection-resolution revision and snapshot
+  credential revision; token A can never be installed and labeled revision B;
+- a late operation from authority N can neither obtain N+1's token nor let an
+  N-era rejection invalidate N+1, even when the principal id is the same. A
+  request also passes the `credentialRevision` it actually used, so a late 401
+  from token A cannot invalidate newer token B within the same authority;
+- one host-owned auth coordinator serializes and compare-and-swaps every
+  credential-changing bootstrap, sign-in, callback commit, refresh replacement,
+  and sign-out against the applicable authority, credential revision, or sign-in
+  transaction id. It may use an internal ticket/mutex, but there is no separate
+  public operation-revision identity, cache key, or product concept;
+- `startSignIn` creates a credential-free transaction id bound to the expected
+  deployment and starting authority. OAuth/SSO state carries that id. Callback
+  credential commit succeeds only if that transaction is still current;
+- `signOut(expected)` compare-and-swaps against the expected authority. A late
+  generation N clear cannot erase generation N+1. Web must also serialize
+  cookie-changing responses so a late logout `Set-Cookie` cannot clear a newer
+  login; server revocation is token-specific;
+- all credential storage writes/clears and normalized auth-state changes go
+  through that coordinator. Raw Cloud middleware and stream code never mutate
+  storage behind the auth store;
+- successful current operations may publish/replace credentials; only a commit
+  that replaces session authority advances `authGeneration`. Ordinary refresh
+  keeps that generation and advances only `credentialRevision`. Stale
+  callback/logout/refresh results are discarded without storage or state
+  mutation;
+- login, logout, actor change, and deployment change advance scope and fence
+  stale work;
+- auth UI consumes normalized methods and truthful server-advertised methods;
+- Desktop's optional semantic deployment connect/switch/reset methods live in
+  the deployment group and internally use native primitives. Web omits those
+  methods; the Desktop bridge does not own a duplicate deployment API.
+
+### 7.3 Cloud transport authority
+
+The host owns credential transport and exposes exactly one scoped Cloud SDK
+client factory for the current auth/deployment state. The product client owns Cloud
+queries, mutations, workspace classification, gateway lookup, managed-cloud
+connection resolution, product orchestration, and query keys. A host must not
+own a parallel managed-cloud workspace resolver or module-global Cloud client.
+
+The seam is a factory, not a client singleton. Conceptually:
+
+```ts
+interface ProductCloudHost {
+  createScopedClient(input: {
+    deployment: ProductDeployment;
+    authority: ProductAuthorityHandle;
+  }): { client: CloudClient; dispose(): void };
+}
+```
+
+`ProductScopeBoundary` calls it for the current authority and disposes the
+returned handle on scope teardown. Product-client supplies the bound authority
+handle plus all product-specific query/mutation behavior. A client cannot
+outlive its ProductScope.
+
+Organization identity is operation input, not mutable transport ambient state:
+
+```ts
+type CloudOwnerContext =
+  | { ownerScope: "personal"; organizationId: null }
+  | { ownerScope: "organization"; organizationId: string };
+```
+
+The Cloud SDK query-key helpers already support owner scope and organization
+identity; this migration preserves those correct keys and audits callsites for
+missing/mismatched owner context. Every owner-sensitive query/mutation captures
+one immutable `CloudOwnerContext` before it creates its query key and request,
+and passes that same value explicitly to header construction. Middleware must
+not consult `useOrganizationStore.getState()` or another live organization
+getter. An organization switch therefore cannot turn an A-keyed operation into
+a request against B.
+
+The current Cloud SDK React provider writes its resolved client into the Cloud
+SDK's process-global singleton, and `useCloudClient()` falls back to that
+singleton outside context. PR 1 removes both behaviors: the React provider
+never publishes globally, and `useCloudClient()` fails closed when no provider
+is mounted. Every plain Cloud SDK call moved into the connected product
+receives the scoped client explicitly. A legacy global API may remain for
+out-of-scope non-React consumers during this migration, but ProductClient,
+Desktop, and Web may neither populate nor read it for authenticated product
+work.
+
+This split matters because:
+
+- Web uses refresh-cookie/CSRF semantics and an in-memory access token;
+- Desktop uses its native credential/deployment mechanism;
+- the connected product must use one Cloud SDK React behavior after the client
+  has been created;
+- host transport cannot import a product-client store to discover the current
+  organization. The product operation supplies its captured request context.
+
+### 7.4 Persistence authority
+
+The persistence group is only for non-secret, device-local product state:
+
+```ts
+interface ProductPersistenceHost {
+  read(key: ProductPersistenceKey): Promise<unknown>;
+  write(key: ProductPersistenceKey, value: unknown): Promise<void>;
+  remove(key: ProductPersistenceKey): Promise<void>;
+}
+```
+
+The implementation is host-backed: Web uses browser persistence; Desktop's
+typed adapter dispatches each key to its existing owner (for example Tauri
+Store or WebView `localStorage`). PR 1/PR 2 do not silently move a key between
+backends or rename it. Any backend/key migration requires an explicit
+read-old/write-new transition, idempotency and rollback tests, and a declared
+old-value retirement point. The adapter does not store bearer tokens, refresh
+credentials, PKCE verifiers, native credential material, or provider API
+keys.
+
+The key set is typed and owned by product-client; arbitrary string access is
+not part of the interface.
+
+### 7.5 Link/navigation authority
+
+Internal product navigation is shared React Router behavior. The links group
+owns only actions whose encoding/execution differs by host:
+
+- open an external URL;
+- request a semantic "open this location in Desktop" handoff;
+- generate/copy a shareable link for the current deployment;
+- open a system browser from Desktop;
+- accept a host-decoded inbound deep link.
+
+The shared product asks for semantic locations such as a workspace or workflow
+identity. It does not concatenate a Tauri protocol URL or a hosted-Web origin.
+
+Inbound transport state crosses the boundary as a normalized, validated,
+credential-free, one-shot `ProductEntryIntent`, for example SSO login intent,
+organization invitation, workspace/workflow location, or a completed billing
+return. The links group owns this protocol:
+
+```ts
+interface ProductEntryIntentHost {
+  observePending(listener: (intent: ProductEntryIntent) => void): () => void;
+  acknowledge(
+    intentId: string,
+    disposition: "accepted" | "handed-off",
+  ): Promise<boolean>;
+  quarantine(
+    intentId: string,
+    reason: ProductEntryIntentRejection,
+  ): Promise<boolean>;
+}
+```
+
+Host callback/deep-link code validates and persists the intent before
+publishing it into a durable FIFO of unacknowledged intents; a later arrival
+never overwrites an earlier one. `observePending` is one atomic replaying
+subscription: from the observer's perspective, an intent published during
+subscription is delivered either by replay or by the live event and cannot
+fall between a separate restore and subscribe call. Delivery is at-least-once.
+
+Exactly one ProductEntryIntent coordinator lives above replaceable
+ProductScopes. It is the sole consumer, processes the FIFO serially, and
+deduplicates by `intentId`. The owning workflow accepts idempotently by
+`intentId`; only then does the coordinator acknowledge and remove the queue
+entry. Unacknowledged work replays after scope replacement or process restart.
+There is no claim/lease protocol unless a future design introduces genuinely
+independent consumers or a cross-tab shared queue.
+
+Desktop ingress registers the live URL listener before draining the initial
+`getCurrent()` value, persists before notifying, and deduplicates any overlap.
+This prevents a live deep link from falling between startup drain and listener
+registration.
+
+Every intent includes a normalized credential-free target deployment key.
+The coordinator dispatches only while that deployment is current. Desktop may
+perform its explicit validated deployment-switch/relaunch flow and then resume
+the queue. A foreign-deployment head item may not starve later valid work:
+hosted Web atomically acknowledges it as `handed-off` after a successful
+Desktop handoff, or moves it to a durable non-blocking quarantine with a
+user-visible recovery/dismiss action. An explicit terminal rejection uses the
+same quarantine path. An unacknowledged dispatchable intent survives a Web
+OAuth redirect, ProductScope replacement, or Desktop
+deployment-switch/relaunch without being misapplied to another server. Raw
+callback URLs, OAuth state, credentials, and arbitrary navigation strings
+never enter the product intent.
+
+### 7.6 Telemetry authority
+
+The product client emits typed product events and errors. The host installs
+Sentry/PostHog/native diagnostics, supplies release/runtime identity, and owns
+vendor lifecycle. Product state is not granted direct access to vendor SDKs.
+
+The telemetry group also supplies one narrow route-instrumentation component
+compatible with React Router's `<Routes>` contract. ProductClient renders its
+shared route definitions through that component; Desktop and Web may wrap it
+with their existing Sentry router instrumentation without importing Sentry
+into product-client. This is the sole infrastructure render adapter and is not
+a page, settings, chat, or workspace render slot.
+
+Existing replay-masking and payload restrictions continue to apply. Moving a
+component does not authorize new payload fields.
+
+### 7.7 Desktop bridge
+
+`desktop` is either `null` or one typed bridge. It groups actual native
+capabilities required by product behavior, for example:
+
+- local runtime readiness and connection;
+- repository/folder selection and local worktree actions;
+- open/reveal path, editor, terminal, and shell operations;
+- local agent/provider credential operations (product-user authentication
+  credentials remain exclusively owned by `ProductAuthHost`);
+- native context menu, application menu, dock, and window operations;
+- updater/version/relaunch actions;
+- desktop worker and local automation execution;
+- SSH target/tunnel operations;
+- scratch-file persistence;
+- diagnostics and support-attachment collection.
+
+The bridge is demand-driven: add a typed method only when moved product code
+needs it. It must never expose generic Tauri `invoke`, raw command names, or a
+filesystem primitive broad enough to bypass product policy.
+
+Desktop-only product orchestration may live in product-client and call this
+bridge. Raw execution remains in `apps/desktop`. This lets local automation,
+agent reconcile, updater UI, and native menus observe shared product state
+without making the Desktop app import product-client's internal stores.
+
+## 8. Product scope and provider composition
+
+### 8.1 Scope identity
+
+Remote caches and live streams must be scoped at least by:
+
+- deployment;
+- authenticated principal (or explicit anonymous state);
+- the current in-memory auth generation.
+
+That tuple is exact. `bootstrapping` and `unreachable` never participate in a
+cache key. A transiently unreachable authenticated authority retains its
+principal and generation; an unreachable client with no resolved authority
+does not mount authenticated remote providers. Only a deliberate
+invalidation/logout transitions to explicit anonymous and advances the epoch.
+
+`authGeneration` is a process-local, monotonically increasing **session
+authority epoch**, not deployment identity or access-token version. The
+product scope changes independently when deployment changes.
+`authGeneration` advances when:
+
+- anonymous becomes authenticated or authenticated becomes anonymous;
+- the authenticated principal changes;
+- logout, revocation, or a replacement login invalidates the prior session
+  authority.
+
+It does not advance for an ordinary access-token refresh that continues the
+same authenticated session. Routine Web token rotation must update transport
+credentials without remounting the QueryClient or tearing down active
+AnyHarness streams.
+
+The target model deliberately separates three concerns, using one current SDK
+primitive and one current Desktop-only lifecycle owner as its starting point:
+
+- the current SDK accepts a caller-defined `AnyHarnessRuntime.cacheScopeKey`
+  and includes it in its query keys; PR 0b makes Desktop supply the exact
+  deployment + actor + authority-generation identity;
+- current AnyHarness workspace query keys already include the logical
+  workspace id;
+- current AnyHarness runtime-level query keys still include `runtimeUrl`; PR 0c
+  replaces that transport-address identity with target slot + generation so a
+  gateway URL refresh neither aliases another target nor churns semantic data;
+- materialization/runtime generation is currently observed by a
+  Desktop-owned, Cloud-only materialization tracker. PR 0c replaces that
+  narrow owner with a generic Cloud/local/SSH target-transition boundary.
+
+Do not overload `cacheScopeKey` with workspace or materialization identity.
+Credentials and expiring gateway URLs never participate in semantic cache
+identity.
+
+Current-main status:
+
+- `bdd11aa5a` threads `cacheScopeKey` through SDK React query keys and derives
+  a credential-free Desktop key from deployment + status/principal;
+- it does not yet distinguish two login authorities for the same principal;
+- SDK React still has a module-global AnyHarness client map whose key embeds
+  raw runtime URL + bearer token and has no scope teardown;
+- Cloud SDK React still publishes/falls back through a process-global client;
+- it does not replace Desktop's module-global QueryClient or scope all Cloud
+  queries/mutations.
+
+PR 0b adds an in-memory authority generation and includes it in the existing
+AnyHarness scope key. PR 0c replaces the global client map and generalizes
+target transition ownership. PR 1 then creates the full ProductScopeBoundary
+and a scope-owned QueryClient. None invents a product-client-only parallel SDK
+scheme.
+
+### 8.2 Provider order
+
+The intended composition is:
+
+```text
+Host bootstrap and auth transport
+  -> ProductHostProvider
+    -> ProductEntryIntentCoordinator (durable FIFO; survives scope replacement)
+      -> lightweight ProductClient auth/readiness gate
+        -> when authority is resolved:
+          ProductScopeBoundary (deployment + principal/anonymous + auth generation)
+            -> scope-owned QueryClientProvider
+              -> scope-owned CloudClientProvider
+                -> anonymous: shared login/join content
+                -> authenticated: scope-owned AnyHarness client registry
+                  -> shared AnyHarness runtime/workspace providers
+                    -> lazy AuthenticatedProductClient
+```
+
+The exact component split may differ, but these properties are mandatory:
+
+- no module-global QueryClient in Desktop, Web, or product-client;
+- no Cloud React provider write to, or hook fallback through, the Cloud SDK
+  process-global client;
+- no module-global AnyHarness client registry or credential-bearing client
+  cache;
+- bootstrapping/unreachable presentation state cannot churn a retained
+  authority's scope key;
+- a scope change cancels or makes unreachable old queries, streams, and
+  connection completions;
+- Cloud and AnyHarness consumers see the same scope;
+- providers are not copied separately into each host;
+- Web does not mount the Desktop local-runtime subtree;
+- teardown runs once and removes every listener, timer, subscription, and
+  stream owned by the prior scope.
+
+### 8.3 Product state classes
+
+Each state owner is explicit:
+
+| State | Owner | Lifetime |
+| --- | --- | --- |
+| Server entities and remote results | Query cache / owning SDK | Product scope |
+| Active AnyHarness connection/stream | AnyHarness SDK React plus scoped target/stream transition owner | Target slot + generation + product authority |
+| Actor-sensitive selection, drafts, pending prompts, tabs | Product-client scoped store factories | Product authority; reset before replacement authority renders |
+| Organization-sensitive client state | Product-client organization-scoped stores | Deployment + principal + organization |
+| Workspace-local UI state | Product-client stores keyed by logical workspace id | Workspace within product authority |
+| Non-sensitive device preferences | Product-client store + host persistence | Device |
+| Auth secrets and pending OAuth state | Host auth transport | Host security rules |
+| Native runtime/process state | Desktop host/bridge | Desktop process |
+| Pure product decisions | `product-domain` or product-client `lib/domain` | Stateless |
+
+PR 1 inventories every module-global store and classifies each field into one
+of those lifetimes. Actor-sensitive stores are scope-owned factories
+instantiated under `ProductScopeBoundary`; organization-sensitive stores are
+factories under a nested organization boundary. A reset module-global
+singleton is not sufficient because an old Promise can retain its setter and
+write after rollover. Workspace-sensitive stores are likewise keyed/factored
+so a delayed writer can reach only the old instance. Every asynchronous writer
+also captures/checks the owning authority epoch before emitting external side
+  effects. Preserve existing organization-aware query keys and repair any
+  callsite whose key owner context differs from its request owner context. The
+  authority QueryClient itself need not remount because it also owns the
+  organization inventory used to select that id.
+
+Persisted device-global keys preserve Desktop's existing backend, key, and
+schema through PR 2; the Desktop adapter may dispatch per typed key.
+Actor-, organization-, and workspace-sensitive persisted values are
+credential-free but namespaced by their declared lifetime and removed/ignored
+on rollover. PR 1 establishes the adapters and rollover behavior; PR 2 moves
+the owning stores without changing it. Old Web stores receive no compatibility
+migration.
+
+## 9. Authentication and deployment flows
+
+### 9.1 Shared product behavior
+
+The product client owns:
+
+- bootstrapping/anonymous/authenticated presentation;
+- login-method presentation driven by server truth;
+- password, OAuth, and SSO intent selection;
+- signed-in shell readiness;
+- common error and retry presentation;
+- sign-out product behavior;
+- organization invitation product flow after a host has decoded its entry
+  point.
+
+It does not know which credential storage mechanism was used.
+
+`ProductClient` itself is the lightweight shared auth/product gate. It renders
+the shared login/join presentation and route fallbacks, then route-lazily
+imports `AuthenticatedProductClient` only after normalized auth is ready. The
+hosts retain callback/entry decoders, not separate login product screens.
+
+### 9.2 Desktop sequence
+
+```text
+1. Desktop boot reads/selects the deployment configuration.
+2. Desktop auth transport restores the native credential state.
+3. It publishes normalized auth state to ProductHost.
+4. ProductClient renders login or the authenticated product.
+5. OAuth/SSO opens the system browser.
+6. The Desktop host receives the protocol deep link (or owning poll result),
+   validates the pending transaction, compare-and-swap commits credentials
+   only if it is still current, stores them natively, and advances auth scope.
+7. ProductClient remounts remote providers under the new principal.
+```
+
+Self-host server connection remains Desktop-owned:
+
+```text
+enter server URL -> host validates server metadata/trust -> persist config ->
+relaunch/rebootstrap -> authenticate to that deployment -> mount ProductClient
+```
+
+The shared login screen may expose this action only when the deployment group
+provides semantic connect/switch capability; it does not check `desktop`.
+
+### 9.3 Web sequence
+
+```text
+1. Web boot resolves its configured API deployment.
+2. Web auth transport exchanges the HttpOnly refresh cookie using CSRF.
+3. The short-lived access token stays in memory.
+4. ProductClient renders login or the authenticated product.
+5. Browser OAuth/SSO stores PKCE verifier/state in sessionStorage and redirects.
+6. A Web-owned callback route validates/exchanges the response and
+   compare-and-swap commits only the still-current sign-in transaction.
+7. Auth state advances and ProductClient remounts its scope.
+8. Refresh is scheduled or single-flighted on demand; gateway connections call
+   the current ProductScope's bound authority handle rather than retaining a
+   stale snapshot or calling an unscoped host token getter. A successful
+   same-authority refresh advances `credentialRevision`, causing new/reconnect
+   AnyHarness work to refresh connection material without remounting scope.
+```
+
+Production Web must not persist its bearer in localStorage. Any token-store
+path retained for explicit dev/test injection is named and unavailable in the
+normal production flow.
+
+Web's product gate uses server-declared access/readiness. It must not equate
+"GitHub connected" with "allowed to use the product," because password and SSO
+users can be valid.
+
+### 9.4 Self-hosted Web
+
+The product-client contract permits a Web host to supply a different
+deployment and password/SSO auth later. This migration does not ship the
+runtime configuration, distribution, callback origins, or invitation flow
+needed to claim self-hosted Web support.
+
+No shared product code may assume the only Web deployment is the hosted
+production origin; the current hosted Web host may.
+
+## 10. Routing, callbacks, and deep links
+
+There is one `BrowserRouter` per app and one shared product route tree. Host
+callback/intent entrypoints sit beside one catch-all `ProductClient`; the
+lightweight ProductClient root owns login/readiness and lazily loads the
+authenticated route tree.
+
+### 10.1 Host-owned entrypoints
+
+Hosts own routes that terminate a transport protocol, such as:
+
+- Web OAuth/PKCE callback;
+- Web auth error callback;
+- Web SSO-slug and organization-invitation entry decoders;
+- Stripe/billing return decoder when required by the server contract;
+- Desktop native protocol/deep-link ingress;
+- development-only host diagnostics/playgrounds.
+
+Those entrypoints decode/validate external input, update the owning transport,
+and navigate to a canonical shared product location.
+
+### 10.2 Product-owned routes
+
+The product client owns Desktop's canonical product model:
+
+- home/current workspace shell;
+- workspaces list and workspace selection/deep link;
+- workflows and workflow detail;
+- settings with Desktop's existing typed query-string section selection;
+- ordinary login and organization-join presentation after the host decodes
+  any transport-specific entry intent;
+- fallbacks into the canonical product home.
+
+The warm `MainScreen`/workspace shell behavior is preserved: it stays mounted
+across authenticated route changes, and Settings continues to overlay it. This
+is a performance and transcript/stream-continuity invariant.
+
+PR 2 must carry Desktop's current route semantics into product-client. It
+must not redesign session URLs merely to match the old Web routes.
+
+### 10.3 No old Web product compatibility layer
+
+The following can be removed instead of aliased:
+
+- old Web `/cloud/workspaces/**` paths;
+- old Web automation route components/controllers (bounded Web edge redirects
+  and Desktop's existing thin legacy redirects are disposed explicitly below);
+- Web's separate settings-modal background-location convention;
+- dead Desktop handoff routes.
+
+Every producer of an inbound URL is audited and changes to the canonical route
+unless this plan explicitly retains its host transport entrypoint:
+
+- OAuth redirect configuration;
+- Stripe return URLs;
+- GitHub App authorization/installation returns;
+- invitation/email links;
+- any server-generated Web link;
+- Desktop handoff URLs.
+
+The deploy ordering is not a multi-system flag day. Web permanently retains
+`/auth/callback`, `/auth/error`, `/join/:organizationId`, and the
+`/settings/cloud` billing-return decoder, so browser OAuth, SSO, invitations,
+and Desktop checkout/portal returns do not require a flag day. The billing
+decoder handles `returnSurface=desktop` before navigating browser returns to
+shared `/settings?section=billing`; it is a host transport entrypoint, not an
+old settings page. Cutover release R adds a small Vercel 307 redirect set
+**before** the SPA catch-all. This `redirects` array is new work: root
+`vercel.json` currently has only the SPA `rewrites` rule.
+
+```json
+[
+  {
+    "source": "/cloud/workspaces/:workspaceId/chats/:chatId",
+    "destination": "/workspaces/:workspaceId",
+    "permanent": false
+  },
+  {
+    "source": "/cloud/workspaces/:workspaceId",
+    "destination": "/workspaces/:workspaceId",
+    "permanent": false
+  },
+  {
+    "source": "/workspaces/:workspaceId/chats/:chatId",
+    "destination": "/workspaces/:workspaceId",
+    "permanent": false
+  },
+  {
+    "source": "/settings/account",
+    "destination": "/settings?section=account",
+    "permanent": false
+  },
+  {
+    "source": "/settings/organization",
+    "destination": "/settings?section=organization",
+    "permanent": false
+  },
+  {
+    "source": "/settings/organizations",
+    "destination": "/settings?section=organization",
+    "permanent": false
+  },
+  {
+    "source": "/settings/environments",
+    "destination": "/settings?section=environments",
+    "permanent": false
+  },
+  {
+    "source": "/auth",
+    "destination": "/login",
+    "permanent": false
+  },
+  {
+    "source": "/automations/:path*",
+    "destination": "/workflows/:path*",
+    "permanent": false
+  }
+]
+```
+
+Vercel preserves query strings on the redirected routes. `/settings/cloud`
+bypasses the edge redirect set and reaches its host decoder so Desktop Stripe
+return state is handled before shared-product navigation. PR 4/release R
+changes every repository-owned producer in the same landing as the new
+handlers and redirects. After R smoke passes, dashboard and
+deployed-environment registrations whose canonical destination changed are
+updated one producer at a time per the rollout ledger's external-item schema
+(source change → activation → live-consumption proof → smoke; mutation only
+after the landing merges and the reviewed PRODUCTION surfaces deploy at the
+exact merge SHA); Desktop-aware billing returns continue to use the retained
+decoder. Keep the
+redirects through R+1 and for at least seven days, then remove them only after
+the producer ledger is rechecked. This is a bounded deploy-ordering shim, not
+an old Web controller, route component, or feature flag.
+
+### 10.4 Canonical route and producer ledger
+
+PR 2 makes these the shared product routes:
+
+```text
+/login
+/
+/workflows
+/workflows/:workflowId
+/workspaces
+/workspaces/:workspaceId
+/settings?section=<sectionId>
+```
+
+This deliberately preserves Desktop's current URL/state semantics. Workspace
+selection is reconciled from `/workspaces/:workspaceId`; active sessions remain
+tab/store-owned, and Settings sections remain query-string state. The migration
+does not introduce a second URL-owned session or settings store.
+
+PR 2 also preserves these current Desktop host/legacy entrypoints explicitly;
+they are not silently lost in the mechanical move:
+
+| Current Desktop route | PR 2 disposition |
+| --- | --- |
+| `/index.html` | Thin Desktop host redirect to `/` |
+| `/setup` | Existing authenticated redirect to `/` |
+| `/settings/cloud` and `/settings/billing` | Retain the Desktop billing-return/deep-link decoder, then normalize to shared `/settings?section=billing` |
+| `/automations` and `/automations/:workflowId` | Retain thin redirects to `/workflows` and `/workflows/:workflowId` through the Web R+1 redirect window; removal is a separate audited cleanup |
+| `/playground/**` | Retain Desktop-only development host routes; never include them in the production Web product router |
+
+These routes contain no second product UI or controller. The Desktop billing
+decoder and protocol ingress remain host transport; the canonical destination
+is always a shared product route.
+
+Current Web declares `/settings`, generic `/settings/:sectionId`, and a
+separate `/settings/cloud` transport route. The concrete settings URLs below
+are known inbound/producer values handled through those declarations; they are
+not all separately declared React routes.
+
+PR 4 uses this concrete route disposition:
+
+| Current Web inbound path/pattern | Target/disposition |
+| --- | --- |
+| `/auth` | Bounded edge redirect to shared `/login` |
+| `/auth/callback` | Retain as Web host callback; OAuth/SSO registration need not churn |
+| `/auth/error` | Retain as Web host callback/error entry |
+| `/login` | Shared ProductClient login screen |
+| `/login/:slug` | Retain as a thin Web auth entry decoder that renders the shared login screen with validated SSO intent |
+| `/join/:organizationId` | Retain as a thin Web invitation entry decoder feeding the shared organization-join flow |
+| `/connect-github` | Delete; shared onboarding/readiness renders the required GitHub action in place |
+| `/auth/desktop/handoff` | Delete after proving no deployed producer remains; Desktop uses its protocol flow |
+| `/settings/cloud` | Retain as Web host billing-return decoder: Desktop handoff for `returnSurface=desktop`, otherwise navigate to shared `/settings?section=billing` |
+| `/settings/account` | Repository producers change to `/settings?section=account`; exact bounded edge redirect covers in-flight GitHub App state |
+| `/settings/organization` and `/settings/organizations` | Repository producers/allowlist change to `/settings?section=organization`; exact bounded redirects cover in-flight callbacks |
+| `/settings/environments` | Repository producers change to `/settings?section=environments`; exact bounded redirect covers in-flight callbacks |
+| Other `/settings/:sectionId` | Intentionally unsupported; no generic redirect may shadow `/settings/cloud` billing transport |
+| `/cloud/workspaces/:id` | Producers change to `/workspaces/:id` |
+| `/cloud/workspaces/:id/chats/:chatId` | Producers change to `/workspaces/:id`; bounded redirect opens the owning workspace |
+| `/workspaces/:id/chats/:chatId` | Bounded redirect opens `/workspaces/:id`; session selection remains shared store state |
+| `/automations/**` | Current Web entries are already thin React redirects to `/workflows/**`; replace them with the bounded edge redirect for R/R+1, then remove the alias |
+| `/support` | Delete as a route; shared Desktop support-modal behavior is canonical |
+
+Before PR 4 is production-ready, its release packet contains a checked producer
+ledger. At minimum it audits and updates:
+
+| Producer/consumer | Concrete owner to inspect |
+| --- | --- |
+| Browser OAuth and SSO return | `apps/web/src/lib/access/cloud/auth/web-auth-flow.ts`, Web route config, provider registration, server redirect validation/tests |
+| GitHub App installation/user authorization return | shared settings workflows plus `server/proliferate/server/cloud/github_app/service.py` and `FRONTEND_BASE_URL` behavior |
+| Stripe checkout/portal returns | `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`, `STRIPE_CUSTOMER_PORTAL_RETURN_URL`, `server/.env.example`, server billing tests, deployment secrets/config |
+| Organization invitations | `server/proliferate/server/organizations/join_links.py`, email templates/tests, `/join/:organizationId` |
+| Workspace/session links | Product link helpers, Desktop open-in-Web workflow/tests, notifications/email/Slack producers, Mobile associated-link declarations if they consume the hosted URL |
+| Desktop handoff/deep links | Web handoff helper, Desktop protocol decoder/tests, local-dev scheme |
+| Telemetry/scrubbing classifiers | Web telemetry path classifiers, product-domain URL scrub tests, worker/supervisor logging scrub tests |
+
+The audit uses repository search plus deployed configuration review; a code-only
+search cannot prove provider registrations and Stripe dashboard/env values
+changed. Release R's smoke gate opens both old and canonical forms of each
+redirected inbound class. PR 3 may delete the old route components because the
+ordering shim lives at the Vercel edge.
+
+## 11. AnyHarness and workspace resolution
+
+### 11.1 One shared provider path
+
+Normal product code never constructs `AnyHarnessClient`. It uses the shared
+SDK React providers and hooks:
+
+```text
+logical workspace selection
+  -> classify selected materialization
+  -> resolve a connection for that target
+  -> AnyHarnessWorkspace
+  -> shared chat/transcript/files/terminal/subagent/config hooks
+```
+
+The product client owns logical workspace classification, materialization
+selection, Cloud workspace records, and shared provider composition.
+
+### 11.2 Target matrix
+
+| Target | Desktop | Web | Resolution owner |
+| --- | --- | --- | --- |
+| Managed cloud sandbox | Commandable | Commandable | Shared Cloud gateway resolver |
+| Desktop local runtime | Commandable | Unavailable | Desktop bridge |
+| Direct SSH target | Commandable | Unavailable | Desktop bridge |
+| Desktop-exposed local record | Commandable from owning Desktop rules | Read-only/handoff | Server metadata + Desktop bridge |
+| Unmaterialized/pending cloud workspace | Shared pending UI | Shared pending UI | Product-client + Cloud SDK |
+
+Cloud files, changes, terminals, chat, transcript streaming, plans,
+integrations, and subagents are not Desktop-only merely because Desktop
+implemented them first. If the selected managed-cloud AnyHarness exposes the
+capability, Web uses the same product UI through the gateway.
+
+### 11.3 Cloud gateway resolver
+
+Both hosts use one product-client resolver for managed cloud. Conceptually it:
+
+1. loads the selected cloud workspace/materialization through the shared Cloud
+   cache, confirms it is Web-commandable, and derives its stable target slot
+   plus logical workspace attachment;
+2. asks that slot's connection-material coordinator for the current record.
+   Normal concurrent callers share one in-flight resolution; a forced refresh
+   allocates the next monotonic revision and supersedes an older attempt;
+3. the winning attempt asks the current ProductScope's bound authority handle
+   for one atomic fresh product-token + credential-revision snapshot;
+4. it keeps the full Cloud connection record (including runtime generation) for
+   lifecycle observation, while mapping only runtime URL, fresh access token,
+   AnyHarness workspace id, WebSocket auth transport, target slot,
+   target-generation identity, and connection-resolution revision into the SDK's
+   `AnyHarnessResolvedConnection`;
+5. installs the result only if its connection revision is still latest and its
+   credential revision still equals the authority coordinator's current
+   observed revision. A caller whose A result is superseded by B joins/adopts
+   B's current record (or receives an internal retryable superseded result that
+   the resolver immediately retries); stale A is never exposed to product code;
+6. reports the accepted connection observation to the shared generic
+   transition boundary so a changed AnyHarness workspace id or runtime
+   generation evicts the prior target's attached caches and reconnects live
+   work.
+
+Expiring tokens and gateway URLs are connection material, not logical identity.
+Connection-resolution revision is an in-memory ordering fence, not a query key
+or persisted identity. If the latest attempt fails, the boundary retries; it
+does not fall back to installing an older in-flight result.
+
+Managed-gateway target records also remember the authority
+`credentialRevision` with which their connection material was resolved. The
+slot coordinator subscribes to the bound authority handle and marks that
+material stale when the revision advances, without changing ProductScope,
+target generation, or query identity. Every new AnyHarness operation and every
+stream reconnect must first ensure current material; a stale revision or a
+current-authority 401 forces the slot-owned refresh. Already-connected streams
+are not torn down merely because the revision advanced. Local/direct targets
+that do not depend on product auth ignore this signal.
+
+PR 0c uses these collision-proof identities:
+
+```text
+target slot (stable owner)
+  cloud:<deployment-key>:<logical-cloud-workspace-id>
+  local:<desktop-runtime-slot-id>
+  ssh:<deployment-key>:<ssh-target-id>
+
+target generation (current incarnation within that slot)
+  cloud:<anyharness-workspace-id>:<runtime-generation>
+  local:<process-generation>
+  ssh:<tunnel-generation>
+```
+
+The full credential-free connection identity is target slot + target
+generation. Target kind and stable owner are mandatory: two SSH targets at
+generation 1 must not collide, and neither may collide with a local process at
+generation 1. Every workspace, session/feed stream, terminal stream, client,
+and query owned by a target registers against its target slot and generation.
+The Desktop runtime slot id is a stable logical profile/installation slot that
+survives a sidecar process restart; it is never a PID or random process-instance
+id. Each launched process is represented only by `process-generation`.
+
+Connection material and workspace attachment are separate. One local sidecar
+or SSH tunnel has one slot-owned URL/auth/transport record even when several
+logical workspaces resolve to different AnyHarness workspace ids. Those
+workspace callers share/adopt the winning target record; their attachment
+records do not supersede one another. Cloud currently uses one logical Cloud
+workspace per slot, so its AnyHarness workspace id participates in that slot's
+generation.
+
+The transition boundary serializes generation changes. It marks the old
+generation closed and the new generation current before it enumerates cleanup.
+Every async resource uses an atomic registration operation equivalent to
+`register(authority, slot, generation, resource)`: a late old-generation
+registration is rejected and immediately closed. Session/feed/terminal
+callbacks and reconnect timers capture the returned lease and check that it is
+current before publishing or reconnecting.
+
+Client lookup also returns a lease. When accepted URL/token material rotates
+within one generation, the old client is marked retired before the replacement
+is published: it grants no new operations, already-started HTTP work may
+settle, and its registry reference is disposed after its operation leases reach
+zero. Existing separately registered streams may continue to drain; any
+reconnect resolves the current material. Authority or target-generation
+teardown force-closes every lease.
+
+At the SDK boundary, the surrounding runtime owns product authority scope and
+the workspace provider owns logical selection plus current connection
+resolution:
+
+```tsx
+<AnyHarnessRuntime
+  cacheScopeKey={productAuthorityScope}
+>
+  <AnyHarnessConnectionTransitionBoundary>
+    <AnyHarnessWorkspace
+      workspaceId={selectedLogicalWorkspaceId}
+      resolveConnection={resolveCurrentConnection}
+    >
+      {children}
+    </AnyHarnessWorkspace>
+  </AnyHarnessConnectionTransitionBoundary>
+</AnyHarnessRuntime>
+```
+
+- `cacheScopeKey` changes when deployment, actor, or authority generation
+  changes;
+- logical workspace identity remains in the SDK's workspace query keys;
+- runtime-level SDK query keys use authority scope + credential-free target
+  slot + generation, not `runtimeUrl`, token, or connection revision;
+- PR 0c query helpers receive that target identity from the accepted resolved
+  connection (or an explicit target descriptor for target-wide inventory),
+  while `runtimeUrl` remains transport material used only to execute requests;
+- materialization/runtime-generation replacement causes targeted cancellation,
+  removal/reset, stream closure/reconnection, and connection re-resolution
+  through the boundary;
+- the scope-owned client registry holds at most one current client per
+  credential-free target identity and is cleared on authority teardown;
+- `resolveConnection` may return a refreshed token or gateway URL without
+  changing logical workspace identity;
+- logout/server switch still tears down the entire surrounding product scope;
+- the implementation uses the merged SDK/query-scope primitive rather than
+  inventing a product-client-only parallel key.
+
+### 11.4 Desktop local resolver
+
+Desktop additionally supplies local/SSH connection authority through its
+bridge. The shared provider selects it only for a target whose product model
+is local or direct SSH.
+
+Desktop retains dynamic runtime resolution; it does not bake a local URL into
+product-client. Its resolver supplies the sidecar/process generation; the SSH
+resolver supplies tunnel generation. Restart/reconnect changes that generation
+even when the URL is reused. A local sidecar or SSH tunnel may serve multiple
+workspaces, so the generic transition boundary closes and reconnects **every**
+workspace/session/feed/terminal resource attached to the old generation of
+that stable target slot while leaving unrelated local, SSH, and Cloud slots
+alone.
+
+### 11.5 Web negative guarantees
+
+On Web:
+
+- `desktop` is `null`;
+- no local runtime bootstrap executes;
+- no global local workspace/repo/cowork inventory query executes;
+- no local AnyHarness URL is constructed;
+- no direct SSH connection is attempted;
+- no raw AnyHarness client is created at a page or workflow callsite;
+- selecting a server-visible local record renders an honest Desktop handoff,
+  not an endlessly loading chat.
+
+These are test assertions, not merely hidden controls.
+
+## 12. Product capability policy
+
+Capability checks have three sources:
+
+1. **Host/device:** Desktop bridge present or absent.
+2. **Deployment/server:** capabilities returned by the connected API.
+3. **Selected resource:** what the workspace/runtime record can actually do.
+
+Do not create one giant manually synchronized boolean capability object.
+Derive user actions from these sources.
+
+| Product action/surface | Desktop | Web |
+| --- | --- | --- |
+| Home, sidebar, account, organizations | Full | Same shared product |
+| Managed-cloud workspace create/open/resume | Full | Same shared product |
+| Managed-cloud chat/transcript/config | Full | Same shared product |
+| Managed-cloud files/changes/terminal/subagents | Full when runtime supports it | Same when runtime supports it |
+| Create/attach local repository/workspace | Full | Hidden; Desktop handoff may be offered |
+| Create local worktree | Full | Hidden |
+| Local chat/session/runtime inventory | Full | Not queried or rendered as commandable |
+| Direct SSH target | Full | Read-only metadata/handoff at most |
+| Native file picker/reveal/editor/terminal | Full | Native action hidden; Web-safe cloud action remains |
+| Local agent credentials/reconcile/settings | Full | Hidden |
+| API-key vs managed-gateway session configuration | Shared product where deployment/runtime supports it | Same for managed cloud |
+| Cloud secrets/integrations/org policy | Shared | Shared |
+| Local-only secrets/settings | Full | Hidden |
+| Cloud workflow create/edit/run | Shared | Shared |
+| Local workflow/automation execution/config | Full | Read-only server-visible summary + Desktop handoff |
+| Local automation run metadata synced to server | Shared display | Read-only display/handoff |
+| Billing/usage/plan settings | Shared, server-gated | Shared, server-gated |
+| Native updater/version/restart | Full | Hidden |
+| Self-host deployment switch | Full | Not in hosted Web migration |
+| Native diagnostics/support attachments | Full | Web support without native collection |
+
+Controls are either functional or absent/replaced with a truthful handoff. Do
+not render dead disabled controls simply to make the layouts look identical.
+
+### 12.1 Context menus
+
+Menu content is product behavior and is shared where possible. Desktop
+may use its native context-menu bridge. Web uses a DOM menu for Web-safe
+actions. Native-only actions such as "Reveal in Finder" are omitted on Web;
+product actions such as copy reference or operate on a cloud file remain.
+
+This is a rendering adapter difference, not a separate Web controller.
+
+## 13. Styling, assets, and selectors
+
+Desktop's rendered product is the visual source of truth.
+
+- Add `apps/packages/design/src/css/product.css` as the shared Desktop-derived
+  product stylesheet. It imports the DOM foundation/fonts and receives the
+  product selectors/tokens currently living in `desktop.css`.
+- Reduce `desktop.css` to importing `product.css` plus genuinely native/Tauri
+  window-chrome overrides.
+- Preserve one defined cascade with no duplicate import: Desktop
+  `apps/desktop/src/index.css` imports `@proliferate/design/desktop.css`, which
+  imports `product.css` first and then native overrides; Web
+  `apps/web/src/index.css` imports `@proliferate/design/product.css` directly
+  and then browser-host CSS.
+- Before rendering the product, each host preserves the existing root marker:
+
+  ```ts
+  document.documentElement.dataset.proliferateClient = "desktop"; // or "web"
+  ```
+
+  `product.css` exposes `desktop:`/`web:` Tailwind variants (or equivalent
+  root selectors) from this marker for genuine visual differences. It is not
+  used to hide controls whose hooks/queries would still execute.
+- Add `@source "../../../product-client/src"` to the owning Tailwind source
+  configuration. Without this, classes in moved JSX are silently omitted from
+  both production bundles.
+- Add the export map/build tests for `product.css` and prove the existing
+  generic CSS copier emits it; change that copier only if the proof fails.
+  Keep the CSS drift tests pointed at the new cascade.
+- Product fonts and product assets move with product-client or remain in the
+  lower shared design/UI packages.
+- Appearance rules and CSS-token application move with product-client. It
+  exposes a small synchronous pre-render appearance initializer that both host
+  mains call, then its normal preference lifecycle hydrates persisted choices
+  through `ProductPersistenceHost`.
+- The CSS default must equal the product default so first paint remains
+  correct before asynchronous preference hydration.
+- no Web-specific restyling is performed during cutover.
+- Tauri window chrome and macOS safe-area elements remain Desktop host UI.
+- durable semantic test IDs/accessibility roles live with the shared product,
+  so the same Playwright journey can drive both hosts.
+
+### 13.1 Hosted Web performance budget
+
+The current checked-out old-Web production artifact has an approximately 491
+kB gzip initial JS+CSS closure and no emitted font assets. That number is
+informational; the old Web product is not instrumented or retained merely to
+serve as a migration harness.
+
+The Desktop-derived product currently has a much larger static entry and
+statically imports both login and authenticated roots. PR 1 therefore includes
+a **feasibility build before the PR 2 freeze**: split the in-place candidate
+root into a lightweight `ProductClient` auth gate and a lazy
+`AuthenticatedProductClient`, mount it in a deterministic browser-safe host,
+and measure `/login` and authenticated `/`. The candidate root stays at stable
+Desktop-owned paths through PR 1 and consumes the package's host/provider/scope
+primitives; the package itself exports no `ProductClient` until PR 2 moves the
+proven root. The shared candidate root—not the throwaway old Web root—defines:
+
+```text
+data-product-ready="login"
+data-product-ready="authenticated-home"
+```
+
+These are the desired acceptance targets for that feasibility build:
+
+| Route/readiness point | Budget |
+| --- | ---: |
+| Shared `/login` JavaScript (gzip level 9) | 525,000 bytes |
+| Shared `/login` CSS (gzip level 9) | 45,000 bytes |
+| Shared `/login` fonts/images (emitted bytes) | 100,000 bytes |
+| Shared `/login` total measured assets | 670,000 bytes |
+| Authenticated `/` total measured assets | 1,750,000 bytes |
+| Web-only overhead over the PR 2 ProductClient home fixture | 5% maximum |
+
+The byte targets are not presented as already-proven facts. PR 1 must either
+prove them or commit an evidence-backed replacement budget before PR 2 is
+authorized; a replacement requires an explicit spec review and cannot silently
+ratchet to whatever the build happens to emit. Independently of the exact
+numbers, login/callback entries must exclude authenticated product roots,
+Monaco, Shiki grammars/themes, xterm, editors, and non-entry routes.
+
+Implementation requirements:
+
+- enable Vite manifest generation and build a deterministic route-asset
+  measurement command;
+- in PR 1, define both readiness markers on the in-place Desktop-derived
+  candidate shared root and run the feasibility build before scheduling the
+  mechanical move;
+- serve the production build, use a fresh-cache Playwright context with fixed
+  auth fixtures, visit `/login` and authenticated `/`, and wait for a durable
+  shared `data-product-ready` marker, `document.fonts.ready`, and a bounded
+  network-idle settle before closing the request ledger;
+- collect each unique same-origin script, stylesheet, font, image, and audio
+  asset requested before readiness; map it to `dist`, gzip JS/CSS at level 9,
+  and count already-compressed font/image/audio files by emitted bytes;
+- run the feasibility check in PR 1 and the shipping Web check in the existing
+  `web-frontend` CI job before Web cutover;
+- count route-loaded dynamic chunks; exclude only chunks/assets that the
+  measured route did not request and report them separately;
+- preserve that root split when PR 2 mechanically moves it into
+  product-client; the production Vite fixture then imports the moved
+  ProductClient with the same deterministic browser-safe host and commits its
+  measured asset ledger;
+- in PR 4, run the same measurement against the actual Web host, enforcing the
+  committed login/home budgets and at most 5% additional bytes over the PR 2
+  ProductClient-only ledger.
+
+The budget gates bytes needed to make each route usable, not total deploy
+size. Total deploy size is misleading because language/theme/editor chunks are
+intentionally lazy. Desktop font imports cannot silently enter Web's signup
+critical path without fitting the font/asset and total budgets.
+
+## 14. Lifecycle ownership
+
+Moving `App.tsx` is not enough. Every existing root effect must be assigned an
+owner.
+
+### 14.1 Host bootstrap/process lifecycles
+
+These remain app-owned when they do not require internal product state:
+
+- API/deployment configuration bootstrap;
+- Web cookie/PKCE transport installation;
+- Desktop vault/protocol transport installation;
+- Sentry/PostHog/native telemetry installation;
+- renderer startup diagnostics and performance guards;
+- Tauri reload/context-menu policies;
+- local sidecar process bootstrap and raw health transport;
+- window/process-level listeners.
+
+### 14.2 Shared product lifecycles
+
+These move with product-client:
+
+- durable inbound-entry-intent queue coordination above ProductScope;
+- organization selection;
+- session/workspace selection and intent dispatch;
+- query/stream-connected product behavior;
+- preference hydration and persistence orchestration;
+- home deferred launches;
+- support UI/report workflow state;
+- product command/shortcut interpretation;
+- Cloud workspace and workflow orchestration.
+
+### 14.3 Desktop-capability product lifecycles
+
+Desktop-specific behavior that needs product state lives in product-client and
+calls the optional bridge, for example:
+
+- local agent reconcile/auth synchronization;
+- local automation execution;
+- Desktop worker enrollment tied to auth transitions;
+- updater presentation/restart behavior;
+- product-aware native menu dispatch;
+- local worktree preference synchronization;
+- native support/diagnostic collection initiated by the product.
+
+The effect is not mounted when the bridge is absent.
+
+Important invariants from the current Desktop root:
+
+- auth bootstrap completes its initial decision before runtime-dependent
+  product work assumes a principal;
+- runtime bootstrap starts only after auth is no longer `bootstrapping`;
+- worker enrollment observes the authenticated-to-anonymous transition so it
+  can tear down correctly;
+- preference hydration completes before default-sync effects write;
+- updater, menu, deep-link, and global dispatch listeners mount once;
+- every timer/listener/stream has deterministic cleanup;
+- the workspace shell remains warm across routes;
+- provider/scope teardown cannot let a stale completion mutate the next actor.
+
+## 15. Source disposition
+
+### 15.1 Desktop
+
+| Current owner | Target |
+| --- | --- |
+| Most `components/**`, `pages/**`, product `hooks/**`, `stores/**` | Move to product-client |
+| Product `lib/domain/**`, `lib/workflows/**`, config/copy/assets | Move to product-client |
+| Shared half of `AppProviders` and authenticated route tree | Move to product-client |
+| Cloud/AnyHarness product queries and orchestration | Move to product-client |
+| `src-tauri/**` | Retain in Desktop |
+| `lib/access/tauri/**` | Retain as raw Desktop implementation |
+| Native auth/deployment transport | Retain in Desktop |
+| Native telemetry/diagnostics bootstrap | Retain in Desktop |
+| Native runtime/process/updater/SSH/shell primitives | Retain behind Desktop bridge |
+| Tauri React wrappers that own product behavior | Move behavior; call Desktop bridge |
+| Embedded browser/webview | Delete with its live workspace-panel/tab/action callers in the named pre-PR-2 cleanup; do not move or bridge it |
+| Dev product playgrounds | Move only if they exercise shared product; host-native playgrounds stay Desktop |
+
+### 15.2 Existing shared packages
+
+| Current owner | Target |
+| --- | --- |
+| `product-surfaces` source | Move into product-client and remove old package name |
+| `product-ui` | Keep as lower presentation package |
+| `product-domain` | Keep as pure cross-platform rules package |
+| `ui` | Keep as the only DOM primitive layer |
+| `design` | Keep as token/assets foundation |
+
+`product-client` becomes the sole connected shared DOM product owner. Existing
+`product-surfaces` exports needed by the still-old Web app may be carried under
+the new package for the short interval between PR 2 and the stacked PR 3/PR 4
+cutover, then simplified.
+
+### 15.3 Web
+
+Retain/adapt:
+
+- `main.tsx` as browser bootstrap;
+- environment/deployment configuration;
+- refresh-cookie, CSRF, in-memory bearer, and PKCE flow;
+- browser auth/callback/error route controllers;
+- browser credentialed Cloud transport factory;
+- browser telemetry installation;
+- host-only CSS.
+
+Delete after cutover:
+
+- Web application shell/navigation;
+- Web Home, Chat, Settings, Workflows, and Support product pages;
+- Web product components and controllers;
+- Web home/chat/settings hooks;
+- Web product-domain copies for chat/sidebar/home;
+- Web cloud prompt/config/session draft stores;
+- Web raw AnyHarness client and polling path;
+- Web-specific pending-home-prompt and transient-recovery product owners;
+- legacy product route aliases and settings-modal routing;
+- `apps/web/src/lib/access/cloud/auth-token-store.ts` and every production
+  read/write of its `proliferate.web.authToken` localStorage bearer. If a test
+  injector remains useful, it is a separate test-only in-memory adapter that is
+  excluded from production bundles.
+
+Public callback code is retained only when a live external producer still
+uses it.
+
+## 16. Migration sequence
+
+The cutover has an ordered runtime/authority prerequisite stack, two Desktop
+checkpoints, and a stacked Web replacement. The sequence deliberately separates
+behavioral refactoring from the repository-wide file move.
+
+### 16.1 PR 0 — finish the runtime/cache-scope prerequisite
+
+#### PR 0a — landed
+
+Commit `bdd11aa5a` established the narrow AnyHarness foundation:
+
+- SDK React query keys accept a credential-free `cacheScopeKey`;
+- Desktop derives that key from deployment plus user id for authenticated
+  state, and deployment plus raw auth status for non-authenticated states;
+- tokens and other credentials stay out of cache identity;
+- the Desktop provider supplies the scope to AnyHarness.
+
+#### PR 0b — authority-generation correction
+
+The landed authenticated branch is currently equivalent to
+`deployment + user:<userId>`; its non-authenticated branch is
+`deployment + <raw-auth-status>`. The authenticated key is insufficient when
+the same user logs out and back in: the new authority would receive the same
+key and a stale completion from the old authority could target the new cache.
+
+Add one in-memory `authGeneration` to Desktop's normalized auth state:
+
+- advance it when authority is replaced: interactive/persisted login,
+  explicit logout, revocation, or transition to anonymous;
+- do not advance it for ordinary token refresh or background recovery of the
+  same authority; advance a separate non-identity `credentialRevision` when a
+  current access token is replaced;
+- change `buildAnyHarnessCacheScopeKey` to accept explicit authority
+  (`user:<id>` or `anonymous`) plus generation. Remove raw auth status from the
+  key; `bootstrapping`/`unreachable` are presentation/transport state. PR 0b
+  introduces the normalized Desktop `unreachable` state (current Desktop auth
+  has only bootstrapping/anonymous/authenticated). Retain principal+generation
+  during a transient authenticated outage and do not mount remote providers
+  before any authority is resolved;
+- route every definitive refresh rejection/revocation through one normalized
+  `invalidateAuthority` transition that compare-and-swaps both authority and
+  the credential revision used by the failed request, clears stored
+  credentials, advances the epoch, and publishes anonymous state; transient
+  network failure may publish `unreachable` without invalidating the authority;
+- explicitly replace the current raw storage write/clear paths in
+  `loadValidSession`, `authMiddleware.onResponse`,
+  `fetchDesktopCloudStream`, and transient-recovery refresh handling in
+  `apps/desktop/src/lib/access/cloud/client.ts`, then inventory the rest of the
+  repo for equivalent mutations. No refresh/401 path may mutate storage behind
+  the auth store's back;
+- fold the exact deployment + explicit authority + generation tuple into
+  provider memoization;
+- add the Desktop auth-coordinator ordering/CAS described in Section 7.2 so a
+  late bootstrap, login callback, refresh, 401, or sign-out completion cannot
+  write/clear a newer credential authority;
+- test same-user generation N versus N+1, old credential revision A receiving
+  a 401 after revision B commits, competing callback transactions A/B,
+  bootstrap versus a live callback, refresh versus logout, and stale
+  credential-changing operations;
+- run the focused SDK/Desktop tests and one isolated Desktop profile.
+
+#### PR 0c — AnyHarness client and target-generation lifecycle
+
+The SDK React `clientCache` is currently a process-global map keyed by
+`runtimeUrl + raw bearer token`, with no teardown. Replace it before Web token
+rotation can use the shared product:
+
+- introduce an SDK React client registry owned by the current authority
+  `cacheScopeKey`; remove the module-global credential-keyed map;
+- extend resolved target metadata with the exact credential-free target slot,
+  target generation, and in-memory resolution revision defined in Section
+  11.3. Key registry entries by full slot + generation, never by a token;
+- change SDK React runtime-level query keys from `runtimeUrl` to authority scope
+  + target slot + generation. Preserve logical workspace ids in workspace keys;
+  URL/token/revision changes within a generation do not create semantic keys;
+- implement one slot-owned connection-material coordinator. Normal concurrent
+  workspace callers share its in-flight result; a forced refresh allocates a
+  revision and supersedes the older attempt. If B installs before delayed A,
+  A is discarded and A's waiters adopt/retry B. If latest B fails, retry rather
+  than installing A;
+- when accepted URL/token material changes within one target generation,
+  replace the one current client and release the old registry reference rather
+  than accumulating entries. Routine credential rotation does not alter query
+  identity or target generation;
+- record the bound authority's non-identity `credentialRevision` on managed
+  connection material using the handle's atomic token+revision snapshot.
+  Installation compare-and-swaps both connection revision and current observed
+  credential revision. A revision change marks material stale; every new
+  operation/reconnect and current-authority 401 ensures/forces a slot-owned
+  refresh before using a client. Existing streams are not torn down solely for
+  token rotation;
+- generalize the current Desktop Cloud-only materialization tracker into one
+  transition boundary. It indexes every attached workspace/query/client/live
+  resource by target slot + generation and cancels/removes/resets all resources
+  attached to the replaced generation;
+- make target activation plus resource registration atomic. Mark the prior
+  generation closed before cleanup; reject/close any late registration against
+  it. Every resource callback/reconnect runner checks its current lease before
+  publishing or reconnecting;
+- explicitly adapt Desktop's current module-global
+  `session-stream-handles.ts`, session reconnect timers/offline runners,
+  `terminal-stream-registry.ts`, and feed-stream connection effects to consume
+  that boundary. Authority teardown closes every handle/timer/runner; target
+  rollover closes and lets mounted consumers reconnect every attached SSE/WS
+  resource. Query/client eviction alone is not accepted as stream teardown;
+- fan out a local-process or SSH-tunnel generation transition to every
+  workspace attached to that stable target slot. Leave unrelated target slots
+  alone;
+- clear the registry and every registered live resource on authority teardown.
+  Plain non-React callers receive an injected registry/transition owner or use
+  an explicitly non-caching client factory;
+- give registry clients operation leases. Same-generation connection-material
+  replacement retires the old client (no new work), permits already-started
+  operations to settle, and releases it at zero leases; separately registered
+  streams may drain, but reconnect through current material;
+- prove two concurrent SSH targets do not collide, a shared local runtime
+  restart rolls all of its workspaces, token B cannot be replaced by delayed
+  token A, credential revision forces new work/reconnect onto B without
+  remounting queries or tearing a healthy stream, access-token rotation does
+  not grow the registry, and
+  deployment/logout/target-generation changes fence old clients, queries,
+  streams, timers, and late completions.
+
+PR 0 is complete only after PR 0b and PR 0c. These close the AnyHarness
+prerequisite; they do not yet remove Desktop's module-global product
+QueryClient or module-global product stores. Full product ownership belongs to
+PR 1.
+
+### 16.2 PR 1 — make Desktop host-aware in place
+
+Goal: introduce and prove the complete host boundary without moving the hot
+Desktop product tree. This is behavioral refactoring at stable paths and may
+run alongside ordinary product UI work before the launch freeze. Root, auth,
+telemetry, Cloud-access, and native-access slices use explicit ownership while
+their corresponding PR 1 change is active.
+
+Land it as a short stack of reviewable changes if that improves reviewability,
+but preserve this order:
+
+1. Create a source-consumed `@proliferate/product-client` skeleton and prove
+   its package-private `#product/*` imports in TypeScript, Vite, and Vitest.
+   The PR 1 export map exposes host/provider/scope/package-resolution
+   primitives and their types only — no `ProductClient` export until PR 2.
+2. Refine the canonical feature spec
+   (`specs/codebase/features/web-desktop-client-unification.md`, promoted by
+   the docs preflight before PR 0b) and the frontend structure docs with the
+   implementation inventory; do not re-promote the contract.
+3. Generalize both enforcement scripts for product-client immediately.
+   `scripts/report_frontend_structure.py` adds product-client to every
+   applicable hard-coded root collection and package map.
+   `scripts/check_frontend_boundaries.py` replaces its single `DESKTOP_SRC`
+   traversal and literal Desktop-path predicates with an explicit
+   ownership-root/rule-applicability table covering Desktop and product-client
+   (and Web only where a rule applies). Tests plant a violation for every
+   intended root/rule pair and prove the script catches it, including package
+   shape, hook/component shape, DOM primitives, raw Tauri/Cloud/AnyHarness
+   access, query ownership, and package-import rules.
+   Migrate `frontend_structure_allowlist.txt` and
+   `frontend_boundaries_allowlist.txt` deliberately as paths move. Install the
+   Tailwind source assertion and ProductClient performance-fixture check at the
+   same loud-failure boundary.
+4. Define the single composite `ProductHost`, its provider, the
+   existing `data-proliferate-client` marker contract, and the narrow Desktop
+   implementation.
+5. Build a checked host-dependency ledger and adapt every future-moved Desktop
+   product callsite while paths remain stable. The ledger covers raw Tauri;
+   native auth/deployment and callback transport; the app Cloud client/global
+   factory; direct `localStorage`/`sessionStorage`; host URL/deep-link encoding;
+   persisted inbound entry intents; and vendor telemetry/bootstrap. Each
+   becomes the declared ProductHost seam or remains in the thin host. Raw
+   access remains under Desktop's access layer, and fail-closed import scans
+   prove no future-moved file bypasses the seam. Prove the atomic replaying
+   entry-intent queue cannot miss an intent between startup drain/live
+   delivery, overwrite a second pending intent, cross deployment, or execute
+   one `intentId` twice. Also prove bootstrap auth validation and a live auth
+   callback are serialized correctly.
+6. Split Desktop root composition into host bootstrap, shared product
+   lifecycles, and optional Desktop-capability lifecycles.
+7. Inventory every product store/persistence key, implement the
+   authority/organization/workspace rollover and namespacing rules from
+   Section 8.3, and prove same-renderer logout/re-login cannot expose drafts,
+   prompts, tabs, or selection from the prior authority. A deliberately
+   delayed Promise writing through an old setter must be unable to mutate the
+   replacement scope.
+8. Replace the module-global authenticated product QueryClient with a
+   `ProductScopeBoundary`-owned client keyed by deployment, principal, and
+   `authGeneration`. Bind and dispose the exact `ProductAuthorityHandle` at
+   this boundary. Remove the Cloud React provider's process-global write and
+   `useCloudClient()` global fallback; pass the scoped client explicitly to
+   future-moved plain SDK calls. Preserve and audit existing organization-aware
+   query keys, repairing mismatched callsites, and replace live
+   selected-organization middleware with the same immutable per-operation owner
+   context. Prove scope teardown
+   fences stale queries, mutations, streams, and manual cache writes, and prove
+   authority N's delayed request/rejection can neither obtain N+1's token nor
+   invalidate or reach N+1's Cloud client after same-user re-login.
+9. Build the in-place ProductClient split/fixture from Section 13.1 at stable
+   Desktop-owned paths (the package exports no ProductClient in PR 1), define
+   the readiness markers there, and prove or explicitly revise the byte
+   targets before authorizing the mechanical move.
+10. Prove Web-mode composition can exist with `desktop: null` and without
+   local runtime discovery — a host/provider/capability composition proof, not
+   a package-owned product mount — but do not migrate or embellish the old Web
+   product here.
+11. Run focused tests and a real isolated Desktop profile.
+
+PR 1 moves no product pages, stores, or hooks. Desktop should render exactly
+as it did before; it is simply ready to be moved mechanically. It is complete
+only when the host-dependency and store-lifetime ledgers have no unclassified
+future-moved callsite/state and both enforcement scripts fail on a deliberate
+product-client boundary violation.
+
+Before PR 2, land one separately reviewable embedded-browser removal. Delete
+`WorkspaceBrowserPanel`, `BrowserSurfaces`, the native webview surface and raw
+`lib/access/tauri/browser-webview.ts` path, their hooks/actions/tab state, and
+the workspace-shell caller after a checked reference scan. This is an explicit
+product deletion already chosen for the migration—not a host capability and
+not part of the mechanical move. The ordinary workspace files/changes/terminal
+surfaces remain.
+
+### 16.3 PR 2 — mechanically move Desktop into product-client
+
+Goal: Desktop imports and mounts the shared package one hundred percent, with
+no duplicate connected product left under `apps/desktop/src`.
+
+This lands in a one-to-two-day Desktop feature freeze after the July 22, 2026
+launch window (or the equivalent first quiet window if that date changes).
+The freeze gate is binding: it opens only on an explicit dated user signal
+plus a merged PR-2 freeze ledger (timestamp, base SHA, owner, planned
+duration, and a disposition for every live conflicting Desktop
+branch/worktree) appended to the rollout ledger at
+`specs/developing/deploying/web-desktop-unification-rollout.md`, and freeze
+validity is revalidated at PR 2 launch, immediately before its
+review-acceptance, and immediately before its merge. Before the freeze, merge
+or explicitly park every live Desktop UI branch; announce the cutover commit
+and do not accept new hot-surface changes until the gate is green.
+
+Recommended commit order:
+
+1. Rename/absorb `product-surfaces` into `product-client` and update workspace,
+   package, build, test, structure/boundary enforcement, and allowlist
+   configuration.
+2. Move Desktop-owned product pages, components, hooks, stores, product rules,
+   connected providers, route tree, and shared lifecycle owners with `git mv`
+   where feasible.
+3. Use an AST module-specifier codemod to rewrite moved `@/...` imports to
+   `#product/...`. Do not use blind text replacement; strings such as regexes
+   and generated content must remain untouched.
+4. Move product assets and generated-path ownership, split shared
+   `product.css` from native Desktop chrome, and update Tailwind scanning.
+5. Make the thin Desktop app install its auth/telemetry/storage/link/Desktop
+   host implementations and mount `ProductClient`.
+6. Keep old Web buildable temporarily by pointing any required shared imports
+   at `product-client`; do not change its product behavior.
+7. Delete the old Desktop copies and `product-surfaces`. Do not leave forwarding
+   wrappers, duplicate stores, or a second mutation owner.
+8. Run every static/build/test gate, the native smoke, and a real isolated
+   Desktop profile before ending the freeze.
+
+PR 2 is a mechanical cutover, not a feature PR. Review it by ownership map,
+codemod audit, deletions, and the verification gate rather than attempting to
+manually re-review every moved line.
+
+### 16.4 PR 3 — delete the old Web product, retain a thin browser host
+
+Goal: remove the hand-built parallel Web product before wiring the replacement.
+
+Delete Web's product pages, product controllers, chat/polling implementation,
+product stores, raw AnyHarness callsites, and the production localStorage
+bearer-token store. Retain a buildable thin browser host with:
+
+- environment/deployment bootstrap;
+- Web auth, PKCE callback, error, billing-return decoder, refresh, and
+  telemetry ownership;
+- host-only CSS and the Web bundle-budget measurement;
+- the bounded Vercel redirects from the release ledger;
+- a temporary authenticated holding shell if required for buildability.
+
+PR 3 must pass Web build/typecheck/CI. It is a permanently review-only stacked
+diff based on post-PR-2 `main` and is **never merged**; its reviewed commits
+land only through the cutover landing branch's cherry-pick replay (see the
+canonical spec §10.4 and the rollout ledger).
+
+### 16.5 PR 4 — mount product-client from Web
+
+Goal: Web installs browser implementations and renders the same connected
+product for managed-cloud work.
+
+1. Implement browser deployment, auth, persistence, links, telemetry, and the
+   scoped credentialed Cloud transport in `ProductHost`. Managed-cloud
+   workspace classification, gateway lookup, connection resolution, and
+   materialization eviction remain shared product-client owners.
+   Production bearer state is memory-only; no replacement localStorage token
+   store is allowed.
+2. Add refresh singleflight, real authority-bound atomic credential-snapshot
+   semantics, auth-mutation transaction/CAS ordering, and the same in-memory
+   authority-generation behavior used by Desktop. Refresh, callback, and
+   sign-out work is keyed to the bound operation/authority: a late generation N
+   result cannot publish into, clear, or invalidate same-user generation N+1.
+3. Set `data-proliferate-client="web"`, supply `desktop: null`, and mount a
+   lightweight `ProductClient` at the canonical product catch-all; it owns the
+   shared auth gate and lazy-loads `AuthenticatedProductClient`.
+4. Remove Web's module-global QueryClient; authenticated state is owned by the
+   shared `ProductScopeBoundary`.
+5. Retain `/auth/callback`, `/auth/error`, and the `/settings/cloud` billing
+   return decoder; update the live inbound-link ledger, deploy one-release
+   redirects, and keep old aliases out of the React product router.
+6. Add only the capability absences and truthful Desktop handoffs named in the
+   matrix above. Do not create Web-specific replacement controllers.
+7. Remove temporary exports and any holding shell used only between PR 3 and
+   PR 4.
+8. Run both host lanes, shared Playwright journeys, Web negative-capability
+   assertions, callback tests, and the evidence-backed committed bundle
+   budgets.
+
+PR 4 is complete only when Web has no independent chat, transcript, composer,
+workspace, settings, or workflow controller. PR 4 stacks on reviewed PR 3;
+neither PR ever merges. After both are review-accepted, a separate landing
+branch created from fresh `main` cherry-picks exactly the recorded ordered
+commit list from the PR 3 base through the accepted PR 4 head, proves
+tree/range-diff equivalence from the preserved evidence branches, runs the
+combined gate battery, and is the only merged Web-cutover PR; PR 3 and PR 4
+then close as review-only records (canonical spec §10.4; rollout ledger §1.1).
+CI rejects a production Web artifact that lacks the ProductClient mount. This
+preserves separate review units without ever putting the holding host on
+`main` or staging/production.
+
+### 16.6 Follow-up — self-hosted Web
+
+Hosted Web cutover does not silently invent self-hosted Web packaging. A
+follow-up specifies configurable API origins, callback origins, BasicAuth/SSO
+and invitation behavior, deployment selection, and installer/deployment
+ownership before enabling that surface.
+
+### 16.7 During and after cutover — use the shared client as the test harness
+
+World provisioners, manifests, strict runner policy, and existing Desktop
+collectors can be built in parallel with the structural cutover. Full shared
+host collection becomes possible once PR 4 mounts hosted Web on the one product
+client; scenario fanout then targets that client instead of maintaining two
+product implementations.
+
+The shared Playwright journeys become the harness used while deeper billing,
+managed-cloud, self-hosting, agent, and upgrade scenarios are completed.
+
+## 17. Landing window and parallel feature work
+
+The migration is intentionally sequenced around the active launch work:
+
+The initial 2026-07-13 snapshot and dispositions are recorded in
+[web-desktop-unification-intake-ledger.md](web-desktop-unification-intake-ledger.md).
+Refresh that ledger rather than treating its branch statuses as permanent.
+The **binding** PR-1 intake snapshot and PR-2 freeze ledger are appended as
+committed docs-only phases to the rollout ledger at
+`specs/developing/deploying/web-desktop-unification-rollout.md`; the tbd
+ledger is historical sweep input only.
+
+- before PR 0b/0c or PR 1 starts, create the first intake ledger from **all**
+  open PRs plus local dirty, detached, and unpushed worktrees—not only GitHub
+  branches. Give each item `{owner, head SHA, touched slice,
+  merge|salvage|retarget|supersede|cancel}`. Refresh status at execution time;
+  the document does not permanently assume an item remains open;
+- now through the July 22, 2026 launch window: land PR 0b, PR 0c, and the
+  in-place PR 1 stack; ordinary Desktop product UI branches may continue
+  because paths do not move, while PR 1's root/auth/telemetry/Cloud/native
+  slices are temporarily owner-locked;
+- land the separately reviewable embedded-browser removal before the PR 2
+  freeze; it may proceed alongside PR 1 once its workspace-shell slice is
+  owner-locked;
+- immediately before PR 2: inventory every open PR/worktree touching Desktop,
+  confirm the embedded-browser cleanup is merged, merge ready work, and
+  explicitly park or retarget the rest — recorded as the binding PR-2 freeze
+  ledger in the rollout ledger, gated on an explicit dated user signal;
+- first quiet window after launch: freeze Desktop UI changes for one to two
+  days, land PR 2, run its full gate, then reopen feature development at the
+  new paths;
+- after PR 2: all connected Desktop/Web DOM product work targets
+  `product-client` directly;
+- review PR 3 and PR 4 as a stack, then land their combined diff to `main` in
+  one commit/landing PR after both are green.
+
+The initial ledger explicitly includes current PRs #1143 (Workflow V1 product
+work touching Desktop/Web/shared surfaces) and #1142 (release test foundation)
+as merge-or-disposition-before-freeze work. It also includes the known local
+migration/test branches `codex/anyharness-query-scope`,
+`codex/wdu0-contract-ledger`, `codex/wdu2-scope-contract`,
+`codex/wdu2-server-identity`, `codex/wdu2-native-vault`,
+`codex/wdu2-desktop-query-scope`, `codex/wdu-harness-foundation`,
+`codex/test-dual-host-mainline`, and `codex/test-foundation-combined`.
+Main's `bdd11aa5a` may supersede part of `codex/anyharness-query-scope`, but the
+ledger audits remaining commits instead of assuming the whole branch is dead.
+
+Additional parallel-work rules:
+
+- Workflow engine/contracts/server work is unaffected by the frontend move.
+  Workflow product UI lands before the PR 2 freeze or rebases once onto
+  `product-client` afterward.
+- A branch intentionally parked across PR 2 replays only its functional diff
+  at the new path; it must not restore deleted Desktop files.
+- No parallel branch builds new product behavior in the old Web controllers.
+- Any feature adding a genuinely host-specific operation extends the one host
+  contract narrowly and adds both its positive and negative host tests.
+- Before starting PR 1, use that initial ledger to cancel or retarget queued
+  structure-alignment swarm work that assumes app-owned product pages or a
+  separate Web controller.
+  Audit `specs/tbd/frontend-structure-alignment-migration.md`,
+  `specs/tbd/structure-alignment-coordinator-model.md`, their related swarm
+  notes, and every live structure-alignment worktree. Superseded work is
+  closed; still-useful checks are retargeted to PR 1/PR 2. No competing
+  migration continues in parallel.
+
+This freeze is intentionally attached only to the mechanical move. It avoids
+turning ordinary host-boundary work into a launch-month repository-wide merge
+conflict.
+
+## 18. Verification plan
+
+### 18.1 Static/package checks
+
+Every checkpoint remains buildable and runs the checks relevant to its
+ownership change:
+
+| Checkpoint | Required static/build evidence |
+| --- | --- |
+| PR 0b/0c | SDK React + Desktop auth/cache-scope/client-registry/target-generation tests and typecheck |
+| PR 1 | product-client import-map proof (primitives-only export map — no ProductClient export); Desktop and Web typecheck/build/tests; shared packages; structure and boundary scripts prove every relevant rule scanned product-client; in-place ProductClient split/readiness/performance feasibility build at Desktop-owned paths |
+| Pre-PR-2 browser cleanup | Desktop build/tests and isolated profile; checked reference scan proves no embedded-browser/webview owner or caller remains |
+| PR 2 | product-client, Desktop, Web, and shared package builds/tests; both Vite bundles resolve package imports/assets/CSS; structure/boundary scripts and allowlists; codemod/import scans; committed ProductClient authenticated-home performance fixture ledger |
+| PR 3 | thin Web host typecheck/build/test; old Web product-owner absence scan; redirects and bundle-budget check |
+| PR 4 | both app builds/tests; product-client tests; callback/route checks; login/home asset budgets and host-overhead comparison; shared browser journeys |
+
+The final import/ownership scans prove:
+
+- product-client contains no app, Tauri, browser-auth transport, or vendor
+  telemetry imports;
+- product-client contains no `@/...` Desktop aliases;
+- neither app imports package-private `#product/...` paths;
+- final bundles contain no unresolved `#product/...` text;
+- no `@proliferate/product-surfaces` import or package remains after PR 2;
+- no old Web product owner remains after PR 3;
+- direct public export-map imports resolve in both Vite builds.
+
+At minimum the move gate includes these literal scans, plus both frontend
+structure and boundary scripts' AST/path checks so alternate quote styles
+cannot evade enforcement:
+
+```bash
+rg -F '"@/' apps/packages/product-client/src
+rg -F '"#product/' apps/desktop/src apps/web/src
+rg -F '#product/' apps/desktop/dist apps/web/dist
+rg -F '@proliferate/product-surfaces' apps package.json pnpm-lock.yaml
+```
+
+### 18.2 Unit/component tests
+
+Move Desktop's existing tests with their owners. Add focused tests for:
+
+- ProductHost capability derivation;
+- Web negative actions;
+- managed-cloud versus local target classification;
+- host-independent product routing;
+- normalized entry-intent FIFO replay/acknowledge behavior, including multiple
+  queued intents, process-scope deduplication, idempotent handler acceptance,
+  deployment binding, OAuth redirect, and Desktop relaunch;
+- Desktop startup drain versus live deep-link arrival (including an arrival at
+  the old `getCurrent()`/listener-registration gap) and auth bootstrap
+  validation versus a live auth callback;
+- auth state normalization;
+- scope rollover on actor/deployment/auth-generation change;
+- authority-bound token acquisition and compare-and-swap invalidation: delayed
+  generation N work cannot receive or invalidate same-user generation N+1;
+- auth-coordinator ordering: competing callback transactions A/B, bootstrap
+  versus callback, refresh versus logout, and stale sign-out results cannot
+  overwrite or clear a later authority/credential commit;
+- request/stream credential revision A receiving a 401 after revision B or
+  same-user authority N+1 commits cannot clear or overwrite storage/auth state;
+- transient authenticated `unreachable` status retains principal, generation,
+  and cache scope;
+- actor/organization/workspace store rollover and persistence namespacing;
+- delayed old-authority store/workflow writes cannot reach a replacement
+  scope;
+- organization-sensitive query-key/request-context ownership;
+- an organization A operation keeps immutable A request context after a switch
+  to B;
+- provider teardown and stale-completion fencing;
+- materialization-generation targeted eviction;
+- scope-owned AnyHarness client replacement/teardown and bounded registry size
+  across token rotation;
+- runtime query keys use target slot/generation and stay stable across
+  URL/token/revision-only refresh;
+- managed credential-revision notification makes every new operation/reconnect
+  refresh stale connection material while a healthy stream remains mounted;
+- Cloud, local-restart, and SSH-reconnect target-generation transitions,
+  including multi-workspace local/SSH fanout and two simultaneous SSH targets;
+- connection-revision ordering where accepted B cannot be replaced by delayed
+  A carrying stale URL/token material;
+- atomic credential-snapshot installation where rotation between snapshot and
+  install rejects token A instead of labeling it with revision B;
+- session/feed/terminal stream handles and reconnect timers close on authority
+  and target rollover;
+- a late old-generation resource registration is rejected/closed, and retired
+  clients grant no new operation leases;
+- Cloud React hooks fail closed without their scoped provider and never publish
+  or fall back to the process-global Cloud SDK client;
+- Desktop bridge action mapping without raw Tauri in product code;
+- retained Web billing-return decoding for Desktop versus browser;
+- host route-instrumentation adapter preservation;
+- Web-safe versus native context-menu items.
+
+Avoid snapshotting entire screens. Assert product behavior and ownership seams.
+
+### 18.3 Shared Playwright model
+
+Use one journey body with host fixtures:
+
+```text
+journey
+  + Desktop web-renderer fixture
+  + hosted Web fixture
+  + optional native Desktop fixture for Tauri-only assertions
+```
+
+The shared journey owns semantic product actions/selectors. Host fixtures own
+only bootstrap/auth and unavailable capability expectations.
+
+Initial shared journeys must cover:
+
+- authenticate and enter the product;
+- render the same home/sidebar/settings shell;
+- open/create a managed-cloud workspace up to the available test seam;
+- open a cloud session and exercise shared chat UI where the tier permits;
+- change a shared setting and observe it persist;
+- navigate away/back while the warm workspace shell preserves state;
+- log out and prove prior actor state is unavailable.
+
+Host-specific tests cover:
+
+- Desktop local workspace/repository/runtime behavior;
+- Desktop native updater, deep-link, and system actions;
+- Web OAuth/PKCE/cookie refresh callbacks;
+- Web absence of local-runtime requests and controls;
+- Web Desktop-handoff encoding.
+
+Browser-mode Desktop proves shared DOM behavior. It does not prove Tauri. A
+native lane remains required for native operations.
+
+### 18.4 Local profile gates
+
+PR 0b, PR 0c, and PR 1 each run the focused Desktop profile relevant to their
+state, runtime, or host-boundary change. PR 2 runs the complete Desktop cutover
+profile:
+
+```bash
+make setup PROFILE=<migration-profile>
+make build
+make run PROFILE=<migration-profile>
+```
+
+Exercise real Desktop auth bootstrap, local runtime readiness, managed-cloud
+navigation, a session/transcript, Settings, and restart. Use an isolated
+profile as required by the local development spec.
+
+PR 3 needs no product-flow profile because it is a buildable deletion
+checkpoint and is not deployed alone. PR 4 additionally runs the Web host
+against the same appropriate local/staging server configuration and executes
+the shared Web-capable Playwright subset.
+
+### 18.5 Tier ownership
+
+This migration changes flows and must update the automated flow registry as
+tests become enforceable:
+
+- Tier 1 owns pure capability, routing, target, scope, and adapter rules.
+- Tier 2 owns host-neutral product flows that do not require a real agent or
+  sandbox, running common journeys on Desktop-web and hosted Web where host
+  integration is itself part of the guarantee.
+- Tier 3 proves Desktop against the real local AnyHarness world, Desktop and
+  hosted Web against the real managed-cloud world, and packaged Desktop against
+  the self-host world. Hosted Web never pretends it can reach local AnyHarness.
+- Tier 4 remains the real N-1 to N updater/convergence suite.
+
+The migration does not weaken an existing clean test. Existing tests continue
+to run or are moved to the new owner.
+
+### 18.6 Canonical release-world consumption
+
+This document owns host structure, not the release-test inventory. The
+canonical contracts live under
+[`specs/developing/testing/`](../developing/testing/README.md) and are owned
+by the release-testing program (their spec pack lands with that program, not
+with this migration):
+
+- `core-release-validation.md` for required guarantees, cell semantics, and
+  fail-closed gates;
+- `release-worlds-and-fixtures.md` for artifacts, topology, readiness, and
+  fixture lifetime;
+- `tier-3-scenario-contract.md` for exact local-runtime, managed-cloud,
+  billing, and self-host journeys; and
+- `tier-4-scenario-contract.md` for the two standing N-1→N journeys.
+
+The migration consumes those worlds as follows:
+
+| World | Host execution after cutover | Migration-owned proof |
+| --- | --- | --- |
+| Tier 2 deterministic | Desktop web renderer and hosted Web for shared host cells; one host for host-neutral domain behavior | Auth bootstrap, callback/deep-link ingress, capability differences, no Web local-runtime requests |
+| Tier 3 local runtime | Desktop only; broad renderer lane plus native cells | `LOCAL-1` through `LOCAL-9` and `LOCAL-BILL-*`; no hosted-Web permutation |
+| Tier 3 managed cloud | Heavy cloud effects once; `CLOUD-HOSTS-1` on Desktop, hosted Web, and cross-host | Both hosts reach the same commandable cloud product state and converge stream/replay once |
+| Tier 3 self-host | Packaged Desktop plus server-rendered setup/register pages | Native server connect, relaunch/keychain, invitee login, and origin isolation |
+| Tier 4 Desktop | Exact retained packaged Desktop N-1 | Real Tauri N update and bundled AnyHarness/native CLI/ACP convergence |
+| Tier 4 managed cloud | Host-neutral controller plus a real N-1 E2B target | Heartbeat→Supervisor→AnyHarness convergence and preserved session |
+
+The target manifest, collector metadata, and generated execution manifest own
+which cells are required. This migration adds host metadata and collectors; it
+does not copy scenario prose or hand-maintain pointer/status tables.
+
+## 19. Failure and rollback rules
+
+Each PR stays buildable at its boundary.
+
+- PR 0b, PR 0c, and the in-place PR 1 stack are ordinary reversible refactors;
+  paths remain stable and no repo-wide feature freeze is required. The active
+  root/auth/telemetry/Cloud/native slice still has one declared owner.
+- PR 2 may be reverted as one mechanical unit while the old Web product still
+  exists. Do not accept Desktop feature work between its codemod and green
+  cutover gate.
+- PR 3 and PR 4 are never merged. They are reviewed as separate stacked
+  diffs; a landing branch cherry-picks their exact recorded commit list, is
+  equivalence-proven, and is the single merged Web-cutover unit; CI refuses
+  any production Web build without the ProductClient mount.
+- The Vercel redirects deploy with the cutover landing; external/deployed URL
+  producers are then updated one producer at a time per the rollout ledger's
+  external-item schema — only after the landing merges and the reviewed
+  PRODUCTION surfaces deploy at the exact merge SHA. Retain the redirects
+  through R+1 and at least seven days.
+- Do not keep a permanent old/new runtime flag as rollback infrastructure.
+- During a PR, temporary forwarding imports are allowed only in intermediate
+  commits and are removed before review.
+- If a Desktop behavior cannot be preserved through the proposed bridge, stop
+  and model the missing narrow capability; do not move raw Tauri access into
+  product-client.
+- If Web cannot execute an action, show a truthful absence/handoff; do not add
+  a Web-specific imitation with a second product owner.
+
+## 20. Canonical docs and tooling changed during PR 1/PR 2
+
+PR 1 promotes the host/package contract and installs loud structural checks.
+PR 2 updates path-specific law as the source moves. Together they must
+reconcile, not silently violate, at least:
+
+- `specs/codebase/structures/frontend/README.md`;
+- `specs/codebase/structures/frontend/packages/README.md`;
+- the frontend component, hook, state, access, lib, config, styling, telemetry,
+  and mental-model guides where their package/app ownership changes;
+- `specs/codebase/structures/frontend/architecture.md`;
+- `specs/codebase/structures/sdk/README.md` for the AnyHarness SDK React
+  query/client/transition ownership changed by PR 0c;
+- the frontend access/state guides explicitly for the scoped Cloud SDK React
+  provider and immutable organization request-context contract changed by PR 1;
+- `specs/codebase/features/web-cloud-local-parity.md` (replace/supersede the
+  separate-controller model);
+- `specs/tbd/frontend-structure-alignment-migration.md` (remove the obsolete
+  separate Web chat decomposition and app-owned-page assumptions);
+- relevant auth, chat, transcript, composer, workspace, workflow, and update
+  feature docs as ownership paths move;
+- `scripts/report_frontend_structure.py`;
+- `scripts/check_frontend_boundaries.py`;
+- `scripts/frontend_structure_allowlist.txt` and
+  `scripts/frontend_boundaries_allowlist.txt`;
+- `pnpm-workspace.yaml`, root/app package scripts and dependencies, and
+  `.github/workflows/ci.yml` repo-shape, Desktop, Web, and shared-package job
+  commands;
+- `scripts/ci-cd/detect-deploy-surfaces.mjs`;
+- the end-to-end flow registry for materially changed paths.
+
+The promoted feature contract lives at
+`specs/codebase/features/web-desktop-client-unification.md`. This TBD plan is
+the reduced rollout-detail record; the binding execution/freeze ledger lives
+at `specs/developing/deploying/web-desktop-unification-rollout.md`.
+
+## 21. Definition of done
+
+The migration is done when all of the following are true.
+
+### Ownership
+
+- `@proliferate/product-client` is the only connected shared DOM product.
+- Desktop and Web import and mount the same `ProductClient`.
+- `product-surfaces` no longer exists.
+- Desktop app source contains native/bootstrap/transport ownership, not a
+  duplicate product tree.
+- Web app source contains browser/bootstrap/transport ownership, not a
+  duplicate product tree.
+- Mobile imports remain unchanged and DOM-free.
+
+### Behavior
+
+- Desktop visual and behavioral baseline is preserved.
+- Desktop local, direct SSH, managed-cloud, native settings, updater, and
+  self-host connection paths remain functional.
+- Web exposes the same managed-cloud product experience.
+- Web never attempts local runtime discovery or connection.
+- unsupported Web actions are absent or truthfully hand off to Desktop.
+- cloud chat/transcript/config/files/terminal behavior has one SDK React owner.
+- the warm workspace shell and route continuity remain intact.
+
+### Security and state isolation
+
+- auth secrets remain host-owned;
+- Web bearer tokens are memory-only in production;
+- connection code requests fresh tokens through an authority-bound handle;
+- delayed old-authority token/rejection/sign-in/sign-out work cannot read,
+  overwrite, clear, or invalidate a replacement authority for the same
+  principal;
+- no cache, stream, draft, prompt, tab, or selection crosses deployment/actor/
+  authority-generation scope;
+- organization-sensitive state is keyed/reset by organization, and a replaced
+  workspace materialization triggers targeted AnyHarness cache eviction;
+- credentials are absent from query/cache identity;
+- AnyHarness runtime query identity uses target slot/generation rather than
+  transport URL, and credential revision refreshes new work without scope
+  churn;
+- no module-global QueryClient owns authenticated product state;
+- Cloud React never publishes to or falls back through a process-global client;
+- no module-global AnyHarness client map retains bearer-token-keyed clients.
+
+### Deletion
+
+- old Web polling/raw AnyHarness client is gone;
+- old Web product stores/controllers/pages are gone;
+- duplicate Desktop source copies are gone;
+- the embedded Tauri browser panel, actions/state, raw webview access, and
+  callers are gone before the mechanical move;
+- no generic Tauri bridge exists;
+- no permanent compatibility flag, wrapper forest, or duplicate mutation owner
+  remains.
+
+### Verification
+
+- both apps build and typecheck;
+- moved tests pass under product-client;
+- Desktop's full relevant test suite passes;
+- shared Playwright journeys pass in Desktop web-renderer and hosted Web lanes;
+- native Desktop smoke covers Tauri-only boundaries;
+- a real local Desktop profile has been exercised after PR 0b, PR 0c, PR 1,
+  and the PR 2 mechanical cutover;
+- Web's shared `/login` and authenticated `/` readiness paths remain within
+  the evidence-backed JS/CSS/font/asset/total budgets committed after the PR 1
+  feasibility build;
+- Web adds no more than 5% host-only bytes over the committed PR 2
+  ProductClient authenticated-home fixture ledger;
+- relevant existing E2E tests remain registered and runnable.
+
+## 22. Guarantees after completion
+
+The completed migration gives us these practical guarantees:
+
+1. A product behavior fixed in the shared connected client is fixed for both
+   Desktop and Web unless a real host capability makes the behavior different.
+2. Desktop remains the full-capability product; extraction does not make it a
+   lowest-common-denominator Web app.
+3. Web cloud chat is not a separately maintained approximation. It uses the
+   same AnyHarness provider, stream, transcript, composer, configuration, and
+   session logic as Desktop.
+4. Web cannot accidentally probe a user's local runtime because that
+   capability is structurally absent, not merely hidden with CSS.
+5. Auth credentials and refresh behavior remain appropriate to each security
+   environment while the product sees one normalized signed-in model.
+6. A single shared Playwright journey can validate the common product surface;
+   host fixtures test only the real differences.
+7. Future workflow, billing, integration, agent, and cloud functionality gets
+   one connected frontend owner and can be tested once per relevant world,
+   rather than once per historical frontend implementation.
+
+## 23. Named follow-ups that do not block this cutover
+
+- self-hosted Web packaging, runtime API configuration, callback origins,
+  password/SSO invitation flow, and deployment selection;
+- deeper normalization of Desktop's moved folder structure;
+- deciding whether additional lower presentation code should fold from
+  `product-ui` into product-client;
+- server-side synchronization of preferences that are currently device-local;
+- full Tier 2/3/4 scenario implementation described by the testing program;
+- richer read-only Web presentation for Desktop-local workflow/run metadata;
+- any future support for commanding a Desktop-exposed runtime through Cloud;
+- Mobile redesign/rebuild.
+
+These follow-ups must not recreate a second Web product controller.

--- a/specs/tbd/web-desktop-unification-migration.md
+++ b/specs/tbd/web-desktop-unification-migration.md
@@ -1987,17 +1987,19 @@ The migration is intentionally sequenced around the active launch work:
 
 The initial 2026-07-13 snapshot and dispositions are recorded in
 [web-desktop-unification-intake-ledger.md](web-desktop-unification-intake-ledger.md).
-Refresh that ledger rather than treating its branch statuses as permanent.
-The **binding** PR-1 intake snapshot and PR-2 freeze ledger are appended as
-committed docs-only phases to the rollout ledger at
-`specs/developing/deploying/web-desktop-unification-rollout.md`; the tbd
-ledger is historical sweep input only.
+That tbd ledger is frozen history and is never refreshed. ALL future
+intake refreshes, readiness checks, and freeze gating happen exclusively in
+the binding rollout ledger at
+`specs/developing/deploying/web-desktop-unification-rollout.md`, where the
+PR-1 intake snapshot and PR-2 freeze ledger are appended as committed
+docs-only phases; do not treat the tbd ledger's branch statuses as current.
 
-- before PR 0b/0c or PR 1 starts, create the first intake ledger from **all**
-  open PRs plus local dirty, detached, and unpushed worktrees—not only GitHub
-  branches. Give each item `{owner, head SHA, touched slice,
-  merge|salvage|retarget|supersede|cancel}`. Refresh status at execution time;
-  the document does not permanently assume an item remains open;
+- the first intake ledger was created (2026-07-13) from **all** open PRs plus
+  local dirty, detached, and unpushed worktrees—not only GitHub branches—with
+  each item recorded as `{owner, head SHA, touched slice,
+  merge|salvage|retarget|supersede|cancel}`. Status is re-derived at
+  execution time in the rollout ledger's snapshots; no document permanently
+  assumes an item remains open;
 - now through the July 22, 2026 launch window: land PR 0b, PR 0c, and the
   in-place PR 1 stack; ordinary Desktop product UI branches may continue
   because paths do not move, while PR 1's root/auth/telemetry/Cloud/native
@@ -2281,9 +2283,11 @@ Each PR stays buildable at its boundary.
 
 ## 20. Canonical docs and tooling changed during PR 1/PR 2
 
-PR 1 promotes the host/package contract and installs loud structural checks.
-PR 2 updates path-specific law as the source moves. Together they must
-reconcile, not silently violate, at least:
+The A2 docs preflight promoted the host/package contract to the canonical
+feature spec; PR 1 refines that canonical spec with the implementation
+inventory and installs loud structural checks. PR 2 updates path-specific law
+as the source moves. Together they must reconcile, not silently violate, at
+least:
 
 - `specs/codebase/structures/frontend/README.md`;
 - `specs/codebase/structures/frontend/packages/README.md`;


### PR DESCRIPTION
Phase A2 (docs-only reconciliation preflight) of the Web/Desktop ProductClient unification chain. Base is exact post-PR-#1143 main (`5e86a7faf`). The orchestrator reviews and merges; this PR stays draft.

Eight commits: `61b0872ef` (the promotion), `a9cac2263` (first-review corrections), `658ceb5cb` (second-review corrections), `f0dc39960` (rollout re-review corrections), `99b348282` (terminality-rule generalization), `e93d3638a` (barrier-scope wording fix), `577923652` (emission-accounting contradiction fix), `d657bda92` (stale no-emission absolute removed). **8 files, +4350/−5 vs base, docs-only.**

## What this does

`specs/tbd/README.md` forbids TBD docs as code-review/release authority, so this PR promotes the settled contract to canonical NOW and creates the binding execution ledger under deploying authority:

1. **Canonical spec**: `specs/codebase/features/web-desktop-client-unification.md` — the settled contract as current operating law (package ownership/build contract, composite host contract, product scope/authority isolation, routing/capability policy, styling/budgets, lifecycle ownership, migration governance §10.1–10.7, enforcement, definition of done).
2. **Owning index link**: row added to `specs/codebase/features/README.md`.
3. **Binding rollout ledger**: `specs/developing/deploying/web-desktop-unification-rollout.md` — the readiness authority I1/I2 append to and D/F verify; indexed in `specs/developing/deploying/README.md`.
4. **TBD migration plan** reduced to non-authoritative rollout history (header + contradiction alignment; §16 recipes/tables retained as rollout detail).
5. **TBD intake ledger** committed as past-tense, non-authoritative snapshot history plus the `specs/tbd/README.md` index rows.
6. **`specs/developing/deploying/ci-cd.md`**: deploy-gate inventory reconciled against the actual workflow files.

No code, enforcement, or testing files are touched. Decisions are preserved, not redesigned.

## Stale no-emission absolute removed (`d657bda92`)

- Rollout §4.2's cleanup invariant still asserted no failure path may "permit a later source CI completion to emit staging" — contradicting the terminality rule, which allows that race and requires emitted runs to be enumerated and handled. The sentence now states the actual fail-closed invariant: no failure path may leave the temporary overrides active, and no failure path may release the hold while any downstream Deploy Staging emission remains unenumerated, non-terminal, or unhandled. Repo-wide scan confirms the phrase is gone and the canonical spec carried no equivalent claim.

## Emission-accounting contradiction fix (`577923652`)

- The barrier clause required each cancellation-requested source main-CI run to prove it emitted NO downstream Deploy Staging run while simultaneously describing how an emitted run is handled — and `workflow_run` can create one for any completed conclusion, so the no-emission requirement could make hold release impossible. Canonical §10.5 + rollout §4.2 now require: across the bounded event-propagation barrier, every downstream Deploy Staging run emitted by every cancellation-requested source main-CI run (regardless of terminal conclusion) is ENUMERATED AND ACCOUNTED FOR; zero emissions is acceptable; each emitted run routes through the abnormal-staging terminality/side-effect assessment-or-recovery rule and must be fully handled; the barrier proves no late or otherwise unaccounted emission remains before hold release; any unaccounted, late, or unhandled run retains the hold and hard-stops production. The contradictory no-emission phrasing ("emitted no/NO downstream", "downstream-emission absence") is removed repo-wide.

## Barrier-scope wording fix (`e93d3638a`)

- The downstream event-propagation barrier applied only to a "cancelled source main-CI run" — too narrow, since a cancellation-requested run can win the race, complete SUCCESS, emit Deploy Staging, and escape the barrier. The terminality rule in canonical §10.5 + rollout §4.2 now requires the barrier for EVERY cancellation-requested source main-CI run REGARDLESS of terminal conclusion (explicitly including a SUCCESS finish despite the cancellation request); any Deploy Staging run it emitted routes through the abnormal-staging terminality/side-effect recovery clause. No summary retains the narrower wording (repo-wide scan: zero "cancelled source main-CI" hits).

## Terminality-rule generalization (`99b348282`)

- The hold-extension rule is no longer limited to an "unexpected Deploy Staging run." Canonical §10.5 + rollout §4.2 now bind a general **terminality rule** once overrides are armed: every cancellation-requested run — source main-CI or any deploy run — must be confirmed terminal; every cancelled source main-CI run must additionally be proven, across a bounded event-propagation barrier, to have emitted NO downstream Deploy Staging run (an emitted run is handled like any other staging execution); and every abnormal, failed, cancelled, timed-out, or unverifiable staging execution — including the expected exact-landing-SHA run executing unexpected lanes — must be confirmed terminal with per-lane/deploy-summary/log proof of no side effects, OR every possibly affected staging surface restored to its recorded pre-landing staging baseline with artifact/health/routes re-verified. Any unproven terminality, downstream-emission absence, side-effect assessment, or recovery retains the hold and hard-stops production with escalation. Gate restoration (read-back verified) remains prompt in every case; a fully proven failure path releases the hold only into halted-for-review, never promotion. The general cleanup wording in both docs now defers to this rule so it cannot release the hold early in any of these cases.

## Final rollout re-review corrections (`f0dc39960`)

- **Unexpected-run cancellation is not terminal proof.** A cancellation request does not prove a Deploy Staging run stopped, and a cancelled run may have partially deployed. Canonical §10.5 + rollout §4.2 now: on any unexpected run after the first override mutation, request cancellation and restore/read back the gates promptly, but KEEP the landing hold until the run is confirmed terminal AND its per-lane/deploy-summary/log evidence proves no side effects — or every possibly affected staging surface is restored to its recorded pre-landing staging baseline with artifact/health/routes re-verified. Unprovable terminality, side-effect assessment, or recovery keeps the hold and hard-stops production (escalated). Hold release requires confirmed terminality + absent/recovered effects + verified gate restoration, and still lands in halted-for-review — never straight to promotion. The generic cleanup wording now carves out this case so it cannot release the hold early. Failure/recovery proof is retained per the standing Phase V / incident-record requirements.
- **Uncertain source-write settling proof.** One re-read cannot rule out a late asynchronous apply. Canonical §10.5 + rollout §4.3: proven-unchanged now requires either an authoritative terminal status for the write PLUS a confirming authoritative read, or a bounded settling barrier with repeated authoritative reads proving the prior value stayed stable; without that proof the item is treated as changed/unverifiable and runs the full recovery while halted.

## Second-review corrections (`658ceb5cb`)

- **Live gate audit corrected.** `gh variable list --repo proliferate-ai/proliferate --env staging|Production` proves `WORKERS_DEPLOY_ENABLED=false` exists ENVIRONMENT-LEVEL in BOTH environments (the prior audit sentence wrongly claimed it absent — a pagination artifact of the earlier `gh api` read). Rollout §4.1 now records the exact sets — staging: `MOBILE_DEPLOY_ENABLED=true`, `EAS_SUBMIT_ENABLED=true`, `LITELLM_DEPLOY_ENABLED=true`, `WORKERS_DEPLOY_ENABLED=false`, `DESKTOP_DEPLOY_ENABLED` absent (+`DESKTOP_CHANNEL=beta`); Production: `MOBILE_DEPLOY_ENABLED=true`, `EAS_SUBMIT_ENABLED=true`, `LITELLM_DEPLOY_ENABLED=true`, `WORKERS_DEPLOY_ENABLED=false`, `DESKTOP_DEPLOY_ENABLED=true` — with the restore implication stated: staging Workers restores BY VALUE to `false`, not by deletion; only staging `DESKTOP_DEPLOY_ENABLED` restores prior absence by deletion.
- **Manual Deploy Staging dispatch covered.** `.github/workflows/deploy-staging.yml` exposes an independent `workflow_dispatch` trigger. Canonical §10.5 + rollout §4.2 now: the landing hold explicitly blocks manual Deploy Staging dispatches (not only main merges/main-CI reruns/dispatches); pre-override quiescence drains every queued/running Deploy Staging run REGARDLESS of trigger source plus qualifying main-CI/source correlations across the bounded propagation barrier; from the first override mutation, any unexpected Deploy Staging run from any trigger is cancelled immediately and enters the finally-style cleanup.
- **Uncertain source-write outcomes.** Canonical §10.5 + rollout §4.3: a source-of-truth write that fails, times out, or returns an unverifiable result is treated as a possible mutation — re-read the source; proven-unchanged is recorded as evidence and halts before continuing; changed-or-unverifiable runs the full recovery (restore recorded prior value, re-activate at the same landing SHA, live rollback proof, mapped recovery smoke, record, halt); failed recovery remains halted.
- **Phase V record schema completed.** Canonical §10.6 + rollout §5.2 now explicitly seal: deploy-run links for every cited staging/production run; for every external item its secret-safe source location, actual before value, actual after value, required-change classification, activation mechanism, live-consumption proof, and who applied it and when; and for every mapped smoke the flow run, result, and timestamp (explicit item→smoke mapping for shared smokes).

## First-review corrections (`a9cac2263`)

- **P0 — LiteLLM deploy gate.** LiteLLM is gated by `LITELLM_DEPLOY_ENABLED` (`.github/workflows/_deploy-litellm.yml`, default `'false'`). Corrected in canonical §10.5 (gated = Mobile/Desktop/Workers/LiteLLM; ungated = Server/Web/E2B), rollout §4.1, and ci-cd.md in seven places (env-gate list, pre-deploy checklist, both "only mobile/desktop/workers have gates" claims, workflow file tree, deploy-graph lane bullets, `# litellm, when enabled` env-var section, staging inventory `LITELLM_DEPLOY_ENABLED=true`). Gate lists verified against every `_deploy-*.yml`.
- **P1 — override cleanup invariant.** Finally-style cleanup armed at the FIRST override mutation; every failure/non-success/unverifiable path restores every gate to prior value/absence with read-back verification before the hold releases; failed restoration hard-stops production and keeps the hold; only verified staging success + verified restoration proceed.
- **P1 — external mutation rollback.** Any failure after a producer's source-of-truth mutation (activation or live-proof failure/unverifiability, not only smoke) triggers restore + re-activate at the same landing SHA + live rollback proof + mapped recovery smoke + halt; unprovable recovery stays halted.
- **P2 — evidence-branch timing.** `wdu-evidence/**` branches are deleted only AFTER Phase V merges, per its committed branch index.
- **P1 — release closure / Phase V schema.** Canonical §10.6 + rollout §5: Phase H dispositions every user-facing release surface (landing page, public docs, changelog/release notes, in-app release notes/copy, install/download, support/runbook, discovered surfaces) as update-in-this-landing / update-post-landing(owner+deadline) / no-change-needed(reason); Phase V seals the enumerated evidence classes.
- **P1 — TBD history fully demoted.** Intake ledger §1/§3.2/§4.4/§5/§6 past-tensed with completion annotations; all future refresh/readiness/freeze work directed exclusively to the rollout ledger; migration doc §17 says the tbd ledger is frozen history and never refreshed.
- **P2 — promotion ownership.** Migration doc §20: A2 promoted the contract; PR 1 refines it.

## Self-check (canonical clarifications (a)–(e), from `61b0872ef`, still hold)

- (a) Primitives-only PR 1 package: §3.4 staged export map; no ProductClient export until PR 2; TBD §6.4/§16.2(1,9,10)/§18.1/§13.1 aligned.
- (b) Candidate root at Desktop-owned paths through PR 1, moved in PR 2: §3.4, §8, §10.1.
- (c) Sliding two-PR stack, orchestrator-only review-acceptance/merging, PARENT_AT_FORK restacks, `wdu-evidence/**`: §10.2.
- (d) I1/I2 committed ledger phases; freeze = explicit dated user signal + merged ledger, revalidated at F launch/acceptance/merge: §10.3.
- (e) G/H review-only never merge; L cherry-picks exact `G_BASE..H_HEAD` with tree/range-diff equivalence proofs; three reviewed sets with per-surface dispositions; external mutation only after landing merge + PRODUCTION deploy at exact SHA, one producer at a time; sealed by Phase V: §10.4–10.6.

**Index links:** `specs/codebase/features/README.md` → canonical spec; `specs/developing/deploying/README.md` → rollout ledger. **Rollout ledger sections:** §1 chain state (+§1.1 landing mechanics), §2 PR-1 intake template, §3 PR-2 freeze template, §4 selection sets + landing order + external-item schema, §5 release closure + Phase V record.

## Verification evidence

- Gate truth: `grep -rn "_ENABLED" .github/workflows/` — gates are exactly `MOBILE_DEPLOY_ENABLED`, `DESKTOP_DEPLOY_ENABLED`, `WORKERS_DEPLOY_ENABLED`, `LITELLM_DEPLOY_ENABLED` (+ `EAS_SUBMIT_ENABLED` submission-only); no gate in `_deploy-server/web/e2b`. Live values via `gh variable list --env staging` / `--env Production` as recorded in rollout §4.1. `deploy-staging.yml` `on:` block confirms the independent `workflow_dispatch` trigger.
- Consistency scans clean: no doc lists LiteLLM as ungated; no "mobile, desktop, and workers"-only gate claim in `specs/`; no "PR 1 promotes"; no "refresh this/that ledger" command in `specs/tbd/`; no stale WORKERS-absence claim; dispatch coverage, uncertain-write rule, deploy-run links, and who/when fields present in BOTH canonical spec and rollout ledger.
- Relative-link check over all 8 touched docs: clean. Code-fence parity per file: even. Docs-only diff confirmed (`git diff --name-only`).
- Both repo-shape scripts exit 0 (`report_frontend_structure.py`, `check_frontend_boundaries.py`).

Head SHA: `d657bda92`
