### PR TITLE
test(release): define qualification worlds and scenarios

### DIFF
--- a/scripts/ci-cd/core-release-scenario-manifest.test.mjs
+++ b/scripts/ci-cd/core-release-scenario-manifest.test.mjs
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const testingDir = path.join(repoRoot, "specs/developing/testing");
+const contractPath = path.join(testingDir, "core-release-validation.md");
+const manifestPath = path.join(testingDir, "core-release-scenario-manifest.json");
+const tier3ContractPath = path.join(testingDir, "tier-3-scenario-contract.md");
+const tier4ContractPath = path.join(testingDir, "tier-4-scenario-contract.md");
+const worldsContractPath = path.join(testingDir, "release-worlds-and-fixtures.md");
+const migrationContractPath = path.join(repoRoot, "specs/tbd/web-desktop-unification-migration.md");
+const contract = readFileSync(contractPath, "utf8");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const tier3Contract = readFileSync(tier3ContractPath, "utf8");
+const tier4Contract = readFileSync(tier4ContractPath, "utf8");
+const worldsContract = readFileSync(worldsContractPath, "utf8");
+const migrationContract = readFileSync(migrationContractPath, "utf8");
+
+function contractScenarioIds() {
+  return [...contract.matchAll(/^\| `(T([234])-[^`]+)` \|/gm)].map((match) => ({
+    id: match[1],
+    tier: Number(match[2]),
+  }));
+}
+
+test("the machine scenario inventory exactly matches the authoritative contract", () => {
+  assert.equal(manifest.schemaVersion, 5);
+  assert.equal(manifest.authoritativeContract, "core-release-validation.md");
+  assert.deepEqual(
+    manifest.requiredScenarios.map(({ id, tier }) => ({ id, tier })),
+    contractScenarioIds(),
+  );
+});
+
+test("composed world journeys exactly match the Tier 3 and standing Tier 4 contracts", () => {
+  const tier3JourneyIds = [...tier3Contract.matchAll(/^#### `((?:LOCAL|CLOUD|SH)-[^`]+)`/gm)]
+    .map((match) => match[1]);
+  const tier4JourneyIds = [...tier4Contract.matchAll(/^### `(T4-(?:DESKTOP-CLEAN|DESKTOP|RUNTIME|SELFHOST)-1)`/gm)]
+    .map((match) => match[1]);
+  const contractJourneyIds = [...tier3JourneyIds, ...tier4JourneyIds];
+  const journeys = manifest.composedJourneys;
+  assert.deepEqual(journeys.map(({ id }) => id), contractJourneyIds);
+  assert.equal(new Set(contractJourneyIds).size, contractJourneyIds.length);
+  assert.equal(journeys.length, 47);
+
+  const targetIds = new Set(manifest.requiredScenarios.map(({ id }) => id));
+  const validWorlds = new Set([
+    "local-runtime",
+    "managed-cloud",
+    "self-host",
+    "tier-4",
+  ]);
+  const validHosts = new Set([
+    "host-neutral",
+    "desktop-renderer",
+    "desktop-native",
+    "hosted-web",
+    "cross-host",
+  ]);
+  const validTier4Targets = new Set([
+    "desktop-clean-install",
+    "desktop-upgrade",
+    "managed-cloud-runtime-upgrade",
+    "self-host-upgrade",
+  ]);
+  for (const journey of journeys) {
+    assert.ok(validWorlds.has(journey.world), `${journey.id}: invalid world`);
+    assert.ok(Array.isArray(journey.requiredHosts) && journey.requiredHosts.length > 0);
+    assert.ok(journey.requiredHosts.every((host) => validHosts.has(host)), `${journey.id}: invalid host`);
+    assert.ok(Array.isArray(journey.targetScenarioRefs) && journey.targetScenarioRefs.length > 0);
+    assert.ok(
+      journey.targetScenarioRefs.every((id) => targetIds.has(id)),
+      `${journey.id}: unknown target scenario reference`,
+    );
+    assert.ok(
+      journey.targetScenarioRefs.some((id) => id.startsWith(`T${journey.tier}-`)),
+      `${journey.id}: journey must contribute to its own tier`,
+    );
+    assert.deepEqual(journey.implementation, { status: "planned" });
+
+    if (journey.tier === 3) {
+      assert.equal(journey.target, undefined, `${journey.id}: Tier 3 has no target dimension`);
+      assert.ok(
+        !journey.requiredHosts.includes("desktop-native"),
+        `${journey.id}: packaged/native Desktop belongs to Tier 4`,
+      );
+    } else if (journey.tier === 4) {
+      assert.equal(journey.world, "tier-4");
+      assert.ok(validTier4Targets.has(journey.target), `${journey.id}: invalid Tier 4 target`);
+    }
+
+    if (journey.id.startsWith("LOCAL-")) {
+      assert.equal(journey.world, "local-runtime");
+      assert.ok(!journey.requiredHosts.includes("hosted-web"));
+      assert.ok(!journey.requiredHosts.includes("cross-host"));
+    } else if (journey.id.startsWith("CLOUD-")) {
+      assert.equal(journey.world, "managed-cloud");
+    } else if (journey.id.startsWith("SH-")) {
+      assert.equal(journey.world, "self-host");
+      assert.ok(!journey.requiredHosts.includes("hosted-web"));
+    }
+  }
+
+  assert.deepEqual(
+    journeys.find(({ id }) => id === "CLOUD-HOSTS-1")?.requiredHosts,
+    ["desktop-renderer", "hosted-web", "cross-host"],
+  );
+  assert.deepEqual(
+    journeys.filter(({ tier }) => tier === 4).map(({ target }) => target),
+    [...validTier4Targets],
+  );
+});
+
+test("Tier 3 standing and deferred qualification sets are exhaustive and derived", () => {
+  assert.deepEqual(manifest.qualificationPolicy, {
+    tier3StandingSelection: {
+      includeComposedJourneyReferences: true,
+      standaloneScenarioIds: [],
+      unreferencedDisposition: "deferred",
+      fullCoreQualificationRequiresNoDeferred: true,
+    },
+    tier4TargetSelection: {
+      standingTargets: [
+        "desktop-clean-install",
+        "desktop-upgrade",
+        "managed-cloud-runtime-upgrade",
+      ],
+      changeTriggeredTargets: ["self-host-upgrade"],
+      independentEvidenceRequired: true,
+    },
+  });
+
+  const tier3Ids = manifest.requiredScenarios
+    .filter(({ tier }) => tier === 3)
+    .map(({ id }) => id);
+  const tier3IdSet = new Set(tier3Ids);
+  const journeyRefs = new Set(
+    manifest.composedJourneys
+      .filter(({ tier }) => tier === 3)
+      .flatMap(({ targetScenarioRefs }) => targetScenarioRefs)
+      .filter((id) => id.startsWith("T3-")),
+  );
+  const standaloneIds = manifest.qualificationPolicy
+    .tier3StandingSelection.standaloneScenarioIds;
+  assert.ok(standaloneIds.every((id) => tier3IdSet.has(id)));
+
+  const standing = new Set([...journeyRefs, ...standaloneIds]);
+  const deferred = tier3Ids.filter((id) => !standing.has(id));
+  assert.equal(standing.size + deferred.length, tier3Ids.length);
+  assert.ok(standing.size > 0, "foundation needs a non-empty standing Tier 3 set");
+  assert.ok(deferred.length > 0, "foundation must expose the not-yet-composed Tier 3 set");
+
+  for (const prefix of ["T3-BILL-", "T3-SH-"]) {
+    const requiredCoreDomainIds = tier3Ids.filter((id) => id.startsWith(prefix));
+    assert.ok(requiredCoreDomainIds.length > 0);
+    assert.ok(
+      requiredCoreDomainIds.every((id) => standing.has(id)),
+      `${prefix} guarantees must all be reachable in the foundation wave`,
+    );
+  }
+});
+
+test("journey-to-guarantee mappings live only in the machine manifest", () => {
+  const duplicateMappingPattern = /Maps primarily|map(?:s|ped)? (?:directly|collectively) to/i;
+  assert.doesNotMatch(tier3Contract, duplicateMappingPattern);
+  assert.doesNotMatch(tier4Contract, duplicateMappingPattern);
+});
+
+test("the required target has 69 Tier 2, 90 Tier 3, and 27 Tier 4 unique scenarios", () => {
+  const scenarios = manifest.requiredScenarios;
+  assert.equal(scenarios.length, 186);
+  assert.equal(new Set(scenarios.map(({ id }) => id)).size, scenarios.length);
+  assert.deepEqual(
+    Object.fromEntries([2, 3, 4].map((tier) => [
+      tier,
+      scenarios.filter((scenario) => scenario.tier === tier).length,
+    ])),
+    { 2: 69, 3: 90, 4: 27 },
+  );
+  for (const scenario of scenarios) {
+    assert.match(scenario.id, new RegExp(`^T${scenario.tier}-[A-Z0-9-]+$`));
+  }
+});
+
+test("target presence is never treated as executable coverage", () => {
+  const validStatuses = new Set(["planned", "collected", "enforced"]);
+  const validGates = new Set(["merge", "staging", "release", "nightly"]);
+  const validEvidence = new Set(["diagnostic", "partial", "qualification"]);
+
+  for (const scenario of manifest.requiredScenarios) {
+    const implementation = scenario.implementation;
+    assert.equal(typeof implementation, "object", `${scenario.id} must declare implementation state`);
+    assert.ok(validStatuses.has(implementation?.status), `${scenario.id} has an invalid implementation status`);
+
+    if (implementation.status === "planned") {
+      assert.deepEqual(
+        Object.keys(implementation).sort(),
+        ["status"],
+        `${scenario.id}: planned rows cannot carry unaudited execution claims`,
+      );
+      continue;
+    }
+
+    assert.match(implementation.collector, /\.(?:ts|tsx|py|mjs|sh|ya?ml)$/);
+    assert.ok(
+      existsSync(path.resolve(repoRoot, implementation.collector)),
+      `${scenario.id}: collector does not exist: ${implementation.collector}`,
+    );
+    assert.equal(typeof implementation.testId, "string");
+    assert.ok(implementation.testId.length > 0, `${scenario.id}: collected test id is required`);
+    assert.ok(Array.isArray(implementation.lanes) && implementation.lanes.length > 0);
+    assert.equal(new Set(implementation.lanes).size, implementation.lanes.length);
+    assert.ok(implementation.lanes.every((lane) => typeof lane === "string" && lane.length > 0));
+    assert.ok(validGates.has(implementation.gate), `${scenario.id}: invalid gate`);
+    assert.ok(validEvidence.has(implementation.evidenceStatus), `${scenario.id}: invalid evidence status`);
+    if (implementation.status === "collected") {
+      assert.notEqual(implementation.evidenceStatus, "qualification");
+    }
+    if (implementation.status === "enforced") {
+      assert.equal(implementation.evidenceStatus, "qualification");
+    }
+  }
+});
+
+test("foundation recovery leaves target rows planned until execution mapping is audited", () => {
+  assert.equal(
+    manifest.requiredScenarios.filter(({ implementation }) => implementation.status === "planned").length,
+    manifest.requiredScenarios.length,
+  );
+});
+
+test("runtime activation authority is Worker mailbox to Supervisor, never Worker direct activation", () => {
+  const runtimeRow = contract.match(/^\| `T4-RUNTIME-1` \|.*$/m)?.[0] ?? "";
+  const workerRow = contract.match(/^\| `T4-WORKER-1` \|.*$/m)?.[0] ?? "";
+  assert.match(runtimeRow, /Worker.*writes the atomic mailbox request/);
+  assert.match(runtimeRow, /Supervisor.*swaps AnyHarness/);
+  assert.match(runtimeRow, /rolls back/);
+  assert.match(workerRow, /Worker.*writes the atomic mailbox request/);
+  assert.match(workerRow, /Supervisor.*swaps Worker/);
+  assert.match(workerRow, /rolls back/);
+  assert.doesNotMatch(`${runtimeRow}\n${workerRow}`, /Worker (?:downloads|swaps|restarts|activates)/i);
+});
+
+test("every local link in the canonical testing and migration contracts resolves", () => {
+  const unresolved = [];
+  for (const { contents, baseDir, label } of [
+    { contents: contract, baseDir: testingDir, label: "core" },
+    { contents: tier3Contract, baseDir: testingDir, label: "tier3" },
+    { contents: tier4Contract, baseDir: testingDir, label: "tier4" },
+    { contents: worldsContract, baseDir: testingDir, label: "worlds" },
+    {
+      contents: migrationContract,
+      baseDir: path.dirname(migrationContractPath),
+      label: "web-desktop migration",
+    },
+  ]) {
+    for (const match of contents.matchAll(/\]\(([^)]+)\)/g)) {
+      const target = match[1].trim();
+      if (target.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(target)) {
+        continue;
+      }
+      const relativePath = decodeURIComponent(target.split("#", 1)[0].split("?", 1)[0]);
+      if (!relativePath) {
+        continue;
+      }
+      const resolved = path.resolve(baseDir, relativePath);
+      if (!existsSync(resolved)) {
+        unresolved.push(`${label}: ${target}`);
+      }
+    }
+  }
+  assert.deepEqual(unresolved, []);
+});

--- a/specs/README.md
+++ b/specs/README.md
@@ -53,7 +53,7 @@ migration exception and state the canonical owner/rule directly.
 | Cloud provisioning, workspace creation, commands, auth, MCPs, billing, claiming | `specs/codebase/primitives/README.md`; focused primitive specs under `specs/codebase/primitives/`, including `specs/codebase/primitives/workspace-provisioning.md` for managed workspace creation read order |
 | Product workflows and surfaces | `specs/codebase/features/README.md`; focused feature specs under `specs/codebase/features/`; `specs/codebase/features/support-reporting.md` for private support capture; `specs/codebase/features/support-system.md` for the closed-loop issue, attribution, release, and changelog contract |
 | Local dev, CI/CD, deployment, env vars, debugging, analytics, QA | `specs/developing/README.md`; focused process docs under `specs/developing/local/`, `specs/developing/deploying/`, `specs/developing/debugging/`, `specs/developing/analytics/`, `specs/developing/qa/`, `specs/developing/runbooks/`, and `specs/developing/reference/` |
-| Automated testing standard + flow registry | `specs/developing/testing/README.md` (tiers, placement, gates), `specs/developing/testing/flows.md` (flows that must never break) |
+| Automated testing and release qualification | `specs/developing/testing/README.md` (tiers and placement), `specs/developing/testing/core-release-validation.md` (required guarantees and gates), `specs/developing/testing/release-worlds-and-fixtures.md` (worlds/artifacts/fixtures), and the Tier 3/Tier 4 scenario contracts in the same folder |
 | Draft planning notes | `specs/tbd/README.md`; files under `specs/tbd/` are non-authoritative until promoted. |
 
 ## Spec Rules

--- a/specs/developing/README.md
+++ b/specs/developing/README.md
@@ -23,8 +23,9 @@ the area docs under `specs/codebase/structures/**`.
     freshness expectations
 - [testing/README.md](testing/README.md)
   - automated testing standard: the four tiers, per-language placement,
-    merge-vs-release gates, contract fixtures, and the flow registry
-    ([testing/flows.md](testing/flows.md))
+    merge-vs-release gates, and contract fixtures; the complete target lives in
+    [testing/core-release-validation.md](testing/core-release-validation.md),
+    with world and journey contracts beside it
 - [qa/README.md](qa/README.md)
   - manual release QA process and per-surface verification checklist
 - [runbooks/README.md](runbooks/README.md)
@@ -44,7 +45,7 @@ the area docs under `specs/codebase/structures/**`.
 | Developing locally with profiles, Stripe, and mobile | [local/README.md](local/README.md), [local/dev-profiles.md](local/dev-profiles.md), [local/stripe-local-testing.md](local/stripe-local-testing.md), and [local/mobile.md](local/mobile.md). |
 | Debugging and support issue triage | [debugging/README.md](debugging/README.md), [debugging/support-reports.md](debugging/support-reports.md), and [debugging/performance-profiling.md](debugging/performance-profiling.md). |
 | Analytics and keeping observability fresh | [analytics/README.md](analytics/README.md) plus the Customer.io, Metabase, PostHog, Sentry, and anonymous telemetry docs in that folder. |
-| Automated testing standard and flow registry | [testing/README.md](testing/README.md) and [testing/flows.md](testing/flows.md). |
+| Automated testing and release qualification | [testing/README.md](testing/README.md), [testing/core-release-validation.md](testing/core-release-validation.md), and [testing/release-worlds-and-fixtures.md](testing/release-worlds-and-fixtures.md). |
 | QA and release verification | [qa/README.md](qa/README.md), with feature-specific acceptance criteria under [../codebase/features/](../codebase/features/) and primitive smoke expectations under [../codebase/primitives/](../codebase/primitives/). |
 
 PR title, label, release-note, and checklist rules live in

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -2,8 +2,13 @@
 
 How tests are organized across the repo: what each tier owns, where test files
 live, what gates merges vs releases, and how a change decides which tests it
-must add. `flows.md` (sibling) is the registry of end-to-end flows that must
-never break; this doc is the law those flows are enforced under.
+must add. [`core-release-validation.md`](core-release-validation.md) owns the
+complete target guarantee and qualification semantics;
+[`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md),
+[`tier-3-scenario-contract.md`](tier-3-scenario-contract.md), and
+[`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) own the live world
+and journey composition. `flows.md` is a legacy current-coverage view being
+replaced by generated manifest/collector output.
 
 Companion: `specs/developing/qa/README.md` owns *manual* release QA. This doc
 owns automated testing. A flow covered by an automated tier here does not also
@@ -16,17 +21,20 @@ need a manual QA checklist entry.
 Code is state and logic. Every test is defined by which state is real and
 where the boundary to fakes sits. Four tiers:
 
-| Tier | What is real | What is faked | Runs | Gates |
+| Tier | What is real | What is faked or absent | Runs | Gates |
 | --- | --- | --- | --- | --- |
 | **1 — Unit / contract** | Logic; Postgres/SQLite where the guarantee lives in the DB | Everything across a network | Every PR, seconds | **Merge** |
-| **2 — Mocked intent** | Server + desktop web frontend + real Postgres, booted on a port | AnyHarness, sandbox provider, LLM, IdP, email, Slack — every third party | Every PR, minutes | **Merge** |
-| **3 — Live end-to-end** | Everything: real E2B template for the version, real AnyHarness binary, real agents on cheap models | Nothing (cheap LLM + cheap sandbox tier, but real) | Release train + nightly | **Release** |
-| **4 — Upgrade path** | An N−1 install upgraded in place to N | The update feed (stub server; the artifacts it serves are real) | Release train | **Release** |
+| **2 — Mocked intent** | Server + Desktop renderer in Chromium + real Postgres, booted on ports; real Stripe test mode for billing | AnyHarness, sandbox provider, LLM, IdP, email, Slack, and every other external provider | Every PR, minutes | **Merge** |
+| **3 — Live end-to-end** | The selected world's real candidate server/runtime/provider boundaries, real agents on cheap models, and exact deploy artifacts | Boundaries outside the selected world are absent rather than simulated | Release train + nightly | **Release** |
+| **4 — Packaged install / upgrade** | Exact signed candidate packages plus retained production N−1 state upgraded through shipped mechanisms to exact candidate N | No claimed product boundary; updater/control channels are isolated while their artifacts and verification remain real | Release train | **Release** |
 
-**The gate rule (hard):** the merge gate is tiers 1–2 only. No real LLM, real
-sandbox, or real third party ever runs in the merge gate. A flaky merge gate
-poisons agent-driven merging; tier 3/4 failures block the *release* and file
-issues into the issues service — they never block a merge.
+**The gate rule (hard):** the merge gate is tiers 1–2 only. No real LLM or real
+sandbox runs in the merge gate. Stripe test mode is the one explicit
+real-network exception; trusted CI fails if its test credential or required
+billing cells are missing. Tier 3/4 failures block the *release* and file issues
+into the issues service — they never block an ordinary merge. Current-main
+fail-open exceptions are recorded, without being normalized as success, in
+[`core-release-validation.md`](core-release-validation.md#current-enforcement-exception).
 
 **Real-LLM tests assert outcomes, not transcripts.** "Run reached `completed`,
 file exists, emit validated against schema" — never "the agent said X."
@@ -71,21 +79,22 @@ Rust engine tests that need a step executor use a scripted fake implementing
 
 ## Tier 2 — mocked intent
 
-Real server + real desktop **web frontend** served on a port, seeded Postgres,
-Playwright driving a browser. **There is no fake sandbox provider and no mock
+Real server + the real Desktop renderer served on a port, seeded Postgres, and
+Playwright driving Chromium. Hosted Web joins only after product-client
+unification. **There is no fake sandbox provider and no mock
 LLM (deliberate ruling, 2026-07-07):** flows that need a sandbox or an LLM are
 tier 3 by definition; building and maintaining those two fakes costs more than
 the per-merge coverage they buy, and tier 1 already owns the logic in those
 paths. If nightly/promotion gaps in agent/workflow flows bite repeatedly, that
 evidence — not speculation — justifies building a fake then.
 
-The fakes that do exist are cheap and stable:
+The controlled dependencies are:
 
-| Dependency | Fake |
+| Dependency | Test control |
 | --- | --- |
 | SSO IdP | Mock OIDC container (asserts any identity on demand) |
 | Invite/notification email | Token capture (test-only endpoint), no send |
-| Stripe | Stripe test mode + test clocks |
+| Stripe | **Real network exception:** Stripe test mode + test clocks; required and fail-closed in trusted CI |
 | Poll feeds | Stub feed (replaying, per the poll contract) |
 
 Lives in `tests/intent/`: one stack-boot fixture (`stack/`), fakes as
@@ -104,80 +113,105 @@ state — never sandbox readiness or run completion, which are tier 3.
 
 ## Tier 3 — live end-to-end
 
-Tests the **deploy artifact, not just the code**: build (or cache-resolve) the
-E2B template for the version, run the real AnyHarness binary, drive real
-agents on cheap models through core flows — provision/pause/resume/connect,
-chat per cataloged agent × auth method, workflow services live (schedule +
-poll triggers, emit, chaining, Slack delivery), config updates applied by live
-agents, local↔cloud migration, billing metering integrity.
+Tests the **deploy artifact, not just the code** in three deliberately distinct
+worlds:
 
-- Lives in `tests/release/` as **one runner CLI with lane flags**
-  (`make release-e2e LANE=... DESKTOP=web|native AGENTS=...`). GitHub Actions
-  is one caller of it; the runner must work identically from a laptop. No
-  CI-only setup steps in workflow YAML.
-- Desktop web-port mode is the default lane; native-shell smoke is a separate
-  nightly/pre-release lane that reuses the release build's artifact in CI and
-  the local dev build locally.
-- The E2B template build is cached by content hash of its inputs (runtime
-  binary, Dockerfile, agent pins); unchanged inputs resolve to the
-  already-uploaded template.
+- local runtime deeply covers candidate AnyHarness, every supported harness,
+  managed-gateway and user-key routes, live configuration, local workspaces,
+  sessions, integrations, and managed-LLM billing;
+- managed cloud covers public candidate API, immutable candidate E2B template,
+  Worker/Supervisor enrollment, repository materialization, cloud access,
+  secrets, compute accounting, holds, and recovery; and
+- self-host covers disposable candidate installation, TLS, setup/claim,
+  invitation/login, Desktop-renderer connection, advertised capabilities, and
+  selected optional profiles.
+
+No world repeats the complete Cartesian product already proved by another.
+The exact dependency matrix lives in
+[`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md#world-dependency-matrix).
+
+- Lives in `tests/release/` as **one runner CLI with explicit world, product-host,
+  selector, and diagnostic/strict inputs**. Existing lane flags are migration
+  compatibility only. GitHub Actions is one caller of the same provisioners and
+  scenarios used from a laptop; workflow YAML supplies protected inputs and
+  shard selection, not a second setup implementation.
+- Every Tier 3 world uses Desktop's browser renderer in Chromium. Packaged or
+  native Desktop, its bundled sidecar, native filesystem/keychain ownership,
+  relaunch, clean installation, and updater behavior are Tier 4 only. Hosted
+  Web is deferred until product-client unification and later reuses selected
+  shared cloud journeys rather than the expensive Tier 3 matrix.
+- The E2B template build is cached by a complete input hash covering every
+  runtime bundle input, bootstrap/install file, pinned dependency, and build
+  argument; unchanged inputs resolve to the already-uploaded immutable
+  template.
 - Tier 3 is also the **per-agent catalog bump gate**: a candidate agent
   version bump runs that agent's smoke on staging; failure means the agent
   stays pinned to last-good and an issue is filed.
 
-### Tier-3 environment (the wired-in infrastructure)
+### Tier-3 environment
 
-The tier-3 stack is a real deployment, not a laptop assembly: sandbox-mode
-Stripe, the real LLM gateway configured with cheap models, the real API
-server, desktop (web-port lane by default), real agents in real E2B
-sandboxes. Two constraints:
+The selected Tier 3 world uses real dependencies. It does not boot E2B, EC2,
+Stripe, or hosted Web merely because another world or cell needs it. Every
+Tier 3 world serves the candidate Desktop renderer; other candidate AnyHarness,
+server, template, and self-host artifacts are built once per content identity
+and reused across compatible shards. Stable
+provider capacity such as the qualification LiteLLM deployment, Stripe test
+account, E2B team, GitHub App, and AWS network may be reused, while every
+actor, virtual key, customer, sandbox, instance, repository grant, and desired
+version remains run-scoped.
 
-- **The API server must be publicly reachable** — sandboxes call back into it
-  for integrations, gateway auth, and the worker control loop. Staging
-  satisfies this; a purely local tier-3 lane still needs a tunnel or a
-  reachable server URL.
-- Credentials the runner burns (cheap-LLM key, E2B team, test Slack
-  workspace, test provider accounts) are named in
+Two constraints apply:
+
+- **The API server must be publicly reachable when the selected world or cell
+  has a remote callback/runtime boundary.** Managed-cloud sandboxes call back
+  into it for integrations, gateway auth, and the Worker control loop. The
+  local-runtime world does not acquire a public tunnel merely because another
+  world needs one.
+- Credentials the selected cells require (cheap-LLM key, E2B team, Stripe
+  test mode, test GitHub App, test provider accounts) are named in
   `specs/developing/reference/env-vars.yaml`, never hardcoded in scenarios.
 
 ---
 
-## Tier 4 — upgrade path
+## Tier 4 — packaged install and upgrade
 
-Fresh-install testing never catches a broken updater, and a broken updater
-strands every existing user. There is no single "upgrade path" — five distinct
-mechanisms exist, and each is tested at its own seam. The general pattern:
-boot N−1 from kept artifacts with seeded N−1 data, stub the *feed* (the
-artifacts it serves are real), trigger the mechanism, assert convergence.
+Tier 4 is one qualification stage with four independently evidenced target
+cells. It uses exact shipped packages or immutable runtime artifacts and does
+not rerun the Tier 3 functional matrix:
 
-| Mechanism | Learns via | Feed knob | Testable today? |
-| --- | --- | --- | --- |
-| Worker self-update (sandbox only) | Heartbeat `desiredVersions.worker` | Server pins (`WORKER_VERSION`) + CDN base `DESKTOP_DOWNLOADS_BASE_URL` — both **server-side** env vars (the worker asks the API server, which 302-redirects to the CDN base; stub by pointing the base at a file server the sandbox can reach, e.g. via ngrok) | **Yes** — the priority scenario |
-| Agent catalog convergence (existing sandboxes + local runtimes) | Heartbeat `desiredVersions.catalogVersion` → worker pushes catalog → runtime reconcile reinstalls drifted CLIs | Server catalog version | **Yes** — full-chain test; today only per-hop units exist |
-| AnyHarness binary self-update (sandbox only) | Heartbeat `desiredVersions.anyharness` → worker downloads pinned runtime, stops/swaps/relaunches it in place | Server pin (`RUNTIME_VERSION`) + the download base the redirect resolves to — both **server-side** (same stub shape as the worker row) | Mechanism built (`specs/tbd/anyharness-self-update-v1.md`); scenario written (`tests/release/src/scenarios/upgrade/t4-cloud-1.ts`, T4-CLOUD-1). Two gaps it surfaced: the `runtime/`/`worker/` CDN trees the redirects resolve to were never published (now `scripts/ci-cd/publish-runtime-cdn.sh` + release-runtime.yml `publish-cdn`), and the binary's hardcoded `CARGO_PKG_VERSION` (0.1.0) `--version`/`/health` fails the worker's exact-match preflight/health-gate — no real pin converges (issue #1089) |
-| Desktop app (Tauri updater; bundles anyharness/worker sidecars) | 30-min poll of `latest.json` | Shipped default hardcoded in `tauri.conf.json`; **build-overridable** via a `tauri build --config` overlay (`make desktop-test-build UPDATER_URL=...`) — the shipped build is untouched | **Yes** — build an N−1 app pointed at a local feed and drive a real update. See [desktop-update-testing.md](./desktop-update-testing.md) |
-| E2B template | Build-time only; rolling `:staging`/`:production` tags affect **new** sandboxes only | `E2B_TEMPLATE_NAME` / `E2B_TEMPLATE_REF` | Yes — new-sandbox-gets-new-template + old-workspace-still-wakes |
-| SQLite/Alembic migrations | Ships inside the new binary/server | — | Yes — forward-apply on kept N−1 data |
+1. **Clean candidate Desktop N:** install the exact signed candidate package,
+   boot its bundled AnyHarness, reconcile candidate catalog/native-agent/ACP
+   pins, complete one local turn, and prove native self-host connection,
+   keychain/origin persistence, and packaged-app relaunch.
+2. `T4-DESKTOP-1`: launch the exact retained production N−1 Desktop, complete
+   a real turn, perform the signed Tauri update to the already-built candidate
+   N, relaunch against the same runtime home, reconcile installed native CLIs
+   and ACP agent processes to N's pins, preserve auth/workspace/session state,
+   and complete another turn.
+3. `T4-RUNTIME-1`: provision the exact production N−1 E2B template against the
+   candidate qualification API, complete a real turn, change only that target's
+   desired AnyHarness version to N, let Worker heartbeat write the durable
+   request, let Supervisor verify/activate/health-gate it, reconcile installed
+   native CLIs and ACP agent processes, preserve state, and complete another
+   turn.
+4. **Self-host N−1 → N:** when the bundle, server image, Compose topology,
+   migrations, or updater changed, install the retained production bundle,
+   create representative state, run the shipped update against exact candidate
+   digests, and prove health/migrations, preservation, retry, recovery, and a
+   post-update turn.
 
-The two heartbeat-driven mechanisms are the priority: they are the ones that
-run **unattended against every live customer sandbox** on every release, and
-neither has an end-to-end test today (coverage is per-hop unit tests). The
-worker scenario must include a live session on the box surviving the
-swap-and-exec.
+Other Tier 4 rows are selected by a changed artifact or persisted contract and
+reuse the smallest retained target state inside this same stage. Public
+artifact integrity remains an every-release gate.
 
-Sandbox AnyHarness in-place update is **built**
-(`specs/tbd/anyharness-self-update-v1.md`): the sandbox worker watches
-`desiredVersions.anyharness`, downloads the pinned runtime through the server
-redirect, and stops/swaps/relaunches the binary in place, health-gating and
-rolling back on failure. A new anyharness now reaches a running sandbox without
-a new template. Desktop gets a new anyharness only via the app bundle, and that
-remains bundle-only by design (the worker leaves the gate off). The supervisor
-`update/` module validates and stages artifacts handed to it but fetches and
-swaps nothing, and is deliberately not the update owner in v1. The end-to-end
-T4 scenario that asserts convergence (binary **and** agent versions, cloud and
-local consistent) is the remaining follow-up.
+The current direct-Worker activation implementation is a migration exception:
+the target owner is Supervisor. The first ownership-transition release needs a
+dedicated bridge test; thereafter only the ordinary N−1→N path remains. Exact
+artifact, controller, evidence, and current-gap details live in
+[`tier-4-scenario-contract.md`](tier-4-scenario-contract.md).
 
-Lives in `tests/release/upgrade/`, runs under the same runner CLI.
+Tier 4 lives under `tests/release/src/scenarios/upgrade/` and runs through the
+same runner and candidate/retained manifests locally and in GitHub Actions.
 
 ---
 
@@ -193,11 +227,13 @@ Lives in `tests/release/upgrade/`, runs under the same runner CLI.
    (new spec file, or extend one).
 5. Does it need a real agent, sandbox, or the deploy artifact? → Tier 3
    scenario (extend the existing smoke; do not add a new boot-the-world test).
-6. Did it touch the updater, template versioning, or migrations? → Tier 4.
+6. Did it touch packaged/native installation, the updater, template versioning,
+   or migrations? → Tier 4.
 
 **PR obligation:** a PR that adds or changes a flow adds/updates tests at the
-tier where its guarantees live, and names them in the PR description. New
-end-to-end flows also add a row to `flows.md` in the same PR.
+tier where its guarantees live, and names them in the PR description. New or
+changed guarantees update the target manifest/contract and collector metadata
+in the same PR; generated flow and execution views must remain clean.
 
 **Postmortem rule:** any bug caught at tier 3/4 or in production gets an
 answer to "which lower tier should have owned this," and that test lands with
@@ -214,7 +250,7 @@ the harness that already exists and lands in the right gate.
 ### Tier 2 — a new mocked-intent spec
 
 Tier 2 lives entirely in `tests/intent/`. It boots the **real server + real
-desktop web build** (`apps/desktop` in web-port mode) against a seeded
+Desktop renderer** (`apps/desktop` in web-port mode) against a seeded
 Postgres and drives a browser with Playwright. Everything across a network —
 sandbox provider, LLM, IdP, email, Slack — is faked or absent; a flow that
 genuinely needs a real agent or sandbox is tier 3, not tier 2.
@@ -241,10 +277,11 @@ genuinely needs a real agent or sandbox is tier 3, not tier 2.
   (Google/GitHub OAuth, live IdP) are tier 3; tier 2 asserts the *seam that
   decides* which flow fires (discovery answer, availability probe, redirect
   kicked off).
-- **Naming:** scenario ids are `T2-<AREA>-<n>` (e.g. `T2-AUTH-5`). Define the
-  scenario in `scenarios.md`, then register the flow's row in `flows.md`
-  pointing at the spec file — **in the same PR** (the PR obligation and the
-  `flows.md` completeness audit both enforce this).
+- **Naming/registration:** guarantee ids are `T2-<AREA>-<n>` (for example
+  `T2-AUTH-5`). The spec declares those ids in collected metadata; the
+  bidirectional manifest audit proves every claimed id exists and every
+  enforced cell is collected. Do not hand-edit a pointer/status row in
+  `flows.md`.
 - **Run it locally:** `pnpm -C tests/intent test` (or a single file, e.g.
   `pnpm -C tests/intent exec playwright test specs/<flow>.spec.ts`).
   `TIER2_INTENT_SKIP_RUNTIME=1` skips building the Rust runtime (nothing in
@@ -254,9 +291,10 @@ genuinely needs a real agent or sandbox is tier 3, not tier 2.
 
 ### Tier 3 — a new live scenario
 
-Tier 3 lives in `tests/release/` as **one runner CLI with lane flags**, not a
-pile of independent test files. It builds/cache-resolves the real E2B template,
-runs the real AnyHarness binary, and drives real agents on cheap models.
+Tier 3 lives in `tests/release/` as **one runner CLI**, not a pile of
+independent test files. It selects an explicit world and cell set, consumes the
+exact candidate artifact receipt, and drives the real boundaries that world
+owns.
 
 - **Extend the existing smoke; do not add a new boot-the-world test.** Tier 3
   stays O(1) per lane, not O(features) — a per-feature tier-3 test is the smell
@@ -269,49 +307,89 @@ runs the real AnyHarness binary, and drives real agents on cheap models.
 - **No credential ever lives in a scenario.** Every key the runner needs is
   inventoried in `specs/developing/reference/env-vars.yaml`; the runner
   fails fast with a named-variable error when one is missing.
-- **Run it locally** — this is a first-class path, not a CI afterthought:
-  `make release-e2e LANE=... DESKTOP=web AGENTS=...`, pointed at staging (the
-  default, same publicly reachable API the sandboxes call back into) or a local
-  stack plus tunnel. A red CI run must reproduce by copying its lane flags into
-  the local command.
-- **Naming/registration:** scenario ids are `T3-<AREA>-<n>`; define in
-  `scenarios.md` and register the `flows.md` row (tier 3) in the same PR.
+- **Run it locally** — this is a first-class path, not a CI afterthought. Select
+  the same world, allowed product host, cell set, behavior, and candidate
+  manifest as CI. Tier 3 currently means the Desktop renderer; packaged/native
+  hosts are Tier 4 only. A managed-cloud run still provisions real remote E2B
+  and a publicly reachable candidate API when invoked from a laptop; “local”
+  describes the
+  execution host, not a different product world.
+- **Naming/registration:** stable guarantee ids are `T3-<AREA>-<n>` and
+  composed journey ids are defined in the Tier 3 contract. Register both in
+  the target manifest and declare collected cell metadata on the executable
+  scenario. Generated views, not prose pointer cells, report coverage.
 
 Deciding *which* tier a change belongs in is the "Deciding where a change's
 tests go" checklist above; this section is only about mechanics once you know
 the tier.
 
+### Construction sequence
+
+Build the qualification system in dependency order:
+
+1. validate persistent LiteLLM, GitHub, E2B, Stripe, AWS, ingress, and artifact
+   capacity;
+2. implement the shared run/shard, preflight, artifact-receipt, typed-world,
+   readiness, cleanup, evidence, and diagnostic/strict spine;
+3. build and smoke exact candidate artifacts;
+4. prove one vertical slice per Tier 3 world locally and immediately reproduce
+   that same slice in GitHub Actions;
+5. fan out the remaining Tier 3 scenarios only after every world has one green
+   local and Actions slice; and
+6. complete the packaged Tier 4 target cells after the Tier 3 worlds are stable.
+
+This is construction order, not a permanent serialization requirement: once
+implemented, independent qualification jobs may run concurrently.
+
 ---
 
-## What gates what (current CI mapping)
+## What gates what
+
+### Current enforcement
 
 | Gate | Jobs |
 | --- | --- |
-| Merge (every PR) | `repo-shape`, `cargo test --workspace`, server `pytest tests/unit tests/integration`, shared-package vitest (`product-domain` + `product-ui` full suites plus the focused `product-surfaces` workflow-definition surface file `WorkflowDefinitionsSurface.test.tsx`; desktop vitest is **not** yet gated — see the migration exceptions below), and the focused fail-closed tier-2 job `Workflow definition lifecycle (tier-2)` in `ci.yml` (runs only `workflow-definitions.spec.ts`; a red result fails CI and blocks the Deploy Staging spine, and the check is eligible for a future repository required-status rule — none exists today). The broad tier-2 lanes (`intent-tests` + `intent-billing` in `.github/workflows/intent-tests.yml`) run on every PR but are **provisional/non-blocking** — a named migration exception until they earn a flake-free record |
-| Staging → production promotion | Tier 3 runner per lane + tier 4 upgrade scenario, against staging. Red blocks promotion and files an issue. **Flake-tolerant:** a green re-run unblocks; repeated red on the same scenario is a real failure, not a flake |
-| Nightly | Tier 3 lanes (incl. native-shell smoke) against whatever is on staging; failures file issues, never block merges |
+| Merge (every PR) | `repo-shape`, `cargo test --workspace`, server `pytest tests/unit tests/integration`, shared-package vitest (`product-domain` + `product-ui` full suites plus the focused `product-surfaces` workflow-definition surface file `WorkflowDefinitionsSurface.test.tsx`; desktop vitest is **not** yet gated — see the migration exceptions below), and the focused fail-closed tier-2 job `Workflow definition lifecycle (tier-2)` in `ci.yml` (runs only `workflow-definitions.spec.ts`; a red result fails CI and blocks the Deploy Staging spine, and the check is eligible for a future repository required-status rule — none exists today). The broad tier-2 lanes (`intent-tests` + `intent-billing` in `.github/workflows/intent-tests.yml`) run on every PR but are **provisional/non-blocking** — a named migration exception until they earn a flake-free record. |
+| Staging → production promotion | Existing Tier 3/Tier 4 jobs provide diagnostic signal but promotion does not yet consume strict aggregate release evidence. |
+| Nightly | Existing Tier 3 lanes run against staging and file failures without blocking merges. |
+
+### Target enforcement
+
+| Gate | Jobs |
+| --- | --- |
+| Merge queue | Tier 1 plus the complete trusted Tier 2 cell set, including real Stripe test mode; every required cell is green. |
+| Staging → production promotion | Strict Tier 3 standing cells plus selected Tier 4 target cells for the exact SHA/artifact manifest; signed aggregate evidence is required by promotion. |
+| Nightly / local diagnostic | Broad cells may report blocked/expected-fail and continue for signal, but always emit non-qualifying evidence and alert on newly blocked cells. |
+
+The precise current exception and closure order are in
+[`core-release-validation.md`](core-release-validation.md#current-enforcement-exception).
 
 ## Running tier 3/4 locally
 
-Local runs are a first-class path, not a CI afterthought — the runner is
-developed and debugged locally against staging:
+Local runs are a first-class path, not a CI afterthought. Laptop and GitHub
+Actions invocations call the same artifact loaders, preflight, world
+provisioners, readiness checks, scenarios, evidence collector, and cleanup
+reconciler:
 
-- `make release-e2e LANE=... DESKTOP=web AGENTS=...` runs from a laptop,
-  pointed either at **staging** (default for debugging what CI saw — same
-  publicly reachable API the sandboxes call back into) or at a local stack
-  plus tunnel.
-- Every key the runner needs (cheap-LLM key, E2B team, sandbox-mode Stripe,
-  test Slack workspace, test provider accounts) is inventoried in
-  `specs/developing/reference/env-vars.yaml` with where to obtain it. A missing
-  key blocks only the scenarios/lanes that require it (reported as blocked, the
-  same as an out-of-band gate) rather than failing the whole run, so a
-  partially-credentialed environment still produces signal. No scenario ever
-  embeds a credential. The CI local lane additionally self-seeds its durable
-  user per run through the real `/setup` claim, so the local-lane server-
-  mediated scenarios run without any repo secret (the durable-user env stays
-  the mechanism for the staging lane).
-- A red CI run must be reproducible by copying the run's lane flags into the
-  local command against the same staging deploy.
+- select the same world, product host, required-cell selector, result behavior,
+  and candidate manifest used by CI;
+- remote dependencies remain remote and real: a laptop-managed-cloud run still
+  uses E2B, AWS-hosted public qualification services, the qualification
+  LiteLLM deployment, Stripe test mode where selected, and the test GitHub App;
+- each key is loaded from ignored local secret storage or protected GitHub
+  environments and is inventoried in
+  `specs/developing/reference/env-vars.yaml`; no scenario embeds a credential;
+- diagnostic behavior may report only affected cells blocked and always emits
+  non-qualifying evidence; strict behavior fails preflight before provisioning
+  or spend when any selected requirement is missing; and
+- reproducing CI means using its candidate/retained manifest hashes, world,
+  selector, product host, and scenario inputs. Shared durable staging users and
+  mutable global staging version pins are diagnostic legacy mechanisms, not
+  qualification fixtures.
+
+Merge and release are selectors for different required cell sets. The runner
+itself has only diagnostic and strict result behavior; planning/dry-run cannot
+produce green qualification evidence.
 
 Migration exceptions, named per house rule: desktop vitest (443 files) is not
 yet wired into the merge gate, and the broad tier-2 intent lanes

--- a/specs/developing/testing/core-release-scenario-manifest.json
+++ b/specs/developing/testing/core-release-scenario-manifest.json
@@ -1,0 +1,1708 @@
+{
+  "schemaVersion": 5,
+  "authoritativeContract": "core-release-validation.md",
+  "note": "Complete guarantee inventory plus composed world journeys. A planned row is not executable coverage; collected or enforced rows must declare concrete collectors, collected test ids, required cells, gates, and evidence status. During foundation construction, Tier 3 standing guarantees are selected from journey references plus the explicit standalone list; every other Tier 3 guarantee is visibly deferred and prevents a full-core claim. Tier 4 is one world whose target field distinguishes four independently evidenced install/update cells.",
+  "qualificationPolicy": {
+    "tier3StandingSelection": {
+      "includeComposedJourneyReferences": true,
+      "standaloneScenarioIds": [],
+      "unreferencedDisposition": "deferred",
+      "fullCoreQualificationRequiresNoDeferred": true
+    },
+    "tier4TargetSelection": {
+      "standingTargets": [
+        "desktop-clean-install",
+        "desktop-upgrade",
+        "managed-cloud-runtime-upgrade"
+      ],
+      "changeTriggeredTargets": ["self-host-upgrade"],
+      "independentEvidenceRequired": true
+    }
+  },
+  "requiredScenarios": [
+    {
+      "id": "T2-AUTH-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTH-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTH-3",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTH-4",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTH-5",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTH-6",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-INV-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-INV-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-ORG-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-ORG-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SURF-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SURF-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-COMPOSER-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-TRANSCRIPT-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SETTINGS-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-MOBILE-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-DISPATCH-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-API-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-DELEGATE-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SUPPORT-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WS-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WS-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WS-3",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WS-4",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WS-5",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-MOBILITY-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-GHAPP-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SEC-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-INT-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-MCP-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AGENTAUTH-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-RUNTIMECFG-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-MODELREG-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-POL-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-PERM-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SESSION-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTHZ-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-CMD-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-3",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-4",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-5",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-6",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-WF-7",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTO-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-AUTO-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SLACK-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-3",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-4",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-5",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-6",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-7",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-8",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-9",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-10",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-11",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-12",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-13",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-14",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-BILL-15",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SH-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SH-2",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SH-3",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-SH-4",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-OBS-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T2-UPDATER-1",
+      "tier": 2,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTH-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTH-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTH-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SURF-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-ONBOARD-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-PROV-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-PROV-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-PROV-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-REPO-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MOBILITY-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MOBILITY-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-LIFE-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-CLAIM-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-FILES-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-FILES-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-TERM-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-DISPATCH-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-API-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-GHAPP-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MOBILE-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MOBILE-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-CHAT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTHROUTE-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AGENT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-CFG-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SESSION-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-TRANSCRIPT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-PLAN-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-POL-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-PERM-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MCP-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-CRASH-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BYOK-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AGENTAUTH-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-RUNTIMECFG-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-MODELREG-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SUBAGENT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-COWORK-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-REVIEW-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-ARTIFACT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-DELEGATE-UI-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-ARTIFACT-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WORKER-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WORKER-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WORKER-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SUP-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-ISO-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-ISO-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-CMD-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-DESKTOP-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-TEMPLATE-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SDK-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SEC-MAT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SEC-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-INT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-INT-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-INT-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-NOTIFY-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SLACK-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SUPPORT-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-4",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-5",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-6",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-7",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-8",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-9",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-10",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-BILL-11",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-4",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-5",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-6",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-7",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-8",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-9",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-WF-10",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTO-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-AUTO-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SH-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SH-2",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SH-3",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SH-4",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-SH-5",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T3-OBS-1",
+      "tier": 3,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-WORKER-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-RUNTIME-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-SUPERVISOR-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-CATALOG-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-MODELREG-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-RUNTIMECFG-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-SEED-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-DESKTOP-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-MOBILE-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-DATA-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-MOBILITY-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-DELEGATE-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-COWORKART-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-SLACK-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-SUPPORT-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-TEMPLATE-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-ROLLING-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-CONTRACT-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-DISPATCH-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-CREDENTIAL-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-GHAPP-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-BILL-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-BILL-2",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-BILL-3",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-BILL-4",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-SELFHOST-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    },
+    {
+      "id": "T4-ARTIFACT-1",
+      "tier": 4,
+      "implementation": {
+        "status": "planned"
+      }
+    }
+  ],
+  "composedJourneys": [
+    {
+      "id": "LOCAL-1",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-WT-1", "T3-REPO-1", "T3-DESKTOP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-2",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-CHAT-1", "T3-AUTHROUTE-1", "T3-AGENT-1", "T3-BILL-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-3",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-CHAT-1", "T3-AUTHROUTE-1", "T3-BYOK-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-4",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-CFG-1", "T3-MODELREG-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-5",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-AGENT-1", "T3-SESSION-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-6",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-AUTHROUTE-1", "T3-SESSION-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-7",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-INT-1", "T3-MCP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-1",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-2",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-2"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-3",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-3"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-4",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-4"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-5",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-5"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-6",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-6"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "LOCAL-BILL-7",
+      "tier": 3,
+      "world": "local-runtime",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-6"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-PROVISION-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-1", "T3-TEMPLATE-1", "T3-WORKER-1", "T3-SUP-1", "T3-ISO-2", "T3-GHAPP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-FREE-COMPUTE-GATE-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-1", "T3-BILL-7"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-PROVISION-RECOVERY-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-3"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-GITHUB-CALLBACK-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-1", "T3-GHAPP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-REPO-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-GHAPP-1", "T3-REPO-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-WARM-ACCESS-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-WAKE-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-PROV-2", "T3-SESSION-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-HOSTS-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer", "hosted-web", "cross-host"],
+      "targetScenarioRefs": ["T3-SURF-1", "T3-CHAT-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-GATEWAY-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-AUTHROUTE-1", "T3-CHAT-1", "T3-BILL-3"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-APIKEY-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-AUTHROUTE-1", "T3-CHAT-1", "T3-BYOK-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-SECRETS-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SEC-MAT-1", "T3-SEC-2"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-INTEGRATION-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-INT-1", "T3-MCP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-PRODUCT-MCP-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-MCP-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-COMPUTE-METER-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-3"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-COMPUTE-EXHAUST-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-7"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-COMPUTE-REFILL-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-BILL-8", "T3-PROV-2"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-COMPUTE-OVERAGE-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-9"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-COMPUTE-RENEW-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-4", "T3-BILL-8", "T3-PROV-2"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-BILLING-RECONCILE-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-10"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "CLOUD-BILLING-CONCURRENCY-1",
+      "tier": 3,
+      "world": "managed-cloud",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-BILL-11"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-INSTALL-CLAIM",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-SH-1", "T3-SH-4"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-DESKTOP-OWNER",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-2", "T3-SH-4"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-BASE-TURN",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-INVITEE",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-GITHUB-AUTH",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-1", "T3-AUTH-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-SWITCH-ISOLATION",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-2"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-GATEWAY",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-3"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-CLOUD-ADDON",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["desktop-renderer"],
+      "targetScenarioRefs": ["T3-SH-5"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "SH-CFN-WRAPPER",
+      "tier": 3,
+      "world": "self-host",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T3-SH-4"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "T4-DESKTOP-CLEAN-1",
+      "tier": 4,
+      "world": "tier-4",
+      "target": "desktop-clean-install",
+      "requiredHosts": ["desktop-native"],
+      "targetScenarioRefs": ["T4-DESKTOP-1", "T4-CATALOG-1", "T4-SEED-1", "T4-CREDENTIAL-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "T4-DESKTOP-1",
+      "tier": 4,
+      "world": "tier-4",
+      "target": "desktop-upgrade",
+      "requiredHosts": ["desktop-native"],
+      "targetScenarioRefs": ["T4-DESKTOP-1", "T4-CATALOG-1", "T4-SEED-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "T4-RUNTIME-1",
+      "tier": 4,
+      "world": "tier-4",
+      "target": "managed-cloud-runtime-upgrade",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T4-RUNTIME-1", "T4-CATALOG-1"],
+      "implementation": { "status": "planned" }
+    },
+    {
+      "id": "T4-SELFHOST-1",
+      "tier": 4,
+      "world": "tier-4",
+      "target": "self-host-upgrade",
+      "requiredHosts": ["host-neutral"],
+      "targetScenarioRefs": ["T4-SELFHOST-1"],
+      "implementation": { "status": "planned" }
+    }
+  ]
+}

--- a/specs/developing/testing/core-release-validation.md
+++ b/specs/developing/testing/core-release-validation.md
@@ -1,0 +1,682 @@
+# Core Release Validation Contract
+
+Status: target contract for automated Tier 2, Tier 3, and Tier 4 product
+qualification. The final section names current-main enforcement exceptions;
+none of them count as qualification.
+
+This document is the complete target manifest for deciding whether a
+Proliferate release works as intended. It owns the required guarantees and the
+meaning of a passing release. The surrounding testing documents have narrower
+roles:
+
+- [`README.md`](README.md) owns tier mechanics, placement, and test-writing
+  rules.
+- [`flows.md`](flows.md) is the current legacy flow view. Its future pointer,
+  collection, lane, and run-status columns are generated from the target
+  manifest, executable registries, and run evidence; they are not separately
+  hand-owned truth.
+- [`scenarios.md`](scenarios.md) is the current migration/finding ledger. Stable
+  journey semantics move to the tier contracts below; implementation history
+  belongs in issues and generated evidence rather than registry prose.
+- [`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md) owns
+  candidate artifacts, world topology, infrastructure lifetime, and readiness.
+- [`tier-3-scenario-contract.md`](tier-3-scenario-contract.md) owns the agreed
+  Tier 3 journey composition beneath the target IDs in this manifest.
+- [`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) owns the single
+  packaged-install/update stage, its four target cells, and the
+  retained-production artifact contract.
+- [`self-hosting.md`](self-hosting.md) owns the self-host deployment fixture,
+  current mechanism notes, and lower-tier implementation hand-off. The Tier 3
+  contract owns `SH-*` qualification actions and assertions; this contract and
+  the target manifest own stable guarantee identity and qualification state.
+- [`core-release-scenario-manifest.json`](core-release-scenario-manifest.json)
+  is the one machine-owned target inventory. It contains stable guarantee IDs
+  and composed journey children. Presence is not coverage: `planned` means
+  unqualified until a real collector, collected test id, required cells, gate,
+  and evidence mapping are audited.
+- The execution manifest is generated from actual Playwright collection and
+  the Tier 3/4 code registry. It is deliberately not recovered from the old
+  worktree because that file referenced collectors absent from current main.
+- Every run emits immutable evidence separately from both manifests. Static
+  implementation state never substitutes for an observed result.
+- [`../qa/README.md`](../qa/README.md) owns manual verification that cannot be
+  automated.
+
+When another testing document describes a smaller or provisional matrix, this
+contract wins. Product behavior remains owned by the relevant feature and
+primitive specs under `specs/codebase/**`.
+
+## Contract Vocabulary And Source Of Truth
+
+The testing system keeps five concepts separate:
+
+1. A **guarantee** is a stable product claim such as `T3-AUTHROUTE-1` or
+   `T4-RUNTIME-1`. The target manifest owns its identity, tier, implementation
+   state, and qualification disposition. Journey rows own world and host
+   composition; change-trigger predicates remain beside their guarantee until
+   the executable selector is added to the manifest.
+2. A **journey** is a composed execution such as `LOCAL-2` or
+   `CLOUD-COMPUTE-EXHAUST-1`. The Tier 3 and Tier 4 contracts own its actions,
+   assertions, and evidence. A journey can prove several guarantees.
+3. A **cell** is one required expansion of a guarantee or journey across a
+   derived dimension: host, runtime lane, harness, auth route, plan, role, or
+   changed artifact. Qualification resolves the exact cell set before running.
+4. A **collector** is executable test code. Tier 2 Playwright metadata and Tier
+   3/4 `ScenarioDefinition` registrations declare which cells they collect.
+5. **Run evidence** records what actually happened for one candidate. It binds
+   every final cell result to the merged SHA, candidate manifest, world handle,
+   artifacts, correlations, and cleanup result.
+
+No hand-maintained document owns collector pointers or current run status.
+CI discovers collectors in both directions and fails when a required manifest
+cell has no collector, a collector names an unknown cell, an implemented cell
+is not selected by its claimed gate, or duplicate collectors claim one final
+cell. `flows.md` and execution reports are generated views.
+
+Matrix collectors return explicit child-cell results. A parent scenario that
+returns successfully after swallowing a per-harness, per-route, or per-host
+skip cannot qualify the matrix.
+
+## Qualification rule
+
+A release is qualified only when all of the following are true for the exact
+merged `main` SHA and the exact artifacts being promoted:
+
+1. Every required Tier 1 check passes.
+2. Every Tier 2 row in this document passes on the merge candidate or exact
+   merged SHA.
+3. Every active standing Tier 3 row selected by the target manifest passes
+   against the deployed candidate.
+4. Every standing Tier 4 target selected for the release and every
+   change-triggered Tier 4 row passes against exact candidate packages or kept
+   N-1 artifacts and data as applicable.
+5. The qualification evidence contains no missing, skipped, blocked,
+   expected-fail, cancelled, duplicate, or failed final required result.
+   Superseded attempts remain recorded separately and never replace a product
+   assertion failure.
+
+`green` is the only passing state. Missing credentials, an unavailable
+provider, fixture exhaustion, or an infrastructure outage means the candidate
+is not qualified; it never means the product passed. Provider recovery may
+trigger a rerun of the same SHA. A product assertion failure requires triage
+and normally a new SHA.
+
+No required job, matrix cell, or assertion may be neutralized with
+`continue-on-error`, a skipped-success fallback, or exit-code normalization.
+Independent siblings may continue after one failure to collect complete
+diagnostics, and cleanup/evidence steps run unconditionally, but the aggregate
+check remains red.
+
+Tier 3 and Tier 4 do not block ordinary merges. They block production
+promotion, stable updater publication, and promotion of affected runtime,
+worker, catalog, or template artifacts.
+
+During foundation construction, the active standing Tier 3 set is the union
+of Tier 3 guarantee references from composed journeys plus any explicitly
+listed standalone standing guarantees. An unreferenced Tier 3 guarantee is
+machine-classified `deferred`, appears in every evidence summary, and does not
+silently pass. Such a run may be called **foundation qualification** for its
+named set, never full core-release qualification. Full core-release
+qualification is available only when the manifest has no deferred Tier 3
+guarantees and every Tier 3 row is green. This lets the gate ratchet from an
+honest vertical slice without weakening the end-state contract.
+
+Cell selection and result behavior are separate. A selector resolves the exact
+required cells before execution:
+
+- the merge selector resolves the trusted Tier 1/2 set for the exact
+  integration commit; and
+- the release selector resolves standing Tier 3 plus change-triggered Tier 4
+  cells for the exact candidate artifacts.
+
+The runner has two result behaviors:
+
+- `diagnostic` may report `blocked` and `expected_fail`, continues independent
+  siblings, always emits non-qualifying evidence, and alerts when the blocked
+  set grows; and
+- `strict` requires every selected required cell to be present exactly once and
+  green, with valid artifact/world identity and successful cleanup.
+
+There is no blocked budget under `strict`, regardless of selector. Optional or
+change-untriggered cells resolve to `not_required` before execution. Planning
+or dry-run emits no green evidence. During the foundation migration, a smaller
+strict baseline may ratchet upward, but its evidence is explicitly `partial`
+and must never be labeled full core-release qualification. The end state
+requires every core row in this contract.
+
+## Required proof shape
+
+Every core behavior has two proofs:
+
+1. A deterministic lower-tier proof that enumerates decisions, permissions,
+   errors, races, retries, replay, and persistence.
+2. The smallest real deployed path proving that the server, clients,
+   AnyHarness, agents, providers, and artifacts are connected correctly.
+
+Every scenario asserts observable outcomes rather than implementation steps or
+LLM prose. Where applicable, a scenario covers:
+
+- the happy path and every supported role, plan, route, harness, and lane;
+- unauthorized and alternate-entry bypass attempts;
+- duplicate, concurrent, reordered, and lost-response delivery;
+- provider failure, process crash, restart, and recovery;
+- durable state and external effects after reconnect or relaunch;
+- audit, usage, correlation, and redaction requirements;
+- cleanup and absence of duplicate money movement or tool execution;
+- the latency or propagation budget owned by the relevant feature spec.
+
+Agent, model, mode, provider, tool, and auth-route matrices are derived from
+the shipped catalogs and contracts. The same rule applies to Product MCPs,
+workflow step and trigger kinds, worker reconcile domains, billing entry
+points, and update mechanisms. A newly supported value enters the matrix
+automatically; a hand-maintained allowlist cannot silently omit it.
+
+## Gate cadence
+
+| Gate | Required work | Required behavior |
+| --- | --- | --- |
+| Pull request | Tier 1 plus every collected Tier 2 row allowed by the event's trust boundary; trusted same-repository PRs also run secret-bearing rows | Any executed required row fails closed. A secret-bearing job on a fork or Dependabot PR is explicitly skipped and non-qualifying, never reported as product evidence. |
+| Merge queue | Rerun Tier 1 and the complete Tier 2 manifest on the integration commit | Missing credentials or skipped required work fails qualification. Real-agent/E2B work remains Tier 3 and does not run conditionally inside this gate. |
+| Staging qualification | Deploy immutable artifacts for the exact merged SHA; run the complete active standing Tier 3 set and triggered Tier 4 rows | The aggregate contains exactly one final green result per required ID/lane and enumerates deferred guarantees. All attempts remain visible; duplicate final claims or effects fail qualification. A full-core label additionally requires no deferred Tier 3 rows. |
+| Production promotion | Verify trusted qualification evidence for the same SHA and artifact digests before mutating production | Missing, stale, mismatched, or non-green evidence fails closed. |
+| Nightly | Rerun Tier 3, the full Tier 4 battery, native surfaces, and the broadest supported compatibility matrix | Failures remain visibly red and create incidents. Nightly signal does not replace exact-SHA release qualification. |
+
+## Fixture contract
+
+Live qualification uses a disposable, run-scoped world rather than shared
+mutable staging state:
+
+- fresh owner, admin, member, removed member, and outsider identities;
+- separate personal and organization billing subjects for free, funded,
+  exhausted, overage, payment-failed, and cancelled states;
+- separate personal managed-LLM allocation/free-entitlement/budget states and
+  activated Core organization budget states for funded, exhausted, capped,
+  top-up-enabled, top-up-declined, and needs-review paths;
+- Stripe test customers, subscriptions, payment methods, checkout sessions,
+  and test clocks;
+- LiteLLM provider configuration and subject-scoped LiteLLM virtual keys with
+  cheap-model, token, and spend caps; administrative credentials remain private
+  to the server/provisioner;
+- fresh E2B sandboxes built from the candidate template;
+- dedicated GitHub repositories or branches and GitHub App grants;
+- run-scoped integration credentials, poll feeds, email capture, and Slack
+  destinations;
+- a disposable self-hosted installation when self-host scenarios run.
+
+Every resource carries the run correlation id, has deterministic teardown, and
+has a TTL janitor for interrupted runs. Secrets never appear in logs or
+qualification artifacts.
+
+Cheap real models are intentional. Live scenarios use bounded turns, tool
+budgets, deadlines, and the cheapest catalog-compatible model. Deterministic
+scripted agents remain the correct lower-tier tool for exact permission,
+crash, malformed-message, and replay matrices; real-agent tests prove the
+shipped integration path.
+
+### Billing invariants
+
+Every billing row proves the applicable invariants, not merely the expected
+HTTP response:
+
+- closed billable compute seconds equal credit-covered seconds plus
+  overage-attributed seconds plus explicit write-off seconds;
+- locally exported compute-overage cents equal Stripe's accepted meter
+  quantity under the declared rounding/remainder rule and never exceed the
+  configured cap;
+- for managed-LLM events, LiteLLM-recorded LLM cost equals the imported
+  event and entitlement debit after bounded reconciliation; BYOK cost may be
+  imported for attribution but never debits managed credit;
+- one paid invoice issues at most one grant; every billable second is consumed,
+  exported, or written off exactly once across any number of accounting passes;
+  and each Stripe meter-event identifier is accepted at most once;
+- personal work bills the personal subject; organization work bills the
+  organization and correct member, with no cross-subject leakage;
+- an open, failed, incomplete, or uncollected invoice grants nothing;
+- an active compute hold blocks every compute-dependent entry point;
+  managed-credit exhaustion blocks managed starts/turns and disables its
+  virtual key, but does not itself block valid BYOK or require immediate E2B
+  pause;
+- compute seconds and managed-LLM currency are separate ledgers: a mutation in
+  one cannot refill, debit, hold, or attribute the other without an explicit
+  product transition;
+- LiteLLM budgets bound runtime spend while Proliferate's imported ledger is
+  canonical; missing, zero, or unsafe cost remains `needs_review` and blocks
+  new managed launches until reconciled;
+- Stripe, Postgres, LiteLLM, E2B, billing APIs, workspace events, and every
+  supported visible billing surface agree after bounded convergence.
+
+## Tier 2 required manifest
+
+Tier 2 runs the real server, product browser surfaces, and Postgres. It stops
+at a sandbox, real-agent, or provider-execution boundary, except that Stripe
+test mode and the mock OIDC/email/poll fixtures are part of the Tier 2
+contract.
+
+Stripe test mode is an explicit real-network exception, not a fake. Trusted CI
+must provide an `sk_test_` credential and treat absence, provider failure, or a
+skipped billing cell as a red merge result. Untrusted fork events cannot access
+the credential and are visibly non-qualifying; the trusted merge-queue commit
+must execute the complete Tier 2 set. Local diagnostics may report these cells
+blocked when the developer intentionally omits Stripe.
+
+### Authentication, organizations, and surfaces
+
+| ID | Required validation |
+| --- | --- |
+| `T2-AUTH-1` | Fresh `/setup` claim, password login, logout, relogin, wrong-password rejection, and permanent second-claim rejection. |
+| `T2-AUTH-2` | Access/refresh rotation and revocation: every existing browser or token loses access immediately and cannot silently reauthenticate. |
+| `T2-AUTH-3` | Mock-OIDC discovery, start, callback, JIT membership, identity reuse, disabled JIT, disallowed domain, unknown user, tampered state, issuer mismatch, and audience mismatch. |
+| `T2-AUTH-4` | Google/GitHub availability, PKCE/state/callback error handling, button truthfulness, and uniform non-enumerating failures up to the real-provider boundary. |
+| `T2-AUTH-5` | Slug, org-id, join, and cold-login SSO entry points; unknown and unconfigured organizations return the same non-enumerating answer. |
+| `T2-AUTH-6` | Unknown email, inactive user, OAuth-only user, wrong password, normalized-email/IP throttles, trusted-proxy rules, and the password-login kill switch preserve non-enumerating responses and dummy verification. Exact-email/domain Web-beta allowlists match case-insensitively for existing users and OAuth callbacks, deny with the stable 403/redirect code, and never gate Desktop or mobile. |
+| `T2-INV-1` | Invite, fresh-browser acceptance, role assignment, resend/rotation, revoke, expiry, reuse, duplicate, and wrong-email rejection. |
+| `T2-INV-2` | Single-org register-via-invite creates the account and membership atomically; a bad token or email creates neither. |
+| `T2-ORG-1` | Every supported organization-creation path, role promotion and demotion, last-owner protection, member removal, and immediate permission refresh. |
+| `T2-ORG-2` | Owner/admin/member/removed-member/outsider visibility and mutation boundaries across organization, workspace, secret, billing, integration, and workflow APIs and UI. |
+| `T2-SURF-1` | Desktop-web, hosted Web, and mobile-web auth/navigation/settings entry points render the same server truth, preserve auth correctly, and expose no unsupported native action. |
+| `T2-SURF-2` | Onboarding and pending-shell states preserve the user's prompt/config through readiness blockers, remap projected ids to one durable workspace/session, and never duplicate or lose intent on failure, retry, or abort. |
+
+### Product clients, chat, delegated work, and support
+
+| ID | Required validation |
+| --- | --- |
+| `T2-COMPOSER-1` | Prompt, approval, user-input, MCP form, runtime/delegated context, model/mode switch, plan/todo, and parent-with-background-work states obey ordering and availability rules. Proposed plans remain durable transcript cards; plan-reference attach/handoff preserves the trusted snapshot hash and never leaks content to telemetry. |
+| `T2-TRANSCRIPT-1` | Controlled SSE/history covers batch flush, detach/reconnect, gap-free replay, optimistic/waiting reconciliation, bounded older-history paging, virtualization, scroll anchoring, repinning, streaming handoff, tool/delegated receipts, file/provider links, code blocks, unknown tools, and malformed fallbacks without missing or duplicate rows. |
+| `T2-SETTINGS-1` | User/Org/Repo/Agents scopes, section order, renamed-route redirects, focus deep links, Web filtering, and Integrations/Workflows/Plugins placement are exact. Member-hidden/direct admin routes and server mutations deny consistently; owner/admin routes work; status vocabulary and telemetry section ids match the contract. |
+| `T2-MOBILE-1` | Mobile-web intent covers auth/readiness, repo/owner/model selection, final-looking pending shell, ordered materialize/start/send, zero/new/existing session sends, claim, config accept/rollback, navigation/deep links, Automations/Settings queries, and auth/network failure without losing input or duplicating a command. |
+| `T2-DISPATCH-1` | Continue remotely creates or reuses one cloud workspace and private exposure; disable removes Web/mobile visibility without a passive wake. Open-in-Web/mobile/Desktop, QR/copy, signed-out handoff, source/exposure indicators, scoped direct attach, and deep links enforce the same access decision. |
+| `T2-API-1` | Personal and admin-gated organization Cowork API keys show the raw value once, persist only an HMAC/prefix, expire/revoke, and deny cross-organization use. Programmatic create/send/poll with auto-cascade converges runtime-config then agent-auth once, caps retry, and reports typed failure without duplicate work. |
+| `T2-DELEGATE-1` | Subagent, Cowork, plan-review, and code-review items share canonical identity/status ordering across tabs, popovers, sidebar, transcript, and details. Parent provenance, wake receipts, raw-id hiding, contiguous hierarchy, close/delete confirmation, and parent-composer availability remain correct. |
+| `T2-SUPPORT-1` | With controlled S3 and tracker providers, native-window/modal job shapes, diagnostics scope, attachments, urgent/notify/credit/log flags, outreach email, immediate-close queueing, immutable idempotent creation, safe target reissue, exact completion manifest, unauthorized workspace handling, no-wake collection, and full content/secret sanitization hold. |
+
+### Workspaces, configuration, secrets, and integrations
+
+| ID | Required validation |
+| --- | --- |
+| `T2-WS-1` | Cloud workspace happy request reaches `pending` or `materializing` and the projected UI shell; missing repo configuration, billing block, duplicate request, and lost response create no duplicate workspace. |
+| `T2-WS-2` | Local, linked-local, worktree, and cloud Add-Repo branches validate inputs and native/web capability boundaries truthfully. |
+| `T2-WS-3` | Repository environment CRUD, default branch, action/setup scripts, environment variables, protected-name validation, and authorization round-trip to the launch seam. |
+| `T2-WS-4` | Pending workspace/session projection hands off once to durable ids; passive reads never wake a paused sandbox; archived or superseded targets reject late results. |
+| `T2-WS-5` | Shared-unclaimed claim is atomic and one-way; non-claimers lose interaction while admins retain audit-only visibility; queued pre-claim work may finish, later unauthorized work is denied, and only Desktop may request direct-attach credentials. |
+| `T2-MOBILITY-1` | Every supported move direction, claimer/admin eligibility, destination and direct-attach preflight, exposure intent, atomic canonical-side cutover, per-item cleanup, retry caps, cleanup failure, repair, and resume preserve one durable workspace/session identity and never roll back after cutover. |
+| `T2-GHAPP-1` | GitHub product identity and GitHub App repository authority stay separate. User authorization, installation, selected-repo and human-access coverage, invalid webhook signature, replay/reordered install/repository events, suspend/delete/remove, missed-webhook live fallback, and authorize/install/grant/reconnect states fail closed; no raw lease, refresh token, or App secret reaches a product client. |
+| `T2-SEC-1` | Personal, organization, workspace env-var, and file secret create/update/delete; values never echo, versions advance, binary/invalid uploads fail, member writes are denied, and materialization enters pending exactly once. |
+| `T2-INT-1` | API-key and OAuth kickoff seams; connect, rotate, enable/disable, organization policy composition, health, disconnect, write-only credentials, and unauthorized administration. |
+| `T2-MCP-1` | MCP/skill/plugin CRUD, ownership, organization publication, write-only auth/OAuth reconnect state, and unauthorized access are exact; mutations emit the owning runtime-config refresh intent rather than constructing a launch bundle directly. |
+| `T2-AGENTAUTH-1` | Personal/organization credential CRUD, sharing, slot selection, capability flags, resync, target replacement, grant-rotation intent, revoke-cleanup plan, and restart revisioning are exact at browser/server seams. Missing/expired/stale selections fail typed; compiled protected-env and cleanup paths are allowlisted before command persistence and captured plans contain no secret echo. |
+| `T2-RUNTIMECFG-1` | Resolver/compiler intent covers plugin expansion, dependencies, publicization, deterministic duplicate renaming, manifest redaction/content-hash idempotency, OAuth reconnect blockers, desired/applied drift, seeded resolution responses, disable/removal, revisioning, and stale-launch preflight, with no legacy plugin-bundle/MCP launch path. |
+| `T2-MODELREG-1` | Bundled catalog, trusted registry snapshot, cloud projection, and seeded ACP projection remain distinct truths. Alias canonicalization, opt-in/visibility overrides, last-visible protection, stale saved intent, explicit fallback, target/workspace scope, refresh errors, and shared chat/Automation/Slack defaults never silently substitute a model. |
+
+### Agent policy, permissions, and session-control seams
+
+| ID | Required validation |
+| --- | --- |
+| `T2-POL-1` | Organization agent-policy UI/API CRUD, plan and role gates, route/harness allowlists, stale-violation reporting, compliant selection, denied selection, remediation, and personal-scope isolation. |
+| `T2-PERM-1` | Seeded permission interactions render the exact options and context; allow/deny submission is scoped to the session/request, duplicate or stale resolution is rejected, and cancel/close removes pending UI. |
+| `T2-SESSION-1` | Create, prompt, queued-prompt edit/delete, config update, cancel, dismiss/restore, close, fork, title, goal, loop, and workflow-held mutation boundaries reach the correct runtime seam and preserve idempotency keys. |
+| `T2-AUTHZ-1` | Every registered AnyHarness and cloud route declares method/scope authorization; expired, revoked, wrong-issuer, wrong-audience, wrong-target, cross-workspace, and cross-session tokens fail closed. Forged advisory origin, prompt provenance, attachment source, MCP summary, or public `workflow_internal` fields never grant authority. |
+| `T2-CMD-1` | Every registered cloud-command kind declares wake, runtime-config, agent-auth, exposure, ordering, and idempotency behavior. Lease/redelivery, lost result, archived-target supersession, concurrent wake, wake denial/failure/timeout, passive no-wake reads, inactive projection, and mismatched results converge to one typed state. |
+
+### Workflows and automations
+
+| ID | Required validation |
+| --- | --- |
+| `T2-WF-1` | UI definition creation/edit, immutable versions, live reference validation, input coercion/interpolation, manual launch, and local/cloud delivery intent. |
+| `T2-WF-2` | Poll item deduplication, invalid item reporting, cursor advancement only after scheduling, replay safety, dead endpoint behavior, and enabled-state truth. |
+| `T2-WF-3` | Function invocation CRUD, args schema, reserved namespace, write-only headers, rotation, and endpoint validation. |
+| `T2-WF-4` | Chat/workflow default-access authoring composes to the frozen provider/tool scope carried by a run. |
+| `T2-WF-5` | Session binding, wrong workspace/harness, all-mutation lockout, acknowledged takeover, cancellation, quiescence, and ownership release. |
+| `T2-WF-6` | Both `/init` flows, signature derivation/diff, SSRF validation, first-call failure, and saved-definition truth. |
+| `T2-WF-7` | Schedule/poll CRUD, every missed-run policy, disabled-trigger behavior, concurrent tick claiming, queue ordering, and crash-safe outbox/retry seams. |
+| `T2-AUTO-1` | Personal/team automation CRUD, ownership/admin gates, target mode, immutable run-config snapshot, pause/enable/delete, manual trigger, and exposure intent. |
+| `T2-AUTO-2` | Scheduled occurrence deduplication and the runtime-config/agent-auth preflight cascade enqueue each convergence command once, read back applied revisions, retry within policy, and fail with a typed terminal error. |
+| `T2-SLACK-1` | Slack Bot OAuth state, one active connection, admin configuration, fixed/auto repo routing, allowed channels, inherited run config, and write-only token storage are exact. Signature/timestamp/challenge, event/thread dedupe, sub-three-second ack, follow-up reuse, ambiguity with zero workspace, config/auth cascade, outbound idempotency, rate limiting, retry, and reauth all hold. |
+
+### Billing
+
+Billing Tier 2 uses Stripe test mode and test clocks. A missing Stripe test
+credential fails the required check.
+
+| ID | Required validation |
+| --- | --- |
+| `T2-BILL-1` | Checkout to subscription/grant, ordered consumption, cutoff, LLM and compute top-up/reactivation, Core subscription/payment recovery, duplicate checkout, and lost-response idempotency. Unsupported top-up attempts fail with the declared typed error and grant nothing. |
+| `T2-BILL-2` | A GitHub-deduplicated free personal identity receives one lifetime `$2` managed-LLM grant. Core costs `$20` per active billed seat per month and contributes `$5` managed-LLM plus `$15`-equivalent compute allocation per seat to separate shared organization pools. Cancellation retains period entitlement through `current_period_end`, then downgrades. |
+| `T2-BILL-3` | Seat invite/accept/remove/reinvite, exact Stripe quantity, prorated grant once, no refund/double grant, retry exhaustion, and later convergence. |
+| `T2-BILL-4` | Core checkout pending organization, successful activation only after verified payment, staged invites, failed billing state, 24-hour expiry, replay, and absence of orphan active organizations. |
+| `T2-BILL-5` | Compute overage seconds-to-cents conversion, remainder carry, Stripe export idempotency, per-seat cap, writeoff after cap, and immediate cutoff when disabled. |
+| `T2-BILL-6` | Managed-LLM exhaustion disables the scoped LiteLLM virtual key and blocks managed turns without pausing compute; a valid user API key remains usable. Explicit LLM auto-top-up is independent from compute overage/top-up: successful payment grants and reactivates once, while disabled or declined top-up charges/grants nothing and stays blocked. |
+| `T2-BILL-7` | Stripe webhook signature, exact replay, concurrent duplicate, handler crash/reclaim, out-of-order convergence, and one notification per real transition. |
+| `T2-BILL-8` | Payment-failed hold/recovery, period-end and immediate cancellation, clean deletion versus dunning, rollover grace, and off/observe/enforce behavior. `invoice.upcoming` and `trial_will_end` each emit one informational decision/patch and never hold or block. |
+| `T2-BILL-9` | A free personal actor has `$2` lifetime managed-LLM credit and zero compute: sandbox create/ensure remains gated and makes no provider call. Concurrent/replayed authorization may converge on one logical sandbox row but cannot create E2B; successful Core activation unlocks exactly one provider sandbox for the same actor. |
+| `T2-BILL-10` | Stripe test-clock renewal, invoice generation, new-period grants, seat renewal, dunning, payment recovery, cancellation, and carry/expiry behavior across period boundaries. |
+| `T2-BILL-11` | Reconciler startup, singleton/advisory lock, concurrent workers, crash after claim/export/charge, restart, shutdown, and exactly-once convergence. |
+| `T2-BILL-12` | Usage summary, timeseries, per-user attribution, LLM balance, billing settings, portal/refill actions, blocked-state copy, and audit values match seeded ledger truth. Workspace billing envelopes and `billing_patch` SSE update every matching workspace and no unrelated workspace, including warning, hold/block reason, remaining seconds, cap, and used cents. |
+| `T2-BILL-13` | Every create/ensure/resume/connect/wake/command/workflow/automation and managed-credit start/turn seam covers allowed, compute-exhausted, cap-exhausted, payment-held, organization-capped, and user-capped subjects. Compute gates the sandbox; managed-credit exhaustion gates managed starts without requiring an immediate sandbox pause; compute holds also block managed turns; BYOK still obeys the compute gate. Denial precedes downstream delivery and records one typed decision. |
+| `T2-BILL-14` | Personal onboarding creates the `$2` `agent_gateway_free_credits` allocation once, guarded by GitHub provider id across concurrent/cross-account attempts; missing identity gets no allocation. Activated Core creates an organization budget subject, not another personal free entitlement. Budget, provider configuration, and subject-scoped LiteLLM virtual key are idempotent with explicit allowed models and no raw administrative credential. Mocked LiteLLM no-key/unlisted-provider/model/key, admin outage, missing returned secret, and auth-apply failure leave no incomplete plan, block launch, expose typed pending/failed state, and recover idempotently; lifecycle changes disable old keys and audit. |
+| `T2-BILL-15` | LiteLLM usage import uses overlap-window pagination, resumes its cursor, deduplicates spend logs, resolves payer/materialization, and debits managed credit once. Unknown cost becomes `needs_review` and fails closed; crashes around event/cursor writes and remote-disable failure converge. Concurrent keys enforce the configured shared budget; any permitted in-flight allowance must be defined by the owning primitive and recorded in evidence before this row can pass. |
+
+### Self-hosted and degraded configuration
+
+| ID | Required validation |
+| --- | --- |
+| `T2-SH-1` | Single-org claim/owner semantics, invite registration, adaptive password/GitHub/SSO entry, and permanently closed setup. |
+| `T2-SH-2` | Live `/meta` capability/version/deployment/support contract for base, add-on, and hosted postures. |
+| `T2-SH-3` | Missing or partial E2B, gateway, SSO, support, and billing configuration never crash-loops the control plane and returns actionable, secret-safe errors. |
+| `T2-SH-4` | Gateway-only model eligibility rejects native ids and accepts cataloged gateway ids through a real local runtime HTTP seam without an LLM call. |
+| `T2-OBS-1` | Telemetry routing is exact for local development, self-managed, and hosted-product postures. Vendor capture is hosted-only, anonymous telemetry honors opt-out and typed low-cardinality schemas, exceptions emit once, replay defaults off, and prompts/files/paths/repos/settings/credentials stay masked or blocked. |
+| `T2-UPDATER-1` | Desktop and Supervisor component-updater decision matrices reject equal/downgrade versions, bad signatures/checksums, unsafe component/path/size/archive input, partial downloads, interrupted staging, and unhealthy activation. Atomic swap, last-good rollback, retry, and cleanup leave exactly one trusted active version; no failed candidate is reported healthy. |
+
+## Tier 3 required manifest
+
+Tier 3 tests the deployed candidate with real AnyHarness binaries, real E2B,
+real provider handshakes where supported, Stripe test mode, and cheap real
+models. Its three standing worlds use the Desktop product renderer in Chromium:
+local runtime, managed cloud/E2B, and self-hosted. Packaged/native Desktop,
+bundled-sidecar lifecycle, keychain/config persistence, clean installation, and
+relaunch belong to Tier 4. Hosted Web joins selected parity journeys after the
+Web/Desktop unification. Before a target row can become `implemented` or
+`blocking`, the machine manifest must assign its concrete lane. A `planned` row
+has no execution claim. No mapped row silently inherits a local or cloud lane,
+and matrices enumerate only routes valid for that target.
+
+### Identity, surfaces, and workspace lifecycle
+
+| ID | Required validation |
+| --- | --- |
+| `T3-AUTH-1` | Real hosted Google and GitHub sign-in, PKCE/state/callback, account linking, logout/revocation, and provider denial against deployed TLS/DNS. |
+| `T3-AUTH-2` | Deployed OIDC SSO and invitation/email delivery round-trip with JIT, existing-user reuse, role assignment, and negative identities. |
+| `T3-AUTH-3` | Native iOS/Android Apple sign-in plus mobile password/provider session path covers callback/deep link, account-link collision, SecureStore refresh after kill/reopen, provider revocation, logout/cache clearing, and GitHub-readiness transition against deployed TLS. |
+| `T3-SURF-1` | Desktop product renderer, hosted Web after unification, mobile Web, and native mobile can sign in, open the same cloud workspace, send a bounded prompt, observe completion, and reload history. Desktop/Web render billing management; mobile renders the supported plan summary and policy/account state without inventing unsupported checkout/portal controls. Packaged Desktop host integration is Tier 4. |
+| `T3-ONBOARD-1` | Fresh Desktop, Web, iOS, and Android users traverse identity, provider, run, and workspace readiness to first useful work. GitHub, billing, managed-credit/BYOK, agent-auth, and target blockers preserve the prompt and resume; pending ids reconcile once; analytics contain only stable blocker codes. |
+| `T3-PROV-1` | A paid Core actor starts with no authorization or sandbox, captures real actor-bound signed GitHub state, and completes the shared production authorization tail under concurrent replay. Exactly one active DB sandbox and one actor-bound, running E2B sandbox use the immutable candidate template receipt; one current Worker, Supervisor-owned AnyHarness, and live agents report exact candidate identities. Actor B cannot list, proxy, address, or directly authenticate to actor A's target. A free actor may create only the logical row and compute gate until Core activates; cancelled or invalid authorization provisions nothing. |
+| `T3-PROV-2` | Existing workspace pause makes it inaccessible; wake/reconnect restores commandability, files, session history, secrets, and billing attribution within budget. |
+| `T3-PROV-3` | Failure after provider create, worker enrollment, runtime launch, repo clone, materialization, or session start is adopted or cleaned on retry; stale results are inert and no sandbox/workspace/session/prompt is duplicated. |
+| `T3-WT-1` | Local and sandbox worktrees use the correct base branch, isolate edits, run a session, and clean up without modifying the base tree. |
+| `T3-REPO-1` | Default branch, setup/action scripts, environment variables, and protected configuration take effect in fresh local and sandbox workspaces. |
+| `T3-MOBILITY-1` | Local-to-cloud and cloud-to-local migration preserve files, git state, sessions, secrets references, and ownership. Retry or pre-cutover rollback never duplicates or loses a workspace; after cutover, destination remains canonical and recovery proceeds only through cleanup/repair. |
+| `T3-MOBILITY-2` | Shared-to-personal, shared-to-local, personal-to-shared, and cloud-to-cloud moves preserve files, dirty state, sessions/transcript, stable cloud identity, ownership, and exposure. Cutover happens once; stale source reports are fenced; cleanup retries per item; executor loss after cutover enters repair without reverting or orphaning rows. |
+| `T3-LIFE-1` | Archive, restore, retire, purge, and orphan cleanup preserve visibility/access rules, reject late commands/results, and never wake on passive reads. |
+| `T3-CLAIM-1` | Claim/direct-attach scopes a shared workspace to the claimer, denies forced non-claimer/admin interaction, supports concurrent direct/cloud prompts without duplication, rotates/revokes tokens, and never exposes a direct token to Web or mobile. |
+| `T3-FILES-1` | Browse/search/open/edit/save, stale-version conflicts, binary/large-file safety, Changes/stage/undo/branch views, and terminal stream/replay/resize/close match real filesystem and git state in local and sandbox workspaces. |
+| `T3-FILES-2` | In the Desktop renderer, every Viewer/Scratch/Changes entry opens the canonical target; legacy tabs normalize; render/edit and split/unified state persist across workspace switch and page reload. Scratch is the default tool without forcing the panel open and never enters the repository. Staged/unstaged and Last-turn filters stay truthful; unsafe/stale/conflicted/partial undo changes nothing. Native Tauri persistence/relaunch belongs to Tier 4. |
+| `T3-TERM-1` | First terminal uses the renderer's measured grid and shows a clean prompt on row one; reopen/history replay, font-driven resize, hidden-pane fallback grid, stream reconnect, resize, and close remain usable without wrap artifacts or duplicate output. |
+| `T3-DISPATCH-1` | The Desktop renderer plus separate candidate local runtime exposes a local workspace through Continue remotely; Web/mobile see it and send one prompt to the local target. Host-adapter deep-link intent and claimed Desktop open work; disabling access stops tailing, removes remote visibility, and rejects later commands without affecting local work. Packaged deep-link handling belongs to Tier 4. |
+| `T3-API-1` | Real personal and organization Cowork API keys create work, auto-converge stale config/auth, start a session, send a cheap-model prompt, and poll terminal state. Expired/revoked/cross-org and unauthorized org keys create no work; lost response/retry creates one workspace/session/prompt. |
+| `T3-GHAPP-1` | A real GitHub App authorization and selected-repository installation lets the Worker mint a short-lived user-to-server lease; clone/fetch/commit/push-dry-run works through the helper. Rotation precedes expiry; repo removal, installation suspend/delete, user-access loss, or revocation blocks later Git with no OAuth fallback/leak. During transient refresh failure the current lease works only to expiry, then Git fails closed; provider recovery rotates without reusing/exposing the old token. |
+| `T3-MOBILE-1` | iOS and Android cover fresh auth/link, cloud create and final-looking pending shell, first response, session create/switch/send, blocker recovery, claim/send, config accept/reject, projection fallback, background/network recovery, universal link, Automations, Settings, keyboard/safe area, and relaunch continuity. |
+| `T3-MOBILE-2` | On iOS and Android, real Automations list/create/pause/resume/delete and run-to-workspace/session navigation work. Settings shows account/GitHub, organizations/owner scope, supported plan summary, repo/profile defaults, agent readiness, build/support/legal state, and sign-out; auth expiry, refresh, Android Back, keyboard/safe area, and claim failure recover. |
+
+### Agents, sessions, policy, permissions, and MCP
+
+| ID | Required validation |
+| --- | --- |
+| `T3-CHAT-1` | In the Desktop-local runtime world, every probed, registry-supported, target-compatible harness installs its trusted pin, selects the cheapest eligible real model, completes a bounded turn, and reopens history. Managed cloud and self-host use one representative compatible harness to prove their distinct wiring rather than repeating the harness Cartesian product. Cataloged-but-incompatible entries return truthful typed unsupported/readiness state; every resolved matrix cell is independently required. |
+| `T3-AUTHROUTE-1` | In the Desktop-local runtime world, every harness completes one managed-LiteLLM and one user-API-key bounded turn. Managed cloud repeats each route with one representative harness to prove Worker/runtime materialization; self-host proves only routes its deployed posture advertises. Invalid, revoked, or lane-incompatible routes fail closed in deterministic lower tiers. Route choice is frozen per agent process: a setting change affects a new session or explicit process restart, never an existing process in place. |
+| `T3-AGENT-1` | Install a missing harness, reinstall/update it from its trusted pin, and switch harnesses inside one workspace without leaking config/credentials; existing sessions remain attached to their original harness. |
+| `T3-CFG-1` | Create-time model/mode/defaults derive from the bundled catalog. In an existing session, mutate only controls and values advertised by live ACP, read back exactly, apply on the next turn, and survive reconnect; stale/unknown values fail without mutating state. |
+| `T3-SESSION-1` | Queued prompts, config-while-busy, cancel, fork, dismiss/restore, runtime restart, worker restart, and sandbox pause/resume preserve exact event ordering and execute effects at most once. |
+| `T3-TRANSCRIPT-1` | Scripted high-volume plus real-agent transcript across Desktop/Web/mobile survives disconnect during batch, background/reopen, older-history paging, and turn completion with every sequence once. Scroll anchor/pinning and streaming-status-to-prose handoff remain stable in virtualized and normal rows. |
+| `T3-PLAN-1` | Real agents emit structured todo and proposed-plan events. Plans persist through reload; approve, reject, implement-here, trusted-snapshot attach, and handoff perform exactly their contract without mutating source decision state, leaking content, or duplicating a plan. |
+| `T3-POL-1` | Admin narrows route/harness policy; UI and materialization update; new selection, stale selection, on-disk key, existing session, new session, second member, and workflow trigger cannot bypass; widening restores access. |
+| `T3-PERM-1` | Every production harness's permission adapter performs a bounded file/shell action: allow-once executes exactly once, deny executes zero times, and allow-always persists only in intended scope. Read-only/plan cannot write; supported bypass completes unattended; unsupported modes fail preflight. Malformed/duplicate/wrong-session resolution and crash/reconnect settle once. |
+| `T3-MCP-1` | Each product MCP server and required third-party MCP completes one real read and permitted mutation; capability tokens enforce workspace/session/read-only/expiry/revocation/frozen-target boundaries. |
+| `T3-CRASH-1` | Scripted and real-agent process kills at prompt, tool, permission, persistence, and terminal-event boundaries recover without missing/duplicated events or external effects. |
+| `T3-BYOK-1` | Personal/organization user API keys materialize only into the explicitly permitted runtime target and bypass managed LiteLLM spend. Unlisted provider/model/key makes zero provider data-plane calls; private/metadata destinations receive zero bytes; unsafe redirects never reach forbidden targets; wrong Bedrock ExternalId performs one denied STS exchange and zero inference. Lifecycle changes remove old materializations and repair orphans. |
+| `T3-AGENTAUTH-1` | Synced-file auth revoke, share revoke, profile disable, and selection replacement apply allowlisted cleanup paths, report `applied_cleanup_paths`, and force-restart/fence old sessions where required. Near-expiry grants rotate with bounded overlap; target replacement rematerializes; failed cleanup/apply remains unapplied and blocks launch without deleting unallowlisted paths. |
+| `T3-RUNTIMECFG-1` | In cloud, install a plugin with MCP/skill children: Server compiles, Worker fetches hash-pinned artifacts/materializes credentials, AnyHarness resolves, and a real agent uses both. In Desktop-local, the same compiled intent applies directly to AnyHarness without a Worker. Restart re-resolves safely; disable/revoke removes capability before launch; no legacy bundle bypass exists. |
+| `T3-MODELREG-1` | Dynamic discovery refreshes locally and Cloud-to-Worker-to-runtime; Web/mobile/Slack see the same scoped list. Alias resolves to the exact live id, stale online refreshes, stale offline fails explicitly, workspace-scoped models do not leak, and harness update invalidates the snapshot. |
+| `T3-SUBAGENT-1` | Subagents MCP covers catalog launch options, create with prompt/config, busy-child queued send, atomic wake-on-completion, one parent wake, status/list/latest-turn/search, close, and descendant cascade. Token/handle isolation, completion race, restart, lost response, and replay produce no duplicate child/prompt/wake. |
+| `T3-COWORK-1` | Cowork creates a managed workspace and multiple scoped agents, sends/reads/wakes/closes, opens the correct child UI, and preserves parent relationship. Limits, wrong scope, nested-cowork denial, restart, and lost response create no duplicate. Closing hides the relationship and ends active delegated work but never deletes the managed directory, durable history, or transcript. |
+| `T3-REVIEW-1` | Plan/code review sessions expose only reviewer authority and finish only through one submitted result; multiple results aggregate into durable artifacts once. Parent feedback/revision/finish, retryable reviewer failure, stale result, active delete, reload, and parent revision preserve run identity and a commandable parent. |
+| `T3-ARTIFACT-1` | Markdown, HTML, SVG, JSX, and TSX artifact create/list/get/update/delete preserve stable ids, safe paths, types, sorted manifest, renderer, protection, and one turn-end commit. Read-only/wrong-scope tokens, unsupported paths/types, traversal, duplicates, and commit failure leave zero partial mutation. |
+| `T3-DELEGATE-UI-1` | In the Desktop product renderer, live subagent, Cowork, plan-review, and code-review work agrees across tabs, Agents popover, sidebar, transcript receipts, and details. Canonical identity/status, contiguous hierarchy, breadcrumb, attention filtering, close-tab versus end-work confirmation, page reload, and transcript retention hold. |
+| `T3-ARTIFACT-2` | Thread open, turn end, and manual refresh fetch the normalized artifact manifest; HTTP detail selects the correct renderer for every type, unknown id returns 404, and missing/invalid backing file returns 409. Clients never parse or mutate the manifest themselves. |
+
+### Worker, supervisor, isolation, and packaged runtime
+
+| ID | Required validation |
+| --- | --- |
+| `T3-WORKER-1` | Enrollment, inventory, control polling, runtime-config/agent-auth/exposure/revocation reconcile domains, content-hash readback, heartbeat, and lost-doorbell recovery converge exactly once without owning command delivery or event-tail semantics. |
+| `T3-WORKER-2` | Atomic private materialization rejects root escape, traversal, symlink/special-file and unsafe-archive attacks; a kill mid-write leaves a complete old or new state and no token enters git URLs, inventory, events, or logs. |
+| `T3-WORKER-3` | Repeated failure in one reconcile domain backs off without hot-looping; siblings and unrelated commands continue, dependent commands fail fast, applied state advances only after runtime readback, and a new revision/provider recovery resumes without duplicate apply. |
+| `T3-SUP-1` | Supervisor stays alive through child failure: Worker exit restarts Worker only; AnyHarness exit kills/waits Worker and restarts both in dependency order. Identity, revisions, cursors, pending results, workspace, and session recover without duplicate work; a second Worker process is rejected by the process lock. |
+| `T3-ISO-1` | Adversarial agent shell cannot read/write runtime home, SQLite, credential vault, private callbacks/sockets, leases, checkpoints, control-process environment/memory, or signal/ptrace control processes; unsupported isolation fails preflight. |
+| `T3-ISO-2` | One tenant's sandbox cannot access another tenant's filesystem/materialization or target auth. In unattended workflow/bypass isolation, repo config cannot override protected provider/base-url/key settings and control listeners/cloud metadata are reachable only through authenticated brokered channels; unsupported isolation fails preflight. |
+| `T3-CMD-1` | Against a paused sandbox, wake-required commands persist before one wake and the full workspace/session family leases/delivers in order once. Worker/Cloud loss after local acceptance uploads one saved result; archived reports are inert. Exposure tailing owns inactive-drop and contiguous cursor/gap/backfill repair before live tail resumes. |
+| `T3-DESKTOP-1` | The Desktop product renderer connects through its host-adapter boundary to the candidate local runtime, resolves a prepared repository through real AnyHarness, creates a workspace/session, completes a bounded turn, and preserves renderer-visible state across ordinary page reload. Packaged installation, bundled-sidecar lifecycle, native persistence, and app relaunch belong to Tier 4. |
+| `T3-TEMPLATE-1` | The exact immutable candidate template reports expected runtime/worker/supervisor versions and checksums, contains catalog pins, enrolls successfully, and completes one throwaway real session before a rolling tag moves. |
+| `T3-SDK-1` | Published `@anyharness/sdk` dynamically covers every curated public resource group—including runtime, agents/readiness/install, workspace/session, file/git/terminal, processes, hosting, and pull requests—plus SSE reconnect and typed errors; transcript reduction is replay-stable. `@anyharness/sdk-react` invalidation and forward-field tolerance need no app fallback. |
+
+### Secrets, integrations, and notifications
+
+| ID | Required validation |
+| --- | --- |
+| `T3-SEC-MAT-1` | Personal/organization/workspace environment secrets and supported personal/workspace text-file secrets materialize to correct scopes; update/delete propagates within budget; manifests match; another user/workspace cannot read them. Binary secret-file upload remains rejected. |
+| `T3-SEC-2` | Rotate/delete while paused and while a session is live; only the new value reaches future permitted work, old processes cannot retain it, failed apply remains blocked/retryable, and no transcript, support artifact, telemetry, log, or crash output contains plaintext. |
+| `T3-INT-1` | Every harness in the Desktop-local runtime world calls one real API-key integration through Product MCP. Managed cloud repeats the positive call with one representative harness to prove cloud materialization without duplicating the Cartesian product. Audit records exact provider/tool/outcome; deterministic lower tiers own disable/revoke and zero-upstream-call failure matrices. |
+| `T3-INT-2` | OAuth/hosted-MCP integration authorization, refresh, expiry, revocation, reconnect, and organization policy work through a real provider test account. |
+| `T3-INT-3` | Provider timeout, 429, 401/reauth, malformed response, partial failure, credential rotation, worker re-enrollment, and provider recovery produce typed errors, isolate sibling calls, invalidate caches, and retry at most once externally. |
+| `T3-NOTIFY-1` | A real email and Slack notification is delivered once with the correct sanitized content; retry, replay, and post-acceptance crash create no duplicate. |
+| `T3-SLACK-1` | Real Slack OAuth/config, signed mention, sub-three-second ack, one shared-unclaimed workspace/session/prompt, cheap-agent result, and sanitized same-thread reply complete. Duplicate/ambiguous/429/revoke/reauth/crash paths do not duplicate; disallowed channel creates zero work; after claim, claimer follow-up reuses the session while non-claimer creates zero prompt and receives the claimed-work error. |
+| `T3-SUPPORT-1` | The Desktop renderer with its candidate host adapter uploads message/attachments and bounded local/authorized-cloud diagnostics through real private presigned S3 targets. Expiry resumes the same job; completion, Slack, GitHub, and optional Linear effects occur once; privacy/encryption/retention, no-wake, public consent, correlation, and content/secret redaction hold. Packaged native-job persistence belongs to Tier 4. |
+
+### Billing golden lifecycle
+
+The Tier 3 billing rows share one run-scoped lifecycle but report independent
+results. Setup may move test clocks or seed a deliberately tiny grant; the
+money movement, provider delivery, metering, gates, and recovery under test
+are real.
+
+| ID | Required validation |
+| --- | --- |
+| `T3-BILL-1` | A fresh GitHub-backed personal identity receives one lifetime `$2` managed-LLM grant across concurrent/replayed enrollment and cross-account attempts. A real LiteLLM turn debits the exact imported USD cost; a real user-key turn debits nothing. |
+| `T3-BILL-2` | Real Core Stripe test checkout activates only after verified payment at `$20` per active billed seat. Seat add/remove/re-add and proration produce exactly `$5` managed-LLM plus `$15`-equivalent compute allocation per billed seat; Stripe, portal, product UI, and ledgers agree. |
+| `T3-BILL-3` | Real organization-member LiteLLM turns and a real E2B running interval debit their separate shared organization pools while retaining correct member attribution. Personal grants remain unchanged; LiteLLM spend logs, imported LLM events, E2B segments, and compute ledger reconcile exactly. |
+| `T3-BILL-4` | Test-clock renewal, payment failure, dunning recovery, voluntary/immediate cancellation, and webhook replay transition subscription and period grants identically. Only a paid invoice creates one per-seat grant in each ledger; finalized, failed, open, or uncollected invoices grant nothing. |
+| `T3-BILL-5` | Managed-LLM exhaustion disables or rejects the scoped LiteLLM key and blocks existing/new managed turns with a typed error, but does not pause E2B. No charge or grant occurs when LLM auto-top-up is disabled; a valid user API key remains usable. |
+| `T3-BILL-6` | Explicit LLM auto-top-up is independent from compute overage/top-up. Crossing its threshold creates at most one Stripe payment attempt; successful payment grants once, rematerializes/reactivates the scoped key, and permits a real managed turn. Decline grants nothing, remains blocked, preserves user-key use, and cannot charge-storm. |
+| `T3-BILL-7` | Compute exhaustion creates the owned hold and pauses/blocks real E2B without changing LLM credit. Direct create/ensure/resume/wake, stale session, forced provider resume, old token, second member, workflow, and automation cannot bypass the gate; provider-side resume is re-paused. |
+| `T3-BILL-8` | A successful compute top-up or paid Core renewal grants compute once, clears the applicable hold, genuinely wakes E2B, and preserves repository/workspace/session/filesystem state. Failed or uncollected payment grants nothing. Compute recovery never refills LLM credit, and LLM recovery never clears a compute hold. |
+| `T3-BILL-9` | Compute overage bills exact cents to the configured per-seat cap, then writes off and blocks without overcharge. Enabling compute overage never authorizes an LLM top-up, charge, or grant. |
+| `T3-BILL-10` | Delay/drop/replay real E2B, LiteLLM, and Stripe callbacks; restart server, reconciler, Worker, and usage importers; overlap spend-log pages and materialization drift. Provider polling and repair converge, every interval/log/payment/grant imports once, held sandboxes re-pause inline, and no receipt/export/cursor stays stuck. |
+| `T3-BILL-11` | Concurrent sandboxes/virtual keys spend the same nearly exhausted personal or Core organization pool. Usage stays within its configured budget plus only an owning-spec-defined evidenced in-flight allowance; all keys/gates converge, a later launch fails before scheduling, every event imports once, and personal/organization plus LLM/compute balances remain isolated. An undefined allowance fails qualification. |
+
+### Workflows and automations
+
+The strict workflow matrix is additive: each row must produce durable run,
+step, receipt, audit, and external-effect evidence. Denial is proven by zero
+upstream calls, never by agent prose.
+
+| ID | Required validation |
+| --- | --- |
+| `T3-WF-1` | UI author/launch, strict emit schema, corrective retry, deterministic branch, and required-invocation receipt reach a terminal run. |
+| `T3-WF-2` | Allowed function call captures schema-valid arguments once; denied call records scope denial and makes zero upstream requests. |
+| `T3-WF-3` | Connected-but-ungranted integration is absent from listing, forced call is denied, and zero provider traffic occurs. |
+| `T3-WF-4` | Sequential slot reuse and parallel dirty-state fork/lane work/merge/join preserve lane-qualified state and downstream visibility. |
+| `T3-WF-5` | Poll `/init`, item-to-input delivery, exactly-once cursor advancement, invalid item handling, failure recovery, and replay safety work end to end. |
+| `T3-WF-6` | Cloud schedule fires within budget, queue drains FIFO, every missed-run policy holds, and duplicate scheduler ticks create no duplicate run. |
+| `T3-WF-7` | Desktop schedule claim, heartbeat, execution, relay, terminal completion, lost response, and reclaim are exactly once. |
+| `T3-WF-8` | Workflow agent listing and messaging respect run/session scope and persist messages exactly once across reconnect. |
+| `T3-WF-9` | Bound-session lockout covers every mutation; acknowledged takeover quiesces the prior owner before releasing the binding. |
+| `T3-WF-10` | One real Slack notification survives post-acceptance crash/retry and is reconciled exactly once. |
+| `T3-AUTO-1` | Personal and organization manual/scheduled automations converge stale config/auth, create one workspace/session/prompt, complete a cheap real-agent turn, preserve the frozen config, and enforce private/shared exposure; disabled or policy-blocked automations create no work. |
+| `T3-AUTO-2` | Candidate Desktop worker/runtime plus the Desktop renderer claims, heartbeats, executes, and relays a local scheduled automation once; controlled worker/runtime restart after claim resumes or fails the same run durably without a second workspace/session/prompt. Packaged-app relaunch belongs to Tier 4. |
+
+### Self-hosted and operational product paths
+
+| ID | Required validation |
+| --- | --- |
+| `T3-SH-1` | Production compose cold boot over real TLS/DNS, claim, invite, registration, login, workspace, and one real agent turn. |
+| `T3-SH-2` | Isolated Desktop product-renderer pages inspect real server metadata, reject invalid/non-Proliferate origins, connect and authenticate to server A or B through the shared host-adapter boundary, and never leak credentials, cache, or product state across server origins. Native configuration, keychain persistence, and packaged-app relaunch belong to Tier 4. |
+| `T3-SH-3` | Optional gateway profile boots and completes a real cheap-model turn; base install remains commandable without hosted capabilities. |
+| `T3-SH-4` | `/meta`, `/health`, advertised auth methods, support, pricing, versions, and capabilities match the real deployed posture. |
+| `T3-SH-5` | Self-host cloud-sandbox add-on with its GitHub App, E2B key, and self-built immutable template configures a repo, provisions one workspace, completes a real turn, and pauses/wakes with state intact; disabling the add-on leaves the base installation healthy and truthful. |
+| `T3-OBS-1` | Core journeys emit required audit/usage/correlation records, redact secrets and user content as specified, and produce enough identifiers for support diagnosis. |
+
+## Tier 4 required manifest
+
+Tier 4 owns one packaged-install and upgrade qualification stage. Its
+independently evidenced standing targets are clean candidate Desktop install,
+production Desktop N-1 to N, and production E2B runtime N-1 to candidate N;
+self-host N-1 to N joins when its bundle/update trigger changed. The Desktop
+targets compose under `T4-DESKTOP-1`, the runtime target under `T4-RUNTIME-1`,
+and applicable agent convergence under `T4-CATALOG-1`. They are separate final
+cells, not separate worlds and not one pass inferred from another.
+[`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) owns their exact
+artifact, fixture, action, and evidence contract.
+
+Every other row below is mandatory when its trigger changed. Nightly may run
+the broadest implemented compatibility set, but the table does not create 27
+always-on deployed permutations. Public artifact integrity remains an
+every-release gate without becoming another upgrade world.
+
+| ID | Trigger | Required validation |
+| --- | --- | --- |
+| `T4-WORKER-1` | Worker artifact or update protocol changes | N-1 Worker observes desired N, writes the atomic mailbox request, and stays out of download/swap/restart ownership. Supervisor consumes the mailbox, downloads/verifies and atomically swaps Worker N, restarts it, health-gates convergence, and rolls back to last-good on corrupt or unhealthy N. Identity, cursors, pending results, and a live session survive. |
+| `T4-RUNTIME-1` | Standing core when AnyHarness/runtime artifacts are promoted | A sandbox from the exact retained production N-1 E2B template completes a turn while its target-scoped desired version remains N-1. After only that target changes to exact candidate N, Worker writes the atomic mailbox request rather than activating it; Supervisor verifies/stages and swaps AnyHarness N, restarts in dependency order, health-gates N, and rolls back on failed activation; AnyHarness reconciles installed agents from N's bundled inputs. Worker state and the completed durable session remain commandable, event sequence stays monotonic, and a post-update turn succeeds. |
+| `T4-SUPERVISOR-1` | Supervisor artifact, config, install layout, service, mailbox, or update-staging changes | N Supervisor consumes Worker-authored component mailbox requests, verifies and privately stages artifacts, rejects invalid component/path/size/checksum, swaps/restarts/health-gates Worker and AnyHarness in dependency order, and rolls either component back to last-good. Managed-cloud and SSH-generated service/config layouts provide the explicit child environment. Supervisor self-upgrade activation remains a separate unclaimed mechanism until its owner is specified and tested. |
+| `T4-CATALOG-1` | Bundled catalog, trusted registry, agent pins, installer, or reconciliation changes | Embedded in the applicable Desktop and managed-cloud runtime target cells rather than creating another world: N AnyHarness contains the N bundled catalog and trusted registry inputs; installed-only reconcile verifies sources/pins, updates naturally drifted managed native CLIs and ACP agent processes, preserves sessions, and leaves equal pins alone. No server-pushed catalog becomes a trusted runtime input. |
+| `T4-MODELREG-1` | Model catalog, registry, alias, visibility, or saved-intent changes | N-1 saved intents, aliases, snapshots, visibility overrides, Automation defaults, and Slack defaults resolve under N without silent model-class substitution. Renames canonicalize; removed/unavailable models surface repair or only the explicitly stored fallback. |
+| `T4-RUNTIMECFG-1` | MCP/skill/plugin schema, compiler, manifest, artifact, or launch-contract changes | N-1 configured items, publicization, revisions, artifacts, and OAuth state upgrade and recompile idempotently; Worker applies and existing sessions relaunch with intended tools. Secrets stay absent, lazy resolution survives restart, and no legacy bundle path reactivates. |
+| `T4-SEED-1` | Desktop agent seed, launcher, or bundled agent resources change | Seed-owned unchanged/missing artifacts upgrade or repair; user-owned or modified artifacts remain untouched; unsafe archive/checksum/target fails; launchers resolve the final runtime home. |
+| `T4-DESKTOP-1` | Standing core when Desktop artifacts are promoted | Two independent cells consume the exact signed candidate N. Clean install on an empty supported machine launches the packaged bundled runtime, hydrates seeds/reconciles agents, completes a turn, connects natively to a prepared self-host server, and preserves server selection/keychain/auth plus local state across packaged-app relaunch. Separately, an exact retained production N-1 Desktop with real sidecars/seed completes a turn, discovers/verifies/installs N from an isolated trusted feed, and actually relaunches it without moving public stable. Runtime/worker and native/ACP agent identities converge to N; the update cell preserves runtime home, auth, workspace, completed session, and transcript and completes a post-update turn. |
+| `T4-MOBILE-1` | Native mobile release, storage, auth, or deep-link changes | N-1→N preserves secure auth and navigation state, applies storage migrations, and still completes login/deep-link/chat on supported platforms. |
+| `T4-DATA-1` | Alembic, SQLite, event, catalog, or persisted-contract changes | Kept N-1 Postgres, AnyHarness SQLite, and Worker SQLite migrate forward once and repeatedly idempotently. Realistic product rows plus Worker identity, applied revision/backoff state, upload cursor/gap state, exposure cache, command-result outbox, and pending reconciliation remain readable and commandable. |
+| `T4-MOBILITY-1` | Mobility schema, executor, exposure, or cleanup changes | Upgrade moves in preparing, transferring, pre-cutover, cleanup-pending, cleanup-failed, and repair-required states. N preserves canonical side/attestation, never repeats import/cutover, fences N-1 reports, resumes each cleanup item once, and leaves no orphan exposure/projection/cursor. |
+| `T4-DELEGATE-1` | Session-link, subagent, Cowork, review, wake, or prompt-policy changes | Upgrade while children/reviewers run, messages queue, wakes arm, a review is partially submitted, and a Cowork workspace is active. Handles, provenance, cursors, prompts, results, hierarchy, and closure survive; each queued effect occurs once and old tokens cannot widen scope. |
+| `T4-COWORKART-1` | Artifact manifest/domain/MCP/HTTP/rendering changes | N reads N-1 manifests for every supported type and old Cowork aliases while preserving ids, paths, metadata, files, git history, and protection. New routes and atomic mutations work; malformed/partial old manifests fail visibly without rewriting user files. |
+| `T4-SLACK-1` | Slack schema, Worker, OAuth, event, or outbound queue changes | Upgrade an active connection/thread with claimed inbound work, accepted/queued outbound work, and a rate-limit retry. Config and mappings persist, replay creates no second work, accepted messages are not resent, and N drains retryable work with the same idempotency keys. |
+| `T4-SUPPORT-1` | Desktop support job, server report, S3 manifest, or tracker schema changes | An N-1 queued/partial report survives N; compatible defaults apply, local upload resumes, targets refresh without object-set conflict, and completion/Slack/GitHub/Linear effects occur once while privacy/correlation/redaction remain intact. |
+| `T4-TEMPLATE-1` | E2B image, bootstrap, runtime, Worker, or agent seed changes | New sandboxes use the N immutable template. An existing paused N-1 sandbox wakes on its existing image with data intact; only separately supported Worker/runtime/catalog mechanisms may converge in place. Rolling-tag movement affects new sandboxes only. |
+| `T4-ROLLING-1` | Server/API/Worker/runtime deployment order changes | Supported mixed-version rollout orders preserve health, command/event continuity, and in-flight work while components drain/restart; rollback returns to the last-good operational set. Wire-shape compatibility belongs to `T4-CONTRACT-1`. |
+| `T4-CONTRACT-1` | AnyHarness/OpenAPI/SDK/event/Worker wire contract changes | N-1 SDK/Desktop/Worker with N peers and N clients with supported N-1 peers complete workspace/session/stream flows. Empty resume bodies, optional fields, unknown events, enum/error casing, generated artifacts, and reducers remain compatible; unsupported breaks fail explicitly instead of corrupting or misrouting. |
+| `T4-DISPATCH-1` | Cowork API key, exposure, live stream, or deep-link contract changes | N-1 Desktop/Web/mobile and API keys remain within the supported N server window; exposure and SSE resume without lost/duplicate patches, revoked keys stay revoked, auto-cascade converges once, and deep links retain workspace/session identity after client upgrade. |
+| `T4-CREDENTIAL-1` | Auth, secret, integration, keychain, or materialization schema changes | Existing native/provider auth, LiteLLM/agent-auth keys, integrations, and secret materializations survive or rotate through upgrade without plaintext leakage or stale authorization. |
+| `T4-GHAPP-1` | GitHub App auth, Worker lease, helper, or repository-authority schema changes | N-1 encrypted authorization/install/cache and active lease metadata migrate; N refreshes and Git fetch succeeds. Revoked/expired authority stays revoked, old token files stop working, and no product-OAuth fallback appears. |
+| `T4-BILL-1` | Billing, managed-credit, LiteLLM-materialization/importer, accounting, webhook, price, meter, or entitlement schema changes | N-1 subjects/subscriptions/grants/segments/holds/receipts/exports/remainders/limits plus allocation guard, `AgentGatewayBudgetSubject`, `AgentGatewayFreeCreditEntitlement`, `SandboxAgentAuthSelection`, LiteLLM materialization/usage/import cursor, auth revision, encrypted key references, and audit rows upgrade with conservation intact; new and replayed N-1 events process once. |
+| `T4-BILL-2` | Server, worker, runtime, template, or billing reconciler changes | Checkout, billed sandbox interval, LiteLLM request/spend-log import, compute meter export, and webhook in flight across N-1→N produce no lost/duplicate charge, grant, debit, log, or export. Import cursor and scoped key state survive; desired-state key replacement is atomic and no provider/admin secret leaks. |
+| `T4-BILL-3` | Stripe catalog or public billing artifact changes | Historic N-1 subscriptions continue renewal, seats, cancellation, overage, and replay under N while new checkout uses the N test catalog; account mode, currency, prices, meter names, webhook endpoint, and API version are verified before promotion. |
+| `T4-BILL-4` | Desktop, SDK, billing envelope, SSE, or typed-error changes | N-1 Desktop/SDK against N server, then upgraded N client, can read plan/usage/hold envelopes, consume billing patches, open Checkout/Portal, and handle typed denials. Additive fields remain compatible and a stale client cannot bypass a new server-side gate. |
+| `T4-SELFHOST-1` | Self-host bundle, compose, migration, or update script changes | Production N-1 updates to N over real TLS and preserves data/auth/config through success plus injected image-pull, migration/restart, and post-update-health failures. N is never reported healthy early; N-1 stays recoverable; retry converges without reopening setup or duplicating effects; a post-update agent turn succeeds. |
+| `T4-ARTIFACT-1` | Every public release | Server redirects, CDN trees, manifests, signatures, checksums, tags, platform artifacts, versions, and immutable SHA lineage agree before any rolling tag or stable feed moves. |
+
+## Qualification evidence
+
+Trusted CI emits one immutable qualification artifact containing:
+
+- merged SHA, trusted workflow/run identity, and required-manifest hash;
+- server, Web, Desktop, mobile, runtime, worker, and self-host artifact digests;
+- E2B template immutable reference and content hash;
+- Supervisor version/digest, bundled agent-catalog hash, trusted-registry hash,
+  generated OpenAPI/SDK artifact hashes, Alembic revision, and distinct
+  AnyHarness/Worker SQLite schema revisions;
+- every required scenario id, lane, status, duration, attempt, and correlation
+  id;
+- sanitized Stripe, E2B, LiteLLM provider/key/spend-log,
+  router-materialization, budget-subject, free-entitlement, and import-cursor
+  identifiers plus repository, integration, and notification fixture ids;
+- separate compute-conservation and managed-credit-reconciliation results;
+- zero non-green final-result counters, superseded attempt history, and the
+  cleanup result.
+
+Production promotion verifies the evidence signature/attestation, repository,
+workflow identity, `main` ref, SHA, manifest hash, and artifact identities.
+User-supplied JSON or evidence from a different SHA is never accepted.
+
+Blind retries that may repeat an external effect are forbidden. After a
+timeout or lost response, the scenario reconciles provider state first; any
+retry uses the same correlation and provider idempotency key. A fresh,
+full-scenario rerun may replace an infrastructure-failed attempt on the same
+artifacts, but both attempts remain in the evidence and the replacement uses a
+new run-scoped world. Sharding may change execution time but cannot change the
+required manifest or allow a partial aggregate to pass.
+
+## Traceability and change control
+
+The machine-readable target inventory and this document contain the same
+scenario ids; CI enforces that equality, uniqueness, tier counts, local link
+integrity, and explicit implementation state. Target presence never counts as
+execution. A row may remain `planned`; a row marked `collected` or `enforced`
+must name its concrete collector, collected test id, required cells, lanes,
+gate, and evidence status, and CI validates that mapping. Full qualification additionally requires
+an execution manifest that validates that:
+
+- every required id has a collected test implementation;
+- every required lane is present exactly once;
+- the owning workflow invokes it in strict mode;
+- no required test contains an unconditional skip, expected-fail, or
+  environment-based green escape;
+- every generated collector pointer exists; and
+- every collected Tier 2/3/4 core scenario maps back to one id here.
+
+A product change that adds a supported plan, provider, auth route, harness,
+model, mode, tool, workspace type, trigger, billing transition, cloud-command
+kind, runtime-config/plugin expansion kind, SDK public resource group, GitHub
+App webhook/lease contract, or upgrade mechanism updates this contract, its
+machine-readable manifest, and the enforcing test in the same PR.
+
+## Legacy Collector ID Migration
+
+Current collectors predate the target manifest. Until the bidirectional
+collector audit is implemented, they must be ported through this table rather
+than copied or treated as target coverage by name.
+
+| Legacy claim | Canonical destination |
+| --- | --- |
+| legacy `T2-SH-1` connect/switch | Retire the Tier 2 claim; renderer connection is composed by `SH-DESKTOP-OWNER` and `SH-SWITCH-ISOLATION` under `T3-SH-2`/`T3-SH-4`. Native config/keychain/relaunch proof belongs to Tier 4. |
+| legacy `T2-SH-2`, `T2-SH-3`, `T2-SH-4` | Fold claim, invite/register, and adaptive-auth collectors into canonical `T2-SH-1`. |
+| legacy `T2-SH-5` | Rename the live `/meta` capability collector claim to canonical `T2-SH-2`. |
+| legacy `T2-SH-6` | Reclassify partial-E2B safety as one cell of canonical `T2-SH-3`. |
+| legacy `T2-SH-7` | Split incomplete-SSO truth into `T2-SH-3`/`T2-AUTH-5`; gateway eligibility becomes canonical `T2-SH-4`. |
+| legacy `T3-GW-1` | Retire the guarantee ID and audit its real gateway collector beneath `LOCAL-2`, contributing to `T3-CHAT-1`, `T3-AUTHROUTE-1`, and the managed-spend cell of `T3-BILL-1`. |
+| legacy `T3-UPDATE-1` | Split steady-state install/catalog proof into `T3-AGENT-1`/`T3-MODELREG-1`; real N-1→N behavior belongs to `T4-RUNTIME-1` with `T4-CATALOG-1`. The old server-pushed catalog model is not trusted input. |
+| old `T3-SH-1` through `T3-SH-4` | Keep the canonical IDs only after expanding their partial collectors across the `SH-*` journeys. Name equality alone is not coverage. |
+| old `T3-SH-5` adaptive sign-in | Move the collector under `T3-SH-4`. Canonical `T3-SH-5` now means the self-host cloud/E2B add-on; this semantic collision must not be auto-renamed. |
+| legacy `T4-CLOUD-1` | Rewrite, not merely rename, as `T4-RUNTIME-1` plus `T4-CATALOG-1` using target-scoped desired state, Worker mailbox, and Supervisor activation. |
+| legacy `T4-SH-1` | Audit the success collector beneath change-triggered `T4-SELFHOST-1`; do not infer N-1 by patch decrement. |
+| legacy `T4-SH-2` | Audit the HTTP/CDN collector beneath every-release `T4-ARTIFACT-1`. |
+| legacy `T3-FIXTURE`, `T3-EXAMPLE`, `T3-A`, `T3-B` | Fixture/reporter test data, not guarantees. Rename outside the `T[234]-*` production namespace before registry auditing. |
+
+## Current enforcement exception
+
+Current main is materially fail-open and no current run may claim qualification
+from this contract:
+
+- both Tier 2 workflow jobs use `continue-on-error`; the billing job skips all
+  billing specs when `STRIPE_TEST_SECRET_KEY` is absent;
+- every Tier 3/4 workflow job is advisory, and whole-lane preflights can skip
+  cleanly when credentials or public infrastructure are absent;
+- the release runner converts missing dependencies, explicit blocked errors,
+  and expected failures into a successful process exit when no ordinary error
+  was thrown; some matrix scenarios also swallow individual harness failures;
+- only red scenarios write structured reports, so green, blocked, missing, and
+  expected-fail cells have no immutable aggregate evidence;
+- production promotion validates staging deployment evidence but does not
+  invoke or verify Tier 3/4 qualification evidence;
+- hosted Web is not booted by the existing Tier 2 world;
+- the Tier 4 Desktop and cloud update journeys cannot qualify in CI today; and
+- canonical agent-auth primitive docs still describe Bifrost as the managed
+  data plane even though the settled target is LiteLLM only. Those product
+  specs and owning code must be reconciled before their collectors can be
+  audited; the stale Bifrost contract does not override this target; and
+- product billing constants still encode the prior `$5` free managed-LLM grant
+  and twenty managed-cloud hours per seat rather than the settled `$2` free and
+  Core `$5 LLM + $15 compute` allocation.
+
+The foundation closes these gaps in this order:
+
+1. restore this target contract and bind composed journeys into the target
+   manifest;
+2. add collector metadata and bidirectional manifest/collection audits;
+3. always emit per-cell run summaries with candidate and world identity;
+4. add strict runner behavior and make missing Stripe credentials fail trusted
+   CI;
+5. wire exact-SHA qualification evidence into production promotion;
+6. build and validate each world foundation as a vertical slice; and
+7. fan out scenario implementation and bug fixing in parallel, ratcheting the
+   enforced baseline upward until every core cell is required.
+
+`continue-on-error` may remain only on explicitly diagnostic callers during
+the migration. It is never allowed on a job or matrix cell whose output is
+consumed as merge, promotion, updater-feed, template-tag, catalog, or runtime
+qualification evidence.

--- a/specs/developing/testing/desktop-update-testing.md
+++ b/specs/developing/testing/desktop-update-testing.md
@@ -1,16 +1,19 @@
-# Desktop auto-update testing (tier 4)
+# Desktop auto-update mechanism testing
 
-How to build an N−1 desktop app that points at a local update feed, stage an N
-artifact there, and watch the real Tauri auto-updater converge. This is the
-tier-4 "Desktop app" mechanism from the [testing README](./README.md); read that
-first for the tier model.
+How the current local prototype builds an N−1-shaped Desktop app, points it at
+a local update feed, stages an N artifact, and exercises the real Tauri updater
+engine. This is useful mechanism signal, but it is not the complete
+`T4-DESKTOP-1` qualification journey. Read the target artifact, relaunch,
+state-continuity, AnyHarness, native CLI, ACP agent-process, and post-update-turn
+contract in [`tier-4-scenario-contract.md`](tier-4-scenario-contract.md).
 
 Read the product and UI acceptance contract in
 [`desktop-updates.md`](../../codebase/features/desktop-updates.md) alongside
-this mechanism. T4-DESKTOP-1 proves manifest fetch, semver selection, signature
-verification, and the real bundle swap headlessly. It does not render the
-packaged WebView: release-notice presentation and interaction are covered by
-focused renderer tests plus a packaged-WebView smoke when preparing a release.
+this mechanism. The current collector proves manifest fetch, semver selection,
+signature verification, and a bundle swap headlessly. It does not launch the
+installed N application, run real bundled sidecars, preserve a real runtime
+home/session, or reconcile installed agents, so it cannot claim
+`T4-DESKTOP-1` qualification by itself.
 
 The shipped app is not touched. `apps/desktop/src-tauri/tauri.conf.json` keeps
 its production endpoint (`https://downloads.proliferate.com/desktop/stable/latest.json`)
@@ -124,15 +127,18 @@ The mock app reports package version `0.1.0`, so a feed serving `>0.1.0` yields
 
 ## Running the T4 scenario
 
-The steps above are wired into one scenario, **T4-DESKTOP-1**, under the
-release-e2e runner (`tests/release/`). It builds both apps, stages the feed, and
-drives the real updater headlessly — no GUI clicking.
+The steps above are wired into the current **T4-DESKTOP-1 prototype
+collector** under the release-e2e runner. It builds both apps, stages the feed,
+and drives the updater headlessly. The target journey must replace its
+N−1-shaped build with the exact retained production artifact, use the exact
+already-built candidate N, relaunch it, and collect the remaining runtime/state
+cells.
 
 **Pieces:**
 
 | Piece | Path | What it does |
 | --- | --- | --- |
-| Scenario | `tests/release/src/scenarios/t4-desktop-1.ts` | Registered T4-DESKTOP-1. Gates on platform / CI / opt-in and shells out to the orchestrator. |
+| Scenario | `tests/release/src/scenarios/upgrade/t4-desktop-1.ts` | Current partial T4-DESKTOP-1 collector. Gates on platform / CI / opt-in and shells out to the orchestrator. |
 | Orchestrator | `tests/release/upgrade/run-t4-desktop.mjs` | Builds N-1 + N (cached), stages the feed, copies the N-1 bundle, runs the driver, asserts N-1 → N. |
 | Headless driver | `tests/release/upgrade/updater-driver/` | A **workspace-detached** cargo crate. Drives the real `tauri_plugin_updater` `check()` + `download_and_install()` against a real N-1 `.app`. |
 
@@ -161,19 +167,20 @@ RELEASE_E2E_DESKTOP_T4=1 make release-e2e LANE=local SCENARIOS=T4-DESKTOP-1
 node tests/release/upgrade/run-t4-desktop.mjs --from 0.3.17 --to 0.3.18
 ```
 
-- **Local-macOS-aarch64-only, opt-in.** Without `RELEASE_E2E_DESKTOP_T4=1`, on a
-  non-macOS-aarch64 host, or in CI (GitHub Actions), the scenario reports
-  `blocked` cleanly — it never goes red on the release gate. That is correct:
-  the gate does not provision two macOS `tauri build`s and a bundle swap.
+- **Local-macOS-aarch64-only, opt-in today.** Without
+  `RELEASE_E2E_DESKTOP_T4=1`, on a non-macOS-aarch64 host, or in CI, the current
+  scenario reports blocked. That is acceptable only for diagnostic signal.
+  Strict qualification requires a protected macOS runner and treats the
+  required Desktop cell as red when it cannot run.
 - **Builds are cached.** The orchestrator caches the built N-1 `.app`, the N
   `.app.tar.gz` + `.sig`, the signing keypair, and the driver's cargo target
   dir under `tests/release/.output/t4-desktop/` (override with `T4_WORK_DIR`).
   Re-runs skip the ~10-min builds; pass `--force` or `T4_FORCE_REBUILD=1` to
   rebuild.
-- **Sidecar stubs.** The orchestrator stages tiny placeholder executables for
-  the three `externalBin` sidecars so `tauri build` succeeds without the
-  ~10-min real anyharness runtime build (the updater test does not run the
-  agent runtime).
+- **Sidecar stubs.** The current orchestrator stages tiny placeholder
+  executables for the three `externalBin` sidecars. That is adequate for this
+  updater-engine prototype and explicitly disqualifies it as production
+  artifact or AnyHarness-convergence evidence.
 - **Version mutation is restored.** The orchestrator edits
   `tauri.conf.json`'s `version` for each build and restores it (even on
   failure) — don't commit a changed version from a T4 run.

--- a/specs/developing/testing/flows.md
+++ b/specs/developing/testing/flows.md
@@ -1,14 +1,14 @@
 # Flow Registry
 
-The inventory of end-to-end flows that must never break. Owned and dictated by
-Pablo; agents keep the pointers live. Rules:
+Legacy human-readable inventory of end-to-end flows that must never break.
+Owned and dictated by Pablo. Until the generated view replaces this file:
 
-- Adding or materially changing a flow adds/updates a row **in the same PR**.
-- `Test pointer` names the spec/scenario file that enforces the flow at its
-  tier. `—` means not yet implemented; an empty pointer is a to-do, not an
-  excuse.
-- A completeness audit (agent-run) checks: every row has a live pointer, and
-  every pointer's test actually runs in the gate its tier claims.
+- Adding or materially changing a guarantee updates the canonical target
+  manifest and collector metadata in the same PR.
+- `Test pointer` is a temporary view of known collection. It is not run status
+  or qualification evidence.
+- The replacement generator discovers collectors in both directions and emits
+  this view; no claimed completeness audit exists on current main yet.
 
 Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 **3** = live end-to-end (release train), **4** = upgrade path (release train).
@@ -17,13 +17,13 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Google OAuth sign-in (mocked provider per-merge) | 2 | — |
-| `/setup` instance claim → password login → logout → re-login | 2 | — |
-| Session revocation ends access | 2 | — |
-| Invitation: invite → accept in fresh browser → membership + role | 2 | — |
-| Invitation negatives: expired / reused / wrong-email token | 2 | — |
-| SSO: OIDC round-trip via mock IdP → user linked, domain policy applied | 2 | — |
-| SSO negatives: disallowed domain, unknown user, audience/issuer mismatch | 2 | — |
+| OAuth login-method availability seam (real provider dance remains Tier 3) | 2 | tests/intent/specs/login-methods.spec.ts (T2-AUTH-4) |
+| `/setup` instance claim → password login → logout → re-login | 2 | tests/intent/specs/auth.spec.ts (T2-AUTH-1) |
+| Session revocation ends access | 2 | tests/intent/specs/auth.spec.ts (T2-AUTH-2) |
+| Invitation: invite → accept in fresh browser → membership + role | 2 | tests/intent/specs/invitation.spec.ts (T2-INV-1) |
+| Invitation negatives: expired / revoked / wrong-email / duplicate pending | 2 | tests/intent/specs/invitation.spec.ts (T2-INV-1) |
+| SSO: OIDC round-trip via mock IdP → user linked, domain policy applied | 2 | tests/intent/specs/sso.spec.ts (T2-AUTH-3) |
+| SSO negatives: disallowed domain, unknown user, audience/issuer mismatch | 2 | tests/intent/specs/sso.spec.ts (T2-AUTH-3; see spec for currently reachable cells) |
 | SSO org entry points: slug + org-id discovery (unknown / no-SSO collapse to one non-enumerating answer; enabled connection returns start ids) and the desktop cold-login affordance | 2 | tests/intent/specs/sso-entry-points.spec.ts (T2-AUTH-5; entry-point seam only — the OIDC round-trip is the row above. The `apps/web` slug/`join` pages are not booted by this suite; their logic sits on the same discover seam asserted here) |
 | Real provider handshakes (Google/GitHub OAuth dance) | 3 | — |
 
@@ -31,10 +31,10 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Create organization | 2 | — |
-| Invite users; promote/demote roles | 2 | — |
-| Admin-only surfaces gated: member cannot see/do admin actions | 2 | — |
-| Member visibility boundaries (sees own work, not others' private state) | 2 | — |
+| Create organization | 2 | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1; current single-org posture exercises the instance org) |
+| Invite users; promote/demote roles | 2 | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1) |
+| Admin-only surfaces gated: member cannot see/do admin actions | 2 | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1) |
+| Member visibility boundaries (sees own work, not others' private state) | 2 | tests/intent/specs/member-visibility.spec.ts (T2-ORG-2) |
 | Remove user; access ends | 2 | tests/intent/specs/organization-roles.spec.ts (T2-ORG-1; "remove a member -> membership status 'removed' -> their next org-scoped call fails" — 200 while active, 404 organization_not_found on the next org-scoped call post-removal, gone from the active roster, and a later relist 403s instance_access_removed rather than silently re-adding them) |
 
 ## Workspaces
@@ -43,7 +43,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 | --- | --- | --- |
 | Local workspace create | 3 | — |
 | Worktree workspace create — locally AND inside a cloud sandbox | 3 | tests/release/src/scenarios/t3-wt-1.ts (T3-WT-1; local lane green, sandbox lane blocked on current_product_user) |
-| Cloud workspace create: request path + UI state up to the provisioning seam | 2 | — |
+| Cloud workspace create: request path + UI state up to the provisioning seam | 2 | tests/intent/specs/cloud-workspace.spec.ts (T2-WS-1; configured-repo happy seam remains a collected gap) |
 | Add-Repo flow entry: local/cloud branches render + desktop-web fallback limits (no native picker outside Tauri) | 2 | tests/intent/specs/workspace-entry.spec.ts |
 | New user cold path: GitHub App authorization triggers first-ever sandbox provisioned from zero, within time budget | 3 | tests/release/src/scenarios/t3-prov-1.ts (T3-PROV-1; REAL trigger — seeds the App-auth callback's outcome via github_app_seed.py, real user token + real installation token, then runs the real post-callback body → real E2B sandbox; asserts positive AND negative trigger contract; fallback seam when seed creds absent) |
 | Existing user warm path: reopen, pause (inaccessible), resume, state intact | 3 | tests/release/src/scenarios/t3-prov-2.ts (T3-PROV-2; #1041 — real and green end-to-end on --lane local against a real E2B sandbox: front-door reconnect via the anyharness gateway proxy, direct-E2B pause/resume with ground truth verified, filesystem state proven intact across the cycle; RELEASE_E2E_E2B_API_KEY-gated, expected-fail without it; blocked, not red, when the durable org's cloud-sandbox credits are exhausted) |
@@ -67,7 +67,7 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Secrets CRUD in UI: org, personal, file secrets | 2 | — |
+| Secrets CRUD in UI: org, personal, file secrets | 2 | tests/intent/specs/secrets.spec.ts (T2-SEC-1; personal/org CRUD and workspace configuration seam) |
 | Org secret set → materializes into the owner's personal cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (T3-SEC-MAT-1; #1042 — real and green on --lane local: personal + org env-var secrets PUT, materialization polled to ready, then E2B-direct in-sandbox verification of global.env content and manifest sha256s, plus the update-propagation cycle; RELEASE_E2E_E2B_API_KEY-gated, expected-fail without it; blocked, not red, when the durable org's cloud-sandbox credits are exhausted) |
 | Personal secret set → materializes into the owner's personal cloud sandbox | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario) |
 | Workspace file secret set → lands at the right path in a fresh cloud workspace | 3 | tests/release/src/scenarios/t3-sec-mat-1.ts (same scenario; this half needs a seeded GitHub App user authorization for the durable identity — real on --lane local when the seed is available, expected-fail citing #1043's environmental gap otherwise; never attempted on --lane staging) |
@@ -83,7 +83,9 @@ Tiers per `README.md`: **2** = mocked intent (per-PR, blocks merge),
 
 Every self-hosted deploy is the production compose bundle (hand-run
 `bootstrap.sh` or the AWS one-click), single-org, claimed once via `/setup`.
-Spec of record + scenario definitions: `specs/developing/testing/self-hosting.md`.
+Canonical guarantee IDs and journeys live in `core-release-validation.md`, the
+target manifest, and the Tier 3/4 scenario contracts. `self-hosting.md` is the
+legacy implementation/evidence hand-off for the pointers below.
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
@@ -122,8 +124,8 @@ Spec of record + scenario definitions: `specs/developing/testing/self-hosting.md
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
 | Checkout → grants → consumption → cut-off → reactivation (Stripe test mode + test clocks); grant drain order | 2 | tests/intent/specs/billing/core.spec.ts (T2-BILL-1; real Stripe test-clock subscription + invoice.paid grant, real accounting-pass drain, snapshot cut-off/reactivate) |
-| Seat-based billing on Pro orgs: invite/remove/re-invite reconciles Stripe quantity + proration grants, no double-grant | 2 | tests/intent/specs/billing/seats.spec.ts (T2-BILL-3) |
-| Team checkout: new-org-via-checkout activation + failure/expiry terminal states | 2 | tests/intent/specs/billing/seats.spec.ts (T2-BILL-4; intent-create + activation idempotency; failed_billing_state/expiry noted tier-1) |
+| Seat-based Core billing: invite/remove/re-invite reconciles Stripe quantity + proration grants, no double-grant | 2 | tests/intent/specs/billing/seats.spec.ts (T2-BILL-3; current collector still reflects pre-migration allocations) |
+| Core checkout: new-org-via-checkout activation + failure/expiry terminal states | 2 | tests/intent/specs/billing/seats.spec.ts (T2-BILL-4; intent-create + activation idempotency; failed_billing_state/expiry noted tier-1) |
 | Compute overage: bills metered usage up to cap, writes off past it, then hard-blocks; disabled → immediate cutoff | 2 | tests/intent/specs/billing/overage.spec.ts (T2-BILL-5) |
 | LLM credits: exhaustion disables key, admin caps independent of credit refill, auto top-up incl. declined-card fail-closed | 2 | tests/intent/specs/billing/overage.spec.ts (T2-BILL-6; balance/cap surfaces + fail-closed top-up; LiteLLM key-disable is tier-3) |
 | Stripe webhook robustness: duplicate/replay idempotent, concurrent 409, failure retried once-only, out-of-order safe | 2 | tests/intent/specs/billing/webhooks.spec.ts (T2-BILL-7) |
@@ -133,75 +135,22 @@ Spec of record + scenario definitions: `specs/developing/testing/self-hosting.md
 | Out of credits: sandbox paused and not accessible — **including every bypass route** (direct API resume, stale session, webhook race, pre-exhaustion key, other org member, trigger-driven start) | 3 | tests/release/src/scenarios/t3-bill-2.ts (T3-BILL-2; exhaustion setup via drain-grants green; enforcement + 6-route bypass sweep blocked on github_link_required — cloud routes need a real sandbox + gate lift PR #1023) |
 | Out of credits: gateway LLM access gated; reactivates on refill | 3 | tests/release/src/scenarios/t3-bill-2.ts (T3-BILL-2, LLM side; blocked on RELEASE_E2E_GATEWAY_TEST_KEY — no key to reject) |
 | Overage bills real money correctly: compute metered events + amounts match up to cap then hard-block; LLM auto top-up charges once then fail-closes on payment failure | 3 | — |
-| Plan gates the model list: user sees/uses exactly the models their plan allows | 3 | — |
-
-## Self-hosting
-
-Scenario definitions, tier-2 escalations, and infra prerequisites:
-[self-hosting.md](self-hosting.md). `2*` = needs the tier-2 escalation in
-that doc's §4 (the connect UI is Tauri-gated; desktop-web never renders it —
-tests drive the LoginScreen fixture instead).
-
-| Flow | Tier | Test pointer |
-| --- | --- | --- |
-| `single_org_mode` derivation: self_managed telemetry ⇒ single-org; override respected | 1 | — |
-| SSO env aliasing: bare `SSO_*` ≡ `PROLIFERATE_SSO_*` (AliasChoices) | 1 | — |
-| `GET /meta` response contract (fields the desktop connect dialog parses) | 1 | — |
-| Desktop connect-to-server: enter URL → `/meta` verify (host+version shown) → confirm → relaunch → connected banner | 2* | — |
-| Desktop server switch: reset to Cloud → connect to a second server | 2* | — |
-| `/setup` claim through the UI → admin lands in instance org (self-hosted framing of the claim flow) | 2 | — |
-| Invite → browser `/register` with token → invitee desktop password login | 2 | — |
-| Sign-in surface adapts to `GET /auth/desktop/methods` (password form vs GitHub button) | 2 | — |
-| Self-hosted server on real EC2 + real TLS: boot → claim → login → invite lands in DB | 3 | — |
-| Two-server connect/switch against real staging servers (alpha/beta) | 3 | — |
-| Model gateway add-on: `--profile agent-gateway` boot, agent request routes through LiteLLM | 3 | — |
-| `./update.sh`: N−1 pin → update → migrated + healthy + `/meta` reports N | 4 | — |
-| Release artifact chain intact: server desktop-pin → updater manifest → artifact URL 200 → artifact tag contains the release SHA | 4 | — |
 
 ## Upgrade & release
 
-There is no single "upgrade path" — five distinct mechanisms, each tested at
-its own seam. Mechanism map and current-coverage audit: the tier-4 section of
-`README.md`.
+The target contract and current red gaps live in
+[`tier-4-scenario-contract.md`](tier-4-scenario-contract.md). These pointers
+name current collectors only; they do not imply complete qualification.
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Worker self-update: sandbox worker N−1 heartbeats, downloads N from stubbed CDN base (`DESKTOP_DOWNLOADS_BASE_URL`), verifies, swaps, execs — with a live session on the box that survives | 4 | — |
-| Catalog convergence full chain (sandbox): server catalog version bump → heartbeat → worker push → runtime reconcile → agent CLI in an **existing** sandbox reinstalled at the new pin — independent of any worker binary update | 4 | tests/release/src/scenarios/t3-update-1.ts (T3-UPDATE-1; blocked on current_product_user) |
-| Catalog convergence on desktop local: same chain through the bundled desktop worker → local runtime → agent CLI reinstalled at the new pin | 4 | tests/release/src/scenarios/t3-update-1.ts (T3-UPDATE-1; expected-fail — no such mechanism exists for the local runtime today, filed as issue #1025) |
-| AnyHarness binary self-update (sandbox): worker sees `desiredVersions.anyharness` bump → downloads pinned runtime → stops/swaps/relaunches it in place → a live session on the box restarts and completes → heartbeat reports the new version and agent CLIs reconcile to the new registry's pins | 4 | tests/release/src/scenarios/upgrade/t4-cloud-1.ts (T4-CLOUD-1; feed knob = staging server RUNTIME_VERSION via an ECS task-def override, gated behind `RELEASE_E2E_STAGING_ECS_PIN_BUMP` and `assertNotProduction`, restored in a finally. Blocked without a live E2B-backed sandbox + the ECS opt-in. **Product blocker found building this test:** the released anyharness binary reports `CARGO_PKG_VERSION` (hardcoded 0.1.0, never stamped) from both `anyharness --version` and `/health` `version`, but the worker's convergence preflight + health-gate require an exact match to the pinned semver — so no real pin can converge. Marked expected-fail with that diagnosis when it reaches the mechanism. Also: nothing published the `runtime/`|`worker/` CDN trees the redirects resolve to until scripts/ci-cd/publish-runtime-cdn.sh + the release-runtime.yml publish-cdn job) |
-| Desktop app update replaces bundled anyharness + worker sidecars; post-update catalog reconcile installs the right agent CLIs | 4 | tests/release/src/scenarios/upgrade/t4-desktop-1.ts (T4-DESKTOP-1 covers the bundle-swap half — the whole `.app`, sidecars included, is replaced N−1 → N; the post-update catalog reconcile half is T3-UPDATE-1) |
-| Desktop feed artifact valid per release: `latest.json` shape, signature verifies against bundled pubkey, bundle sidecars report correct versions | 4 | tests/release/src/scenarios/upgrade/t4-desktop-1.ts (T4-DESKTOP-1; `latest.json` schema served by serve-updater-feed.mjs, real minisign signature verified at download against the N−1-trusted pubkey) |
-| Desktop real N−1 → N auto-update (nightly native lane; needs a test build with overridable feed endpoint) | 4 | tests/release/src/scenarios/upgrade/t4-desktop-1.ts (T4-DESKTOP-1; local-macOS-aarch64-only, opt-in `RELEASE_E2E_DESKTOP_T4=1`, blocked cleanly in CI) |
-| SQLite migrations forward-apply on real N−1 data | 4 | — |
-| New release's sandboxes provision from the new E2B template; existing paused workspaces still wake on their old image | 4 | — |
+| Desktop real N−1 → N update, bundled AnyHarness, installed native CLI/ACP reconciliation, preserved session, post-update turn | 4 | tests/release/src/scenarios/upgrade/t4-desktop-1.ts (current partial collector; not qualifying) |
+| Existing E2B sandbox N−1 → candidate AnyHarness N through heartbeat and Supervisor ownership, installed native CLI/ACP reconciliation, preserved session, post-update turn | 4 | tests/release/src/scenarios/upgrade/t4-cloud-1.ts (current direct-Worker prototype; not qualifying; version-stamping blocker #1089) |
+| Change-triggered self-host `update.sh` preserves data/auth/config and remains recoverable on failure | 4 | tests/release/src/scenarios/upgrade/t4-sh-1.ts (current collector requires execution audit) |
+| Public release artifact chain is complete and immutable before feeds/tags move | 4 | tests/release/src/scenarios/upgrade/t4-sh-2.ts (current collector requires execution audit) |
+| Forward migrations preserve retained Postgres, AnyHarness SQLite, and Worker SQLite state | 4 | — |
 
-Old-template → new-template workspace movement is the managed-target
-replacement path, which is a placeholder runbook today
-(`specs/developing/runbooks/managed-target-replacement.md`) — its test enters
-this registry when the mechanism is built.
-
-**Sandbox anyharness in-place update is built**
-(`specs/tbd/anyharness-self-update-v1.md`): the sandbox worker acts on
-`desiredVersions.anyharness` and swaps the runtime binary in place (download →
-stop → swap → relaunch → health-gate → roll back on failure) — the row above
-tracks it, and the end-to-end scenario is now written
-(tests/release/src/scenarios/upgrade/t4-cloud-1.ts). Building it surfaced two
-gaps: (1) nothing in-repo published the `runtime/`/`worker/` bare-binary CDN
-trees the server redirects resolve to — now published by
-scripts/ci-cd/publish-runtime-cdn.sh and the release-runtime.yml publish-cdn
-job; (2) the released binary's `--version` and `/health` version are hardcoded
-`CARGO_PKG_VERSION` (0.1.0), which the worker's exact-match preflight/health-gate
-reject, so no real pin converges (issue #1089). A new
-anyharness now reaches a running sandbox without a new template. Desktop gets
-it only inside the app bundle, and that stays bundle-only by design (the worker
-leaves the gate off). The supervisor `update/` module stages but never fetches
-or swaps, and is not the update owner in v1.
-
-## Deferred — add on first production break
-
-Explicitly not in scope until one breaks in production (postmortem rule then
-applies and the test lands with the fix):
-
-- OpenCode configuration correctness per harness
-- Full agent × auth-method matrix (beyond the default auth method per agent)
+The target Tier 3 local-runtime contract derives every supported harness and
+visible configuration from the live probe, including OpenCode. It exercises
+managed LiteLLM and user API-key routes in GitHub Actions. Native CLI-login
+permutations are deliberately outside that qualification matrix.

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -1,0 +1,758 @@
+# Release Worlds And Fixtures
+
+Status: target contract for the Tier 2, Tier 3, and core Tier 4 test
+infrastructure. The scenario manifest defines what must be proved; this document
+defines the worlds and fixtures in which those scenarios run. Current-main
+enforcement gaps are named in [`core-release-validation.md`](core-release-validation.md)
+and never weaken the target contract silently.
+[`tier-3-scenario-contract.md`](tier-3-scenario-contract.md) defines how those
+fixtures compose into the exact Tier 3 journeys and matrix cells.
+[`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) defines how the
+retained production artifacts and candidate handles compose into the packaged
+install/update target cells.
+
+## Core Principle
+
+Run each scenario in the smallest realistic composition containing every
+boundary that can break its guarantee. Do not rerun the complete product suite
+for every host, deployment topology, or authentication permutation.
+
+Local invocation and GitHub Actions use the same runner, world provisioners,
+candidate manifests, scenario implementations, and readiness checks. "Local"
+means the runner was invoked from a developer machine; remote dependencies such
+as AWS, E2B, Stripe, and the public qualification gateway remain real.
+
+## Vocabulary
+
+These axes are independent and must not be collapsed into a generic `lane`:
+
+- **execution host**: the laptop or GitHub Actions runner executing the test
+  process;
+- **world**: `tier-2`, `local-runtime`, `managed-cloud`, `self-host`, or
+  `tier-4`;
+- **product host**: Desktop's browser renderer, packaged/native Desktop, or
+  hosted Web;
+- **target**: the independently evidenced Tier 4 target cell when `world` is
+  `tier-4` — clean candidate Desktop, Desktop N-1→N, E2B runtime N-1→N, or
+  change-triggered self-host N-1→N;
+- **selector**: the required cell set, such as the merge set or release
+  qualification set; and
+- **behavior**: `diagnostic` or `strict` result handling.
+
+Moving a run from a laptop to GitHub Actions changes the execution host and
+secret source, not the selected world, product behavior, preparation code, or
+assertions. Existing `LANE` and runtime-lane flags are migration inputs only;
+new contracts use the explicit axes above.
+
+## Shared Lifecycle
+
+Every world uses one runner-owned lifecycle:
+
+```text
+resolve selected cells and exact artifact receipts
+  -> create run and shard identity
+  -> preflight required local capabilities and credentials
+  -> prepare the selected world
+  -> prove readiness and return a typed ready-world handle
+  -> compose run-scoped actor/repository/billing fixtures
+  -> execute cells and record every final result
+  -> reconcile the cleanup ledger
+  -> evaluate diagnostic or strict behavior
+```
+
+This lifecycle is shared infrastructure, not a second implementation of the
+product journeys. A world is prepared once per compatible shard and reused by
+the cells whose isolation contract permits it.
+
+## Candidate Artifacts
+
+Every live or upgrade run begins with a content-addressed candidate manifest:
+
+```text
+candidate-manifest.json
+  source SHA and source-content hash
+  server image digest
+  Desktop renderer build identity
+  hosted Web build identity when enabled
+  signed packaged Desktop artifacts and updater signature
+  AnyHarness binaries per supported platform
+  Worker and Supervisor binaries per supported platform
+  catalog.json and registry.json hashes
+  E2B template ID and complete template-input hash
+  self-host bundle and image digest
+```
+
+Build each artifact once per candidate content hash and platform, then reuse it
+across worlds. Compilation caches may accelerate the build, but a cache entry is
+not qualification evidence. Downstream jobs download the prepared artifact and
+verify its digest against the candidate manifest.
+
+Tier 4 additionally resolves the retained manifest for the last qualified
+production release, N-1. N-1 is not inferred by decrementing a patch version or
+rebuilding current source with an older version string.
+
+Both manifests are versioned machine contracts. Each available artifact slot
+contains an immutable locator plus the digest/checksum needed to verify the
+downloaded bytes; E2B slots contain an immutable template ID and complete input
+hash. A slot may be explicitly unavailable while the foundation is under
+construction, but strict execution rejects an unavailable slot required by a
+selected world. Rolling references such as `latest` or unverified `stable`
+cannot satisfy an artifact slot.
+
+The retained-production manifest also binds the production release/source SHA
+to the trusted qualification evidence that allowed it to be promoted. It is
+the receipt for the actual production N-1 artifacts, not a request to rebuild
+them.
+
+The self-host artifact slot binds both the server image digest and the exact
+`proliferate-deploy.tar.gz`. The tarball contains `install.sh`,
+`docker-compose.production.yml`, `Caddyfile`, bootstrap/update/preflight/
+health/doctor scripts, the environment template, and `VERSION`. Optional
+self-host cloud cells additionally bind the Linux AnyHarness, Worker,
+Supervisor, catalog/registry, credential-helper, and bootstrap inputs they
+install. Scenarios never reconstruct this bundle from loose source files.
+
+The qualification LiteLLM deployment is persistent external infrastructure,
+not a candidate artifact rebuilt by every run. World evidence records its
+deployed image/configuration identity and readiness, while scenarios receive
+fresh run/actor/cell-scoped virtual keys and budgets.
+
+`tests/release/src/template/cache-manifest.ts` is only a local E2B content-cache
+index. `core-release-scenario-manifest.json` is only the target scenario
+inventory. Neither is a candidate or retained-production artifact manifest.
+
+Scenarios consume prepared artifact handles. They do not select versions,
+build binaries, publish templates, or decide which feed to use.
+
+## Infrastructure Lifetime
+
+### Long-lived qualification infrastructure
+
+- AWS IAM, networking, security groups, Route53 authority, TLS/ingress, and
+  artifact storage capacity
+- a dedicated publicly reachable qualification API ingress; the candidate
+  deployment and mutable product/database state behind it remain isolated per
+  run or release channel
+- a dedicated publicly reachable LiteLLM inference endpoint; its admin surface
+  remains private
+- a publicly reachable qualification callback relay for Stripe and E2B; it
+  preserves exact signed provider bytes while its delay/replay controls remain
+  private
+- the E2B team and provider account
+- the Stripe test account and test catalog
+- qualification GitHub App, bot actor, organization, repository, and permanent
+  App installation
+- durable encrypted GitHub refresh-token storage and a distributed lock for
+  token rotation across shards
+- test provider accounts
+- Desktop signing and updater-test infrastructure
+- GitHub environments and encrypted secret storage
+
+Long-lived infrastructure is reusable capacity. It is not shared mutable
+product state.
+
+### Run-scoped resources and product state
+
+- candidate API deployment or isolated release channel
+- users, organizations, invitations, and authentication sessions
+- Stripe customers, subscriptions, grants, meters, and webhook events
+- callback-relay routes, delivery ledgers, and controlled delay/replay handles
+- LiteLLM teams, virtual keys, budgets, and usage correlation
+- E2B sandboxes, Worker identities, and enrollment tokens
+- actor GitHub authorizations, product repository registrations/environments,
+  repository grants, and any run-specific working branches
+- self-host EC2 instances and DNS names
+- Desktop updater feed paths
+- desired-version pins for upgrade targets
+- cleanup ledger and correlation identifiers
+
+Destructive scenarios must not use a shared durable staging user or mutate a
+global staging version pin. Every created external resource is registered in
+the cleanup ledger immediately. Scenario cleanup is followed by provider
+reconciliation and a TTL janitor for abandoned runs.
+
+## World Dependency Matrix
+
+Dependencies are selected per world and per cell; the runner never boots every
+provider merely because it is available.
+
+| World | Required composition | Conditional composition | Explicitly absent |
+| --- | --- | --- | --- |
+| Tier 2 | Real server, Postgres, Desktop renderer in Chromium, deterministic external-service fixtures | Stripe test mode for selected billing cells | Real agent inference, E2B, packaged Desktop, and hosted Web |
+| Local runtime | Candidate server/Postgres, candidate AnyHarness, Desktop renderer, installed harnesses, provider route, public qualification LiteLLM | Stripe test mode for billing cells | E2B, self-host EC2, packaged Desktop, and hosted Web |
+| Managed cloud | Public candidate API/database, Desktop renderer, immutable candidate E2B template, E2B, Worker, Supervisor, AnyHarness, qualification LiteLLM, persistent qualification GitHub App/bot/install/repository | Stripe for billing cells; integration provider accounts for their cells | Self-host EC2, packaged Desktop, hosted Web, and the full local harness Cartesian product |
+| Self-host | Disposable EC2, DNS/TLS, exact candidate bundle/server image, Postgres, Desktop renderer, separate candidate AnyHarness, run-scoped BYOK credential | Operator LiteLLM profile, GitHub OAuth, or E2B add-on only for their advertised-posture cells | Packaged Desktop, managed-product billing, and unrelated hosted services |
+| Tier 4 | Candidate and retained-production manifests plus packaged/native controllers and the exact selected target handles | Clean candidate Desktop, Desktop N-1→N, E2B runtime N-1→N, and change-triggered self-host N-1→N cells select only their own composition | The complete Tier 3 functional Cartesian product |
+
+Candidate AnyHarness, Desktop renderer/package, E2B-template, server, and
+self-host artifacts are
+built once per content identity and reused across compatible world shards.
+Long-lived LiteLLM, Stripe, GitHub App, E2B-team, and AWS capacity may be reused,
+but every user, key, customer, sandbox, instance, repository grant, and desired
+version written for a run is isolated and ledgered.
+
+## Tier 2 World
+
+```text
+real server
+real Postgres
+Stripe test mode where relevant
+Desktop renderer in Chromium
+controlled external-service fixtures
+no E2B sandbox
+no complete cloud Worker/Supervisor stack
+no packaged Desktop
+no hosted Web until product-client unification
+```
+
+Tier 2 owns server, database, browser, authorization, billing-state-machine,
+webhook-replay, policy, and deterministic integration guarantees. It may use a
+narrow non-LLM AnyHarness HTTP seam, but it does not launch an agent or replace
+a Tier 3 journey.
+
+Stripe test mode is the one standing real-network Tier 2 exception. It is not a
+fake: the tests use Stripe's test API, customers, subscriptions, payments, and
+test clocks. Trusted CI must have the test credential and fail closed when it
+is absent. A developer's explicitly diagnostic local run may report the Stripe
+cells blocked when the credential is unavailable.
+
+The runner boots the same world locally and in GitHub Actions. Workflow YAML is
+a caller, not an alternate implementation of stack preparation.
+
+## Tier 3 Local-Runtime World
+
+```text
+candidate server and Postgres
+real local AnyHarness
+Desktop renderer in Chromium
+real installed harnesses
+real cheap LLM requests
+LiteLLM gateway
+no E2B
+```
+
+This is the deep runtime world. It tests every supported harness, managed
+gateway and user-key route, live-discovered configuration option, Desktop-local
+workspace, and core chat/session behavior. It uses the Desktop renderer in
+Chromium for every product interaction. Ordinary application preferences are
+Tier 2; packaged/native Desktop, its bundled sidecar, native filesystem/
+keychain behavior, clean installation, and relaunch are Tier 4 only.
+
+Hosted Web is deliberately absent: it cannot and must not reach a local
+AnyHarness. The current Tier 2 and Tier 3 contracts use the Desktop renderer;
+after product-client unification, selected shared cloud journeys add hosted Web
+without duplicating the expensive matrix.
+
+All local-runtime qualification uses the same persistent public qualification
+LiteLLM deployment. The runner never resets its global state: the candidate
+server provisions fresh run/actor/cell-scoped virtual keys and budgets, then
+correlates spend by immutable key identity. Only required inference routes are
+public; master keys and administrative routes remain private to the server or
+provisioner. World readiness records the exact deployed gateway image/
+configuration identity.
+
+## Tier 3 Managed-Cloud World
+
+```text
+public candidate API
+candidate server and database
+Desktop renderer in Chromium
+immutable candidate E2B template
+Worker, Supervisor, and AnyHarness
+public qualification LiteLLM inference endpoint
+Stripe test mode when selected
+GitHub and provider integrations
+```
+
+Base-world preparation creates reusable capacity without pre-completing the
+first-user provisioning behavior:
+
+```text
+prepare candidate runtime bundle once
+  -> build immutable E2B template once
+  -> smoke the template
+  -> deploy the candidate API
+  -> verify E2B, gateway, GitHub App, Stripe, and callback capabilities selected
+     by the shard
+  -> return the managed-cloud base handle
+```
+
+`CLOUD-PROVISION-1` starts from that handle with a fresh actor and proves that
+the real GitHub authorization/product path creates exactly one sandbox,
+enrolls Worker/Supervisor, and reaches AnyHarness readiness. Other cloud cells
+may reuse a separately prepared sandbox resource after that provisioning path
+has an independently green result; they never seed workspace/session state
+that their own journey is meant to prove.
+
+GitHub qualification keeps three boundaries distinct:
+
+- product GitHub login identifies the Proliferate actor;
+- GitHub App user authorization provides that actor's real user-to-server token
+  and triggers the personal-sandbox path; and
+- the permanent qualification App installation grants repository coverage.
+
+The App remains installed on the durable qualification organization/repository.
+Ordinary parallel qualification mocks only the human approval page and the
+one-time authorization-code exchange. Playwright clicks the real product
+control, captures the generated GitHub URL and signed state, and asks a private
+controller to finish approval. That controller verifies the state belongs to
+the expected actor, refreshes the real qualification-bot authorization under a
+distributed token-rotation lock, and calls the same production-owned completion
+tail as the HTTP callback:
+
+```text
+completeAuthorizationSuccess(state, realAuthorization)
+  -> validate signed state and actor binding
+  -> store the real authorization
+  -> ensure the personal sandbox row
+  -> schedule real materialization after commit
+  -> refresh the real installation cache
+```
+
+The paid-Core provisioning cell requires this tail to create exactly one real
+E2B sandbox. A separate fresh-free-actor cell proves authorization succeeds but
+provider creation remains compute-gated until paid credit exists. One serial
+periodic smoke drives the real interactive redirect, code exchange, and HTTP
+callback end to end. No qualification path may mock GitHub identity/token,
+installation/repository authority, E2B, Worker, Supervisor, or AnyHarness.
+
+This world tests cloud-specific boundaries: provisioning, enrollment,
+connection, repository materialization, secrets, usage import, billing
+consumption, pause/wake/resume, callbacks, and cleanup. It does not repeat the
+entire local harness/configuration Cartesian product. One representative cloud
+harness proves Worker/runtime packaging; every-harness coverage remains local.
+
+After Web/Desktop unification, one host-specific cloud-access journey runs on
+both Desktop and hosted Web against the same candidate deployment. It proves
+authentication bootstrap, gateway connection, stream continuity, deep-link
+ingress, and capability truth. Expensive provisioning, metering, exhaustion,
+and recovery actions still execute once per required world/shard, not once per
+historical frontend.
+
+The complete E2B template identity includes every runtime-bundle input:
+AnyHarness, Worker, Supervisor, credential helper, agent seed/catalog inputs,
+bootstrap scripts, install layout, and pinned dependencies. A rolling template
+tag moves only after strict qualification; scenarios consume immutable template
+IDs.
+
+## Tier 3 Self-Host World
+
+```text
+disposable EC2 instance
+production self-host bundle and Compose topology
+real TLS and DNS
+candidate server image
+Postgres
+optional operator-owned LiteLLM
+optional E2B/cloud add-on
+Desktop renderer pointed at the instance
+separate candidate AnyHarness for the representative local turn
+```
+
+Base-world preparation reserves disposable EC2/network/DNS capacity, supplies
+the immutable candidate bundle handle, and provides a clean Desktop-renderer
+controller plus separate candidate AnyHarness. It does not install or claim the
+product. The composed base self-host journey then performs the transitions
+being qualified:
+
+```text
+provision the disposable EC2 target
+  -> install the exact candidate bundle
+  -> obtain the setup token
+  -> claim the administrator
+  -> create an invitation and user
+  -> connect the Desktop renderer
+  -> verify login, capability truth, and selected optional profiles
+  -> perform one representative real agent turn
+  -> terminate the instance
+```
+
+This world owns installer, TLS, setup, registration, login, invitations,
+renderer-level server switching, server-origin isolation, optional-profile
+behavior, and truthful capability reporting. Native config/keychain writes,
+packaged-app relaunch, and restoration after relaunch remain Tier 4. It does not
+rerun every managed-cloud or local-runtime scenario.
+
+## Tier 4 Packaged-Install / Upgrade Stage
+
+Tier 4 is one qualification world/stage with four independently evidenced
+target cells:
+
+1. clean candidate Desktop N;
+2. retained production Desktop N-1 to candidate N;
+3. retained production E2B runtime N-1 to candidate AnyHarness N; and
+4. retained production self-host N-1 to candidate N when that deployment
+   boundary changed.
+
+It does not rerun Tier 3. It starts from the smallest ordinary working state
+needed by each target, uses packaged/native artifacts and the real shipped
+mechanism, proves exact candidate artifacts and agent pins, preserves state,
+and completes a post-install or post-update turn.
+
+Here N-1 means the exact retained artifacts from the last qualified production
+release, resolved by manifest and digest. It never means a decremented patch
+number or candidate source rebuilt with an older version string. Candidate N is
+built once during candidate preparation and reused by the selected target
+cells.
+
+MCP servers are a separate runtime-configuration surface; they are not ACP
+agent processes and do not share this reconciliation assertion.
+
+### Clean candidate Desktop N
+
+```text
+exact signed candidate Desktop N package
+bundled candidate AnyHarness and seed resources
+isolated native HOME, keychain, and runtime home
+prepared candidate self-host instance for the native connection cell
+```
+
+Flow:
+
+```text
+install candidate Desktop N in an isolated native environment
+  -> launch its bundled candidate AnyHarness
+  -> reconcile candidate catalog, native-agent, and ACP-adapter pins
+  -> perform a cheap local turn
+  -> connect to the prepared self-host instance through native Connect Server
+  -> relaunch the packaged app
+  -> prove origin/keychain/auth restoration
+```
+
+This cell proves the candidate package can be installed fresh. It is not a
+substitute for the retained-production updater cell below.
+
+### Desktop N-1 to N
+
+```text
+retained production N-1 Desktop
+real N-1 AnyHarness and installed agents
+isolated signed updater feed containing N
+```
+
+Flow:
+
+```text
+launch Desktop N-1
+  -> record Desktop, AnyHarness, catalog, native CLI, and ACP process identities
+  -> trigger the real Tauri update
+  -> install and relaunch Desktop N
+  -> launch bundled AnyHarness N against the existing runtime home
+  -> wait for seed hydration and agent reconciliation
+  -> assert exact N binary and installed-agent pins
+  -> perform a cheap real agent turn
+```
+
+The updater feed is local to the developer Mac or macOS CI runner. It contains
+the exact candidate updater artifact and signature but never moves the public
+production stable feed. The retained N-1 application contains its real
+production sidecars and seed resources; placeholder sidecars are not qualifying
+evidence. Because the production endpoint is currently compiled into the app,
+the isolated feed is supplied through the external or previously shipped safe
+mechanism defined by the Tier 4 scenario contract without patching N-1 payload
+bytes or bypassing signature verification.
+
+When an agent pin differs between N-1 and N, the scenario proves the real
+artifact update. When the pins are equal, it proves the startup reconcile is a
+no-op. Deterministic pin-drift edge cases remain focused lower-tier tests rather
+than artificial Tier 4 world states.
+
+### Managed-cloud sandbox N-1 to N
+
+```text
+candidate qualification API
+immutable N-1 E2B template
+N-1 Worker, Supervisor, and AnyHarness
+candidate N artifacts in immutable qualification storage
+run-scoped desired-version channel
+```
+
+Flow:
+
+```text
+set this run's desired versions to N-1
+  -> provision an N-1 sandbox
+  -> verify the baseline versions
+  -> change only this target/run to desired N
+  -> Worker heartbeat observes desired N
+  -> Worker persists an update request
+  -> Supervisor verifies and activates AnyHarness N
+  -> Supervisor health-gates the new runtime
+  -> AnyHarness reconciles installed native CLIs and ACP agent processes
+  -> assert exact N versions and pins
+  -> perform a cheap real agent turn
+```
+
+The candidate API redirects the target updater to run-scoped immutable
+artifacts, for example:
+
+```text
+qualification/<run-id>/<candidate-sha>/linux-x86_64/anyharness
+qualification/<run-id>/<candidate-sha>/linux-x86_64/anyharness.sha256
+```
+
+No test copies a binary or catalog into the sandbox after provisioning. The
+product heartbeat and update path must cause convergence.
+
+The intended ownership contract is:
+
+- Worker observes desired state, persists the update request, and later reports
+  convergence.
+- Supervisor downloads/verifies or consumes verified staged components,
+  activates them in dependency order, health-gates them, and rolls back.
+- AnyHarness never replaces its own binary. After N starts, it owns installed
+  agent reconciliation.
+
+The current direct-Worker activation implementation does not satisfy this
+intended boundary. The first release that introduces the Worker-to-Supervisor
+handoff requires a dedicated transition test. Subsequent releases use the
+ordinary N-1-to-N flow above.
+
+### Self-host N-1 to N
+
+This cell is selected when the self-host deploy bundle, server image, Compose
+topology, migrations, or update mechanism changed:
+
+```text
+install exact retained production N-1 bundle behind real DNS/TLS
+  -> claim the instance and create representative auth/product state
+  -> perform one representative turn
+  -> run the shipped update mechanism with exact candidate bundle/image digests
+  -> prove migrations and health are not reported complete early
+  -> prove data, auth, and configuration survive
+  -> prove retry is idempotent and N-1 is recoverable on failure
+  -> perform one post-update turn
+```
+
+This target reuses the Tier 3 self-host provisioner but uses packaged retained
+state and the real updater. It does not repeat owner/invitation/profile matrices
+already qualified in Tier 3.
+
+## Shared Fixtures
+
+A fixture creates reusable prerequisite product state. It must not pre-complete
+the behavior the scenario is meant to prove.
+
+World setup is not a fixture: candidate artifacts, API/database/runtime
+processes, E2B or EC2 capacity, run/shard identity, readiness, evidence sinks,
+and cleanup ledgers belong to provisioners. Provider access is also not a
+fixture: Stripe, LiteLLM, GitHub, E2B, AWS, and integration controllers run in
+the privileged test process and load secrets from local ignored storage or
+protected GitHub environments. Those credentials never enter the browser unless
+a scenario intentionally enters a user-owned provider key through product UI.
+
+The shared fixture surface is deliberately limited to six constructors:
+
+1. `authenticatedActor(role)` returns a registered, authenticated owner,
+   existing member, or owner in a different organization. It binds user,
+   organization, seat, billing-subject, and real product-session identities and
+   uses isolated browser storage.
+2. `freshIdentity()` returns a unique unused identity for signup, invitation
+   acceptance, first-owner claim, or another authentication transition. It does
+   not perform that transition.
+3. `preparedRepository(actor, world)` uses the durable qualification repository
+   at its known default branch and baseline commit. For local-runtime and the
+   self-host local turn, setup clones it to a run-scoped controller path and the
+   fixture calls real AnyHarness `POST /v1/repo-roots/resolve`; AnyHarness
+   validates/persists the main Git root and returns its repo-root identity. For
+   managed cloud there is no controller-side clone: the fixture saves the
+   actor's real `kind: "cloud"` repository environment through the server, which
+   verifies GitHub authority and materializes the repository inside E2B. The
+   fixture returns owner/repository, default branch, baseline commit, and the
+   world-specific repo-root or environment handle.
+4. `productPage(actor?)` returns a fresh Playwright `BrowserContext` and `Page`
+   running the Desktop renderer. With an actor it installs that actor's valid
+   product session; without one it starts logged out. It points the same renderer
+   at the selected ready world's API/runtime target: local candidate API plus
+   separate local AnyHarness, public candidate API plus E2B runtime, or self-host
+   EC2 API plus separate local AnyHarness. Hosted Web may later become a second
+   host for selected shared journeys; packaged Desktop is never returned here.
+5. `unregisteredGithubRepository()` is only for managed-cloud onboarding. It
+   returns the durable qualification repository as visible to the real
+   qualification GitHub actor but not yet registered in Proliferate for this
+   test actor. The App installation already exists; the scenario performs user
+   authorization, product registration, sandbox provisioning, and materialization.
+6. `billingThreshold(actor, balance)` is only for exhaustion/auto-top-up cells.
+   A private qualification controller positions the disposable actor's real
+   ledger just above the requested threshold. For LLM credit it expires prior
+   active grants, creates a run-tagged administrative grant equal to imported
+   spend plus the requested remaining balance, and reconciles the LiteLLM
+   budget. For compute it reduces the real active compute grant to the requested
+   remaining seconds. The scenario must then cross the threshold through real
+   LiteLLM usage or real E2B runtime so metering, Stripe payment/webhook, holds,
+   top-up, gating, and recovery remain production behavior. Fresh signup grants,
+   checkout, plan credits, and ordinary consumption are never seeded.
+
+Workspace/session creation, harness/model/configuration choice, provider-key
+entry, integration connection/use, secret CRUD/materialization, invitations,
+GitHub onboarding, sandbox create/pause/wake, checkout/grants/usage/top-ups/
+holds/recovery, self-host install/claim/login, and Tier 4 baseline/update state
+are scenario actions rather than initial fixtures. A transition may return a
+typed handle for compatible later cells only after its own scenario is
+independently green.
+
+## Construction Sequence
+
+Build this qualification system in dependency order:
+
+1. freeze the scenario/world/fixture contracts and machine inventory;
+2. validate persistent LiteLLM, GitHub, E2B, Stripe, AWS, public-ingress, and
+   artifact/download capacity;
+3. implement the shared artifact-receipt, run/shard, preflight, typed-world,
+   readiness, cleanup, evidence, and diagnostic/strict spine;
+4. build and independently smoke exact candidate artifacts;
+5. prove one local-runtime, managed-cloud, and self-host vertical slice locally,
+   then immediately reproduce each same slice in GitHub Actions:
+   - local: actor → prepared repository → Desktop renderer → candidate
+     AnyHarness → cheap managed-gateway turn → correlated LiteLLM spend;
+   - managed cloud: paid actor → GitHub authorization seam → exactly one E2B
+     sandbox → Worker/Supervisor/AnyHarness ready → repository materialized →
+     cheap turn → cleanup; and
+   - self-host: fresh EC2 → candidate bundle → owner claim/login → Desktop
+     renderer connection → representative BYOK turn → cleanup;
+6. fan out the remaining Tier 3 cells only after every world has one green local
+   and Actions slice; and
+7. complete the packaged Tier 4 target cells after the Tier 3 worlds are stable.
+
+This is implementation order. Once the platform exists, independent Tier 3 and
+Tier 4 qualification jobs may execute concurrently.
+
+## Local And GitHub Actions Execution
+
+Both environments call the same preparation and scenario code:
+
+```text
+local
+  credentials from ignored local secret storage
+  artifacts from a content-addressed local cache
+  remote E2B, AWS, Stripe, and qualification gateway remain real
+  Desktop Tier 4 runs on the developer Mac
+
+GitHub Actions
+  credentials from protected GitHub environments
+  prepare-candidate builds and uploads artifacts once
+  downstream world jobs download and verify them
+  independent Tier 3 and Tier 4 jobs run in parallel
+```
+
+A red CI run must reproduce by using its candidate manifest and runner flags
+locally. Secrets are named in the environment-variable catalog and never
+embedded in scenarios, artifacts, logs, or evidence.
+
+## Foundation Contracts
+
+### Run and shard identity
+
+The runner creates identity once, before any provider mutation:
+
+- `runId` groups the complete invocation and all of its evidence;
+- `shardId` identifies one deterministic parallel partition;
+- `attemptId` distinguishes a retry without erasing the original attempt;
+- source SHA and candidate/retained-manifest hashes identify what was tested;
+  and
+- GitHub workflow metadata or local origin is attached automatically for
+  traceability, not supplied as product configuration.
+
+Every provider resource, ready-world handle, cell attempt, evidence record, and
+cleanup entry carries the run and shard identity. A one-shard local run still
+has an explicit shard identity so its output aggregates exactly like CI.
+
+### Secret preflight
+
+Preflight runs after cell and artifact selection but before world provisioning,
+account mutation, or provider spend. It derives requirements from
+the selected worlds and cells and checks only local availability and safe basic
+shape: for example an E2B key/team pair, a Stripe `sk_test_` key, readable key
+files, supported host platform, and public-HTTPS URL shape. It never prints
+values and does not substitute for provider authentication or health checks.
+
+The laptop reads ignored local secret storage with the ambient environment
+taking precedence. GitHub Actions supplies protected environment secrets. Both
+invoke the same preflight implementation. Diagnostic behavior marks only the
+affected cells blocked and emits non-qualifying evidence; strict behavior fails
+before any external mutation. Actual provider permissions, callback delivery,
+and reachability are world-readiness checks.
+
+### Typed ready-world handles
+
+Environment variables and configuration are preparation inputs. Scenarios
+receive a verified typed handle, not a loose environment map. Every ready
+handle contains run/shard and artifact identities, sanitized endpoints or
+clients, readiness observations, and references to the evidence sink and
+cleanup ledger. A base-world handle exposes prepared capacity; scenario actions
+such as first sandbox provisioning, self-host claim, workspace creation, or
+integration connection return narrower typed resource handles and register
+them in the same ledger. This prevents setup from pre-completing the behavior
+being tested. World-specific base fields expose only what that world owns:
+
+- local runtime: candidate API/database, local AnyHarness, Desktop-renderer
+  controller, and qualification gateway;
+- managed cloud: public API, immutable template, E2B provider access,
+  qualification gateway, persistent GitHub authority, and the Desktop-renderer
+  controller; provisioned sandboxes add enrolled Worker/Supervisor/runtime
+  handles;
+- self-host: instance/network/DNS capacity, exact candidate bundle, SSH/SSM
+  control, a clean Desktop-renderer controller, and separate candidate
+  AnyHarness; installation and claim add TLS/API, setup-token,
+  advertised-capability, and authenticated-client handles; and
+- Tier 4: candidate/retained manifests plus only the selected target handles —
+  isolated clean or N-1 Desktop installation/runtime home and signed updater
+  feed, N-1 sandbox identities with candidate API/immutable artifact route/
+  target-scoped desired-version controller, or retained/candidate self-host
+  bundle handles.
+
+A provisioner returns the handle only after process/schema health, public
+reachability where required, artifact identity, controller enrollment, and
+credential applicability have all been observed.
+
+### Cleanup ledger
+
+Every external resource is appended to durable run output immediately after
+creation and before it is handed to another operation. A ledger entry records
+only safe provider/type/resource identity, owning world, creation state,
+cleanup state, attempts, and timestamps; credentials and arbitrary provider
+payloads are forbidden. Cleanup runs in reverse registration order, continues
+through independent failures, and persists every transition atomically.
+
+Normal completion, assertion failure, interruption, and provisioning failure
+all enter the same reconciliation path. A cleanup-by-run command can replay
+idempotent provider cleanup after a process or runner crash, and a TTL janitor
+is the final abandoned-run backstop. Later janitor success does not
+retroactively turn a strict run with failed cleanup green.
+
+### Per-cell evidence and result behavior
+
+Each world provisioner returns a typed ready handle only after validating its
+real boundaries: process health, schema readiness, artifact identity, public
+reachability where required, and run-scoped credentials. Scenario execution
+starts only after world readiness.
+
+A required world that cannot reach readiness fails strict qualification. A
+required row cannot be converted to green with `continue-on-error`, an
+expected-failure status, a missing credential, or a silently skipped external
+dependency. There is no blocked budget in qualification: every required cell
+must produce exactly one final green result. Optional and change-untriggered
+cells are resolved as `not_required`, never disguised as blocked.
+
+Diagnostic local and scheduled runs may report `blocked` or `expected_fail` so
+partially configured environments still produce useful signal. They always
+emit non-qualifying evidence, compare their blocked set with the previous run,
+and may not be consumed by promotion. A newly blocked diagnostic cell is a
+regression alert even when the diagnostic command itself continues.
+
+There are two result behaviors:
+
+- `diagnostic` continues independent cells and reports blocked or unfinished
+  work, but its aggregate is always non-qualifying; and
+- `strict` requires exactly one final green result for every selected required
+  cell, complete world readiness, valid artifact receipts, and successful
+  cleanup.
+
+Merge and release qualification are selectors for different required cell
+sets, not separate execution behaviors. Planning/dry-run is also not a passing
+behavior: it may emit a plan but cannot emit green product evidence.
+
+Strict evidence binds the source identity, candidate-manifest hash, world
+identity, artifact digests, scenario IDs, final results, and cleanup result.
+Production feeds, rolling tags, and desired-version pins move only after that
+evidence is green.

--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -1,9 +1,10 @@
 # Scenario Definitions
 
-Status: DRAFT for Pablo's ruling. Once blessed, this is the contract the test
-agents implement against — a scenario's steps and assertions define what
-"works" means for its registry row in `flows.md`. Grounded in a code survey
-2026-07-07; endpoints/tables cited are as-built, not aspirational.
+Status: legacy implementation survey and finding ledger from 2026-07-07. It is
+not the canonical target inventory, collector registry, or current run status.
+Stable requirements live in `core-release-validation.md` and the Tier 3/Tier 4
+scenario contracts; findings move to issues as collectors are audited. Do not
+copy status prose from this file into qualification evidence.
 
 Conventions:
 - Every tier-2 scenario runs against the stack-boot fixture: seeded Postgres,
@@ -227,10 +228,6 @@ Assert: free-plan repo limit enforced (`repo_limit_for_billing_snapshot` →
 `repo_limit_exceeded` on scheduling past the cap); agent-gateway policy edit
 gated by `agent_gateway_policy_min_plan` (`org_agent_policy_plan_required`,
 403, on a free org when min plan is `pro`).
-Survey flag for the registry row "plan gates the model list": **no
-plan-conditioned model list exists in code today.** Row stays in `flows.md`
-only if that behavior is planned product work; otherwise it should be
-deleted. [PABLO TO RULE]
 
 ### T2-BILL-3: seats — invite/remove/re-invite on a Pro org
 Pro billing is seat-based; every membership change must reconcile Stripe seat
@@ -374,8 +371,10 @@ stays enabled.
 ## Self-hosting
 
 Full narrative + tier-3/4 definitions live in
-`specs/developing/testing/self-hosting.md` (the self-hosting spec of record);
-the tier-1/2 scenarios that the test suite implements are indexed here.
+the canonical core-release and Tier 3/4 contracts. `self-hosting.md` preserves
+the historical implementation/evidence hand-off; the tier-1/2 scenarios that
+the current test suite implements are indexed here with legacy IDs pending the
+canonical migration map.
 
 ### T1-SH-1: single-org derivation (unit)
 `telemetry_mode == "self_managed"` OR `"local_dev"` ⇒ `single_org_mode` true;
@@ -795,15 +794,15 @@ scenario").
 
 ---
 
-## Open rulings collected
+## Remaining configuration parameters
 
-1. "Plan gates the model list" — not in code; keep as planned work or delete
-   the row (T2-BILL-2).
-2. T3-PROV-1 time budget number.
-3. T2-WS-2: is seam-only coverage of local/worktree create acceptable for
-   tier 2, with full coverage in tier 3's desktop lane?
-4. Google OAuth stays tier-3-only (mock not feasible without product change)
-   — confirm.
+These are not world-design decisions:
+
+1. the canonical conversion from Core's `$15` compute allocation to compute
+   units;
+2. exact LLM and compute top-up pack sizes/prices with positive margin; and
+3. cold-provision and paused-wake SLOs. Already-ready access is targeted at
+   less than five seconds to commandable AnyHarness.
 
 ## Product findings from the billing survey (2026-07-08) — rule before fixing
 

--- a/specs/developing/testing/self-hosting.md
+++ b/specs/developing/testing/self-hosting.md
@@ -1,14 +1,18 @@
 # Self-Hosting Test Hand-Off
 
-Status: hand-off from the self-hosting launch pass (2026-07-09) to the testing
-arc. Maps the self-hosting surface onto the 4-tier standard (`README.md`);
-scenario steps follow `scenarios.md` conventions. Grounded in code + a full
-local production-compose smoke run 2026-07-09, and one live incident (the
-desktop-artifact gap, §5) that this battery must be able to catch.
+Status: legacy implementation and evidence hand-off from the self-hosting
+launch pass (2026-07-09). It remains useful for mechanism history and existing
+collector pointers, but its old IDs and standing-server topology are not the
+target qualification contract.
 
-Ruling already made by Pablo: self-hosting E2E runs against **standing staging
-servers** (real EC2), and tier-2 desktop flows **prefer desktop-web, escalate
-gaps** (gaps enumerated in §4).
+`core-release-validation.md` and `core-release-scenario-manifest.json` own
+self-host guarantee IDs and qualification scope;
+`release-worlds-and-fixtures.md` owns the run-scoped disposable self-host
+world; `tier-3-scenario-contract.md` and `tier-4-scenario-contract.md` own
+composed journey semantics. This file, `flows.md`, and `scenarios.md` are
+legacy implementation/evidence views and must not define or renumber target
+scenarios. The standing `alpha`/`beta` notes below describe prior evidence;
+strict qualification provisions disposable EC2 instances by candidate digest.
 
 ---
 
@@ -42,10 +46,9 @@ is coverage that does not exist yet.
 
 ## 2. Flow registry rows
 
-Registered in `flows.md` under the **Self-hosting** section (same PR as this
-doc), same rules as the rest of the registry: pointer per row,
-audit-checked, `—` is a to-do. `2*` = needs the tier-2 escalation in §4 (not
-reachable from plain desktop-web).
+The rows below record the legacy collector vocabulary. The canonical ID
+migration table in `core-release-validation.md` controls how each pointer is
+folded, renamed, split, or rewritten before it can claim target coverage.
 
 ## 3. Scenario definitions
 
@@ -94,7 +97,7 @@ password form rendered (no GitHub button); with `GITHUB_OAUTH_CLIENT_ID/
 SECRET` set ⇒ GitHub button rendered. Driven purely by
 `GET /auth/desktop/methods`.
 
-### Tier 3 (standing staging servers)
+### Tier 3 (historical standing-server evidence)
 
 Two long-lived EC2 boxes, `alpha` and `beta`, each running the production
 compose bundle behind real DNS + Caddy-issued TLS (staging subdomains — needs

--- a/specs/developing/testing/tier-3-scenario-contract.md
+++ b/specs/developing/testing/tier-3-scenario-contract.md
@@ -1,0 +1,819 @@
+# Tier 3 Scenario Contract
+
+Status: target contract for the first standing Tier 3 foundation qualification
+wave. This document defines the exact scenario composition, fixtures,
+observable evidence, and intentional non-duplication across the local-runtime,
+managed-cloud, and self-host worlds.
+
+[`core-release-validation.md`](core-release-validation.md) owns the broader
+release inventory. [`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md)
+owns artifact preparation and world lifetimes. This document turns the aligned
+Tier 3 subset into executable cases. Case names such as `LOCAL-2` and
+`CLOUD-PROVISION-1` are composed journeys beneath the existing `T3-*` target
+IDs; they do not create a second guarantee inventory. The machine target
+manifest is the sole journey-to-guarantee map. This document deliberately owns
+only actions, assertions, evidence, and world reuse, so prose mappings cannot
+drift from the executable selector.
+
+## What Is Settled
+
+There is no remaining architectural choice blocking implementation of these
+scenarios. Two pricing constants remain configuration inputs:
+
+- the canonical conversion from the Core plan's `$15` compute allocation to
+  Proliferate Compute Units;
+- the exact LLM and compute top-up pack sizes and prices, which must preserve a
+  positive margin.
+
+Those values are configuration inputs. They do not change the worlds, fixture
+boundaries, test actions, or required evidence below.
+
+Already-ready cloud access has a settled product target of less than five
+seconds to commandable AnyHarness. Cold authorization-to-ready and paused
+wake-to-ready are measured separately until product SLOs are set for them.
+
+## Product Rulings Exercised By These Tests
+
+These are test inputs, not conclusions that a test may reinterpret:
+
+1. Proliferate does not use Bifrost. The managed model gateway is LiteLLM.
+2. A managed-gateway session receives only the public inference URL and its
+   scoped virtual key. LiteLLM administrative credentials never enter a
+   runtime target.
+3. A user-key session may receive the user's raw provider credential in the
+   explicitly permitted runtime target. It must not consume managed LLM credit.
+4. Route selection is frozen when an agent process starts. Changing the
+   selected route affects a new session, or an explicit process restart where
+   that operation is supported; it does not mutate a live process in place.
+5. Free personal users receive one lifetime `$2` managed-LLM grant, deduplicated
+   by GitHub identity rather than merely by a Proliferate account id.
+6. Core costs `$20` per active billed seat per month. Each active billed seat
+   contributes `$5` managed-LLM credit and `$15`-equivalent compute credit to
+   the organization's shared pools. Usage retains member attribution.
+7. LLM balances and top-ups are denominated in USD. Compute remains denominated
+   in its canonical compute unit.
+8. LLM auto-top-up and compute overage/top-up are separate explicit settings.
+   Enabling one never authorizes charges for the other.
+9. Managed-LLM exhaustion blocks managed gateway use. It does not pause a
+   sandbox, and a valid user API key remains usable.
+10. Compute exhaustion pauses and gates cloud compute. It does not consume or
+    refill managed-LLM credit.
+11. A top-up grant exists only after a successful Stripe payment event. Invoice
+    creation, finalization, failure, or an uncollected invoice grants nothing.
+12. Organization route policy is flag-only in this qualification wave. Policy
+    enforcement can be expanded without changing these base route proofs.
+
+The `$2` free grant and Core `$20 = $5 managed LLM + $15 compute` allocation
+are intentional target behavior. Current code still contains the prior `$5`
+free-credit and twenty-managed-cloud-hours posture. That mismatch is a product
+migration gap to fix against these cases, not a reason to weaken the cases.
+
+## Composition Rule
+
+Each guarantee runs in the smallest real composition containing every boundary
+that can break it:
+
+| World | Deeply proves | Does not repeat |
+| --- | --- | --- |
+| Local runtime | Desktop-renderer workspace/runtime behavior, every supported harness, managed gateway and user API-key routes, live-discovered configuration, session/tab semantics, and per-harness Product MCP integration | Ordinary product preferences, native Desktop persistence/restart, Hosted Web, E2B provisioning, compute metering, cloud secret materialization, self-host installation |
+| Managed cloud | GitHub-to-user sandbox binding, immutable template, repo materialization, warm access, Desktop-renderer cloud access, future Web parity, cloud credentials, integrations, compute accounting, holds, and recovery | The full harness/configuration Cartesian product already proved locally |
+| Self-host | Candidate install, TLS, first-owner claim, invitations, Desktop-renderer login, origin isolation, optional gateway, and optional cloud add-on | Native Tauri persistence/relaunch, Hosted identity matrix, all local harness options, all managed-cloud billing variants |
+
+A shared prerequisite is proved once and reused within a shard. For example,
+an authenticated actor and prepared repository may support several scenarios;
+workspace creation, session creation, integration connection, billing
+transitions, and provider effects remain scenario actions when they are the
+behavior under test.
+
+## Fixture Vocabulary
+
+### World setup
+
+World setup creates expensive shared capacity and verifies readiness. It does
+not pre-complete a behavior a scenario is supposed to prove.
+
+- exact candidate manifest and verified artifact handles;
+- candidate API/database, persistent qualification LiteLLM identity, and the
+  public TLS endpoints required by the selected world;
+- local candidate AnyHarness or the immutable candidate E2B template plus the
+  artifacts/configuration needed for later Worker/Supervisor enrollment;
+- disposable self-host instance where applicable;
+- Stripe, GitHub App, E2B, and provider qualification account access;
+- run id, resource ledger, evidence sink, and TTL cleanup registration.
+
+Actual actor authorization, E2B creation, Worker/Supervisor enrollment, and
+AnyHarness startup in the first-user path remain `CLOUD-PROVISION-1` actions;
+world setup supplies capacity and verified inputs only.
+
+### Reusable fixtures
+
+Fixtures provide preconditions whose creation is not the assertion of the
+scenario using them:
+
+- `authenticatedActor(role)`: a registered owner, existing member, or owner in
+  a different organization, with isolated browser storage, a real product
+  session, and returned user, organization, seat, and billing-subject identity;
+- `freshIdentity()`: a unique unused identity for signup, invitation acceptance,
+  first-owner claim, and other authentication journeys whose transition remains
+  scenario behavior;
+- `preparedRepository(actor, world)`: the durable qualification repository at a
+  known default branch and baseline commit, prepared through the production path
+  for the selected world. Local-runtime and self-host setup clone it to a
+  run-scoped runner path and resolve it through AnyHarness
+  `POST /v1/repo-roots/resolve`; managed cloud saves the actor's cloud repository
+  environment and materializes it inside E2B without a controller-side clone;
+- `productPage(actor?)`: a fresh Playwright browser context and page running the
+  Desktop product renderer, pointed at the selected ready world. It installs the
+  actor's real product session when supplied and starts logged out when login or
+  registration is the behavior under test;
+- `unregisteredGithubRepository()`: a real covered qualification repository that
+  is not yet registered in Proliferate. The qualification GitHub App is already
+  installed; authorization, registration, sandbox provisioning, and repository
+  materialization remain managed-cloud scenario actions;
+- `billingThreshold(actor, balance)`: a private qualification controller that
+  positions a disposable actor's real LLM or compute ledger just above a target
+  threshold. For LLM credit it expires prior active grants, creates a run-tagged
+  administrative fixture adjustment equal to imported spend plus the requested
+  remainder, and reconciles the LiteLLM budget. For compute it reduces the real
+  active compute grant to the requested remainder.
+
+Raw provider and integration keys are privileged controller inputs, not
+fixtures. They come from the local qualification secret file or GitHub Actions
+secrets and enter the browser only when a scenario deliberately stores a
+user-owned credential through the product UI. Gateway enrollment, provider-key
+selection, integration connection, and the product grant or payment being
+asserted remain scenario actions.
+
+The gateway actor and user-key actor are normally different fresh users. A
+route-switch scenario intentionally gives one actor both routes so it can prove
+process-bound route semantics. Every fresh actor also gets its own registered
+repository fixture.
+
+### Scenario-owned state
+
+Unless a case explicitly says otherwise, the scenario itself creates:
+
+- the workspace and session;
+- selected harness, model, mode, and reasoning configuration;
+- gateway enrollment and provider-key configuration;
+- integration connection and MCP use;
+- scoped secret creation/update/deletion;
+- invitation, registration, GitHub authorization, repository registration, and
+  first-owner claim when those transitions are under test;
+- checkout, payment, renewal, top-up, usage, exhaustion, hold, and recovery;
+- sandbox creation, pause, wake, or provider-side transition being asserted.
+
+There are no generic `emptyWorkspace` or `workspaceWithSession` fixtures for
+the core cases. Those states are important product transitions and are created
+in the test.
+
+## Cross-World Evidence Contract
+
+Every case records:
+
+- source SHA, candidate-manifest hash, and every artifact digest or template
+  id used by the world;
+- world, run, shard, actor, organization, repository, workspace, session, and
+  sandbox identifiers as applicable;
+- exact route, harness, probed capability snapshot, selected model, and process
+  generation;
+- sanitized provider request, usage, Stripe, E2B, Worker, and product ledger
+  correlation identifiers needed by the case;
+- measured readiness and propagation timings;
+- cleanup registration and final reconciliation result.
+
+Secrets, raw virtual keys, provider keys, refresh tokens, setup tokens, and
+integration credentials never enter logs or evidence.
+
+A required case has one final state: green or red. Missing credentials,
+unavailable infrastructure, a blocked provider, a missing product path, or an
+unimplemented assertion is red for qualification. Diagnostic siblings and
+cleanup may continue after a failure, but `continue-on-error`, expected-fail,
+skip-as-success, and normalized exit codes cannot make the aggregate green.
+
+Matrix journeys emit one explicit result per required harness, route, host, or
+other derived cell. A journey-level return without those child results cannot
+mark the matrix green. This prevents one successful harness from hiding a
+skipped or swallowed failure in another.
+
+## Local-Runtime World
+
+### Matrix discovery
+
+The bundled catalog is not assumed to be the sole source of truth. The runner
+composes shipped registry/catalog intent, product policy and overlays, and the
+live AnyHarness/ACP probe. The live probe is authoritative for what an
+installed harness can actually select.
+
+For each supported harness, the runner chooses the cheapest bounded model from
+the intersection of the qualification allowlist and the live probed model
+set. It first completes one real turn. Only after that proof does it exercise
+every visible probed mode, reasoning option, and configuration control.
+
+GitHub Actions exercises managed gateway and user API-key routes. Native agent
+authentication is not part of this qualification matrix.
+
+### Local cases
+
+#### `LOCAL-1` — repository to workspace
+
+Given an authenticated actor and prepared local repository, create a local
+workspace through the product surface. Assert the correct repository and
+default branch, commandable AnyHarness, one visible empty chat, and reload
+continuity. Do not seed the workspace or session directly.
+
+#### `LOCAL-2` — managed gateway turn for every harness
+
+For every supported probed harness:
+
+1. create a fresh gateway actor and register its repository;
+2. enroll it through the production server path, producing a new LiteLLM
+   virtual key and recorded `token_id`;
+3. if the harness is not installed, install it through the candidate
+   AnyHarness path and verify the exact trusted pin plus ready state;
+4. select managed gateway, create a new session, and send one bounded prompt on
+   the cheapest eligible model;
+5. assert session completion and one stable response after reload;
+6. poll LiteLLM unsummarized spend logs and find exactly the correlated request
+   under `api_key == token_id`, with real request, model, token, and cost data;
+7. assert the product usage event and managed balance reconcile to that request.
+
+The launch evidence must identify the managed route and public LiteLLM origin
+without exposing the key. Configuration success alone is not route proof.
+For OpenCode, the test explicitly selects a model from the runtime gateway
+catalog's injected `proliferate` provider so a native or direct provider cannot
+satisfy the turn.
+
+#### `LOCAL-3` — user API-key turn for every harness
+
+For every supported probed harness, read a run-scoped provider key from the
+controller's secret environment, store and select it through the product UI,
+create a new user-key session, and complete the same bounded turn. Assert the
+launch route is user key, the turn completes, no LiteLLM spend row appears for
+the actor/run/session, and no managed balance changes. For OpenCode, select a
+model belonging to the matching direct provider rather than the injected
+`proliferate` gateway provider.
+
+This is provider-agnostic qualification of the user-key route. Individual
+harness tests do not encode unrelated provider-specific behavior.
+
+#### `LOCAL-4` — live configuration matrix
+
+After the harness has completed its cheap baseline turn, iterate the controls
+advertised by its live probe:
+
+- visible models eligible for qualification;
+- visible modes;
+- visible reasoning options and levels; and
+- other mutable ACP configuration controls.
+
+For each value, select it through the product UI, wait beyond the normal
+rejection window, and assert that the UI still shows the accepted value. A
+rejected value must leave the last accepted value intact. A paid LLM turn is not
+required for every option unless the control's contract cannot otherwise be
+observed.
+
+#### `LOCAL-5` — session and tab semantics
+
+Prove all of the following in one workspace:
+
+- switching harness in a visible empty chat preserves one visible tab but
+  replaces the unused backend runtime session; the session id changes;
+- switching harness after the current session has messages preserves the old
+  transcript and creates a new session tab immediately to its right;
+- selecting the same harness and changing a supported model stays in the
+  session where the harness contract permits it; and
+- reload preserves tab order, active tab, harness attachment, and transcript.
+
+#### `LOCAL-6` — route-change semantics
+
+Use a representative single-source harness and give one actor both a valid user
+key and gateway enrollment. Start and prove a user-key session, then change the
+selected route to managed gateway through the product UI and wait for the new
+auth-state revision:
+
+- the existing process remains on the user-key route;
+- a new session starts on the gateway route and produces correlated LiteLLM
+  spend;
+- the old session remains attached to its original route.
+
+OpenCode is excluded from this switch case because its gateway and direct
+provider sources intentionally coexist. Its two routes are proved independently
+by `LOCAL-2` and `LOCAL-3` with route-specific models.
+
+#### `LOCAL-7` — Product MCP integration for every harness
+
+For each supported harness, connect the deterministic real integration through
+the product UI, create a fresh session so startup MCP injection is exercised,
+and use the cheapest eligible model to make one real call through the
+Proliferate integrations MCP. Assert the expected provider/tool operation and
+product audit correlation.
+
+This case proves positive per-harness Product MCP translation. It does not
+assert hidden server credential state or a disconnect/failure matrix.
+
+### Local managed-LLM billing cases
+
+#### `LOCAL-BILL-1` — free personal grant and drawdown
+
+Create a fresh GitHub-backed personal identity. Assert one `$2` lifetime grant,
+including concurrent/replayed enrollment and a second Proliferate account with
+the same GitHub identity. Complete a real managed turn and reconcile LiteLLM
+cost to the USD balance debit. Complete a user-key turn and assert no debit.
+
+#### `LOCAL-BILL-2` — Core checkout, seats, and initial grants
+
+Use a real Stripe test checkout for Core. Assert activation only after verified
+payment, `$20 × active billed seats` subscription quantity, the correct
+proration for seat changes, `$5 × seats` LLM grant, and `$15 × seats` compute
+allocation using the configured canonical conversion. Product UI, Stripe, and
+both ledgers must agree.
+
+#### `LOCAL-BILL-3` — organization pool and member attribution
+
+Have two members consume real managed turns. Assert both debit the shared
+organization LLM pool, each usage record retains the correct member, and no
+member's personal `$2` grant changes.
+
+#### `LOCAL-BILL-4` — renewal and replay
+
+Advance a Stripe test clock through renewal. Assert a paid invoice creates
+exactly one per-seat LLM and compute period grant, replay creates none, and an
+unpaid or failed renewal creates none.
+
+#### `LOCAL-BILL-5` — LLM exhaustion with auto-top-up disabled
+
+Arrange only a small remaining managed balance, spend through it with a real
+turn, and assert the scoped managed key is disabled or rejected. The next new
+managed session and any existing managed process fail with the owned typed
+error; no charge or grant occurs. A user-key session remains usable. No sandbox
+pause is expected.
+
+#### `LOCAL-BILL-6` — successful LLM auto-top-up
+
+Enable only LLM auto-top-up, cross the threshold with real LiteLLM usage, and
+assert one real Stripe test payment. Only the successful payment event creates
+the configured top-up grant. Assert key reactivation/rematerialization and a
+subsequent real managed turn. Compute overage remains unchanged.
+
+#### `LOCAL-BILL-7` — declined LLM auto-top-up
+
+Use a declining Stripe test payment method, cross the threshold, and assert no
+grant, the managed key remains blocked, a user-key turn still works, and retries
+cannot create an unbounded charge storm.
+
+Compute provider effects remain in the cloud world.
+
+## Managed-Cloud World
+
+### Ownership and GitHub qualification controller
+
+The supported base model is one active personal E2B sandbox per product user,
+containing multiple workspaces. Organization-owned sandboxes are not part of
+this wave.
+
+GitHub App user authorization is user-scoped and ensures the logical personal
+sandbox row. Provider materialization remains compute-gated. GitHub App
+installation is organization-scoped and grants repository coverage; it must not
+create a second sandbox. Effective repository authority is the intersection of
+the user's authorization and installation coverage.
+
+Qualification uses a dedicated GitHub bot, a qualification GitHub App installed
+on a test organization, one covered private repository, and one uncovered
+repository. World setup owns that persistent installation, protected rotating
+refresh token, App credential, and distributed refresh lock; it does not
+authorize a disposable actor or pre-create that actor's sandbox.
+
+The production HTTP callback and private qualification controller call one
+production-owned `complete_authorization_success(state, authorization)`
+service. Playwright clicks the real Authorize GitHub control and captures its
+real signed state. The controller verifies that state is bound to the expected
+actor, refreshes the bot's real authorization under the distributed lock, and
+passes it to the shared completion service. That service persists the
+authorization, ensures the logical personal sandbox row, schedules real
+materialization after commit, and refreshes the real installation cache.
+
+Ordinary qualification may mock only the human GitHub approval page and
+one-time authorization-code exchange. Identity and token authority, signed
+state, App installation, repository authority, E2B creation, Worker and
+Supervisor startup, credential delivery, clone/fetch/worktree operations, and
+AnyHarness remain real. Qualification never installs or uninstalls the GitHub
+App per shard.
+
+### Cloud cases
+
+#### `CLOUD-PROVISION-1` — authorization binds exactly one candidate sandbox
+
+Start with paid Core actor A and no GitHub App user authorization, logical
+sandbox row, or provider sandbox. Click the real product authorization control,
+capture its signed state, and complete it through the qualification controller.
+Assert the state is bound to actor A and that the resulting real authorization
+can access the covered qualification repository.
+
+Replay the same real authorization payload through the shared completion
+service concurrently in separate transactions. Every attempt must converge
+without an unhandled error. Assert exactly one active database sandbox row for
+actor A and exactly one E2B sandbox whose provider metadata contains actor A's
+id and that database sandbox id. This paired database/provider assertion must
+detect both duplicate rows and orphaned provider sandboxes.
+
+Compare the run's candidate template receipt—template id, build id, complete
+input hash, and AnyHarness, Worker, and Supervisor versions and hashes—with the
+raw E2B sandbox record and the matching receipt baked inside the sandbox. Query
+E2B directly and require that same provider sandbox to be `running`; the
+product's aggregate `ready` state is not sufficient evidence.
+
+Require exactly one active `cloud_sandbox` Worker bound to actor A and the
+sandbox, a recent heartbeat, and self-reported candidate Worker and AnyHarness
+versions. Require Supervisor to be the running parent of Worker and AnyHarness
+and to attest its candidate version. Authenticated AnyHarness `/health` must
+report the candidate version and `/v1/agents` must return the expected non-empty
+live catalog.
+
+With isolated actor B, assert the product API does not reveal actor A's sandbox,
+the gateway cannot proxy to it, actor A's workspace and session ids return
+not-found, and the direct AnyHarness endpoint rejects missing or actor-B product
+credentials. Database, E2B, process, heartbeat, and HTTP assertions each emit
+independent evidence rather than trusting one aggregate readiness flag.
+
+#### `CLOUD-FREE-COMPUTE-GATE-1` — free authorization remains compute-gated
+
+Start with a fresh free actor. Complete GitHub App user authorization through
+the same product and qualification path. Assert the actor receives only the
+settled `$2` managed-LLM grant and no compute allocation. The authorization tail
+may create the logical personal-sandbox row, but no provider E2B sandbox may
+start. The product must show the owned compute/payment gate. After a successful
+Core checkout, the same actor and logical row materialize exactly one real
+sandbox.
+
+#### `CLOUD-PROVISION-RECOVERY-1` — accepted-work recovery is duplicate-safe
+
+Inject one failure at each important accepted-work boundary: provider creation,
+Worker enrollment, runtime readiness, repository materialization, and workspace
+creation. At each boundary, retry through the normal product path and assert the
+system adopts or cleans partial state without creating a duplicate sandbox,
+workspace, session, or prompt.
+
+#### `CLOUD-GITHUB-CALLBACK-1` — serial real callback smoke
+
+On the periodic provider lane, drive the real GitHub browser redirect, approval,
+one-time code exchange, HTTP callback, and resulting product state end to end.
+This serial smoke is not repeated in ordinary pull-request shards, which may
+bypass only the interactive approval/code exchange and never signed-state or
+callback-tail behavior.
+
+#### `CLOUD-REPO-1` — real covered-repository materialization
+
+Through the Worker credential path, materialize the covered private repository
+and assert clone/fetch, expected default branch and commit, and a secret-free
+remote URL. Assert the uncovered repository is rejected. No OAuth fallback or
+long-lived token may appear in the repository.
+
+#### `CLOUD-WARM-ACCESS-1` — already-ready access under five seconds
+
+With the personal sandbox ready and repository already materialized, create a
+cloud workspace and measure from the successful create-workspace response
+received by the client until the first authenticated AnyHarness health/read
+request for that workspace succeeds. The budget is less than five seconds.
+UI-click-to-response and pending-shell render time are recorded separately and
+cannot substitute for commandability.
+
+Cold authorization-to-ready and paused wake-to-ready are separate measured
+budgets and do not use the five-second warm guarantee.
+
+#### `CLOUD-WAKE-1` — ordinary pause/wake continuity
+
+After one real turn in a ready sandbox, record the repository commit,
+workspace/session ids, a sentinel filesystem value, transcript sequence, and
+Worker/AnyHarness identities. Pause the sandbox through the supported product
+lifecycle and confirm E2B ground truth. Open the workspace through the normal
+product path, assert exactly one wake, measure wake-request-to-commandable, and
+verify every recorded state value plus monotonic transcript replay. Complete
+one post-wake turn exactly once. This journey uses funded compute and therefore
+tests the ordinary wake mechanism independently from exhaustion or paid
+recovery.
+
+#### `CLOUD-HOSTS-1` — Desktop and hosted Web cloud access after Web unification
+
+Authenticate the same disposable actor independently in Desktop and hosted
+Web. Against one prepared candidate sandbox, assert both hosts observe the same
+repository, workspace, sessions, transcript, configuration, and server-owned
+state; each can open a commandable cloud session through the product gateway;
+and a message sent from one host becomes visible exactly once on the other
+after stream/replay convergence.
+
+Also assert the contract differences: hosted Web exposes no local workspace or
+local worktree creation, never constructs a localhost/local-runtime request,
+and uses Web callback/deep-link ingress; Desktop retains its native/local
+capabilities and Desktop deep links. This journey proves host integration once.
+The remaining expensive cloud cases are not duplicated per host.
+
+#### `CLOUD-GATEWAY-1` — representative cloud managed-gateway turn
+
+Enroll the cloud actor through the product server path, create a fresh session
+with a representative harness, and complete one cheap real turn through the
+public qualification LiteLLM endpoint. Assert that only the scoped virtual key
+reaches the sandbox, then correlate its `token_id`, model, tokens, USD cost,
+imported usage event, payer, member attribution, and visible balance. This case
+proves cloud Worker/runtime gateway materialization; the local world owns the
+every-harness matrix.
+
+#### `CLOUD-APIKEY-1` — representative cloud user-key turn
+
+Materialize a run-scoped provider key through the production cloud credential
+path, create a fresh session with a representative harness, and complete one
+cheap real turn. Assert the user-key route and zero LiteLLM spend. The local
+world, not this case, owns every-harness repetition.
+
+#### `CLOUD-SECRETS-1` — scoped secret materialization
+
+Create personal, organization, and workspace environment secrets plus supported
+personal/workspace text-file secrets through product surfaces. Assert exact
+target paths or environment scope by hash, then update and delete them and
+observe propagation. Another user and workspace cannot read them, and plaintext
+is absent from transcript, events, logs, and evidence.
+
+#### `CLOUD-INTEGRATION-1` — representative cloud integration
+
+Connect the deterministic real integration through the product, create a fresh
+cloud session, and complete one real integration-backed Product MCP call. Assert
+the provider operation and product audit correlation. Per-harness repetition
+belongs to `LOCAL-7`.
+
+#### `CLOUD-PRODUCT-MCP-1` — built-in Product MCP smoke
+
+Where the candidate claims built-in Product MCP features such as reviews or
+subagents, complete one representative real read and permitted mutation using
+the candidate runtime. This is separate from third-party integration proof.
+
+#### `CLOUD-COMPUTE-METER-1` — real E2B usage accounting
+
+Generate genuine E2B open/close provider events and assert one closed compute
+segment with real duration. Reconcile billable seconds and organization payer
+plus member attribution. The actor's personal compute subject remains
+unchanged, and no overage is exported while included credit remains.
+
+#### `CLOUD-COMPUTE-EXHAUST-1` — exhaustion pauses and fails closed
+
+Arrange only a few remaining compute seconds, then use real E2B running time to
+cross zero. Invoke the production accounting/reconciler synchronously if needed
+to avoid a polling delay. Assert the real sandbox is paused, an active typed
+compute hold exists, and create/ensure/wake/command/stale-session/second-member
+entry points are blocked. If the provider is resumed directly for the drill,
+the product immediately re-pauses it.
+
+#### `CLOUD-COMPUTE-REFILL-1` — paid recovery and state preservation
+
+Complete a real compute top-up payment through the supported product path.
+Assert no grant before payment, exactly one grant after payment, hold clearance,
+actual E2B wake, and recovery of repository, workspace, filesystem, and session
+state. Record payment-to-gate-clear and gate-clear-to-commandable separately.
+
+This scenario is a required product target even while the modern compute pack
+path is an implementation gap.
+
+#### `CLOUD-COMPUTE-OVERAGE-1` — bounded compute overage
+
+Enable only compute overage, cross included compute with real E2B time, and
+assert exact Stripe meter quantity/cents up to the configured per-seat cap.
+After the cap, write-off and compute hold occur without overcharge. LLM
+auto-top-up remains disabled and no LLM grant or charge occurs.
+
+#### `CLOUD-COMPUTE-RENEW-1` — paid renewal recovery
+
+Use a Stripe test clock to pay the next Core period. Assert one per-seat compute
+grant, replay safety, hold clearance, real wake, and preserved state. A failed
+or uncollected renewal grants nothing and leaves the applicable hold in place.
+
+#### `CLOUD-BILLING-RECONCILE-1` — provider delivery and importer convergence
+
+Use the signed qualification callback relay to delay and replay genuine Stripe
+and E2B deliveries while restarting the candidate API, production billing
+reconciler, usage importers, and one affected Worker at recorded accepted-work
+boundaries. Rotate that actor's scoped LiteLLM key through the product path
+while the Worker is offline, then let desired-state repair converge after
+restart. Generate enough cheap LiteLLM requests to cross spend-log pages and
+overlap one polling window. Assert every payment, grant, E2B interval, LiteLLM
+request/cost, receipt, cursor, hold, materialization revision, and provider
+export converges exactly once after recovery; held sandboxes re-pause inline;
+and no provider or administrative secret enters evidence. The relay preserves
+exact signed provider bytes and cannot synthesize an event.
+
+Report independent required child cells for Stripe delivery, E2B delivery,
+LiteLLM pagination/import, process-restart recovery, and scoped-key
+materialization repair. They may share the prepared actor and sandbox, but one
+green child cannot hide another child's skip or failure.
+
+#### `CLOUD-BILLING-CONCURRENCY-1` — shared-pool concurrency bound
+
+Prepare two Core organization members with distinct personal sandboxes and
+scoped LiteLLM virtual keys. Run two isolated child cells: concurrent virtual
+key requests against a nearly exhausted organization LLM pool while compute is
+funded, then concurrent sandboxes against a nearly exhausted organization
+compute pool while LLM credit is funded. Before each cell, record that ledger's
+owning product contract and maximum evidenced in-flight allowance. Assert usage
+never exceeds the applicable pool plus its allowance, later launches fail
+before scheduling, all keys or compute gates converge, every usage event
+imports once with its member attribution, and personal/organization plus
+LLM/compute balances remain isolated. A missing, cross-ledger, or
+runtime-invented allowance fails the relevant child cell.
+
+### Permitted acceleration
+
+The runner may position a small starting balance through the run-tagged
+administrative fixture adjustment owned by `billingThreshold` and synchronously
+invoke production accounting/reconciliation. That adjustment is fixture state,
+not evidence of the product grant under test. It may directly pause or resume
+E2B only to generate a genuine provider event or read provider ground truth. It
+may not fabricate a usage segment, asserted plan/top-up grant, hold, gate
+decision, Stripe payment, provider state, or product recovery outcome.
+
+## Self-Host World
+
+### Base posture and authentication
+
+The base world deploys the exact candidate image and production bundle to a
+disposable EC2 instance behind real DNS and TLS. It is a single-organization
+installation. Tier 3 drives the Desktop product renderer in Chromium with
+Playwright plus a separate candidate AnyHarness for the representative local
+turn. Packaged Desktop and its native boundaries are Tier 4 concerns.
+
+First-owner claim is always the server-rendered `/setup` flow. The runner reads
+the one-time setup token through SSH/SSM, creates the initial email/password
+user and owner organization, and asserts `/setup` is permanently closed. Here,
+"password auth" is Proliferate email/password bearer authentication, not HTTP
+Basic Auth.
+
+Through the shared product host adapter, Connect Server normalizes the operator
+URL, fetches `/meta`, presents host/version/capability trust, points the Desktop
+renderer at the selected API base URL, and exposes the server's advertised auth
+methods. The owner then signs in with the setup password. Native Tauri config
+writing, keychain persistence, packaged-app relaunch, and restoration after
+relaunch are proved in Tier 4.
+
+Invitations currently use the server-rendered registration URL. The invited
+user opens `/register?token=...&email=...` in a browser, creates a password,
+then opens a second isolated product page pointed at the same server and logs
+in. No automatic browser-to-Desktop handoff is required by the current
+contract.
+
+The base release gate requires password auth. A separate configured GitHub
+OAuth case proves:
+
+- setup still uses password;
+- a verified matching GitHub email links to the existing owner rather than
+  creating a duplicate;
+- a new GitHub identity needs a pending invitation, consumes it, and receives
+  its role; and
+- an uninvited identity is denied.
+
+New password, GitHub, and Google accounts require invitations. Only an
+explicitly configured SSO JIT policy may bypass that rule.
+
+### Self-host cases
+
+#### `SH-INSTALL-CLAIM` — exact candidate installation and owner claim
+
+Install by the production installer using an immutable candidate
+manifest/image digest and checksum. Assert TLS, `/health`, `/meta`, advertised
+candidate versions, base capabilities, first owner claim, permanent second
+claim rejection, restart persistence, and truthful absence of vendor billing,
+pricing, hosted Web, or optional services.
+
+#### `SH-DESKTOP-OWNER` — Desktop-renderer connection and login
+
+Through the shared product host adapter in an isolated Desktop-renderer page,
+reject an invalid URL and a healthy non-Proliferate host, confirm that only
+public metadata is fetched before trust, point the renderer at the candidate
+instance, select password auth, and log in as the owner. Assert the single
+organization and candidate capabilities. Tier 4 separately proves native
+configuration persistence, keychain behavior, packaged-app relaunch, and
+restored login.
+
+#### `SH-BASE-TURN` — base self-host product turn
+
+As the authenticated owner, store a run-scoped user API key through the
+self-host product, create a local workspace through the Desktop renderer and
+separate candidate AnyHarness, and complete one bounded turn with a
+representative harness. Assert the self-host server, Desktop renderer, local
+AnyHarness, workspace, session, and transcript remain
+commandable without the optional LiteLLM or E2B profiles.
+
+#### `SH-INVITEE` — invitation, registration, and isolated member page
+
+Invite a member through the product UI, capture the qualification email or
+invitation response, register through the browser page, and connect/login from
+a second isolated product page. Assert the assigned role and one authenticated
+member action. Wrong-email, revoked, replayed, expired, duplicate, and
+uninvited registration matrices remain deterministic Tier 2 requirements and
+are not repeated against EC2.
+
+#### `SH-GITHUB-AUTH` — configured optional GitHub auth
+
+Using fixed qualification DNS and OAuth application configuration, claim the
+owner through password, sign in through GitHub as that verified owner and
+assert account reuse, then accept a pending invite as a second GitHub user.
+Assert an uninvited GitHub identity is denied.
+
+#### `SH-SWITCH-ISOLATION` — server-origin isolation
+
+Provision real servers A and B. Authenticate isolated Desktop-renderer product
+state to A, then switch that product state to B through the shared host adapter.
+Assert no A access token, refresh token, pending state, provider credential,
+runtime identity, workspace, or session is sent to or visible on B. B begins
+anonymous, can authenticate independently, and reconnecting to A restores only
+origin-scoped A state under the chosen reset/reconnect contract. Tier 4 owns the
+corresponding native config/keychain persistence and app-relaunch boundary.
+
+This case is fail-closed and currently expected to expose a product bug; that
+does not make it optional.
+
+#### `SH-GATEWAY` — optional operator LiteLLM profile
+
+Boot the documented optional gateway profile from the installation bundle.
+Enroll a product actor through the self-host server, materialize a scoped
+virtual key, and complete one cheap AnyHarness turn through the operator's
+LiteLLM endpoint. A direct call using a master key is not product proof. The
+base installation remains healthy and truthful when this profile is absent.
+
+#### `SH-CLOUD-ADDON` — optional self-host cloud capability
+
+Configure the instance's own GitHub App, E2B account, and immutable self-built
+template. Using the generic cloud helpers, prepare one covered repository,
+provision a personal sandbox/workspace, complete one representative turn, and
+pause/wake with state intact. Disabling the add-on leaves the base installation
+healthy and removes cloud capability truthfully.
+
+#### `SH-CFN-WRAPPER` — shallow infrastructure wrapper proof
+
+When CloudFormation is a supported install entry point, verify candidate input
+digests, stack outputs, DNS/TLS, and `/meta` version. Do not repeat the owner,
+invite, and Desktop authentication journey already proved above.
+
+Self-hosted Web, when supported, is the instance's same-origin Web application.
+It reuses product assertions but has no server picker, config rewrite, relaunch,
+or cross-server switch. Hosted Proliferate Web is never pointed arbitrarily at
+a self-hosted API.
+
+## Sharding And Reuse
+
+- Local route/harness cells use a distinct actor and gateway key when they run
+  in parallel. Configuration cells may reuse the already-qualified harness
+  process where state ordering is explicit.
+- Managed cloud reuses one candidate sandbox and prepared repository per
+  non-destructive shard. Billing/exhaustion cases get separate actors and
+  sandboxes so holds and balances cannot contaminate other cases.
+- Self-host auth journeys reuse one candidate instance. Cross-server isolation
+  alone provisions two. Tier 4 uses a separate N-1 instance.
+- Candidate binaries, E2B template, server image, Desktop artifact, and
+  LiteLLM deployment identity are built once per content hash and verified
+  before reuse across worlds.
+
+The same runner and world code execute locally and in GitHub Actions. Workflow
+YAML supplies credentials and selects shards; it does not contain a second
+implementation of setup or assertions.
+
+## Known Initial Red Gaps
+
+These are implementation work, not unresolved test design and not permitted
+skips:
+
+- the release E2B lane is not yet consistently bound to the immutable candidate
+  template;
+- the current provisioning collector proves mainly aggregate readiness and
+  `/v1/agents`; provider-side exact-one evidence, full baked receipt comparison,
+  Worker/Supervisor attestation, concurrent completion, free-user compute
+  gating, actor isolation, and accepted-work recovery are not yet collected;
+- staging E2B webhook signature validation has rejected real callbacks, which
+  prevents genuine compute metering evidence;
+- cloud wake currently ensures product state without reliably resuming the real
+  E2B sandbox;
+- the intended Worker GitHub lease target is not fully implemented; the current
+  materializer can write a token directly;
+- the cloud lane does not yet drive representative user-key, managed-gateway,
+  and integration turns through the complete Worker/runtime path;
+- the existing `T3-CHAT-1` collector carries a hand-maintained harness allowlist
+  rather than deriving the resolved matrix from the candidate catalog and live
+  probe;
+- self-host Desktop-renderer connection and login are not yet driven by the
+  existing Playwright lane; native config, keychain, and relaunch proof belongs
+  to Tier 4;
+- Desktop auth/runtime state is not yet safely partitioned by server origin;
+- the self-host provisioner can select a rolling `stable` artifact rather than
+  the exact candidate digest;
+- invitation-gated GitHub self-host login is not fully enforced;
+- a modern compute top-up pack and its paid wake path are not complete;
+- existing release workflows contain non-blocking/expected-failure behavior
+  that must be removed from the qualification aggregate;
+- current billing constants implement the previous `$5` free-credit and
+  twenty-hour compute posture rather than the settled `$2` and `$5 + $15`
+  policy;
+- hosted Web is not booted by the current shared Playwright world and has no
+  real managed-cloud host cell;
+- the current runner can swallow per-harness non-green results and still mark
+  the parent scenario green instead of emitting explicit matrix-cell results.
+
+Implementation proceeds world foundation first, then independent scenario
+shards, then bug fixing against the same cases. A case becomes blocking only
+after its collector, evidence, and candidate binding are audited, but a missing
+case never counts as a passed release guarantee.

--- a/specs/developing/testing/tier-4-scenario-contract.md
+++ b/specs/developing/testing/tier-4-scenario-contract.md
@@ -1,0 +1,525 @@
+# Tier 4 Scenario Contract
+
+Status: target contract for the core Tier 4 packaged-install and upgrade
+guarantee. This document defines the retained production inputs, candidate
+artifacts, qualification stage, actions, observables, and current gaps for the
+clean Desktop install, Desktop N-1 to N, managed-cloud runtime N-1 to N, and
+change-triggered self-host N-1 to N target cells.
+
+[`core-release-validation.md`](core-release-validation.md) owns the complete
+change-triggered compatibility inventory.
+[`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md) owns shared
+artifact preparation and infrastructure lifetimes. This document owns the four
+independently evidenced target cells beneath `T4-DESKTOP-1`, `T4-RUNTIME-1`,
+`T4-SELFHOST-1`, and their applicable embedded `T4-CATALOG-1` assertions.
+
+## Core Guarantee
+
+Tier 4 does not rerun Tier 3 on an old installation. It owns the packaged/native
+boundary and proves the narrower, more dangerous install and transition paths:
+
+```text
+exact already-built candidate N Desktop -> clean packaged install -> one real turn
+
+real retained production N-1 state
+  -> real shipped update mechanism
+  -> exact already-built candidate N artifacts
+  -> preserved state
+  -> installed agent artifacts converge to N pins
+  -> one real post-update turn
+```
+
+These are target cells inside one Tier 4 qualification stage, not separate
+worlds:
+
+1. clean-install the exact packaged candidate Desktop N and prove its bundled
+   AnyHarness plus managed agent artifacts;
+2. update a production N-1 Desktop through Tauri to Desktop N;
+3. update a production N-1 E2B sandbox after its target-scoped desired
+   AnyHarness version changes from N-1 to N; and
+4. when the self-host bundle changed, update a production N-1 self-host install
+   to N through its shipped update mechanism.
+
+The broader Tier 4 manifest contains legitimate change-triggered migration and
+compatibility guarantees. It is not an instruction to create 27 always-on live
+upgrade worlds. Those rows reuse retained data or one of these targets only when
+their owning surface changed.
+
+Self-host `update.sh` qualification is change-triggered when the self-host
+bundle, Compose topology, migrations, or update script changes. It is important
+release coverage but does not create another world. Public
+artifact-chain integrity remains an every-release gate without booting another
+upgrade world.
+
+## Artifact Identity
+
+### N-1 means the last qualified production release
+
+N-1 is resolved from the retained manifest for the last production release
+qualified before N. It is never:
+
+- inferred by subtracting one patch version;
+- rebuilt from candidate source with an older version string;
+- selected from a rolling `stable` tag without digest proof; or
+- replaced by whichever old artifact happens to remain on staging.
+
+The retained N-1 manifest identifies at least:
+
+```text
+production source SHA
+production Desktop app and updater artifact digests
+Desktop updater trust identity
+bundled Desktop AnyHarness, Worker, seed, catalog, and registry identities
+immutable production E2B template ID and input hash
+Worker, Supervisor, and AnyHarness versions and digests in that template
+installed seed/catalog agent pins
+production self-host deployment bundle and server image digest
+```
+
+### N is built once
+
+Candidate preparation already builds and records N. Tier 4 consumes those
+artifacts; a scenario does not rebuild them:
+
+```text
+candidate source SHA and manifest hash
+signed Desktop N updater artifact
+bundled Desktop AnyHarness, Worker, seed, catalog, and registry identities
+Linux AnyHarness N binary, digest, size, and checksum
+candidate Worker/Supervisor artifacts when their triggered rows apply
+immutable E2B template N for Tier 3 new-sandbox qualification
+immutable self-host bundle N and server image digest
+```
+
+The Desktop and cloud scenarios compare every activated artifact to this one
+candidate manifest.
+
+Each selected target emits explicit results for installation or transition,
+preserved state where applicable, every applicable already-installed managed
+native CLI and ACP agent process, and the post-install/update turn. A
+healthy parent process cannot hide a skipped or failed reconciliation child
+cell.
+
+## One Stage, Target-Specific Controllers
+
+An old target remains connected to one controller throughout its scenario. The
+controller changes the desired version; the test does not replace files in the
+target itself. Clean installation starts from an empty target and consumes the
+same candidate package later used by the Desktop update cell.
+
+| Target | N-1 source | Controller | Upgrade signal | N source |
+| --- | --- | --- | --- | --- |
+| Clean Desktop | Empty isolated machine | Native installer/package driver | Install the exact signed candidate package | Signed candidate Desktop package |
+| Desktop update | Retained production N-1 application | Isolated updater feed trusted by the N-1 application | Feed changes from no update to signed N available | Signed candidate Desktop updater artifact |
+| E2B sandbox | Retained immutable production N-1 template | Candidate qualification API written into Worker config at provisioning | This target's desired AnyHarness version changes N-1 to N | Run-scoped immutable AnyHarness artifact route |
+| Self-host | Retained production N-1 deployment bundle and data | Candidate release metadata/artifact endpoint consumed by shipped `update.sh` | Selected N release becomes available to the target | Immutable candidate self-host bundle and server image digest |
+
+The Desktop product API URL does not change during the update. The E2B Worker
+API URL also does not change after provisioning. Only the updater manifest or
+target desired version changes.
+
+## Natural N-1 State
+
+Each update target creates only the ordinary state needed to prove that an
+upgrade preserves a working product:
+
+- an authenticated actor;
+- a real repository and workspace;
+- a real session with one completed cheap-model turn;
+- the naturally installed N-1 catalog-managed native agent CLI and ACP
+  agent-process artifacts; and
+- recorded version, digest, catalog, agent, runtime-home, session, and event
+  identities.
+
+The live world does not manufacture missing, corrupt, user-modified, or
+user-owned artifact permutations. `T2-UPDATER-1` owns signature, checksum,
+unsafe-input, partial-download, atomic-swap, retry, last-good, and rollback
+decision matrices for both updater mechanisms. The Tier 4 update targets prove
+the natural N-1 to valid-N success transition and do not claim a
+live corrupt-candidate rollback drill. When an updater mechanism itself
+changes, its triggered Tier 4 row adds the smallest real failure injection
+needed to prove activation remains fail-closed.
+
+MCP servers are not ACP agent processes. Product and third-party MCP runtime
+configuration upgrades belong to `T4-RUNTIMECFG-1`, not the catalog
+reconciliation assertions in the selected targets.
+
+## Clean Candidate Desktop Install
+
+### `T4-DESKTOP-CLEAN-1` — packaged candidate install
+
+This target starts from a disposable supported macOS machine with no existing
+Proliferate application data, keychain entry, runtime home, or installed
+application. It consumes the exact signed candidate N package recorded by the
+candidate manifest; a development renderer, placeholder sidecar, or separately
+launched AnyHarness process is not acceptable evidence.
+
+Required actions and assertions:
+
+1. Install and launch the exact candidate N package through the shipped native
+   installation path.
+2. Complete product authentication and create a local workspace/session.
+3. Prove the packaged application starts its bundled candidate AnyHarness and
+   Worker from the expected paths and creates a fresh isolated runtime home.
+4. Wait for seed hydration and installed-agent reconciliation to reach explicit
+   successful terminal states.
+5. Complete one bounded turn on the cheapest eligible real model.
+6. Through the packaged native Connect Server path, select a prepared candidate
+   self-host instance, inspect its public metadata, authenticate, and prove one
+   server-backed product read.
+7. Quit and relaunch the packaged application; prove native server selection,
+   keychain/authentication, workspace, session, transcript, runtime home, and
+   installed managed agent identities remain intact and both the self-host
+   connection and local session remain commandable.
+
+Evidence includes the candidate manifest hash; signed package and installed
+application digests; application, AnyHarness, Worker, seed, catalog, registry,
+native CLI, and ACP agent-process versions; runtime-info and health; persisted
+workspace/session/auth identities; and the bounded-turn correlation id.
+
+## Desktop N-1 To N
+
+### World preparation
+
+The Desktop input is the actual retained production N-1 artifact whenever the
+shipped app can be directed safely to an isolated qualification feed. It must
+contain its real production AnyHarness/Worker sidecars and real agent seed.
+Placeholder sidecars are never qualification evidence.
+
+The production Desktop currently bakes its updater endpoint and trusted public
+key into the app. Pre-promotion testing therefore needs a safe isolated-feed
+mechanism that preserves signature verification. An external native
+qualification driver may supply only the alternate endpoint to the real Tauri
+updater engine while targeting a disposable byte-identical copy of the retained
+N-1 application and retaining the production public key. It must compare
+against the application's actual N-1 version and consume the exact
+production-key-signed candidate archive. The composed scenario then launches
+the swapped N application and proves the product integration; the external
+transaction alone is only updater-engine evidence.
+
+A previously shipped endpoint-only qualification hook or isolated DNS/TLS
+interception on a disposable macOS runner are also acceptable. None may
+override the trusted public key, patch the retained N-1 payload, or move the
+public production stable feed.
+
+If the exact production artifact cannot be driven safely, a retained
+qualification twin built from the exact N-1 production source is a bootstrap
+exception only. It must contain the exact production sidecar, seed, catalog,
+and registry payload hashes; its only permitted divergence is the updater
+endpoint, and it retains the production public key. A twin using a throwaway
+key is only updater-mechanism signal. Rebuilding current candidate source with
+an N-1 version is not permitted.
+
+The isolated feed initially reports no version newer than N-1. After the
+baseline turn, it exposes the already-built candidate N updater artifact and
+signature under the N-1 production trust chain. A throwaway trust chain may
+exercise the mechanism during development but cannot qualify production
+artifacts.
+
+The world runs on a supported disposable macOS runner with an isolated HOME,
+app data, keychain scope, runtime home, installation directory, updater feed,
+and cleanup ledger.
+
+### `T4-DESKTOP-1` — real application update
+
+#### Baseline
+
+1. Install and launch the retained N-1 application.
+2. Authenticate through the product and create a local workspace/session.
+3. Wait for N-1 AnyHarness readiness, seed hydration, and installed-agent
+   reconciliation.
+4. Complete one bounded turn on the cheapest eligible real model.
+5. Record Desktop, AnyHarness, Worker, seed, catalog, registry, native CLI, ACP
+   agent-process, runtime-home, workspace, session, transcript, event cursor,
+   and auth identities.
+
+#### Upgrade
+
+1. Make candidate N available through the isolated signed updater feed.
+2. Trigger the same Tauri check, download, signature verification, installation,
+   and relaunch path used by the product.
+3. Assert the installed application is the exact candidate N artifact.
+4. Launch the N application, which starts its bundled AnyHarness N against the
+   existing N-1 runtime home.
+5. Wait for N seed hydration and installed-only catalog reconciliation.
+
+#### Required assertions
+
+- Desktop reports version N and its installed bundle digest matches the
+  candidate manifest.
+- The bundled AnyHarness and Worker are real candidate artifacts, not test
+  placeholders.
+- AnyHarness reports N, uses the same runtime home, and reads the previous
+  workspace/session/transcript.
+- Seed hydration reaches a non-failed terminal state with the expected N seed
+  version, target, and seeded agents.
+- Agent reconciliation reaches terminal completion with zero failed per-agent
+  outcomes; top-level HTTP health alone is insufficient.
+- The active bundled catalog and trusted registry identities match N.
+- Every already-installed catalog-managed native CLI and ACP agent-process
+  artifact matches its N pin and verified source. A naturally unchanged pin is
+  an evidenced no-op; a naturally changed pin performs the real update.
+- Authentication and app/runtime state survive the real relaunch.
+- The existing session remains readable and completes one additional bounded
+  turn without duplicated transcript events.
+- A second reconciliation is idempotent.
+
+### Desktop evidence
+
+Evidence includes:
+
+- retained N-1 and candidate N manifest hashes and Desktop artifact digests;
+- updater endpoint identity, feed manifest hash, signature verification result,
+  and installed application version;
+- bundled sidecar/seed/catalog/registry digests;
+- `runtime-info.json`, `/health`, runtime home, seed and reconcile snapshots;
+- `/v1/catalogs/agents/version`, per-agent native and ACP artifact status,
+  versions, paths, and install-manifest hashes;
+- pre/post workspace, session, transcript, event cursor, and auth continuity;
+  and
+- the post-update turn correlation id.
+
+## Managed-Cloud Sandbox N-1 To N
+
+### World preparation
+
+The candidate N qualification API is deployed first. Running candidate server
+code while holding an old target at N-1 is intentional: it matches the real
+rollout order and proves the supported N server to N-1 Worker protocol.
+
+The qualification API is configured to provision the exact immutable
+production N-1 E2B template. After E2B creation, the server writes a fresh
+enrollment token and its own public Worker base URL into the sandbox Worker
+configuration. The API URL is a runtime provisioning input, not a value baked
+permanently into the E2B template.
+
+Before launching the Worker, the world creates a run/target-scoped desired
+version record set to N-1. The same API exposes exact candidate N artifacts
+through immutable manifest-bound routes, but it does not advertise N to that
+target until the baseline is complete.
+
+Required preparation:
+
+```text
+candidate N qualification API
+  + immutable production N-1 E2B template ID
+  + target-scoped desired AnyHarness version initially N-1
+  + exact candidate N AnyHarness artifact route and checksum
+  + disposable actor, qualification GitHub authority/repository, enrollment,
+    and target
+```
+
+The disposable actor uses the same qualification GitHub App authorization,
+installation coverage, and prepared-repository fixture as ordinary managed
+cloud provisioning. If the production path eagerly creates the personal
+sandbox when user authorization completes, the baseline drives that real path
+with the run scoped to the N-1 template. Tier 4 does not repeat the complete
+OAuth negative matrix; it proves that an ordinarily authorized user receives a
+working N-1 target that can later update in place.
+
+The Desktop product renderer in Chromium drives the cloud product actions, but
+the product client is not upgraded in `T4-RUNTIME-1`. Desktop N-1 to N is
+exclusively `T4-DESKTOP-1`; combining the two transitions would make a failure
+impossible to attribute and would retest unrelated state. Hosted Web may reuse
+this path after the unification cutover, but is not required by this contract.
+
+The world must not mutate the API deployment's global version environment,
+roll a shared staging service, use a durable shared user, or fall back to a
+rolling artifact.
+
+### `T4-RUNTIME-1` — heartbeat-driven runtime update
+
+#### Baseline
+
+1. Authenticate a disposable actor and provision its sandbox through the
+   product using the immutable N-1 template.
+2. Assert N-1 Supervisor, Worker, AnyHarness, bundled catalog/registry, and
+   installed native/ACP agent identities.
+3. Create a cloud workspace/session and complete one bounded turn.
+4. Record Worker identity/store state, applied revisions, event cursor, pending
+   command results, runtime home, session, transcript, and target status.
+
+#### Upgrade
+
+1. Change only this target's desired AnyHarness version from N-1 to exact N.
+2. The N-1 Worker receives N on its ordinary heartbeat and atomically writes a
+   durable update request. It does not download, replace, restart, or roll back
+   the runtime itself.
+3. The N-1 Supervisor consumes the request, resolves the candidate manifest,
+   downloads and verifies the N artifact, privately stages it, quiesces the
+   dependency pair, atomically activates it, and restarts in dependency order.
+4. Supervisor health-gates AnyHarness N and restores the last-good runtime if
+   activation cannot become healthy.
+5. Worker reconnects with its durable identity and reports convergence.
+6. AnyHarness N opens the existing runtime home and performs installed-only
+   reconciliation from its N bundled catalog and trusted registry.
+
+#### Required assertions
+
+- The heartbeat response for this target changes N-1 to N while unrelated
+  targets remain unchanged.
+- Exactly one durable request is produced for the divergence; replayed
+  heartbeats do not duplicate activation.
+- Worker performs no direct binary swap or process kill.
+- Supervisor's staged artifact version, size, checksum, and digest match the
+  candidate manifest; no `stable` fallback is accepted.
+- AnyHarness N becomes healthy and reports the exact candidate version/digest.
+- Worker reconnects and reports N using the same durable target identity,
+  applied revisions, cursor, and pending-result state.
+- The existing workspace/session/transcript remains readable and event sequence
+  stays monotonic across restart.
+- Every already-installed managed native CLI and ACP agent-process artifact
+  matches its N catalog pin with zero per-agent reconcile failures.
+- A naturally unchanged pin is an evidenced no-op; a naturally changed pin is
+  actually downloaded, verified, and activated.
+- One additional cheap turn completes in the existing session.
+- The sandbox remains based on its immutable N-1 E2B image. Tier 3 separately
+  proves that new sandboxes use the N template.
+
+### Cloud evidence
+
+Evidence includes:
+
+- retained N-1 manifest and immutable E2B template identities;
+- target/run id and before/after target-scoped desired-version records;
+- runtime-written Worker base URL origin and enrollment identity without raw
+  tokens;
+- Worker heartbeat versions and durable update-request identity;
+- Supervisor request, manifest, checksum, staging, activation, restart,
+  health-gate, and final status records;
+- before/after component digests, runtime health, catalog/registry identities,
+  and per-agent native/ACP artifact results;
+- Worker durable identity, revision, cursor, and pending-result continuity;
+- workspace/session/transcript/event continuity and post-update turn id; and
+- cleanup and provider reconciliation.
+
+## Self-Host N-1 To N
+
+### `T4-SELFHOST-1` — shipped bundle update
+
+This target is selected when the self-host bundle, server image, Compose
+topology, migrations, Caddy configuration, bootstrap/update/preflight/health
+scripts, or environment contract changes. It begins with the exact retained
+production N-1 deployment bundle and persisted data on a disposable EC2 host
+behind real DNS/TLS. It then consumes the exact candidate N bundle and server
+image digest through the shipped `update.sh` path.
+
+Required actions and assertions:
+
+1. Install N-1, claim the owner, authenticate through an isolated Desktop
+   product renderer, and complete one representative user-key agent turn.
+2. Record database, auth, configuration, Compose, image, TLS, workspace,
+   session, and transcript identities.
+3. Publish exact candidate N to the isolated qualification release endpoint and
+   invoke the unmodified N-1 update mechanism.
+4. Prove preflight, backup, pull, migration, restart, health gate, and final
+   version reporting consume the manifest-bound N artifacts and never report N
+   healthy before the complete stack is ready.
+5. Prove data, auth, configuration, workspace, session, and transcript survive;
+   complete one additional turn in the existing session.
+6. Inject the narrow image-pull, migration/restart, and post-update-health
+   failures required by `T4-SELFHOST-1`. N-1 remains recoverable, no failed N is
+   reported healthy, and retry converges once without reopening setup or
+   duplicating effects.
+
+Native Desktop updater behavior is not composed into this target: the browser
+renderer supplies product actions while the real remote deployment owns the
+self-host update boundary. Evidence includes retained and candidate bundle
+receipts, exact image digests, update/backup/migration/health logs, pre/post
+data identities, and both bounded-turn correlations.
+
+## First Supervisor-Ownership Transition
+
+The standing cloud scenario assumes the production N-1 installation already
+contains and runs a Supervisor that understands the durable request protocol.
+Candidate N code cannot retroactively give an older Worker/Supervisor that
+ability.
+
+The first release moving from today's direct-Worker activation to
+Worker-request/Supervisor-activation therefore requires a one-time bridge with
+its own strict transition proof. The implementation must declare how existing
+production sandboxes reach the new ownership model—for example, through a
+compatible legacy updater that installs and activates the bridge—without
+reprovisioning or losing user state. Once that bridge release is production
+N-1, subsequent releases use the ordinary standing scenario.
+
+This transition is an implementation prerequisite, not permission to keep two
+permanent activation paths. The legacy direct-Worker path is removed after the
+supported transition window.
+
+## Change-Triggered Tier 4 Inventory
+
+The remaining `T4-*` rows are selected by changed artifacts and contracts:
+
+- Worker or Supervisor update mechanics trigger their component lifecycle rows.
+- Agent seed/catalog changes reuse the selected targets' reconciliation
+  assertions plus focused lower-tier ownership/safety cases.
+- Schema, billing, credential, GitHub, workflow/delegation, support, mobile,
+  self-host, and wire-contract changes load their retained N-1 state and run
+  their narrow compatibility row.
+- E2B template identity is primarily Tier 3 for new sandboxes; Tier 4 only
+  proves an existing N-1 sandbox retains its base image and supported in-place
+  components converge.
+- Public artifact integrity is a release gate but not a third upgrade world.
+
+Change-triggered rows may share a prepared Desktop or sandbox when isolation is
+explicit. They do not cause the complete Tier 3 suite or all other Tier 4 rows
+to rerun for every permutation.
+
+## Local And GitHub Actions
+
+The same scenario code and artifact manifests execute in both environments:
+
+- Desktop runs on a supported disposable macOS machine. Locally it uses an
+  isolated HOME/feed; CI uses a protected macOS runner and protected signing
+  material or the retained qualification trust chain.
+- Managed cloud always uses real E2B and the public qualification API. Local
+  invocation changes only where the runner process lives.
+- The selected self-host update target always uses disposable EC2 plus real
+  DNS/TLS; local invocation again changes only the runner location.
+- Candidate artifacts are prepared once and downloaded by digest.
+- N-1 artifacts are resolved from the retained production manifest.
+- Workflow YAML selects the scenario and supplies protected handles; it does
+  not rebuild N-1/N or perform the upgrade itself.
+
+## Current Initial Red Gaps
+
+The agreed contract is not implemented today:
+
+- current Desktop automation builds candidate source twice with version edits,
+  stages placeholder sidecars, swaps a bundle without relaunching it, and does
+  not exercise runtime/session/agent convergence;
+- candidate Worker/AnyHarness version identity is not release-stamped end to
+  end: current binaries can report the crate's hard-coded `0.1.0`, and the
+  existing cloud update prototype expected-fails on that mismatch (#1089).
+  CI/CD artifact construction plus Worker/runtime version reporting own this
+  prerequisite; neither runtime update target can qualify until the reported
+  version and digest identify exact candidate N;
+- the exact retained production Desktop cannot yet be safely directed to an
+  isolated updater feed in the complete product journey;
+- Desktop Tier 4 is opt-in/local-only and reports blocked in CI;
+- cloud desired versions are global image environment pins, not target/run
+  scoped;
+- cloud artifact routes can fall back to rolling `stable` rather than failing
+  closed on a missing candidate artifact;
+- managed cloud launches AnyHarness and Worker separately; Supervisor is not
+  the active product parent;
+- Worker directly downloads/swaps/restarts itself and AnyHarness instead of
+  writing a durable Supervisor request;
+- Supervisor can verify/stage artifacts but does not consume requests,
+  activate, health-gate, or orchestrate rollback;
+- current cloud automation mutates shared staging, chooses hard-coded published
+  versions, checks only runtime health, and allows expected failure;
+- the release workflows do not invoke the required Tier 4 target cells as a
+  strict promotion dependency;
+- the local/Desktop catalog convergence path required after Desktop N relaunch
+  is not implemented today; it must be built rather than removed from the
+  contract;
+- seed/reconcile work is asynchronous and best-effort, while top-level health
+  can remain `ok`; qualification must inspect its terminal per-agent results;
+  and
+- the first direct-Worker to Supervisor-ownership bridge is not designed.
+
+No item above may become a skipped or expected-success release result. Machine
+manifest rows remain `planned` until exact collectors, lanes, candidate binding,
+evidence, and fail-closed aggregation are audited.


### PR DESCRIPTION
## Summary

- establish the authoritative Tier 2, Tier 3, and Tier 4 qualification model, world boundaries, fixture ownership, infrastructure lifetimes, and construction sequence
- encode 186 stable guarantees and 47 composed journeys in schema-v5 machine-readable inventory, including the three renderer-driven Tier 3 worlds and four independently evidenced Tier 4 targets
- reconcile the testing overview and legacy flow/scenario/self-host/update documents with the new source of truth without claiming planned coverage is implemented
- add a consistency test that locks Markdown/manifest identity, journey composition, target dimensions, counts, implementation-state honesty, runtime update ownership, and local links

## Impact

This is the decision-complete contract for building the shared qualification spine and vertical slices. Every executable mapping remains marked planned until a real collector and qualifying evidence are audited.

## Validation

- node --test scripts/ci-cd/core-release-scenario-manifest.test.mjs (9/9)
- jq schema/count validation: 186 guarantees, 47 journeys
- git diff --check origin/main...HEAD