### PR TITLE
feat(test): truthful release-runner results and combined reporting (Q1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ LANE ?= local
 DESKTOP ?= web
 AGENTS ?= all
 SCENARIOS ?= all
+BEHAVIOR ?= diagnostic
 DRY_RUN ?=
 FILE_ISSUES ?=
 DESKTOP_RELEASE_TARGET_OS ?= macos
@@ -784,10 +785,11 @@ test-cloud-all: cloud-runtime-build server-db-ready
 # (specs/developing/testing/README.md "Running tier 3/4 locally"). One runner
 # CLI with lane flags; this target is a thin wrapper so CI and laptops call it
 # identically. LANE=local|staging DESKTOP=web|native AGENTS=<list|all>
-# SCENARIOS=<list|all> DRY_RUN=1 FILE_ISSUES=1.
+# SCENARIOS=<list|all> BEHAVIOR=diagnostic|strict DRY_RUN=1 FILE_ISSUES=1.
 release-e2e:
 	pnpm install --silent
 	cd tests/release && pnpm exec tsx src/cli/run.ts \
+		--behavior $(BEHAVIOR) \
 		--lane $(LANE) \
 		--desktop $(DESKTOP) \
 		--agents $(AGENTS) \

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -4,6 +4,9 @@ How tests are organized across the repo: what each tier owns, where test files
 live, what gates merges vs releases, and how a change decides which tests it
 must add. [`core-release-validation.md`](core-release-validation.md) owns the
 complete target guarantee and qualification semantics;
+[`qualification-runner-core.md`](qualification-runner-core.md) owns the frozen
+test runner and results-reporting contract: selection, run identity, one final
+result per selected test, the combined report, and diagnostic/strict behavior;
 [`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md),
 [`tier-3-scenario-contract.md`](tier-3-scenario-contract.md), and
 [`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) own the live world

--- a/specs/developing/testing/qualification-runner-core.md
+++ b/specs/developing/testing/qualification-runner-core.md
@@ -1,0 +1,401 @@
+# Test Runner and Results Reporting
+
+Status: frozen implementation contract for the first qualification-platform
+slice. Revision: `Q1-frozen-2`. Audited base:
+`2ec15eaf8cfc870cbdbb42c225a5f1428e5282b4`.
+
+## Outcome
+
+The release-test command runs the selected tests and truthfully reports what
+happened:
+
+```text
+receive selected tests
+→ check their declared requirements
+→ run or plan them
+→ record exactly one final result for every selected test
+→ write one combined machine-readable report
+→ exit using the status recorded in that report
+```
+
+This contract owns test selection, run identity, normalized results, the
+combined report, and diagnostic/strict exit behavior. It does not provision
+providers or worlds, build candidates, or add scenarios.
+
+## Vocabulary
+
+A **selected test** is one current `ScenarioDefinition` expanded across one of
+its declared runtime lanes:
+
+```ts
+interface SelectedTestV1 {
+  test_id: `${string}/${"local" | "sandbox"}`;
+  scenario_id: string;
+  registry_flow_ref: string;
+  runtime_lane: "local" | "sandbox";
+}
+```
+
+`test_id = scenario_id/runtime_lane`.
+
+This slice does not expose child results for agent, harness, model,
+authentication route, configuration, target API lane, or Desktop mode. A
+scenario that internally swallows one of those outcomes cannot claim that
+child as covered; later scenario work owns that expansion.
+
+## Current → target control flow
+
+Current behavior:
+
+```text
+parse flags
+→ select scenarios
+→ best-effort local setup
+→ run each scenario/runtime pair
+→ separately count green, blocked, expected-fail, and failed outcomes
+→ write JSON only for ordinary failures
+→ exit nonzero only for ordinary failures
+```
+
+This permits blocked-only and expected-fail-only runs to exit `0` without a
+complete record of what actually ran. Dry-run also does not call each
+scenario's `plan()` method.
+
+Target behavior:
+
+```text
+parse and validate invocation
+→ resolve run identity
+→ expand and deduplicate selected tests
+→ initialize one pending result slot per selected test
+→ preflight declared requirements
+→ plan or execute according to behavior
+→ normalize every outcome
+→ synthesize any missing result as an integrity error
+→ derive verdict and intended exit code
+→ validate and atomically write one combined report
+→ exit using the persisted verdict
+```
+
+## Run identity
+
+```ts
+interface RunIdentityV1 {
+  run_id: string;
+  shard_id: string;
+  attempt: number;
+  source_sha: string;
+  origin: {
+    kind: "local" | "github_actions";
+    github_run_id: string | null;
+    github_job: string | null;
+  };
+}
+```
+
+- IDs match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`.
+- GitHub Actions identity applies only when `GITHUB_ACTIONS === "true"`.
+- GitHub defaults are `GITHUB_RUN_ID`, `GITHUB_JOB`,
+  `GITHUB_RUN_ATTEMPT`, and `GITHUB_SHA`.
+- The attempt is separate from `run_id`; retries preserve the logical run.
+- Local defaults are `local-<timestamp>-<suffix>`, shard `local-0`, attempt
+  `1`, and `git rev-parse HEAD`.
+- Explicit run/shard/attempt overrides win without changing the recorded
+  origin.
+- Invalid or incomplete identity exits `2` before selection executes.
+
+Every local invocation still has a shard so local and parallel CI reports have
+the same shape.
+
+## Preflight and execution
+
+Preflight is limited to existing `requiredEnv` declarations and existing local
+seed applicability. It does not contact or provision providers.
+
+Diagnostic behavior:
+
+```text
+missing requirement → affected test blocked
+satisfied independent test → execute
+```
+
+Strict behavior is fail-closed:
+
+```text
+if any selected test lacks a requirement:
+  affected tests → blocked / missing_requirement
+  otherwise-runnable tests → cancelled / strict_preflight_failed
+  execute zero scenario bodies
+  write selected_tests_failed report
+  exit 1
+```
+
+Outside strict preflight, both behaviors continue independent sibling tests
+after green, failed, blocked, or expected-fail outcomes.
+
+Diagnostic dry-run calls every selected scenario's `plan()` and no scenario's
+`run()`. A successful plan produces `not_run / dry_run`; a planning exception
+produces `not_run / plan_error`, records a runner error, continues sibling
+planning where possible, and exits `2`. Strict dry-run is invalid.
+
+## Final test results
+
+`pending` is internal and never serialized. Every selected test ends in
+exactly one state:
+
+```ts
+type FinalTestStatus =
+  | "green"
+  | "failed"
+  | "blocked"
+  | "expected_fail"
+  | "cancelled"
+  | "not_run"
+  | "missing";
+```
+
+| State | Meaning |
+| --- | --- |
+| `green` | The real test completed and passed its assertions. |
+| `failed` | The real test found a product, assertion, or runtime failure. |
+| `blocked` | A known requirement prevented a meaningful assertion. |
+| `expected_fail` | The test reached an explicitly diagnosed known product gap. |
+| `cancelled` | Execution was requested, but a run-level condition prevented the test from running. |
+| `not_run` | Diagnostic dry-run planned rather than executed the test. |
+| `missing` | Finalization found no result for a selected test; runner-integrity failure. |
+
+The first accepted final result wins. Duplicate finalization preserves the
+first result, records an integrity error, and exits `2`.
+
+## Diagnostic and strict verdicts
+
+Diagnostic is for local investigation. Its report always says
+`non_qualifying`; exit `0` means the diagnostic sweep completed within its
+tolerated policy, not that the product qualified.
+
+Strict is a future gate input. It requires every selected real test to be
+green. This slice lacks candidate-build identity, world readiness, cleanup
+proof, and full scenario coverage, so a green strict run says only
+`selected_tests_passed` with `completeness = partial`.
+
+| Result set or runner condition | Diagnostic | Strict |
+| --- | --- | --- |
+| Every selected real test green | Exit `0`; `non_qualifying` | Exit `0`; `selected_tests_passed` |
+| Blocked only | Exit `0`; `non_qualifying` | Exit `1`; `selected_tests_failed` |
+| Expected-fail only | Exit `0`; `non_qualifying` | Exit `1`; `selected_tests_failed` |
+| Any failed | Exit `1`; `non_qualifying` | Exit `1`; `selected_tests_failed` |
+| Any cancelled or missing | Exit `1`; `non_qualifying` | Exit `1`; `selected_tests_failed` |
+| Successful diagnostic dry-run | Exit `0`; every test `not_run` | Invalid; exit `2` |
+| Planning, runner, or integrity error | Exit `2`; `non_qualifying` if persisted | Exit `2`; failed if persisted |
+| Invalid invocation, identity, or selection | Exit `2`; no selected-set report | Same |
+| Combined report cannot be validated/written | Exit `2`; no persisted report | Same |
+
+Exit precedence is:
+
+```text
+invalid invocation or identity before a valid selected set → 2
+report validation/write, runner, or integrity error → 2
+otherwise diagnostic/strict result policy → 0 or 1
+```
+
+Custom graceful signal handling is deferred.
+
+## Command-line contract
+
+Existing flags remain:
+
+```text
+--lane <local|staging>
+--desktop <web|native>
+--agents <list|all>
+--scenarios <list|all>
+--only <id-or-list>
+--dry-run
+--file-issues
+--output-dir <path>
+--help
+```
+
+Add:
+
+```text
+--behavior <diagnostic|strict>  required for direct command use
+--run-id <safe-id>              optional override
+--shard-id <safe-id>            optional override
+--attempt <positive-integer>    optional override
+```
+
+`make release-e2e` passes `--behavior` explicitly and defaults
+`BEHAVIOR ?= diagnostic`. No workflow YAML changes in this slice.
+
+Reject empty lists, duplicate selections, unknown scenarios, mixed `all` plus
+named values, and strict dry-run. `--help` exits `0` without identity or a
+report.
+
+Issue filing remains auxiliary and behavior-compatible. It consumes a view
+derived only from normalized `failed` results after the combined test report;
+this slice does not redesign issue filing or its failure semantics.
+
+## Combined report
+
+Write one artifact per invocation/shard/attempt:
+
+```text
+<output-dir>/<run-id>/<shard-id>/attempt-<n>/qualification-evidence.json
+```
+
+```ts
+interface TestRunReportV1 {
+  schema_version: 1;
+  kind: "proliferate.test-run";
+  run: RunIdentityV1 & {
+    behavior: "diagnostic" | "strict";
+    execution: "real" | "dry_run";
+    started_at: string;
+    finished_at: string;
+  };
+  inputs: {
+    target_lane: "local" | "staging";
+    desktop: "web" | "native";
+    agents: string[] | "all";
+    scenarios: string[] | "all";
+  };
+  selected_tests: SelectedTestV1[];
+  results: Array<{
+    test_id: string;
+    scenario_id: string;
+    registry_flow_ref: string;
+    runtime_lane: "local" | "sandbox";
+    status: FinalTestStatus;
+    started_at: string | null;
+    finished_at: string;
+    duration_ms: number | null;
+    reason: { code: string; message: string } | null;
+    plan_steps: string[];
+  }>;
+  summary: {
+    selected: number;
+    finalized: number;
+    by_status: Record<FinalTestStatus, number>;
+    integrity_errors: Array<{ code: string; message: string }>;
+    runner_errors: Array<{ code: string; message: string }>;
+    intended_exit_code: 0 | 1 | 2;
+  };
+  verdict: {
+    status:
+      | "selected_tests_passed"
+      | "selected_tests_failed"
+      | "non_qualifying";
+    scope: "selected_tests";
+    completeness: "partial";
+    reasons: string[];
+  };
+}
+```
+
+The report guarantees:
+
+- selected and result test IDs are unique and exactly equal;
+- `selected === finalized === results.length`;
+- `by_status` contains all seven keys and exactly counts the results;
+- verdict and intended exit match behavior, results, and errors;
+- the write is atomic and refuses to overwrite an existing attempt;
+- exact resolved secret values are replaced with `[REDACTED]`;
+- messages are bounded to 4,096 Unicode code points;
+- raw stacks and provider payloads are not serialized;
+- no candidate, provider, world, cleanup, or correlation evidence is invented.
+
+Per-failure JSON files disappear. Existing `FailureReport` construction may
+remain only as an in-memory compatibility mapping from normalized `failed`
+results to issue filing.
+
+## Failure behavior
+
+- Invalid command, selection, or identity runs no tests and exits `2`.
+- Diagnostic missing requirements block affected tests and continue satisfied
+  siblings.
+- Strict missing requirements execute no test bodies and exit `1` with a
+  complete failed selected-set report.
+- Product/test failures become `failed` and do not stop independent siblings.
+- Known gaps become `expected_fail`; only diagnostic tolerates them.
+- Missing results are synthesized as `missing`, record an integrity error, and
+  exit `2`.
+- Duplicate finalization preserves the first result, records an integrity
+  error, and exits `2`.
+- Report validation or write failure exits `2`; no success may be claimed
+  without a persisted report.
+
+## Ownership and file plan
+
+```text
+Makefile                                      modify
+tests/release/src/
+  cli/
+    args.ts                                   modify
+    args.test.ts                              add
+    run.ts                                    thin process adapter
+  runner/
+    identity.ts                               add
+    identity.test.ts                          add
+    result.ts                                 add
+    result.test.ts                            add
+    execute.ts                                add
+    execute.test.ts                           add
+  evidence/
+    schema.ts                                 add
+    write.ts                                  add
+    write.test.ts                             add
+  scenarios/
+    types.ts                                  comments/contracts only
+  report/
+    types.ts                                  modify
+    failure-reporter.ts                       failed-result mapping only
+    failure-reporter.test.ts                  modify
+    issue-filer.ts                            unchanged
+```
+
+No workflow YAML or scenario implementation changes.
+
+## Acceptance proof
+
+Focused tests prove:
+
+- explicit/omitted behavior, preserved flags, help, list validation, strict
+  dry-run rejection, and identity overrides;
+- GitHub/local identity, stable logical run across retries/shards, safe IDs,
+  source SHA, and non-overwriting attempt paths;
+- unique scenario/runtime expansion and invalid selection rejection;
+- normal return, blocked, expected-fail, ordinary error, and non-Error throw
+  normalization;
+- diagnostic continuation and strict zero-execution preflight;
+- dry-run calls every `plan()` and no `run()`;
+- missing and duplicate result integrity behavior;
+- every diagnostic/strict matrix row and exit code;
+- one valid aggregate for every representable result/error state;
+- exact selected/result equality, counters, verdict, exit code, redaction,
+  bounds, atomic write, and overwrite refusal;
+- failed results still derive issue-filing compatibility payloads;
+- the existing release-runner suite and typecheck remain green.
+
+Required local proof:
+
+```bash
+pnpm -C tests/release test
+pnpm -C tests/release typecheck
+```
+
+No live provider, model, sandbox, EC2 instance, Stripe event, packaged Desktop,
+or candidate artifact is required.
+
+## Non-goals
+
+- Provider provisioning, Terraform, or persistent test services.
+- Candidate or retained-production builders and receipts.
+- Local-runtime, managed-cloud, or self-hosted world startup/readiness.
+- Cleanup tracking.
+- Scenario or guarantee expansion and per-harness child results.
+- GitHub Actions redesign or removal of workflow `continue-on-error`.
+- Production-promotion evidence consumption.
+- Issue-tracker redesign.
+- Custom graceful signal handling.
+- Product bug fixes found by later scenarios.

--- a/tests/release/src/cli/args.test.ts
+++ b/tests/release/src/cli/args.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CliUsageError, parseArgs } from "./args.js";
+
+test("parses explicit diagnostic and strict behaviors", () => {
+  assert.equal(parseArgs(["--behavior", "diagnostic"]).behavior, "diagnostic");
+  assert.equal(parseArgs(["--behavior", "strict"]).behavior, "strict");
+});
+
+test("rejects an omitted --behavior", () => {
+  assert.throws(() => parseArgs([]), CliUsageError);
+});
+
+test("rejects an invalid --behavior value", () => {
+  assert.throws(() => parseArgs(["--behavior", "lenient"]), CliUsageError);
+});
+
+test("rejects strict dry-run", () => {
+  assert.throws(() => parseArgs(["--behavior", "strict", "--dry-run"]), CliUsageError);
+});
+
+test("allows diagnostic dry-run", () => {
+  const args = parseArgs(["--behavior", "diagnostic", "--dry-run"]);
+  assert.equal(args.dryRun, true);
+});
+
+test("parses valid run/shard/attempt overrides", () => {
+  const args = parseArgs([
+    "--behavior",
+    "diagnostic",
+    "--run-id",
+    "run-1",
+    "--shard-id",
+    "shard.a",
+    "--attempt",
+    "3",
+  ]);
+  assert.equal(args.runId, "run-1");
+  assert.equal(args.shardId, "shard.a");
+  assert.equal(args.attempt, 3);
+});
+
+test("rejects invalid attempt values", () => {
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--attempt", "0"]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--attempt", "-1"]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--attempt", "1.5"]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--attempt", "abc"]), CliUsageError);
+});
+
+test("preserves existing lane/desktop/agents/scenarios/issue/output flags", () => {
+  const args = parseArgs([
+    "--behavior",
+    "diagnostic",
+    "--lane",
+    "staging",
+    "--desktop",
+    "native",
+    "--agents",
+    "claude,codex",
+    "--scenarios",
+    "T3-WT-1,T3-CHAT-1",
+    "--file-issues",
+    "--output-dir",
+    "out",
+  ]);
+  assert.equal(args.lane, "staging");
+  assert.equal(args.desktop, "native");
+  assert.deepEqual(args.agents, ["claude", "codex"]);
+  assert.deepEqual(args.scenarios, ["T3-WT-1", "T3-CHAT-1"]);
+  assert.equal(args.fileIssues, true);
+  assert.equal(args.outputDir, "out");
+});
+
+test("--only remains an alias for --scenarios", () => {
+  const args = parseArgs(["--behavior", "diagnostic", "--only", "T3-WT-1"]);
+  assert.deepEqual(args.scenarios, ["T3-WT-1"]);
+});
+
+test("rejects empty lists", () => {
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--scenarios", ","]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--agents", " , "]), CliUsageError);
+});
+
+test("rejects duplicate list values", () => {
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--scenarios", "T3-A,T3-A"]), CliUsageError);
+});
+
+test("rejects mixing all with named values", () => {
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--scenarios", "all,T3-A"]), CliUsageError);
+});
+
+test("a lone all parses to the all selector", () => {
+  assert.equal(parseArgs(["--behavior", "diagnostic", "--scenarios", "all"]).scenarios, "all");
+});
+
+test("--help parses without --behavior (help never needs identity or a report)", () => {
+  const args = parseArgs(["--help"]);
+  assert.equal(args.help, true);
+});
+
+test("rejects unknown flags and invalid lane/desktop values as usage errors", () => {
+  assert.throws(() => parseArgs(["--nope"]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--lane", "prod"]), CliUsageError);
+  assert.throws(() => parseArgs(["--behavior", "diagnostic", "--desktop", "mobile"]), CliUsageError);
+});

--- a/tests/release/src/cli/args.ts
+++ b/tests/release/src/cli/args.ts
@@ -1,21 +1,34 @@
 import { parseDesktopMode, parseTargetLane, type DesktopMode, type TargetLane } from "../config/types.js";
+import type { ResultBehavior } from "../runner/result.js";
 
 export interface CliArgs {
   lane: TargetLane;
   desktop: DesktopMode;
   agents: string[] | "all";
   scenarios: string[] | "all";
+  behavior: ResultBehavior;
   dryRun: boolean;
   fileIssues: boolean;
   outputDir: string;
+  runId?: string;
+  shardId?: string;
+  attempt?: number;
   help: boolean;
 }
 
-const DEFAULTS: Omit<CliArgs, "help"> = {
-  lane: "local",
-  desktop: "web",
-  agents: "all",
-  scenarios: "all",
+/** Invalid command-line syntax or an invalid invocation; the process exits 2. */
+export class CliUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliUsageError";
+  }
+}
+
+const DEFAULTS = {
+  lane: "local" as TargetLane,
+  desktop: "web" as DesktopMode,
+  agents: "all" as string[] | "all",
+  scenarios: "all" as string[] | "all",
   dryRun: false,
   fileIssues: false,
   // Relative to this package's own cwd (`tests/release/`), which is what
@@ -29,31 +42,48 @@ const DEFAULTS: Omit<CliArgs, "help"> = {
 /**
  * Manual argv parser, matching this repo's existing script convention
  * (see scripts/build-template.mjs) rather than adding a CLI-parsing
- * dependency for a handful of flags.
+ * dependency for a handful of flags. All syntax and invocation validation
+ * happens here, before any identity, setup, or scenario work.
  */
 export function parseArgs(argv: readonly string[]): CliArgs {
-  const args: CliArgs = { ...DEFAULTS, help: false };
+  const args: Omit<CliArgs, "behavior"> & { behavior?: ResultBehavior } = { ...DEFAULTS, help: false };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
       case "--lane":
-        args.lane = parseTargetLane(requireValue(argv, i, arg));
+        args.lane = wrapUsage(() => parseTargetLane(requireValue(argv, i, arg)));
         i += 1;
         break;
       case "--desktop":
-        args.desktop = parseDesktopMode(requireValue(argv, i, arg));
+        args.desktop = wrapUsage(() => parseDesktopMode(requireValue(argv, i, arg)));
         i += 1;
         break;
       case "--agents":
-        args.agents = parseListFlag(requireValue(argv, i, arg));
+        args.agents = parseListFlag(arg, requireValue(argv, i, arg));
         i += 1;
         break;
       case "--scenarios":
       case "--only":
         // --only is sugar for --scenarios (per the tier-3 build task: "runner
         // should support --only <id>"); both set the same field.
-        args.scenarios = parseListFlag(requireValue(argv, i, arg));
+        args.scenarios = parseListFlag(arg, requireValue(argv, i, arg));
+        i += 1;
+        break;
+      case "--behavior":
+        args.behavior = parseBehavior(requireValue(argv, i, arg));
+        i += 1;
+        break;
+      case "--run-id":
+        args.runId = requireValue(argv, i, arg);
+        i += 1;
+        break;
+      case "--shard-id":
+        args.shardId = requireValue(argv, i, arg);
+        i += 1;
+        break;
+      case "--attempt":
+        args.attempt = parseAttempt(requireValue(argv, i, arg));
         i += 1;
         break;
       case "--dry-run":
@@ -71,43 +101,90 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         args.help = true;
         break;
       default:
-        throw new Error(`Unknown flag: ${arg}. Run with --help for usage.`);
+        throw new CliUsageError(`Unknown flag: ${arg}. Run with --help for usage.`);
     }
   }
 
-  return args;
+  if (args.help) {
+    return { ...args, behavior: args.behavior ?? "diagnostic" };
+  }
+  if (args.behavior === undefined) {
+    throw new CliUsageError("--behavior <diagnostic|strict> is required for direct command use.");
+  }
+  if (args.behavior === "strict" && args.dryRun) {
+    throw new CliUsageError("--behavior strict cannot be combined with --dry-run.");
+  }
+  return { ...args, behavior: args.behavior };
 }
 
-function parseListFlag(value: string): string[] | "all" {
-  if (value === "all") {
-    return "all";
+function parseBehavior(value: string): ResultBehavior {
+  if (value === "diagnostic" || value === "strict") {
+    return value;
   }
-  return value
+  throw new CliUsageError(`--behavior must be "diagnostic" or "strict", got "${value}".`);
+}
+
+function parseAttempt(value: string): number {
+  const attempt = Number(value);
+  if (!Number.isInteger(attempt) || attempt < 1 || !/^\d+$/.test(value)) {
+    throw new CliUsageError(`--attempt must be a positive integer, got "${value}".`);
+  }
+  return attempt;
+}
+
+function parseListFlag(flag: string, value: string): string[] | "all" {
+  const entries = value
     .split(",")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+  if (entries.length === 0) {
+    throw new CliUsageError(`${flag} received an empty list.`);
+  }
+  if (entries.includes("all")) {
+    if (entries.length > 1) {
+      throw new CliUsageError(`${flag} cannot mix "all" with named values.`);
+    }
+    return "all";
+  }
+  const duplicates = entries.filter((entry, index) => entries.indexOf(entry) !== index);
+  if (duplicates.length > 0) {
+    throw new CliUsageError(`${flag} has duplicate value(s): ${[...new Set(duplicates)].join(", ")}.`);
+  }
+  return entries;
 }
 
 function requireValue(argv: readonly string[], index: number, flag: string): string {
   const value = argv[index + 1];
   if (value === undefined || value.startsWith("--")) {
-    throw new Error(`${flag} requires a value`);
+    throw new CliUsageError(`${flag} requires a value`);
   }
   return value;
 }
 
+function wrapUsage<T>(parse: () => T): T {
+  try {
+    return parse();
+  } catch (error) {
+    throw new CliUsageError(error instanceof Error ? error.message : String(error));
+  }
+}
+
 export const HELP_TEXT = `
-Usage: pnpm exec tsx src/cli/run.ts [flags]
-   or: make release-e2e LANE=local|staging DESKTOP=web|native AGENTS=all SCENARIOS=all DRY_RUN=1
+Usage: pnpm exec tsx src/cli/run.ts --behavior <diagnostic|strict> [flags]
+   or: make release-e2e BEHAVIOR=diagnostic|strict LANE=local|staging DESKTOP=web|native AGENTS=all SCENARIOS=all DRY_RUN=1
 
 Flags:
+  --behavior <diagnostic|strict>  Required. Diagnostic tolerates blocked/expected-fail; strict is a fail-closed gate.
   --lane <local|staging>     Which target server the runtime lanes talk to (default: local)
   --desktop <web|native>     Desktop lane to drive (default: web)
   --agents <list|all>        Comma-separated harness kinds, or "all" (default: all)
   --scenarios <list|all>     Comma-separated scenario ids, or "all" (default: all)
   --only <id>                Alias for --scenarios with a single id (e.g. --only T3-WT-1)
-  --dry-run                  Report the plan + env manifest; never call a real provider/LLM
+  --dry-run                  Plan every selected test (calls plan(), never run()); diagnostic only
   --file-issues              File one GitHub issue per distinct failure via \`gh\` (default: off)
-  --output-dir <path>        Where failure reports are written, relative to tests/release/ (default: .output)
+  --output-dir <path>        Where the combined report is written, relative to tests/release/ (default: .output)
+  --run-id <safe-id>         Optional run identity override
+  --shard-id <safe-id>       Optional shard identity override
+  --attempt <n>              Optional attempt override (positive integer)
   --help                     Show this text
 `;

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -87,14 +87,6 @@ async function main(): Promise<void> {
       inputs: { targetLane: args.lane, desktop: args.desktop, agents: args.agents, scenarios: args.scenarios },
       scenarios,
       locallySeeded,
-      fileIssues: args.fileIssues
-        ? async (failed) => {
-            const urls = await fileIssuesForFailures(toFailureReports(failed));
-            for (const url of urls) {
-              console.error(`Filed issue: ${url}`);
-            }
-          }
-        : undefined,
       log: (message) => console.log(`  ${message}`),
     });
   } catch (error) {
@@ -116,6 +108,26 @@ async function main(): Promise<void> {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 2;
     return;
+  }
+
+  // Issue filing is auxiliary and runs after the authoritative report is
+  // persisted, from the report's own sanitized failed results. A filing
+  // failure keeps its existing semantics: reported, never rewriting the
+  // already-derived verdict or exit.
+  if (args.fileIssues) {
+    const payloads = toFailureReports(report.results);
+    if (payloads.length > 0) {
+      try {
+        const urls = await fileIssuesForFailures(payloads);
+        for (const url of urls) {
+          console.error(`Filed issue: ${url}`);
+        }
+      } catch (error) {
+        console.error(
+          `Issue filing failed (verdict unchanged): ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
   }
 
   if (report.summary.intended_exit_code !== 0) {

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -1,34 +1,68 @@
 import { HELP_TEXT, parseArgs } from "./args.js";
-import { resolveEnv, missingRequiredForLane, blockedReasonForMissingEnv } from "../config/env-resolution.js";
+import { resolveEnv } from "../config/env-resolution.js";
 import { envVarNames, DEFAULT_LOCAL_RUNTIME_URL } from "../config/env-manifest.js";
 import { pushGatewayAuthState } from "../fixtures/agent-auth.js";
-import { selectScenarios, allScenarioIds } from "../scenarios/registry.js";
-import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
+import { selectScenarios } from "../scenarios/registry.js";
 import {
   DEFAULT_LOCAL_DURABLE_USER_EMAIL,
   DEFAULT_LOCAL_DURABLE_USER_PASSWORD,
   ensureLocalDurableUser,
 } from "../fixtures/identity.js";
-import type { ScenarioFailure } from "../report/types.js";
-import { writeFailureReports, toFailureReport } from "../report/failure-reporter.js";
+import { toFailureReports } from "../report/failure-reporter.js";
 import { fileIssuesForFailures } from "../report/issue-filer.js";
+import { IdentityError, resolveRunIdentity } from "../runner/identity.js";
+import { executeSelectedTests, SelectionError } from "../runner/execute.js";
+import { writeReport } from "../evidence/write.js";
+import type { TestRunReportV1 } from "../evidence/schema.js";
 
+/**
+ * Thin process adapter (specs/developing/testing/qualification-runner-core.md
+ * "Ownership and file plan"): parse/validate, resolve identity, run the local
+ * setup hooks, delegate orchestration to runner/execute.ts, write the combined
+ * report, and convert the persisted intended exit into process.exitCode. No
+ * scenario policy lives here.
+ */
 async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
+  }
 
   if (args.help) {
     console.log(HELP_TEXT);
     return;
   }
 
+  let identity;
+  try {
+    identity = await resolveRunIdentity({
+      overrides: { runId: args.runId, shardId: args.shardId, attempt: args.attempt },
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
+  }
+
   console.log(
-    `release-e2e: lane=${args.lane} desktop=${args.desktop} agents=${formatSelector(args.agents)} ` +
-      `scenarios=${formatSelector(args.scenarios)} dryRun=${args.dryRun}`,
+    `release-e2e: behavior=${args.behavior} lane=${args.lane} desktop=${args.desktop} ` +
+      `agents=${formatSelector(args.agents)} scenarios=${formatSelector(args.scenarios)} ` +
+      `dryRun=${args.dryRun} run=${identity.run_id} shard=${identity.shard_id} attempt=${identity.attempt}`,
   );
 
-  const scenarios = selectScenarios(args.scenarios);
-  if (scenarios.length === 0) {
-    console.log(`No scenarios selected. Known scenarios: ${allScenarioIds().join(", ")}`);
+  let scenarios;
+  try {
+    scenarios = selectScenarios(args.scenarios);
+    if (scenarios.length === 0) {
+      throw new SelectionError("Selection resolved to zero scenarios.");
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
     return;
   }
 
@@ -44,112 +78,75 @@ async function main(): Promise<void> {
 
   printEnvManifestReport();
 
-  const neededEnvNames = [...new Set(scenarios.flatMap((scenario) => scenario.requiredEnv))];
-  const neededEnv = resolveEnv(neededEnvNames);
-
-  const agentsSelector = args.agents;
-  const failures: ScenarioFailure[] = [];
-  const blocked: Array<{ scenarioId: string; lane: string; reason: string }> = [];
-  const expectedFail: Array<{ scenarioId: string; lane: string; diagnosis: string }> = [];
-  let greenCount = 0;
-
-  for (const scenario of scenarios) {
-    for (const runtimeLane of scenario.lanes) {
-      // A missing required credential blocks just the scenarios/lanes that need
-      // it (#1069), instead of the old run-fatal env gate. Reported as blocked
-      // — the same convention as an out-of-band gate — so the run still exits
-      // success when everything non-green is blocked/expected-fail.
-      const missingEnv = args.dryRun
-        ? []
-        : missingRequiredForLane(scenario.requiredEnv, runtimeLane, neededEnv, locallySeeded);
-      if (missingEnv.length > 0) {
-        blocked.push({
-          scenarioId: scenario.id,
-          lane: runtimeLane,
-          reason: blockedReasonForMissingEnv(scenario.id, runtimeLane, missingEnv, locallySeeded),
-        });
-        continue;
-      }
-      try {
-        await scenario.run({
-          targetLane: args.lane,
-          runtimeLane,
-          desktop: args.desktop,
-          agents: agentsSelector === "all" ? ["all"] : agentsSelector,
-          dryRun: args.dryRun,
-          env: neededEnv,
-        });
-        greenCount += 1;
-      } catch (error) {
-        if (error instanceof ScenarioBlockedError) {
-          blocked.push({ scenarioId: scenario.id, lane: runtimeLane, reason: error.reason });
-          continue;
-        }
-        if (error instanceof ScenarioExpectedFailError) {
-          expectedFail.push({ scenarioId: scenario.id, lane: runtimeLane, diagnosis: error.diagnosis });
-          continue;
-        }
-        failures.push({
-          scenarioId: scenario.id,
-          registryFlowRef: scenario.registryFlowRef,
-          lane: runtimeLane,
-          expected: `${scenario.title} completes without error`,
-          error,
-        });
-      }
+  let report: TestRunReportV1;
+  try {
+    report = await executeSelectedTests({
+      behavior: args.behavior,
+      execution: args.dryRun ? "dry_run" : "real",
+      identity,
+      inputs: { targetLane: args.lane, desktop: args.desktop, agents: args.agents, scenarios: args.scenarios },
+      scenarios,
+      locallySeeded,
+      fileIssues: args.fileIssues
+        ? async (failed) => {
+            const urls = await fileIssuesForFailures(toFailureReports(failed));
+            for (const url of urls) {
+              console.error(`Filed issue: ${url}`);
+            }
+          }
+        : undefined,
+      log: (message) => console.log(`  ${message}`),
+    });
+  } catch (error) {
+    if (error instanceof SelectionError || error instanceof IdentityError) {
+      console.error(error.message);
+    } else {
+      console.error(`runner error: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`);
     }
-  }
-
-  if (!args.dryRun) {
-    console.log(`\n${greenCount} scenario run(s) green.`);
-    if (blocked.length > 0) {
-      console.log(`${blocked.length} scenario run(s) blocked (known gate, not a fresh failure):`);
-      for (const entry of blocked) {
-        console.log(`  - [${entry.scenarioId}/${entry.lane}] ${entry.reason}`);
-      }
-    }
-    if (expectedFail.length > 0) {
-      console.log(`${expectedFail.length} scenario run(s) expected-fail (diagnosed, tracked, not blocking):`);
-      for (const entry of expectedFail) {
-        console.log(`  - [${entry.scenarioId}/${entry.lane}] ${entry.diagnosis}`);
-      }
-    }
-  }
-
-  if (failures.length > 0) {
-    const reports = failures.map(toFailureReport);
-    console.error(`\n${failures.length} scenario run(s) failed:`);
-    for (const report of reports) {
-      // First line of the observed error, inline in the log — the JSON reports
-      // are the full record, but the runner is often read straight from the CI
-      // log (where the report artifact may not be fetched), so surface the
-      // reason there too.
-      const firstLine = report.observed.split("\n")[0];
-      console.error(`  - [${report.scenario_id}/${report.lane}] ${firstLine}`);
-    }
-    const written = await writeFailureReports(failures, args.outputDir);
-    console.error("Reports written:");
-    for (const filePath of written) {
-      console.error(`  - ${filePath}`);
-    }
-    if (args.fileIssues) {
-      const urls = await fileIssuesForFailures(reports);
-      console.error("Filed issues:");
-      for (const url of urls) {
-        console.error(`  - ${url}`);
-      }
-    }
-    if (!args.dryRun) {
-      process.exitCode = 1;
-    }
+    process.exitCode = 2;
     return;
   }
 
-  if (args.dryRun) {
-    console.log(`\nAll ${countRuns(scenarios)} scenario run(s) completed with no failures.`);
-  } else {
-    console.log(`\nNo red scenario runs (${greenCount} green, ${blocked.length} blocked, ${expectedFail.length} expected-fail).`);
+  printSummary(report);
+
+  try {
+    const written = await writeReport(args.outputDir, report);
+    console.log(`Combined report written: ${written}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+    return;
   }
+
+  if (report.summary.intended_exit_code !== 0) {
+    process.exitCode = report.summary.intended_exit_code;
+  }
+}
+
+function printSummary(report: TestRunReportV1): void {
+  const counts = report.summary.by_status;
+  console.log(
+    `\n${counts.green} green, ${counts.failed} failed, ${counts.blocked} blocked, ` +
+      `${counts.expected_fail} expected-fail, ${counts.cancelled} cancelled, ` +
+      `${counts.not_run} not-run, ${counts.missing} missing ` +
+      `(verdict: ${report.verdict.status}, intended exit ${report.summary.intended_exit_code}).`,
+  );
+  for (const result of report.results) {
+    if (result.status !== "green") {
+      const reason = result.reason ? ` — ${firstLine(result.reason.message)}` : "";
+      console.log(`  [${result.status}] ${result.test_id}${reason}`);
+    }
+  }
+  for (const error of report.summary.integrity_errors) {
+    console.error(`  integrity error: ${error.message}`);
+  }
+  for (const error of report.summary.runner_errors) {
+    console.error(`  runner error (${error.code}): ${error.message}`);
+  }
+}
+
+function firstLine(message: string): string {
+  return message.split("\n")[0];
 }
 
 /**
@@ -244,10 +241,6 @@ function printEnvManifestReport(): void {
     const shown = entry.present && !entry.spec.secret ? ` = ${entry.value}` : "";
     console.log(`  [${status}] ${entry.spec.name}${shown}`);
   }
-}
-
-function countRuns(scenarios: ReturnType<typeof selectScenarios>): number {
-  return scenarios.reduce((total, scenario) => total + scenario.lanes.length, 0);
 }
 
 function formatSelector(selector: string[] | "all"): string {

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -2,6 +2,7 @@ import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
 import {
   ALL_FINAL_STATUSES,
+  deriveVerdict,
   type FinalTestResultV1,
   type FinalTestStatus,
   type IntegrityErrorV1,
@@ -150,25 +151,42 @@ export function validateReport(report: TestRunReportV1): void {
     }
   }
 
-  const hasErrors =
-    report.summary.integrity_errors.length > 0 || report.summary.runner_errors.length > 0;
-  const exit = report.summary.intended_exit_code;
-  if (report.run.behavior === "diagnostic" && report.verdict.status !== "non_qualifying") {
-    throw new ReportValidationError("Diagnostic reports must be non_qualifying.");
-  }
-  if (report.run.behavior === "strict") {
-    const allGreen =
-      report.results.length > 0 && report.results.every((result) => result.status === "green");
-    const expected: VerdictStatus =
-      allGreen && !hasErrors ? "selected_tests_passed" : "selected_tests_failed";
-    if (report.verdict.status !== expected) {
-      throw new ReportValidationError(`Strict verdict must be ${expected}.`);
-    }
-    if (expected === "selected_tests_passed" && exit !== 0) {
-      throw new ReportValidationError("selected_tests_passed requires intended exit 0.");
+  const knownStatuses = new Set<string>(ALL_FINAL_STATUSES);
+  for (const result of report.results) {
+    if (!knownStatuses.has(result.status)) {
+      throw new ReportValidationError(`Unknown result status "${result.status}" for ${result.test_id}.`);
     }
   }
-  if (hasErrors && exit !== 2) {
-    throw new ReportValidationError("Runner/integrity errors require intended exit 2.");
+
+  // A not_run result during real execution is only representable alongside
+  // its integrity error; without it the report would disguise unexecuted
+  // work as a tolerated outcome.
+  if (report.run.execution === "real" && report.results.some((result) => result.status === "not_run")) {
+    const flagged = report.summary.integrity_errors.some((error) => error.code === "real_execution_not_run");
+    if (!flagged) {
+      throw new ReportValidationError(
+        "not_run during real execution requires a real_execution_not_run integrity error.",
+      );
+    }
+  }
+
+  // Recompute the complete verdict/exit policy from the results and errors
+  // and require the persisted fields to match — the validator, not the
+  // producer, is the last line against false-success evidence.
+  const expected = deriveVerdict({
+    behavior: report.run.behavior,
+    results: report.results,
+    integrityErrors: report.summary.integrity_errors,
+    runnerErrors: report.summary.runner_errors,
+  });
+  if (report.verdict.status !== expected.status) {
+    throw new ReportValidationError(
+      `Verdict "${report.verdict.status}" does not match the recomputed "${expected.status}".`,
+    );
+  }
+  if (report.summary.intended_exit_code !== expected.intendedExitCode) {
+    throw new ReportValidationError(
+      `intended_exit_code ${report.summary.intended_exit_code} does not match the recomputed ${expected.intendedExitCode}.`,
+    );
   }
 }

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -90,13 +90,48 @@ export function redactUrlCredentials(message: string): string {
 }
 
 /**
+ * Withholds external response/provider details after the safe diagnostic
+ * prefix. Release scenarios wrap those payloads in several ways (HTTP
+ * `-> 502:`, `error:`, `failed:`, `returned:`, provider command output, and
+ * similar); retaining the prefix preserves the operation/status while keeping
+ * raw bodies, SSE messages, and provider stdout/stderr out of evidence.
+ */
+export function redactExternalPayloads(message: string): string {
+  return message
+    .replace(
+      /(\bexited\s+(?:-?\d+|null)\s*:\s*)[\s\S]*$/i,
+      "$1(output withheld from evidence)",
+    )
+    .replace(
+      /(\b(?:ssh command|git [^:\n]{0,160})\s+failed(?:\s*\([^\n)]*\))?\s*:\s*)[\s\S]*$/i,
+      "$1(output withheld from evidence)",
+    )
+    .replace(
+      /(\bcould not parse\b[^:\n]{0,160}\bjson\b[^:\n]{0,160}:\s*)[\s\S]*$/i,
+      "$1(output withheld from evidence)",
+    )
+    .replace(
+      /(\bsandbox\b[^:\n]{0,160}\bdid not reach\b[^:\n]{0,160}\blast observed\s*:\s*)[\s\S]*$/i,
+      "$1response body withheld from evidence)",
+    )
+    .replace(
+      /((?:->\s*\d{3}|\b(?:provider|gateway|sandbox|materializer|provisioning|completion|turn|session|claim|e2b[\w.-]*)\b[^:\n]{0,160}\b(?:error|errored|failed|warning|returned|reported|got|exited)\b[^:\n]{0,80}|\b(?:last error|got iserror|did not print valid json)\b[^:\n]{0,80}|\b(?:error|failure)\b[^:\n]{0,160}\(got|\(error)\s*:\s*)[\s\S]*$/i,
+      "$1(response body withheld from evidence)",
+    )
+    .replace(
+      /\(got\s+(?:\{|\[)[\s\S]*$/i,
+      "(provider response withheld from evidence)",
+    );
+}
+
+/**
  * Applies redaction + bounding to every message-bearing field in the report.
  * Runs before validation/serialization so no exact secret value or overlong
  * message can enter the persisted artifact.
  */
 export function sanitizeReport(report: TestRunReportV1, secretValues: readonly string[]): TestRunReportV1 {
   const clean = (message: string): string =>
-    boundMessage(redactUrlCredentials(redactSecrets(message, secretValues)));
+    boundMessage(redactExternalPayloads(redactUrlCredentials(redactSecrets(message, secretValues))));
   return {
     ...report,
     results: report.results.map((result) => ({
@@ -170,13 +205,16 @@ export function validateReport(report: TestRunReportV1): void {
   }
 
   // Execution semantics: strict dry-run is an invalid invocation and can
-  // never be honest persisted evidence, and a dry-run cannot produce a real
-  // result — planning only finalizes not_run.
+  // never be honest persisted evidence. Diagnostic planning normally
+  // finalizes not_run; a post-selection runner defect may instead synthesize
+  // missing, which remains valid only with its integrity error below.
   if (report.run.execution === "dry_run") {
     if (report.run.behavior === "strict") {
       throw new ReportValidationError("A strict dry-run report is not representable evidence.");
     }
-    const executed = report.results.find((result) => result.status !== "not_run");
+    const executed = report.results.find(
+      (result) => result.status !== "not_run" && result.status !== "missing",
+    );
     if (executed) {
       throw new ReportValidationError(
         `Dry-run cannot produce a real result: ${executed.test_id} is "${executed.status}".`,

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -80,12 +80,23 @@ export function redactSecrets(message: string, secretValues: readonly string[]):
 }
 
 /**
+ * Scrubs URL userinfo credentials (`scheme://user:token@host`) regardless of
+ * where they came from. Exact-value redaction only knows environment-manifest
+ * secrets; credentials discovered at runtime (e.g. `gh auth token` embedded
+ * in a clone URL) would otherwise pass through untouched.
+ */
+export function redactUrlCredentials(message: string): string {
+  return message.replace(/(\/\/)[^\s/@]+@/g, "$1[REDACTED]@");
+}
+
+/**
  * Applies redaction + bounding to every message-bearing field in the report.
  * Runs before validation/serialization so no exact secret value or overlong
  * message can enter the persisted artifact.
  */
 export function sanitizeReport(report: TestRunReportV1, secretValues: readonly string[]): TestRunReportV1 {
-  const clean = (message: string): string => boundMessage(redactSecrets(message, secretValues));
+  const clean = (message: string): string =>
+    boundMessage(redactUrlCredentials(redactSecrets(message, secretValues)));
   return {
     ...report,
     results: report.results.map((result) => ({
@@ -155,6 +166,35 @@ export function validateReport(report: TestRunReportV1): void {
   for (const result of report.results) {
     if (!knownStatuses.has(result.status)) {
       throw new ReportValidationError(`Unknown result status "${result.status}" for ${result.test_id}.`);
+    }
+  }
+
+  // Execution semantics: strict dry-run is an invalid invocation and can
+  // never be honest persisted evidence, and a dry-run cannot produce a real
+  // result — planning only finalizes not_run.
+  if (report.run.execution === "dry_run") {
+    if (report.run.behavior === "strict") {
+      throw new ReportValidationError("A strict dry-run report is not representable evidence.");
+    }
+    const executed = report.results.find((result) => result.status !== "not_run");
+    if (executed) {
+      throw new ReportValidationError(
+        `Dry-run cannot produce a real result: ${executed.test_id} is "${executed.status}".`,
+      );
+    }
+  }
+
+  // A missing result exists only as a runner-integrity failure; without its
+  // integrity error the report would present unrecorded work as an ordinary
+  // (exit-1) outcome instead of forcing exit 2.
+  if (report.results.some((result) => result.status === "missing")) {
+    const flagged = report.summary.integrity_errors.some(
+      (error) => error.code === "selection_result_mismatch",
+    );
+    if (!flagged) {
+      throw new ReportValidationError(
+        "A missing result requires its selection_result_mismatch integrity error.",
+      );
     }
   }
 

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -1,0 +1,174 @@
+import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
+import type { RunIdentityV1 } from "../runner/identity.js";
+import {
+  ALL_FINAL_STATUSES,
+  type FinalTestResultV1,
+  type FinalTestStatus,
+  type IntegrityErrorV1,
+  type ResultBehavior,
+  type RunnerErrorV1,
+  type SelectedTestV1,
+  type VerdictStatus,
+} from "../runner/result.js";
+
+/**
+ * The versioned combined-report contract, per
+ * specs/developing/testing/qualification-runner-core.md ("Combined report").
+ * One artifact per invocation/shard/attempt; validated before writing.
+ */
+export interface TestRunReportV1 {
+  schema_version: 1;
+  kind: "proliferate.test-run";
+  run: RunIdentityV1 & {
+    behavior: ResultBehavior;
+    execution: "real" | "dry_run";
+    started_at: string;
+    finished_at: string;
+  };
+  inputs: {
+    target_lane: TargetLane;
+    desktop: DesktopMode;
+    agents: string[] | "all";
+    scenarios: string[] | "all";
+  };
+  selected_tests: SelectedTestV1[];
+  results: FinalTestResultV1[];
+  summary: {
+    selected: number;
+    finalized: number;
+    by_status: Record<FinalTestStatus, number>;
+    integrity_errors: IntegrityErrorV1[];
+    runner_errors: RunnerErrorV1[];
+    intended_exit_code: 0 | 1 | 2;
+  };
+  verdict: {
+    status: VerdictStatus;
+    scope: "selected_tests";
+    completeness: "partial";
+    reasons: string[];
+  };
+}
+
+export class ReportValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReportValidationError";
+  }
+}
+
+export const MAX_MESSAGE_CODE_POINTS = 4096;
+
+/** Bounds a message to 4,096 Unicode code points. */
+export function boundMessage(message: string): string {
+  const codePoints = [...message];
+  if (codePoints.length <= MAX_MESSAGE_CODE_POINTS) {
+    return message;
+  }
+  return `${codePoints.slice(0, MAX_MESSAGE_CODE_POINTS - 1).join("")}…`;
+}
+
+/** Replaces exact resolved secret values anywhere in the string with [REDACTED]. */
+export function redactSecrets(message: string, secretValues: readonly string[]): string {
+  let redacted = message;
+  for (const secret of secretValues) {
+    if (secret.length > 0) {
+      redacted = redacted.split(secret).join("[REDACTED]");
+    }
+  }
+  return redacted;
+}
+
+/**
+ * Applies redaction + bounding to every message-bearing field in the report.
+ * Runs before validation/serialization so no exact secret value or overlong
+ * message can enter the persisted artifact.
+ */
+export function sanitizeReport(report: TestRunReportV1, secretValues: readonly string[]): TestRunReportV1 {
+  const clean = (message: string): string => boundMessage(redactSecrets(message, secretValues));
+  return {
+    ...report,
+    results: report.results.map((result) => ({
+      ...result,
+      reason: result.reason ? { ...result.reason, message: clean(result.reason.message) } : null,
+      plan_steps: result.plan_steps.map(clean),
+    })),
+    summary: {
+      ...report.summary,
+      integrity_errors: report.summary.integrity_errors.map((error) => ({
+        ...error,
+        message: clean(error.message),
+      })),
+      runner_errors: report.summary.runner_errors.map((error) => ({ ...error, message: clean(error.message) })),
+    },
+    verdict: { ...report.verdict, reasons: report.verdict.reasons.map(clean) },
+  };
+}
+
+/**
+ * Validates the report invariants before writing: unique + exactly-equal
+ * selected/result test ids, finalized counts, all seven status keys with
+ * exact counts, and verdict/exit consistency.
+ */
+export function validateReport(report: TestRunReportV1): void {
+  if (report.schema_version !== 1 || report.kind !== "proliferate.test-run") {
+    throw new ReportValidationError("Report must be schema_version 1, kind proliferate.test-run.");
+  }
+
+  const selectedIds = report.selected_tests.map((test) => test.test_id);
+  const resultIds = report.results.map((result) => result.test_id);
+  if (new Set(selectedIds).size !== selectedIds.length) {
+    throw new ReportValidationError("Selected test ids are not unique.");
+  }
+  if (new Set(resultIds).size !== resultIds.length) {
+    throw new ReportValidationError("Result test ids are not unique.");
+  }
+  const selectedSet = new Set(selectedIds);
+  if (resultIds.length !== selectedIds.length || !resultIds.every((id) => selectedSet.has(id))) {
+    throw new ReportValidationError("Selected and result test ids are not exactly equal sets.");
+  }
+
+  if (report.summary.selected !== selectedIds.length || report.summary.finalized !== report.results.length) {
+    throw new ReportValidationError("summary.selected/finalized do not match the selected/result counts.");
+  }
+
+  const byStatus = report.summary.by_status;
+  for (const status of ALL_FINAL_STATUSES) {
+    if (typeof byStatus[status] !== "number") {
+      throw new ReportValidationError(`summary.by_status is missing the "${status}" key.`);
+    }
+  }
+  const counted = { ...Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) } as Record<
+    FinalTestStatus,
+    number
+  >;
+  for (const result of report.results) {
+    counted[result.status] += 1;
+  }
+  for (const status of ALL_FINAL_STATUSES) {
+    if (byStatus[status] !== counted[status]) {
+      throw new ReportValidationError(`summary.by_status.${status} does not match the results.`);
+    }
+  }
+
+  const hasErrors =
+    report.summary.integrity_errors.length > 0 || report.summary.runner_errors.length > 0;
+  const exit = report.summary.intended_exit_code;
+  if (report.run.behavior === "diagnostic" && report.verdict.status !== "non_qualifying") {
+    throw new ReportValidationError("Diagnostic reports must be non_qualifying.");
+  }
+  if (report.run.behavior === "strict") {
+    const allGreen =
+      report.results.length > 0 && report.results.every((result) => result.status === "green");
+    const expected: VerdictStatus =
+      allGreen && !hasErrors ? "selected_tests_passed" : "selected_tests_failed";
+    if (report.verdict.status !== expected) {
+      throw new ReportValidationError(`Strict verdict must be ${expected}.`);
+    }
+    if (expected === "selected_tests_passed" && exit !== 0) {
+      throw new ReportValidationError("selected_tests_passed requires intended exit 0.");
+    }
+  }
+  if (hasErrors && exit !== 2) {
+    throw new ReportValidationError("Runner/integrity errors require intended exit 2.");
+  }
+}

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -124,6 +124,86 @@ test("validateReport enforces the strict verdict against results and errors", ()
   assert.throws(() => validateReport(errorButPassed), ReportValidationError);
 });
 
+test("validateReport rejects false-success evidence: failed result with exit 0", () => {
+  const diagnostic = validReport();
+  diagnostic.results[0].status = "failed";
+  diagnostic.summary.by_status.green = 0;
+  diagnostic.summary.by_status.failed = 1;
+  // verdict name is "correct" for diagnostic, but the exit is a lie
+  assert.throws(() => validateReport(diagnostic), ReportValidationError);
+
+  const strict = validReport();
+  strict.run.behavior = "strict";
+  strict.results[0].status = "failed";
+  strict.summary.by_status.green = 0;
+  strict.summary.by_status.failed = 1;
+  strict.verdict.status = "selected_tests_passed";
+  assert.throws(() => validateReport(strict), ReportValidationError);
+});
+
+test("validateReport rejects not_run during real execution without its integrity error", () => {
+  const report = validReport();
+  report.results[0].status = "not_run";
+  report.summary.by_status.green = 0;
+  report.summary.by_status.not_run = 1;
+  assert.throws(() => validateReport(report), ReportValidationError);
+});
+
+test("validateReport rejects an unknown result status", () => {
+  const report = validReport();
+  (report.results[0] as { status: string }).status = "sorta_passed";
+  assert.throws(() => validateReport(report), ReportValidationError);
+});
+
+// Every verdict-matrix row must survive validation when produced honestly.
+const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" | "strict"; exit: 0 | 1 | 2; verdict: TestRunReportV1["verdict"]["status"]; execution?: "real" | "dry_run" }> = [
+  { statuses: ["green"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
+  { statuses: ["green"], behavior: "strict", exit: 0, verdict: "selected_tests_passed" },
+  { statuses: ["blocked"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
+  { statuses: ["blocked"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["expected_fail"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
+  { statuses: ["expected_fail"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["green", "failed"], behavior: "diagnostic", exit: 1, verdict: "non_qualifying" },
+  { statuses: ["green", "failed"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["cancelled"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["missing"], behavior: "diagnostic", exit: 1, verdict: "non_qualifying" },
+  { statuses: ["not_run"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying", execution: "dry_run" },
+];
+
+for (const [index, row] of MATRIX_ROWS.entries()) {
+  test(`validateReport accepts honest matrix row ${index}: ${row.behavior} ${row.statuses.join(",")}`, () => {
+    const report = validReport();
+    report.run.behavior = row.behavior;
+    report.run.execution = row.execution ?? "real";
+    report.selected_tests = row.statuses.map((_, i) => ({
+      test_id: `S${i}/local`,
+      scenario_id: `S${i}`,
+      registry_flow_ref: `specs#S${i}`,
+      runtime_lane: "local" as const,
+    }));
+    report.results = row.statuses.map((status, i) => ({
+      ...report.results[0],
+      test_id: `S${i}/local`,
+      scenario_id: `S${i}`,
+      registry_flow_ref: `specs#S${i}`,
+      status,
+    }));
+    report.summary.selected = row.statuses.length;
+    report.summary.finalized = row.statuses.length;
+    const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
+      FinalTestStatus,
+      number
+    >;
+    for (const status of row.statuses) {
+      byStatus[status] += 1;
+    }
+    report.summary.by_status = byStatus;
+    report.summary.intended_exit_code = row.exit;
+    report.verdict.status = row.verdict;
+    validateReport(report);
+  });
+}
+
 test("validateReport requires exit 2 whenever runner/integrity errors exist", () => {
   const report = validReport();
   report.summary.integrity_errors = [{ code: "duplicate_result", message: "dup" }];

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   boundMessage,
   redactSecrets,
+  redactUrlCredentials,
   ReportValidationError,
   validateReport,
   type TestRunReportV1,
@@ -156,7 +157,9 @@ test("validateReport rejects an unknown result status", () => {
 });
 
 // Every verdict-matrix row must survive validation when produced honestly.
-const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" | "strict"; exit: 0 | 1 | 2; verdict: TestRunReportV1["verdict"]["status"]; execution?: "real" | "dry_run" }> = [
+// A `missing` result is only honest alongside its integrity error, which
+// forces exit 2.
+const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" | "strict"; exit: 0 | 1 | 2; verdict: TestRunReportV1["verdict"]["status"]; execution?: "real" | "dry_run"; integrity?: boolean }> = [
   { statuses: ["green"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
   { statuses: ["green"], behavior: "strict", exit: 0, verdict: "selected_tests_passed" },
   { statuses: ["blocked"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
@@ -166,7 +169,7 @@ const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" |
   { statuses: ["green", "failed"], behavior: "diagnostic", exit: 1, verdict: "non_qualifying" },
   { statuses: ["green", "failed"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
   { statuses: ["cancelled"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
-  { statuses: ["missing"], behavior: "diagnostic", exit: 1, verdict: "non_qualifying" },
+  { statuses: ["missing"], behavior: "diagnostic", exit: 2, verdict: "non_qualifying", integrity: true },
   { statuses: ["not_run"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying", execution: "dry_run" },
 ];
 
@@ -198,11 +201,59 @@ for (const [index, row] of MATRIX_ROWS.entries()) {
       byStatus[status] += 1;
     }
     report.summary.by_status = byStatus;
+    if (row.integrity) {
+      report.summary.integrity_errors = [
+        { code: "selection_result_mismatch", message: "synthesized missing result" },
+      ];
+    }
     report.summary.intended_exit_code = row.exit;
     report.verdict.status = row.verdict;
     validateReport(report);
   });
 }
+
+test("validateReport rejects a strict dry-run report outright", () => {
+  const report = validReport();
+  report.run.behavior = "strict";
+  report.run.execution = "dry_run";
+  report.results[0].status = "not_run";
+  report.summary.by_status.green = 0;
+  report.summary.by_status.not_run = 1;
+  report.verdict.status = "selected_tests_failed";
+  report.summary.intended_exit_code = 1;
+  assert.throws(() => validateReport(report), /strict dry-run/i);
+
+  // Even a "green + qualified + exit 0" strict dry-run must not validate.
+  const disguised = validReport();
+  disguised.run.behavior = "strict";
+  disguised.run.execution = "dry_run";
+  disguised.verdict.status = "selected_tests_passed";
+  assert.throws(() => validateReport(disguised), ReportValidationError);
+});
+
+test("validateReport rejects real-result statuses inside a diagnostic dry-run", () => {
+  const report = validReport();
+  report.run.execution = "dry_run";
+  // results[0] is green — planning can never produce a real result
+  assert.throws(() => validateReport(report), /Dry-run cannot produce a real result/);
+});
+
+test("validateReport rejects a missing result without its integrity error", () => {
+  const report = validReport();
+  report.results[0].status = "missing";
+  report.summary.by_status.green = 0;
+  report.summary.by_status.missing = 1;
+  report.summary.intended_exit_code = 1;
+  assert.throws(() => validateReport(report), /selection_result_mismatch/);
+});
+
+test("redactUrlCredentials scrubs userinfo tokens from URLs", () => {
+  assert.equal(
+    redactUrlCredentials("clone https://x-access-token:ghp_abc123@github.com/o/r.git failed"),
+    "clone https://[REDACTED]@github.com/o/r.git failed",
+  );
+  assert.equal(redactUrlCredentials("https://github.com/o/r.git"), "https://github.com/o/r.git");
+});
 
 test("validateReport requires exit 2 whenever runner/integrity errors exist", () => {
   const report = validReport();

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 
 import {
   boundMessage,
+  redactExternalPayloads,
   redactSecrets,
   redactUrlCredentials,
   ReportValidationError,
@@ -253,6 +254,47 @@ test("redactUrlCredentials scrubs userinfo tokens from URLs", () => {
     "clone https://[REDACTED]@github.com/o/r.git failed",
   );
   assert.equal(redactUrlCredentials("https://github.com/o/r.git"), "https://github.com/o/r.git");
+});
+
+test("redactExternalPayloads retains safe context and withholds external detail", () => {
+  const marker = "RAW_PROVIDER_PAYLOAD";
+  assert.equal(
+    redactExternalPayloads(`gateway /mcp -> 502: {"token":"${marker}"}`),
+    "gateway /mcp -> 502: (response body withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`T3: provisioning failed: ${marker}`),
+    "T3: provisioning failed: (response body withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`gateway providers mismatch (got [{"token":"${marker}"}])`),
+    "gateway providers mismatch (provider response withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`prov1_fallback.py (provision) exited 1: ${marker}`),
+    "prov1_fallback.py (provision) exited 1: (output withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`T3-SH-3: ssh command failed (1): ${marker}`),
+    "T3-SH-3: ssh command failed (1): (output withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`T4-SH-2: git status failed: ${marker}`),
+    "T4-SH-2: git status failed: (output withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(`provisionSelfHostBox: could not parse box JSON from selfhost-box.sh: ${marker}`),
+    "provisionSelfHostBox: could not parse box JSON from selfhost-box.sh: (output withheld from evidence)",
+  );
+  assert.equal(
+    redactExternalPayloads(
+      `warmPersonalCloudSandbox: sandbox did not reach status=ready within 120000ms ` +
+        `(last observed: {"lastError":"${marker}"}).`,
+    ),
+    "warmPersonalCloudSandbox: sandbox did not reach status=ready within 120000ms " +
+      "(last observed: response body withheld from evidence)",
+  );
+  assert.equal(redactExternalPayloads("ordinary assertion failed"), "ordinary assertion failed");
 });
 
 test("validateReport requires exit 2 whenever runner/integrity errors exist", () => {

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  boundMessage,
+  redactSecrets,
+  ReportValidationError,
+  validateReport,
+  type TestRunReportV1,
+} from "./schema.js";
+import { reportPath, ReportWriteError, writeReport } from "./write.js";
+import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
+
+function validReport(overrides: Partial<TestRunReportV1> = {}): TestRunReportV1 {
+  const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
+    FinalTestStatus,
+    number
+  >;
+  byStatus.green = 1;
+  return {
+    schema_version: 1,
+    kind: "proliferate.test-run",
+    run: {
+      run_id: "run-1",
+      shard_id: "shard-1",
+      attempt: 1,
+      source_sha: "d".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+      behavior: "diagnostic",
+      execution: "real",
+      started_at: "2026-07-13T00:00:00Z",
+      finished_at: "2026-07-13T00:01:00Z",
+    },
+    inputs: { target_lane: "local", desktop: "web", agents: "all", scenarios: "all" },
+    selected_tests: [
+      { test_id: "A/local", scenario_id: "A", registry_flow_ref: "specs#A", runtime_lane: "local" },
+    ],
+    results: [
+      {
+        test_id: "A/local",
+        scenario_id: "A",
+        registry_flow_ref: "specs#A",
+        runtime_lane: "local",
+        status: "green",
+        started_at: "2026-07-13T00:00:01Z",
+        finished_at: "2026-07-13T00:00:59Z",
+        duration_ms: 58_000,
+        reason: null,
+        plan_steps: [],
+      },
+    ],
+    summary: {
+      selected: 1,
+      finalized: 1,
+      by_status: byStatus,
+      integrity_errors: [],
+      runner_errors: [],
+      intended_exit_code: 0,
+    },
+    verdict: { status: "non_qualifying", scope: "selected_tests", completeness: "partial", reasons: [] },
+    ...overrides,
+  };
+}
+
+test("validateReport accepts a consistent report", () => {
+  validateReport(validReport());
+});
+
+test("validateReport rejects selected/result set mismatch and duplicates", () => {
+  const extraSelected = validReport();
+  extraSelected.selected_tests.push({
+    test_id: "B/local",
+    scenario_id: "B",
+    registry_flow_ref: "specs#B",
+    runtime_lane: "local",
+  });
+  extraSelected.summary.selected = 2;
+  assert.throws(() => validateReport(extraSelected), ReportValidationError);
+
+  const duplicated = validReport();
+  duplicated.selected_tests.push({ ...duplicated.selected_tests[0] });
+  assert.throws(() => validateReport(duplicated), ReportValidationError);
+});
+
+test("validateReport rejects wrong counts, missing status keys, and count drift", () => {
+  const wrongSelected = validReport();
+  wrongSelected.summary.selected = 5;
+  assert.throws(() => validateReport(wrongSelected), ReportValidationError);
+
+  const missingKey = validReport();
+  delete (missingKey.summary.by_status as Record<string, number>).missing;
+  assert.throws(() => validateReport(missingKey), ReportValidationError);
+
+  const drifted = validReport();
+  drifted.summary.by_status.green = 0;
+  drifted.summary.by_status.failed = 1;
+  assert.throws(() => validateReport(drifted), ReportValidationError);
+});
+
+test("validateReport rejects a diagnostic report that claims qualification", () => {
+  const report = validReport();
+  report.verdict.status = "selected_tests_passed";
+  assert.throws(() => validateReport(report), ReportValidationError);
+});
+
+test("validateReport enforces the strict verdict against results and errors", () => {
+  const passing = validReport();
+  passing.run.behavior = "strict";
+  passing.verdict.status = "selected_tests_passed";
+  validateReport(passing);
+
+  const mislabeled = validReport();
+  mislabeled.run.behavior = "strict";
+  mislabeled.verdict.status = "selected_tests_failed";
+  assert.throws(() => validateReport(mislabeled), ReportValidationError);
+
+  const errorButPassed = validReport();
+  errorButPassed.run.behavior = "strict";
+  errorButPassed.verdict.status = "selected_tests_passed";
+  errorButPassed.summary.runner_errors = [{ code: "runner_error", message: "x" }];
+  assert.throws(() => validateReport(errorButPassed), ReportValidationError);
+});
+
+test("validateReport requires exit 2 whenever runner/integrity errors exist", () => {
+  const report = validReport();
+  report.summary.integrity_errors = [{ code: "duplicate_result", message: "dup" }];
+  report.summary.intended_exit_code = 0;
+  assert.throws(() => validateReport(report), ReportValidationError);
+});
+
+test("boundMessage caps at 4096 code points; redactSecrets replaces exact values", () => {
+  assert.equal(boundMessage("short"), "short");
+  assert.equal([...boundMessage("x".repeat(5000))].length, 4096);
+  assert.equal(redactSecrets("key=abc123 done", ["abc123"]), "key=[REDACTED] done");
+  assert.equal(redactSecrets("nothing here", ["abc123"]), "nothing here");
+});
+
+test("writeReport writes one parseable artifact at the attempt path with trailing newline", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
+  try {
+    const report = validReport();
+    const written = await writeReport(dir, report);
+    assert.equal(written, path.join(dir, "run-1", "shard-1", "attempt-1", "qualification-evidence.json"));
+    const raw = await readFile(written, "utf8");
+    assert.ok(raw.endsWith("\n"));
+    const parsed = JSON.parse(raw);
+    assert.equal(parsed.kind, "proliferate.test-run");
+    assert.equal(parsed.summary.by_status.green, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeReport refuses to overwrite an existing attempt artifact", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
+  try {
+    await writeReport(dir, validReport());
+    await assert.rejects(writeReport(dir, validReport()), ReportWriteError);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("distinct attempts write distinct non-overwriting paths", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
+  try {
+    const first = validReport();
+    const second = validReport();
+    second.run.attempt = 2;
+    const path1 = await writeReport(dir, first);
+    const path2 = await writeReport(dir, second);
+    assert.notEqual(path1, path2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeReport validates before writing: an invalid report writes nothing", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
+  try {
+    const invalid = validReport();
+    invalid.summary.selected = 99;
+    await assert.rejects(writeReport(dir, invalid), ReportValidationError);
+    await assert.rejects(readFile(reportPath(dir, invalid), "utf8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/evidence/write.ts
+++ b/tests/release/src/evidence/write.ts
@@ -1,0 +1,51 @@
+import { link, mkdir, unlink, writeFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+import { validateReport, type TestRunReportV1 } from "./schema.js";
+
+export class ReportWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReportWriteError";
+  }
+}
+
+export function reportPath(outputDir: string, report: TestRunReportV1): string {
+  return path.join(
+    outputDir,
+    report.run.run_id,
+    report.run.shard_id,
+    `attempt-${report.run.attempt}`,
+    "qualification-evidence.json",
+  );
+}
+
+/**
+ * Validates and writes the combined report: exactly one artifact per
+ * invocation/shard/attempt. The write is atomic within the destination
+ * filesystem (temp file + hard link, which fails with EEXIST instead of
+ * replacing) and refuses to overwrite an existing attempt artifact, so a
+ * retry can never destroy earlier evidence.
+ */
+export async function writeReport(outputDir: string, report: TestRunReportV1): Promise<string> {
+  validateReport(report);
+  const destination = reportPath(outputDir, report);
+  try {
+    await mkdir(path.dirname(destination), { recursive: true });
+    const temp = `${destination}.tmp-${randomBytes(4).toString("hex")}`;
+    await writeFile(temp, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    try {
+      await link(temp, destination);
+    } finally {
+      await unlink(temp).catch(() => undefined);
+    }
+  } catch (error) {
+    throw new ReportWriteError(
+      `Could not persist the combined report at ${destination}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  return destination;
+}

--- a/tests/release/src/fixtures/git.test.ts
+++ b/tests/release/src/fixtures/git.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { describeGitFailure } from "./git.js";
+
+// Production-path regression for the runtime-credential leak: the clone URL
+// embeds a dynamically resolved token (`gh auth token` or
+// RELEASE_E2E_GITHUB_TEST_TOKEN), and git also echoes the URL into stderr.
+// This is the exact formatting function runGit uses to build its Error.
+
+test("describeGitFailure never renders credential-bearing clone URLs", () => {
+  const token = "gho_runtimeResolvedToken42";
+  const url = `https://x-access-token:${token}@github.com/proliferate-e2e/e2e-fixture.git`;
+  const message = describeGitFailure(
+    ["clone", url, "/tmp/dest"],
+    "/work",
+    128,
+    `Cloning into '/tmp/dest'...\nfatal: unable to access '${url}': The requested URL returned error: 403\n`,
+  );
+  assert.ok(!message.includes(token));
+  assert.match(message, /git clone https:\/\/\[REDACTED\]@github\.com/);
+  assert.match(message, /fatal: unable to access 'https:\/\/\[REDACTED\]@github\.com/);
+  assert.match(message, /failed \(128\)/);
+});
+
+test("describeGitFailure leaves credential-free commands readable", () => {
+  const message = describeGitFailure(["fetch", "--all", "--prune"], "/repo", 1, "some error\n");
+  assert.match(message, /^git fetch --all --prune \(cwd=\/repo\) failed \(1\): some error/);
+});

--- a/tests/release/src/fixtures/git.ts
+++ b/tests/release/src/fixtures/git.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import os from "node:os";
 
 import { ScenarioBlockedError } from "../scenarios/types.js";
+import { redactUrlCredentials } from "../evidence/schema.js";
 
 /**
  * Ensures a local clone of `owner/repo` exists at a stable scratch path,
@@ -82,6 +83,22 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Renders a git failure without leaking credentials: the clone URL may embed
+ * a runtime-discovered token (`gh auth token`) that no environment-manifest
+ * redaction knows about, and git also echoes the remote URL into stderr.
+ * Exported for the production-path regression test.
+ */
+export function describeGitFailure(
+  args: readonly string[],
+  cwd: string,
+  code: number | null,
+  stderr: string,
+): string {
+  const shownArgs = args.map((arg) => redactUrlCredentials(arg)).join(" ");
+  return `git ${shownArgs} (cwd=${cwd}) failed (${code}): ${redactUrlCredentials(stderr)}`;
+}
+
 function runGit(args: string[], cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn("git", args, {
@@ -99,7 +116,7 @@ function runGit(args: string[], cwd: string): Promise<void> {
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code !== 0) {
-        reject(new Error(`git ${args.join(" ")} (cwd=${cwd}) failed (${code}): ${stderr}`));
+        reject(new Error(describeGitFailure(args, cwd, code, stderr)));
         return;
       }
       resolve();

--- a/tests/release/src/report/failure-reporter.test.ts
+++ b/tests/release/src/report/failure-reporter.test.ts
@@ -1,72 +1,51 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { test } from "node:test";
 
-import { toFailureReport, writeFailureReports } from "./failure-reporter.js";
-import type { ScenarioFailure } from "./types.js";
+import { toFailureReports } from "./failure-reporter.js";
+import type { FinalTestResultV1 } from "../runner/result.js";
 
-test("toFailureReport serializes an Error's stack into observed", () => {
-  const failure: ScenarioFailure = {
-    scenarioId: "T3-EXAMPLE",
-    registryFlowRef: "specs/developing/testing/scenarios.md#T3-EXAMPLE",
-    lane: "local",
-    expected: "example completes without error",
-    error: new Error("boom"),
+function failedResult(overrides: Partial<FinalTestResultV1> = {}): FinalTestResultV1 {
+  return {
+    test_id: "T3-EXAMPLE/local",
+    scenario_id: "T3-EXAMPLE",
+    registry_flow_ref: "specs/developing/testing/scenarios.md#T3-EXAMPLE",
+    runtime_lane: "local",
+    status: "failed",
+    started_at: "2026-07-13T00:00:00Z",
+    finished_at: "2026-07-13T00:00:01Z",
+    duration_ms: 1000,
+    reason: { code: "scenario_failure", message: "boom" },
+    plan_steps: [],
+    ...overrides,
   };
-  const report = toFailureReport(failure);
+}
+
+test("toFailureReports maps a normalized failed result to the issue payload", () => {
+  const [report] = toFailureReports([failedResult()]);
   assert.equal(report.scenario_id, "T3-EXAMPLE");
-  assert.equal(report.flow, failure.registryFlowRef);
+  assert.equal(report.flow, "specs/developing/testing/scenarios.md#T3-EXAMPLE");
   assert.equal(report.lane, "local");
   assert.match(report.observed, /boom/);
+  assert.equal(report.timestamp, "2026-07-13T00:00:01Z");
   assert.deepEqual(report.correlation_ids, []);
 });
 
-test("toFailureReport stringifies a non-Error thrown value", () => {
-  const failure: ScenarioFailure = {
-    scenarioId: "T3-EXAMPLE",
-    registryFlowRef: "specs/developing/testing/scenarios.md#T3-EXAMPLE",
-    lane: "sandbox",
-    expected: "example completes without error",
-    error: "a plain string throw",
-  };
-  const report = toFailureReport(failure);
-  assert.equal(report.observed, "a plain string throw");
+test("toFailureReports produces payloads only for failed results", () => {
+  const results: FinalTestResultV1[] = [
+    failedResult(),
+    failedResult({ test_id: "T3-B/local", scenario_id: "T3-B", status: "blocked" }),
+    failedResult({ test_id: "T3-C/local", scenario_id: "T3-C", status: "expected_fail" }),
+    failedResult({ test_id: "T3-D/local", scenario_id: "T3-D", status: "cancelled" }),
+    failedResult({ test_id: "T3-E/local", scenario_id: "T3-E", status: "not_run" }),
+    failedResult({ test_id: "T3-F/local", scenario_id: "T3-F", status: "missing" }),
+    failedResult({ test_id: "T3-G/local", scenario_id: "T3-G", status: "green" }),
+  ];
+  const reports = toFailureReports(results);
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].scenario_id, "T3-EXAMPLE");
 });
 
-test("writeFailureReports writes nothing and returns [] for an empty failure list", async () => {
-  const written = await writeFailureReports([], path.join(os.tmpdir(), "should-not-be-created"));
-  assert.deepEqual(written, []);
-});
-
-test("writeFailureReports writes one JSON file per failure, parseable back to the same shape", async () => {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "release-e2e-report-test-"));
-  try {
-    const failures: ScenarioFailure[] = [
-      {
-        scenarioId: "T3-A",
-        registryFlowRef: "specs/developing/testing/scenarios.md#T3-A",
-        lane: "local",
-        expected: "A completes without error",
-        error: new Error("first"),
-      },
-      {
-        scenarioId: "T3-B",
-        registryFlowRef: "specs/developing/testing/scenarios.md#T3-B",
-        lane: "sandbox",
-        expected: "B completes without error",
-        error: new Error("second"),
-      },
-    ];
-    const written = await writeFailureReports(failures, dir);
-    assert.equal(written.length, 2);
-    for (const filePath of written) {
-      const parsed = JSON.parse(await readFile(filePath, "utf8"));
-      assert.ok(typeof parsed.scenario_id === "string");
-      assert.ok(typeof parsed.observed === "string");
-    }
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
+test("toFailureReports handles a failed result with no recorded reason", () => {
+  const [report] = toFailureReports([failedResult({ reason: null })]);
+  assert.match(report.observed, /no recorded reason/);
 });

--- a/tests/release/src/report/failure-reporter.ts
+++ b/tests/release/src/report/failure-reporter.ts
@@ -1,52 +1,26 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import path from "node:path";
-import type { FailureReport, ScenarioFailure } from "./types.js";
+import type { FinalTestResultV1 } from "../runner/result.js";
+import type { FailureReport } from "./types.js";
 
 /**
- * Single place that turns a scenario failure into the on-disk (and, later,
- * POSTable) report shape. Per specs/developing/testing/README.md, tier 3/4
- * failures file issues into the issues service and never block a merge — this
- * module produces the payload that flow will eventually consume.
+ * In-memory compatibility mapping from normalized `failed` results to the
+ * issue-filing payload (specs/developing/testing/qualification-runner-core.md
+ * "Failure behavior"). Only normalized failed results produce a payload; no
+ * status writes a per-failure JSON file — the combined report
+ * (src/evidence/write.ts) is the only on-disk artifact.
  */
-export function toFailureReport(failure: ScenarioFailure): FailureReport {
+export function toFailureReports(failed: readonly FinalTestResultV1[]): FailureReport[] {
+  return failed.filter((result) => result.status === "failed").map(toFailureReport);
+}
+
+function toFailureReport(result: FinalTestResultV1): FailureReport {
   return {
-    flow: failure.registryFlowRef,
-    scenario_id: failure.scenarioId,
-    lane: failure.lane,
-    expected: failure.expected,
-    observed: describeError(failure.error),
-    logs_excerpt: failure.logsExcerpt ?? "",
-    correlation_ids: failure.correlationIds ?? [],
-    timestamp: new Date().toISOString(),
+    flow: result.registry_flow_ref,
+    scenario_id: result.scenario_id,
+    lane: result.runtime_lane,
+    expected: `${result.scenario_id} completes without error on the ${result.runtime_lane} lane`,
+    observed: result.reason?.message ?? "scenario failed with no recorded reason",
+    logs_excerpt: "",
+    correlation_ids: [],
+    timestamp: result.finished_at,
   };
-}
-
-function describeError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
-  }
-  return String(error);
-}
-
-/**
- * Writes one JSON file per failed scenario under `outputDir`, named
- * `<scenario_id>-<lane>-<timestamp>.json`. Returns the written file paths.
- */
-export async function writeFailureReports(
-  failures: readonly ScenarioFailure[],
-  outputDir: string,
-): Promise<string[]> {
-  if (failures.length === 0) {
-    return [];
-  }
-  await mkdir(outputDir, { recursive: true });
-  const written: string[] = [];
-  for (const failure of failures) {
-    const report = toFailureReport(failure);
-    const safeTimestamp = report.timestamp.replace(/[:.]/g, "-");
-    const filePath = path.join(outputDir, `${report.scenario_id}-${report.lane}-${safeTimestamp}.json`);
-    await writeFile(filePath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-    written.push(filePath);
-  }
-  return written;
 }

--- a/tests/release/src/report/types.ts
+++ b/tests/release/src/report/types.ts
@@ -17,12 +17,3 @@ export interface FailureReport {
   timestamp: string;
 }
 
-export interface ScenarioFailure {
-  scenarioId: string;
-  registryFlowRef: string;
-  lane: string;
-  expected: string;
-  error: unknown;
-  logsExcerpt?: string;
-  correlationIds?: string[];
-}

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -283,6 +283,48 @@ test("secrets are redacted even when no selected scenario declares them", async 
   assert.ok(!JSON.stringify(report).includes(secret));
 });
 
+test("provider response bodies never reach the report or issue payloads", async () => {
+  // The ApiRequestError/LocalRuntimeError shape: Error.message embeds the
+  // complete response body. The normalized evidence must withhold it.
+  const providerPayload = '{"api_key":"sk-live-9999","customer_email":"a@b.c","stack":"Traceback..."}';
+  class FakeApiRequestError extends Error {
+    readonly status = 500;
+    readonly body = providerPayload;
+    constructor() {
+      super(`POST /v1/checkout -> 500: ${providerPayload}`);
+      this.name = "ApiRequestError";
+    }
+  }
+  const scenarios = [fakeScenario({ id: "PROV", run: async () => { throw new FakeApiRequestError(); } })];
+  const report = await executeSelectedTests(baseOptions(scenarios));
+  const serialized = JSON.stringify(report);
+  assert.ok(!serialized.includes("sk-live-9999"));
+  assert.ok(!serialized.includes("customer_email"));
+  assert.match(report.results[0].reason!.message, /POST \/v1\/checkout -> 500/);
+  assert.match(report.results[0].reason!.message, /withheld from evidence/);
+});
+
+test("runtime-discovered URL credentials are scrubbed even when unknown to the redactor", async () => {
+  // A `gh auth token` embedded in a clone URL is not in the env manifest, so
+  // exact-value redaction cannot know it; the URL-userinfo scrub must catch it.
+  const token = "ghp_dynamicallyDiscovered123";
+  const scenarios = [
+    fakeScenario({
+      id: "GIT",
+      run: async () => {
+        throw new Error(
+          `git clone https://x-access-token:${token}@github.com/o/r.git failed (128): ` +
+            `fatal: unable to access 'https://x-access-token:${token}@github.com/o/r.git'`,
+        );
+      },
+    }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios, { resolveSecretValues: () => [] }));
+  const serialized = JSON.stringify(report);
+  assert.ok(!serialized.includes(token));
+  assert.match(report.results[0].reason!.message, /\[REDACTED\]@github\.com/);
+});
+
 test("rejects duplicate scenario ids even with disjoint lanes", () => {
   assert.throws(
     () =>

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import type { EnvResolution, ResolvedEnvVar } from "../config/env-resolution.js";
+import { validateReport } from "../evidence/schema.js";
+import { gatewayJsonRpc } from "../fixtures/integration-gateway.js";
+import { toFailureReports } from "../report/failure-reporter.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
 import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
 import { executeSelectedTests, expandSelectedTests, SelectionError, type ExecuteOptions } from "./execute.js";
@@ -249,6 +252,21 @@ test("a post-selection runner defect finalizes every pending test and still prod
   assert.equal(report.summary.intended_exit_code, 2);
 });
 
+test("a diagnostic dry-run runner defect still produces valid persistable evidence", async () => {
+  const report = await executeSelectedTests(
+    baseOptions([fakeScenario({ id: "DRY-A" }), fakeScenario({ id: "DRY-B" })], {
+      execution: "dry_run",
+      resolveNeededEnv: () => { throw new Error("preflight resolver failed"); },
+    }),
+  );
+
+  assert.deepEqual(report.results.map((result) => result.status), ["missing", "missing"]);
+  assert.equal(report.summary.runner_errors.length, 1);
+  assert.equal(report.summary.integrity_errors.length, 2);
+  assert.equal(report.summary.intended_exit_code, 2);
+  assert.doesNotThrow(() => validateReport(report));
+});
+
 test("exact resolved secret values are redacted from the report", async () => {
   const secret = "sk-super-secret-value";
   const scenarios = [
@@ -302,6 +320,64 @@ test("provider response bodies never reach the report or issue payloads", async 
   assert.ok(!serialized.includes("customer_email"));
   assert.match(report.results[0].reason!.message, /POST \/v1\/checkout -> 500/);
   assert.match(report.results[0].reason!.message, /withheld from evidence/);
+});
+
+test("plain integration-gateway response bodies never reach evidence or issue payloads", async () => {
+  const providerPayload = '{"access_token":"RAW_GATEWAY_TOKEN","detail":"provider traceback"}';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(providerPayload, { status: 502 });
+  try {
+    const scenario = fakeScenario({
+      id: "GATEWAY",
+      run: async () => {
+        await gatewayJsonRpc(
+          {
+            workerId: "worker-1",
+            desktopInstallId: "desktop-1",
+            mcpUrl: "https://gateway.example.test/mcp",
+            authorization: "Bearer worker-token",
+          },
+          { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+        );
+      },
+    });
+    const report = await executeSelectedTests(baseOptions([scenario], { resolveSecretValues: () => [] }));
+    const issues = toFailureReports(report.results);
+
+    assert.equal(report.results[0].status, "failed");
+    assert.ok(!JSON.stringify(report).includes("RAW_GATEWAY_TOKEN"));
+    assert.ok(!JSON.stringify(issues).includes("RAW_GATEWAY_TOKEN"));
+    assert.match(report.results[0].reason!.message, /response body withheld from evidence/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("provider payloads stay out of blocked and expected-fail evidence", async () => {
+  const blockedPayload = "RAW_BLOCKED_PROVIDER_BODY";
+  const expectedPayload = "RAW_EXPECTED_PROVIDER_BODY";
+  const report = await executeSelectedTests(
+    baseOptions([
+      fakeScenario({
+        id: "BLOCKED-PAYLOAD",
+        run: async () => {
+          throw new ScenarioBlockedError(`gateway unavailable -> 503: ${blockedPayload}`);
+        },
+      }),
+      fakeScenario({
+        id: "EXPECTED-PAYLOAD",
+        run: async () => {
+          throw new ScenarioExpectedFailError(`provisioning failed: ${expectedPayload}`);
+        },
+      }),
+    ]),
+  );
+  const serialized = JSON.stringify(report);
+
+  assert.ok(!serialized.includes(blockedPayload));
+  assert.ok(!serialized.includes(expectedPayload));
+  assert.equal(report.results[0].status, "blocked");
+  assert.equal(report.results[1].status, "expected_fail");
 });
 
 test("runtime-discovered URL credentials are scrubbed even when unknown to the redactor", async () => {

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { EnvResolution, ResolvedEnvVar } from "../config/env-resolution.js";
+import type { ScenarioDefinition } from "../scenarios/types.js";
+import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
+import { executeSelectedTests, expandSelectedTests, SelectionError, type ExecuteOptions } from "./execute.js";
+import type { RunIdentityV1 } from "./identity.js";
+
+const IDENTITY: RunIdentityV1 = {
+  run_id: "run-1",
+  shard_id: "shard-1",
+  attempt: 1,
+  source_sha: "c".repeat(40),
+  origin: { kind: "local", github_run_id: null, github_job: null },
+};
+
+interface FakeScenarioOptions {
+  id: string;
+  lanes?: Array<"local" | "sandbox">;
+  requiredEnv?: string[];
+  run?: ScenarioDefinition["run"];
+  plan?: ScenarioDefinition["plan"];
+}
+
+function fakeScenario(options: FakeScenarioOptions): ScenarioDefinition {
+  return {
+    id: options.id,
+    title: `${options.id} title`,
+    registryFlowRef: `specs#${options.id}`,
+    lanes: options.lanes ?? ["local"],
+    requiredEnv: options.requiredEnv ?? [],
+    plan: options.plan ?? (() => [{ description: `plan ${options.id}` }]),
+    run: options.run ?? (async () => undefined),
+  };
+}
+
+function fakeEnv(presentNames: string[] = [], secretValues: Record<string, string> = {}): EnvResolution {
+  const names = new Set([...presentNames, ...Object.keys(secretValues)]);
+  const all: ResolvedEnvVar[] = [...names].map((name) => ({
+    spec: {
+      name,
+      description: name,
+      whereItLives: "test",
+      secret: name in secretValues,
+    } as ResolvedEnvVar["spec"],
+    value: secretValues[name] ?? "value",
+    present: true,
+  }));
+  return {
+    all,
+    missing: [],
+    present: (name) => names.has(name),
+    get: (name) => (names.has(name) ? (secretValues[name] ?? "value") : undefined),
+    require: (name) => {
+      const value = secretValues[name] ?? (names.has(name) ? "value" : undefined);
+      if (value === undefined) {
+        throw new Error(`missing ${name}`);
+      }
+      return value;
+    },
+  };
+}
+
+function baseOptions(scenarios: ScenarioDefinition[], overrides: Partial<ExecuteOptions> = {}): ExecuteOptions {
+  return {
+    behavior: "diagnostic",
+    execution: "real",
+    identity: IDENTITY,
+    inputs: { targetLane: "local", desktop: "web", agents: "all", scenarios: "all" },
+    scenarios,
+    resolveNeededEnv: () => fakeEnv(),
+    ...overrides,
+  };
+}
+
+test("expands scenarios across declared lanes with stable unique test ids", () => {
+  const selected = expandSelectedTests([
+    fakeScenario({ id: "A", lanes: ["local", "sandbox"] }),
+    fakeScenario({ id: "B", lanes: ["sandbox"] }),
+  ]);
+  assert.deepEqual(
+    selected.map((testEntry) => testEntry.test_id),
+    ["A/local", "A/sandbox", "B/sandbox"],
+  );
+});
+
+test("rejects duplicate expanded test ids before execution", () => {
+  assert.throws(
+    () => expandSelectedTests([fakeScenario({ id: "A" }), fakeScenario({ id: "A" })]),
+    SelectionError,
+  );
+});
+
+test("rejects a selection that expands to zero tests", () => {
+  assert.throws(() => expandSelectedTests([]), SelectionError);
+});
+
+test("normal return normalizes to green with timestamps and duration", async () => {
+  const report = await executeSelectedTests(baseOptions([fakeScenario({ id: "A" })]));
+  const [result] = report.results;
+  assert.equal(result.status, "green");
+  assert.ok(result.started_at !== null);
+  assert.ok(typeof result.duration_ms === "number");
+  assert.equal(report.verdict.status, "non_qualifying");
+  assert.equal(report.summary.intended_exit_code, 0);
+});
+
+test("ScenarioBlockedError, ScenarioExpectedFailError, Error, and non-Error throws normalize correctly", async () => {
+  const scenarios = [
+    fakeScenario({ id: "BLOCKED", run: async () => { throw new ScenarioBlockedError("gate"); } }),
+    fakeScenario({ id: "XFAIL", run: async () => { throw new ScenarioExpectedFailError("known gap"); } }),
+    fakeScenario({ id: "RED", run: async () => { throw new Error("assertion failed"); } }),
+    fakeScenario({ id: "WEIRD", run: async () => { throw "a string"; } }),
+    fakeScenario({ id: "GREEN" }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios));
+  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  assert.equal(byId.get("BLOCKED/local")?.status, "blocked");
+  assert.equal(byId.get("BLOCKED/local")?.reason?.code, "scenario_blocked");
+  assert.equal(byId.get("XFAIL/local")?.status, "expected_fail");
+  assert.equal(byId.get("XFAIL/local")?.reason?.code, "known_gap");
+  assert.equal(byId.get("RED/local")?.status, "failed");
+  assert.equal(byId.get("RED/local")?.reason?.code, "scenario_failure");
+  assert.equal(byId.get("WEIRD/local")?.status, "failed");
+  // Diagnostic continues every independent sibling after each terminal state.
+  assert.equal(byId.get("GREEN/local")?.status, "green");
+  assert.equal(report.summary.intended_exit_code, 1);
+});
+
+test("strict also continues siblings after runtime non-green states", async () => {
+  const ran: string[] = [];
+  const scenarios = [
+    fakeScenario({ id: "RED", run: async () => { ran.push("RED"); throw new Error("boom"); } }),
+    fakeScenario({ id: "GREEN", run: async () => { ran.push("GREEN"); } }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios, { behavior: "strict" }));
+  assert.deepEqual(ran, ["RED", "GREEN"]);
+  assert.equal(report.verdict.status, "selected_tests_failed");
+  assert.equal(report.summary.intended_exit_code, 1);
+});
+
+test("diagnostic missing requirements block only affected tests", async () => {
+  const ran: string[] = [];
+  const scenarios = [
+    fakeScenario({ id: "NEEDY", requiredEnv: ["MISSING_VAR"], run: async () => { ran.push("NEEDY"); } }),
+    fakeScenario({ id: "FREE", run: async () => { ran.push("FREE"); } }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios));
+  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  assert.equal(byId.get("NEEDY/local")?.status, "blocked");
+  assert.equal(byId.get("NEEDY/local")?.reason?.code, "missing_requirement");
+  assert.equal(byId.get("FREE/local")?.status, "green");
+  assert.deepEqual(ran, ["FREE"]);
+  assert.equal(report.summary.intended_exit_code, 0);
+});
+
+test("strict missing preflight executes zero test bodies, blocks affected, cancels the rest", async () => {
+  const ran: string[] = [];
+  const scenarios = [
+    fakeScenario({ id: "NEEDY", requiredEnv: ["MISSING_VAR"], run: async () => { ran.push("NEEDY"); } }),
+    fakeScenario({ id: "FREE", run: async () => { ran.push("FREE"); } }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios, { behavior: "strict" }));
+  assert.deepEqual(ran, []);
+  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  assert.equal(byId.get("NEEDY/local")?.status, "blocked");
+  assert.equal(byId.get("NEEDY/local")?.reason?.code, "missing_requirement");
+  assert.equal(byId.get("FREE/local")?.status, "cancelled");
+  assert.equal(byId.get("FREE/local")?.reason?.code, "strict_preflight_failed");
+  assert.equal(report.verdict.status, "selected_tests_failed");
+  assert.equal(report.summary.intended_exit_code, 1);
+});
+
+test("locally seeded vars do not satisfy the sandbox lane", async () => {
+  const scenarios = [
+    fakeScenario({ id: "A", lanes: ["local", "sandbox"], requiredEnv: ["SEEDED_VAR"] }),
+  ];
+  const report = await executeSelectedTests(
+    baseOptions(scenarios, {
+      resolveNeededEnv: () => fakeEnv(["SEEDED_VAR"]),
+      locallySeeded: new Set(["SEEDED_VAR"]),
+    }),
+  );
+  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  assert.equal(byId.get("A/local")?.status, "green");
+  assert.equal(byId.get("A/sandbox")?.status, "blocked");
+});
+
+test("dry-run calls each plan() exactly once, never run(), and finalizes not_run/dry_run", async () => {
+  const planCalls: string[] = [];
+  let runCalled = false;
+  const scenarios = [
+    fakeScenario({
+      id: "A",
+      lanes: ["local", "sandbox"],
+      plan: ({ runtimeLane }) => {
+        planCalls.push(`A/${runtimeLane}`);
+        return [{ description: `step for ${runtimeLane}` }];
+      },
+      run: async () => { runCalled = true; },
+    }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios, { execution: "dry_run" }));
+  assert.deepEqual(planCalls, ["A/local", "A/sandbox"]);
+  assert.equal(runCalled, false);
+  for (const result of report.results) {
+    assert.equal(result.status, "not_run");
+    assert.equal(result.reason?.code, "dry_run");
+    assert.equal(result.plan_steps.length, 1);
+  }
+  assert.equal(report.run.execution, "dry_run");
+  assert.equal(report.verdict.status, "non_qualifying");
+  assert.equal(report.summary.intended_exit_code, 0);
+});
+
+test("a throwing plan() becomes not_run/plan_error, records a runner error, continues, exits 2", async () => {
+  const scenarios = [
+    fakeScenario({ id: "BROKEN", plan: () => { throw new Error("plan bug"); } }),
+    fakeScenario({ id: "FINE" }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios, { execution: "dry_run" }));
+  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  assert.equal(byId.get("BROKEN/local")?.status, "not_run");
+  assert.equal(byId.get("BROKEN/local")?.reason?.code, "plan_error");
+  assert.equal(byId.get("FINE/local")?.status, "not_run");
+  assert.equal(byId.get("FINE/local")?.reason?.code, "dry_run");
+  assert.equal(report.summary.runner_errors.length, 1);
+  assert.equal(report.summary.by_status.failed, 0);
+  assert.equal(report.verdict.status, "non_qualifying");
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("an issue-filing failure records a runner error and exits 2 without changing statuses", async () => {
+  const scenarios = [fakeScenario({ id: "RED", run: async () => { throw new Error("boom"); } })];
+  const report = await executeSelectedTests(
+    baseOptions(scenarios, {
+      fileIssues: async () => { throw new Error("gh exploded"); },
+    }),
+  );
+  assert.equal(report.results[0].status, "failed");
+  assert.equal(report.summary.runner_errors[0].code, "issue_filing_failed");
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("issue filing receives only normalized failed results", async () => {
+  let received: string[] = [];
+  const scenarios = [
+    fakeScenario({ id: "RED", run: async () => { throw new Error("boom"); } }),
+    fakeScenario({ id: "BLOCKED", run: async () => { throw new ScenarioBlockedError("gate"); } }),
+    fakeScenario({ id: "GREEN" }),
+  ];
+  await executeSelectedTests(
+    baseOptions(scenarios, {
+      fileIssues: async (failed) => {
+        received = failed.map((result) => result.test_id);
+      },
+    }),
+  );
+  assert.deepEqual(received, ["RED/local"]);
+});
+
+test("issue filing is not invoked when nothing failed", async () => {
+  let called = false;
+  await executeSelectedTests(
+    baseOptions([fakeScenario({ id: "GREEN" })], {
+      fileIssues: async () => { called = true; },
+    }),
+  );
+  assert.equal(called, false);
+});
+
+test("exact resolved secret values are redacted from the report", async () => {
+  const secret = "sk-super-secret-value";
+  const scenarios = [
+    fakeScenario({
+      id: "LEAKY",
+      requiredEnv: ["SECRET_VAR"],
+      run: async () => { throw new Error(`request failed with key ${secret}`); },
+    }),
+  ];
+  const report = await executeSelectedTests(
+    baseOptions(scenarios, { resolveNeededEnv: () => fakeEnv([], { SECRET_VAR: secret }) }),
+  );
+  const serialized = JSON.stringify(report);
+  assert.ok(!serialized.includes(secret));
+  assert.match(report.results[0].reason!.message, /\[REDACTED\]/);
+});
+
+test("overlong messages are bounded to 4096 code points", async () => {
+  const scenarios = [
+    fakeScenario({ id: "LOUD", run: async () => { throw new Error("x".repeat(10_000)); } }),
+  ];
+  const report = await executeSelectedTests(baseOptions(scenarios));
+  assert.ok([...report.results[0].reason!.message].length <= 4096);
+});
+
+test("the report records identity, inputs, behavior, and selected/result equality", async () => {
+  const report = await executeSelectedTests(
+    baseOptions([fakeScenario({ id: "A", lanes: ["local", "sandbox"] })], {
+      inputs: { targetLane: "staging", desktop: "native", agents: ["claude"], scenarios: ["A"] },
+    }),
+  );
+  assert.equal(report.run.run_id, "run-1");
+  assert.equal(report.run.behavior, "diagnostic");
+  assert.equal(report.inputs.target_lane, "staging");
+  assert.deepEqual(report.inputs.agents, ["claude"]);
+  assert.deepEqual(
+    report.selected_tests.map((testEntry) => testEntry.test_id).sort(),
+    report.results.map((result) => result.test_id).sort(),
+  );
+  assert.equal(report.summary.selected, report.summary.finalized);
+});
+
+test("strict all-green is the only strict exit-0 result", async () => {
+  const report = await executeSelectedTests(
+    baseOptions([fakeScenario({ id: "A" }), fakeScenario({ id: "B" })], { behavior: "strict" }),
+  );
+  assert.equal(report.verdict.status, "selected_tests_passed");
+  assert.equal(report.verdict.scope, "selected_tests");
+  assert.equal(report.verdict.completeness, "partial");
+  assert.equal(report.summary.intended_exit_code, 0);
+});

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -231,43 +231,22 @@ test("a throwing plan() becomes not_run/plan_error, records a runner error, cont
   assert.equal(report.summary.intended_exit_code, 2);
 });
 
-test("an issue-filing failure records a runner error and exits 2 without changing statuses", async () => {
-  const scenarios = [fakeScenario({ id: "RED", run: async () => { throw new Error("boom"); } })];
+test("a post-selection runner defect finalizes every pending test and still produces a report", async () => {
+  // Simulates e.g. a scenario referencing an env var that resolveEnv rejects
+  // (undeclared in the manifest): the selected set must not be lost.
+  const scenarios = [fakeScenario({ id: "A" }), fakeScenario({ id: "B" })];
   const report = await executeSelectedTests(
     baseOptions(scenarios, {
-      fileIssues: async () => { throw new Error("gh exploded"); },
+      resolveNeededEnv: () => { throw new Error('resolveEnv: "NOT_IN_MANIFEST" is not declared'); },
     }),
   );
-  assert.equal(report.results[0].status, "failed");
-  assert.equal(report.summary.runner_errors[0].code, "issue_filing_failed");
+  assert.equal(report.results.length, 2);
+  for (const result of report.results) {
+    assert.equal(result.status, "missing");
+  }
+  assert.equal(report.summary.runner_errors.length, 1);
+  assert.match(report.summary.runner_errors[0].message, /NOT_IN_MANIFEST/);
   assert.equal(report.summary.intended_exit_code, 2);
-});
-
-test("issue filing receives only normalized failed results", async () => {
-  let received: string[] = [];
-  const scenarios = [
-    fakeScenario({ id: "RED", run: async () => { throw new Error("boom"); } }),
-    fakeScenario({ id: "BLOCKED", run: async () => { throw new ScenarioBlockedError("gate"); } }),
-    fakeScenario({ id: "GREEN" }),
-  ];
-  await executeSelectedTests(
-    baseOptions(scenarios, {
-      fileIssues: async (failed) => {
-        received = failed.map((result) => result.test_id);
-      },
-    }),
-  );
-  assert.deepEqual(received, ["RED/local"]);
-});
-
-test("issue filing is not invoked when nothing failed", async () => {
-  let called = false;
-  await executeSelectedTests(
-    baseOptions([fakeScenario({ id: "GREEN" })], {
-      fileIssues: async () => { called = true; },
-    }),
-  );
-  assert.equal(called, false);
 });
 
 test("exact resolved secret values are redacted from the report", async () => {
@@ -280,11 +259,39 @@ test("exact resolved secret values are redacted from the report", async () => {
     }),
   ];
   const report = await executeSelectedTests(
-    baseOptions(scenarios, { resolveNeededEnv: () => fakeEnv([], { SECRET_VAR: secret }) }),
+    baseOptions(scenarios, {
+      resolveNeededEnv: () => fakeEnv([], { SECRET_VAR: secret }),
+      resolveSecretValues: () => [secret],
+    }),
   );
   const serialized = JSON.stringify(report);
   assert.ok(!serialized.includes(secret));
   assert.match(report.results[0].reason!.message, /\[REDACTED\]/);
+});
+
+test("secrets are redacted even when no selected scenario declares them", async () => {
+  // A fixture can use a secret opportunistically (e.g. an optional GitHub
+  // token in a clone URL) without listing it in requiredEnv; redaction draws
+  // from the full manifest, injected here via resolveSecretValues.
+  const secret = "ghp_undeclared_token";
+  const scenarios = [
+    fakeScenario({ id: "LEAKY", run: async () => { throw new Error(`clone https://x:${secret}@github.com failed`); } }),
+  ];
+  const report = await executeSelectedTests(
+    baseOptions(scenarios, { resolveSecretValues: () => [secret] }),
+  );
+  assert.ok(!JSON.stringify(report).includes(secret));
+});
+
+test("rejects duplicate scenario ids even with disjoint lanes", () => {
+  assert.throws(
+    () =>
+      expandSelectedTests([
+        fakeScenario({ id: "A", lanes: ["local"] }),
+        fakeScenario({ id: "A", lanes: ["sandbox"] }),
+      ]),
+    SelectionError,
+  );
 });
 
 test("overlong messages are bounded to 4096 code points", async () => {

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -179,12 +179,21 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
  * report message in `sanitizeReport`.
  */
 function evidenceSafeMessage(error: unknown): string {
+  if (error instanceof SyntaxError) {
+    return "SyntaxError: invalid JSON response (payload withheld from evidence)";
+  }
   const status = error instanceof Error ? (error as { status?: unknown }).status : undefined;
   if (error instanceof Error && typeof status === "number" && "body" in error) {
     // Message shape is `${method} ${path} -> ${status}: ${body}`; keep the
     // safe prefix, withhold everything after it.
     const prefix = /^(.*?->\s*\d+)/.exec(error.message)?.[1] ?? `request failed with status ${status}`;
     return `${error.name}: ${prefix} (response body withheld from evidence)`;
+  }
+  if (
+    error instanceof Error &&
+    ("stdout" in error || "stderr" in error)
+  ) {
+    return `${error.name}: external command failed (output withheld from evidence)`;
   }
   return error instanceof Error ? error.message : String(error);
 }

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -1,0 +1,299 @@
+import type { EnvResolution } from "../config/env-resolution.js";
+import { blockedReasonForMissingEnv, missingRequiredForLane, resolveEnv } from "../config/env-resolution.js";
+import type { DesktopMode, TargetLane } from "../config/types.js";
+import type { ScenarioDefinition } from "../scenarios/types.js";
+import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
+import type { TestRunReportV1 } from "../evidence/schema.js";
+import { sanitizeReport } from "../evidence/schema.js";
+import type { RunIdentityV1 } from "./identity.js";
+import {
+  countByStatus,
+  deriveVerdict,
+  ResultTracker,
+  type FinalTestResultV1,
+  type ResultBehavior,
+  type SelectedTestV1,
+} from "./result.js";
+
+export class SelectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SelectionError";
+  }
+}
+
+/**
+ * Expands scenarios across their declared runtime lanes into selected tests
+ * (`test_id = scenario_id/runtime_lane`) and rejects duplicate expanded ids,
+ * so a duplicate cell can never execute or record twice.
+ */
+export function expandSelectedTests(scenarios: readonly ScenarioDefinition[]): SelectedTestV1[] {
+  const selected: SelectedTestV1[] = [];
+  const seen = new Set<string>();
+  for (const scenario of scenarios) {
+    for (const runtimeLane of scenario.lanes) {
+      const testId = `${scenario.id}/${runtimeLane}`;
+      if (seen.has(testId)) {
+        throw new SelectionError(`Duplicate expanded test id "${testId}".`);
+      }
+      seen.add(testId);
+      selected.push({
+        test_id: testId,
+        scenario_id: scenario.id,
+        registry_flow_ref: scenario.registryFlowRef,
+        runtime_lane: runtimeLane,
+      });
+    }
+  }
+  if (selected.length === 0) {
+    throw new SelectionError("Selection expanded to zero tests.");
+  }
+  return selected;
+}
+
+export interface ExecuteInputs {
+  targetLane: TargetLane;
+  desktop: DesktopMode;
+  agents: string[] | "all";
+  scenarios: string[] | "all";
+}
+
+export interface ExecuteOptions {
+  behavior: ResultBehavior;
+  execution: "real" | "dry_run";
+  identity: RunIdentityV1;
+  inputs: ExecuteInputs;
+  scenarios: readonly ScenarioDefinition[];
+  /** Names satisfied only by this run's local durable-user seeding. */
+  locallySeeded?: ReadonlySet<string>;
+  /** Injectable for tests; defaults to resolveEnv over the union of requiredEnv. */
+  resolveNeededEnv?: (names: readonly string[]) => EnvResolution;
+  /** Called with normalized failed results after execution; a throw becomes issue_filing_failed + exit 2. */
+  fileIssues?: (failed: readonly FinalTestResultV1[]) => Promise<void>;
+  now?: () => Date;
+  log?: (message: string) => void;
+}
+
+/**
+ * Runs the required control flow: initialize one pending slot per selected
+ * test, preflight declared requirements, plan or execute per behavior,
+ * normalize every outcome, synthesize missing results, and derive the
+ * verdict/intended exit — returning an unwritten, sanitized combined report.
+ */
+export async function executeSelectedTests(options: ExecuteOptions): Promise<TestRunReportV1> {
+  const now = options.now ?? (() => new Date());
+  const log = options.log ?? (() => undefined);
+  const startedAt = now().toISOString();
+  const selected = expandSelectedTests(options.scenarios);
+  const tracker = new ResultTracker(selected);
+  const scenariosById = new Map(options.scenarios.map((scenario) => [scenario.id, scenario]));
+  const locallySeeded = options.locallySeeded ?? new Set<string>();
+
+  const neededEnvNames = [...new Set(options.scenarios.flatMap((scenario) => scenario.requiredEnv))];
+  const resolveNeeded = options.resolveNeededEnv ?? ((names: readonly string[]) => resolveEnv(names));
+  const neededEnv = resolveNeeded(neededEnvNames);
+
+  if (options.execution === "dry_run") {
+    await planAll(selected, scenariosById, tracker, options, now);
+  } else {
+    await runAll(selected, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
+  }
+
+  const results = tracker.finalizeRun(options.execution);
+
+  const failed = results.filter((result) => result.status === "failed");
+  if (options.fileIssues && failed.length > 0) {
+    try {
+      await options.fileIssues(failed);
+    } catch (error) {
+      tracker.recordRunnerError(
+        "issue_filing_failed",
+        `Issue filing failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  const verdict = deriveVerdict({
+    behavior: options.behavior,
+    results,
+    integrityErrors: tracker.integrityErrors,
+    runnerErrors: tracker.runnerErrors,
+  });
+
+  const report: TestRunReportV1 = {
+    schema_version: 1,
+    kind: "proliferate.test-run",
+    run: {
+      ...options.identity,
+      behavior: options.behavior,
+      execution: options.execution,
+      started_at: startedAt,
+      finished_at: now().toISOString(),
+    },
+    inputs: {
+      target_lane: options.inputs.targetLane,
+      desktop: options.inputs.desktop,
+      agents: options.inputs.agents,
+      scenarios: options.inputs.scenarios,
+    },
+    selected_tests: [...selected],
+    results,
+    summary: {
+      selected: selected.length,
+      finalized: results.length,
+      by_status: countByStatus(results),
+      integrity_errors: [...tracker.integrityErrors],
+      runner_errors: [...tracker.runnerErrors],
+      intended_exit_code: verdict.intendedExitCode,
+    },
+    verdict: {
+      status: verdict.status,
+      scope: "selected_tests",
+      completeness: "partial",
+      reasons: verdict.reasons,
+    },
+  };
+
+  const secretValues = neededEnv.all
+    .filter((entry) => entry.spec.secret && entry.value !== undefined)
+    .map((entry) => entry.value as string);
+  return sanitizeReport(report, secretValues);
+}
+
+async function planAll(
+  selected: readonly SelectedTestV1[],
+  scenariosById: ReadonlyMap<string, ScenarioDefinition>,
+  tracker: ResultTracker,
+  options: ExecuteOptions,
+  now: () => Date,
+): Promise<void> {
+  const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
+  for (const test of selected) {
+    const scenario = scenariosById.get(test.scenario_id)!;
+    try {
+      const steps = scenario.plan({
+        runtimeLane: test.runtime_lane,
+        desktop: options.inputs.desktop,
+        agents,
+      });
+      tracker.finalize(test.test_id, {
+        status: "not_run",
+        reason: { code: "dry_run", message: "Diagnostic dry-run planned this test instead of executing it." },
+        planSteps: steps.map((step) => step.description),
+        finishedAt: now().toISOString(),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      tracker.finalize(test.test_id, {
+        status: "not_run",
+        reason: { code: "plan_error", message: `plan() threw: ${message}` },
+        finishedAt: now().toISOString(),
+      });
+      tracker.recordRunnerError("runner_error", `plan() for "${test.test_id}" threw: ${message}`);
+    }
+  }
+}
+
+async function runAll(
+  selected: readonly SelectedTestV1[],
+  scenariosById: ReadonlyMap<string, ScenarioDefinition>,
+  tracker: ResultTracker,
+  options: ExecuteOptions,
+  neededEnv: EnvResolution,
+  locallySeeded: ReadonlySet<string>,
+  now: () => Date,
+  log: (message: string) => void,
+): Promise<void> {
+  const missingByTest = new Map<string, string[]>();
+  for (const test of selected) {
+    const scenario = scenariosById.get(test.scenario_id)!;
+    const missing = missingRequiredForLane(scenario.requiredEnv, test.runtime_lane, neededEnv, locallySeeded);
+    if (missing.length > 0) {
+      missingByTest.set(test.test_id, missing);
+    }
+  }
+
+  // Strict preflight is fail-closed: any unsatisfied selected requirement
+  // means zero scenario bodies execute.
+  if (options.behavior === "strict" && missingByTest.size > 0) {
+    for (const test of selected) {
+      const missing = missingByTest.get(test.test_id);
+      if (missing) {
+        tracker.finalize(test.test_id, {
+          status: "blocked",
+          reason: {
+            code: "missing_requirement",
+            message: blockedReasonForMissingEnv(test.scenario_id, test.runtime_lane, missing, locallySeeded),
+          },
+          finishedAt: now().toISOString(),
+        });
+      } else {
+        tracker.finalize(test.test_id, {
+          status: "cancelled",
+          reason: {
+            code: "strict_preflight_failed",
+            message: "Strict preflight found unsatisfied requirements on sibling tests; no test body ran.",
+          },
+          finishedAt: now().toISOString(),
+        });
+      }
+    }
+    return;
+  }
+
+  const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
+  for (const test of selected) {
+    const scenario = scenariosById.get(test.scenario_id)!;
+    const missing = missingByTest.get(test.test_id);
+    if (missing) {
+      tracker.finalize(test.test_id, {
+        status: "blocked",
+        reason: {
+          code: "missing_requirement",
+          message: blockedReasonForMissingEnv(test.scenario_id, test.runtime_lane, missing, locallySeeded),
+        },
+        finishedAt: now().toISOString(),
+      });
+      continue;
+    }
+    const startedAt = now().toISOString();
+    const startedMs = now().getTime();
+    const finish = (status: "green" | "failed" | "blocked" | "expected_fail", reason: FinalTestResultV1["reason"]) =>
+      tracker.finalize(test.test_id, {
+        status,
+        reason: reason ?? undefined,
+        startedAt,
+        finishedAt: now().toISOString(),
+        durationMs: now().getTime() - startedMs,
+      });
+    try {
+      log(`running ${test.test_id}`);
+      await scenario.run({
+        targetLane: options.inputs.targetLane,
+        runtimeLane: test.runtime_lane,
+        desktop: options.inputs.desktop,
+        agents,
+        dryRun: false,
+        env: neededEnv,
+      });
+      finish("green", null);
+    } catch (error) {
+      if (error instanceof ScenarioBlockedError) {
+        finish("blocked", { code: "scenario_blocked", message: error.reason });
+      } else if (error instanceof ScenarioExpectedFailError) {
+        finish("expected_fail", { code: "known_gap", message: error.diagnosis });
+      } else {
+        // The report stores the normalized message, never the raw stack
+        // (spec: "raw stacks and provider payloads are not serialized");
+        // the stack still reaches the console via the runner's own logging.
+        finish("failed", {
+          code: "scenario_failure",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        log(
+          `failed ${test.test_id}: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+        );
+      }
+    }
+  }
+}

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -118,10 +118,7 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
       await runAll(selected, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
     }
   } catch (error) {
-    tracker.recordRunnerError(
-      "runner_error",
-      `Runner failed after selection: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    tracker.recordRunnerError("runner_error", `Runner failed after selection: ${evidenceSafeMessage(error)}`);
   }
 
   const results = tracker.finalizeRun(options.execution);
@@ -172,6 +169,27 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
 }
 
 /**
+ * Normalizes a thrown value into an evidence-safe message. Known
+ * payload-carrying errors (the ApiRequestError/LocalRuntimeError shape: a
+ * numeric `status` plus a captured `body`) are summarized without their
+ * response body — existing clients embed complete provider/HTTP payloads in
+ * `Error.message`, which must never reach the report or issue payloads. The
+ * raw error still exists in process memory for console diagnostics only.
+ * URL-credential scrubbing and exact-secret redaction then apply to every
+ * report message in `sanitizeReport`.
+ */
+function evidenceSafeMessage(error: unknown): string {
+  const status = error instanceof Error ? (error as { status?: unknown }).status : undefined;
+  if (error instanceof Error && typeof status === "number" && "body" in error) {
+    // Message shape is `${method} ${path} -> ${status}: ${body}`; keep the
+    // safe prefix, withhold everything after it.
+    const prefix = /^(.*?->\s*\d+)/.exec(error.message)?.[1] ?? `request failed with status ${status}`;
+    return `${error.name}: ${prefix} (response body withheld from evidence)`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
  * Every present secret value in the full env manifest — not only the selected
  * scenarios' requiredEnv — because fixtures may use a secret opportunistically
  * (e.g. an optional GitHub token embedded in a clone URL) without declaring it.
@@ -205,7 +223,7 @@ async function planAll(
         finishedAt: now().toISOString(),
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = evidenceSafeMessage(error);
       tracker.finalize(test.test_id, {
         status: "not_run",
         reason: { code: "plan_error", message: `plan() threw: ${message}` },
@@ -310,7 +328,7 @@ async function runAll(
         // the stack still reaches the console via the runner's own logging.
         finish("failed", {
           code: "scenario_failure",
-          message: error instanceof Error ? error.message : String(error),
+          message: evidenceSafeMessage(error),
         });
         log(
           `failed ${test.test_id}: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -1,5 +1,6 @@
 import type { EnvResolution } from "../config/env-resolution.js";
 import { blockedReasonForMissingEnv, missingRequiredForLane, resolveEnv } from "../config/env-resolution.js";
+import { envVarNames } from "../config/env-manifest.js";
 import type { DesktopMode, TargetLane } from "../config/types.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
 import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
@@ -30,7 +31,16 @@ export class SelectionError extends Error {
 export function expandSelectedTests(scenarios: readonly ScenarioDefinition[]): SelectedTestV1[] {
   const selected: SelectedTestV1[] = [];
   const seen = new Set<string>();
+  const seenScenarioIds = new Set<string>();
   for (const scenario of scenarios) {
+    // Duplicate scenario ids are rejected outright (not only duplicate
+    // expanded test ids): later lookup is by scenario id, so two definitions
+    // sharing an id — even with disjoint lanes — could execute one body
+    // while reporting the other's metadata.
+    if (seenScenarioIds.has(scenario.id)) {
+      throw new SelectionError(`Duplicate scenario id "${scenario.id}" in the selection.`);
+    }
+    seenScenarioIds.add(scenario.id);
     for (const runtimeLane of scenario.lanes) {
       const testId = `${scenario.id}/${runtimeLane}`;
       if (seen.has(testId)) {
@@ -68,8 +78,12 @@ export interface ExecuteOptions {
   locallySeeded?: ReadonlySet<string>;
   /** Injectable for tests; defaults to resolveEnv over the union of requiredEnv. */
   resolveNeededEnv?: (names: readonly string[]) => EnvResolution;
-  /** Called with normalized failed results after execution; a throw becomes issue_filing_failed + exit 2. */
-  fileIssues?: (failed: readonly FinalTestResultV1[]) => Promise<void>;
+  /**
+   * Injectable for tests; defaults to every present secret value in the full
+   * env manifest — not only the selected scenarios' requiredEnv — so a secret
+   * a fixture uses opportunistically is still redacted from evidence.
+   */
+  resolveSecretValues?: () => string[];
   now?: () => Date;
   log?: (message: string) => void;
 }
@@ -89,29 +103,28 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
   const scenariosById = new Map(options.scenarios.map((scenario) => [scenario.id, scenario]));
   const locallySeeded = options.locallySeeded ?? new Set<string>();
 
-  const neededEnvNames = [...new Set(options.scenarios.flatMap((scenario) => scenario.requiredEnv))];
-  const resolveNeeded = options.resolveNeededEnv ?? ((names: readonly string[]) => resolveEnv(names));
-  const neededEnv = resolveNeeded(neededEnvNames);
+  // Once a valid selected set exists, a recoverable runner defect (e.g. a
+  // scenario referencing an undeclared env var) must not lose the selected
+  // results: it becomes a runner error, pending tests finalize as missing,
+  // and the report is still produced for persistence.
+  try {
+    const neededEnvNames = [...new Set(options.scenarios.flatMap((scenario) => scenario.requiredEnv))];
+    const resolveNeeded = options.resolveNeededEnv ?? ((names: readonly string[]) => resolveEnv(names));
+    const neededEnv = resolveNeeded(neededEnvNames);
 
-  if (options.execution === "dry_run") {
-    await planAll(selected, scenariosById, tracker, options, now);
-  } else {
-    await runAll(selected, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
+    if (options.execution === "dry_run") {
+      await planAll(selected, scenariosById, tracker, options, now);
+    } else {
+      await runAll(selected, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
+    }
+  } catch (error) {
+    tracker.recordRunnerError(
+      "runner_error",
+      `Runner failed after selection: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   const results = tracker.finalizeRun(options.execution);
-
-  const failed = results.filter((result) => result.status === "failed");
-  if (options.fileIssues && failed.length > 0) {
-    try {
-      await options.fileIssues(failed);
-    } catch (error) {
-      tracker.recordRunnerError(
-        "issue_filing_failed",
-        `Issue filing failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
 
   const verdict = deriveVerdict({
     behavior: options.behavior,
@@ -154,10 +167,19 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
     },
   };
 
-  const secretValues = neededEnv.all
-    .filter((entry) => entry.spec.secret && entry.value !== undefined)
+  const resolveSecrets = options.resolveSecretValues ?? defaultResolveSecretValues;
+  return sanitizeReport(report, resolveSecrets());
+}
+
+/**
+ * Every present secret value in the full env manifest — not only the selected
+ * scenarios' requiredEnv — because fixtures may use a secret opportunistically
+ * (e.g. an optional GitHub token embedded in a clone URL) without declaring it.
+ */
+function defaultResolveSecretValues(): string[] {
+  return resolveEnv(envVarNames())
+    .all.filter((entry) => entry.spec.secret && entry.value !== undefined)
     .map((entry) => entry.value as string);
-  return sanitizeReport(report, secretValues);
 }
 
 async function planAll(

--- a/tests/release/src/runner/identity.test.ts
+++ b/tests/release/src/runner/identity.test.ts
@@ -98,6 +98,30 @@ test("explicit overrides win without changing the recorded origin", async () => 
   assert.equal(identity.source_sha, FULL_SHA);
 });
 
+test("overrides cannot bypass required GitHub provenance", async () => {
+  const env = githubEnv();
+  delete env.GITHUB_RUN_ID;
+  await assert.rejects(
+    resolveRunIdentity({ env, overrides: { runId: "release-42" } }),
+    IdentityError,
+  );
+  const envNoJob = githubEnv();
+  delete envNoJob.GITHUB_JOB;
+  await assert.rejects(
+    resolveRunIdentity({ env: envNoJob, overrides: { shardId: "shard-1" } }),
+    IdentityError,
+  );
+});
+
+test("origin fields are always populated for a GitHub run, even with overrides", async () => {
+  const identity = await resolveRunIdentity({
+    env: githubEnv(),
+    overrides: { runId: "release-42", shardId: "shard-1" },
+  });
+  assert.equal(identity.origin.github_run_id, "123456");
+  assert.equal(identity.origin.github_job, "release-e2e-local");
+});
+
 test("two shards can share one run id, and a retry preserves the logical run", async () => {
   const shardA = await resolveRunIdentity({
     env: {},

--- a/tests/release/src/runner/identity.test.ts
+++ b/tests/release/src/runner/identity.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { IdentityError, isSafeId, resolveRunIdentity } from "./identity.js";
+
+const FULL_SHA = "a".repeat(40);
+
+function githubEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    GITHUB_ACTIONS: "true",
+    GITHUB_RUN_ID: "123456",
+    GITHUB_JOB: "release-e2e-local",
+    GITHUB_RUN_ATTEMPT: "2",
+    GITHUB_SHA: FULL_SHA,
+    ...overrides,
+  };
+}
+
+const gitHead = async () => `${"b".repeat(40)}\n`;
+
+test("derives GitHub identity: run id excludes GITHUB_RUN_ATTEMPT", async () => {
+  const identity = await resolveRunIdentity({ env: githubEnv() });
+  assert.equal(identity.run_id, "123456");
+  assert.equal(identity.shard_id, "release-e2e-local");
+  assert.equal(identity.attempt, 2);
+  assert.equal(identity.source_sha, FULL_SHA);
+  assert.deepEqual(identity.origin, {
+    kind: "github_actions",
+    github_run_id: "123456",
+    github_job: "release-e2e-local",
+  });
+});
+
+test("GitHub origin applies only when GITHUB_ACTIONS === \"true\"", async () => {
+  const identity = await resolveRunIdentity({
+    env: { GITHUB_ACTIONS: "false", GITHUB_RUN_ID: "999" },
+    resolveGitHead: gitHead,
+  });
+  assert.equal(identity.origin.kind, "local");
+
+  const alsoLocal = await resolveRunIdentity({
+    env: { GITHUB_RUN_ID: "999" },
+    resolveGitHead: gitHead,
+  });
+  assert.equal(alsoLocal.origin.kind, "local");
+});
+
+test("rejects incomplete GitHub context", async () => {
+  for (const missing of ["GITHUB_RUN_ID", "GITHUB_JOB", "GITHUB_RUN_ATTEMPT", "GITHUB_SHA"]) {
+    const env = githubEnv();
+    delete env[missing];
+    await assert.rejects(resolveRunIdentity({ env }), IdentityError);
+  }
+});
+
+test("rejects a malformed GITHUB_SHA and GITHUB_RUN_ATTEMPT", async () => {
+  await assert.rejects(resolveRunIdentity({ env: githubEnv({ GITHUB_SHA: "abc123" }) }), IdentityError);
+  await assert.rejects(
+    resolveRunIdentity({ env: githubEnv({ GITHUB_RUN_ATTEMPT: "zero" }) }),
+    IdentityError,
+  );
+});
+
+test("derives local defaults: generated run id, local-0, attempt 1, git HEAD", async () => {
+  const identity = await resolveRunIdentity({
+    env: {},
+    resolveGitHead: gitHead,
+    now: () => new Date("2026-07-13T01:02:03Z"),
+  });
+  assert.match(identity.run_id, /^local-20260713T010203Z-[0-9a-f]{6}$/);
+  assert.equal(identity.shard_id, "local-0");
+  assert.equal(identity.attempt, 1);
+  assert.equal(identity.source_sha, "b".repeat(40));
+  assert.deepEqual(identity.origin, { kind: "local", github_run_id: null, github_job: null });
+});
+
+test("failure to resolve a local source SHA is an identity error", async () => {
+  await assert.rejects(
+    resolveRunIdentity({ env: {}, resolveGitHead: async () => { throw new Error("not a git repo"); } }),
+    IdentityError,
+  );
+  await assert.rejects(
+    resolveRunIdentity({ env: {}, resolveGitHead: async () => "short-sha" }),
+    IdentityError,
+  );
+});
+
+test("explicit overrides win without changing the recorded origin", async () => {
+  const identity = await resolveRunIdentity({
+    env: githubEnv(),
+    overrides: { runId: "release-42", shardId: "shard-3", attempt: 5 },
+  });
+  assert.equal(identity.run_id, "release-42");
+  assert.equal(identity.shard_id, "shard-3");
+  assert.equal(identity.attempt, 5);
+  assert.equal(identity.origin.kind, "github_actions");
+  assert.equal(identity.origin.github_run_id, "123456");
+  assert.equal(identity.source_sha, FULL_SHA);
+});
+
+test("two shards can share one run id, and a retry preserves the logical run", async () => {
+  const shardA = await resolveRunIdentity({
+    env: {},
+    resolveGitHead: gitHead,
+    overrides: { runId: "release-42", shardId: "shard-a" },
+  });
+  const shardB = await resolveRunIdentity({
+    env: {},
+    resolveGitHead: gitHead,
+    overrides: { runId: "release-42", shardId: "shard-b", attempt: 2 },
+  });
+  assert.equal(shardA.run_id, shardB.run_id);
+  assert.notEqual(shardA.shard_id, shardB.shard_id);
+  assert.equal(shardB.attempt, 2);
+});
+
+test("rejects invalid override ids and attempts", async () => {
+  await assert.rejects(
+    resolveRunIdentity({ env: {}, resolveGitHead: gitHead, overrides: { runId: "-bad" } }),
+    IdentityError,
+  );
+  await assert.rejects(
+    resolveRunIdentity({ env: {}, resolveGitHead: gitHead, overrides: { shardId: "has space" } }),
+    IdentityError,
+  );
+  await assert.rejects(
+    resolveRunIdentity({ env: {}, resolveGitHead: gitHead, overrides: { attempt: 0 } }),
+    IdentityError,
+  );
+});
+
+test("isSafeId enforces the documented pattern", () => {
+  assert.ok(isSafeId("a"));
+  assert.ok(isSafeId("release-42.b_1"));
+  assert.ok(!isSafeId(""));
+  assert.ok(!isSafeId(".leading-dot"));
+  assert.ok(!isSafeId("x".repeat(129)));
+  assert.ok(isSafeId("x".repeat(128)));
+});

--- a/tests/release/src/runner/identity.ts
+++ b/tests/release/src/runner/identity.ts
@@ -69,9 +69,15 @@ export async function resolveRunIdentity(options: ResolveIdentityOptions = {}): 
   validateOverrides(overrides);
 
   if (isGitHub) {
-    const runId = overrides.runId ?? requireGitHubEnv(env, "GITHUB_RUN_ID", "run id");
-    const shardId = overrides.shardId ?? requireGitHubEnv(env, "GITHUB_JOB", "shard id");
-    const attempt = overrides.attempt ?? parseGitHubAttempt(env);
+    // Provenance is required regardless of overrides: an explicit --run-id /
+    // --shard-id / --attempt changes the logical identity but may not erase
+    // or bypass the real GitHub context recorded in `origin`.
+    const githubRunId = requireGitHubEnv(env, "GITHUB_RUN_ID", "run id");
+    const githubJob = requireGitHubEnv(env, "GITHUB_JOB", "shard id");
+    const githubAttempt = parseGitHubAttempt(env);
+    const runId = overrides.runId ?? githubRunId;
+    const shardId = overrides.shardId ?? githubJob;
+    const attempt = overrides.attempt ?? githubAttempt;
     const sourceSha = requireGitHubEnv(env, "GITHUB_SHA", "source SHA");
     if (!FULL_SHA_PATTERN.test(sourceSha)) {
       throw new IdentityError(
@@ -85,8 +91,8 @@ export async function resolveRunIdentity(options: ResolveIdentityOptions = {}): 
       source_sha: sourceSha,
       origin: {
         kind: "github_actions",
-        github_run_id: nonEmpty(env.GITHUB_RUN_ID) ?? null,
-        github_job: nonEmpty(env.GITHUB_JOB) ?? null,
+        github_run_id: githubRunId,
+        github_job: githubJob,
       },
     });
   }

--- a/tests/release/src/runner/identity.ts
+++ b/tests/release/src/runner/identity.ts
@@ -1,0 +1,182 @@
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { promisify } from "node:util";
+
+/**
+ * Run identity per specs/developing/testing/qualification-runner-core.md
+ * ("Run identity"). Resolved exactly once, before selection executes; every
+ * invocation — local or GitHub Actions — carries the same shape so local and
+ * parallel CI reports look alike.
+ */
+export interface RunIdentityV1 {
+  run_id: string;
+  shard_id: string;
+  attempt: number;
+  source_sha: string;
+  origin: {
+    kind: "local" | "github_actions";
+    github_run_id: string | null;
+    github_job: string | null;
+  };
+}
+
+/** Explicit CLI overrides. They win over derived values without changing the recorded origin. */
+export interface IdentityOverrides {
+  runId?: string;
+  shardId?: string;
+  attempt?: number;
+}
+
+/** Invalid or incomplete identity: the runner exits 2 before selection executes. */
+export class IdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IdentityError";
+  }
+}
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export function isSafeId(value: string): boolean {
+  return SAFE_ID_PATTERN.test(value);
+}
+
+export interface ResolveIdentityOptions {
+  overrides?: IdentityOverrides;
+  env?: NodeJS.ProcessEnv;
+  /** Injectable for tests; defaults to `git rev-parse HEAD`. */
+  resolveGitHead?: () => Promise<string>;
+  /** Injectable for tests; defaults to wall-clock now. */
+  now?: () => Date;
+}
+
+/**
+ * Derives the run identity. GitHub Actions identity applies only when
+ * `GITHUB_ACTIONS === "true"`; an unrelated `GITHUB_*` variable does not flip
+ * the origin. In GitHub Actions each of run/shard/attempt falls back to
+ * `GITHUB_RUN_ID` / `GITHUB_JOB` / `GITHUB_RUN_ATTEMPT` when not explicitly
+ * overridden (the run id deliberately excludes the run attempt so retries
+ * preserve the logical run), and `GITHUB_SHA` must be a full commit SHA.
+ * Locally the defaults are a generated `local-<timestamp>-<suffix>` run id,
+ * shard `local-0`, attempt `1`, and `git rev-parse HEAD`.
+ */
+export async function resolveRunIdentity(options: ResolveIdentityOptions = {}): Promise<RunIdentityV1> {
+  const env = options.env ?? process.env;
+  const overrides = options.overrides ?? {};
+  const isGitHub = env.GITHUB_ACTIONS === "true";
+
+  validateOverrides(overrides);
+
+  if (isGitHub) {
+    const runId = overrides.runId ?? requireGitHubEnv(env, "GITHUB_RUN_ID", "run id");
+    const shardId = overrides.shardId ?? requireGitHubEnv(env, "GITHUB_JOB", "shard id");
+    const attempt = overrides.attempt ?? parseGitHubAttempt(env);
+    const sourceSha = requireGitHubEnv(env, "GITHUB_SHA", "source SHA");
+    if (!FULL_SHA_PATTERN.test(sourceSha)) {
+      throw new IdentityError(
+        `GITHUB_SHA must be a full 40-hex commit SHA in GitHub Actions, got "${sourceSha}".`,
+      );
+    }
+    return validated({
+      run_id: runId,
+      shard_id: shardId,
+      attempt,
+      source_sha: sourceSha,
+      origin: {
+        kind: "github_actions",
+        github_run_id: nonEmpty(env.GITHUB_RUN_ID) ?? null,
+        github_job: nonEmpty(env.GITHUB_JOB) ?? null,
+      },
+    });
+  }
+
+  const resolveGitHead = options.resolveGitHead ?? defaultResolveGitHead;
+  let sourceSha: string;
+  try {
+    sourceSha = (await resolveGitHead()).trim();
+  } catch (error) {
+    throw new IdentityError(
+      `Could not resolve the local source SHA via git rev-parse HEAD: ${describe(error)}`,
+    );
+  }
+  if (!FULL_SHA_PATTERN.test(sourceSha)) {
+    throw new IdentityError(`Local source SHA must be a full 40-hex commit SHA, got "${sourceSha}".`);
+  }
+  const now = options.now ?? (() => new Date());
+  return validated({
+    run_id: overrides.runId ?? generateLocalRunId(now()),
+    shard_id: overrides.shardId ?? "local-0",
+    attempt: overrides.attempt ?? 1,
+    source_sha: sourceSha,
+    origin: { kind: "local", github_run_id: null, github_job: null },
+  });
+}
+
+function validateOverrides(overrides: IdentityOverrides): void {
+  if (overrides.runId !== undefined && !isSafeId(overrides.runId)) {
+    throw new IdentityError(`--run-id must match ${SAFE_ID_PATTERN}, got "${overrides.runId}".`);
+  }
+  if (overrides.shardId !== undefined && !isSafeId(overrides.shardId)) {
+    throw new IdentityError(`--shard-id must match ${SAFE_ID_PATTERN}, got "${overrides.shardId}".`);
+  }
+  if (overrides.attempt !== undefined && (!Number.isInteger(overrides.attempt) || overrides.attempt < 1)) {
+    throw new IdentityError(`--attempt must be a positive integer, got "${overrides.attempt}".`);
+  }
+}
+
+function validated(identity: RunIdentityV1): RunIdentityV1 {
+  if (!isSafeId(identity.run_id)) {
+    throw new IdentityError(`Run id must match ${SAFE_ID_PATTERN}, got "${identity.run_id}".`);
+  }
+  if (!isSafeId(identity.shard_id)) {
+    throw new IdentityError(`Shard id must match ${SAFE_ID_PATTERN}, got "${identity.shard_id}".`);
+  }
+  if (!Number.isInteger(identity.attempt) || identity.attempt < 1) {
+    throw new IdentityError(`Attempt must be a positive integer, got "${identity.attempt}".`);
+  }
+  return identity;
+}
+
+function requireGitHubEnv(env: NodeJS.ProcessEnv, name: string, what: string): string {
+  const value = nonEmpty(env[name]);
+  if (value === undefined) {
+    throw new IdentityError(
+      `GITHUB_ACTIONS is "true" but ${name} is missing or empty; cannot derive the ${what}.`,
+    );
+  }
+  return value;
+}
+
+function parseGitHubAttempt(env: NodeJS.ProcessEnv): number {
+  const raw = requireGitHubEnv(env, "GITHUB_RUN_ATTEMPT", "attempt");
+  const attempt = Number(raw);
+  if (!Number.isInteger(attempt) || attempt < 1) {
+    throw new IdentityError(`GITHUB_RUN_ATTEMPT must be a positive integer, got "${raw}".`);
+  }
+  return attempt;
+}
+
+function generateLocalRunId(now: Date): string {
+  const timestamp = now
+    .toISOString()
+    .replace(/\.\d{3}Z$/, "Z")
+    .replace(/[-:]/g, "");
+  const suffix = randomBytes(3).toString("hex");
+  return `local-${timestamp}-${suffix}`;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const execFileAsync = promisify(execFile);
+
+async function defaultResolveGitHead(): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"]);
+  return stdout;
+}

--- a/tests/release/src/runner/result.test.ts
+++ b/tests/release/src/runner/result.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  ALL_FINAL_STATUSES,
+  countByStatus,
+  deriveVerdict,
+  ResultTracker,
+  type FinalTestResultV1,
+  type FinalTestStatus,
+  type SelectedTestV1,
+} from "./result.js";
+
+function selected(id: string): SelectedTestV1 {
+  return {
+    test_id: `${id}/local`,
+    scenario_id: id,
+    registry_flow_ref: `specs#${id}`,
+    runtime_lane: "local",
+  };
+}
+
+function result(id: string, status: FinalTestStatus): FinalTestResultV1 {
+  return {
+    test_id: `${id}/local`,
+    scenario_id: id,
+    registry_flow_ref: `specs#${id}`,
+    runtime_lane: "local",
+    status,
+    started_at: null,
+    finished_at: "2026-07-13T00:00:00Z",
+    duration_ms: null,
+    reason: null,
+    plan_steps: [],
+  };
+}
+
+test("every selected test gets exactly one result; missing is synthesized with an integrity error", () => {
+  const tracker = new ResultTracker([selected("A"), selected("B")]);
+  tracker.finalize("A/local", { status: "green" });
+  const results = tracker.finalizeRun("real");
+  assert.equal(results.length, 2);
+  assert.equal(results[0].status, "green");
+  assert.equal(results[1].status, "missing");
+  assert.equal(results[1].reason?.code, "missing_result");
+  assert.equal(tracker.integrityErrors.length, 1);
+});
+
+test("duplicate finalization preserves the first result and records an integrity error", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("A/local", { status: "green" });
+  tracker.finalize("A/local", { status: "failed" });
+  const results = tracker.finalizeRun("real");
+  assert.equal(results[0].status, "green");
+  assert.equal(tracker.integrityErrors.length, 1);
+  assert.equal(tracker.integrityErrors[0].code, "duplicate_result");
+});
+
+test("a result for an unselected test is a selection/result mismatch", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("GHOST/local", { status: "green" });
+  assert.equal(tracker.integrityErrors[0].code, "selection_result_mismatch");
+});
+
+test("not_run during real execution is an integrity error", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("A/local", { status: "not_run", reason: { code: "dry_run", message: "planned" } });
+  tracker.finalizeRun("real");
+  assert.ok(tracker.integrityErrors.some((error) => error.code === "real_execution_not_run"));
+});
+
+test("not_run during dry_run is not an integrity error", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("A/local", { status: "not_run", reason: { code: "dry_run", message: "planned" } });
+  tracker.finalizeRun("dry_run");
+  assert.equal(tracker.integrityErrors.length, 0);
+});
+
+test("countByStatus serializes all seven keys with exact counts", () => {
+  const counts = countByStatus([result("A", "green"), result("B", "blocked"), result("C", "green")]);
+  assert.deepEqual(Object.keys(counts).sort(), [...ALL_FINAL_STATUSES].sort());
+  assert.equal(counts.green, 2);
+  assert.equal(counts.blocked, 1);
+  assert.equal(counts.failed, 0);
+});
+
+// The full diagnostic/strict verdict matrix from the frozen spec.
+const MATRIX: Array<{
+  name: string;
+  statuses: FinalTestStatus[];
+  diagnostic: { exit: number; verdict: string };
+  strict: { exit: number; verdict: string } | null;
+}> = [
+  {
+    name: "every selected real test green",
+    statuses: ["green", "green"],
+    diagnostic: { exit: 0, verdict: "non_qualifying" },
+    strict: { exit: 0, verdict: "selected_tests_passed" },
+  },
+  {
+    name: "blocked only",
+    statuses: ["green", "blocked"],
+    diagnostic: { exit: 0, verdict: "non_qualifying" },
+    strict: { exit: 1, verdict: "selected_tests_failed" },
+  },
+  {
+    name: "expected-fail only",
+    statuses: ["green", "expected_fail"],
+    diagnostic: { exit: 0, verdict: "non_qualifying" },
+    strict: { exit: 1, verdict: "selected_tests_failed" },
+  },
+  {
+    name: "any failed",
+    statuses: ["green", "failed", "blocked"],
+    diagnostic: { exit: 1, verdict: "non_qualifying" },
+    strict: { exit: 1, verdict: "selected_tests_failed" },
+  },
+  {
+    name: "any cancelled",
+    statuses: ["green", "cancelled"],
+    diagnostic: { exit: 1, verdict: "non_qualifying" },
+    strict: { exit: 1, verdict: "selected_tests_failed" },
+  },
+  {
+    name: "any missing",
+    statuses: ["green", "missing"],
+    diagnostic: { exit: 1, verdict: "non_qualifying" },
+    strict: { exit: 1, verdict: "selected_tests_failed" },
+  },
+  {
+    name: "successful diagnostic dry-run (every test not_run)",
+    statuses: ["not_run", "not_run"],
+    diagnostic: { exit: 0, verdict: "non_qualifying" },
+    strict: null, // strict dry-run is invalid at parse time; no verdict exists
+  },
+];
+
+for (const row of MATRIX) {
+  test(`matrix: ${row.name} (diagnostic)`, () => {
+    const results = row.statuses.map((status, index) => result(`S${index}`, status));
+    const verdict = deriveVerdict({ behavior: "diagnostic", results, integrityErrors: [], runnerErrors: [] });
+    assert.equal(verdict.intendedExitCode, row.diagnostic.exit);
+    assert.equal(verdict.status, row.diagnostic.verdict);
+  });
+  if (row.strict) {
+    test(`matrix: ${row.name} (strict)`, () => {
+      const results = row.statuses.map((status, index) => result(`S${index}`, status));
+      const verdict = deriveVerdict({ behavior: "strict", results, integrityErrors: [], runnerErrors: [] });
+      assert.equal(verdict.intendedExitCode, row.strict!.exit);
+      assert.equal(verdict.status, row.strict!.verdict);
+    });
+  }
+}
+
+test("runner or integrity errors force exit 2 in both behaviors", () => {
+  const results = [result("A", "green")];
+  const integrity = [{ code: "duplicate_result" as const, message: "dup" }];
+  const runner = [{ code: "issue_filing_failed" as const, message: "gh failed" }];
+
+  const d1 = deriveVerdict({ behavior: "diagnostic", results, integrityErrors: integrity, runnerErrors: [] });
+  assert.equal(d1.intendedExitCode, 2);
+  assert.equal(d1.status, "non_qualifying");
+
+  const s1 = deriveVerdict({ behavior: "strict", results, integrityErrors: [], runnerErrors: runner });
+  assert.equal(s1.intendedExitCode, 2);
+  assert.equal(s1.status, "selected_tests_failed");
+});
+
+test("strict all-green with any error cannot pass", () => {
+  const verdict = deriveVerdict({
+    behavior: "strict",
+    results: [result("A", "green")],
+    integrityErrors: [{ code: "summary_mismatch", message: "off by one" }],
+    runnerErrors: [],
+  });
+  assert.equal(verdict.status, "selected_tests_failed");
+  assert.equal(verdict.intendedExitCode, 2);
+});

--- a/tests/release/src/runner/result.test.ts
+++ b/tests/release/src/runner/result.test.ts
@@ -155,7 +155,7 @@ for (const row of MATRIX) {
 test("runner or integrity errors force exit 2 in both behaviors", () => {
   const results = [result("A", "green")];
   const integrity = [{ code: "duplicate_result" as const, message: "dup" }];
-  const runner = [{ code: "issue_filing_failed" as const, message: "gh failed" }];
+  const runner = [{ code: "runner_error" as const, message: "post-selection failure" }];
 
   const d1 = deriveVerdict({ behavior: "diagnostic", results, integrityErrors: integrity, runnerErrors: [] });
   assert.equal(d1.intendedExitCode, 2);

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -64,7 +64,7 @@ export interface FinalTestResultV1 {
 }
 
 export interface RunnerErrorV1 {
-  code: "issue_filing_failed" | "runner_error";
+  code: "runner_error";
   message: string;
 }
 

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -1,0 +1,241 @@
+import type { RuntimeLane } from "../config/types.js";
+
+/**
+ * Cell state, finalization invariants, behavior policy, verdict, and intended
+ * exit code, per specs/developing/testing/qualification-runner-core.md
+ * ("Final test results" / "Diagnostic and strict verdicts").
+ */
+
+export type ResultBehavior = "diagnostic" | "strict";
+
+/** `pending` is internal only and never serialized. */
+export type FinalTestStatus =
+  | "green"
+  | "failed"
+  | "blocked"
+  | "expected_fail"
+  | "cancelled"
+  | "not_run"
+  | "missing";
+
+export const ALL_FINAL_STATUSES: readonly FinalTestStatus[] = [
+  "green",
+  "failed",
+  "blocked",
+  "expected_fail",
+  "cancelled",
+  "not_run",
+  "missing",
+];
+
+export type ResultReasonCode =
+  | "missing_requirement"
+  | "scenario_blocked"
+  | "known_gap"
+  | "scenario_failure"
+  | "strict_preflight_failed"
+  | "dry_run"
+  | "plan_error"
+  | "missing_result";
+
+export interface ResultReason {
+  code: ResultReasonCode;
+  message: string;
+}
+
+export interface SelectedTestV1 {
+  test_id: string;
+  scenario_id: string;
+  registry_flow_ref: string;
+  runtime_lane: RuntimeLane;
+}
+
+export interface FinalTestResultV1 {
+  test_id: string;
+  scenario_id: string;
+  registry_flow_ref: string;
+  runtime_lane: RuntimeLane;
+  status: FinalTestStatus;
+  started_at: string | null;
+  finished_at: string;
+  duration_ms: number | null;
+  reason: ResultReason | null;
+  plan_steps: string[];
+}
+
+export interface RunnerErrorV1 {
+  code: "issue_filing_failed" | "runner_error";
+  message: string;
+}
+
+export interface IntegrityErrorV1 {
+  code: "duplicate_result" | "selection_result_mismatch" | "summary_mismatch" | "real_execution_not_run";
+  message: string;
+}
+
+export type VerdictStatus = "selected_tests_passed" | "selected_tests_failed" | "non_qualifying";
+
+export interface Finalization {
+  status: FinalTestStatus;
+  reason?: ResultReason;
+  startedAt?: string | null;
+  finishedAt?: string;
+  durationMs?: number | null;
+  planSteps?: string[];
+}
+
+/**
+ * Tracks one pending slot per selected test and enforces the finalization
+ * invariants: exactly one final result per selected test, first accepted
+ * result wins, duplicates and missing results are integrity errors.
+ */
+export class ResultTracker {
+  private readonly selected: readonly SelectedTestV1[];
+  private readonly results = new Map<string, FinalTestResultV1>();
+  readonly integrityErrors: IntegrityErrorV1[] = [];
+  readonly runnerErrors: RunnerErrorV1[] = [];
+
+  constructor(selected: readonly SelectedTestV1[]) {
+    this.selected = selected;
+  }
+
+  get selectedTests(): readonly SelectedTestV1[] {
+    return this.selected;
+  }
+
+  pendingTests(): SelectedTestV1[] {
+    return this.selected.filter((test) => !this.results.has(test.test_id));
+  }
+
+  recordRunnerError(code: RunnerErrorV1["code"], message: string): void {
+    this.runnerErrors.push({ code, message });
+  }
+
+  finalize(testId: string, finalization: Finalization): void {
+    const test = this.selected.find((candidate) => candidate.test_id === testId);
+    if (!test) {
+      this.integrityErrors.push({
+        code: "selection_result_mismatch",
+        message: `Result recorded for "${testId}", which is not a selected test.`,
+      });
+      return;
+    }
+    if (this.results.has(testId)) {
+      this.integrityErrors.push({
+        code: "duplicate_result",
+        message: `Duplicate finalization for "${testId}" (${finalization.status}); the first result is retained.`,
+      });
+      return;
+    }
+    this.results.set(testId, {
+      test_id: test.test_id,
+      scenario_id: test.scenario_id,
+      registry_flow_ref: test.registry_flow_ref,
+      runtime_lane: test.runtime_lane,
+      status: finalization.status,
+      started_at: finalization.startedAt ?? null,
+      finished_at: finalization.finishedAt ?? new Date().toISOString(),
+      duration_ms: finalization.durationMs ?? null,
+      reason: finalization.reason ?? null,
+      plan_steps: finalization.planSteps ?? [],
+    });
+  }
+
+  /**
+   * Synthesizes `missing` for any selected test with no recorded outcome and
+   * records the integrity error; returns every result in selection order.
+   */
+  finalizeRun(execution: "real" | "dry_run"): FinalTestResultV1[] {
+    for (const test of this.pendingTests()) {
+      this.integrityErrors.push({
+        code: "selection_result_mismatch",
+        message: `Selected test "${test.test_id}" ended with no recorded result; synthesized as missing.`,
+      });
+      this.finalize(test.test_id, {
+        status: "missing",
+        reason: { code: "missing_result", message: "Finalization found no result for this selected test." },
+      });
+    }
+    const results = this.selected.map((test) => this.results.get(test.test_id)!);
+    if (execution === "real") {
+      for (const result of results) {
+        if (result.status === "not_run") {
+          this.integrityErrors.push({
+            code: "real_execution_not_run",
+            message: `"${result.test_id}" is not_run during real execution.`,
+          });
+        }
+      }
+    }
+    return results;
+  }
+}
+
+export interface VerdictInput {
+  behavior: ResultBehavior;
+  results: readonly FinalTestResultV1[];
+  integrityErrors: readonly IntegrityErrorV1[];
+  runnerErrors: readonly RunnerErrorV1[];
+}
+
+export interface DerivedVerdict {
+  status: VerdictStatus;
+  reasons: string[];
+  intendedExitCode: 0 | 1 | 2;
+}
+
+export function countByStatus(results: readonly FinalTestResultV1[]): Record<FinalTestStatus, number> {
+  const counts = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
+    FinalTestStatus,
+    number
+  >;
+  for (const result of results) {
+    counts[result.status] += 1;
+  }
+  return counts;
+}
+
+/**
+ * The diagnostic/strict verdict matrix. Diagnostic is always non-qualifying;
+ * strict passes only when every selected real test is green and there are no
+ * runner or integrity errors. Any runner/integrity error exits 2 in both
+ * behaviors.
+ */
+export function deriveVerdict(input: VerdictInput): DerivedVerdict {
+  const counts = countByStatus(input.results);
+  const reasons: string[] = [];
+  const hasErrors = input.integrityErrors.length > 0 || input.runnerErrors.length > 0;
+
+  for (const error of input.integrityErrors) {
+    reasons.push(`integrity error: ${error.message}`);
+  }
+  for (const error of input.runnerErrors) {
+    reasons.push(`runner error (${error.code}): ${error.message}`);
+  }
+
+  const nonGreen = ALL_FINAL_STATUSES.filter((status) => status !== "green" && counts[status] > 0);
+  for (const status of nonGreen) {
+    reasons.push(`${counts[status]} selected test(s) finished ${status}`);
+  }
+
+  if (input.behavior === "diagnostic") {
+    reasons.push("diagnostic behavior never qualifies a candidate");
+    const failedLike = counts.failed + counts.cancelled + counts.missing;
+    const exit: 0 | 1 | 2 = hasErrors ? 2 : failedLike > 0 ? 1 : 0;
+    return { status: "non_qualifying", reasons, intendedExitCode: exit };
+  }
+
+  const allGreen = input.results.length > 0 && input.results.every((result) => result.status === "green");
+  if (allGreen && !hasErrors) {
+    return {
+      status: "selected_tests_passed",
+      reasons: ["every selected test is green; scope is selected tests only, completeness partial"],
+      intendedExitCode: 0,
+    };
+  }
+  return {
+    status: "selected_tests_failed",
+    reasons,
+    intendedExitCode: hasErrors ? 2 : 1,
+  };
+}

--- a/tests/release/src/scenarios/types.ts
+++ b/tests/release/src/scenarios/types.ts
@@ -12,7 +12,9 @@ export interface ScenarioPlanStep {
  * `src/fixtures/identity.ts`. Distinct from `ScenarioFailure`: a blocked run
  * does not fail the release gate and does not get an issue filed against it
  * (the blocker already has its own tracking); it is reported so the gap stays
- * visible instead of silently passing or silently failing.
+ * visible instead of silently passing or silently failing. How a blocked
+ * outcome affects the verdict and exit code is owned by the runner policy in
+ * `../runner/result.ts`, not by this class.
  */
 export class ScenarioBlockedError extends Error {
   readonly reason: string;
@@ -28,8 +30,9 @@ export class ScenarioBlockedError extends Error {
  * Thrown when a scenario was attempted for real (per README's "3 real
  * attempts, then mark expected-fail" rule) and the diagnosis is recorded
  * here, distinct from an actual product bug (which gets a filed issue
- * instead — see `../report/issue-filer.ts`). An expected-fail run does not
- * fail the release gate; it is a documented, known gap.
+ * instead — see `../report/issue-filer.ts`). Whether an expected-fail run is
+ * tolerated (diagnostic) or fails the gate (strict) is owned by the runner
+ * policy in `../runner/result.ts`; it is a documented, known gap either way.
  */
 export class ScenarioExpectedFailError extends Error {
   readonly diagnosis: string;
@@ -71,8 +74,8 @@ export interface ScenarioDefinition {
   /**
    * Executes the scenario for one runtime lane. Throws `ScenarioBlockedError`
    * for a known out-of-band gate, `ScenarioExpectedFailError` for a diagnosed
-   * real gap, or any other error for a genuine red — see the two classes
-   * above for how the CLI (`src/cli/run.ts`) reports each differently.
+   * real gap, or any other error for a genuine red — the runner
+   * (`src/runner/execute.ts`) normalizes each into a final test status.
    */
   run(ctx: ScenarioRunContext): Promise<void>;
 }


### PR DESCRIPTION
Implements the frozen **Test Runner and Results Reporting** contract
(`specs/developing/testing/qualification-runner-core.md`, revision `Q1-frozen-2`,
audited base `2ec15eaf8`). The spec-freeze commit is included as the first
commit of this PR since it has not landed on main yet.

## What changes

One runner invocation now performs the required control flow: parse/validate →
resolve identity → expand/dedupe selected tests → preflight declared
requirements → run or plan → exactly one normalized final result per selected
test → one validated, atomically written combined report → exit using the
persisted verdict.

- `--behavior <diagnostic|strict>` is required for direct CLI use; `make
  release-e2e` passes it explicitly with `BEHAVIOR ?= diagnostic` (no workflow
  YAML changes).
- Strict preflight is fail-closed: any missing requirement blocks affected
  tests, cancels the rest, executes zero scenario bodies, and exits 1.
- Dry-run calls every `plan()` and no `run()`; strict dry-run is invalid.
- Run/shard/attempt/source-SHA/origin identity (GitHub Actions when
  `GITHUB_ACTIONS === "true"`, local git otherwise); retries preserve the
  logical run and never overwrite earlier attempt artifacts.
- One `qualification-evidence.json` per invocation/shard/attempt: set-equality/
  count/verdict invariants validated before an atomic non-overwriting write;
  secrets redacted, messages bounded to 4096 code points, no raw stacks.
- Verdicts: diagnostic is always `non_qualifying`; strict is
  `selected_tests_passed` (all green, no errors) or `selected_tests_failed`.
- Missing results are synthesized as `missing`; duplicates keep the first
  result; both are integrity errors and exit 2.
- Per-failure JSON files are removed; issue filing consumes an in-memory
  mapping from normalized `failed` results only, and a filing failure is a
  runner error (exit 2) without changing any test's status.
- `cli/run.ts` is a thin process adapter; no scenario implementation changed.

## Key files

- `tests/release/src/runner/identity.ts` — `RunIdentityV1`, `resolveRunIdentity`
- `tests/release/src/runner/result.ts` — `ResultTracker`, `deriveVerdict`, status/verdict types
- `tests/release/src/runner/execute.ts` — `expandSelectedTests`, `executeSelectedTests`
- `tests/release/src/evidence/schema.ts` — `TestRunReportV1`, `validateReport`, `sanitizeReport`
- `tests/release/src/evidence/write.ts` — `writeReport` (atomic, non-overwriting)
- `tests/release/src/cli/args.ts` — invocation validation incl. `--behavior`, overrides, list rules
- `tests/release/src/report/failure-reporter.ts` — `toFailureReports` (mapping only)

## Verification

- `pnpm -C tests/release test` — 130 pass (56 baseline + 74 new), 0 fail
- `pnpm -C tests/release typecheck` — clean
- CLI smoke: `--help` → 0; omitted `--behavior`, strict `--dry-run`, unknown
  scenario → 2; diagnostic `--dry-run` → 0 with a parseable combined report at
  `<out>/<run>/<shard>/attempt-1/qualification-evidence.json`

## Notes / assumptions

- Custom graceful signal handling is deferred per the frozen spec (non-goal).
- `report/types.ts`: removed the now-unused `ScenarioFailure` interface (its
  only consumers were the deleted per-failure write path); `FailureReport`
  wire shape unchanged.
- `--lane`/`--desktop` keep their existing defaults; only `--behavior` is newly
  required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)