### PR TITLE
feat(desktop): adopt ProductHostProvider with real Desktop host and bridge

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:built": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
-    "build": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc && vite build",
+    "dev:built": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/product-client build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && vite",
+    "build": "pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/product-client build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "pretest": "pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && bash scripts/check-design-system.sh",
+    "pretest": "pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/product-client build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && bash scripts/check-design-system.sh",
     "test": "vitest run",
     "check:design": "bash scripts/check-design-system.sh",
     "test:watch": "vitest"
@@ -31,6 +31,7 @@
     "@proliferate/cloud-sdk": "workspace:*",
     "@proliferate/cloud-sdk-react": "workspace:*",
     "@proliferate/design": "workspace:*",
+    "@proliferate/product-client": "workspace:*",
     "@proliferate/product-domain": "workspace:*",
     "@proliferate/product-surfaces": "workspace:*",
     "@proliferate/product-ui": "workspace:*",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,12 +13,10 @@ import { useDebugSessionActivity } from "@/hooks/app/lifecycle/use-debug-session
 import { useDesktopWorkerEnrollment } from "@/hooks/cloud/lifecycle/use-desktop-worker-enrollment"
 import { useDevDesktopHandoff } from "@/hooks/app/lifecycle/use-dev-desktop-handoff"
 import { useOrganizationJoinAuthLaunch } from "@/hooks/organizations/lifecycle/use-organization-join-auth-launch"
-import { useExportRunningAgentCount } from "@/hooks/app/lifecycle/use-export-running-agent-count"
 import { useUpdateRestartWatcher } from "@/hooks/access/tauri/use-update-restart-watcher"
 import { useWorkspaceActivityIndicator } from "@/hooks/app/lifecycle/use-workspace-activity-indicator"
 import { useAppShortcuts } from "@/hooks/app/lifecycle/use-app-shortcuts"
 import { useAppCommandActions } from "@/hooks/app/workflows/use-app-command-actions"
-import { useAuthBootstrap } from "@/hooks/auth/lifecycle/use-auth-bootstrap"
 import { useAgentAutoReconcile } from "@/hooks/agents/lifecycle/use-agent-auto-reconcile"
 import { useFirstRunAuthAdoption } from "@/hooks/agents/lifecycle/use-first-run-auth-adoption"
 import { useGatewayCatalogMirrorSync } from "@/hooks/agents/lifecycle/use-gateway-catalog-mirror-sync"
@@ -59,7 +57,9 @@ import { SettingsCloudRedirect } from "@/pages/SettingsCloudRedirect"
 import { useAuthStore } from "@/stores/auth/auth-store"
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store"
 import { AppCommandActionsProvider } from "@/providers/AppCommandActionsProvider"
+import { DesktopProductLifecycleRoot } from "@/providers/DesktopProductLifecycleRoot"
 import { ShortcutRevealProvider } from "@/providers/ShortcutRevealProvider"
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider"
 
 const APP_RUNTIME_RENDER_MILESTONES = new Set([1, 2, 3, 5, 10, 25, 50, 100, 250])
 
@@ -143,7 +143,7 @@ function AppRuntime() {
     recordBootDiagnostic("app_runtime.render.pass", { count: appRuntimeRenderCount })
   }
   recordBootDiagnosticOnce("app_runtime.render.before.use_auth_bootstrap")
-  const bootstrapAuth = useAuthBootstrap()
+  const bootstrapAuth = useProductHost().auth.restoreSession
   recordBootDiagnosticOnce("app_runtime.render.after.use_auth_bootstrap")
   recordBootDiagnosticOnce("app_runtime.render.before.auth_status")
   const authStatus = useAuthStore((s) => s.status)
@@ -151,9 +151,6 @@ function AppRuntime() {
   recordBootDiagnosticOnce("app_runtime.render.before.use_app_command_actions")
   const appCommandActions = useAppCommandActions()
   recordBootDiagnosticOnce("app_runtime.render.after.use_app_command_actions")
-  recordBootDiagnosticOnce("app_runtime.render.before.use_export_running_agent_count")
-  useExportRunningAgentCount()
-  recordBootDiagnosticOnce("app_runtime.render.after.use_export_running_agent_count")
   useConnectivityListeners()
   useUpdateRestartWatcher()
   useDebugSessionActivity()
@@ -260,6 +257,7 @@ function AppRuntime() {
           <MacWindowControlsSafeArea />
           <UpdateRestartDialog />
           <WorkspaceActivityIndicatorMount />
+          <DesktopProductLifecycleRoot />
           <WorktreeCleanupPolicySyncGate />
           <InstrumentedRoutes>
             <Route path="/index.html" element={<Navigate to="/" replace />} />

--- a/apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+// Drive the busy count off a plain `busy` flag on each entry so the test does
+// not depend on the full directory-entry / activity shapes.
+vi.mock("@proliferate/product-domain/sessions/activity", () => ({
+  isSessionSlotBusy: (snapshot: { busy?: boolean } | null) =>
+    snapshot?.busy === true,
+}));
+vi.mock("@/lib/domain/sessions/directory/directory-activity", () => ({
+  activitySnapshotFromDirectoryEntry: (entry: unknown) => entry,
+  // Also mocked because the session-directory store imports it at module load.
+  activityFromTranscript: () => ({}),
+}));
+
+import { useExportRunningAgentCount } from "./use-export-running-agent-count";
+
+type Entries = Record<string, { busy: boolean }>;
+
+function setEntries(entries: Entries) {
+  useSessionDirectoryStore.setState({ entriesById: entries as never });
+}
+
+beforeEach(() => {
+  setEntries({});
+});
+
+describe("useExportRunningAgentCount", () => {
+  it("exports the initial busy count once on mount", () => {
+    setEntries({ a: { busy: true } });
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useExportRunningAgentCount(setRunningAgentCount));
+
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+    expect(setRunningAgentCount).toHaveBeenCalledWith(1);
+  });
+
+  it("exports only when the busy count changes", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => useExportRunningAgentCount(setRunningAgentCount));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(0);
+
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(1);
+
+    act(() => setEntries({ a: { busy: true }, b: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(2);
+
+    act(() => setEntries({ a: { busy: false }, b: { busy: false } }));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(0);
+
+    // initial(0) + 1 + 2 + 0
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not re-export when the count is unchanged", () => {
+    setEntries({ a: { busy: true } });
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => useExportRunningAgentCount(setRunningAgentCount));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    // Directory changes but the busy count stays 1.
+    act(() => setEntries({ a: { busy: true }, b: { busy: false } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-subscribe when the same callback is passed again", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ cb }) => useExportRunningAgentCount(cb),
+      { initialProps: { cb: setRunningAgentCount } },
+    );
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    rerender({ cb: setRunningAgentCount });
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-exports the initial count when the callback identity changes", () => {
+    const first = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ cb }) => useExportRunningAgentCount(cb),
+      { initialProps: { cb: first } },
+    );
+    expect(first).toHaveBeenCalledTimes(1);
+
+    const second = vi.fn().mockResolvedValue(undefined);
+    rerender({ cb: second });
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledWith(0);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = renderHook(() =>
+      useExportRunningAgentCount(setRunningAgentCount),
+    );
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { isSessionSlotBusy } from "@proliferate/product-domain/sessions/activity";
 import { activitySnapshotFromDirectoryEntry } from "@/lib/domain/sessions/directory/directory-activity";
-import { useTauriWindowActions } from "@/hooks/access/tauri/use-window-actions";
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
 
 type SessionEntries = ReturnType<typeof useSessionDirectoryStore.getState>["entriesById"];
@@ -12,11 +11,12 @@ function countBusy(entries: SessionEntries): number {
   ).length;
 }
 
-// Owns exporting the current busy-agent count to the native window layer.
+// Owns exporting the current busy-agent count to the native window layer via
+// the supplied export function (host.desktop.nativeUi.setRunningAgentCount).
 // It does not own session activity rules or native window primitives.
-export function useExportRunningAgentCount(): void {
-  const { setRunningAgentCount } = useTauriWindowActions();
-
+export function useExportRunningAgentCount(
+  setRunningAgentCount: (count: number) => Promise<void>,
+): void {
   useEffect(() => {
     let lastCount = countBusy(useSessionDirectoryStore.getState().entriesById);
     void setRunningAgentCount(lastCount);

--- a/apps/desktop/src/lib/access/browser/product-storage.test.ts
+++ b/apps/desktop/src/lib/access/browser/product-storage.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { desktopProductStorage } from "./product-storage";
+
+describe("desktopProductStorage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getItem returns the stored string value", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => "test-value"),
+    });
+
+    const result = await desktopProductStorage.getItem("test-key");
+
+    expect(result).toBe("test-value");
+    expect(window.localStorage.getItem).toHaveBeenCalledWith("test-key");
+  });
+
+  it("getItem returns null when key does not exist", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+    });
+
+    const result = await desktopProductStorage.getItem("nonexistent-key");
+
+    expect(result).toBeNull();
+    expect(window.localStorage.getItem).toHaveBeenCalledWith("nonexistent-key");
+  });
+
+  it("setItem writes the value to localStorage", async () => {
+    const setItemMock = vi.fn();
+    vi.stubGlobal("localStorage", {
+      setItem: setItemMock,
+    });
+
+    await desktopProductStorage.setItem("test-key", "test-value");
+
+    expect(setItemMock).toHaveBeenCalledWith("test-key", "test-value");
+  });
+
+  it("removeItem removes the key from localStorage", async () => {
+    const removeItemMock = vi.fn();
+    vi.stubGlobal("localStorage", {
+      removeItem: removeItemMock,
+    });
+
+    await desktopProductStorage.removeItem("test-key");
+
+    expect(removeItemMock).toHaveBeenCalledWith("test-key");
+  });
+
+  it("getItem rejects when localStorage throws", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => {
+        throw new Error("Storage quota exceeded");
+      }),
+    });
+
+    await expect(desktopProductStorage.getItem("test-key")).rejects.toThrow(
+      "Storage quota exceeded"
+    );
+  });
+
+  it("setItem rejects when localStorage throws", async () => {
+    vi.stubGlobal("localStorage", {
+      setItem: vi.fn(() => {
+        throw new Error("Storage quota exceeded");
+      }),
+    });
+
+    await expect(
+      desktopProductStorage.setItem("test-key", "test-value")
+    ).rejects.toThrow("Storage quota exceeded");
+  });
+
+  it("removeItem rejects when localStorage throws", async () => {
+    vi.stubGlobal("localStorage", {
+      removeItem: vi.fn(() => {
+        throw new Error("Storage quota exceeded");
+      }),
+    });
+
+    await expect(desktopProductStorage.removeItem("test-key")).rejects.toThrow(
+      "Storage quota exceeded"
+    );
+  });
+
+});

--- a/apps/desktop/src/lib/access/browser/product-storage.ts
+++ b/apps/desktop/src/lib/access/browser/product-storage.ts
@@ -1,0 +1,18 @@
+import type { ProductStorage } from "@proliferate/product-client/host/product-host";
+
+// Thin asynchronous ProductStorage over the window's localStorage. Browser
+// storage exceptions (quota, disabled storage) reject the returned promise
+// instead of throwing synchronously. No existing key is copied or migrated.
+export const desktopProductStorage: ProductStorage = {
+  async getItem(key: string): Promise<string | null> {
+    return window.localStorage.getItem(key);
+  },
+
+  async setItem(key: string, value: string): Promise<void> {
+    window.localStorage.setItem(key, value);
+  },
+
+  async removeItem(key: string): Promise<void> {
+    window.localStorage.removeItem(key);
+  },
+};

--- a/apps/desktop/src/lib/access/tauri/deep-link.test.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const deepLinkMocks = vi.hoisted(() => ({
+  getCurrent: vi.fn(),
+  onOpenUrl: vi.fn(),
+}))
+
+vi.mock("@tauri-apps/plugin-deep-link", () => deepLinkMocks)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+// The module holds live subscriber/listener state at module scope, so each
+// test loads a fresh copy.
+async function loadDeepLink() {
+  vi.resetModules()
+  return import("./deep-link")
+}
+
+describe("deep-link raw source", () => {
+  beforeEach(() => {
+    deepLinkMocks.getCurrent.mockReset()
+    deepLinkMocks.onOpenUrl.mockReset()
+  })
+
+  it("delivers the initial getCurrent snapshot and subsequent live urls to an active listener", async () => {
+    deepLinkMocks.getCurrent.mockResolvedValue(["proliferate://initial"])
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+      openUrlCallback = cb
+      return () => {}
+    })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const received: string[] = []
+    subscribeDeepLinkUrls((url) => received.push(url))
+
+    await vi.waitFor(() => expect(received).toContain("proliferate://initial"))
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+
+    openUrlCallback?.(["proliferate://live"])
+
+    expect(received).toEqual(["proliferate://initial", "proliferate://live"])
+  })
+
+  it("shares a single native live listener across multiple subscribers", async () => {
+    deepLinkMocks.getCurrent.mockResolvedValue(null)
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+      openUrlCallback = cb
+      return () => {}
+    })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const receivedA: string[] = []
+    const receivedB: string[] = []
+    subscribeDeepLinkUrls((url) => receivedA.push(url))
+    subscribeDeepLinkUrls((url) => receivedB.push(url))
+
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+    expect(deepLinkMocks.onOpenUrl).toHaveBeenCalledTimes(1)
+
+    openUrlCallback?.(["proliferate://live"])
+
+    expect(receivedA).toEqual(["proliferate://live"])
+    expect(receivedB).toEqual(["proliferate://live"])
+  })
+
+  it("is race-safe when unsubscribed before native registration and the initial snapshot settle", async () => {
+    const current = deferred<string[]>()
+    deepLinkMocks.getCurrent.mockReturnValue(current.promise)
+    const registration = deferred<() => void>()
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl.mockImplementation((cb: (urls: string[]) => void) => {
+      openUrlCallback = cb
+      return registration.promise
+    })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const received: string[] = []
+    const unsubscribe = subscribeDeepLinkUrls((url) => received.push(url))
+    unsubscribe()
+
+    current.resolve(["proliferate://initial"])
+    registration.resolve(() => {})
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+
+    openUrlCallback?.(["proliferate://live"])
+
+    // Flush the still-settling initial-snapshot drain.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(received).toEqual([])
+  })
+
+  it("unsubscribing one listener does not affect another sharing the native listener", async () => {
+    deepLinkMocks.getCurrent.mockResolvedValue(null)
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+      openUrlCallback = cb
+      return () => {}
+    })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const receivedA: string[] = []
+    const receivedB: string[] = []
+    const unsubscribeA = subscribeDeepLinkUrls((url) => receivedA.push(url))
+    subscribeDeepLinkUrls((url) => receivedB.push(url))
+
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+    unsubscribeA()
+
+    openUrlCallback?.(["proliferate://live"])
+
+    expect(receivedA).toEqual([])
+    expect(receivedB).toEqual(["proliferate://live"])
+  })
+
+  it("does not replay an already-delivered live url to a later subscriber", async () => {
+    deepLinkMocks.getCurrent.mockResolvedValue(null)
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+      openUrlCallback = cb
+      return () => {}
+    })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const receivedA: string[] = []
+    subscribeDeepLinkUrls((url) => receivedA.push(url))
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+
+    openUrlCallback?.(["proliferate://live-before"])
+    expect(receivedA).toEqual(["proliferate://live-before"])
+
+    // A subscriber joining later only gets its own getCurrent snapshot, not
+    // urls already delivered to earlier subscribers.
+    deepLinkMocks.getCurrent.mockResolvedValue(["proliferate://later-snapshot"])
+    const receivedB: string[] = []
+    subscribeDeepLinkUrls((url) => receivedB.push(url))
+    await vi.waitFor(() => expect(receivedB).toContain("proliferate://later-snapshot"))
+    expect(receivedB).toEqual(["proliferate://later-snapshot"])
+
+    openUrlCallback?.(["proliferate://live-after"])
+    expect(receivedA).toEqual(["proliferate://live-before", "proliferate://live-after"])
+    expect(receivedB).toEqual(["proliferate://later-snapshot", "proliferate://live-after"])
+  })
+
+  it("swallows getCurrent/onOpenUrl failures outside Tauri for subscribeDeepLinkUrls", async () => {
+    deepLinkMocks.getCurrent.mockRejectedValue(new Error("no tauri"))
+    deepLinkMocks.onOpenUrl.mockRejectedValue(new Error("no tauri"))
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const received: string[] = []
+    expect(() => subscribeDeepLinkUrls((url) => received.push(url))).not.toThrow()
+
+    await vi.waitFor(() => expect(deepLinkMocks.getCurrent).toHaveBeenCalled())
+    expect(received).toEqual([])
+  })
+
+  describe("ensureDeepLinkBridge", () => {
+    it("drains the current snapshot then forwards live urls to the handler", async () => {
+      deepLinkMocks.getCurrent.mockResolvedValue(["proliferate://initial"])
+      let openUrlCallback: ((urls: string[]) => void) | undefined
+      deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+        openUrlCallback = cb
+        return () => {}
+      })
+
+      const { ensureDeepLinkBridge } = await loadDeepLink()
+      const handler = vi.fn().mockResolvedValue(true)
+      await ensureDeepLinkBridge(handler)
+
+      expect(handler).toHaveBeenCalledWith("proliferate://initial")
+
+      openUrlCallback?.(["proliferate://live"])
+
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(handler).toHaveBeenLastCalledWith("proliferate://live")
+    })
+
+    it("swallows getCurrent/onOpenUrl failures outside Tauri and still resolves", async () => {
+      deepLinkMocks.getCurrent.mockRejectedValue(new Error("no tauri"))
+      deepLinkMocks.onOpenUrl.mockRejectedValue(new Error("no tauri"))
+
+      const { ensureDeepLinkBridge } = await loadDeepLink()
+      await expect(ensureDeepLinkBridge(vi.fn())).resolves.toBeUndefined()
+    })
+  })
+})

--- a/apps/desktop/src/lib/access/tauri/deep-link.test.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.test.ts
@@ -224,5 +224,39 @@ describe("deep-link raw source", () => {
         process.off("unhandledRejection", onUnhandled)
       }
     })
+
+    it("memoizes the first call — a second call registers nothing and shares one live listener", async () => {
+      deepLinkMocks.getCurrent.mockResolvedValue(["proliferate://initial"])
+      let openUrlCallback: ((urls: string[]) => void) | undefined
+      deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+        openUrlCallback = cb
+        return () => {}
+      })
+
+      const { ensureDeepLinkBridge } = await loadDeepLink()
+      const handlerA = vi.fn().mockResolvedValue(true)
+      const handlerB = vi.fn().mockResolvedValue(true)
+
+      const first = ensureDeepLinkBridge(handlerA)
+      const second = ensureDeepLinkBridge(handlerB)
+
+      expect(second).toBe(first)
+      await first
+      await second
+
+      // getCurrent (the drain) only ran once, for the first registration.
+      expect(deepLinkMocks.getCurrent).toHaveBeenCalledTimes(1)
+      expect(handlerA).toHaveBeenCalledTimes(1)
+      expect(handlerA).toHaveBeenCalledWith("proliferate://initial")
+      expect(handlerB).not.toHaveBeenCalled()
+
+      openUrlCallback?.(["proliferate://live"])
+
+      // Only the first handler ever registered — one invocation total for
+      // the live url, not two.
+      expect(handlerA).toHaveBeenCalledTimes(2)
+      expect(handlerA).toHaveBeenLastCalledWith("proliferate://live")
+      expect(handlerB).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/desktop/src/lib/access/tauri/deep-link.test.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.test.ts
@@ -193,5 +193,36 @@ describe("deep-link raw source", () => {
       const { ensureDeepLinkBridge } = await loadDeepLink()
       await expect(ensureDeepLinkBridge(vi.fn())).resolves.toBeUndefined()
     })
+
+    it("contains handler rejections for both initial and live urls", async () => {
+      deepLinkMocks.getCurrent.mockResolvedValue(["proliferate://initial"])
+      let openUrlCallback: ((urls: string[]) => void) | undefined
+      deepLinkMocks.onOpenUrl.mockImplementation(async (cb: (urls: string[]) => void) => {
+        openUrlCallback = cb
+        return () => {}
+      })
+
+      const unhandled: unknown[] = []
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason)
+      }
+      process.on("unhandledRejection", onUnhandled)
+      try {
+        const { ensureDeepLinkBridge } = await loadDeepLink()
+        const handler = vi.fn().mockRejectedValue(new Error("callback failed"))
+        await expect(ensureDeepLinkBridge(handler)).resolves.toBeUndefined()
+        expect(handler).toHaveBeenCalledWith("proliferate://initial")
+
+        openUrlCallback?.(["proliferate://live"])
+        expect(handler).toHaveBeenLastCalledWith("proliferate://live")
+
+        // Give any escaped rejection two macrotask turns to reach the hook.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off("unhandledRejection", onUnhandled)
+      }
+    })
   })
 })

--- a/apps/desktop/src/lib/access/tauri/deep-link.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.ts
@@ -2,38 +2,113 @@ import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link"
 
 export type DeepLinkUrlHandler = (url: string) => Promise<boolean>
 
-let deepLinkBridgePromise: Promise<void> | null = null
+type DeepLinkListener = (url: string) => void
 
-/**
- * Ensures the Tauri deep-link listener is registered exactly once.
- * Drains any URLs that arrived before the listener was set up, then
- * forwards every subsequent deep-link URL to `handler`.
- *
- * Safe to call outside Tauri — errors are silently swallowed.
- */
-export function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
-  if (deepLinkBridgePromise) {
-    return deepLinkBridgePromise
+interface DeepLinkSubscription {
+  listener: DeepLinkListener
+  active: boolean
+}
+
+// Every active subscription, in subscribe order. Delivery always reads this
+// set fresh, so removing a subscription (or flipping `active` off) takes
+// effect immediately for both the in-flight initial snapshot and any live
+// URL still queued on the microtask/event loop.
+const subscriptions = new Set<DeepLinkSubscription>()
+
+// At most one native live listener is ever registered; this memoizes the
+// in-flight/settled registration so concurrent subscribers share it.
+let liveListenerPromise: Promise<void> | null = null
+
+function ensureLiveListener(): Promise<void> {
+  if (!liveListenerPromise) {
+    liveListenerPromise = Promise.resolve()
+      .then(() =>
+        onOpenUrl((urls) => {
+          for (const url of urls) {
+            for (const subscription of subscriptions) {
+              if (subscription.active) {
+                subscription.listener(url)
+              }
+            }
+          }
+        }),
+      )
+      .then(() => undefined)
   }
+  return liveListenerPromise
+}
 
-  deepLinkBridgePromise = (async () => {
+function deliverInitialSnapshot(subscription: DeepLinkSubscription): Promise<void> {
+  return (async () => {
     try {
       const currentUrls = await getCurrent()
-      if (currentUrls?.length) {
+      if (subscription.active && currentUrls?.length) {
         for (const url of currentUrls) {
-          await handler(url)
+          subscription.listener(url)
         }
       }
-
-      await onOpenUrl((urls) => {
-        for (const url of urls) {
-          void handler(url)
-        }
-      })
     } catch {
       // Ignore when running outside Tauri or before the plugin is available.
     }
   })()
+}
 
-  return deepLinkBridgePromise
+/**
+ * Subscribes to the raw Tauri deep-link source. Delivers Tauri's current
+ * `getCurrent()` snapshot (if any) to this subscriber only, then forwards
+ * every URL that arrives while the subscription is active. At most one
+ * native live listener is ever registered — it is created lazily on the
+ * first subscription and shared by every subscriber.
+ *
+ * There is no history or queue: a URL delivered before a later subscriber
+ * mounts is never replayed to it, and no raw URL is retained after delivery.
+ *
+ * Returns a synchronous unsubscribe function. Unsubscribing is race-safe
+ * even while native registration (or this subscriber's initial snapshot
+ * drain) is still in flight — no further delivery reaches this listener
+ * after unsubscribe, and other subscribers are unaffected.
+ *
+ * Safe to call outside Tauri — errors are silently swallowed.
+ */
+export function subscribeDeepLinkUrls(listener: DeepLinkListener): () => void {
+  const subscription: DeepLinkSubscription = { listener, active: true }
+  subscriptions.add(subscription)
+
+  void deliverInitialSnapshot(subscription)
+  void ensureLiveListener().catch(() => {
+    // Ignore when running outside Tauri or before the plugin is available.
+  })
+
+  return () => {
+    subscription.active = false
+    subscriptions.delete(subscription)
+  }
+}
+
+/**
+ * Legacy adapter over the multiplexed raw source above. Drains any URLs
+ * that arrived before subscription, then forwards every subsequent
+ * deep-link URL to `handler`. Unlike `subscribeDeepLinkUrls`, this handler
+ * is never unsubscribed — it lives for the process, matching the existing
+ * bootstrap-time callback consumer.
+ *
+ * Safe to call outside Tauri — errors are silently swallowed. The returned
+ * promise resolves once the initial drain and the live-listener
+ * registration attempt have both settled.
+ */
+export function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
+  const subscription: DeepLinkSubscription = {
+    listener: (url) => {
+      void handler(url)
+    },
+    active: true,
+  }
+  subscriptions.add(subscription)
+
+  return Promise.all([
+    deliverInitialSnapshot(subscription),
+    ensureLiveListener().catch(() => {
+      // Ignore when running outside Tauri or before the plugin is available.
+    }),
+  ]).then(() => undefined)
 }

--- a/apps/desktop/src/lib/access/tauri/deep-link.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.ts
@@ -85,6 +85,11 @@ export function subscribeDeepLinkUrls(listener: DeepLinkListener): () => void {
   }
 }
 
+// Memoizes the first `ensureDeepLinkBridge` call: only the first handler is
+// ever registered, matching the pre-multiplex bridge's once-only semantics.
+// Later calls return this same promise and register nothing.
+let deepLinkBridgePromise: Promise<void> | null = null
+
 /**
  * Legacy adapter over the multiplexed raw source above. Drains any URLs
  * that arrived before subscription, then forwards every subsequent
@@ -92,38 +97,47 @@ export function subscribeDeepLinkUrls(listener: DeepLinkListener): () => void {
  * is never unsubscribed — it lives for the process, matching the existing
  * bootstrap-time callback consumer.
  *
+ * Only the first call registers a handler; subsequent calls (e.g. a
+ * duplicate bootstrap invocation under React.StrictMode) are no-ops that
+ * resolve once the original registration settles.
+ *
  * Safe to call outside Tauri — errors are silently swallowed. The returned
  * promise resolves once the initial drain and the live-listener
  * registration attempt have both settled.
  */
-export async function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
-  // Drain the initial snapshot exactly like the pre-multiplex bridge: each
-  // URL is awaited in order and a handler rejection is contained here rather
-  // than escaping as an unhandled rejection.
-  try {
-    const currentUrls = await getCurrent()
-    if (currentUrls?.length) {
-      for (const url of currentUrls) {
-        await handler(url)
+export function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
+  if (!deepLinkBridgePromise) {
+    deepLinkBridgePromise = (async () => {
+      // Drain the initial snapshot exactly like the pre-multiplex bridge: each
+      // URL is awaited in order and a handler rejection is contained here rather
+      // than escaping as an unhandled rejection.
+      try {
+        const currentUrls = await getCurrent()
+        if (currentUrls?.length) {
+          for (const url of currentUrls) {
+            await handler(url)
+          }
+        }
+      } catch {
+        // Ignore when running outside Tauri or before the plugin is available.
       }
-    }
-  } catch {
-    // Ignore when running outside Tauri or before the plugin is available.
-  }
 
-  // Live URLs begin flowing only after the drain, matching the original
-  // registration order. Handler results are discarded; rejections are
-  // contained so a failing callback cannot surface as an unhandled rejection.
-  subscriptions.add({
-    listener: (url) => {
-      void handler(url).catch(() => {
-        // Callback failures are contained by this legacy adapter.
+      // Live URLs begin flowing only after the drain, matching the original
+      // registration order. Handler results are discarded; rejections are
+      // contained so a failing callback cannot surface as an unhandled rejection.
+      subscriptions.add({
+        listener: (url) => {
+          void handler(url).catch(() => {
+            // Callback failures are contained by this legacy adapter.
+          })
+        },
+        active: true,
       })
-    },
-    active: true,
-  })
 
-  await ensureLiveListener().catch(() => {
-    // Ignore when running outside Tauri or before the plugin is available.
-  })
+      await ensureLiveListener().catch(() => {
+        // Ignore when running outside Tauri or before the plugin is available.
+      })
+    })()
+  }
+  return deepLinkBridgePromise
 }

--- a/apps/desktop/src/lib/access/tauri/deep-link.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.ts
@@ -96,19 +96,34 @@ export function subscribeDeepLinkUrls(listener: DeepLinkListener): () => void {
  * promise resolves once the initial drain and the live-listener
  * registration attempt have both settled.
  */
-export function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
-  const subscription: DeepLinkSubscription = {
+export async function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void> {
+  // Drain the initial snapshot exactly like the pre-multiplex bridge: each
+  // URL is awaited in order and a handler rejection is contained here rather
+  // than escaping as an unhandled rejection.
+  try {
+    const currentUrls = await getCurrent()
+    if (currentUrls?.length) {
+      for (const url of currentUrls) {
+        await handler(url)
+      }
+    }
+  } catch {
+    // Ignore when running outside Tauri or before the plugin is available.
+  }
+
+  // Live URLs begin flowing only after the drain, matching the original
+  // registration order. Handler results are discarded; rejections are
+  // contained so a failing callback cannot surface as an unhandled rejection.
+  subscriptions.add({
     listener: (url) => {
-      void handler(url)
+      void handler(url).catch(() => {
+        // Callback failures are contained by this legacy adapter.
+      })
     },
     active: true,
-  }
-  subscriptions.add(subscription)
+  })
 
-  return Promise.all([
-    deliverInitialSnapshot(subscription),
-    ensureLiveListener().catch(() => {
-      // Ignore when running outside Tauri or before the plugin is available.
-    }),
-  ]).then(() => undefined)
+  await ensureLiveListener().catch(() => {
+    // Ignore when running outside Tauri or before the plugin is available.
+  })
 }

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
@@ -332,10 +332,13 @@ describe("updater", () => {
   });
 
   it("accumulates chunk lengths into a bounded 0..1 fraction", async () => {
+    // updater.ts adapts the real Started/Progress DownloadEvent union into
+    // these (chunkLength, contentLength) tuples: Started(100) captures the
+    // total, then each Progress forwards its own chunk length.
     mocks.downloadAndInstall.mockImplementation(async (_handle, cb) => {
-      cb?.(50, 100);
-      cb?.(50, 100);
-      cb?.(50, 100); // overshoot -> clamped to 1
+      cb?.(40, 100);
+      cb?.(60, 100);
+      cb?.(10, 100); // overshoot -> clamped to 1
     });
 
     const fractions: number[] = [];
@@ -346,7 +349,7 @@ describe("updater", () => {
 
     expect(mocks.downloadAndInstall).toHaveBeenCalledTimes(1);
     expect(mocks.downloadAndInstall.mock.calls[0][0]).toEqual({ id: 1 });
-    expect(fractions).toEqual([0.5, 1, 1]);
+    expect(fractions).toEqual([0.4, 1, 1]);
   });
 
   it("does not call onProgress while total length is unknown", async () => {

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
@@ -1,0 +1,521 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getRuntimeInfo: vi.fn(),
+  restartRuntime: vi.fn(),
+  listConfiguredEnvVarNames: vi.fn(),
+  setEnvVarSecret: vi.fn(),
+  deleteEnvVarSecret: vi.fn(),
+  pickFolder: vi.fn(),
+  getHomeDir: vi.fn(),
+  pathIsDirectory: vi.fn(),
+  listAvailableEditors: vi.fn(),
+  listOpenTargets: vi.fn(),
+  openTarget: vi.fn(),
+  revealInFinder: vi.fn(),
+  openInTerminal: vi.fn(),
+  showNativeContextMenu: vi.fn(),
+  listenForShortcutMenuEvents: vi.fn(),
+  setRunningAgentCount: vi.fn(),
+  setWebviewZoom: vi.fn(),
+  setWorkspaceActivityIndicator: vi.fn(),
+  checkForUpdate: vi.fn(),
+  downloadAndInstall: vi.fn(),
+  getAppVersion: vi.fn(),
+  isTauriPackaged: vi.fn(),
+  relaunch: vi.fn(),
+  getDesktopInstallId: vi.fn(),
+  ensureDesktopDispatchWorker: vi.fn(),
+  stopDesktopDispatchWorker: vi.fn(),
+  getSshDirectTargetProfile: vi.fn(),
+  setSshDirectTargetProfile: vi.fn(),
+  deleteSshDirectTargetProfile: vi.fn(),
+  ensureSshAnyHarnessTunnel: vi.fn(),
+  readWorkspaceScratchPad: vi.fn(),
+  writeWorkspaceScratchPad: vi.fn(),
+  logRendererEvent: vi.fn(),
+  collectSupportDiagnostics: vi.fn(),
+  saveDiagnosticJson: vi.fn(),
+  stageSupportReportAttachment: vi.fn(),
+  readStagedSupportReportAttachment: vi.fn(),
+  deleteStagedSupportReportAttachment: vi.fn(),
+}));
+
+vi.mock("@/lib/access/tauri/runtime", () => ({
+  getRuntimeInfo: mocks.getRuntimeInfo,
+}));
+vi.mock("@/lib/access/tauri/credentials", () => ({
+  listConfiguredEnvVarNames: mocks.listConfiguredEnvVarNames,
+  setEnvVarSecret: mocks.setEnvVarSecret,
+  deleteEnvVarSecret: mocks.deleteEnvVarSecret,
+  restartRuntime: mocks.restartRuntime,
+}));
+vi.mock("@/lib/access/tauri/shell", () => ({
+  pickFolder: mocks.pickFolder,
+  getHomeDir: mocks.getHomeDir,
+  pathIsDirectory: mocks.pathIsDirectory,
+  listAvailableEditors: mocks.listAvailableEditors,
+  listOpenTargets: mocks.listOpenTargets,
+  openTarget: mocks.openTarget,
+  revealInFinder: mocks.revealInFinder,
+  openInTerminal: mocks.openInTerminal,
+}));
+vi.mock("@/lib/access/tauri/context-menu", () => ({
+  showNativeContextMenu: mocks.showNativeContextMenu,
+}));
+vi.mock("@/lib/access/tauri/menu", () => ({
+  listenForShortcutMenuEvents: mocks.listenForShortcutMenuEvents,
+}));
+vi.mock("@/lib/access/tauri/window", () => ({
+  setRunningAgentCount: mocks.setRunningAgentCount,
+  setWebviewZoom: mocks.setWebviewZoom,
+}));
+vi.mock("@/lib/access/tauri/dock", () => ({
+  setWorkspaceActivityIndicator: mocks.setWorkspaceActivityIndicator,
+}));
+vi.mock("@/lib/access/tauri/updater", () => ({
+  checkForUpdate: mocks.checkForUpdate,
+  downloadAndInstall: mocks.downloadAndInstall,
+  getAppVersion: mocks.getAppVersion,
+  isTauriPackaged: mocks.isTauriPackaged,
+  relaunch: mocks.relaunch,
+}));
+vi.mock("@/lib/access/tauri/desktop-install-id", () => ({
+  getDesktopInstallId: mocks.getDesktopInstallId,
+}));
+vi.mock("@/lib/access/tauri/cloud-worker", () => ({
+  ensureDesktopDispatchWorker: mocks.ensureDesktopDispatchWorker,
+  stopDesktopDispatchWorker: mocks.stopDesktopDispatchWorker,
+}));
+vi.mock("@/lib/access/tauri/ssh-target-profile", () => ({
+  getSshDirectTargetProfile: mocks.getSshDirectTargetProfile,
+  setSshDirectTargetProfile: mocks.setSshDirectTargetProfile,
+  deleteSshDirectTargetProfile: mocks.deleteSshDirectTargetProfile,
+}));
+vi.mock("@/lib/access/tauri/ssh-tunnel", () => ({
+  ensureSshAnyHarnessTunnel: mocks.ensureSshAnyHarnessTunnel,
+}));
+vi.mock("@/lib/access/tauri/workspace-scratch", () => ({
+  readWorkspaceScratchPad: mocks.readWorkspaceScratchPad,
+  writeWorkspaceScratchPad: mocks.writeWorkspaceScratchPad,
+}));
+vi.mock("@/lib/access/tauri/diagnostics", () => ({
+  logRendererEvent: mocks.logRendererEvent,
+  collectSupportDiagnostics: mocks.collectSupportDiagnostics,
+  saveDiagnosticJson: mocks.saveDiagnosticJson,
+}));
+vi.mock("@/lib/access/tauri/support", () => ({
+  stageSupportReportAttachment: mocks.stageSupportReportAttachment,
+  readStagedSupportReportAttachment: mocks.readStagedSupportReportAttachment,
+  deleteStagedSupportReportAttachment: mocks.deleteStagedSupportReportAttachment,
+}));
+
+import { desktopBridge } from "@/lib/access/tauri/desktop-bridge";
+
+/** Flush pending microtasks so `.then(...)` registration callbacks run. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("desktopBridge identity", () => {
+  it("is a stable module-level constant", async () => {
+    const again = (await import("@/lib/access/tauri/desktop-bridge")).desktopBridge;
+    expect(again).toBe(desktopBridge);
+  });
+});
+
+describe("runtime", () => {
+  it("maps RuntimeInfo.url to a runtime connection without an auth token", async () => {
+    mocks.getRuntimeInfo.mockResolvedValue({
+      url: "http://127.0.0.1:8457",
+      port: 8457,
+      status: "healthy",
+    });
+
+    const connection = await desktopBridge.runtime.getConnection();
+
+    expect(mocks.getRuntimeInfo).toHaveBeenCalledTimes(1);
+    expect(connection).toEqual({ runtimeUrl: "http://127.0.0.1:8457" });
+    expect(connection).not.toHaveProperty("authToken");
+  });
+
+  it("maps the restarted runtime url the same way", async () => {
+    mocks.restartRuntime.mockResolvedValue({
+      url: "http://127.0.0.1:9000",
+      port: 9000,
+      status: "starting",
+    });
+
+    const connection = await desktopBridge.runtime.restart();
+
+    expect(mocks.restartRuntime).toHaveBeenCalledTimes(1);
+    expect(connection).toEqual({ runtimeUrl: "http://127.0.0.1:9000" });
+  });
+});
+
+describe("files", () => {
+  it("delegates renamed methods to the shell wrappers", async () => {
+    mocks.pickFolder.mockResolvedValue("/repo");
+    mocks.getHomeDir.mockResolvedValue("/home/dev");
+    mocks.pathIsDirectory.mockResolvedValue(true);
+    mocks.revealInFinder.mockResolvedValue(undefined);
+    mocks.openInTerminal.mockResolvedValue(undefined);
+
+    await expect(desktopBridge.files.pickDirectory()).resolves.toBe("/repo");
+    await expect(desktopBridge.files.getHomeDirectory()).resolves.toBe("/home/dev");
+    await expect(desktopBridge.files.isDirectory("/repo")).resolves.toBe(true);
+    expect(mocks.pathIsDirectory).toHaveBeenCalledWith("/repo");
+
+    await desktopBridge.files.reveal("/repo");
+    expect(mocks.revealInFinder).toHaveBeenCalledWith("/repo");
+
+    await desktopBridge.files.openTerminal("/repo");
+    expect(mocks.openInTerminal).toHaveBeenCalledWith("/repo");
+  });
+
+  it("passes editor/open-target methods through unchanged", async () => {
+    mocks.listAvailableEditors.mockResolvedValue([]);
+    mocks.listOpenTargets.mockResolvedValue([]);
+    mocks.openTarget.mockResolvedValue(undefined);
+
+    await desktopBridge.files.listAvailableEditors();
+    expect(mocks.listAvailableEditors).toHaveBeenCalledTimes(1);
+
+    await desktopBridge.files.listOpenTargets("directory");
+    expect(mocks.listOpenTargets).toHaveBeenCalledWith("directory");
+
+    await desktopBridge.files.openTarget("cursor", "/repo");
+    expect(mocks.openTarget).toHaveBeenCalledWith("cursor", "/repo");
+  });
+});
+
+describe("localCredentials", () => {
+  it("delegates list/set/remove to the credentials wrappers", async () => {
+    mocks.listConfiguredEnvVarNames.mockResolvedValue(["OPENAI_API_KEY"]);
+    mocks.setEnvVarSecret.mockResolvedValue(undefined);
+    mocks.deleteEnvVarSecret.mockResolvedValue(undefined);
+
+    await expect(desktopBridge.localCredentials.listConfigured()).resolves.toEqual([
+      "OPENAI_API_KEY",
+    ]);
+
+    await desktopBridge.localCredentials.set("OPENAI_API_KEY", "sk-1");
+    expect(mocks.setEnvVarSecret).toHaveBeenCalledWith("OPENAI_API_KEY", "sk-1");
+
+    await desktopBridge.localCredentials.remove("OPENAI_API_KEY");
+    expect(mocks.deleteEnvVarSecret).toHaveBeenCalledWith("OPENAI_API_KEY");
+  });
+});
+
+describe("nativeUi", () => {
+  it("passes context-menu items and position through", async () => {
+    mocks.showNativeContextMenu.mockResolvedValue(true);
+    const items = [{ id: "copy", label: "Copy" }];
+    const position = { x: 10, y: 20 };
+
+    await expect(
+      desktopBridge.nativeUi.showContextMenu(items, position),
+    ).resolves.toBe(true);
+    expect(mocks.showNativeContextMenu).toHaveBeenCalledWith(items, position);
+  });
+
+  it("delegates state setters to the window/dock wrappers", async () => {
+    mocks.setRunningAgentCount.mockResolvedValue(undefined);
+    mocks.setWorkspaceActivityIndicator.mockResolvedValue(undefined);
+    mocks.setWebviewZoom.mockResolvedValue(undefined);
+
+    await desktopBridge.nativeUi.setRunningAgentCount(3);
+    expect(mocks.setRunningAgentCount).toHaveBeenCalledWith(3);
+
+    await desktopBridge.nativeUi.setWorkspaceActivity({
+      state: "attention",
+      attentionCount: 2,
+    });
+    expect(mocks.setWorkspaceActivityIndicator).toHaveBeenCalledWith({
+      state: "attention",
+      attentionCount: 2,
+    });
+
+    await desktopBridge.nativeUi.setZoom(1.25);
+    expect(mocks.setWebviewZoom).toHaveBeenCalledWith(1.25);
+  });
+
+  it("delivers menu commands to an active subscriber", async () => {
+    let captured: ((id: string) => void) | undefined;
+    const unlisten = vi.fn();
+    mocks.listenForShortcutMenuEvents.mockImplementation((handler) => {
+      captured = handler;
+      return Promise.resolve(unlisten);
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = desktopBridge.nativeUi.subscribeMenuCommands(listener);
+    await flushMicrotasks();
+
+    captured?.("workspace.new");
+    expect(listener).toHaveBeenCalledWith("workspace.new");
+
+    unsubscribe();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("is race-safe when unsubscribed before registration resolves", async () => {
+    let resolveRegistration: ((fn: () => void) => void) | undefined;
+    let captured: ((id: string) => void) | undefined;
+    const registration = new Promise<() => void>((resolve) => {
+      resolveRegistration = resolve;
+    });
+    mocks.listenForShortcutMenuEvents.mockImplementation((handler) => {
+      captured = handler;
+      return registration;
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = desktopBridge.nativeUi.subscribeMenuCommands(listener);
+
+    // Unsubscribe before native registration has resolved.
+    unsubscribe();
+
+    const unlisten = vi.fn();
+    resolveRegistration?.(unlisten);
+    await flushMicrotasks();
+
+    // The eventual unlisten is invoked...
+    expect(unlisten).toHaveBeenCalledTimes(1);
+
+    // ...and no command is ever delivered, even if one slips in.
+    captured?.("workspace.new");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("updater", () => {
+  it("reports support synchronously from isTauriPackaged", () => {
+    mocks.isTauriPackaged.mockReturnValue(true);
+    expect(desktopBridge.updater.isSupported()).toBe(true);
+    expect(mocks.isTauriPackaged).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a current check to null", async () => {
+    mocks.checkForUpdate.mockResolvedValue({ kind: "current" });
+    await expect(desktopBridge.updater.check()).resolves.toBeNull();
+  });
+
+  it("maps an available check to a DesktopUpdate carrying the native handle", async () => {
+    const handle = { downloadAndInstall: vi.fn() };
+    mocks.checkForUpdate.mockResolvedValue({
+      kind: "available",
+      version: "0.4.0",
+      title: "Notes",
+      update: handle,
+    });
+
+    await expect(desktopBridge.updater.check()).resolves.toEqual({
+      version: "0.4.0",
+      title: "Notes",
+      handle,
+    });
+  });
+
+  it("rejects an error check instead of reporting no update", async () => {
+    mocks.checkForUpdate.mockResolvedValue({
+      kind: "error",
+      message: "network down",
+    });
+
+    await expect(desktopBridge.updater.check()).rejects.toThrow("network down");
+  });
+
+  it("accumulates chunk lengths into a bounded 0..1 fraction", async () => {
+    mocks.downloadAndInstall.mockImplementation(async (_handle, cb) => {
+      cb?.(50, 100);
+      cb?.(50, 100);
+      cb?.(50, 100); // overshoot -> clamped to 1
+    });
+
+    const fractions: number[] = [];
+    await desktopBridge.updater.downloadAndInstall(
+      { version: "0.4.0", title: null, handle: { id: 1 } },
+      (fraction) => fractions.push(fraction),
+    );
+
+    expect(mocks.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(mocks.downloadAndInstall.mock.calls[0][0]).toEqual({ id: 1 });
+    expect(fractions).toEqual([0.5, 1, 1]);
+  });
+
+  it("does not call onProgress while total length is unknown", async () => {
+    mocks.downloadAndInstall.mockImplementation(async (_handle, cb) => {
+      cb?.(50, undefined);
+      cb?.(50, undefined);
+    });
+
+    const onProgress = vi.fn();
+    await desktopBridge.updater.downloadAndInstall(
+      { version: "0.4.0", title: null, handle: {} },
+      onProgress,
+    );
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it("delegates getVersion and relaunch", async () => {
+    mocks.getAppVersion.mockResolvedValue("0.4.0");
+    mocks.relaunch.mockResolvedValue(undefined);
+
+    await expect(desktopBridge.updater.getVersion()).resolves.toBe("0.4.0");
+    await desktopBridge.updater.relaunch();
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("worker", () => {
+  it("preserves the ensure result", async () => {
+    const status = { targetId: "t1", status: "started", configPath: "/cfg" };
+    mocks.ensureDesktopDispatchWorker.mockResolvedValue(status);
+
+    await expect(
+      desktopBridge.worker.ensure({ targetId: "t1", enrollmentToken: "tok" }),
+    ).resolves.toEqual(status);
+    expect(mocks.ensureDesktopDispatchWorker).toHaveBeenCalledWith({
+      targetId: "t1",
+      enrollmentToken: "tok",
+    });
+  });
+
+  it("discards the stop result and resolves undefined", async () => {
+    mocks.stopDesktopDispatchWorker.mockResolvedValue({ stopped: true });
+
+    await expect(desktopBridge.worker.stop()).resolves.toBeUndefined();
+    expect(mocks.stopDesktopDispatchWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates getInstallId", async () => {
+    mocks.getDesktopInstallId.mockResolvedValue("install-1");
+    await expect(desktopBridge.worker.getInstallId()).resolves.toBe("install-1");
+  });
+});
+
+describe("ssh", () => {
+  it("passes profile CRUD through", async () => {
+    const profile = {
+      targetId: "t1",
+      sshHost: "host",
+      sshUser: "user",
+      sshPort: 22,
+      identityFile: null,
+      remoteAnyHarnessPort: 8457,
+      workspaceRoot: null,
+    };
+    mocks.getSshDirectTargetProfile.mockResolvedValue(profile);
+    mocks.setSshDirectTargetProfile.mockResolvedValue(undefined);
+    mocks.deleteSshDirectTargetProfile.mockResolvedValue(undefined);
+
+    await expect(desktopBridge.ssh.getProfile("t1")).resolves.toEqual(profile);
+    expect(mocks.getSshDirectTargetProfile).toHaveBeenCalledWith("t1");
+
+    await desktopBridge.ssh.saveProfile(profile);
+    expect(mocks.setSshDirectTargetProfile).toHaveBeenCalledWith(profile);
+
+    await desktopBridge.ssh.removeProfile("t1");
+    expect(mocks.deleteSshDirectTargetProfile).toHaveBeenCalledWith("t1");
+  });
+
+  it("maps the tunnel localUrl to a runtime connection", async () => {
+    mocks.ensureSshAnyHarnessTunnel.mockResolvedValue({
+      localUrl: "http://127.0.0.1:5555",
+      localPort: 5555,
+    });
+
+    const connection = await desktopBridge.ssh.ensureTunnel({
+      targetId: "t1",
+      sshHost: "host",
+      sshUser: "user",
+      sshPort: 22,
+      identityFile: "/id",
+      remoteAnyHarnessPort: 8457,
+      workspaceRoot: "/root",
+    });
+
+    expect(connection).toEqual({ runtimeUrl: "http://127.0.0.1:5555" });
+    expect(mocks.ensureSshAnyHarnessTunnel).toHaveBeenCalledWith({
+      targetId: "t1",
+      sshHost: "host",
+      sshUser: "user",
+      sshPort: 22,
+      identityFile: "/id",
+      remoteAnyHarnessPort: 8457,
+    });
+  });
+});
+
+describe("scratch", () => {
+  it("delegates read/write with renamed methods", async () => {
+    mocks.readWorkspaceScratchPad.mockResolvedValue({
+      content: "note",
+      updatedAtMs: 123,
+    });
+    mocks.writeWorkspaceScratchPad.mockResolvedValue({ updatedAtMs: 456 });
+
+    await expect(desktopBridge.scratch.read("ws-1")).resolves.toEqual({
+      content: "note",
+      updatedAtMs: 123,
+    });
+    expect(mocks.readWorkspaceScratchPad).toHaveBeenCalledWith("ws-1");
+
+    await expect(desktopBridge.scratch.write("ws-1", "next")).resolves.toEqual({
+      updatedAtMs: 456,
+    });
+    expect(mocks.writeWorkspaceScratchPad).toHaveBeenCalledWith("ws-1", "next");
+  });
+});
+
+describe("diagnostics", () => {
+  it("delegates logEvent and collectSupportBundle", async () => {
+    mocks.logRendererEvent.mockResolvedValue(undefined);
+    mocks.collectSupportDiagnostics.mockResolvedValue(null);
+
+    const payload = { source: "renderer", message: "boot" };
+    await desktopBridge.diagnostics.logEvent(payload);
+    expect(mocks.logRendererEvent).toHaveBeenCalledWith(payload);
+
+    await expect(desktopBridge.diagnostics.collectSupportBundle()).resolves.toBeNull();
+  });
+
+  it("maps saveJson object input to positional arguments", async () => {
+    mocks.saveDiagnosticJson.mockResolvedValue("/out.json");
+
+    await expect(
+      desktopBridge.diagnostics.saveJson({
+        suggestedFileName: "bundle.json",
+        contents: "{}",
+      }),
+    ).resolves.toBe("/out.json");
+    expect(mocks.saveDiagnosticJson).toHaveBeenCalledWith("bundle.json", "{}");
+  });
+
+  it("passes attachment operations through", async () => {
+    mocks.stageSupportReportAttachment.mockResolvedValue("/staged");
+    mocks.readStagedSupportReportAttachment.mockResolvedValue("base64");
+    mocks.deleteStagedSupportReportAttachment.mockResolvedValue(undefined);
+
+    const input = { clientFileId: "c1", fileName: "a.png", dataBase64: "b64" };
+    await expect(desktopBridge.diagnostics.stageAttachment(input)).resolves.toBe(
+      "/staged",
+    );
+    expect(mocks.stageSupportReportAttachment).toHaveBeenCalledWith(input);
+
+    await expect(
+      desktopBridge.diagnostics.readAttachment("/staged"),
+    ).resolves.toBe("base64");
+    expect(mocks.readStagedSupportReportAttachment).toHaveBeenCalledWith("/staged");
+
+    await desktopBridge.diagnostics.deleteAttachment("/staged");
+    expect(mocks.deleteStagedSupportReportAttachment).toHaveBeenCalledWith("/staged");
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
@@ -1,0 +1,230 @@
+import type {
+  DesktopBridge,
+  DesktopUpdate,
+  LocalRuntimeConnection,
+  ProductCommand,
+  ScratchRecord,
+  ScratchWriteResult,
+  SshProfile,
+  WorkerStatus,
+  WorkerConfiguration,
+} from "@proliferate/product-client/host/desktop-bridge";
+
+import { getRuntimeInfo } from "./runtime";
+import {
+  deleteEnvVarSecret,
+  listConfiguredEnvVarNames,
+  restartRuntime,
+  setEnvVarSecret,
+} from "./credentials";
+import {
+  getHomeDir,
+  listAvailableEditors,
+  listOpenTargets,
+  openInTerminal,
+  openTarget,
+  pathIsDirectory,
+  pickFolder,
+  revealInFinder,
+} from "./shell";
+import { showNativeContextMenu } from "./context-menu";
+import { listenForShortcutMenuEvents } from "./menu";
+import { setRunningAgentCount, setWebviewZoom } from "./window";
+import { setWorkspaceActivityIndicator } from "./dock";
+import {
+  checkForUpdate,
+  downloadAndInstall as downloadAndInstallUpdate,
+  getAppVersion,
+  isTauriPackaged,
+  relaunch,
+} from "./updater";
+import { getDesktopInstallId } from "./desktop-install-id";
+import {
+  ensureDesktopDispatchWorker,
+  stopDesktopDispatchWorker,
+} from "./cloud-worker";
+import {
+  deleteSshDirectTargetProfile,
+  getSshDirectTargetProfile,
+  setSshDirectTargetProfile,
+} from "./ssh-target-profile";
+import { ensureSshAnyHarnessTunnel } from "./ssh-tunnel";
+import {
+  readWorkspaceScratchPad,
+  writeWorkspaceScratchPad,
+} from "./workspace-scratch";
+import {
+  collectSupportDiagnostics,
+  logRendererEvent,
+  saveDiagnosticJson,
+} from "./diagnostics";
+import {
+  deleteStagedSupportReportAttachment,
+  readStagedSupportReportAttachment,
+  stageSupportReportAttachment,
+} from "./support";
+
+/**
+ * The concrete Desktop bridge. Every method is a thin shape adapter over an
+ * existing `lib/access/tauri` function: it may rename arguments, normalize a
+ * return or callback shape, and perform the explicit updater failure mapping.
+ * It adds no retries, timeouts, caches, validation, logging, telemetry, or
+ * fallbacks beyond what the underlying functions already provide.
+ */
+export const desktopBridge: DesktopBridge = {
+  runtime: {
+    async getConnection(): Promise<LocalRuntimeConnection> {
+      const info = await getRuntimeInfo();
+      return { runtimeUrl: info.url };
+    },
+    async restart(): Promise<LocalRuntimeConnection> {
+      const info = await restartRuntime();
+      return { runtimeUrl: info.url };
+    },
+  },
+
+  files: {
+    pickDirectory: pickFolder,
+    getHomeDirectory: getHomeDir,
+    isDirectory: pathIsDirectory,
+    listAvailableEditors,
+    listOpenTargets,
+    openTarget,
+    reveal: revealInFinder,
+    openTerminal: openInTerminal,
+  },
+
+  localCredentials: {
+    listConfigured: listConfiguredEnvVarNames,
+    set(name: string, secret: string): Promise<void> {
+      return setEnvVarSecret(name, secret);
+    },
+    remove(name: string): Promise<void> {
+      return deleteEnvVarSecret(name);
+    },
+  },
+
+  nativeUi: {
+    showContextMenu: showNativeContextMenu,
+    subscribeMenuCommands(
+      listener: (command: ProductCommand) => void,
+    ): () => void {
+      // Native listener registration is async; expose a synchronous unsubscribe
+      // that is race-safe if the caller unsubscribes before registration
+      // resolves. Once unsubscribed no command is delivered and the eventual
+      // unlisten is invoked as soon as it arrives.
+      let unsubscribed = false;
+      let unlisten: (() => void) | null = null;
+
+      void listenForShortcutMenuEvents((command) => {
+        if (unsubscribed) {
+          return;
+        }
+        listener(command);
+      }).then((fn) => {
+        if (unsubscribed) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+      });
+
+      return () => {
+        unsubscribed = true;
+        if (unlisten) {
+          unlisten();
+          unlisten = null;
+        }
+      };
+    },
+    setRunningAgentCount,
+    setWorkspaceActivity: setWorkspaceActivityIndicator,
+    setZoom: setWebviewZoom,
+  },
+
+  updater: {
+    isSupported: isTauriPackaged,
+    getVersion: getAppVersion,
+    async check(): Promise<DesktopUpdate | null> {
+      const result = await checkForUpdate();
+      if (result.kind === "current") {
+        return null;
+      }
+      if (result.kind === "error") {
+        throw new Error(result.message);
+      }
+      return {
+        version: result.version,
+        title: result.title,
+        handle: result.update,
+      };
+    },
+    async downloadAndInstall(
+      update: DesktopUpdate,
+      onProgress?: (fraction: number) => void,
+    ): Promise<void> {
+      let received = 0;
+      await downloadAndInstallUpdate(
+        update.handle,
+        onProgress
+          ? (chunkLength, contentLength) => {
+              received += chunkLength;
+              // A bounded 0..1 fraction is only meaningful once the total
+              // length is known.
+              if (contentLength !== undefined) {
+                onProgress(Math.min(received / contentLength, 1));
+              }
+            }
+          : undefined,
+      );
+    },
+    relaunch,
+  },
+
+  worker: {
+    getInstallId: getDesktopInstallId,
+    ensure(input: WorkerConfiguration): Promise<WorkerStatus> {
+      return ensureDesktopDispatchWorker(input);
+    },
+    async stop(): Promise<void> {
+      await stopDesktopDispatchWorker();
+    },
+  },
+
+  ssh: {
+    getProfile: getSshDirectTargetProfile,
+    saveProfile: setSshDirectTargetProfile,
+    removeProfile: deleteSshDirectTargetProfile,
+    async ensureTunnel(profile: SshProfile): Promise<LocalRuntimeConnection> {
+      const tunnel = await ensureSshAnyHarnessTunnel({
+        targetId: profile.targetId,
+        sshHost: profile.sshHost,
+        sshUser: profile.sshUser,
+        sshPort: profile.sshPort,
+        identityFile: profile.identityFile,
+        remoteAnyHarnessPort: profile.remoteAnyHarnessPort,
+      });
+      return { runtimeUrl: tunnel.localUrl };
+    },
+  },
+
+  scratch: {
+    read(workspaceId: string): Promise<ScratchRecord> {
+      return readWorkspaceScratchPad(workspaceId);
+    },
+    write(workspaceId: string, content: string): Promise<ScratchWriteResult> {
+      return writeWorkspaceScratchPad(workspaceId, content);
+    },
+  },
+
+  diagnostics: {
+    logEvent: logRendererEvent,
+    collectSupportBundle: collectSupportDiagnostics,
+    saveJson(input) {
+      return saveDiagnosticJson(input.suggestedFileName, input.contents);
+    },
+    stageAttachment: stageSupportReportAttachment,
+    readAttachment: readStagedSupportReportAttachment,
+    deleteAttachment: deleteStagedSupportReportAttachment,
+  },
+};

--- a/apps/desktop/src/lib/access/tauri/updater.test.ts
+++ b/apps/desktop/src/lib/access/tauri/updater.test.ts
@@ -6,7 +6,10 @@ const updaterMocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/plugin-updater", () => updaterMocks);
 
-import { checkForUpdate } from "@/lib/access/tauri/updater";
+import {
+  checkForUpdate,
+  downloadAndInstall,
+} from "@/lib/access/tauri/updater";
 
 describe("Tauri updater access", () => {
   beforeEach(() => {
@@ -39,5 +42,82 @@ describe("Tauri updater access", () => {
       title: null,
       update,
     });
+  });
+});
+
+/**
+ * The real @tauri-apps/plugin-updater emits a DownloadEvent union
+ * (Started/Progress/Finished), not a flat `{ chunk, contentLength }` object.
+ * These tests pin the adaptation into the exported
+ * `(chunkLength, contentLength)` tuple contract.
+ */
+describe("Tauri updater downloadAndInstall progress adaptation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures the Started contentLength and forwards it with each Progress chunk", async () => {
+    const handle = {
+      downloadAndInstall: vi.fn(
+        async (
+          cb?: (
+            event:
+              | { event: "Started"; data: { contentLength?: number } }
+              | { event: "Progress"; data: { chunkLength: number } }
+              | { event: "Finished" },
+          ) => void,
+        ) => {
+          cb?.({ event: "Started", data: { contentLength: 100 } });
+          cb?.({ event: "Progress", data: { chunkLength: 40 } });
+          cb?.({ event: "Progress", data: { chunkLength: 60 } });
+          cb?.({ event: "Finished" });
+        },
+      ),
+    };
+
+    const tuples: Array<[number, number | undefined]> = [];
+    await downloadAndInstall(handle, (chunkLength, contentLength) =>
+      tuples.push([chunkLength, contentLength]),
+    );
+
+    expect(tuples).toEqual([
+      [40, 100],
+      [60, 100],
+    ]);
+  });
+
+  it("reports an undefined total when Started omits the contentLength", async () => {
+    const handle = {
+      downloadAndInstall: vi.fn(
+        async (
+          cb?: (
+            event:
+              | { event: "Started"; data: { contentLength?: number } }
+              | { event: "Progress"; data: { chunkLength: number } }
+              | { event: "Finished" },
+          ) => void,
+        ) => {
+          cb?.({ event: "Started", data: {} });
+          cb?.({ event: "Progress", data: { chunkLength: 40 } });
+        },
+      ),
+    };
+
+    const tuples: Array<[number, number | undefined]> = [];
+    await downloadAndInstall(handle, (chunkLength, contentLength) =>
+      tuples.push([chunkLength, contentLength]),
+    );
+
+    expect(tuples).toEqual([[40, undefined]]);
+  });
+
+  it("installs without registering a callback when no onProgress is given", async () => {
+    const downloadAndInstallSpy = vi.fn(async (_cb?: unknown) => {});
+    const handle = { downloadAndInstall: downloadAndInstallSpy };
+
+    await downloadAndInstall(handle);
+
+    expect(downloadAndInstallSpy).toHaveBeenCalledTimes(1);
+    expect(downloadAndInstallSpy.mock.calls[0][0]).toBeUndefined();
   });
 });

--- a/apps/desktop/src/lib/access/tauri/updater.ts
+++ b/apps/desktop/src/lib/access/tauri/updater.ts
@@ -39,17 +39,34 @@ export async function downloadAndInstall(
 ): Promise<void> {
   const u = update as {
     downloadAndInstall: (
-      cb?: (progress: {
-        chunk: number;
-        contentLength: number | undefined;
-      }) => void,
+      cb?: (
+        event:
+          | { event: "Started"; data: { contentLength?: number } }
+          | { event: "Progress"; data: { chunkLength: number } }
+          | { event: "Finished" },
+      ) => void,
     ) => Promise<void>;
   };
-  await u.downloadAndInstall(
-    onProgress
-      ? (progress) => onProgress(progress.chunk, progress.contentLength)
-      : undefined,
-  );
+  if (!onProgress) {
+    await u.downloadAndInstall();
+    return;
+  }
+  // The plugin emits a DownloadEvent union: contentLength arrives once on
+  // "Started", then each "Progress" carries only its own chunk length. Capture
+  // the total up front so we can forward the (chunkLength, contentLength) tuple.
+  let contentLength: number | undefined;
+  await u.downloadAndInstall((event) => {
+    switch (event.event) {
+      case "Started":
+        contentLength = event.data.contentLength;
+        break;
+      case "Progress":
+        onProgress(event.data.chunkLength, contentLength);
+        break;
+      case "Finished":
+        break;
+    }
+  });
 }
 
 export async function relaunch(): Promise<void> {

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { desktopNavigationTarget } from "@/lib/domain/auth/desktop-navigation";
+import type { ProductEntry } from "@proliferate/product-client/host/product-host";
+import {
+  decodeDesktopProductEntry,
+  desktopNavigationTarget,
+  encodeDesktopReturnUrl,
+} from "@/lib/domain/auth/desktop-navigation";
 
 describe("desktopNavigationTarget", () => {
   it("routes integration OAuth returns to the integrations pane with the flow outcome", () => {
@@ -130,5 +135,190 @@ describe("desktopNavigationTarget", () => {
     expect(desktopNavigationTarget("https://plugins?source=mcp_oauth_callback")).toBeNull();
     expect(desktopNavigationTarget("proliferate://plugins/extra")).toBeNull();
     expect(desktopNavigationTarget("proliferate://workspaces/cloud-1/extra")).toBeNull();
+  });
+});
+
+describe("decodeDesktopProductEntry / encodeDesktopReturnUrl", () => {
+  // Each case is normalized by decode and, where the entry kind has a current
+  // Desktop URL, re-encoded; the entry must survive both directions.
+  const roundTrips: Array<{ name: string; url: string; entry: ProductEntry }> = [
+    {
+      name: "workspace without query",
+      url: "proliferate://workspaces/cloud-workspace-1",
+      entry: { kind: "workspace", workspaceId: "cloud-workspace-1", query: {} },
+    },
+    {
+      name: "workspace with query",
+      url: "proliferate://workspaces/ws-9?session=sess-1&tab=chat",
+      entry: {
+        kind: "workspace",
+        workspaceId: "ws-9",
+        query: { session: "sess-1", tab: "chat" },
+      },
+    },
+    {
+      name: "organization-join without origin",
+      url: "proliferate://join/org-123",
+      entry: { kind: "organization-join", organizationId: "org-123" },
+    },
+    {
+      name: "organization-join with validated https origin",
+      url: "proliferate://join/org-123?origin=https%3A%2F%2Fproliferate.corp.example",
+      entry: {
+        kind: "organization-join",
+        organizationId: "org-123",
+        serverOrigin: "https://proliferate.corp.example",
+      },
+    },
+    {
+      name: "billing-return success",
+      url: "proliferate://billing/success",
+      entry: { kind: "billing-return", status: "success", query: {} },
+    },
+    {
+      name: "billing-return cancel",
+      url: "proliferate://billing/cancel",
+      entry: { kind: "billing-return", status: "cancel", query: {} },
+    },
+    {
+      name: "integration-callback (integration_oauth_callback, full)",
+      url: "proliferate://integrations?source=integration_oauth_callback&status=failed&flowId=flow-2&failureCode=access_denied",
+      entry: {
+        kind: "integration-callback",
+        source: "integration_oauth_callback",
+        status: "failed",
+        flowId: "flow-2",
+        failureCode: "access_denied",
+      },
+    },
+    {
+      name: "integration-callback (mcp_oauth_callback, minimal)",
+      url: "proliferate://integrations?source=mcp_oauth_callback&status=completed",
+      entry: {
+        kind: "integration-callback",
+        source: "mcp_oauth_callback",
+        status: "completed",
+      },
+    },
+    {
+      name: "settings account github-app return URL",
+      url: "proliferate://settings/account?source=github_app_callback",
+      entry: {
+        kind: "settings",
+        section: "account",
+        source: "github_app_callback",
+        query: {},
+      },
+    },
+    {
+      name: "settings organization return URL",
+      url: "proliferate://settings/organization?source=github_app_callback",
+      entry: {
+        kind: "settings",
+        section: "organization",
+        source: "github_app_callback",
+        query: {},
+      },
+    },
+    {
+      name: "settings environments github-app-callback return URL",
+      url: "proliferate://settings/environments?source=github_app_callback",
+      entry: {
+        kind: "settings",
+        section: "environments",
+        source: "github_app_callback",
+        query: {},
+      },
+    },
+    {
+      name: "settings environments github-app-installation-callback (source kept in query)",
+      url: "proliferate://settings/environments?source=github_app_installation_callback",
+      entry: {
+        kind: "settings",
+        section: "environments",
+        query: { source: "github_app_installation_callback" },
+      },
+    },
+  ];
+
+  for (const { name, url, entry } of roundTrips) {
+    it(`decodes ${name}`, () => {
+      expect(decodeDesktopProductEntry(url)).toEqual(entry);
+    });
+
+    it(`round-trips ${name} through the encoder`, () => {
+      const encoded = encodeDesktopReturnUrl(entry);
+      expect(decodeDesktopProductEntry(encoded)).toEqual(entry);
+    });
+  }
+
+  it("preserves the literal github-app return URLs verbatim on re-encode", () => {
+    expect(
+      encodeDesktopReturnUrl({
+        kind: "settings",
+        section: "account",
+        source: "github_app_callback",
+        query: {},
+      }),
+    ).toBe("proliferate://settings/account?source=github_app_callback");
+    expect(
+      encodeDesktopReturnUrl({
+        kind: "settings",
+        section: "environments",
+        source: "github_app_callback",
+        query: {},
+      }),
+    ).toBe("proliferate://settings/environments?source=github_app_callback");
+  });
+
+  it("decodes local-scheme URLs the same as the default scheme", () => {
+    expect(
+      decodeDesktopProductEntry("proliferate-local://billing/cancel"),
+    ).toEqual({ kind: "billing-return", status: "cancel", query: {} });
+  });
+
+  it("decodes settings/cloud legacy links to the billing section", () => {
+    expect(
+      decodeDesktopProductEntry("proliferate://settings/cloud?checkout=done"),
+    ).toEqual({ kind: "settings", section: "billing", query: { checkout: "done" } });
+  });
+
+  it("decodes bare integrations links to the integrations settings pane", () => {
+    expect(decodeDesktopProductEntry("proliferate://integrations/")).toEqual({
+      kind: "settings",
+      section: "integrations",
+      query: {},
+    });
+  });
+
+  it("returns null for auth-callback, malformed, unknown, and wrong-scheme URLs", () => {
+    // Auth callbacks (host "auth") are handled by the callback workflow, not
+    // navigation; they must not decode to a ProductEntry.
+    expect(
+      decodeDesktopProductEntry("proliferate://auth/callback?code=abc&state=xyz"),
+    ).toBeNull();
+    expect(decodeDesktopProductEntry("proliferate://auth?code=abc")).toBeNull();
+    expect(decodeDesktopProductEntry("not a url")).toBeNull();
+    expect(decodeDesktopProductEntry("proliferate://plugins/extra")).toBeNull();
+    expect(decodeDesktopProductEntry("proliferate://workspaces/cloud-1/extra")).toBeNull();
+    expect(decodeDesktopProductEntry("proliferate://settings/unknown")).toBeNull();
+    expect(
+      decodeDesktopProductEntry("https://plugins?source=mcp_oauth_callback"),
+    ).toBeNull();
+  });
+
+  it("throws from the encoder for entry kinds/sections with no current Desktop URL", () => {
+    expect(() =>
+      encodeDesktopReturnUrl({ kind: "workflow", workflowId: "wf-1" }),
+    ).toThrow();
+    expect(() =>
+      encodeDesktopReturnUrl({ kind: "invitation", token: "tok-1" }),
+    ).toThrow();
+    expect(() =>
+      encodeDesktopReturnUrl({ kind: "settings", section: "general", query: {} }),
+    ).toThrow();
+    expect(() =>
+      encodeDesktopReturnUrl({ kind: "billing-return", status: "done", query: {} }),
+    ).toThrow();
   });
 });

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts
@@ -131,6 +131,37 @@ describe("desktopNavigationTarget", () => {
     );
   });
 
+  it("preserves raw percent-encoded query bytes (workspaces keep %20, settings match legacy serialization)", () => {
+    // Workspace routes append the raw URL.search verbatim, so %20 survives.
+    expect(desktopNavigationTarget("proliferate://workspaces/ws-1?note=a%20b")).toBe(
+      "/workspaces/ws-1?note=a%20b",
+    );
+    // Settings routes rebuild via URLSearchParams (byte-identical to the legacy
+    // table), which serializes the space as "+".
+    expect(desktopNavigationTarget("proliferate://settings/account?note=a%20b")).toBe(
+      "/settings?note=a+b&section=account",
+    );
+  });
+
+  it("preserves duplicate query keys instead of collapsing them", () => {
+    expect(desktopNavigationTarget("proliferate://settings/account?x=1&x=2")).toBe(
+      "/settings?x=1&x=2&section=account",
+    );
+    expect(desktopNavigationTarget("proliferate://workspaces/ws-1?x=1&x=2")).toBe(
+      "/workspaces/ws-1?x=1&x=2",
+    );
+  });
+
+  it("passes an integration callback's unrecognized status and extra params straight through", () => {
+    expect(
+      desktopNavigationTarget(
+        "proliferate://integrations?source=integration_oauth_callback&status=weird&flowId=f1&extra=keep&extra2=v2",
+      ),
+    ).toBe(
+      "/settings?source=integration_oauth_callback&status=weird&flowId=f1&extra=keep&extra2=v2&section=integrations",
+    );
+  });
+
   it("rejects unsupported desktop navigation links", () => {
     expect(desktopNavigationTarget("https://plugins?source=mcp_oauth_callback")).toBeNull();
     expect(desktopNavigationTarget("proliferate://plugins/extra")).toBeNull();

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
@@ -4,6 +4,16 @@ import type {
   ProductSettingsEntrySection,
 } from "@proliferate/product-client/host/product-host";
 
+// Legacy in-app route mapping for `proliferate://settings/<path>` deep links.
+// Excludes `/environments` (no nav route) to stay byte-identical to the branches.
+const NAV_SETTINGS_SECTION_BY_PATH: Record<string, ProductSettingsEntrySection> = {
+  "/cloud": "billing",
+  "/billing": "billing",
+  "/account": "account",
+  "/organization": "organization",
+  "/slack-bot": "general",
+};
+
 /**
  * Decode a raw Desktop deep-link URL into the shared {@link ProductEntry}
  * normalization. This is the inverse of {@link encodeDesktopReturnUrl} for the
@@ -147,75 +157,90 @@ export function encodeDesktopReturnUrl(entry: ProductEntry): string {
 
 /**
  * Existing-consumer adapter: the legacy in-app route string for a raw deep
- * link, derived from {@link decodeDesktopProductEntry}. Returns byte-identical
- * strings to the historical route table for every URL that table supported.
- * URLs the table never routed (including the newly decodable `environments`
- * return URL) stay `null`.
+ * link, byte-identical to the historical route table (including exotic query
+ * semantics: percent-encoded spaces, duplicate keys, unrecognized params).
+ *
+ * Intentionally does NOT route through {@link decodeDesktopProductEntry}: the
+ * normalized {@link ProductEntry} codec collapses queries into a lossy
+ * `Record<string, string>` (`x=a%20b`→`x=a+b`, `x=1&x=2`→`x=2`, unknown params
+ * drop), so query-carrying routes are rebuilt from the raw `URL.search`.
  */
 export function desktopNavigationTarget(url: string): string | null {
-  const entry = decodeDesktopProductEntry(url);
-  if (entry === null) {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
     return null;
   }
-  return entryToRoute(entry);
-}
 
-function entryToRoute(entry: ProductEntry): string | null {
-  switch (entry.kind) {
-    case "organization-join": {
-      // Lands on Account (every signed-in user can reach it), not the
-      // admin-gated Members pane — a non-admin invitee must be able to follow
-      // this link and see/accept their invitation.
-      const params = new URLSearchParams({ section: "account" });
-      params.set("joinOrganizationId", entry.organizationId);
-      if (entry.serverOrigin) {
-        params.set("joinServerOrigin", entry.serverOrigin);
-      }
-      return `/settings?${params.toString()}`;
-    }
-    case "workspace":
-      return `/workspaces/${encodeURIComponent(entry.workspaceId)}${queryToSearch(entry.query)}`;
-    case "billing-return": {
-      const params = queryToParams(entry.query);
-      params.set("checkout", entry.status);
-      params.set("section", "billing");
-      return `/settings?${params.toString()}`;
-    }
-    case "integration-callback": {
-      // Integration OAuth browser returns (and legacy plugins/powers links)
-      // land on the user Integrations pane, carrying flowId/status/failureCode
-      // so the pane can toast the flow outcome on arrival.
-      const params = new URLSearchParams();
-      params.set("source", entry.source);
-      if (entry.status) {
-        params.set("status", entry.status);
-      }
-      if (entry.flowId) {
-        params.set("flowId", entry.flowId);
-      }
-      if (entry.failureCode) {
-        params.set("failureCode", entry.failureCode);
-      }
-      params.set("section", "integrations");
-      return `/settings?${params.toString()}`;
-    }
-    case "settings": {
-      // The legacy navigation table never routed "environments"; keep it null
-      // so desktopNavigationTarget stays byte-identical while decode still
-      // recognizes environments return URLs for the ProductLinks path.
-      if (entry.section === "environments") {
-        return null;
-      }
-      const params = queryToParams(entry.query);
-      if (entry.source) {
-        params.set("source", entry.source);
-      }
-      params.set("section", entry.section);
-      return `/settings?${params.toString()}`;
-    }
-    default:
-      return null;
+  if (parsed.protocol !== "proliferate:" && parsed.protocol !== "proliferate-local:") {
+    return null;
   }
+
+  if (parsed.hostname === "join") {
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 1) {
+      const organizationId = decodeRoutePart(segments[0]);
+      // Lands on Account (every signed-in user can reach it), not the
+      // admin-gated Members pane — a non-admin invitee must be able to
+      // follow this link and see/accept their invitation.
+      const params = new URLSearchParams({ section: "account" });
+      params.set("joinOrganizationId", organizationId);
+      // The issuing server stamps its own origin so a self-hosted invite points
+      // the desktop at the right server. Any web page can fire this deep link
+      // with an attacker-supplied origin, so validate hard and DROP anything
+      // untrusted — a dropped origin degrades to today's behavior, never a
+      // silent server switch.
+      const joinServerOrigin = parseJoinServerOrigin(parsed.searchParams.get("origin"));
+      if (joinServerOrigin) {
+        params.set("joinServerOrigin", joinServerOrigin);
+      }
+      return `/settings?${params.toString()}`;
+    }
+  }
+
+  if (parsed.hostname === "settings") {
+    // Legacy settings deep links map their path to a settings section.
+    // SLACK BOT PARKED: /slack-bot lands on General while disabled.
+    const settingsSection = NAV_SETTINGS_SECTION_BY_PATH[parsed.pathname];
+    if (settingsSection) {
+      const params = new URLSearchParams(parsed.search);
+      params.set("section", settingsSection);
+      return `/settings?${params.toString()}`;
+    }
+  }
+
+  if (
+    parsed.hostname === "billing"
+    && (parsed.pathname === "/success" || parsed.pathname === "/cancel")
+  ) {
+    const params = new URLSearchParams(parsed.search);
+    params.set("checkout", parsed.pathname === "/success" ? "success" : "cancel");
+    params.set("section", "billing");
+    return `/settings?${params.toString()}`;
+  }
+
+  if (
+    (parsed.hostname === "integrations" || parsed.hostname === "plugins" || parsed.hostname === "powers")
+    && (parsed.pathname === "" || parsed.pathname === "/")
+  ) {
+    // Integration OAuth browser returns (and legacy plugins/powers links) land on
+    // the user Integrations pane, carrying flowId/status/failureCode so the pane
+    // can toast the flow outcome on arrival.
+    const params = new URLSearchParams(parsed.search);
+    params.set("section", "integrations");
+    return `/settings?${params.toString()}`;
+  }
+
+  if (parsed.hostname === "workspaces") {
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length === 1) {
+      return `/workspaces/${encodeURIComponent(decodeRoutePart(segments[0]))}${parsed.search}`;
+    }
+  }
+
+  return null;
 }
 
 function buildSettingsEntry(

--- a/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
+++ b/apps/desktop/src/lib/domain/auth/desktop-navigation.ts
@@ -1,4 +1,19 @@
-export function desktopNavigationTarget(url: string): string | null {
+import type {
+  ProductEntry,
+  ProductQueryParams,
+  ProductSettingsEntrySection,
+} from "@proliferate/product-client/host/product-host";
+
+/**
+ * Decode a raw Desktop deep-link URL into the shared {@link ProductEntry}
+ * normalization. This is the inverse of {@link encodeDesktopReturnUrl} for the
+ * destinations that round-trip. It recognizes exactly the URLs the legacy
+ * `desktopNavigationTarget` table supported plus the literal return URLs the
+ * codebase emits (github-app callbacks landing on account/organization/
+ * environments). Malformed, auth-callback, and unknown inbound URLs decode to
+ * `null`; the decoder never invents a destination.
+ */
+export function decodeDesktopProductEntry(url: string): ProductEntry | null {
   let parsed: URL;
 
   try {
@@ -11,90 +26,299 @@ export function desktopNavigationTarget(url: string): string | null {
     return null;
   }
 
-  if (parsed.hostname === "join") {
-    const segments = parsed.pathname.split("/").filter(Boolean);
+  const host = parsed.hostname;
+  const pathname = parsed.pathname;
+
+  if (host === "join") {
+    const segments = pathname.split("/").filter(Boolean);
     if (segments.length === 1) {
       const organizationId = decodeRoutePart(segments[0]);
-      // Lands on Account (every signed-in user can reach it), not the
-      // admin-gated Members pane — a non-admin invitee must be able to
-      // follow this link and see/accept their invitation.
-      const params = new URLSearchParams({ section: "account" });
-      params.set("joinOrganizationId", organizationId);
       // The issuing server stamps its own origin so a self-hosted invite can
-      // point the desktop at the right server (the org id is meaningless on
-      // Cloud). Any web page can fire this deep link with an attacker-supplied
-      // origin, so we validate hard and DROP anything untrusted — a dropped
-      // origin degrades to today's behavior (resolve against the current
-      // server), never a silent server switch.
-      const joinServerOrigin = parseJoinServerOrigin(parsed.searchParams.get("origin"));
-      if (joinServerOrigin) {
-        params.set("joinServerOrigin", joinServerOrigin);
-      }
-      return `/settings?${params.toString()}`;
+      // point the desktop at the right server. Validate hard and DROP anything
+      // untrusted — a dropped origin degrades to today's behavior, never a
+      // silent server switch.
+      const serverOrigin = parseJoinServerOrigin(parsed.searchParams.get("origin"));
+      return serverOrigin
+        ? { kind: "organization-join", organizationId, serverOrigin }
+        : { kind: "organization-join", organizationId };
     }
+    return null;
   }
 
-  if (parsed.hostname === "settings" && parsed.pathname === "/cloud") {
-    const params = new URLSearchParams(parsed.search);
-    params.set("section", "billing");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (parsed.hostname === "settings" && parsed.pathname === "/billing") {
-    const params = new URLSearchParams(parsed.search);
-    params.set("section", "billing");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (parsed.hostname === "settings" && parsed.pathname === "/account") {
-    const params = new URLSearchParams(parsed.search);
-    params.set("section", "account");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (
-    parsed.hostname === "billing"
-    && (parsed.pathname === "/success" || parsed.pathname === "/cancel")
-  ) {
-    const params = new URLSearchParams(parsed.search);
-    params.set("checkout", parsed.pathname === "/success" ? "success" : "cancel");
-    params.set("section", "billing");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (parsed.hostname === "settings" && parsed.pathname === "/organization") {
-    const params = new URLSearchParams(parsed.search);
-    params.set("section", "organization");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (parsed.hostname === "settings" && parsed.pathname === "/slack-bot") {
-    const params = new URLSearchParams(parsed.search);
-    // SLACK BOT PARKED: legacy Slack settings links land on General while disabled.
-    params.set("section", "general");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (
-    (parsed.hostname === "integrations" || parsed.hostname === "plugins" || parsed.hostname === "powers")
-    && (parsed.pathname === "" || parsed.pathname === "/")
-  ) {
-    // Integration OAuth browser returns (and legacy plugins/powers links) land on
-    // the user Integrations pane, carrying flowId/status/failureCode so the pane
-    // can toast the flow outcome on arrival.
-    const params = new URLSearchParams(parsed.search);
-    params.set("section", "integrations");
-    return `/settings?${params.toString()}`;
-  }
-
-  if (parsed.hostname === "workspaces") {
-    const segments = parsed.pathname.split("/").filter(Boolean);
+  if (host === "workspaces") {
+    const segments = pathname.split("/").filter(Boolean);
     if (segments.length === 1) {
-      return `/workspaces/${encodeURIComponent(decodeRoutePart(segments[0]))}${parsed.search}`;
+      return {
+        kind: "workspace",
+        workspaceId: decodeRoutePart(segments[0]),
+        query: searchToQuery(parsed.searchParams),
+      };
+    }
+    return null;
+  }
+
+  if (host === "billing" && (pathname === "/success" || pathname === "/cancel")) {
+    return {
+      kind: "billing-return",
+      status: pathname === "/success" ? "success" : "cancel",
+      query: searchToQuery(parsed.searchParams),
+    };
+  }
+
+  if (
+    (host === "integrations" || host === "plugins" || host === "powers")
+    && (pathname === "" || pathname === "/")
+  ) {
+    const source = parsed.searchParams.get("source");
+    if (source === "integration_oauth_callback" || source === "mcp_oauth_callback") {
+      return buildIntegrationCallbackEntry(source, parsed.searchParams);
+    }
+    return buildSettingsEntry("integrations", parsed.searchParams);
+  }
+
+  if (host === "settings") {
+    const section = settingsSectionForPath(pathname);
+    if (section) {
+      return buildSettingsEntry(section, parsed.searchParams);
     }
   }
 
   return null;
+}
+
+/**
+ * Encode a normalized {@link ProductEntry} as the Desktop deep link the app
+ * hands to Cloud mutations as a return URL. Only entry kinds/sections that have
+ * a current Desktop URL are supported; everything else (workflow, invitation,
+ * the parked `general` settings section, and non-round-tripping billing
+ * statuses) throws, because D1a does not invent a route for an unsupported
+ * entry.
+ */
+export function encodeDesktopReturnUrl(entry: ProductEntry): string {
+  switch (entry.kind) {
+    case "workspace":
+      return `proliferate://workspaces/${encodeURIComponent(entry.workspaceId)}${queryToSearch(entry.query)}`;
+    case "organization-join": {
+      const base = `proliferate://join/${encodeURIComponent(entry.organizationId)}`;
+      if (entry.serverOrigin) {
+        const params = new URLSearchParams({ origin: entry.serverOrigin });
+        return `${base}?${params.toString()}`;
+      }
+      return base;
+    }
+    case "billing-return": {
+      if (entry.status !== "success" && entry.status !== "cancel") {
+        throw new Error(
+          `No Desktop return URL for billing-return status: ${entry.status}`,
+        );
+      }
+      return `proliferate://billing/${entry.status}${queryToSearch(entry.query)}`;
+    }
+    case "integration-callback": {
+      const params = new URLSearchParams();
+      params.set("source", entry.source);
+      if (entry.status) {
+        params.set("status", entry.status);
+      }
+      if (entry.flowId) {
+        params.set("flowId", entry.flowId);
+      }
+      if (entry.failureCode) {
+        params.set("failureCode", entry.failureCode);
+      }
+      return `proliferate://integrations?${params.toString()}`;
+    }
+    case "settings": {
+      const base = settingsReturnUrlForSection(entry.section);
+      if (base === null) {
+        throw new Error(`No Desktop return URL for settings section: ${entry.section}`);
+      }
+      const params = queryToParams(entry.query);
+      if (entry.source) {
+        params.set("source", entry.source);
+      }
+      const search = params.toString();
+      return search ? `${base}?${search}` : base;
+    }
+    default:
+      throw new Error(`No Desktop return URL for entry kind: ${(entry as ProductEntry).kind}`);
+  }
+}
+
+/**
+ * Existing-consumer adapter: the legacy in-app route string for a raw deep
+ * link, derived from {@link decodeDesktopProductEntry}. Returns byte-identical
+ * strings to the historical route table for every URL that table supported.
+ * URLs the table never routed (including the newly decodable `environments`
+ * return URL) stay `null`.
+ */
+export function desktopNavigationTarget(url: string): string | null {
+  const entry = decodeDesktopProductEntry(url);
+  if (entry === null) {
+    return null;
+  }
+  return entryToRoute(entry);
+}
+
+function entryToRoute(entry: ProductEntry): string | null {
+  switch (entry.kind) {
+    case "organization-join": {
+      // Lands on Account (every signed-in user can reach it), not the
+      // admin-gated Members pane — a non-admin invitee must be able to follow
+      // this link and see/accept their invitation.
+      const params = new URLSearchParams({ section: "account" });
+      params.set("joinOrganizationId", entry.organizationId);
+      if (entry.serverOrigin) {
+        params.set("joinServerOrigin", entry.serverOrigin);
+      }
+      return `/settings?${params.toString()}`;
+    }
+    case "workspace":
+      return `/workspaces/${encodeURIComponent(entry.workspaceId)}${queryToSearch(entry.query)}`;
+    case "billing-return": {
+      const params = queryToParams(entry.query);
+      params.set("checkout", entry.status);
+      params.set("section", "billing");
+      return `/settings?${params.toString()}`;
+    }
+    case "integration-callback": {
+      // Integration OAuth browser returns (and legacy plugins/powers links)
+      // land on the user Integrations pane, carrying flowId/status/failureCode
+      // so the pane can toast the flow outcome on arrival.
+      const params = new URLSearchParams();
+      params.set("source", entry.source);
+      if (entry.status) {
+        params.set("status", entry.status);
+      }
+      if (entry.flowId) {
+        params.set("flowId", entry.flowId);
+      }
+      if (entry.failureCode) {
+        params.set("failureCode", entry.failureCode);
+      }
+      params.set("section", "integrations");
+      return `/settings?${params.toString()}`;
+    }
+    case "settings": {
+      // The legacy navigation table never routed "environments"; keep it null
+      // so desktopNavigationTarget stays byte-identical while decode still
+      // recognizes environments return URLs for the ProductLinks path.
+      if (entry.section === "environments") {
+        return null;
+      }
+      const params = queryToParams(entry.query);
+      if (entry.source) {
+        params.set("source", entry.source);
+      }
+      params.set("section", entry.section);
+      return `/settings?${params.toString()}`;
+    }
+    default:
+      return null;
+  }
+}
+
+function buildSettingsEntry(
+  section: ProductSettingsEntrySection,
+  params: URLSearchParams,
+): ProductEntry {
+  const query: Record<string, string> = {};
+  let source: "github_app_callback" | undefined;
+  for (const [key, value] of params) {
+    // ProductEntry.settings.source is typed only "github_app_callback"; other
+    // source values (e.g. github_app_installation_callback) stay in query.
+    if (key === "source" && value === "github_app_callback" && source === undefined) {
+      source = value;
+      continue;
+    }
+    query[key] = value;
+  }
+  return source
+    ? { kind: "settings", section, source, query }
+    : { kind: "settings", section, query };
+}
+
+function buildIntegrationCallbackEntry(
+  source: "integration_oauth_callback" | "mcp_oauth_callback",
+  params: URLSearchParams,
+): ProductEntry {
+  const entry: Extract<ProductEntry, { kind: "integration-callback" }> = {
+    kind: "integration-callback",
+    source,
+  };
+  const status = params.get("status");
+  if (status === "completed" || status === "failed") {
+    entry.status = status;
+  }
+  const flowId = params.get("flowId");
+  if (flowId) {
+    entry.flowId = flowId;
+  }
+  const failureCode = params.get("failureCode");
+  if (failureCode) {
+    entry.failureCode = failureCode;
+  }
+  return entry;
+}
+
+function settingsSectionForPath(pathname: string): ProductSettingsEntrySection | null {
+  switch (pathname) {
+    case "/cloud":
+    case "/billing":
+      return "billing";
+    case "/account":
+      return "account";
+    case "/organization":
+      return "organization";
+    case "/environments":
+      return "environments";
+    // SLACK BOT PARKED: legacy Slack settings links land on General while disabled.
+    case "/slack-bot":
+      return "general";
+    default:
+      return null;
+  }
+}
+
+function settingsReturnUrlForSection(section: ProductSettingsEntrySection): string | null {
+  switch (section) {
+    case "account":
+      return "proliferate://settings/account";
+    case "organization":
+      return "proliferate://settings/organization";
+    case "environments":
+      return "proliferate://settings/environments";
+    case "billing":
+      return "proliferate://settings/billing";
+    case "integrations":
+      return "proliferate://integrations";
+    // "general" is the parked slack-bot landing; it has no current return URL.
+    case "general":
+      return null;
+  }
+}
+
+function searchToQuery(params: URLSearchParams): ProductQueryParams {
+  const query: Record<string, string> = {};
+  for (const [key, value] of params) {
+    query[key] = value;
+  }
+  return query;
+}
+
+function queryToParams(query?: ProductQueryParams): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      params.set(key, value);
+    }
+  }
+  return params;
+}
+
+function queryToSearch(query?: ProductQueryParams): string {
+  const search = queryToParams(query).toString();
+  return search ? `?${search}` : "";
 }
 
 function decodeRoutePart(value: string): string {

--- a/apps/desktop/src/providers/AppProviders.tsx
+++ b/apps/desktop/src/providers/AppProviders.tsx
@@ -36,6 +36,7 @@ import { buildAnyHarnessCacheScopeKey } from "@/lib/domain/auth/anyharness-cache
 import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
 import { withFreshCloudSandboxGatewayAccessToken } from "@/lib/access/cloud/cloud-sandbox-gateway";
 import { useCloudWorkspaceMaterializationCacheBoundary } from "@/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary";
+import { DesktopProductHostProvider } from "./DesktopProductHostProvider";
 import { TelemetryProvider } from "./TelemetryProvider";
 
 async function resolveWorkspaceConnectionWithCache(
@@ -68,9 +69,11 @@ export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={appQueryClient}>
       <CloudClientProvider client={cloudClient}>
-        <WorkspaceProviders>
-          <TelemetryProvider>{children}</TelemetryProvider>
-        </WorkspaceProviders>
+        <DesktopProductHostProvider cloudClient={cloudClient}>
+          <WorkspaceProviders>
+            <TelemetryProvider>{children}</TelemetryProvider>
+          </WorkspaceProviders>
+        </DesktopProductHostProvider>
       </CloudClientProvider>
     </QueryClientProvider>
   );

--- a/apps/desktop/src/providers/DesktopProductHostProvider.test.tsx
+++ b/apps/desktop/src/providers/DesktopProductHostProvider.test.tsx
@@ -210,6 +210,56 @@ describe("DesktopProductHostProvider", () => {
     });
   });
 
+  it("does not replace the host when identity fields change while anonymous", () => {
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const before = result.current;
+    expect(before.auth.state).toMatchObject({ status: "anonymous" });
+
+    // Retained user data mutates while anonymous — the AuthState carries no
+    // user here, so this must not replace the host.
+    act(() => {
+      useAuthStore.setState({ status: "anonymous", user: AUTH_USER });
+    });
+
+    expect(result.current).toBe(before);
+  });
+
+  it("does not replace the host when identity fields change while bootstrapping", () => {
+    act(() => {
+      useAuthStore.setState({ status: "bootstrapping", user: null });
+    });
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const before = result.current;
+    expect(before.auth.state).toMatchObject({ status: "loading" });
+
+    act(() => {
+      useAuthStore.setState({ status: "bootstrapping", user: AUTH_USER });
+    });
+
+    expect(result.current).toBe(before);
+  });
+
+  it("replaces the host when identity fields change while authenticated", () => {
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const before = result.current;
+
+    act(() => {
+      useAuthStore.setState({
+        status: "authenticated",
+        user: { ...AUTH_USER, email: "ada.lovelace@example.test" },
+      });
+    });
+
+    expect(result.current).not.toBe(before);
+    expect(result.current.auth.state).toMatchObject({
+      status: "authenticated",
+      user: { email: "ada.lovelace@example.test" },
+    });
+  });
+
   it("does not replace the host on token rotation or unrelated rerenders", () => {
     act(() => {
       useAuthStore.setState({ status: "authenticated", user: AUTH_USER });

--- a/apps/desktop/src/providers/DesktopProductHostProvider.test.tsx
+++ b/apps/desktop/src/providers/DesktopProductHostProvider.test.tsx
@@ -1,0 +1,291 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { DesktopProductHostProvider } from "./DesktopProductHostProvider";
+
+const h = vi.hoisted(() => ({
+  restoreSession: vi.fn(async () => {}),
+  actions: {
+    signInWithGitHub: vi.fn(),
+    signInWithPassword: vi.fn(),
+    signInWithSso: vi.fn(),
+    signOut: vi.fn(),
+    cancelAuthFlow: vi.fn(),
+    linkGoogle: vi.fn(),
+  },
+  deps: {},
+  cloudEnabled: true,
+  authMethods: { passwordLogin: true, github: true } as unknown,
+  github: { enabled: true, clientId: null } as unknown,
+  sso: { enabled: true } as unknown,
+  getProliferateClient: vi.fn(),
+  desktopBridge: { nativeUi: { setRunningAgentCount: vi.fn() } },
+}));
+
+// Auth/capability hooks are mocked so the test drives their outputs directly;
+// auth *status/identity* is driven through the real store below.
+vi.mock("@/hooks/auth/lifecycle/use-auth-bootstrap", () => ({
+  useAuthBootstrap: () => h.restoreSession,
+}));
+vi.mock("@/hooks/auth/workflows/use-auth-actions", () => ({
+  useAuthActions: () => h.actions,
+}));
+vi.mock("@/hooks/auth/workflows/use-auth-orchestration-effects", () => ({
+  useAuthOrchestrationEffects: () => h.deps,
+}));
+vi.mock("@/hooks/capabilities/derived/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({ cloudEnabled: h.cloudEnabled }),
+}));
+vi.mock("@/hooks/access/cloud/auth/use-auth-methods", () => ({
+  useDesktopAuthMethods: () => ({ data: h.authMethods }),
+}));
+vi.mock("@/hooks/access/cloud/auth/use-github-auth-availability", () => ({
+  useGitHubDesktopAuthAvailability: () => ({ data: h.github }),
+}));
+vi.mock("@/hooks/access/cloud/auth/use-sso-discovery", () => ({
+  useSsoDiscovery: () => ({ data: h.sso }),
+}));
+vi.mock("@/lib/domain/auth/auth-mode", () => ({
+  isProductAuthRequired: () => true,
+}));
+// The provider must never construct a second Cloud client.
+vi.mock("@/lib/access/cloud/client", () => ({
+  getProliferateClient: h.getProliferateClient,
+}));
+// Stable bridge double, avoids loading the real Tauri bridge chain.
+vi.mock("@/lib/access/tauri/desktop-bridge", () => ({
+  desktopBridge: h.desktopBridge,
+}));
+// Leaf deps of desktop-product-host: keep host construction real while
+// avoiding any Tauri/telemetry side effects during import/render.
+vi.mock("@/lib/infra/proliferate-api", () => ({
+  getProliferateApiBaseUrl: () => "https://api.example.test",
+}));
+vi.mock("@/lib/access/tauri/config", () => ({ setDesktopAppConfig: vi.fn() }));
+vi.mock("@/lib/access/tauri/updater", () => ({ relaunch: vi.fn() }));
+vi.mock("@/lib/access/tauri/shell", () => ({
+  copyText: vi.fn(),
+  openExternal: vi.fn(),
+}));
+vi.mock("@/lib/access/tauri/deep-link", () => ({
+  subscribeDeepLinkUrls: vi.fn(() => () => {}),
+}));
+vi.mock("@/lib/integrations/auth/orchestration-callback", () => ({
+  handleDesktopCallbackUrl: vi.fn(),
+}));
+vi.mock("@/lib/integrations/auth/proliferate-auth", () => ({
+  DESKTOP_AUTH_REDIRECT_URI: "proliferate://auth/callback",
+}));
+vi.mock("@/lib/integrations/auth/proliferate-sso-auth", () => ({
+  discoverDesktopSso: vi.fn(),
+}));
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  trackProductEvent: vi.fn(),
+  captureTelemetryException: vi.fn(),
+  setTelemetryUser: vi.fn(),
+  clearTelemetryUser: vi.fn(),
+  setTelemetryTag: vi.fn(),
+  getSupportReportReleaseId: vi.fn(() => "desktop@test"),
+  getSupportReportTelemetryRefs: vi.fn(() => undefined),
+}));
+
+let cloudClient: unknown;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <DesktopProductHostProvider cloudClient={cloudClient as never}>
+      {children}
+    </DesktopProductHostProvider>
+  );
+}
+
+const AUTH_USER = {
+  id: "u1",
+  email: "ada@example.test",
+  display_name: "Ada",
+  github_login: "ada",
+  avatar_url: null,
+};
+
+beforeEach(() => {
+  h.cloudEnabled = true;
+  h.authMethods = { passwordLogin: true, github: true };
+  h.github = { enabled: true, clientId: null };
+  h.sso = { enabled: true };
+  h.getProliferateClient.mockClear();
+  cloudClient = { id: "cloud-1" };
+  useAuthStore.setState({
+    status: "anonymous",
+    user: null,
+    session: null,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DesktopProductHostProvider", () => {
+  it("exposes surface desktop, a non-null bridge, and the exact cloud client", () => {
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    expect(result.current.surface).toBe("desktop");
+    expect(result.current.desktop).toBe(h.desktopBridge);
+    expect(result.current.cloud.client).toBe(cloudClient);
+  });
+
+  it("does not construct a second Cloud client", () => {
+    renderHook(() => useProductHost(), { wrapper });
+    expect(h.getProliferateClient).not.toHaveBeenCalled();
+  });
+
+  it("replaces the host and remaps the user when auth status changes", () => {
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const anonymousHost = result.current;
+    expect(anonymousHost.auth.state).toEqual({
+      status: "anonymous",
+      methods: ["password", "github", "sso"],
+    });
+
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+
+    const authedHost = result.current;
+    expect(authedHost).not.toBe(anonymousHost);
+    expect(authedHost.auth.state).toEqual({
+      status: "authenticated",
+      user: {
+        id: "u1",
+        displayName: "Ada",
+        email: "ada@example.test",
+        avatarUrl: null,
+        githubLogin: "ada",
+      },
+    });
+  });
+
+  it("keeps static host groups identical across an auth replacement", () => {
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const before = result.current;
+
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+    const after = result.current;
+
+    expect(after).not.toBe(before);
+    expect(after.auth).not.toBe(before.auth);
+    expect(after.storage).toBe(before.storage);
+    expect(after.links).toBe(before.links);
+    expect(after.clipboard).toBe(before.clipboard);
+    expect(after.telemetry).toBe(before.telemetry);
+    expect(after.deployment).toBe(before.deployment);
+    expect(after.desktop).toBe(before.desktop);
+  });
+
+  it("replaces the host when an authenticated identity field changes", () => {
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+    const { result } = renderHook(() => useProductHost(), { wrapper });
+    const before = result.current;
+
+    act(() => {
+      useAuthStore.setState({
+        status: "authenticated",
+        user: { ...AUTH_USER, display_name: "Ada Lovelace" },
+      });
+    });
+
+    expect(result.current).not.toBe(before);
+    expect(result.current.auth.state).toMatchObject({
+      status: "authenticated",
+      user: { displayName: "Ada Lovelace" },
+    });
+  });
+
+  it("does not replace the host on token rotation or unrelated rerenders", () => {
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+    const { result, rerender } = renderHook(() => useProductHost(), {
+      wrapper,
+    });
+    const host = result.current;
+
+    // A token/session rotation touches no identity field the provider reads.
+    act(() => {
+      useAuthStore.setState({
+        session: { access_token: "rotated" } as never,
+      });
+    });
+    expect(result.current).toBe(host);
+
+    // A parent re-render with unchanged inputs preserves host identity.
+    act(() => {
+      rerender();
+    });
+    expect(result.current).toBe(host);
+  });
+
+  it("replaces the host when the anonymous method list changes", () => {
+    const { result, rerender } = renderHook(() => useProductHost(), {
+      wrapper,
+    });
+    const before = result.current;
+    expect(before.auth.state).toEqual({
+      status: "anonymous",
+      methods: ["password", "github", "sso"],
+    });
+
+    h.github = { enabled: false };
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current).not.toBe(before);
+    expect(result.current.auth.state).toEqual({
+      status: "anonymous",
+      methods: ["password", "sso"],
+    });
+  });
+
+  it("does not replace the host when method availability changes while authenticated", () => {
+    act(() => {
+      useAuthStore.setState({ status: "authenticated", user: AUTH_USER });
+    });
+    const { result, rerender } = renderHook(() => useProductHost(), {
+      wrapper,
+    });
+    const before = result.current;
+
+    h.github = { enabled: false };
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current).toBe(before);
+  });
+
+  it("replaces the host and exposes the exact new client when cloudClient changes", () => {
+    const { result, rerender } = renderHook(() => useProductHost(), {
+      wrapper,
+    });
+    const before = result.current;
+
+    const nextClient = { id: "cloud-2" };
+    cloudClient = nextClient;
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current).not.toBe(before);
+    expect(result.current.cloud.client).toBe(nextClient);
+  });
+});

--- a/apps/desktop/src/providers/DesktopProductHostProvider.tsx
+++ b/apps/desktop/src/providers/DesktopProductHostProvider.tsx
@@ -84,6 +84,16 @@ export function DesktopProductHostProvider({
   // authenticated it must not participate in host replacement.
   const anonymousMethodsKey = status === "anonymous" ? methodsKey : "";
 
+  // Identity fields replace the host only while authenticated; mutations that
+  // arrive during anonymous/bootstrapping (where the AuthState carries no user)
+  // must not participate in host replacement — mirroring anonymousMethodsKey.
+  const isAuthenticated = status === "authenticated";
+  const authenticatedUserId = isAuthenticated ? userId : null;
+  const authenticatedDisplayName = isAuthenticated ? displayName : null;
+  const authenticatedEmail = isAuthenticated ? email : null;
+  const authenticatedAvatarUrl = isAuthenticated ? avatarUrl : null;
+  const authenticatedGithubLogin = isAuthenticated ? githubLogin : null;
+
   const authState = useMemo<AuthState>(() => {
     if (status === "bootstrapping") {
       return { status: "loading" };
@@ -102,9 +112,19 @@ export function DesktopProductHostProvider({
     }
     return { status: "anonymous", methods };
     // methods is folded into anonymousMethodsKey so authenticated method
-    // changes do not recompute the snapshot.
+    // changes do not recompute the snapshot; identity fields are gated to
+    // authenticated status so anonymous/bootstrapping identity mutations do
+    // not recompute it either.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, userId, displayName, email, avatarUrl, githubLogin, anonymousMethodsKey]);
+  }, [
+    status,
+    authenticatedUserId,
+    authenticatedDisplayName,
+    authenticatedEmail,
+    authenticatedAvatarUrl,
+    authenticatedGithubLogin,
+    anonymousMethodsKey,
+  ]);
 
   // Auth operations stay stable as long as the underlying action callbacks do
   // (each is a useCallback keyed on the stable orchestration effects). The deps

--- a/apps/desktop/src/providers/DesktopProductHostProvider.tsx
+++ b/apps/desktop/src/providers/DesktopProductHostProvider.tsx
@@ -1,0 +1,163 @@
+import { useMemo, useRef, type ReactNode } from "react";
+import type { ProliferateCloudClient } from "@proliferate/cloud-sdk";
+import type {
+  AuthState,
+  ProductAuthHost,
+  ProductHost,
+} from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+
+import { desktopProductStorage } from "@/lib/access/browser/product-storage";
+import { desktopBridge } from "@/lib/access/tauri/desktop-bridge";
+import { isProductAuthRequired } from "@/lib/domain/auth/auth-mode";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useAuthBootstrap } from "@/hooks/auth/lifecycle/use-auth-bootstrap";
+import { useAuthActions } from "@/hooks/auth/workflows/use-auth-actions";
+import { useAuthOrchestrationEffects } from "@/hooks/auth/workflows/use-auth-orchestration-effects";
+import { useAppCapabilities } from "@/hooks/capabilities/derived/use-app-capabilities";
+import { useDesktopAuthMethods } from "@/hooks/access/cloud/auth/use-auth-methods";
+import { useGitHubDesktopAuthAvailability } from "@/hooks/access/cloud/auth/use-github-auth-availability";
+import { useSsoDiscovery } from "@/hooks/access/cloud/auth/use-sso-discovery";
+
+import {
+  buildAnonymousMethods,
+  createDesktopAuthOperations,
+  createDesktopDeployment,
+  desktopClipboard,
+  desktopProductLinks,
+  desktopTelemetry,
+  mapProductAuthUser,
+} from "./desktop-product-host";
+
+export interface DesktopProductHostProviderProps {
+  cloudClient: ProliferateCloudClient | null;
+  children: ReactNode;
+}
+
+/**
+ * Constructs the one Desktop-owned ProductHost snapshot and supplies it through
+ * ProductHostProvider. The snapshot is replaced only when an approved reactive
+ * input changes (auth status, authenticated user identity, the anonymous
+ * method list, or the `cloudClient` reference); token rotation, auth errors,
+ * organization selection, routes, workspace/runtime state, and preference
+ * changes do not replace it. Static adapters retain stable identity across
+ * replacements. It constructs no second Cloud/Query/runtime/auth/telemetry
+ * instance — it reuses the exact `cloudClient` passed by AppProviders.
+ */
+export function DesktopProductHostProvider({
+  cloudClient,
+  children,
+}: DesktopProductHostProviderProps) {
+  const status = useAuthStore((state) => state.status);
+  // Read identity fields narrowly so token rotation (which does not touch these
+  // fields) never replaces the host.
+  const userId = useAuthStore((state) => state.user?.id ?? null);
+  const displayName = useAuthStore((state) => state.user?.display_name ?? null);
+  const email = useAuthStore((state) => state.user?.email ?? null);
+  const avatarUrl = useAuthStore((state) => state.user?.avatar_url ?? null);
+  const githubLogin = useAuthStore((state) => state.user?.github_login ?? null);
+
+  const restoreSession = useAuthBootstrap();
+  const actions = useAuthActions();
+  const orchestrationEffects = useAuthOrchestrationEffects();
+
+  const { cloudEnabled } = useAppCapabilities();
+  const { data: authMethods } = useDesktopAuthMethods();
+  const { data: githubAvailability } = useGitHubDesktopAuthAvailability();
+  const { data: ssoDiscovery } = useSsoDiscovery({ enabled: cloudEnabled });
+
+  const passwordAvailable = cloudEnabled && authMethods?.passwordLogin === true;
+  const githubAvailable = cloudEnabled && githubAvailability?.enabled === true;
+  const ssoAvailable = cloudEnabled && ssoDiscovery?.enabled === true;
+
+  const methods = useMemo(
+    () =>
+      buildAnonymousMethods({
+        passwordAvailable,
+        githubAvailable,
+        ssoAvailable,
+      }),
+    [passwordAvailable, githubAvailable, ssoAvailable],
+  );
+  const methodsKey = methods.join(",");
+  // Method availability replaces the host only while anonymous; once
+  // authenticated it must not participate in host replacement.
+  const anonymousMethodsKey = status === "anonymous" ? methodsKey : "";
+
+  const authState = useMemo<AuthState>(() => {
+    if (status === "bootstrapping") {
+      return { status: "loading" };
+    }
+    if (status === "authenticated") {
+      return {
+        status: "authenticated",
+        user: mapProductAuthUser({
+          id: userId ?? "",
+          email: email ?? "",
+          display_name: displayName,
+          github_login: githubLogin,
+          avatar_url: avatarUrl,
+        }),
+      };
+    }
+    return { status: "anonymous", methods };
+    // methods is folded into anonymousMethodsKey so authenticated method
+    // changes do not recompute the snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, userId, displayName, email, avatarUrl, githubLogin, anonymousMethodsKey]);
+
+  // Auth operations stay stable as long as the underlying action callbacks do
+  // (each is a useCallback keyed on the stable orchestration effects). The deps
+  // getter reads the latest effects via a ref without widening those deps.
+  const orchestrationEffectsRef = useRef(orchestrationEffects);
+  orchestrationEffectsRef.current = orchestrationEffects;
+  const authOps = useMemo(
+    () =>
+      createDesktopAuthOperations(
+        actions,
+        () => orchestrationEffectsRef.current,
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      actions.signInWithGitHub,
+      actions.signInWithPassword,
+      actions.signInWithSso,
+      actions.signOut,
+      actions.cancelAuthFlow,
+      actions.linkGoogle,
+    ],
+  );
+
+  const authRequired = isProductAuthRequired();
+  const auth = useMemo<ProductAuthHost>(
+    () => ({
+      authRequired,
+      state: authState,
+      restoreSession,
+      startLogin: authOps.startLogin,
+      finishLogin: authOps.finishLogin,
+      cancelLogin: authOps.cancelLogin,
+      logout: authOps.logout,
+    }),
+    [authRequired, authState, restoreSession, authOps],
+  );
+
+  const deployment = useMemo(() => createDesktopDeployment(), []);
+
+  const host = useMemo<ProductHost>(
+    () => ({
+      surface: "desktop",
+      deployment,
+      auth,
+      cloud: { client: cloudClient },
+      storage: desktopProductStorage,
+      links: desktopProductLinks,
+      clipboard: desktopClipboard,
+      telemetry: desktopTelemetry,
+      desktop: desktopBridge,
+    }),
+    [cloudClient, auth, deployment],
+  );
+
+  return <ProductHostProvider host={host}>{children}</ProductHostProvider>;
+}

--- a/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
+++ b/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  DesktopBridge,
+} from "@proliferate/product-client/host/desktop-bridge";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+
+import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+vi.mock("@proliferate/product-domain/sessions/activity", () => ({
+  isSessionSlotBusy: (snapshot: { busy?: boolean } | null) =>
+    snapshot?.busy === true,
+}));
+vi.mock("@/lib/domain/sessions/directory/directory-activity", () => ({
+  activitySnapshotFromDirectoryEntry: (entry: unknown) => entry,
+  // Also mocked because the session-directory store imports it at module load.
+  activityFromTranscript: () => ({}),
+}));
+
+import { DesktopProductLifecycleRoot } from "./DesktopProductLifecycleRoot";
+
+type Entries = Record<string, { busy: boolean }>;
+
+function setEntries(entries: Entries) {
+  useSessionDirectoryStore.setState({ entriesById: entries as never });
+}
+
+function makeBridge(setRunningAgentCount: (count: number) => Promise<void>) {
+  return { nativeUi: { setRunningAgentCount } } as unknown as DesktopBridge;
+}
+
+function makeHost(desktop: DesktopBridge | null): ProductHost {
+  return {
+    surface: desktop ? "desktop" : "web",
+    deployment: { apiBaseUrl: "https://api.example.test" },
+    auth: {
+      authRequired: true,
+      state: { status: "loading" },
+      restoreSession: async () => {},
+      startLogin: async () => {},
+      finishLogin: async () => {},
+      cancelLogin: async () => {},
+      logout: async () => {},
+    },
+    cloud: { client: null },
+    storage: {
+      getItem: async () => null,
+      setItem: async () => {},
+      removeItem: async () => {},
+    },
+    links: {
+      openExternal: async () => {},
+      buildReturnUrl: () => "",
+      observeInboundEntries: () => () => {},
+    },
+    clipboard: { writeText: async () => {} },
+    telemetry: {
+      track: () => {},
+      captureException: () => {},
+      setUser: () => {},
+      setTag: () => {},
+      routeChanged: () => {},
+      getSupportContext: () => ({ clientReleaseId: "test" }),
+    },
+    desktop,
+  };
+}
+
+function renderRoot(host: ProductHost) {
+  return render(
+    <ProductHostProvider host={host}>
+      <DesktopProductLifecycleRoot />
+    </ProductHostProvider>,
+  );
+}
+
+beforeEach(() => {
+  setEntries({});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DesktopProductLifecycleRoot", () => {
+  it("does not export or subscribe when desktop is null", () => {
+    const subscribeSpy = vi.spyOn(useSessionDirectoryStore, "subscribe");
+    renderRoot(makeHost(null));
+    expect(subscribeSpy).not.toHaveBeenCalled();
+  });
+
+  it("exports the initial busy count through the bridge", () => {
+    setEntries({ a: { busy: true } });
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    renderRoot(makeHost(makeBridge(setRunningAgentCount)));
+
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+    expect(setRunningAgentCount).toHaveBeenCalledWith(1);
+  });
+
+  it("exports only changed counts as sessions go busy and idle", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    renderRoot(makeHost(makeBridge(setRunningAgentCount)));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(0);
+
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(1);
+
+    // Unchanged busy count: no additional export.
+    act(() => setEntries({ a: { busy: true }, b: { busy: false } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(2);
+
+    act(() => setEntries({ a: { busy: false }, b: { busy: false } }));
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(0);
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not duplicate work when the host is replaced with the same bridge", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    const bridge = makeBridge(setRunningAgentCount);
+    const { rerender } = renderRoot(makeHost(bridge));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    // A brand-new host snapshot carrying the same stable bridge.
+    rerender(
+      <ProductHostProvider host={makeHost(bridge)}>
+        <DesktopProductLifecycleRoot />
+      </ProductHostProvider>,
+    );
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    // The single subscription is still live.
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(2);
+    expect(setRunningAgentCount).toHaveBeenLastCalledWith(1);
+  });
+
+  it("cleans up the subscription when the bridge is removed", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderRoot(makeHost(makeBridge(setRunningAgentCount)));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProductHostProvider host={makeHost(null)}>
+        <DesktopProductLifecycleRoot />
+      </ProductHostProvider>,
+    );
+
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the subscription on unmount", () => {
+    const setRunningAgentCount = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = renderRoot(makeHost(makeBridge(setRunningAgentCount)));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => setEntries({ a: { busy: true } }));
+    expect(setRunningAgentCount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/providers/DesktopProductLifecycleRoot.tsx
+++ b/apps/desktop/src/providers/DesktopProductLifecycleRoot.tsx
@@ -1,0 +1,22 @@
+import type { DesktopBridge } from "@proliferate/product-client/host/desktop-bridge";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+
+import { useExportRunningAgentCount } from "@/hooks/app/lifecycle/use-export-running-agent-count";
+
+/**
+ * The single Desktop product-lifecycle root, mounted outside auth and route
+ * gates. It reads the Desktop bridge from the host and, when present, mounts
+ * the running-agent count export through `desktop.nativeUi.setRunningAgentCount`.
+ * On a non-Desktop host (`desktop === null`) it renders nothing.
+ */
+export function DesktopProductLifecycleRoot() {
+  const { desktop } = useProductHost();
+  return desktop === null ? null : <RunningAgentCountLifecycle desktop={desktop} />;
+}
+
+// Nested so hook membership stays valid if `desktop` flips between a bridge and
+// null across a host replacement.
+function RunningAgentCountLifecycle({ desktop }: { desktop: DesktopBridge }) {
+  useExportRunningAgentCount(desktop.nativeUi.setRunningAgentCount);
+  return null;
+}

--- a/apps/desktop/src/providers/desktop-product-host.test.ts
+++ b/apps/desktop/src/providers/desktop-product-host.test.ts
@@ -1,0 +1,488 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthOrchestrationDeps } from "@/lib/integrations/auth/orchestration-effects";
+import type { ProductEntry } from "@proliferate/product-client/host/product-host";
+
+const mocks = vi.hoisted(() => ({
+  getProliferateApiBaseUrl: vi.fn(),
+  setDesktopAppConfig: vi.fn(),
+  relaunch: vi.fn(),
+  copyText: vi.fn(),
+  openExternal: vi.fn(),
+  subscribeDeepLinkUrls: vi.fn(),
+  discoverDesktopSso: vi.fn(),
+  handleDesktopCallbackUrl: vi.fn(),
+  trackProductEvent: vi.fn(),
+  captureTelemetryException: vi.fn(),
+  setTelemetryUser: vi.fn(),
+  clearTelemetryUser: vi.fn(),
+  setTelemetryTag: vi.fn(),
+  getSupportReportReleaseId: vi.fn(),
+  getSupportReportTelemetryRefs: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/proliferate-api", () => ({
+  getProliferateApiBaseUrl: mocks.getProliferateApiBaseUrl,
+}));
+vi.mock("@/lib/access/tauri/config", () => ({
+  setDesktopAppConfig: mocks.setDesktopAppConfig,
+}));
+vi.mock("@/lib/access/tauri/updater", () => ({
+  relaunch: mocks.relaunch,
+}));
+vi.mock("@/lib/access/tauri/shell", () => ({
+  copyText: mocks.copyText,
+  openExternal: mocks.openExternal,
+}));
+vi.mock("@/lib/access/tauri/deep-link", () => ({
+  subscribeDeepLinkUrls: mocks.subscribeDeepLinkUrls,
+}));
+vi.mock("@/lib/integrations/auth/proliferate-sso-auth", () => ({
+  discoverDesktopSso: mocks.discoverDesktopSso,
+}));
+vi.mock("@/lib/integrations/auth/orchestration-callback", () => ({
+  handleDesktopCallbackUrl: mocks.handleDesktopCallbackUrl,
+}));
+vi.mock("@/lib/integrations/auth/proliferate-auth", () => ({
+  DESKTOP_AUTH_REDIRECT_URI: "proliferate://auth/callback",
+}));
+vi.mock("@/lib/integrations/telemetry/client", () => ({
+  trackProductEvent: mocks.trackProductEvent,
+  captureTelemetryException: mocks.captureTelemetryException,
+  setTelemetryUser: mocks.setTelemetryUser,
+  clearTelemetryUser: mocks.clearTelemetryUser,
+  setTelemetryTag: mocks.setTelemetryTag,
+  getSupportReportReleaseId: mocks.getSupportReportReleaseId,
+  getSupportReportTelemetryRefs: mocks.getSupportReportTelemetryRefs,
+}));
+
+import {
+  __resetDesktopTelemetryRouteForTest,
+  buildAnonymousMethods,
+  createDesktopAuthOperations,
+  createDesktopDeployment,
+  desktopClipboard,
+  desktopProductLinks,
+  desktopTelemetry,
+  mapProductAuthUser,
+} from "./desktop-product-host";
+
+const SSO_UNAVAILABLE =
+  "We could not find single sign-on for that workspace. Check the sign-in link your admin shared.";
+
+function makeActions() {
+  return {
+    signInWithGitHub: vi.fn().mockResolvedValue(undefined),
+    signInWithPassword: vi.fn().mockResolvedValue(undefined),
+    signInWithSso: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    cancelAuthFlow: vi.fn().mockResolvedValue(undefined),
+    linkGoogle: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const deps = {} as AuthOrchestrationDeps;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createDesktopDeployment", () => {
+  it("reads apiBaseUrl from the runtime config at construction", () => {
+    mocks.getProliferateApiBaseUrl.mockReturnValue("https://api.example.test");
+    const deployment = createDesktopDeployment();
+    expect(deployment.apiBaseUrl).toBe("https://api.example.test");
+  });
+
+  it("switchDeployment writes config before relaunch", async () => {
+    const order: string[] = [];
+    mocks.setDesktopAppConfig.mockImplementation(async () => {
+      order.push("config");
+    });
+    mocks.relaunch.mockImplementation(async () => {
+      order.push("relaunch");
+    });
+    const deployment = createDesktopDeployment();
+
+    await deployment.switchDeployment!("https://self-hosted.example.test");
+
+    expect(mocks.setDesktopAppConfig).toHaveBeenCalledWith({
+      apiBaseUrl: "https://self-hosted.example.test",
+    });
+    expect(order).toEqual(["config", "relaunch"]);
+  });
+
+  it("resetDeployment writes a null config before relaunch", async () => {
+    const order: string[] = [];
+    mocks.setDesktopAppConfig.mockImplementation(async () => {
+      order.push("config");
+    });
+    mocks.relaunch.mockImplementation(async () => {
+      order.push("relaunch");
+    });
+    const deployment = createDesktopDeployment();
+
+    await deployment.resetDeployment!();
+
+    expect(mocks.setDesktopAppConfig).toHaveBeenCalledWith({ apiBaseUrl: null });
+    expect(order).toEqual(["config", "relaunch"]);
+  });
+
+  it("a config-write failure rejects and does not relaunch", async () => {
+    mocks.setDesktopAppConfig.mockRejectedValue(new Error("write failed"));
+    const deployment = createDesktopDeployment();
+
+    await expect(
+      deployment.switchDeployment!("https://self-hosted.example.test"),
+    ).rejects.toThrow("write failed");
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+  });
+});
+
+describe("mapProductAuthUser", () => {
+  it("maps the Desktop user fields to the product identity", () => {
+    expect(
+      mapProductAuthUser({
+        id: "user-1",
+        email: "a@example.test",
+        display_name: "Ada",
+        avatar_url: "https://avatar.test/a.png",
+        github_login: "ada",
+      }),
+    ).toEqual({
+      id: "user-1",
+      displayName: "Ada",
+      email: "a@example.test",
+      avatarUrl: "https://avatar.test/a.png",
+      githubLogin: "ada",
+    });
+  });
+});
+
+describe("buildAnonymousMethods", () => {
+  it("includes only available methods in a fixed order", () => {
+    expect(
+      buildAnonymousMethods({
+        passwordAvailable: true,
+        githubAvailable: true,
+        ssoAvailable: true,
+      }),
+    ).toEqual(["password", "github", "sso"]);
+  });
+
+  it("omits unavailable methods and never lists google or apple", () => {
+    expect(
+      buildAnonymousMethods({
+        passwordAvailable: false,
+        githubAvailable: true,
+        ssoAvailable: false,
+      }),
+    ).toEqual(["github"]);
+    expect(
+      buildAnonymousMethods({
+        passwordAvailable: false,
+        githubAvailable: false,
+        ssoAvailable: false,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("createDesktopAuthOperations - startLogin disposition", () => {
+  it("password delegates email/password to signInWithPassword", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({
+      kind: "password",
+      email: "a@example.test",
+      password: "pw",
+    });
+    expect(actions.signInWithPassword).toHaveBeenCalledWith({
+      email: "a@example.test",
+      password: "pw",
+    });
+  });
+
+  it("github with omitted purpose delegates prompt to signInWithGitHub", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({ kind: "github" });
+    expect(actions.signInWithGitHub).toHaveBeenCalledWith({ prompt: undefined });
+  });
+
+  it("github with purpose login forwards the select_account prompt", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({
+      kind: "github",
+      purpose: "login",
+      prompt: "select_account",
+    });
+    expect(actions.signInWithGitHub).toHaveBeenCalledWith({
+      prompt: "select_account",
+    });
+  });
+
+  it("github link and required_github_link reject without delegating", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await expect(
+      ops.startLogin({ kind: "github", purpose: "link" }),
+    ).rejects.toThrow();
+    await expect(
+      ops.startLogin({ kind: "github", purpose: "required_github_link" }),
+    ).rejects.toThrow();
+    expect(actions.signInWithGitHub).not.toHaveBeenCalled();
+  });
+
+  it("google link delegates to linkGoogle", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({ kind: "google", purpose: "link" });
+    expect(actions.linkGoogle).toHaveBeenCalledTimes(1);
+  });
+
+  it("google login, required_github_link, and omitted purpose reject", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await expect(
+      ops.startLogin({ kind: "google", purpose: "login" }),
+    ).rejects.toThrow();
+    await expect(
+      ops.startLogin({ kind: "google", purpose: "required_github_link" }),
+    ).rejects.toThrow();
+    await expect(ops.startLogin({ kind: "google" })).rejects.toThrow();
+    expect(actions.linkGoogle).not.toHaveBeenCalled();
+  });
+
+  it("apple rejects for any purpose", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await expect(ops.startLogin({ kind: "apple" })).rejects.toThrow();
+    await expect(
+      ops.startLogin({ kind: "apple", purpose: "login" }),
+    ).rejects.toThrow();
+  });
+
+  it("sso without slug forwards the supplied fields to signInWithSso", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({
+      kind: "sso",
+      email: "a@example.test",
+      organizationId: "org-1",
+      connectionId: "conn-1",
+    });
+    expect(actions.signInWithSso).toHaveBeenCalledWith({
+      email: "a@example.test",
+      organizationId: "org-1",
+      connectionId: "conn-1",
+    });
+    expect(mocks.discoverDesktopSso).not.toHaveBeenCalled();
+  });
+
+  it("sso with slug discovers then signs in with the resolved org/connection", async () => {
+    mocks.discoverDesktopSso.mockResolvedValue({
+      enabled: true,
+      organizationId: "org-resolved",
+      connectionId: "conn-resolved",
+    });
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.startLogin({
+      kind: "sso",
+      slug: "acme",
+      email: "a@example.test",
+      organizationId: "org-hint",
+      connectionId: "conn-hint",
+    });
+    expect(mocks.discoverDesktopSso).toHaveBeenCalledWith({
+      slug: "acme",
+      email: "a@example.test",
+      organizationId: "org-hint",
+      connectionId: "conn-hint",
+    });
+    expect(actions.signInWithSso).toHaveBeenCalledWith({
+      organizationId: "org-resolved",
+      connectionId: "conn-resolved",
+      prompt: "select_account",
+    });
+  });
+
+  it("sso with slug rejects with the generic message when discovery is disabled or unresolved", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+
+    mocks.discoverDesktopSso.mockResolvedValueOnce({ enabled: false });
+    await expect(
+      ops.startLogin({ kind: "sso", slug: "acme" }),
+    ).rejects.toThrow(SSO_UNAVAILABLE);
+
+    mocks.discoverDesktopSso.mockResolvedValueOnce({
+      enabled: true,
+      organizationId: null,
+    });
+    await expect(
+      ops.startLogin({ kind: "sso", slug: "acme" }),
+    ).rejects.toThrow(SSO_UNAVAILABLE);
+
+    expect(actions.signInWithSso).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDesktopAuthOperations - finishLogin", () => {
+  it("rejects when state is missing and never calls the callback handler", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await expect(ops.finishLogin({ code: "abc" })).rejects.toThrow();
+    expect(mocks.handleDesktopCallbackUrl).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs the callback URL and delegates to the existing handler", async () => {
+    mocks.handleDesktopCallbackUrl.mockResolvedValue(true);
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.finishLogin({ code: "abc", state: "xyz" });
+    expect(mocks.handleDesktopCallbackUrl).toHaveBeenCalledWith(
+      "proliferate://auth/callback?code=abc&state=xyz",
+      deps,
+    );
+  });
+
+  it("rejects when the callback handler declines", async () => {
+    mocks.handleDesktopCallbackUrl.mockResolvedValue(false);
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await expect(
+      ops.finishLogin({ code: "abc", state: "xyz" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("createDesktopAuthOperations - cancel/logout", () => {
+  it("cancelLogin delegates to cancelAuthFlow", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.cancelLogin();
+    expect(actions.cancelAuthFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("logout delegates to signOut", async () => {
+    const actions = makeActions();
+    const ops = createDesktopAuthOperations(actions, () => deps);
+    await ops.logout();
+    expect(actions.signOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("clipboard and links adapters", () => {
+  it("clipboard.writeText delegates once to copyText", async () => {
+    await desktopClipboard.writeText("copied");
+    expect(mocks.copyText).toHaveBeenCalledTimes(1);
+    expect(mocks.copyText).toHaveBeenCalledWith("copied");
+  });
+
+  it("links.openExternal delegates once to openExternal", async () => {
+    await desktopProductLinks.openExternal("https://example.test");
+    expect(mocks.openExternal).toHaveBeenCalledTimes(1);
+    expect(mocks.openExternal).toHaveBeenCalledWith("https://example.test");
+  });
+
+  it("links.buildReturnUrl encodes the entry as a Desktop deep link", () => {
+    const entry: ProductEntry = { kind: "workspace", workspaceId: "ws1" };
+    expect(desktopProductLinks.buildReturnUrl(entry)).toBe(
+      "proliferate://workspaces/ws1",
+    );
+  });
+
+  it("links.observeInboundEntries subscribes once and delivers only decoded entries", () => {
+    let rawListener: ((url: string) => void) | null = null;
+    const unsub = vi.fn();
+    mocks.subscribeDeepLinkUrls.mockImplementation((listener) => {
+      rawListener = listener;
+      return unsub;
+    });
+    const received: ProductEntry[] = [];
+    const returned = desktopProductLinks.observeInboundEntries((entry) => {
+      received.push(entry);
+    });
+
+    expect(mocks.subscribeDeepLinkUrls).toHaveBeenCalledTimes(1);
+    expect(returned).toBe(unsub);
+
+    rawListener!("proliferate://workspaces/ws1");
+    rawListener!("https://unknown.example.test/nope");
+
+    expect(received).toEqual([
+      { kind: "workspace", workspaceId: "ws1", query: {} },
+    ]);
+  });
+});
+
+describe("desktopTelemetry", () => {
+  it("track delegates once to trackProductEvent", () => {
+    desktopTelemetry.track({ name: "custom_event", properties: { a: 1 } });
+    expect(mocks.trackProductEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.trackProductEvent).toHaveBeenCalledWith("custom_event", {
+      a: 1,
+    });
+  });
+
+  it("captureException delegates to captureTelemetryException", () => {
+    const error = new Error("boom");
+    desktopTelemetry.captureException(error, { tags: { k: "v" } });
+    expect(mocks.captureTelemetryException).toHaveBeenCalledWith(error, {
+      tags: { k: "v" },
+    });
+  });
+
+  it("setUser maps to the Desktop user, and null clears it", () => {
+    desktopTelemetry.setUser({
+      id: "user-1",
+      email: "a@example.test",
+      displayName: "Ada",
+    });
+    expect(mocks.setTelemetryUser).toHaveBeenCalledWith({
+      id: "user-1",
+      email: "a@example.test",
+      display_name: "Ada",
+    });
+
+    desktopTelemetry.setUser(null);
+    expect(mocks.clearTelemetryUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("setTag delegates to setTelemetryTag", () => {
+    desktopTelemetry.setTag("k", "v");
+    expect(mocks.setTelemetryTag).toHaveBeenCalledWith("k", "v");
+  });
+
+  it("routeChanged emits once per resolved route and suppresses repeats", () => {
+    __resetDesktopTelemetryRouteForTest();
+
+    desktopTelemetry.routeChanged("/");
+    desktopTelemetry.routeChanged("/");
+    desktopTelemetry.routeChanged("/settings");
+
+    // "main" (from "/") emits once, the repeat is suppressed, "settings" emits.
+    expect(mocks.trackProductEvent.mock.calls).toEqual([
+      ["screen_viewed", { route: "main" }],
+      ["screen_viewed", { route: "settings" }],
+    ]);
+    expect(mocks.setTelemetryTag.mock.calls).toEqual([
+      ["route", "main"],
+      ["route", "settings"],
+    ]);
+  });
+
+  it("getSupportContext reads the release id and telemetry refs", () => {
+    mocks.getSupportReportReleaseId.mockReturnValue("desktop@1.2.3+abcdef");
+    mocks.getSupportReportTelemetryRefs.mockReturnValue({
+      posthogDistinctId: "distinct-1",
+    });
+    expect(desktopTelemetry.getSupportContext()).toEqual({
+      clientReleaseId: "desktop@1.2.3+abcdef",
+      telemetryRefs: { posthogDistinctId: "distinct-1" },
+    });
+  });
+});

--- a/apps/desktop/src/providers/desktop-product-host.ts
+++ b/apps/desktop/src/providers/desktop-product-host.ts
@@ -1,0 +1,312 @@
+import type { AuthMethod } from "@proliferate/product-domain/auth/model";
+import type {
+  AuthCallback,
+  LoginRequest,
+  ProductAuthHost,
+  ProductAuthUser,
+  ProductClipboard,
+  ProductDeploymentHost,
+  ProductEntry,
+  ProductLinks,
+  ProductTelemetry,
+} from "@proliferate/product-client/host/product-host";
+
+import type { AuthUser } from "@/lib/domain/auth/auth-user";
+import type { DesktopTelemetryRoute } from "@/lib/domain/telemetry/events";
+import type { AuthOrchestrationDeps } from "@/lib/integrations/auth/orchestration-effects";
+import type { GitHubDesktopSignInOptions } from "@/lib/integrations/auth/proliferate-auth";
+import type { DesktopSsoSignInOptions } from "@/lib/integrations/auth/proliferate-sso-auth";
+import type { PasswordSignInCredentials } from "@/lib/integrations/auth/orchestration-password-flow";
+
+import { getProliferateApiBaseUrl } from "@/lib/infra/proliferate-api";
+import { setDesktopAppConfig } from "@/lib/access/tauri/config";
+import { relaunch } from "@/lib/access/tauri/updater";
+import { copyText, openExternal } from "@/lib/access/tauri/shell";
+import {
+  decodeDesktopProductEntry,
+  encodeDesktopReturnUrl,
+} from "@/lib/domain/auth/desktop-navigation";
+import { subscribeDeepLinkUrls } from "@/lib/access/tauri/deep-link";
+import { resolveDesktopTelemetryRoute } from "@/lib/domain/telemetry/routes";
+import {
+  captureTelemetryException,
+  clearTelemetryUser,
+  getSupportReportReleaseId,
+  getSupportReportTelemetryRefs,
+  setTelemetryTag,
+  setTelemetryUser,
+  trackProductEvent,
+} from "@/lib/integrations/telemetry/client";
+import { handleDesktopCallbackUrl } from "@/lib/integrations/auth/orchestration-callback";
+import { discoverDesktopSso } from "@/lib/integrations/auth/proliferate-sso-auth";
+import { DESKTOP_AUTH_REDIRECT_URI } from "@/lib/integrations/auth/proliferate-auth";
+
+// Same generic string surfaced by the existing slug SSO flow: a missing org,
+// no SSO, or disabled SSO all resolve to one answer so we never confirm which
+// workspaces exist.
+const SSO_UNAVAILABLE =
+  "We could not find single sign-on for that workspace. Check the sign-in link your admin shared.";
+
+// --- Deployment -------------------------------------------------------------
+
+/**
+ * Build the deployment host for the current process. `apiBaseUrl` is read from
+ * the bootstrapped runtime config at construction time, so this is a factory
+ * (not a module constant): the provider memoizes one instance after config
+ * bootstrap. Switching writes `apiBaseUrl` and relaunches; a failed config
+ * write rejects before relaunch so no in-process switch is claimed.
+ */
+export function createDesktopDeployment(): ProductDeploymentHost {
+  return {
+    apiBaseUrl: getProliferateApiBaseUrl(),
+    async switchDeployment(apiBaseUrl: string): Promise<void> {
+      await setDesktopAppConfig({ apiBaseUrl });
+      await relaunch();
+    },
+    async resetDeployment(): Promise<void> {
+      await setDesktopAppConfig({ apiBaseUrl: null });
+      await relaunch();
+    },
+  };
+}
+
+// --- Auth mapping -----------------------------------------------------------
+
+export function mapProductAuthUser(user: AuthUser): ProductAuthUser {
+  return {
+    id: user.id,
+    displayName: user.display_name,
+    email: user.email,
+    avatarUrl: user.avatar_url,
+    githubLogin: user.github_login,
+  };
+}
+
+export interface DesktopAuthMethodAvailability {
+  passwordAvailable: boolean;
+  githubAvailable: boolean;
+  ssoAvailable: boolean;
+}
+
+/**
+ * The anonymous method list, in a fixed order, containing only currently
+ * available methods. Desktop never advertises Google or Apple login.
+ */
+export function buildAnonymousMethods({
+  passwordAvailable,
+  githubAvailable,
+  ssoAvailable,
+}: DesktopAuthMethodAvailability): AuthMethod[] {
+  const methods: AuthMethod[] = [];
+  if (passwordAvailable) {
+    methods.push("password");
+  }
+  if (githubAvailable) {
+    methods.push("github");
+  }
+  if (ssoAvailable) {
+    methods.push("sso");
+  }
+  return methods;
+}
+
+// --- Auth operations --------------------------------------------------------
+
+/**
+ * The subset of `useAuthActions()` the host operations delegate to. Structural
+ * so the concrete hook result (with richer return types) is assignable.
+ */
+export interface DesktopAuthActions {
+  signInWithGitHub: (options?: GitHubDesktopSignInOptions) => Promise<unknown>;
+  signInWithPassword: (credentials: PasswordSignInCredentials) => Promise<unknown>;
+  signInWithSso: (options?: DesktopSsoSignInOptions) => Promise<unknown>;
+  signOut: () => Promise<unknown>;
+  cancelAuthFlow: (message?: string) => Promise<void>;
+  linkGoogle: () => Promise<unknown>;
+}
+
+export type DesktopAuthOperations = Pick<
+  ProductAuthHost,
+  "startLogin" | "finishLogin" | "cancelLogin" | "logout"
+>;
+
+/**
+ * Build the login/finish/cancel/logout operations over the existing Desktop
+ * auth actions. Each `LoginRequest` variant follows the frozen §7.2
+ * disposition exactly; no field is discarded or coerced, and no new Google,
+ * Apple, or GitHub-link login behavior is introduced. `getCallbackDeps`
+ * returns the current orchestration deps so `finishLogin` can delegate to the
+ * existing callback handler.
+ */
+export function createDesktopAuthOperations(
+  actions: DesktopAuthActions,
+  getCallbackDeps: () => AuthOrchestrationDeps,
+): DesktopAuthOperations {
+  async function startLogin(request: LoginRequest): Promise<void> {
+    switch (request.kind) {
+      case "password":
+        await actions.signInWithPassword({
+          email: request.email,
+          password: request.password,
+        });
+        return;
+
+      case "github": {
+        if (
+          request.purpose === "link" ||
+          request.purpose === "required_github_link"
+        ) {
+          throw new Error(
+            "GitHub account linking is not available from Desktop sign-in.",
+          );
+        }
+        // Omitted purpose or "login": the existing action hard-codes login.
+        await actions.signInWithGitHub({ prompt: request.prompt });
+        return;
+      }
+
+      case "google": {
+        if (request.purpose === "link") {
+          await actions.linkGoogle();
+          return;
+        }
+        throw new Error("Google sign-in is not available on Desktop.");
+      }
+
+      case "apple":
+        throw new Error("Apple sign-in is not available on Desktop.");
+
+      case "sso": {
+        if (!request.slug) {
+          await actions.signInWithSso({
+            email: request.email,
+            organizationId: request.organizationId,
+            connectionId: request.connectionId,
+          });
+          return;
+        }
+        const discovery = await discoverDesktopSso({
+          slug: request.slug,
+          email: request.email,
+          organizationId: request.organizationId,
+          connectionId: request.connectionId,
+        });
+        if (!discovery.enabled || !discovery.organizationId) {
+          throw new Error(SSO_UNAVAILABLE);
+        }
+        await actions.signInWithSso({
+          organizationId: discovery.organizationId,
+          connectionId: discovery.connectionId,
+          prompt: "select_account",
+        });
+        return;
+      }
+    }
+  }
+
+  async function finishLogin({ code, state }: AuthCallback): Promise<void> {
+    if (!state) {
+      throw new Error("Desktop OAuth state is required to finish sign-in.");
+    }
+    const params = new URLSearchParams({ code, state });
+    const url = `${DESKTOP_AUTH_REDIRECT_URI}?${params.toString()}`;
+    const handled = await handleDesktopCallbackUrl(url, getCallbackDeps());
+    if (!handled) {
+      throw new Error("The sign-in callback was not accepted.");
+    }
+  }
+
+  async function cancelLogin(): Promise<void> {
+    await actions.cancelAuthFlow();
+  }
+
+  async function logout(): Promise<void> {
+    await actions.signOut();
+  }
+
+  return { startLogin, finishLogin, cancelLogin, logout };
+}
+
+// --- Clipboard, links -------------------------------------------------------
+
+export const desktopClipboard: ProductClipboard = {
+  writeText(value: string): Promise<void> {
+    return copyText(value);
+  },
+};
+
+export const desktopProductLinks: ProductLinks = {
+  openExternal(url: string): Promise<void> {
+    return openExternal(url);
+  },
+  buildReturnUrl(entry: ProductEntry): string {
+    return encodeDesktopReturnUrl(entry);
+  },
+  observeInboundEntries(listener: (entry: ProductEntry) => void): () => void {
+    return subscribeDeepLinkUrls((url) => {
+      const entry = decodeDesktopProductEntry(url);
+      if (entry !== null) {
+        listener(entry);
+      }
+    });
+  },
+};
+
+// --- Telemetry --------------------------------------------------------------
+
+// The last resolved Desktop telemetry route, held across the process so a
+// repeat pathname resolving to the same route suppresses a duplicate emission
+// (mirroring use-telemetry-route-views).
+let previousTelemetryRoute: DesktopTelemetryRoute | null = null;
+
+export const desktopTelemetry: ProductTelemetry = {
+  track({ name, properties }): void {
+    // Boundary adaptation: the shared event is open-typed while the Desktop
+    // sink is keyed by DesktopProductEventMap. The concrete event catalog is
+    // owned by the emitting product code, so this is a localized cast.
+    trackProductEvent(name as never, properties as never);
+  },
+  captureException(error, context): void {
+    captureTelemetryException(
+      error,
+      context as Parameters<typeof captureTelemetryException>[1],
+    );
+  },
+  setUser(user): void {
+    if (user) {
+      // setTelemetryUser needs the Desktop AuthUser shape; construct the
+      // minimal identity fields it reads from the mapped ProductAuthUser.
+      setTelemetryUser({
+        id: user.id,
+        email: user.email ?? "",
+        display_name: user.displayName ?? null,
+      });
+      return;
+    }
+    clearTelemetryUser();
+  },
+  setTag(key: string, value: string): void {
+    setTelemetryTag(key, value);
+  },
+  routeChanged(pathname: string): void {
+    const route = resolveDesktopTelemetryRoute(pathname);
+    if (previousTelemetryRoute === route) {
+      return;
+    }
+    previousTelemetryRoute = route;
+    setTelemetryTag("route", route);
+    trackProductEvent("screen_viewed", { route });
+  },
+  getSupportContext() {
+    return {
+      clientReleaseId: getSupportReportReleaseId(),
+      telemetryRefs: getSupportReportTelemetryRefs(),
+    };
+  },
+};
+
+// Test-only: reset the module-held route ref so route-suppression tests start
+// from a clean slate.
+export function __resetDesktopTelemetryRouteForTest(): void {
+  previousTelemetryRoute = null;
+}

--- a/apps/packages/product-client/src/host/product-host.ts
+++ b/apps/packages/product-client/src/host/product-host.ts
@@ -215,9 +215,12 @@ export interface ProductLinks {
    */
   buildReturnUrl(entry: ProductEntry): string;
   /**
-   * Deliver host-decoded inbound entries (initial + live) to shared routing.
-   * The listener receives any entry that arrived before subscription as well
-   * as every subsequent one; returns an unsubscribe function. This is how
+   * Deliver host-decoded inbound entries (initial + live) to shared routing;
+   * returns an unsubscribe function. "Initial + live" is bounded: the listener
+   * receives the host's current snapshot at subscription time (e.g. the deep
+   * link the process launched with) plus every entry that arrives after it
+   * subscribes. It does not replay live events that arrived before this
+   * listener mounted, and the host keeps no persistence or queue. This is how
    * Desktop OS deep links and Web callback entries reach ProductClient.
    */
   observeInboundEntries(listener: (entry: ProductEntry) => void): () => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@proliferate/design':
         specifier: workspace:*
         version: link:../packages/design
+      '@proliferate/product-client':
+        specifier: workspace:*
+        version: link:../packages/product-client
       '@proliferate/product-domain':
         specifier: workspace:*
         version: link:../packages/product-domain

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -172,6 +172,7 @@ function ensureFrontendBuilt(): void {
     { filter: "@proliferate/cloud-sdk-react", path: "cloud/sdk-react" },
     { filter: "@proliferate/design", path: "apps/packages/design" },
     { filter: "@proliferate/product-domain", path: "apps/packages/product-domain" },
+    { filter: "@proliferate/product-client", path: "apps/packages/product-client" },
     { filter: "@proliferate/ui", path: "apps/packages/ui" },
     { filter: "@proliferate/product-ui", path: "apps/packages/product-ui" },
     { filter: "@proliferate/product-surfaces", path: "apps/packages/product-surfaces" },


### PR DESCRIPTION
Implements the frozen **D1a: Desktop Host Adoption** contract (`specs/codebase/features/web-desktop-client-unification-d1a.md`, revision D1a-r1), plus accepted first/second-review fixes.

- Base: `2ec15eaf8cfc870cbdbb42c225a5f1428e5282b4` (exact frozen base)
- Head: see latest commit (review fixes applied after `18a368288`; blocker round at `8b0ac73a3`; CI-001 fix follows)

## What this does
- `DesktopProductHostProvider` (mounted per §6 inside `CloudClientProvider`, above `WorkspaceProviders`) constructs one immutable `ProductHost` from existing Desktop state. Snapshot replacement follows the frozen table exactly: auth status, authenticated user identity fields (gated to authenticated status per HOST-001), normalized anonymous method list (gated to anonymous), or `cloudClient` reference — nothing else. Static adapters and callbacks keep stable identities across replacements.
- `lib/access/tauri/desktop-bridge.ts` exports the complete stable `DesktopBridge` as thin adapters per the §9 table (runtime URL mapping, race-safe sync menu-command unsubscribe, updater error→rejection + bounded 0..1 progress, worker stop-result discard, SSH `localUrl→runtimeUrl`, diagnostics arg mapping).
- Deep links: `deep-link.ts` multiplexes the raw Tauri source (one native live listener, per-subscription `getCurrent()` snapshot, race-safe sync unsubscribe, no queue/persistence/retry). `ensureDeepLinkBridge` keeps its original once-only memoization (LINK-001) and its sequential awaited initial drain with contained handler rejections (Greptile P1).
- `desktop-navigation.ts` gains pure `ProductEntry` encode/decode for the host path; `desktopNavigationTarget` builds routes from the raw query string, byte-identical to the base implementation including duplicate keys and exotic encodings (NAV-001).
- One auth-bootstrap owner: `AppRuntime` consumes `host.auth.restoreSession`; startup timing/diagnostics stay in `AppRuntime`. §7.2 login-request disposition implemented exactly.
- Running-agent count export moved into `DesktopProductLifecycleRoot` gated by `host.desktop` (only lifecycle moved).
- `ProductStorage` over guarded `window.localStorage`; no key migration.
- Narrow accepted expansions beyond the original §5 plan: `updater.ts` adapted to the real plugin 2.10.1 `DownloadEvent` union so update progress actually reports (UPDATER-001, reviewer-recommended), and `tests/intent/stack/boot.ts` adds ProductClient to the clean intent-stack frontend build (CI-001).
- Only ProductClient edit: `observeInboundEntries` doc clarification (bounded no-queue meaning); no TS shape change.

## Evidence (at review-fix head)
- `pnpm --filter @proliferate/product-client build` ✅
- Focused Vitest run over the 9 touched test files: **153/153 pass** ✅; tsc `--noEmit` clean ✅
- `pnpm --dir apps/desktop test` (exact frozen command) ❌ exits 1 in the pretest design-system check on pre-existing violations in unchanged files, reproduced identically at the frozen base (VERIFY-001 — explicit waiver requested; the Vitest failures in that run are the same 24 pre-existing ones as base)
- `pnpm --dir apps/desktop build` ✅ (tsc clean, vite build ok)
- `python3 scripts/report_frontend_structure.py --strict --summary-only` ✅ (TOTAL: 0)
- `git diff --check` ✅
- Named-profile Desktop smoke (`make run PROFILE=d1a-host`, prebuilt runtime per feature-worktree docs): rerun on the final head (VERIFY-002) — results recorded in PR comments.

## Assumptions / disclosed choices
- `settings/environments` (emitted by literal return URLs, absent from the current route table) decodes/encodes through `ProductEntry` for round-trips, but `desktopNavigationTarget` still returns `null` for it — no new deep-link destination.
- `settings/cloud|billing` decode to a `settings`/billing entry (query preserved) rather than `billing-return`; `billing-return` comes only from `billing/success|cancel`; status `"done"`, `workflow`, `invitation`, and settings-`general` reject from the encoder.
- `source=github_app_callback` is lifted into the typed `source` field; `github_app_installation_callback` stays in `query` (the ProductClient type was not widened).
- Anonymous method availability mirrors the login surfaces: `cloudEnabled && <probe>` for password/GitHub/SSO.
- The slug-SSO generic unavailable message is duplicated from `use-org-slug-sso-sign-in.ts` (not exported there; exporting would exceed the frozen file plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)