### PR TITLE
fix(alembic): merge support-report and workflow-definitions migration heads

### DIFF
--- a/server/alembic/versions/dbf7f8e64a52_merge_support_report_and_workflow_.py
+++ b/server/alembic/versions/dbf7f8e64a52_merge_support_report_and_workflow_.py
@@ -1,0 +1,28 @@
+"""merge support-report and workflow-definitions heads
+
+Revision ID: dbf7f8e64a52
+Revises: c4d5e6f7a8b0, c5d6e7f8a9b1
+Create Date: 2026-07-13 14:20:47.941004
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'dbf7f8e64a52'
+down_revision: Union[str, Sequence[str], None] = ('c4d5e6f7a8b0', 'c5d6e7f8a9b1')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## What

Main has two alembic heads — `c4d5e6f7a8b0` (support_report client_release_provided) and `c5d6e7f8a9b1` (workflow definitions v1) — both parented on `b3c4d5e6f7a9`. This forks the migration history, so `alembic upgrade head` fails everywhere: the repo-shape check, tier-2 intent stack boot, and every fresh dev-profile boot are red on main.

Adds the standard no-op merge revision (`dbf7f8e64a52`) rejoining the two heads, same shape as prior merges (#887, #982, 75e8009a52c7).

## Verification

- `python3 scripts/check_migration_heads.py` → "Migration head check passed (117 revisions, head dbf7f8e64a52)".
- `alembic upgrade heads` applied cleanly against a fresh dev-profile DB (both branches ran, no conflicts — the two migrations touch unrelated tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)