### PR TITLE
ci(release): immutable production proof — lane digests, component deployments (R2)

### DIFF
--- a/.github/workflows/_deploy-e2b.yml
+++ b/.github/workflows/_deploy-e2b.yml
@@ -108,6 +108,15 @@ jobs:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
           E2B_TEAM_ID: ${{ vars.E2B_TEAM_ID }}
+          # Stamp the deterministic build SHA into the runtime crates rebuilt by
+          # build-template.mjs (it runs cargo with `env: process.env`), so the
+          # E2B-bundled anyharness/worker/supervisor carry `+<12-hex-sha>`
+          # (support-system "Release identity"). Version stays the crate version
+          # because build.rs only fails closed when BUILD_VERSION is set. The
+          # promote-don't-rebuild refactor (consume the canonical runtime-v*
+          # artifact instead of `--rebuild-runtime`) is a product-lane follow-up
+          # tracked in the R2 PR; build-template.mjs is product-owned.
+          PROLIFERATE_BUILD_SHA: ${{ inputs.git_sha }}
 
       - name: Smoke test immutable public ref
         run: >

--- a/.github/workflows/_deploy-litellm.yml
+++ b/.github/workflows/_deploy-litellm.yml
@@ -161,10 +161,22 @@ jobs:
           aws ssm put-parameter --name "${parameter_prefix}/xai-api-key" \
             --type SecureString --value "$AGENT_GATEWAY_MANAGED_XAI_API_KEY" --overwrite >/dev/null
 
+          # Canonical LiteLLM release identity (support-system "Release
+          # identity"): proliferate-litellm@<root VERSION>+<12-char image commit>.
+          # The version source is the root VERSION file; the SHA is the deployed
+          # image commit (same short SHA used for the image tag above).
+          litellm_version="$(cat VERSION)"
+          short_sha="${GIT_SHA:0:12}"
+          litellm_release="proliferate-litellm@${litellm_version}+${short_sha}"
+
           jq -n \
             --arg region "${AWS_BEDROCK_REGION:-us-east-1}" \
+            --arg release "$litellm_release" \
+            --arg environment "$DEPLOY_ENVIRONMENT" \
             '[
-              {"name":"AWS_BEDROCK_REGION","value":$region}
+              {"name":"AWS_BEDROCK_REGION","value":$region},
+              {"name":"SENTRY_RELEASE","value":$release},
+              {"name":"SENTRY_ENVIRONMENT","value":$environment}
             ]' > env-updates.json
 
           jq -n \

--- a/.github/workflows/_deploy-mobile.yml
+++ b/.github/workflows/_deploy-mobile.yml
@@ -72,9 +72,32 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: .
 
+      # Canonical mobile release identity (support-system "Release identity"):
+      # proliferate-mobile@<version>+<12-char sha>. The version source is
+      # apps/mobile/app.config.ts, which must equal apps/mobile/package.json; the
+      # SHA is the EAS build commit. Exported as EXPO_PUBLIC_PROLIFERATE_RELEASE
+      # so the telemetry config bakes it into the bundle instead of falling back
+      # to the version-only literal. See the product-lane note in the R2 PR: the
+      # apps/mobile eas.json build profile must forward this env into the EAS
+      # remote build for it to reach the shipped bundle.
+      - name: Resolve mobile release identity
+        id: release
+        if: ${{ steps.switch.outputs.enabled == 'true' }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          short_sha="${GIT_SHA:0:12}"
+          release="proliferate-mobile@${version}+${short_sha}"
+          echo "EXPO_PUBLIC_PROLIFERATE_RELEASE=$release" >> "$GITHUB_ENV"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+        env:
+          GIT_SHA: ${{ inputs.git_sha }}
+
       - name: Build iOS app
         id: build
         if: ${{ steps.switch.outputs.enabled == 'true' }}
+        env:
+          EXPO_PUBLIC_PROLIFERATE_RELEASE: ${{ steps.release.outputs.release }}
         run: |
           set -euo pipefail
           pnpm dlx eas-cli@18.13.0 build \

--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -205,7 +205,15 @@ jobs:
           server_version="$(cat VERSION)"
           short_sha="${GIT_SHA:0:12}"
 
+          # Production fails closed on a missing/degraded server release identity
+          # (support-system "Release identity"). Staging stays permissive.
+          require_release_identity=""
+          case "$DEPLOY_ENVIRONMENT" in
+            production|Production) require_release_identity="1" ;;
+          esac
+
           jq -n \
+            --arg require_release_identity "$require_release_identity" \
             --arg api_url "$API_URL" \
             --arg api_base "$API_BASE_URL" \
             --arg frontend "$WEB_URL" \
@@ -248,10 +256,13 @@ jobs:
               {"name":"PROLIFERATE_TELEMETRY_MODE","value":"hosted_product"},
               {"name":"SENTRY_ENVIRONMENT","value":$environment},
               {"name":"SENTRY_RELEASE","value":$release},
+              (
+                if $require_release_identity == "" then empty else
+                {"name":"PROLIFERATE_REQUIRE_RELEASE_IDENTITY","value":$require_release_identity}
+                end
+              ),
               {"name":"CLOUD_RUNTIME_SENTRY_ENVIRONMENT","value":$environment},
-              {"name":"CLOUD_RUNTIME_SENTRY_RELEASE","value":$release},
               {"name":"CLOUD_TARGET_SENTRY_ENVIRONMENT","value":$environment},
-              {"name":"CLOUD_TARGET_SENTRY_RELEASE","value":$release},
               {"name":"SUPPORT_REPORT_S3_BUCKET","value":$support_report_bucket},
               {"name":"SUPPORT_REPORT_S3_PREFIX","value":$support_report_prefix},
               {"name":"SUPPORT_REPORT_S3_REGION","value":$support_report_region},
@@ -309,10 +320,19 @@ jobs:
                 (.environment // []) as $current
                 | ($updates[0] | map(.name)) as $updated_names
                 | ["SUPPORT_GITHUB_APP_PRIVATE_KEY", "SUPPORT_LINEAR_API_KEY"] as $secret_names
+                # Names the control plane no longer wires: the shared target
+                # release override could not distinguish worker from supervisor,
+                # and the server release must never stamp a runtime/target
+                # process. Each target binary self-stamps its own release ID;
+                # these stay empty in normal operation, so drop any stale value
+                # left on the live task definition. PROLIFERATE_REQUIRE_RELEASE_IDENTITY
+                # is dropped here and re-added only for production above.
+                | ["CLOUD_RUNTIME_SENTRY_RELEASE", "CLOUD_TARGET_SENTRY_RELEASE", "PROLIFERATE_TARGET_SENTRY_RELEASE", "PROLIFERATE_REQUIRE_RELEASE_IDENTITY"] as $drop_names
                 | ($current | map(select(
                     .name as $name
                     | ($updated_names | index($name) | not)
                     and ($secret_names | index($name) | not)
+                    and ($drop_names | index($name) | not)
                   ))) + $updates[0];
 
               def merge_secrets($updates):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           node --check scripts/ci-cd/pr-metadata.mjs
           node --check scripts/ci-cd/resolve-deploy-base.mjs
           node --check scripts/ci-cd/validate-pr-metadata.mjs
+          node --check scripts/ci-cd/collect-lane-proof.mjs
+          node --check scripts/ci-cd/create-component-deployment.mjs
+          node --check scripts/ci-cd/verify-production-deployments.mjs
           node --check scripts/agent-catalog/build-catalog.mjs
           node --check scripts/agent-catalog/check-version-discipline.mjs
           node --check scripts/agent-catalog/resolve-pins.mjs

--- a/.github/workflows/hotfix-production.yml
+++ b/.github/workflows/hotfix-production.yml
@@ -67,6 +67,7 @@ jobs:
       mobile: ${{ steps.detect.outputs.mobile }}
       desktop: ${{ steps.detect.outputs.desktop }}
       runtime: ${{ steps.detect.outputs.runtime }}
+      litellm: ${{ steps.detect.outputs.litellm }}
       desktop_version: ${{ steps.artifacts.outputs.desktop_version }}
       runtime_version: ${{ steps.artifacts.outputs.runtime_version }}
       server_version: ${{ steps.artifacts.outputs.server_version }}
@@ -251,6 +252,16 @@ jobs:
       mode: build_and_promote
     secrets: inherit
 
+  deploy-litellm:
+    needs: [prepare]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
+    with:
+      environment: production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.litellm == 'true' }}
+    secrets: inherit
+
   deploy-server:
     needs: [prepare, promote-e2b]
     if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' }}
@@ -313,6 +324,7 @@ jobs:
       - release-runtime
       - release-server
       - promote-e2b
+      - deploy-litellm
       - deploy-server
       - deploy-workers
       - deploy-web
@@ -330,6 +342,7 @@ jobs:
             (needs.prepare.outputs.server != 'true' || (needs.release-server.result == 'success' && needs.deploy-server.result == 'success')) &&
             (needs.prepare.outputs.desktop != 'true' || needs.deploy-desktop.result == 'success') &&
             (needs.prepare.outputs.e2b != 'true' || needs.promote-e2b.result == 'success') &&
+            (needs.prepare.outputs.litellm != 'true' || needs.deploy-litellm.result == 'success') &&
             (needs.prepare.outputs.workers != 'true' || needs.deploy-workers.result == 'success') &&
             (needs.prepare.outputs.web != 'true' || needs.deploy-web.result == 'success') &&
             (needs.prepare.outputs.mobile != 'true' || needs.deploy-mobile.result == 'success')
@@ -387,6 +400,7 @@ jobs:
       - release-runtime
       - release-server
       - promote-e2b
+      - deploy-litellm
       - deploy-server
       - deploy-workers
       - deploy-web
@@ -406,6 +420,7 @@ jobs:
             echo "- Runtime release: \`${{ needs.release-runtime.result }}\`"
             echo "- Server release: \`${{ needs.release-server.result }}\`"
             echo "- E2B production: \`${{ needs.promote-e2b.result }}\`"
+            echo "- LiteLLM production: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Server production: \`${{ needs.deploy-server.result }}\`"
             echo "- Workers production: \`${{ needs.deploy-workers.result }}\`"
             echo "- Web production: \`${{ needs.deploy-web.result }}\`"

--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -64,6 +64,7 @@ jobs:
       mobile: ${{ steps.detect.outputs.mobile }}
       desktop: ${{ steps.detect.outputs.desktop }}
       runtime: ${{ steps.detect.outputs.runtime }}
+      litellm: ${{ steps.detect.outputs.litellm }}
       desktop_version: ${{ steps.artifacts.outputs.desktop_version }}
       runtime_version: ${{ steps.artifacts.outputs.runtime_version }}
       server_version: ${{ steps.artifacts.outputs.server_version }}
@@ -263,6 +264,16 @@ jobs:
       mode: build_and_promote
     secrets: inherit
 
+  deploy-litellm:
+    needs: [prepare]
+    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
+    with:
+      environment: staging
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.litellm == 'true' }}
+    secrets: inherit
+
   deploy-server:
     needs: [prepare, deploy-e2b]
     if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
@@ -322,6 +333,16 @@ jobs:
       mode: build_and_promote
     secrets: inherit
 
+  deploy-litellm-prod:
+    needs: [prepare, deploy-litellm]
+    if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-litellm.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
+    with:
+      environment: Production
+      git_sha: ${{ needs.prepare.outputs.head_sha }}
+      enabled: ${{ needs.prepare.outputs.litellm == 'true' }}
+    secrets: inherit
+
   deploy-server-prod:
     needs: [prepare, deploy-server, deploy-e2b-prod]
     if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-server.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
@@ -369,6 +390,7 @@ jobs:
       - release-server
       - release-desktop
       - deploy-e2b
+      - deploy-litellm
       - deploy-server
       - deploy-workers
       - deploy-web
@@ -386,6 +408,7 @@ jobs:
             (needs.prepare.outputs.server != 'true' || (needs.release-server.result == 'success' && needs.deploy-server.result == 'success')) &&
             (needs.prepare.outputs.desktop != 'true' || needs.release-desktop.result == 'success') &&
             (needs.prepare.outputs.e2b != 'true' || needs.deploy-e2b.result == 'success') &&
+            (needs.prepare.outputs.litellm != 'true' || needs.deploy-litellm.result == 'success') &&
             (needs.prepare.outputs.workers != 'true' || needs.deploy-workers.result == 'success') &&
             (needs.prepare.outputs.web != 'true' || needs.deploy-web.result == 'success') &&
             (needs.prepare.outputs.mobile != 'true' || needs.deploy-mobile.result == 'success')
@@ -442,11 +465,13 @@ jobs:
       - release-server
       - release-desktop
       - deploy-e2b
+      - deploy-litellm
       - deploy-server
       - deploy-workers
       - deploy-web
       - deploy-mobile
       - deploy-e2b-prod
+      - deploy-litellm-prod
       - deploy-server-prod
       - deploy-workers-prod
       - deploy-web-prod
@@ -466,11 +491,13 @@ jobs:
             echo "- Server release: \`${{ needs.release-server.result }}\`"
             echo "- Desktop release: \`${{ needs.release-desktop.result }}\`"
             echo "- E2B staging: \`${{ needs.deploy-e2b.result }}\`"
+            echo "- LiteLLM staging: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Server staging: \`${{ needs.deploy-server.result }}\`"
             echo "- Workers staging: \`${{ needs.deploy-workers.result }}\`"
             echo "- Web staging: \`${{ needs.deploy-web.result }}\`"
             echo "- Mobile staging: \`${{ needs.deploy-mobile.result }}\`"
             echo "- E2B prod: \`${{ needs.deploy-e2b-prod.result }}\`"
+            echo "- LiteLLM prod: \`${{ needs.deploy-litellm-prod.result }}\`"
             echo "- Server prod: \`${{ needs.deploy-server-prod.result }}\`"
             echo "- Workers prod: \`${{ needs.deploy-workers-prod.result }}\`"
             echo "- Web prod: \`${{ needs.deploy-web-prod.result }}\`"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -212,6 +212,12 @@ jobs:
       - name: Build AnyHarness runtime for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
+        # Stamp the deterministic build SHA into the bundled runtime so the
+        # sidecar's release ID carries `+<12-hex-sha>` (support-system "Release
+        # identity"). The version stays the crate's own version; build.rs
+        # truncates a full 40-char SHA to 12.
+        env:
+          PROLIFERATE_BUILD_SHA: ${{ inputs.git_sha || github.sha }}
         run: |
           cargo build --release -p anyharness --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries
@@ -268,6 +274,8 @@ jobs:
       - name: Build Proliferate worker for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
+        env:
+          PROLIFERATE_BUILD_SHA: ${{ inputs.git_sha || github.sha }}
         run: |
           cargo build --release -p proliferate-worker --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries

--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -81,8 +81,10 @@ jobs:
       # `runtime-v<semver>` tag push derives it by stripping the tag prefix.
       # Anything else (e.g. a workflow_dispatch dry run) leaves it unset so the
       # build falls back to the Cargo.toml version.
-      - name: Resolve build version
+      - name: Resolve build version and SHA
         shell: bash
+        env:
+          INPUT_GIT_SHA: ${{ inputs.git_sha || '' }}
         run: |
           set -euo pipefail
           if [[ -n "${{ inputs.version }}" ]]; then
@@ -90,6 +92,14 @@ jobs:
           elif [[ "${GITHUB_REF_NAME:-}" == runtime-v* ]]; then
             echo "PROLIFERATE_BUILD_VERSION=${GITHUB_REF_NAME#runtime-v}" >> "$GITHUB_ENV"
           fi
+          # Stamp the deterministic build SHA alongside the version so the
+          # binaries carry the canonical `<component>@<version>+<12-hex-sha>`
+          # release identity (support-system "Release identity"). build.rs
+          # truncates a full 40-char SHA to 12 and fails closed when a version is
+          # stamped without one. Always export it (SHA-only stamps are valid for
+          # unversioned dry runs; a version stamp then always has its SHA).
+          build_sha="${INPUT_GIT_SHA:-$GITHUB_SHA}"
+          echo "PROLIFERATE_BUILD_SHA=$build_sha" >> "$GITHUB_ENV"
 
       - name: Install musl-tools (x86_64 linux)
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -266,6 +266,25 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
         working-directory: .
 
+      # Stamp the deterministic runtime release identity into the self-hosted
+      # anyharness/worker/supervisor binaries (support-system "Release identity":
+      # the self-hosted-release lane uses the tracked runtime version and the
+      # current build SHA, never a Cargo 0.1.0 fallback). The version source is
+      # anyharness/sdk/package.json; build.rs fails closed if the version is set
+      # without a SHA.
+      - name: Resolve runtime build stamp
+        env:
+          INPUT_GIT_SHA: ${{ inputs.git_sha || '' }}
+        run: |
+          set -euo pipefail
+          runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
+          : "${runtime_version:?Failed to read the runtime version from anyharness/sdk/package.json.}"
+          build_sha="${INPUT_GIT_SHA:-$GITHUB_SHA}"
+          {
+            echo "PROLIFERATE_BUILD_VERSION=$runtime_version"
+            echo "PROLIFERATE_BUILD_SHA=$build_sha"
+          } >> "$GITHUB_ENV"
+
       - name: Build self-hosted Linux runtime (x86_64)
         run: cargo build --release --target x86_64-unknown-linux-musl -p anyharness -p proliferate-worker -p proliferate-supervisor
         working-directory: .

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,10 @@
-# `cross` runs the build inside a container, so the release version stamp
-# (set by the `build-binaries` job in .github/workflows/release-runtime.yml)
-# must be forwarded into it — otherwise the aarch64-linux binaries fall back
-# to the crate's Cargo.toml version and the self-update gates never converge.
+# `cross` runs the build inside a container, so the release identity stamps
+# (set by the `build-binaries` job in .github/workflows/release-runtime.yml and
+# the self-hosted-release-assets job in server-ci.yml) must be forwarded into
+# it — otherwise the aarch64-linux binaries fall back to the crate's Cargo.toml
+# version and the self-update gates never converge. Both are required together:
+# build.rs fails closed when PROLIFERATE_BUILD_VERSION is set without
+# PROLIFERATE_BUILD_SHA (support-system "Release identity"), so forwarding only
+# the version would panic the cross build.
 [build.env]
-passthrough = ["PROLIFERATE_BUILD_VERSION"]
+passthrough = ["PROLIFERATE_BUILD_VERSION", "PROLIFERATE_BUILD_SHA"]

--- a/scripts/ci-cd/collect-lane-proof.mjs
+++ b/scripts/ci-cd/collect-lane-proof.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// Collect a production lane's immutable artifact-set proof.
+//
+// Contract: specs/codebase/features/support-system.md -> "Release manifest".
+// Each production lane returns an `artifactSetDigest`: the lowercase SHA-256 of
+// its canonical, sorted, immutable provider references. Containers use OCI
+// digests (`sha256:<64hex>`), Vercel/EAS/E2B use immutable provider
+// deployment/build IDs, and desktop/runtime/self-hosted assets use published
+// SHA-256 checksums.
+//
+// The digest is computed over ONLY the normalized+sorted references so that the
+// release finalizer, the GitHub Deployment payload, and
+// verify-production-deployments.mjs all recompute the exact same bytes from the
+// same references. Lane/component identity is enforced separately by the
+// checked-in matrix and never mixed into the digest.
+//
+// CLI:
+//   node collect-lane-proof.mjs --lane hosted-server \
+//     --references '["repo@sha256:<64hex>", "sha256:<64hex>"]'
+//   # or feed newline/comma-separated references with --references-file / stdin.
+// Prints a JSON proof object: {lane, provider, references, artifactSetDigest}.
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_MATRIX_PATH = path.join(HERE, "release-lane-matrix.json");
+
+const OCI_DIGEST_RE = /^(?:[^\s@]+@)?sha256:[0-9a-f]{64}$/;
+const CHECKSUM_RE = /^(?:[^\s:]+:)?[0-9a-f]{64}$/;
+// Immutable provider IDs (Vercel deployment id, EAS build id, E2B build id).
+// They are opaque, case-sensitive, and must never contain whitespace.
+const PROVIDER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+export function loadLaneMatrix(matrixPath = DEFAULT_MATRIX_PATH) {
+  const raw = JSON.parse(fs.readFileSync(matrixPath, "utf8"));
+  if (raw.schemaVersion !== 1) {
+    throw new Error(`Unsupported lane matrix schemaVersion: ${raw.schemaVersion}`);
+  }
+  if (!raw.components || !raw.lanes) {
+    throw new Error("Lane matrix must define both `components` and `lanes`.");
+  }
+  return raw;
+}
+
+export function requiredLanesFor(component, matrix = loadLaneMatrix()) {
+  const lanes = matrix.components[component];
+  if (!lanes) {
+    throw new Error(`Unknown component: ${component}`);
+  }
+  // Return a sorted copy; the matrix is the sole authority for lane membership.
+  return [...lanes].sort();
+}
+
+export function providerForLane(lane, matrix = loadLaneMatrix()) {
+  const laneSpec = matrix.lanes[lane];
+  if (!laneSpec) {
+    throw new Error(`Unknown production lane: ${lane}`);
+  }
+  return laneSpec.provider;
+}
+
+function normalizeReference(provider, rawReference) {
+  if (typeof rawReference !== "string") {
+    throw new Error(`Reference must be a string, got ${typeof rawReference}.`);
+  }
+  const reference = rawReference.trim();
+  if (reference === "") {
+    throw new Error("Reference must not be empty.");
+  }
+  if (/\s/.test(reference)) {
+    throw new Error(`Reference must not contain whitespace: ${JSON.stringify(rawReference)}`);
+  }
+  switch (provider) {
+    case "oci": {
+      const lowered = reference.toLowerCase();
+      if (!OCI_DIGEST_RE.test(lowered)) {
+        throw new Error(
+          `OCI reference must be a pinned sha256 digest (name@sha256:<64hex> or sha256:<64hex>): ${reference}`,
+        );
+      }
+      return lowered;
+    }
+    case "checksum": {
+      const lowered = reference.toLowerCase();
+      if (!CHECKSUM_RE.test(lowered)) {
+        throw new Error(
+          `Checksum reference must be a published SHA-256 (<name>:<64hex> or <64hex>): ${reference}`,
+        );
+      }
+      return lowered;
+    }
+    case "vercel":
+    case "eas":
+    case "e2b": {
+      // Opaque immutable provider deployment/build IDs; case-sensitive.
+      if (!PROVIDER_ID_RE.test(reference)) {
+        throw new Error(`Invalid ${provider} provider reference: ${reference}`);
+      }
+      return reference;
+    }
+    default:
+      throw new Error(`Unsupported provider: ${provider}`);
+  }
+}
+
+// Normalize, reject duplicates, and sort. The sort makes the digest independent
+// of caller ordering; duplicate rejection keeps a mutable/duplicated reference
+// from silently collapsing into a smaller set.
+export function canonicalizeReferences(provider, references) {
+  if (!Array.isArray(references) || references.length === 0) {
+    throw new Error("At least one immutable reference is required.");
+  }
+  const seen = new Set();
+  const normalized = [];
+  for (const reference of references) {
+    const token = normalizeReference(provider, reference);
+    if (seen.has(token)) {
+      throw new Error(`Duplicate immutable reference: ${token}`);
+    }
+    seen.add(token);
+    normalized.push(token);
+  }
+  normalized.sort();
+  return normalized;
+}
+
+export function computeArtifactSetDigest(provider, references) {
+  const canonical = canonicalizeReferences(provider, references);
+  // Hash only the canonical sorted references so any recomputation from the
+  // same references is byte-identical. JSON.stringify of an array of strings is
+  // deterministic (no key ordering to worry about).
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+// Build a full lane proof from provider references. `provider` is resolved from
+// the checked-in matrix by default so callers cannot invent a proof shape.
+export function collectLaneProof({ lane, references, matrix = loadLaneMatrix(), provider }) {
+  const resolvedProvider = provider ?? providerForLane(lane, matrix);
+  const canonical = canonicalizeReferences(resolvedProvider, references);
+  const artifactSetDigest = computeArtifactSetDigest(resolvedProvider, canonical);
+  return {
+    lane,
+    provider: resolvedProvider,
+    references: canonical,
+    artifactSetDigest,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    const name = key.slice(2);
+    const value = argv[i + 1];
+    args[name] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function readReferences(args) {
+  if (args.references != null) {
+    const trimmed = args.references.trim();
+    if (trimmed.startsWith("[")) {
+      return JSON.parse(trimmed);
+    }
+    return trimmed.split(/[\s,]+/).filter(Boolean);
+  }
+  if (args["references-file"]) {
+    const contents = fs.readFileSync(args["references-file"], "utf8").trim();
+    if (contents.startsWith("[")) {
+      return JSON.parse(contents);
+    }
+    return contents.split(/[\s,]+/).filter(Boolean);
+  }
+  throw new Error("Provide --references (JSON array or comma/space list) or --references-file.");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.lane) {
+    throw new Error("--lane is required.");
+  }
+  const matrix = loadLaneMatrix(args.matrix || DEFAULT_MATRIX_PATH);
+  const references = readReferences(args);
+  const proof = collectLaneProof({ lane: args.lane, references, matrix });
+  process.stdout.write(`${JSON.stringify(proof)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/ci-cd/collect-lane-proof.test.mjs
+++ b/scripts/ci-cd/collect-lane-proof.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  canonicalizeReferences,
+  collectLaneProof,
+  computeArtifactSetDigest,
+  loadLaneMatrix,
+  providerForLane,
+  requiredLanesFor,
+} from "./collect-lane-proof.mjs";
+
+const OCI_A = "proliferate-server@sha256:" + "a".repeat(64);
+const OCI_B = "proliferate-server@sha256:" + "b".repeat(64);
+
+test("matrix matches the contract table exactly", () => {
+  const matrix = loadLaneMatrix();
+  assert.deepEqual(requiredLanesFor("proliferate-server", matrix), [
+    "hosted-server",
+    "self-hosted-release",
+  ]);
+  assert.deepEqual(requiredLanesFor("anyharness", matrix), [
+    "desktop-updater",
+    "e2b-production",
+    "runtime-artifacts",
+    "self-hosted-release",
+  ]);
+  assert.deepEqual(requiredLanesFor("proliferate-worker", matrix), [
+    "e2b-production",
+    "runtime-artifacts",
+    "self-hosted-release",
+  ]);
+  // The disabled hosted `workers` surface is not a v1 production lane.
+  assert.equal(matrix.components["proliferate-workers"], undefined);
+  assert.equal(matrix.lanes["hosted-workers"], undefined);
+});
+
+test("digest is byte-deterministic and order-independent (fixture)", () => {
+  const forward = computeArtifactSetDigest("oci", [OCI_A, OCI_B]);
+  const reversed = computeArtifactSetDigest("oci", [OCI_B, OCI_A]);
+  assert.equal(forward, reversed);
+
+  // Exact expected bytes: sha256 over the canonical sorted JSON array.
+  const expected = createHash("sha256")
+    .update(JSON.stringify([OCI_A.toLowerCase(), OCI_B.toLowerCase()].sort()))
+    .digest("hex");
+  assert.equal(forward, expected);
+  assert.match(forward, /^[0-9a-f]{64}$/);
+});
+
+test("OCI references are lowercased and require a pinned digest", () => {
+  const upper = "Repo@SHA256:" + "A".repeat(64);
+  const [normalized] = canonicalizeReferences("oci", [upper]);
+  assert.equal(normalized, upper.toLowerCase());
+  assert.throws(() => canonicalizeReferences("oci", ["repo:latest"]), /pinned sha256 digest/);
+});
+
+test("checksum references accept name-prefixed and bare 64-hex", () => {
+  const digest = "c".repeat(64);
+  assert.deepEqual(canonicalizeReferences("checksum", [`anyharness.tar.gz:${digest}`]), [
+    `anyharness.tar.gz:${digest}`,
+  ]);
+  assert.deepEqual(canonicalizeReferences("checksum", [digest]), [digest]);
+  assert.throws(() => canonicalizeReferences("checksum", ["not-a-hash"]), /published SHA-256/);
+});
+
+test("opaque provider ids (vercel/eas/e2b) keep case and reject whitespace", () => {
+  assert.deepEqual(canonicalizeReferences("vercel", ["dpl_ABC123"]), ["dpl_ABC123"]);
+  assert.deepEqual(canonicalizeReferences("eas", ["b1e2-UUID"]), ["b1e2-UUID"]);
+  assert.throws(() => canonicalizeReferences("e2b", ["has space"]), /whitespace/);
+});
+
+test("duplicate references are rejected", () => {
+  assert.throws(() => canonicalizeReferences("oci", [OCI_A, OCI_A]), /Duplicate/);
+});
+
+test("empty reference set is rejected", () => {
+  assert.throws(() => canonicalizeReferences("oci", []), /At least one/);
+});
+
+test("collectLaneProof resolves provider from the matrix", () => {
+  const proof = collectLaneProof({ lane: "hosted-web", references: ["dpl_live_deployment"] });
+  assert.equal(proof.provider, "vercel");
+  assert.equal(proof.lane, "hosted-web");
+  assert.deepEqual(proof.references, ["dpl_live_deployment"]);
+  assert.equal(proof.artifactSetDigest, computeArtifactSetDigest("vercel", ["dpl_live_deployment"]));
+});
+
+test("providerForLane rejects an unknown lane", () => {
+  assert.throws(() => providerForLane("made-up-lane"), /Unknown production lane/);
+});

--- a/scripts/ci-cd/create-component-deployment.mjs
+++ b/scripts/ci-cd/create-component-deployment.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+// Create (or idempotently reuse) the single GitHub Deployment that attests a
+// component's production promotion.
+//
+// Contract: specs/codebase/features/support-system.md -> "Release manifest".
+// After all required lanes succeed for a component, exactly one Deployment is
+// created in environment `production/<component>` carrying the immutable v1
+// payload: schemaVersion=1, component, releaseId, full headSha, and the sorted
+// lane proofs (each lane's immutable references + digest). The Deployment ID and
+// its FIRST successful status's created_at are the durable attestation
+// identity/time; retries reuse that Deployment and never substitute the clock.
+// A prior Deployment for the same release ID with different artifact digests is
+// a hard failure.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  canonicalizeReferences,
+  computeArtifactSetDigest,
+  loadLaneMatrix,
+  providerForLane,
+  requiredLanesFor,
+} from "./collect-lane-proof.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_MATRIX_PATH = path.join(HERE, "release-lane-matrix.json");
+const GITHUB_API = "https://api.github.com";
+const MAX_PAGES = 50;
+
+// Validate the supplied lane proofs against the checked-in matrix and produce
+// the canonical immutable v1 Deployment payload. Rejects a missing, extra, or
+// duplicate lane and recomputes every digest from its references.
+export function buildDeploymentPayload({ component, releaseId, headSha, proofs, matrix }) {
+  if (!component) throw new Error("component is required.");
+  if (!releaseId) throw new Error("releaseId is required.");
+  if (typeof headSha !== "string" || !/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error(`headSha must be a full 40-character git SHA: ${headSha}`);
+  }
+  const required = requiredLanesFor(component, matrix);
+  const requiredSet = new Set(required);
+
+  const seenLanes = new Set();
+  const artifacts = [];
+  for (const proof of proofs) {
+    if (!proof || typeof proof.lane !== "string") {
+      throw new Error("Each proof must carry a `lane`.");
+    }
+    const { lane, references } = proof;
+    if (!requiredSet.has(lane)) {
+      throw new Error(`Lane ${lane} is not required for component ${component}.`);
+    }
+    if (seenLanes.has(lane)) {
+      throw new Error(`Duplicate lane proof: ${lane}`);
+    }
+    seenLanes.add(lane);
+    const provider = providerForLane(lane, matrix);
+    const canonical = canonicalizeReferences(provider, references);
+    const artifactSetDigest = computeArtifactSetDigest(provider, canonical);
+    if (proof.artifactSetDigest && proof.artifactSetDigest !== artifactSetDigest) {
+      throw new Error(
+        `Lane ${lane} artifactSetDigest mismatch: supplied ${proof.artifactSetDigest}, recomputed ${artifactSetDigest}.`,
+      );
+    }
+    artifacts.push({ lane, provider, artifactSetDigest, references: canonical });
+  }
+
+  const missing = required.filter((lane) => !seenLanes.has(lane));
+  if (missing.length > 0) {
+    throw new Error(`Missing required lane proof(s) for ${component}: ${missing.join(", ")}`);
+  }
+
+  artifacts.sort((a, b) => (a.lane < b.lane ? -1 : a.lane > b.lane ? 1 : 0));
+  return { schemaVersion: 1, component, releaseId, headSha, artifacts };
+}
+
+// Two payloads describe the same immutable artifact set when their per-lane
+// digest maps are identical.
+export function digestMap(payload) {
+  const map = {};
+  for (const artifact of payload.artifacts || []) {
+    map[artifact.lane] = artifact.artifactSetDigest;
+  }
+  return map;
+}
+
+function sameDigests(a, b) {
+  const left = digestMap(a);
+  const right = digestMap(b);
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  for (let i = 0; i < leftKeys.length; i += 1) {
+    if (leftKeys[i] !== rightKeys[i]) return false;
+    if (left[leftKeys[i]] !== right[rightKeys[i]]) return false;
+  }
+  return true;
+}
+
+function createGithubClient({ repository, token, fetchImpl }) {
+  const doFetch = fetchImpl || globalThis.fetch;
+  if (!repository) throw new Error("repository (owner/name) is required.");
+  if (!token) throw new Error("A GitHub token is required.");
+
+  async function request(method, apiPath, body) {
+    const response = await doFetch(`${GITHUB_API}/repos/${repository}${apiPath}`, {
+      method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+        "content-type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub ${method} ${apiPath} failed (${response.status}): ${text}`);
+    }
+    if (response.status === 204) return null;
+    return response.json();
+  }
+
+  // Paginate a GET that returns an array, following the RFC-5988 `Link` header.
+  async function paginate(apiPath) {
+    const results = [];
+    let page = 1;
+    const separator = apiPath.includes("?") ? "&" : "?";
+    for (; page <= MAX_PAGES; page += 1) {
+      const response = await doFetch(
+        `${GITHUB_API}/repos/${repository}${apiPath}${separator}per_page=100&page=${page}`,
+        {
+          headers: {
+            accept: "application/vnd.github+json",
+            authorization: `Bearer ${token}`,
+            "x-github-api-version": "2022-11-28",
+          },
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`GitHub GET ${apiPath} failed (${response.status}): ${text}`);
+      }
+      const batch = await response.json();
+      if (!Array.isArray(batch) || batch.length === 0) {
+        return results;
+      }
+      results.push(...batch);
+      const link = response.headers.get ? response.headers.get("link") : null;
+      if (!link || !link.includes('rel="next"')) {
+        return results;
+      }
+    }
+    throw new Error(`Deployment pagination exceeded ${MAX_PAGES} pages for ${apiPath}.`);
+  }
+
+  return { request, paginate };
+}
+
+// Earliest successful status's created_at, or null when none is success yet.
+function firstSuccessAt(statuses) {
+  const successes = statuses
+    .filter((status) => status.state === "success" && typeof status.created_at === "string")
+    .map((status) => status.created_at)
+    .sort();
+  return successes.length > 0 ? successes[0] : null;
+}
+
+export async function createOrReuseComponentDeployment({
+  repository,
+  component,
+  releaseId,
+  headSha,
+  proofs,
+  token,
+  fetchImpl,
+  matrix = loadLaneMatrix(),
+}) {
+  const payload = buildDeploymentPayload({ component, releaseId, headSha, proofs, matrix });
+  const environment = `production/${component}`;
+  const client = createGithubClient({ repository, token, fetchImpl });
+
+  const deployments = await client.paginate(
+    `/deployments?environment=${encodeURIComponent(environment)}`,
+  );
+
+  // A release ID identifies one immutable artifact set. Any existing deployment
+  // for the same releaseId with different digests is a hard failure, regardless
+  // of head SHA.
+  const sameRelease = deployments.filter(
+    (deployment) => deployment.payload && deployment.payload.releaseId === releaseId,
+  );
+  for (const deployment of sameRelease) {
+    if (!sameDigests(deployment.payload, payload)) {
+      throw new Error(
+        `Release ${releaseId} already has deployment ${deployment.id} with different artifact digests; refusing to attest divergent bytes.`,
+      );
+    }
+  }
+
+  if (sameRelease.length > 0) {
+    // Reuse the existing deployment: preserve its first-success timestamp.
+    const existing = sameRelease.sort((a, b) => a.id - b.id)[0];
+    const statuses = await client.paginate(`/deployments/${existing.id}/statuses`);
+    let created = firstSuccessAt(statuses);
+    if (!created) {
+      const status = await client.request("POST", `/deployments/${existing.id}/statuses`, {
+        state: "success",
+        environment,
+        description: `Attested ${releaseId}`,
+        auto_inactive: false,
+      });
+      created = status.created_at;
+    }
+    return {
+      deploymentId: existing.id,
+      firstSuccessAt: created,
+      reused: true,
+      payload,
+    };
+  }
+
+  const deployment = await client.request("POST", "/deployments", {
+    ref: headSha,
+    environment,
+    payload,
+    auto_merge: false,
+    required_contexts: [],
+    transient_environment: false,
+    production_environment: true,
+    description: `Attest ${releaseId}`,
+  });
+  const status = await client.request("POST", `/deployments/${deployment.id}/statuses`, {
+    state: "success",
+    environment,
+    description: `Attested ${releaseId}`,
+    auto_inactive: false,
+  });
+  return {
+    deploymentId: deployment.id,
+    firstSuccessAt: status.created_at,
+    reused: false,
+    payload,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    args[key.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const proofs = args.proofs
+    ? JSON.parse(args.proofs)
+    : JSON.parse(fs.readFileSync(args["proofs-file"], "utf8"));
+  const result = await createOrReuseComponentDeployment({
+    repository: args.repository || process.env.GITHUB_REPOSITORY,
+    component: args.component,
+    releaseId: args["release-id"],
+    headSha: args["head-sha"],
+    proofs,
+    token,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci-cd/create-component-deployment.test.mjs
+++ b/scripts/ci-cd/create-component-deployment.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildDeploymentPayload,
+  createOrReuseComponentDeployment,
+} from "./create-component-deployment.mjs";
+import { loadLaneMatrix } from "./collect-lane-proof.mjs";
+
+const MATRIX = loadLaneMatrix();
+const HEAD = "d".repeat(40);
+const RELEASE = "proliferate-server@0.3.26+dddddddddddd";
+const SERVER_PROOFS = [
+  { lane: "hosted-server", references: ["proliferate-server@sha256:" + "1".repeat(64)] },
+  { lane: "self-hosted-release", references: ["anyharness.tar.gz:" + "2".repeat(64)] },
+];
+
+function jsonResponse(body, { status = 200, link = null } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+    async text() {
+      return JSON.stringify(body);
+    },
+    headers: { get: (name) => (name.toLowerCase() === "link" ? link : null) },
+  };
+}
+
+// Minimal in-memory GitHub Deployments API. Supports paginated GET of
+// deployments and statuses (one full page + an empty second page) plus POST.
+class FakeGithub {
+  constructor({ deployments = [] } = {}) {
+    this.deployments = deployments; // [{id, payload, statuses:[]}]
+    this.nextId = deployments.reduce((max, d) => Math.max(max, d.id), 100) + 1;
+    this.calls = [];
+    this.fetch = this.fetch.bind(this);
+  }
+
+  async fetch(url, options = {}) {
+    const method = options.method || "GET";
+    const { pathname, searchParams } = new URL(url);
+    const page = Number(searchParams.get("page") || "1");
+    this.calls.push(`${method} ${pathname}?page=${page}`);
+
+    const deploymentsMatch = pathname.match(/\/deployments$/);
+    const statusesMatch = pathname.match(/\/deployments\/(\d+)\/statuses$/);
+
+    if (method === "GET" && deploymentsMatch) {
+      if (page > 1) return jsonResponse([]);
+      const items = this.deployments.map((d) => ({ id: d.id, payload: d.payload, sha: d.payload.headSha }));
+      return jsonResponse(items);
+    }
+    if (method === "POST" && deploymentsMatch) {
+      const payload = JSON.parse(options.body).payload;
+      const deployment = { id: this.nextId++, payload, statuses: [] };
+      this.deployments.push(deployment);
+      return jsonResponse({ id: deployment.id, payload });
+    }
+    if (method === "GET" && statusesMatch) {
+      if (page > 1) return jsonResponse([]);
+      const id = Number(statusesMatch[1]);
+      const deployment = this.deployments.find((d) => d.id === id);
+      return jsonResponse(deployment ? deployment.statuses : []);
+    }
+    if (method === "POST" && statusesMatch) {
+      const id = Number(statusesMatch[1]);
+      const deployment = this.deployments.find((d) => d.id === id);
+      const created_at = `2026-07-13T0${deployment.statuses.length}:00:00Z`;
+      const status = { state: JSON.parse(options.body).state, created_at };
+      deployment.statuses.push(status);
+      return jsonResponse(status);
+    }
+    return jsonResponse({ message: "not found" }, { status: 404 });
+  }
+}
+
+test("buildDeploymentPayload requires exactly the matrix lanes", () => {
+  assert.throws(
+    () => buildDeploymentPayload({ component: "proliferate-server", releaseId: RELEASE, headSha: HEAD, proofs: [SERVER_PROOFS[0]], matrix: MATRIX }),
+    /Missing required lane proof/,
+  );
+  assert.throws(
+    () =>
+      buildDeploymentPayload({
+        component: "proliferate-server",
+        releaseId: RELEASE,
+        headSha: HEAD,
+        proofs: [...SERVER_PROOFS, { lane: "hosted-web", references: ["dpl_x"] }],
+        matrix: MATRIX,
+      }),
+    /not required for component/,
+  );
+  assert.throws(
+    () =>
+      buildDeploymentPayload({
+        component: "proliferate-server",
+        releaseId: RELEASE,
+        headSha: HEAD,
+        proofs: [SERVER_PROOFS[0], SERVER_PROOFS[0]],
+        matrix: MATRIX,
+      }),
+    /Duplicate lane proof/,
+  );
+});
+
+test("buildDeploymentPayload sorts lanes and rejects a bad headSha", () => {
+  const payload = buildDeploymentPayload({
+    component: "proliferate-server",
+    releaseId: RELEASE,
+    headSha: HEAD,
+    proofs: [...SERVER_PROOFS].reverse(),
+    matrix: MATRIX,
+  });
+  assert.deepEqual(payload.artifacts.map((a) => a.lane), ["hosted-server", "self-hosted-release"]);
+  assert.equal(payload.schemaVersion, 1);
+  assert.throws(
+    () => buildDeploymentPayload({ component: "proliferate-server", releaseId: RELEASE, headSha: "short", proofs: SERVER_PROOFS, matrix: MATRIX }),
+    /40-character git SHA/,
+  );
+});
+
+test("creates a new deployment with one success status", async () => {
+  const api = new FakeGithub();
+  const result = await createOrReuseComponentDeployment({
+    repository: "proliferate-ai/proliferate",
+    component: "proliferate-server",
+    releaseId: RELEASE,
+    headSha: HEAD,
+    proofs: SERVER_PROOFS,
+    token: "t",
+    fetchImpl: api.fetch,
+    matrix: MATRIX,
+  });
+  assert.equal(result.reused, false);
+  assert.equal(result.firstSuccessAt, "2026-07-13T00:00:00Z");
+  assert.equal(api.deployments.length, 1);
+  assert.equal(api.deployments[0].statuses.length, 1);
+});
+
+test("reuses the deployment and preserves the first-success timestamp on retry", async () => {
+  const api = new FakeGithub();
+  const first = await createOrReuseComponentDeployment({
+    repository: "proliferate-ai/proliferate",
+    component: "proliferate-server",
+    releaseId: RELEASE,
+    headSha: HEAD,
+    proofs: SERVER_PROOFS,
+    token: "t",
+    fetchImpl: api.fetch,
+    matrix: MATRIX,
+  });
+  const retry = await createOrReuseComponentDeployment({
+    repository: "proliferate-ai/proliferate",
+    component: "proliferate-server",
+    releaseId: RELEASE,
+    headSha: HEAD,
+    proofs: [...SERVER_PROOFS].reverse(),
+    token: "t",
+    fetchImpl: api.fetch,
+    matrix: MATRIX,
+  });
+  assert.equal(retry.reused, true);
+  assert.equal(retry.deploymentId, first.deploymentId);
+  // No second deployment, and the first-success time is unchanged.
+  assert.equal(api.deployments.length, 1);
+  assert.equal(retry.firstSuccessAt, first.firstSuccessAt);
+  assert.equal(api.deployments[0].statuses.length, 1);
+});
+
+test("hard-fails a same-release deployment with different digests", async () => {
+  const api = new FakeGithub();
+  await createOrReuseComponentDeployment({
+    repository: "proliferate-ai/proliferate",
+    component: "proliferate-server",
+    releaseId: RELEASE,
+    headSha: HEAD,
+    proofs: SERVER_PROOFS,
+    token: "t",
+    fetchImpl: api.fetch,
+    matrix: MATRIX,
+  });
+  const tampered = [
+    { lane: "hosted-server", references: ["proliferate-server@sha256:" + "9".repeat(64)] },
+    { lane: "self-hosted-release", references: ["anyharness.tar.gz:" + "2".repeat(64)] },
+  ];
+  await assert.rejects(
+    createOrReuseComponentDeployment({
+      repository: "proliferate-ai/proliferate",
+      component: "proliferate-server",
+      releaseId: RELEASE,
+      headSha: HEAD,
+      proofs: tampered,
+      token: "t",
+      fetchImpl: api.fetch,
+      matrix: MATRIX,
+    }),
+    /different artifact digests/,
+  );
+});

--- a/scripts/ci-cd/release-lane-matrix.json
+++ b/scripts/ci-cd/release-lane-matrix.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "_comment": "Checked-in v1 component-to-production-lane matrix. Authoritative source: specs/codebase/features/support-system.md 'Release manifest'. Release tooling and the tracker both derive required lanes from THIS file; it is never caller-supplied. The disabled hosted 'workers' surface is not a production lane in v1 and has no entry.",
+  "components": {
+    "proliferate-server": ["hosted-server", "self-hosted-release"],
+    "proliferate-litellm": ["hosted-litellm", "self-hosted-release"],
+    "proliferate-web": ["hosted-web"],
+    "proliferate-mobile": ["mobile-production"],
+    "proliferate-desktop": ["desktop-updater"],
+    "proliferate-desktop-native": ["desktop-updater"],
+    "anyharness": ["runtime-artifacts", "e2b-production", "desktop-updater", "self-hosted-release"],
+    "proliferate-worker": ["runtime-artifacts", "e2b-production", "self-hosted-release"],
+    "proliferate-supervisor": ["runtime-artifacts", "e2b-production", "self-hosted-release"]
+  },
+  "lanes": {
+    "hosted-server": { "provider": "oci" },
+    "hosted-litellm": { "provider": "oci" },
+    "hosted-web": { "provider": "vercel" },
+    "mobile-production": { "provider": "eas" },
+    "desktop-updater": { "provider": "checksum" },
+    "runtime-artifacts": { "provider": "checksum" },
+    "e2b-production": { "provider": "e2b" },
+    "self-hosted-release": { "provider": "checksum" }
+  }
+}

--- a/scripts/ci-cd/verify-production-deployments.mjs
+++ b/scripts/ci-cd/verify-production-deployments.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+// Verify that every component in a candidate release manifest has a valid,
+// successful production GitHub Deployment.
+//
+// Contract: specs/codebase/features/support-system.md -> "Release manifest" and
+// specs/tbd/support-system-end-to-end-handoff.md -> "Wave 7". This is the R2
+// deliverable named by the handoff runbook. For each `release.components[]`
+// entry it fetches the full Deployment payload from `production/<component>`,
+// requires schemaVersion=1, component/release/head agreement, recomputes each
+// artifact digest from the immutable provider references, enforces the exact
+// checked-in lane matrix, and rejects a prior same-release deployment with
+// different digests. It is an independent validator, not a substitute for the
+// deployment summary loop.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { digestMap } from "./create-component-deployment.mjs";
+import {
+  canonicalizeReferences,
+  computeArtifactSetDigest,
+  loadLaneMatrix,
+  providerForLane,
+  requiredLanesFor,
+} from "./collect-lane-proof.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_MATRIX_PATH = path.join(HERE, "release-lane-matrix.json");
+const GITHUB_API = "https://api.github.com";
+const MAX_PAGES = 50;
+
+function createReader({ repository, token, fetchImpl }) {
+  const doFetch = fetchImpl || globalThis.fetch;
+  if (!repository) throw new Error("repository (owner/name) is required.");
+
+  async function paginate(apiPath) {
+    const results = [];
+    const separator = apiPath.includes("?") ? "&" : "?";
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const response = await doFetch(
+        `${GITHUB_API}/repos/${repository}${apiPath}${separator}per_page=100&page=${page}`,
+        {
+          headers: {
+            accept: "application/vnd.github+json",
+            ...(token ? { authorization: `Bearer ${token}` } : {}),
+            "x-github-api-version": "2022-11-28",
+          },
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`GitHub GET ${apiPath} failed (${response.status}): ${text}`);
+      }
+      const batch = await response.json();
+      if (!Array.isArray(batch) || batch.length === 0) {
+        return results;
+      }
+      results.push(...batch);
+      const link = response.headers.get ? response.headers.get("link") : null;
+      if (!link || !link.includes('rel="next"')) {
+        return results;
+      }
+    }
+    throw new Error(`Deployment pagination exceeded ${MAX_PAGES} pages for ${apiPath}.`);
+  }
+
+  return { paginate };
+}
+
+function firstSuccessAt(statuses) {
+  const successes = statuses
+    .filter((status) => status.state === "success" && typeof status.created_at === "string")
+    .map((status) => status.created_at)
+    .sort();
+  return successes.length > 0 ? successes[0] : null;
+}
+
+// Validate a single Deployment payload against the checked-in matrix and the
+// manifest component entry. Returns the list of errors (empty when valid).
+export function validatePayload({ payload, component, manifestComponent, matrix }) {
+  const errors = [];
+  if (!payload || typeof payload !== "object") {
+    return [`${component}: deployment has no v1 payload.`];
+  }
+  if (payload.schemaVersion !== 1) {
+    errors.push(`${component}: payload schemaVersion must be 1, got ${payload.schemaVersion}.`);
+  }
+  if (payload.component !== component) {
+    errors.push(`${component}: payload component mismatch (${payload.component}).`);
+  }
+  if (payload.releaseId !== manifestComponent.releaseId) {
+    errors.push(
+      `${component}: payload releaseId ${payload.releaseId} != manifest ${manifestComponent.releaseId}.`,
+    );
+  }
+  if (payload.headSha !== manifestComponent.headSha) {
+    errors.push(
+      `${component}: payload headSha ${payload.headSha} != manifest ${manifestComponent.headSha}.`,
+    );
+  }
+
+  // Recompute every digest from immutable references and enforce the matrix.
+  const required = requiredLanesFor(component, matrix);
+  const seen = new Set();
+  const recomputed = {};
+  for (const artifact of payload.artifacts || []) {
+    if (!required.includes(artifact.lane)) {
+      errors.push(`${component}: unexpected lane ${artifact.lane} not in the checked-in matrix.`);
+      continue;
+    }
+    if (seen.has(artifact.lane)) {
+      errors.push(`${component}: duplicate lane proof ${artifact.lane}.`);
+      continue;
+    }
+    seen.add(artifact.lane);
+    try {
+      const provider = providerForLane(artifact.lane, matrix);
+      const canonical = canonicalizeReferences(provider, artifact.references || []);
+      const digest = computeArtifactSetDigest(provider, canonical);
+      recomputed[artifact.lane] = digest;
+      if (digest !== artifact.artifactSetDigest) {
+        errors.push(
+          `${component}/${artifact.lane}: recomputed digest ${digest} != payload ${artifact.artifactSetDigest}.`,
+        );
+      }
+    } catch (error) {
+      errors.push(`${component}/${artifact.lane}: ${error.message}`);
+    }
+  }
+  for (const lane of required) {
+    if (!seen.has(lane)) {
+      errors.push(`${component}: missing required lane proof ${lane}.`);
+    }
+  }
+
+  // The manifest carries only lane+digest; each must match the payload's
+  // recomputed digest exactly.
+  const manifestDigests = {};
+  for (const artifact of manifestComponent.artifacts || []) {
+    manifestDigests[artifact.lane] = artifact.artifactSetDigest;
+  }
+  const manifestLanes = Object.keys(manifestDigests).sort();
+  if (manifestLanes.join(",") !== [...required].sort().join(",")) {
+    errors.push(
+      `${component}: manifest lanes [${manifestLanes.join(", ")}] do not match required [${[...required].sort().join(", ")}].`,
+    );
+  }
+  for (const lane of manifestLanes) {
+    if (recomputed[lane] && recomputed[lane] !== manifestDigests[lane]) {
+      errors.push(
+        `${component}/${lane}: manifest digest ${manifestDigests[lane]} != recomputed ${recomputed[lane]}.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+export async function verifyProductionDeployments({
+  manifest,
+  repository,
+  token,
+  fetchImpl,
+  matrix = loadLaneMatrix(),
+}) {
+  const errors = [];
+  if (!manifest || manifest.schemaVersion !== 1) {
+    throw new Error("Manifest schemaVersion must be 1.");
+  }
+  const reader = createReader({ repository, token, fetchImpl });
+  const components = (manifest.release && manifest.release.components) || [];
+
+  for (const manifestComponent of components) {
+    const component = manifestComponent.component;
+    if (!matrix.components[component]) {
+      errors.push(`${component}: not a known component in the checked-in matrix.`);
+      continue;
+    }
+    const environment = `production/${component}`;
+    const deployments = await reader.paginate(
+      `/deployments?environment=${encodeURIComponent(environment)}`,
+    );
+    const sameRelease = deployments.filter(
+      (deployment) => deployment.payload && deployment.payload.releaseId === manifestComponent.releaseId,
+    );
+    if (sameRelease.length === 0) {
+      errors.push(`${component}: no production Deployment found for ${manifestComponent.releaseId}.`);
+      continue;
+    }
+
+    // Reject a prior same-release deployment with different digests.
+    const distinct = new Set(sameRelease.map((d) => JSON.stringify(digestMap(d.payload))));
+    if (distinct.size > 1) {
+      errors.push(
+        `${component}: multiple deployments for ${manifestComponent.releaseId} carry different artifact digests.`,
+      );
+      continue;
+    }
+
+    const deployment = sameRelease.sort((a, b) => a.id - b.id)[0];
+    errors.push(
+      ...validatePayload({ payload: deployment.payload, component, manifestComponent, matrix }),
+    );
+
+    const statuses = await reader.paginate(`/deployments/${deployment.id}/statuses`);
+    const created = firstSuccessAt(statuses);
+    if (!created) {
+      errors.push(`${component}: deployment ${deployment.id} has no successful status.`);
+    } else if (manifestComponent.deployedAt && manifestComponent.deployedAt !== created) {
+      errors.push(
+        `${component}: manifest deployedAt ${manifestComponent.deployedAt} != first-success ${created}.`,
+      );
+    }
+    if (
+      manifestComponent.deploymentId != null &&
+      manifestComponent.deploymentId !== deployment.id
+    ) {
+      errors.push(
+        `${component}: manifest deploymentId ${manifestComponent.deploymentId} != found ${deployment.id}.`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    args[key.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.manifest) throw new Error("--manifest is required.");
+  if (!args.repository) throw new Error("--repository is required.");
+  const manifest = JSON.parse(fs.readFileSync(args.manifest, "utf8"));
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const matrix = loadLaneMatrix(args.matrix || DEFAULT_MATRIX_PATH);
+  const { ok, errors } = await verifyProductionDeployments({
+    manifest,
+    repository: args.repository,
+    token,
+    matrix,
+  });
+  if (!ok) {
+    for (const error of errors) {
+      process.stderr.write(`::error::${error}\n`);
+    }
+    process.exit(1);
+  }
+  process.stdout.write("All production deployments verified.\n");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci-cd/verify-production-deployments.test.mjs
+++ b/scripts/ci-cd/verify-production-deployments.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { verifyProductionDeployments } from "./verify-production-deployments.mjs";
+import { buildDeploymentPayload } from "./create-component-deployment.mjs";
+import { loadLaneMatrix } from "./collect-lane-proof.mjs";
+
+const MATRIX = loadLaneMatrix();
+const HEAD = "e".repeat(40);
+const RELEASE = "proliferate-server@0.3.26+eeeeeeeeeeee";
+const PROOFS = [
+  { lane: "hosted-server", references: ["proliferate-server@sha256:" + "1".repeat(64)] },
+  { lane: "self-hosted-release", references: ["anyharness.tar.gz:" + "2".repeat(64)] },
+];
+
+function serverPayload(overrides = {}) {
+  return {
+    ...buildDeploymentPayload({
+      component: "proliferate-server",
+      releaseId: RELEASE,
+      headSha: HEAD,
+      proofs: PROOFS,
+      matrix: MATRIX,
+    }),
+    ...overrides,
+  };
+}
+
+function manifestFor(payload, componentOverrides = {}) {
+  return {
+    schemaVersion: 1,
+    release: {
+      components: [
+        {
+          component: "proliferate-server",
+          releaseId: RELEASE,
+          headSha: HEAD,
+          deploymentId: 500,
+          deployedAt: "2026-07-13T00:00:00Z",
+          artifacts: payload.artifacts.map((a) => ({
+            lane: a.lane,
+            artifactSetDigest: a.artifactSetDigest,
+          })),
+          ...componentOverrides,
+        },
+      ],
+    },
+  };
+}
+
+function jsonResponse(body, { link = null } = {}) {
+  return {
+    ok: true,
+    status: 200,
+    async json() {
+      return body;
+    },
+    async text() {
+      return JSON.stringify(body);
+    },
+    headers: { get: (name) => (name.toLowerCase() === "link" ? link : null) },
+  };
+}
+
+// Fake reader with configurable page size so pagination is exercised.
+function makeFetch({ deployments, statuses, pageSize = 100 }) {
+  return async function fetchImpl(url) {
+    const { pathname, searchParams } = new URL(url);
+    const page = Number(searchParams.get("page") || "1");
+    if (/\/deployments$/.test(pathname)) {
+      const start = (page - 1) * pageSize;
+      const slice = deployments.slice(start, start + pageSize);
+      const hasNext = start + pageSize < deployments.length;
+      return jsonResponse(slice, {
+        link: hasNext ? '<https://api.github.com/next>; rel="next"' : null,
+      });
+    }
+    const statusesMatch = pathname.match(/\/deployments\/(\d+)\/statuses$/);
+    if (statusesMatch) {
+      const id = Number(statusesMatch[1]);
+      const start = (page - 1) * pageSize;
+      const all = statuses[id] || [];
+      const slice = all.slice(start, start + pageSize);
+      const hasNext = start + pageSize < all.length;
+      return jsonResponse(slice, {
+        link: hasNext ? '<https://api.github.com/next>; rel="next"' : null,
+      });
+    }
+    return jsonResponse([]);
+  };
+}
+
+test("valid manifest with a matching successful deployment passes", async () => {
+  const payload = serverPayload();
+  const fetchImpl = makeFetch({
+    deployments: [{ id: 500, payload }],
+    statuses: { 500: [{ state: "success", created_at: "2026-07-13T00:00:00Z" }] },
+  });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("missing deployment fails closed", async () => {
+  const payload = serverPayload();
+  const fetchImpl = makeFetch({ deployments: [], statuses: {} });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /no production Deployment found/);
+});
+
+test("a tampered manifest digest is rejected", async () => {
+  const payload = serverPayload();
+  const manifest = manifestFor(payload);
+  manifest.release.components[0].artifacts[0].artifactSetDigest = "0".repeat(64);
+  const fetchImpl = makeFetch({
+    deployments: [{ id: 500, payload }],
+    statuses: { 500: [{ state: "success", created_at: "2026-07-13T00:00:00Z" }] },
+  });
+  const result = await verifyProductionDeployments({
+    manifest,
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /manifest digest .* != recomputed/);
+});
+
+test("a payload missing a required lane is rejected", async () => {
+  const payload = serverPayload();
+  payload.artifacts = payload.artifacts.filter((a) => a.lane !== "self-hosted-release");
+  const fetchImpl = makeFetch({
+    deployments: [{ id: 500, payload }],
+    statuses: { 500: [{ state: "success", created_at: "2026-07-13T00:00:00Z" }] },
+  });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /missing required lane proof self-hosted-release/);
+});
+
+test("a deployment with no success status is rejected", async () => {
+  const payload = serverPayload();
+  const fetchImpl = makeFetch({
+    deployments: [{ id: 500, payload }],
+    statuses: { 500: [{ state: "in_progress", created_at: "2026-07-13T00:00:00Z" }] },
+  });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /no successful status/);
+});
+
+test("prior same-release deployment with different digests is rejected", async () => {
+  const payload = serverPayload();
+  const tampered = serverPayload();
+  tampered.artifacts[0].artifactSetDigest = "7".repeat(64);
+  const fetchImpl = makeFetch({
+    deployments: [
+      { id: 500, payload },
+      { id: 501, payload: tampered },
+    ],
+    statuses: {
+      500: [{ state: "success", created_at: "2026-07-13T00:00:00Z" }],
+      501: [{ state: "success", created_at: "2026-07-13T01:00:00Z" }],
+    },
+  });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /different artifact digests/);
+});
+
+test("deployments spread across pages are found (pagination)", async () => {
+  const payload = serverPayload();
+  const filler = Array.from({ length: 3 }, (_, i) => ({
+    id: 100 + i,
+    payload: { schemaVersion: 1, component: "proliferate-server", releaseId: "other@0.0.0+abc", headSha: HEAD, artifacts: [] },
+  }));
+  const fetchImpl = makeFetch({
+    deployments: [...filler, { id: 500, payload }],
+    statuses: { 500: [{ state: "success", created_at: "2026-07-13T00:00:00Z" }] },
+    pageSize: 2,
+  });
+  const result = await verifyProductionDeployments({
+    manifest: manifestFor(payload),
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("first-success time mismatch against the manifest is rejected", async () => {
+  const payload = serverPayload();
+  const fetchImpl = makeFetch({
+    deployments: [{ id: 500, payload }],
+    statuses: {
+      500: [
+        { state: "success", created_at: "2026-07-13T05:00:00Z" },
+        { state: "success", created_at: "2026-07-13T00:00:00Z" },
+      ],
+    },
+  });
+  const manifest = manifestFor(payload, { deployedAt: "2026-07-13T05:00:00Z" });
+  const result = await verifyProductionDeployments({
+    manifest,
+    repository: "proliferate-ai/proliferate",
+    fetchImpl,
+    matrix: MATRIX,
+  });
+  assert.equal(result.ok, false);
+  // The earliest success (00:00:00Z) is authoritative, not the later retry.
+  assert.match(result.errors.join("\n"), /!= first-success 2026-07-13T00:00:00Z/);
+});


### PR DESCRIPTION
R2 of the support-system program: immutable release proof plumbing, companion to the merged P2 producers.

- Checked-in `scripts/ci-cd/release-lane-matrix.json` (component→required-lanes, contract table verbatim) — release tooling and tracker both derive policy from it, never caller input
- `collect-lane-proof.mjs`: canonical lowercase-SHA256 `artifactSetDigest` over sorted immutable provider references (OCI digests / provider build IDs / published checksums); duplicate/empty/mutable rejection
- `create-component-deployment.mjs`: one `production/<component>` GitHub Deployment with the exact v1 payload, idempotent reuse preserving the first-success status timestamp, hard-fail on same-releaseId-different-digest
- `verify-production-deployments.mjs` (handoff deliverable): full-payload verification with digest recomputation, matrix enforcement, pagination
- `PROLIFERATE_BUILD_SHA` stamped into every lane that compiles runtime crates (release-runtime, server-ci self-hosted assets, release-desktop, E2B rebuild, Cross.toml passthrough — required by P2's fail-closed build.rs)
- `_deploy-server.yml`: `PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1` on production, dead `CLOUD_TARGET_SENTRY_RELEASE` injection removed and stripped from live task defs
- `_deploy-litellm.yml`/`_deploy-mobile.yml`: canonical `SENTRY_RELEASE` / `EXPO_PUBLIC_PROLIFERATE_RELEASE` injection
- Nightly/hotfix now expose, execute, and gate the detected `litellm` surface (was detect-only)

80 script tests; actionlint + YAML parse clean on all 11 touched workflows.

Known follow-ups (product-owned, listed in the program tracker): promote-don't-rebuild for E2B/desktop/self-hosted runtime artifacts; eas.json env forwarding for the mobile release var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)