### PR TITLE
feat(test): define the exact test matrix and verify every result (ETM1)

### DIFF
--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -5,11 +5,14 @@ live, what gates merges vs releases, and how a change decides which tests it
 must add. [`core-release-validation.md`](core-release-validation.md) owns the
 complete target guarantee and qualification semantics;
 [`qualification-runner-core.md`](qualification-runner-core.md) owns the frozen
-test runner and results-reporting contract: selection, run identity, one final
-result per selected test, the combined report, and diagnostic/strict behavior;
+test-runner foundation: run identity, normalized terminal states, and
+diagnostic/strict behavior;
 [`candidate-build-handoff.md`](candidate-build-handoff.md) owns the frozen
 candidate build map (`CandidateBuildMapV1`), its runner validation, and the
-report V2 candidate-artifact evidence;
+bounded candidate-artifact evidence first introduced in report V2;
+[`exact-test-matrix.md`](exact-test-matrix.md) owns the frozen exact-cell
+planning and execution contract, one explicit result per selected cell, and
+the current report V3 aggregate;
 [`release-worlds-and-fixtures.md`](release-worlds-and-fixtures.md),
 [`tier-3-scenario-contract.md`](tier-3-scenario-contract.md), and
 [`tier-4-scenario-contract.md`](tier-4-scenario-contract.md) own the live world

--- a/specs/developing/testing/candidate-build-handoff.md
+++ b/specs/developing/testing/candidate-build-handoff.md
@@ -234,6 +234,11 @@ comparison fails.
 
 ## Report V2
 
+Successor: [`exact-test-matrix.md`](exact-test-matrix.md) advances the
+combined report to `TestRunReportV3` (exact selected cells and cell results).
+`candidate_build` and its validation/redaction guarantees carry forward
+unchanged into V3; V2 is recorded repository history.
+
 Adding artifact identity changes the aggregate evidence contract, so the
 runner emits `TestRunReportV2` rather than silently changing V1:
 

--- a/specs/developing/testing/candidate-build-handoff.md
+++ b/specs/developing/testing/candidate-build-handoff.md
@@ -5,7 +5,12 @@
   `draft-7-candidate-only`; founder-authorized 2026-07-14)
 - Repository: `proliferate-ai/proliferate`
 - Base SHA: `7850bcffd84263aca0d65a7fcd46743b8145adbe`
-- Pipeline stage: **specification frozen; implementation in progress**
+- Pipeline stage: **implemented and merged in PR #1159**
+
+[`exact-test-matrix.md`](exact-test-matrix.md) preserves the candidate evidence
+introduced by report V2 while advancing the runner's current aggregate to
+report V3. This document remains authoritative for candidate build-map,
+materialization, and AnyHarness handoff behavior.
 
 ## Outcome
 

--- a/specs/developing/testing/exact-test-matrix.md
+++ b/specs/developing/testing/exact-test-matrix.md
@@ -1,0 +1,392 @@
+# Define the Exact Test Matrix and Verify Every Result
+
+- Status: **frozen**
+- Revision: **ETM1-frozen-1**
+- Repository: `proliferate-ai/proliferate`
+- Base SHA: `aafad3ff2456ff0945ab0b61d5f58a883f6a48aa`
+- Founder authorized: 2026-07-14
+- Pipeline stage: **specification frozen; implementation not started**
+
+## Outcome
+
+Extend the existing release runner so every independently judged test is
+selected and reported separately, even when one scenario shares setup across
+several tests.
+
+```text
+select scenarios
+→ deterministically list their exact test cells
+→ validate the candidate build
+→ perform setup
+→ let each scenario batch its related cells
+→ require one explicit result per planned cell
+→ write one report
+→ reject any missing, duplicate, or unplanned result
+```
+
+This slice does not create servers, sandboxes, EC2 instances, provider
+clients, fixtures, or complete product journeys. It makes the existing runner
+capable of representing those journeys truthfully when later slices add them.
+
+## Concrete defect
+
+The current runner selects one broad test for each `scenario × runtime lane`:
+
+```text
+T3-CHAT-1/local
+```
+
+That scenario internally loops over five harnesses. It can log that Codex
+failed, observe that Claude passed, return normally, and leave the broad test
+green. The combined report then has no separate Codex result.
+
+Target:
+
+```text
+T3-CHAT-1/local/harness=claude
+T3-CHAT-1/local/harness=codex
+T3-CHAT-1/local/harness=cursor
+T3-CHAT-1/local/harness=grok
+T3-CHAT-1/local/harness=opencode
+```
+
+The scenario may still create one workspace and reuse shared setup. It must
+return a result for every assigned harness. One green harness cannot hide a
+failed, blocked, or omitted harness.
+
+`T3-CHAT-1` remains a legacy diagnostic scenario in this slice. Making its
+per-harness reporting honest does not claim that canonical `LOCAL-2` is
+implemented or that any target-manifest row is collected.
+
+## Existing foundations
+
+[`qualification-runner-core.md`](qualification-runner-core.md) provides:
+
+- diagnostic and strict behavior;
+- run, shard, attempt, and source identity;
+- result normalization;
+- strict fail-closed preflight;
+- missing/duplicate detection;
+- one sanitized combined report; and
+- report-derived exit codes.
+
+[`candidate-build-handoff.md`](candidate-build-handoff.md) provides:
+
+- exact candidate build-map validation before setup;
+- bounded candidate artifact evidence;
+- exact AnyHarness materialization/launch/health proof; and
+- the CI job that runs release-runner tests, typechecking, and the real
+  AnyHarness handoff smoke.
+
+This slice changes the selected unit from a broad scenario invocation to an
+exact child test cell. It extends the existing `ResultTracker` and
+`validateReport()`; it does not build a second aggregation system.
+
+## Current to target flow
+
+Current:
+
+```text
+parse arguments
+→ create run identity
+→ select scenarios
+→ validate candidate build map
+→ perform local-user/gateway setup
+→ expand one broad test per scenario/runtime lane
+→ execute each broad scenario
+→ write report V2
+```
+
+Target:
+
+```text
+parse arguments
+→ create run identity
+→ select scenarios
+→ validate candidate build map
+→ deterministically expand and validate every selected test cell
+→ only then perform local-user/gateway setup
+→ preflight the exact cells
+→ group runnable cells by scenario/runtime lane
+→ invoke each collector once with its assigned cells
+→ record every returned child result
+→ synthesize omitted cells as missing
+→ derive the existing diagnostic/strict verdict
+→ validate and write report V3
+```
+
+Invalid or empty cell expansion exits `2`, writes no report, and runs no user,
+gateway, provider, fixture, or scenario setup.
+
+## Test-cell contract
+
+The selected-cell array is the complete test plan for this invocation. A
+separate plan file or plan hash is deferred until a real cross-job or
+promotion consumer exists.
+
+```ts
+interface PlannedCellV1 {
+  cell_id: string;
+  scenario_id: string;
+  registry_flow_ref: string;
+  runtime_lane: RuntimeLane;
+  dimensions: Record<string, string>;
+  required_env: string[];
+}
+
+interface ScenarioCellSpec {
+  dimensions: Record<string, string>;
+  requiredEnv?: readonly string[];
+}
+
+interface ScenarioCellOutcome {
+  cellId: string;
+  status: "green" | "failed" | "blocked" | "expected_fail";
+  reason?: ResultReason;
+}
+```
+
+Runner-only terminal states remain `cancelled`, `not_run`, and `missing`.
+Scenario code cannot self-declare those states.
+
+### Scenario definitions
+
+Existing one-cell scenarios remain source-compatible:
+
+```ts
+interface LeafScenarioDefinition extends ScenarioBase {
+  kind?: "leaf";
+  plan(ctx: ScenarioPlanContext): ScenarioPlanStep[];
+  run(ctx: ScenarioRunContext): Promise<void>;
+}
+```
+
+A matrix scenario explicitly declares and reports its child cells:
+
+```ts
+interface MatrixScenarioDefinition extends ScenarioBase {
+  kind: "matrix";
+  expandCells(
+    ctx: ScenarioPlanContext,
+  ): ScenarioCellSpec[] | Promise<ScenarioCellSpec[]>;
+  planCell(
+    ctx: ScenarioPlanContext,
+    cell: PlannedCellV1,
+  ): ScenarioPlanStep[];
+  runCells(
+    ctx: ScenarioRunContext,
+    cells: readonly PlannedCellV1[],
+  ): Promise<ScenarioCellOutcome[]>;
+}
+
+type ScenarioDefinition = LeafScenarioDefinition | MatrixScenarioDefinition;
+```
+
+The runner invokes `runCells()` once per selected scenario/runtime lane, not
+once per child. This preserves efficient shared setup.
+
+## Cell identity
+
+The runner, not scenario code, creates cell IDs.
+
+- Existing leaf cell: `T3-BILL-1/local`
+- Matrix cell: `T3-CHAT-1/local/harness=claude`
+- Dimension keys are sorted lexicographically.
+- Keys are bounded stable identifiers; values are non-empty and safely
+  encoded.
+- Empty, duplicate, or invalid expansions fail before setup.
+- The final selected-cell list is sorted by `cell_id`.
+- Runtime-discovered values such as the exact probed model are execution
+  evidence, not cell dimensions, unless a later product contract makes them
+  independently required claims.
+
+Leaf IDs remain unchanged so existing scenarios and issue references do not
+move unnecessarily.
+
+## Execution and failure behavior
+
+- A leaf scenario keeps its current `run(): Promise<void>` behavior.
+- A matrix collector must return exactly one outcome for every assigned cell.
+- Mixed outcomes stay mixed; returning normally never turns all children
+  green.
+- An unknown or duplicate returned `cellId` is an integrity error.
+- An omitted cell is synthesized as `missing`, records an integrity error,
+  rejects the aggregate, and exits `2`.
+- If a collector throws before returning, its normalized thrown outcome is
+  applied to every runnable cell assigned to that invocation.
+- Independent scenario/runtime collectors continue after one collector fails.
+- `--dry-run` emits one `not_run` result and plan steps per exact cell.
+- Strict preflight with any missing requirement executes zero collector
+  bodies: affected cells are `blocked`, otherwise-runnable cells are
+  `cancelled`, and the command exits nonzero.
+- Diagnostic preflight blocks only affected cells and continues independent
+  runnable cells.
+
+| Situation | Diagnostic | Strict |
+| --- | --- | --- |
+| Every exact cell green | exit `0`, non-qualifying | exit `0`, selected cells passed |
+| Only blocked / expected-fail / dry-run cells | exit `0`, non-qualifying | exit `1` |
+| One ordinary failed or cancelled cell | exit `1`, non-qualifying | exit `1` |
+| Missing, duplicate, unknown result or runner defect | exit `2`, non-qualifying | exit `2` |
+
+The report remains explicitly partial. Passing selected cells is not a claim
+that all Tier 3 or Tier 4 guarantees are implemented.
+
+## Combined report V3
+
+The semantic result unit changes, so the report schema advances rather than
+silently changing V2:
+
+```ts
+interface TestRunReportV3 {
+  schema_version: 3;
+  kind: "proliferate.test-run";
+  candidate_build: CandidateBuildEvidenceV1 | null;
+  run: ExistingRunIdentityAndModeFields;
+  inputs: ExistingCliInputFields;
+  selected_cells: PlannedCellV1[];
+  results: FinalCellResultV1[];
+  summary: ExistingSummaryFields;
+  verdict: {
+    status:
+      | "selected_cells_passed"
+      | "selected_cells_failed"
+      | "non_qualifying";
+    scope: "selected_cells";
+    completeness: "partial";
+    reasons: string[];
+  };
+}
+```
+
+`FinalCellResultV1` repeats the planned cell's identity and dimensions plus the
+existing timestamps, status, reason, and plan steps.
+
+`validateReport()` remains the aggregate verifier. It must:
+
+- reject duplicate selected cell IDs;
+- require exact selected-cell/result ID equality;
+- require every result's scenario, lane, reference, and dimensions to match
+  its selected cell;
+- require summary counts to match the result array;
+- preserve candidate-evidence validation and redaction;
+- recompute the verdict and intended exit code; and
+- reject V3 shape tampering.
+
+Current execution emits only V3. Repository history retains V1 and V2; no
+parallel old/new execution path remains.
+
+## First real matrix consumer
+
+Convert only `T3-CHAT-1` in this slice.
+
+- `--agents all` derives the five shipped harness kinds from
+  `catalogs/agents/catalog.json`, not a second hand-written list.
+- Explicit `--agents` selection produces one cell per selected harness.
+- The same expansion applies independently to local and sandbox runtime lanes.
+- Live probing may choose the cheapest usable model, but cannot remove a
+  planned harness.
+- No compatible model becomes an explicit `blocked` child.
+- A real turn/install/reopen failure becomes an explicit `failed` child.
+- The existing sandbox implementation gap becomes explicit non-green child
+  results rather than one green parent.
+- Existing shared workspace setup and cleanup remain batched.
+- No managed-gateway, BYOK, billing, host-parity, or configuration dimension
+  is claimed in this slice.
+- No canonical target-manifest row changes from `planned`.
+
+The exact AnyHarness candidate-handoff smoke remains separate from the product
+scenario registry. It is the required real regression proof that report V3
+did not break the merged build handoff.
+
+## Non-goals
+
+- Candidate builders beyond the merged AnyHarness handoff.
+- LiteLLM, GitHub, E2B, Stripe, AWS, DNS, ingress, or download setup.
+- Local-workspace, managed-cloud, self-host, or update-world construction.
+- Shared product fixtures or new product test journeys.
+- Named release policies/selectors or target-manifest status promotion.
+- Bidirectional manifest/collector coverage auditing.
+- World, host, service, artifact, isolation, readiness, or cleanup fields on
+  cells.
+- A separate plan artifact, plan digest, or aggregate-verifier subsystem.
+- Cross-shard aggregation, retry/attempt selection, CI attestation, or
+  production-promotion trust.
+- New CLI flags or GitHub Actions workflow design.
+- Migrating every existing scenario to a matrix.
+
+## File plan
+
+```text
+tests/release/src/
+  runner/
+    plan.ts                         add exact-cell expansion/validation
+    plan.test.ts                    add
+    result.ts                       selected cell/result types + tracker
+    result.test.ts                  exact child integrity cases
+    execute.ts                      consume prebuilt cells; batch collectors
+    execute.test.ts                 matrix + strict/diagnostic behavior
+  scenarios/
+    types.ts                        leaf/matrix discriminated contract
+    t3-chat-1.ts                    first real matrix consumer
+    t3-chat-1.test.ts               catalog expansion + honest outcomes
+  cli/
+    command.ts                      create cells before setup; pass to runner
+    command.test.ts                 zero-side-effect planning failures
+  evidence/
+    schema.ts                       replace current report output with V3
+    write.ts                        V3 type update
+    write.test.ts                   V3 validation/write tests
+  report/
+    failure-reporter.ts             use exact cell identity
+    failure-reporter.test.ts        update
+  artifacts/
+    anyharness-smoke.ts             consume/assert report V3 only
+    anyharness-smoke.test.ts        update
+
+specs/developing/testing/
+  exact-test-matrix.md              this contract
+  qualification-runner-core.md      record successor/report terminology
+  candidate-build-handoff.md        record report V3 successor
+  README.md                         link this contract
+```
+
+Delete `expandSelectedTests()` when the exact-cell planner replaces it. Do not
+leave two planning paths. No workflow file should change: the existing
+Candidate build handoff CI job already runs the relevant test, typecheck, and
+real smoke commands.
+
+## Acceptance tests
+
+- Leaf scenarios retain one unchanged `scenario/lane` cell.
+- Matrix cell IDs and ordering are deterministic regardless of declaration or
+  selector order.
+- Invalid, empty, or duplicate expansion exits `2` before setup and writes no
+  report.
+- A fake three-cell collector returning green/failed/green preserves all three
+  outcomes and strict exits `1`.
+- Missing, duplicate, and unknown child outcomes force integrity exit `2`.
+- A one-child matrix still must return one explicit child outcome.
+- A collector-level throw finalizes all assigned runnable cells honestly.
+- Diagnostic and strict cell-level preflight retain the merged behavior.
+- Dry-run lists and reports every exact cell without executing collectors.
+- Report V3 rejects any selected/result identity or dimension mismatch and
+  recomputes verdict/exit.
+- `T3-CHAT-1 --agents all` plans every catalog harness exactly once per lane.
+- One failed or omitted T3 chat harness cannot be hidden by another green
+  harness.
+- Existing redaction, issue-filing, candidate-map, and runner tests remain
+  green.
+- The real candidate AnyHarness handoff still launches the exact binary and
+  produces valid V3 evidence.
+
+Required proof:
+
+```bash
+pnpm -C tests/release test
+pnpm -C tests/release typecheck
+node --test scripts/ci-cd/assemble-candidate-build-map.test.mjs
+make qualification-candidate-handoff-smoke
+```
+
+No live provider credential is required.

--- a/specs/developing/testing/qualification-runner-core.md
+++ b/specs/developing/testing/qualification-runner-core.md
@@ -4,6 +4,15 @@ Status: frozen implementation contract for the first qualification-platform
 slice. Revision: `Q1-frozen-2`. Audited base:
 `2ec15eaf8cfc870cbdbb42c225a5f1428e5282b4`.
 
+Successor: [`exact-test-matrix.md`](exact-test-matrix.md) (ETM1) changes the
+selected unit from one broad `scenario/lane` test to an exact test cell
+(matrix children like `T3-CHAT-1/local/harness=codex`), renames the report's
+selected/result arrays and verdict vocabulary accordingly, and advances the
+combined report to `TestRunReportV3`. This document remains the contract of
+record for run identity, normalization, diagnostic/strict behavior,
+missing/duplicate integrity, sanitization, and report-derived exit codes,
+which ETM1 extends rather than replaces.
+
 ## Outcome
 
 The release-test command runs the selected tests and truthfully reports what

--- a/specs/developing/testing/qualification-runner-core.md
+++ b/specs/developing/testing/qualification-runner-core.md
@@ -22,6 +22,15 @@ This contract owns test selection, run identity, normalized results, the
 combined report, and diagnostic/strict exit behavior. It does not provision
 providers or worlds, build candidates, or add scenarios.
 
+## Successor boundary
+
+[`exact-test-matrix.md`](exact-test-matrix.md) preserves this contract's run
+identity, terminal-state normalization, preflight, diagnostic/strict policy,
+and report-derived exits while replacing the selected unit with exact child
+test cells and advancing the combined report to V3. This document records the
+frozen foundation as implemented; the successor document owns current
+selected-cell and report shape.
+
 ## Vocabulary
 
 A **selected test** is one current `ScenarioDefinition` expanded across one of

--- a/tests/release/src/artifacts/anyharness-smoke.ts
+++ b/tests/release/src/artifacts/anyharness-smoke.ts
@@ -255,8 +255,15 @@ async function mainFromCli(): Promise<void> {
     const packageDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
     await runRunner(packageDir, mapPath, outputDir);
     const report = JSON.parse(await readFile(await findReport(outputDir), "utf8")) as {
+      schema_version: number;
       candidate_build: { artifacts: Array<{ artifact_id: string; version: string; sha256: string }> } | null;
+      selected_cells?: unknown[];
     };
+    // The smoke consumes report V3 only — a runner emitting an older schema
+    // (or an empty exact-cell plan) is a regression, not acceptable evidence.
+    if (report.schema_version !== 3 || !Array.isArray(report.selected_cells) || report.selected_cells.length === 0) {
+      throw new Error("Runner did not produce a valid schema_version 3 report with a non-empty exact-cell plan.");
+    }
     const expected = toCandidateBuildEvidence(map);
     if (JSON.stringify(report.candidate_build) !== JSON.stringify(expected)) {
       throw new Error("Report candidate_build does not equal the launched build map identity.");

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { runReleaseCommand, type CommandDeps } from "./command.js";
 import { BuildMapError, type CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
-import type { TestRunReportV2 } from "../evidence/schema.js";
+import type { TestRunReportV3 } from "../evidence/schema.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
 
@@ -42,14 +42,14 @@ const VALID_MAP: CandidateBuildMapV1 = {
   ],
 };
 
-function fakeReport(candidateBuild: TestRunReportV2["candidate_build"]): TestRunReportV2 {
+function fakeReport(candidateBuild: TestRunReportV3["candidate_build"]): TestRunReportV3 {
   const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
     FinalTestStatus,
     number
   >;
   byStatus.green = 1;
   return {
-    schema_version: 2,
+    schema_version: 3,
     kind: "proliferate.test-run",
     candidate_build: candidateBuild,
     run: {
@@ -60,15 +60,23 @@ function fakeReport(candidateBuild: TestRunReportV2["candidate_build"]): TestRun
       finished_at: "2026-07-14T00:00:01Z",
     },
     inputs: { target_lane: "local", desktop: "web", agents: "all", scenarios: "all" },
-    selected_tests: [
-      { test_id: "T3-FAKE/local", scenario_id: "T3-FAKE", registry_flow_ref: "specs#T3-FAKE", runtime_lane: "local" },
-    ],
-    results: [
+    selected_cells: [
       {
-        test_id: "T3-FAKE/local",
+        cell_id: "T3-FAKE/local",
         scenario_id: "T3-FAKE",
         registry_flow_ref: "specs#T3-FAKE",
         runtime_lane: "local",
+        dimensions: {},
+        required_env: [],
+      },
+    ],
+    results: [
+      {
+        cell_id: "T3-FAKE/local",
+        scenario_id: "T3-FAKE",
+        registry_flow_ref: "specs#T3-FAKE",
+        runtime_lane: "local",
+        dimensions: {},
         status: "green",
         started_at: null,
         finished_at: "2026-07-14T00:00:01Z",
@@ -85,7 +93,7 @@ function fakeReport(candidateBuild: TestRunReportV2["candidate_build"]): TestRun
       runner_errors: [],
       intended_exit_code: 0,
     },
-    verdict: { status: "non_qualifying", scope: "selected_tests", completeness: "partial", reasons: [] },
+    verdict: { status: "non_qualifying", scope: "selected_cells", completeness: "partial", reasons: [] },
   };
 }
 
@@ -197,7 +205,7 @@ test("--help exits 0 without identity, map loading, or a report", async () => {
 });
 
 test("the validated map's evidence reaches execute and the written report", async () => {
-  let written: TestRunReportV2 | undefined;
+  let written: TestRunReportV3 | undefined;
   const { deps } = makeDeps();
   deps.write = async (_outputDir, report) => {
     written = report;
@@ -222,4 +230,40 @@ test("a report write failure still exits 2", async () => {
   };
   const exit = await runReleaseCommand(["--behavior", "diagnostic"], deps);
   assert.equal(exit, 2);
+});
+
+test("an invalid cell expansion exits 2 before any setup side effect and writes no report", async () => {
+  const brokenMatrix = {
+    id: "T3-BROKEN",
+    title: "broken matrix",
+    registryFlowRef: "specs#T3-BROKEN",
+    lanes: ["local"],
+    requiredEnv: [],
+    kind: "matrix",
+    expandCells: () => {
+      throw new Error("expansion bug");
+    },
+    planCell: () => [],
+    runCells: async () => [],
+  } as const;
+  const { deps, calls } = makeDeps();
+  deps.selectScenarios = () => {
+    calls.push("select");
+    return [brokenMatrix as unknown as ScenarioDefinition];
+  };
+  const exit = await runReleaseCommand(["--behavior", "diagnostic"], deps);
+  assert.equal(exit, 2);
+  // Identity and selection happen, planning fails; zero user/gateway/
+  // provider/fixture/scenario setup and no report write follow.
+  assert.deepEqual(calls, ["identity", "select"]);
+});
+
+test("planning happens after map validation and before setup in the dependency order", async () => {
+  const { deps, calls } = makeDeps();
+  const exit = await runReleaseCommand(
+    ["--behavior", "diagnostic", "--candidate-build-map", "/tmp/map.json"],
+    deps,
+  );
+  assert.equal(exit, 0);
+  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "seed", "gateway", "envManifest", "execute", "write"]);
 });

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -19,7 +19,7 @@ import type { TestRunReportV3 } from "../evidence/schema.js";
  * (specs/developing/testing/candidate-build-handoff.md "Runner integration").
  * The required ordering is encoded here: parse → identity → selection →
  * candidate-build-map validation → only then local-user/gateway setup →
- * execute → write report V2 → auxiliary issue filing → persisted exit.
+ * execute → write report V3 → auxiliary issue filing → persisted exit.
  * `cli/run.ts` stays a thin process adapter supplying the real side-effect
  * dependencies.
  */

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -3,14 +3,16 @@ import type { ScenarioDefinition } from "../scenarios/types.js";
 import type { FailureReport } from "../report/types.js";
 import { toFailureReports } from "../report/failure-reporter.js";
 import { IdentityError, type RunIdentityV1 } from "../runner/identity.js";
-import { executeSelectedTests, SelectionError } from "../runner/execute.js";
+import { executeSelectedCells } from "../runner/execute.js";
+import { buildPlannedCells, SelectionError } from "../runner/plan.js";
+import type { PlannedCellV1 } from "../runner/result.js";
 import {
   BuildMapError,
   toCandidateBuildEvidence,
   type CandidateBuildEvidenceV1,
   type CandidateBuildMapV1,
 } from "../artifacts/build-map.js";
-import type { TestRunReportV2 } from "../evidence/schema.js";
+import type { TestRunReportV3 } from "../evidence/schema.js";
 
 /**
  * Testable command orchestration
@@ -33,8 +35,8 @@ export interface CommandDeps {
   seedLocalDurableUser: (seeded: Set<string>) => Promise<void>;
   pushLocalGatewayAuth: () => Promise<void>;
   printEnvManifestReport: () => void;
-  execute: typeof executeSelectedTests;
-  write: (outputDir: string, report: TestRunReportV2) => Promise<string>;
+  execute: typeof executeSelectedCells;
+  write: (outputDir: string, report: TestRunReportV3) => Promise<string>;
   fileIssues: (reports: readonly FailureReport[]) => Promise<string[]>;
   log: (message: string) => void;
   error: (message: string) => void;
@@ -97,6 +99,21 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
     }
   }
 
+  // The exact test plan is expanded and validated deterministically after
+  // the candidate map and before any setup side effect: invalid, empty, or
+  // duplicate expansion exits 2, writes no report, and runs zero
+  // user/gateway/provider/fixture/scenario setup.
+  let cells: PlannedCellV1[];
+  try {
+    cells = await buildPlannedCells(scenarios, {
+      desktop: args.desktop,
+      agents: args.agents === "all" ? ["all"] : args.agents,
+    });
+  } catch (error) {
+    deps.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+
   // Local lane self-seeds its durable user per run (Part 2 of #1069): the CI
   // local lane boots a fresh, ephemeral server, so it mints the durable
   // identity through the real /setup claim instead of depending on a repo
@@ -109,7 +126,7 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
 
   deps.printEnvManifestReport();
 
-  let report: TestRunReportV2;
+  let report: TestRunReportV3;
   try {
     report = await deps.execute({
       behavior: args.behavior,
@@ -117,6 +134,7 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
       identity,
       inputs: { targetLane: args.lane, desktop: args.desktop, agents: args.agents, scenarios: args.scenarios },
       scenarios,
+      cells,
       locallySeeded,
       candidateBuild,
       log: (message) => deps.log(`  ${message}`),
@@ -163,7 +181,7 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
   return report.summary.intended_exit_code;
 }
 
-function printSummary(report: TestRunReportV2, deps: Pick<CommandDeps, "log" | "error">): void {
+function printSummary(report: TestRunReportV3, deps: Pick<CommandDeps, "log" | "error">): void {
   const counts = report.summary.by_status;
   deps.log(
     `\n${counts.green} green, ${counts.failed} failed, ${counts.blocked} blocked, ` +
@@ -174,7 +192,7 @@ function printSummary(report: TestRunReportV2, deps: Pick<CommandDeps, "log" | "
   for (const result of report.results) {
     if (result.status !== "green") {
       const reason = result.reason ? ` — ${firstLine(result.reason.message)}` : "";
-      deps.log(`  [${result.status}] ${result.test_id}${reason}`);
+      deps.log(`  [${result.status}] ${result.cell_id}${reason}`);
     }
   }
   for (const error of report.summary.integrity_errors) {

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -10,7 +10,7 @@ import {
 } from "../fixtures/identity.js";
 import { fileIssuesForFailures } from "../report/issue-filer.js";
 import { resolveRunIdentity } from "../runner/identity.js";
-import { executeSelectedTests } from "../runner/execute.js";
+import { executeSelectedCells } from "../runner/execute.js";
 import { loadCandidateBuildMap } from "../artifacts/build-map.js";
 import { writeReport } from "../evidence/write.js";
 
@@ -122,7 +122,7 @@ process.exitCode = await runReleaseCommand(process.argv.slice(2), {
   seedLocalDurableUser,
   pushLocalGatewayAuth,
   printEnvManifestReport,
-  execute: executeSelectedTests,
+  execute: executeSelectedCells,
   write: writeReport,
   fileIssues: fileIssuesForFailures,
   log: (message) => console.log(message),

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -1,6 +1,7 @@
 import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
 import type { CandidateBuildEvidenceV1 } from "../artifacts/build-map.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
+import { canonicalCellId } from "../runner/plan.js";
 import {
   ALL_FINAL_STATUSES,
   deriveVerdict,
@@ -144,6 +145,10 @@ export function redactExternalPayloads(message: string): string {
 export function sanitizeReport(report: TestRunReportV3, secretValues: readonly string[]): TestRunReportV3 {
   const clean = (message: string): string =>
     boundMessage(redactExternalPayloads(redactUrlCredentials(redactSecrets(message, secretValues))));
+  // Structured identity fields (cell ids, dimension keys/values) cannot be
+  // redacted without making the evidence ambiguous, so a resolved secret
+  // appearing there fails closed: no report is produced at all.
+  assertNoSecretsInIdentity(report, secretValues);
   return {
     ...report,
     results: report.results.map((result) => ({
@@ -164,6 +169,34 @@ export function sanitizeReport(report: TestRunReportV3, secretValues: readonly s
 }
 
 /**
+ * Rejects a report whose structured identity fields carry a resolved secret
+ * value. Exported for the writer-side tests; execution calls it through
+ * `sanitizeReport`.
+ */
+export function assertNoSecretsInIdentity(report: TestRunReportV3, secretValues: readonly string[]): void {
+  const secrets = secretValues.filter((secret) => secret.length > 0);
+  if (secrets.length === 0) {
+    return;
+  }
+  const identityStrings: string[] = [];
+  for (const cell of report.selected_cells) {
+    identityStrings.push(cell.cell_id, ...Object.keys(cell.dimensions), ...Object.values(cell.dimensions));
+  }
+  for (const result of report.results) {
+    identityStrings.push(result.cell_id, ...Object.keys(result.dimensions), ...Object.values(result.dimensions));
+  }
+  for (const value of identityStrings) {
+    for (const secret of secrets) {
+      if (value.includes(secret)) {
+        throw new ReportValidationError(
+          "A resolved secret value appears in a cell id or dimension; refusing to produce evidence.",
+        );
+      }
+    }
+  }
+}
+
+/**
  * Validates the report invariants before writing: unique + exactly-equal
  * selected/result test ids, finalized counts, all seven status keys with
  * exact counts, and verdict/exit consistency.
@@ -171,6 +204,20 @@ export function sanitizeReport(report: TestRunReportV3, secretValues: readonly s
 export function validateReport(report: TestRunReportV3): void {
   if (report.schema_version !== 3 || report.kind !== "proliferate.test-run") {
     throw new ReportValidationError("Report must be schema_version 3, kind proliferate.test-run.");
+  }
+  if (report.run.behavior !== "diagnostic" && report.run.behavior !== "strict") {
+    throw new ReportValidationError(`Unknown behavior "${report.run.behavior}".`);
+  }
+  if (report.run.execution !== "real" && report.run.execution !== "dry_run") {
+    throw new ReportValidationError(`Unknown execution mode "${report.run.execution}".`);
+  }
+  if (report.verdict.scope !== "selected_cells" || report.verdict.completeness !== "partial") {
+    throw new ReportValidationError(
+      "Verdict scope/completeness must be selected_cells/partial; this report cannot claim more.",
+    );
+  }
+  if (report.selected_cells.length === 0) {
+    throw new ReportValidationError("A report with zero selected cells is not representable evidence.");
   }
   validateCandidateBuildEvidence(report.candidate_build);
   // Strict evidence must name the exact bytes it qualified: only diagnostic
@@ -190,6 +237,28 @@ export function validateReport(report: TestRunReportV3): void {
   const selectedSet = new Set(selectedIds);
   if (resultIds.length !== selectedIds.length || !resultIds.every((id) => selectedSet.has(id))) {
     throw new ReportValidationError("Selected and result cell ids are not exactly equal sets.");
+  }
+
+  // Every selected cell's id must be re-derivable from its own
+  // scenario/lane/dimensions through the same canonical derivation the
+  // planner uses — a coordinated edit of cell_id and dimensions together
+  // still cannot validate.
+  for (const cell of report.selected_cells) {
+    if (cell.runtime_lane !== "local" && cell.runtime_lane !== "sandbox") {
+      throw new ReportValidationError(`Unknown runtime lane on "${cell.cell_id}".`);
+    }
+    if (
+      !Array.isArray(cell.required_env) ||
+      cell.required_env.some((name) => typeof name !== "string")
+    ) {
+      throw new ReportValidationError(`required_env on "${cell.cell_id}" is malformed.`);
+    }
+    const expectedId = canonicalCellId(cell.scenario_id, cell.runtime_lane, cell.dimensions ?? {});
+    if (cell.cell_id !== expectedId) {
+      throw new ReportValidationError(
+        `Selected cell id "${cell.cell_id}" is not the canonical id for its scenario/lane/dimensions.`,
+      );
+    }
   }
 
   // Every result must repeat its planned cell's identity and dimensions

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -4,25 +4,27 @@ import type { RunIdentityV1 } from "../runner/identity.js";
 import {
   ALL_FINAL_STATUSES,
   deriveVerdict,
-  type FinalTestResultV1,
+  type FinalCellResultV1,
   type FinalTestStatus,
   type IntegrityErrorV1,
+  type PlannedCellV1,
   type ResultBehavior,
   type RunnerErrorV1,
-  type SelectedTestV1,
   type VerdictStatus,
 } from "../runner/result.js";
 
 /**
  * The versioned combined-report contract, per
- * specs/developing/testing/qualification-runner-core.md ("Combined report")
- * plus specs/developing/testing/candidate-build-handoff.md ("Report V2"),
- * which adds bounded candidate-artifact identity. One artifact per
- * invocation/shard/attempt; validated before writing. V1 is the prior
- * contract recorded in repository history; current code emits only V2.
+ * specs/developing/testing/qualification-runner-core.md ("Combined report"),
+ * specs/developing/testing/candidate-build-handoff.md (candidate-artifact
+ * evidence), and specs/developing/testing/exact-test-matrix.md ("Combined
+ * report V3"), which changes the semantic result unit to an exact test cell.
+ * One artifact per invocation/shard/attempt; validated before writing. V1 and
+ * V2 are prior contracts recorded in repository history; current code emits
+ * only V3.
  */
-export interface TestRunReportV2 {
-  schema_version: 2;
+export interface TestRunReportV3 {
+  schema_version: 3;
   kind: "proliferate.test-run";
   /**
    * Artifact ID/version/SHA-256 from the validated candidate build map, or
@@ -42,8 +44,8 @@ export interface TestRunReportV2 {
     agents: string[] | "all";
     scenarios: string[] | "all";
   };
-  selected_tests: SelectedTestV1[];
-  results: FinalTestResultV1[];
+  selected_cells: PlannedCellV1[];
+  results: FinalCellResultV1[];
   summary: {
     selected: number;
     finalized: number;
@@ -54,7 +56,7 @@ export interface TestRunReportV2 {
   };
   verdict: {
     status: VerdictStatus;
-    scope: "selected_tests";
+    scope: "selected_cells";
     completeness: "partial";
     reasons: string[];
   };
@@ -139,7 +141,7 @@ export function redactExternalPayloads(message: string): string {
  * Runs before validation/serialization so no exact secret value or overlong
  * message can enter the persisted artifact.
  */
-export function sanitizeReport(report: TestRunReportV2, secretValues: readonly string[]): TestRunReportV2 {
+export function sanitizeReport(report: TestRunReportV3, secretValues: readonly string[]): TestRunReportV3 {
   const clean = (message: string): string =>
     boundMessage(redactExternalPayloads(redactUrlCredentials(redactSecrets(message, secretValues))));
   return {
@@ -166,9 +168,9 @@ export function sanitizeReport(report: TestRunReportV2, secretValues: readonly s
  * selected/result test ids, finalized counts, all seven status keys with
  * exact counts, and verdict/exit consistency.
  */
-export function validateReport(report: TestRunReportV2): void {
-  if (report.schema_version !== 2 || report.kind !== "proliferate.test-run") {
-    throw new ReportValidationError("Report must be schema_version 2, kind proliferate.test-run.");
+export function validateReport(report: TestRunReportV3): void {
+  if (report.schema_version !== 3 || report.kind !== "proliferate.test-run") {
+    throw new ReportValidationError("Report must be schema_version 3, kind proliferate.test-run.");
   }
   validateCandidateBuildEvidence(report.candidate_build);
   // Strict evidence must name the exact bytes it qualified: only diagnostic
@@ -177,17 +179,38 @@ export function validateReport(report: TestRunReportV2): void {
     throw new ReportValidationError("Strict reports require non-null candidate_build identity.");
   }
 
-  const selectedIds = report.selected_tests.map((test) => test.test_id);
-  const resultIds = report.results.map((result) => result.test_id);
+  const selectedIds = report.selected_cells.map((cell) => cell.cell_id);
+  const resultIds = report.results.map((result) => result.cell_id);
   if (new Set(selectedIds).size !== selectedIds.length) {
-    throw new ReportValidationError("Selected test ids are not unique.");
+    throw new ReportValidationError("Selected cell ids are not unique.");
   }
   if (new Set(resultIds).size !== resultIds.length) {
-    throw new ReportValidationError("Result test ids are not unique.");
+    throw new ReportValidationError("Result cell ids are not unique.");
   }
   const selectedSet = new Set(selectedIds);
   if (resultIds.length !== selectedIds.length || !resultIds.every((id) => selectedSet.has(id))) {
-    throw new ReportValidationError("Selected and result test ids are not exactly equal sets.");
+    throw new ReportValidationError("Selected and result cell ids are not exactly equal sets.");
+  }
+
+  // Every result must repeat its planned cell's identity and dimensions
+  // exactly — a result that drifts from its plan is tampered evidence.
+  const cellsById = new Map(report.selected_cells.map((cell) => [cell.cell_id, cell]));
+  for (const result of report.results) {
+    const cell = cellsById.get(result.cell_id)!;
+    if (
+      result.scenario_id !== cell.scenario_id ||
+      result.runtime_lane !== cell.runtime_lane ||
+      result.registry_flow_ref !== cell.registry_flow_ref
+    ) {
+      throw new ReportValidationError(
+        `Result "${result.cell_id}" does not match its planned cell's scenario/lane/reference.`,
+      );
+    }
+    const cellDims = JSON.stringify(Object.entries(cell.dimensions).sort());
+    const resultDims = JSON.stringify(Object.entries(result.dimensions ?? {}).sort());
+    if (cellDims !== resultDims) {
+      throw new ReportValidationError(`Result "${result.cell_id}" dimensions do not match its planned cell.`);
+    }
   }
 
   if (report.summary.selected !== selectedIds.length || report.summary.finalized !== report.results.length) {
@@ -216,7 +239,7 @@ export function validateReport(report: TestRunReportV2): void {
   const knownStatuses = new Set<string>(ALL_FINAL_STATUSES);
   for (const result of report.results) {
     if (!knownStatuses.has(result.status)) {
-      throw new ReportValidationError(`Unknown result status "${result.status}" for ${result.test_id}.`);
+      throw new ReportValidationError(`Unknown result status "${result.status}" for ${result.cell_id}.`);
     }
   }
 
@@ -233,7 +256,7 @@ export function validateReport(report: TestRunReportV2): void {
     );
     if (executed) {
       throw new ReportValidationError(
-        `Dry-run cannot produce a real result: ${executed.test_id} is "${executed.status}".`,
+        `Dry-run cannot produce a real result: ${executed.cell_id} is "${executed.status}".`,
       );
     }
   }

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -1,7 +1,7 @@
 import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
 import type { CandidateBuildEvidenceV1 } from "../artifacts/build-map.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
-import { canonicalCellId } from "../runner/plan.js";
+import { canonicalCellId, dimensionShapeProblem } from "../runner/plan.js";
 import {
   ALL_FINAL_STATUSES,
   deriveVerdict,
@@ -253,6 +253,14 @@ export function validateReport(report: TestRunReportV3): void {
     ) {
       throw new ReportValidationError(`required_env on "${cell.cell_id}" is malformed.`);
     }
+    // The planner's complete dimension rules apply to persisted evidence too:
+    // a report carrying dimensions the planner could never have produced
+    // (invalid keys, empty/oversized/non-string values) is not valid even if
+    // its cell id was edited consistently.
+    const dimensionProblem = dimensionShapeProblem(cell.dimensions);
+    if (dimensionProblem) {
+      throw new ReportValidationError(`Selected cell "${cell.cell_id}" has ${dimensionProblem}.`);
+    }
     const expectedId = canonicalCellId(cell.scenario_id, cell.runtime_lane, cell.dimensions ?? {});
     if (cell.cell_id !== expectedId) {
       throw new ReportValidationError(
@@ -359,12 +367,7 @@ export function validateReport(report: TestRunReportV3): void {
   // Recompute the complete verdict/exit policy from the results and errors
   // and require the persisted fields to match — the validator, not the
   // producer, is the last line against false-success evidence.
-  const expected = deriveVerdict({
-    behavior: report.run.behavior,
-    results: report.results,
-    integrityErrors: report.summary.integrity_errors,
-    runnerErrors: report.summary.runner_errors,
-  });
+  const expected = expectedVerdict(report);
   if (report.verdict.status !== expected.status) {
     throw new ReportValidationError(
       `Verdict "${report.verdict.status}" does not match the recomputed "${expected.status}".`,
@@ -375,6 +378,30 @@ export function validateReport(report: TestRunReportV3): void {
       `intended_exit_code ${report.summary.intended_exit_code} does not match the recomputed ${expected.intendedExitCode}.`,
     );
   }
+  // The reasons array is derived evidence too: arbitrary prose (e.g.
+  // "production fully qualified") must not validate.
+  if (JSON.stringify(report.verdict.reasons) !== JSON.stringify(expected.reasons)) {
+    throw new ReportValidationError("verdict.reasons do not match the recomputed derived reasons.");
+  }
+}
+
+/**
+ * The single derivation both the producer (runner/execute.ts, applied after
+ * sanitization) and this validator use for the persisted verdict, including
+ * the bounded reasons array.
+ */
+export function expectedVerdict(report: TestRunReportV3): {
+  status: VerdictStatus;
+  intendedExitCode: 0 | 1 | 2;
+  reasons: string[];
+} {
+  const derived = deriveVerdict({
+    behavior: report.run.behavior,
+    results: report.results,
+    integrityErrors: report.summary.integrity_errors,
+    runnerErrors: report.summary.runner_errors,
+  });
+  return { ...derived, reasons: derived.reasons.map(boundMessage) };
 }
 
 const EVIDENCE_SHA256_PATTERN = /^[0-9a-f]{64}$/;

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -312,7 +312,7 @@ const EVIDENCE_SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const EVIDENCE_ARTIFACT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/;
 
 /**
- * `candidate_build` must be present on every V2 report — an explicit null for
+ * `candidate_build` must be present on every report — an explicit null for
  * diagnostic omission, otherwise only bounded artifact ID/version/SHA-256
  * triples. Anything path-like, oversized, or extra is rejected so map paths
  * and raw map JSON can never masquerade as evidence.

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   assertNoSecretsInIdentity,
   boundMessage,
+  expectedVerdict,
   redactExternalPayloads,
   redactSecrets,
   redactUrlCredentials,
@@ -15,6 +16,7 @@ import {
   type TestRunReportV3,
 } from "./schema.js";
 import { reportPath, ReportWriteError, writeReport } from "./write.js";
+import { canonicalCellId } from "../runner/plan.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
 
 function validReport(overrides: Partial<TestRunReportV3> = {}): TestRunReportV3 {
@@ -77,6 +79,16 @@ function validReport(overrides: Partial<TestRunReportV3> = {}): TestRunReportV3 
   };
 }
 
+/**
+ * Reports carry derived reasons; after a test mutates behavior/results it
+ * re-derives them the same way the producer does, so validation exercises the
+ * field under test instead of tripping the reasons-equality check.
+ */
+function withDerivedReasons(report: TestRunReportV3): TestRunReportV3 {
+  report.verdict.reasons = expectedVerdict(report).reasons;
+  return report;
+}
+
 
 // Minimal valid candidate evidence for strict-report tests (strict requires
 // non-null candidate_build per CBH-001).
@@ -85,7 +97,7 @@ const STRICT_CB: TestRunReportV3["candidate_build"] = {
 };
 
 test("validateReport accepts a consistent report", () => {
-  validateReport(validReport());
+  validateReport(withDerivedReasons(validReport()));
 });
 
 test("validateReport rejects selected/result set mismatch and duplicates", () => {
@@ -132,7 +144,7 @@ test("validateReport enforces the strict verdict against results and errors", ()
   passing.run.behavior = "strict";
   passing.candidate_build = STRICT_CB;
   passing.verdict.status = "selected_cells_passed";
-  validateReport(passing);
+  validateReport(withDerivedReasons(passing));
 
   const mislabeled = validReport();
   mislabeled.run.behavior = "strict";
@@ -237,7 +249,7 @@ for (const [index, row] of MATRIX_ROWS.entries()) {
     }
     report.summary.intended_exit_code = row.exit;
     report.verdict.status = row.verdict;
-    validateReport(report);
+    validateReport(withDerivedReasons(report));
   });
 }
 
@@ -344,7 +356,7 @@ test("boundMessage caps at 4096 code points; redactSecrets replaces exact values
 test("writeReport writes one parseable artifact at the attempt path with trailing newline", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
   try {
-    const report = validReport();
+    const report = withDerivedReasons(validReport());
     const written = await writeReport(dir, report);
     assert.equal(written, path.join(dir, "run-1", "shard-1", "attempt-1", "qualification-evidence.json"));
     const raw = await readFile(written, "utf8");
@@ -360,8 +372,8 @@ test("writeReport writes one parseable artifact at the attempt path with trailin
 test("writeReport refuses to overwrite an existing attempt artifact", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
   try {
-    await writeReport(dir, validReport());
-    await assert.rejects(writeReport(dir, validReport()), ReportWriteError);
+    await writeReport(dir, withDerivedReasons(validReport()));
+    await assert.rejects(writeReport(dir, withDerivedReasons(validReport())), ReportWriteError);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -370,8 +382,8 @@ test("writeReport refuses to overwrite an existing attempt artifact", async () =
 test("distinct attempts write distinct non-overwriting paths", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-"));
   try {
-    const first = validReport();
-    const second = validReport();
+    const first = withDerivedReasons(validReport());
+    const second = withDerivedReasons(validReport());
     second.run.attempt = 2;
     const path1 = await writeReport(dir, first);
     const path2 = await writeReport(dir, second);
@@ -400,13 +412,13 @@ test("validateReport requires candidate_build to be present (null or evidence)",
 
   const withNull = validReport();
   withNull.candidate_build = null;
-  validateReport(withNull);
+  validateReport(withDerivedReasons(withNull));
 
   const withEvidence = validReport();
   withEvidence.candidate_build = {
     artifacts: [{ artifact_id: "anyharness/aarch64-apple-darwin", version: "0.3.27", sha256: "e".repeat(64) }],
   };
-  validateReport(withEvidence);
+  validateReport(withDerivedReasons(withEvidence));
 });
 
 test("validateReport rejects unsafe or path-carrying candidate evidence", () => {
@@ -487,7 +499,7 @@ test("strict reports require non-null candidate_build (CBH-001)", () => {
   strictWithEvidence.candidate_build = {
     artifacts: [{ artifact_id: "anyharness/x", version: "1", sha256: "e".repeat(64) }],
   };
-  validateReport(strictWithEvidence);
+  validateReport(withDerivedReasons(strictWithEvidence));
 });
 
 test("candidate_build rejects undeclared fields beside artifacts (CBH-002)", () => {
@@ -552,4 +564,39 @@ test("a resolved secret in a cell id or dimension fails closed (ETM-004)", () =>
 
   // Clean identities pass, and message redaction still applies elsewhere.
   assertNoSecretsInIdentity(validReport(), [secret]);
+});
+
+test("planner-impossible dimensions reject even with a consistently edited id (ETM-001)", () => {
+  const cases: Array<Record<string, unknown>> = [
+    { "Bad Key": "x" },
+    { harness: "" },
+    { harness: "x".repeat(200) },
+    { harness: ["array", "value"] },
+  ];
+  for (const dimensions of cases) {
+    const report = validReport();
+    const dims = dimensions as Record<string, string>;
+    // Edit the id consistently with the tampered dimensions so only the
+    // dimension-shape rule can catch it.
+    report.selected_cells[0].dimensions = dims;
+    report.results[0].dimensions = dims;
+    try {
+      const id = canonicalCellId("A", "local", dims);
+      report.selected_cells[0].cell_id = id;
+      report.results[0].cell_id = id;
+    } catch {
+      // encodeURIComponent can throw for exotic values; the raw id stays.
+    }
+    assert.throws(() => validateReport(report), ReportValidationError, JSON.stringify(dimensions));
+  }
+});
+
+test("arbitrary verdict reasons cannot validate (ETM-001)", () => {
+  const report = withDerivedReasons(validReport());
+  report.verdict.reasons = ["production fully qualified"];
+  assert.throws(() => validateReport(report), /reasons do not match/);
+
+  const appended = withDerivedReasons(validReport());
+  appended.verdict.reasons = [...appended.verdict.reasons, "and also fully audited"];
+  assert.throws(() => validateReport(appended), /reasons do not match/);
 });

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -11,19 +11,19 @@ import {
   redactUrlCredentials,
   ReportValidationError,
   validateReport,
-  type TestRunReportV2,
+  type TestRunReportV3,
 } from "./schema.js";
 import { reportPath, ReportWriteError, writeReport } from "./write.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
 
-function validReport(overrides: Partial<TestRunReportV2> = {}): TestRunReportV2 {
+function validReport(overrides: Partial<TestRunReportV3> = {}): TestRunReportV3 {
   const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
     FinalTestStatus,
     number
   >;
   byStatus.green = 1;
   return {
-    schema_version: 2,
+    schema_version: 3,
     kind: "proliferate.test-run",
     candidate_build: null,
     run: {
@@ -38,15 +38,23 @@ function validReport(overrides: Partial<TestRunReportV2> = {}): TestRunReportV2 
       finished_at: "2026-07-13T00:01:00Z",
     },
     inputs: { target_lane: "local", desktop: "web", agents: "all", scenarios: "all" },
-    selected_tests: [
-      { test_id: "A/local", scenario_id: "A", registry_flow_ref: "specs#A", runtime_lane: "local" },
-    ],
-    results: [
+    selected_cells: [
       {
-        test_id: "A/local",
+        cell_id: "A/local",
         scenario_id: "A",
         registry_flow_ref: "specs#A",
         runtime_lane: "local",
+        dimensions: {},
+        required_env: [],
+      },
+    ],
+    results: [
+      {
+        cell_id: "A/local",
+        scenario_id: "A",
+        registry_flow_ref: "specs#A",
+        runtime_lane: "local",
+        dimensions: {},
         status: "green",
         started_at: "2026-07-13T00:00:01Z",
         finished_at: "2026-07-13T00:00:59Z",
@@ -63,7 +71,7 @@ function validReport(overrides: Partial<TestRunReportV2> = {}): TestRunReportV2 
       runner_errors: [],
       intended_exit_code: 0,
     },
-    verdict: { status: "non_qualifying", scope: "selected_tests", completeness: "partial", reasons: [] },
+    verdict: { status: "non_qualifying", scope: "selected_cells", completeness: "partial", reasons: [] },
     ...overrides,
   };
 }
@@ -71,7 +79,7 @@ function validReport(overrides: Partial<TestRunReportV2> = {}): TestRunReportV2 
 
 // Minimal valid candidate evidence for strict-report tests (strict requires
 // non-null candidate_build per CBH-001).
-const STRICT_CB: TestRunReportV2["candidate_build"] = {
+const STRICT_CB: TestRunReportV3["candidate_build"] = {
   artifacts: [{ artifact_id: "anyharness/host", version: "1.0.0", sha256: "e".repeat(64) }],
 };
 
@@ -81,17 +89,19 @@ test("validateReport accepts a consistent report", () => {
 
 test("validateReport rejects selected/result set mismatch and duplicates", () => {
   const extraSelected = validReport();
-  extraSelected.selected_tests.push({
-    test_id: "B/local",
+  extraSelected.selected_cells.push({
+    cell_id: "B/local",
     scenario_id: "B",
     registry_flow_ref: "specs#B",
     runtime_lane: "local",
+    dimensions: {},
+    required_env: [],
   });
   extraSelected.summary.selected = 2;
   assert.throws(() => validateReport(extraSelected), ReportValidationError);
 
   const duplicated = validReport();
-  duplicated.selected_tests.push({ ...duplicated.selected_tests[0] });
+  duplicated.selected_cells.push({ ...duplicated.selected_cells[0] });
   assert.throws(() => validateReport(duplicated), ReportValidationError);
 });
 
@@ -112,7 +122,7 @@ test("validateReport rejects wrong counts, missing status keys, and count drift"
 
 test("validateReport rejects a diagnostic report that claims qualification", () => {
   const report = validReport();
-  report.verdict.status = "selected_tests_passed";
+  report.verdict.status = "selected_cells_passed";
   assert.throws(() => validateReport(report), ReportValidationError);
 });
 
@@ -120,19 +130,19 @@ test("validateReport enforces the strict verdict against results and errors", ()
   const passing = validReport();
   passing.run.behavior = "strict";
   passing.candidate_build = STRICT_CB;
-  passing.verdict.status = "selected_tests_passed";
+  passing.verdict.status = "selected_cells_passed";
   validateReport(passing);
 
   const mislabeled = validReport();
   mislabeled.run.behavior = "strict";
   mislabeled.candidate_build = STRICT_CB;
-  mislabeled.verdict.status = "selected_tests_failed";
+  mislabeled.verdict.status = "selected_cells_failed";
   assert.throws(() => validateReport(mislabeled), ReportValidationError);
 
   const errorButPassed = validReport();
   errorButPassed.run.behavior = "strict";
   errorButPassed.candidate_build = STRICT_CB;
-  errorButPassed.verdict.status = "selected_tests_passed";
+  errorButPassed.verdict.status = "selected_cells_passed";
   errorButPassed.summary.runner_errors = [{ code: "runner_error", message: "x" }];
   assert.throws(() => validateReport(errorButPassed), ReportValidationError);
 });
@@ -151,7 +161,7 @@ test("validateReport rejects false-success evidence: failed result with exit 0",
   strict.results[0].status = "failed";
   strict.summary.by_status.green = 0;
   strict.summary.by_status.failed = 1;
-  strict.verdict.status = "selected_tests_passed";
+  strict.verdict.status = "selected_cells_passed";
   assert.throws(() => validateReport(strict), ReportValidationError);
 });
 
@@ -172,16 +182,16 @@ test("validateReport rejects an unknown result status", () => {
 // Every verdict-matrix row must survive validation when produced honestly.
 // A `missing` result is only honest alongside its integrity error, which
 // forces exit 2.
-const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" | "strict"; exit: 0 | 1 | 2; verdict: TestRunReportV2["verdict"]["status"]; execution?: "real" | "dry_run"; integrity?: boolean }> = [
+const MATRIX_ROWS: Array<{ statuses: FinalTestStatus[]; behavior: "diagnostic" | "strict"; exit: 0 | 1 | 2; verdict: TestRunReportV3["verdict"]["status"]; execution?: "real" | "dry_run"; integrity?: boolean }> = [
   { statuses: ["green"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
-  { statuses: ["green"], behavior: "strict", exit: 0, verdict: "selected_tests_passed" },
+  { statuses: ["green"], behavior: "strict", exit: 0, verdict: "selected_cells_passed" },
   { statuses: ["blocked"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
-  { statuses: ["blocked"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["blocked"], behavior: "strict", exit: 1, verdict: "selected_cells_failed" },
   { statuses: ["expected_fail"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying" },
-  { statuses: ["expected_fail"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["expected_fail"], behavior: "strict", exit: 1, verdict: "selected_cells_failed" },
   { statuses: ["green", "failed"], behavior: "diagnostic", exit: 1, verdict: "non_qualifying" },
-  { statuses: ["green", "failed"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
-  { statuses: ["cancelled"], behavior: "strict", exit: 1, verdict: "selected_tests_failed" },
+  { statuses: ["green", "failed"], behavior: "strict", exit: 1, verdict: "selected_cells_failed" },
+  { statuses: ["cancelled"], behavior: "strict", exit: 1, verdict: "selected_cells_failed" },
   { statuses: ["missing"], behavior: "diagnostic", exit: 2, verdict: "non_qualifying", integrity: true },
   { statuses: ["not_run"], behavior: "diagnostic", exit: 0, verdict: "non_qualifying", execution: "dry_run" },
 ];
@@ -194,15 +204,17 @@ for (const [index, row] of MATRIX_ROWS.entries()) {
       report.candidate_build = STRICT_CB;
     }
     report.run.execution = row.execution ?? "real";
-    report.selected_tests = row.statuses.map((_, i) => ({
-      test_id: `S${i}/local`,
+    report.selected_cells = row.statuses.map((_, i) => ({
+      cell_id: `S${i}/local`,
       scenario_id: `S${i}`,
       registry_flow_ref: `specs#S${i}`,
       runtime_lane: "local" as const,
+      dimensions: {},
+      required_env: [],
     }));
     report.results = row.statuses.map((status, i) => ({
       ...report.results[0],
-      test_id: `S${i}/local`,
+      cell_id: `S${i}/local`,
       scenario_id: `S${i}`,
       registry_flow_ref: `specs#S${i}`,
       status,
@@ -236,7 +248,7 @@ test("validateReport rejects a strict dry-run report outright", () => {
   report.results[0].status = "not_run";
   report.summary.by_status.green = 0;
   report.summary.by_status.not_run = 1;
-  report.verdict.status = "selected_tests_failed";
+  report.verdict.status = "selected_cells_failed";
   report.summary.intended_exit_code = 1;
   assert.throws(() => validateReport(report), /strict dry-run/i);
 
@@ -245,7 +257,7 @@ test("validateReport rejects a strict dry-run report outright", () => {
   disguised.run.behavior = "strict";
   disguised.candidate_build = STRICT_CB;
   disguised.run.execution = "dry_run";
-  disguised.verdict.status = "selected_tests_passed";
+  disguised.verdict.status = "selected_cells_passed";
   assert.throws(() => validateReport(disguised), ReportValidationError);
 });
 
@@ -382,7 +394,7 @@ test("writeReport validates before writing: an invalid report writes nothing", a
 
 test("validateReport requires candidate_build to be present (null or evidence)", () => {
   const absent = validReport();
-  delete (absent as Partial<TestRunReportV2>).candidate_build;
+  delete (absent as Partial<TestRunReportV3>).candidate_build;
   assert.throws(() => validateReport(absent), /candidate_build must be present/);
 
   const withNull = validReport();
@@ -399,7 +411,7 @@ test("validateReport requires candidate_build to be present (null or evidence)",
 test("validateReport rejects unsafe or path-carrying candidate evidence", () => {
   const reject = (candidate: unknown, pattern: RegExp): void => {
     const report = validReport();
-    report.candidate_build = candidate as TestRunReportV2["candidate_build"];
+    report.candidate_build = candidate as TestRunReportV3["candidate_build"];
     assert.throws(() => validateReport(report), pattern);
   };
   reject({ artifacts: [] }, /non-empty/);
@@ -439,22 +451,38 @@ test("validateReport rejects unsafe or path-carrying candidate evidence", () => 
   );
 });
 
-test("validateReport rejects a schema_version 1 report", () => {
-  const report = validReport();
-  (report as { schema_version: number }).schema_version = 1;
-  assert.throws(() => validateReport(report), /schema_version 2/);
+test("validateReport rejects prior schema versions", () => {
+  for (const version of [1, 2]) {
+    const report = validReport();
+    (report as { schema_version: number }).schema_version = version;
+    assert.throws(() => validateReport(report), /schema_version 3/);
+  }
+});
+
+test("validateReport rejects a result whose identity or dimensions drift from its planned cell", () => {
+  const wrongLane = validReport();
+  (wrongLane.results[0] as { runtime_lane: string }).runtime_lane = "sandbox";
+  assert.throws(() => validateReport(wrongLane), /scenario\/lane\/reference/);
+
+  const wrongScenario = validReport();
+  wrongScenario.results[0].scenario_id = "B";
+  assert.throws(() => validateReport(wrongScenario), /scenario\/lane\/reference/);
+
+  const wrongDims = validReport();
+  wrongDims.results[0].dimensions = { harness: "codex" };
+  assert.throws(() => validateReport(wrongDims), /dimensions do not match/);
 });
 
 test("strict reports require non-null candidate_build (CBH-001)", () => {
   const strictNull = validReport();
   strictNull.run.behavior = "strict";
-  strictNull.verdict.status = "selected_tests_passed";
+  strictNull.verdict.status = "selected_cells_passed";
   strictNull.candidate_build = null;
   assert.throws(() => validateReport(strictNull), /Strict reports require non-null candidate_build/);
 
   const strictWithEvidence = validReport();
   strictWithEvidence.run.behavior = "strict";
-  strictWithEvidence.verdict.status = "selected_tests_passed";
+  strictWithEvidence.verdict.status = "selected_cells_passed";
   strictWithEvidence.candidate_build = {
     artifacts: [{ artifact_id: "anyharness/x", version: "1", sha256: "e".repeat(64) }],
   };
@@ -466,6 +494,6 @@ test("candidate_build rejects undeclared fields beside artifacts (CBH-002)", () 
   report.candidate_build = {
     artifacts: [{ artifact_id: "anyharness/x", version: "1", sha256: "e".repeat(64) }],
     map_path: "/tmp/leaked-map.json",
-  } as unknown as TestRunReportV2["candidate_build"];
+  } as unknown as TestRunReportV3["candidate_build"];
   assert.throws(() => validateReport(report), /exactly one field: artifacts/);
 });

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  assertNoSecretsInIdentity,
   boundMessage,
   redactExternalPayloads,
   redactSecrets,
@@ -496,4 +497,59 @@ test("candidate_build rejects undeclared fields beside artifacts (CBH-002)", () 
     map_path: "/tmp/leaked-map.json",
   } as unknown as TestRunReportV3["candidate_build"];
   assert.throws(() => validateReport(report), /exactly one field: artifacts/);
+});
+
+test("validateReport rejects invalid modes, false scope/completeness, and empty selections (ETM-001)", () => {
+  const badBehavior = validReport();
+  (badBehavior.run as { behavior: string }).behavior = "lenient";
+  assert.throws(() => validateReport(badBehavior), /Unknown behavior/);
+
+  const badExecution = validReport();
+  (badExecution.run as { execution: string }).execution = "simulated";
+  assert.throws(() => validateReport(badExecution), /Unknown execution mode/);
+
+  const badScope = validReport();
+  (badScope.verdict as { scope: string }).scope = "full_release";
+  assert.throws(() => validateReport(badScope), /scope\/completeness/);
+
+  const badCompleteness = validReport();
+  (badCompleteness.verdict as { completeness: string }).completeness = "complete";
+  assert.throws(() => validateReport(badCompleteness), /scope\/completeness/);
+
+  const empty = validReport();
+  empty.selected_cells = [];
+  empty.results = [];
+  empty.summary.selected = 0;
+  empty.summary.finalized = 0;
+  empty.summary.by_status.green = 0;
+  assert.throws(() => validateReport(empty), /zero selected cells/);
+});
+
+test("validateReport rejects coordinated cell-id/dimension tampering (ETM-001)", () => {
+  // Both the selected cell and its result are edited consistently — the id
+  // no longer derives from the scenario/lane/dimensions, so it must reject.
+  const report = validReport();
+  report.selected_cells[0].cell_id = "A/local/harness=claude";
+  report.results[0].cell_id = "A/local/harness=claude";
+  assert.throws(() => validateReport(report), /not the canonical id/);
+
+  const renamed = validReport();
+  renamed.selected_cells[0].dimensions = { harness: "codex" };
+  renamed.results[0].dimensions = { harness: "codex" };
+  // cell_id still says A/local while dimensions claim a matrix child.
+  assert.throws(() => validateReport(renamed), /not the canonical id/);
+});
+
+test("a resolved secret in a cell id or dimension fails closed (ETM-004)", () => {
+  const secret = "sk-live-in-identity";
+  const inDimension = validReport();
+  inDimension.selected_cells[0].dimensions = { harness: secret };
+  assert.throws(() => assertNoSecretsInIdentity(inDimension, [secret]), /refusing to produce evidence/);
+
+  const inResult = validReport();
+  inResult.results[0].dimensions = { harness: secret };
+  assert.throws(() => assertNoSecretsInIdentity(inResult, [secret]), /refusing to produce evidence/);
+
+  // Clean identities pass, and message redaction still applies elsewhere.
+  assertNoSecretsInIdentity(validReport(), [secret]);
 });

--- a/tests/release/src/evidence/write.ts
+++ b/tests/release/src/evidence/write.ts
@@ -2,7 +2,7 @@ import { link, mkdir, unlink, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 
-import { validateReport, type TestRunReportV2 } from "./schema.js";
+import { validateReport, type TestRunReportV3 } from "./schema.js";
 
 export class ReportWriteError extends Error {
   constructor(message: string) {
@@ -11,7 +11,7 @@ export class ReportWriteError extends Error {
   }
 }
 
-export function reportPath(outputDir: string, report: TestRunReportV2): string {
+export function reportPath(outputDir: string, report: TestRunReportV3): string {
   return path.join(
     outputDir,
     report.run.run_id,
@@ -28,7 +28,7 @@ export function reportPath(outputDir: string, report: TestRunReportV2): string {
  * replacing) and refuses to overwrite an existing attempt artifact, so a
  * retry can never destroy earlier evidence.
  */
-export async function writeReport(outputDir: string, report: TestRunReportV2): Promise<string> {
+export async function writeReport(outputDir: string, report: TestRunReportV3): Promise<string> {
   validateReport(report);
   const destination = reportPath(outputDir, report);
   try {

--- a/tests/release/src/report/failure-reporter.test.ts
+++ b/tests/release/src/report/failure-reporter.test.ts
@@ -2,14 +2,15 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { toFailureReports } from "./failure-reporter.js";
-import type { FinalTestResultV1 } from "../runner/result.js";
+import type { FinalCellResultV1 } from "../runner/result.js";
 
-function failedResult(overrides: Partial<FinalTestResultV1> = {}): FinalTestResultV1 {
+function failedResult(overrides: Partial<FinalCellResultV1> = {}): FinalCellResultV1 {
   return {
-    test_id: "T3-EXAMPLE/local",
+    cell_id: "T3-EXAMPLE/local",
     scenario_id: "T3-EXAMPLE",
     registry_flow_ref: "specs/developing/testing/scenarios.md#T3-EXAMPLE",
     runtime_lane: "local",
+    dimensions: {},
     status: "failed",
     started_at: "2026-07-13T00:00:00Z",
     finished_at: "2026-07-13T00:00:01Z",
@@ -22,7 +23,7 @@ function failedResult(overrides: Partial<FinalTestResultV1> = {}): FinalTestResu
 
 test("toFailureReports maps a normalized failed result to the issue payload", () => {
   const [report] = toFailureReports([failedResult()]);
-  assert.equal(report.scenario_id, "T3-EXAMPLE");
+  assert.equal(report.scenario_id, "T3-EXAMPLE/local");
   assert.equal(report.flow, "specs/developing/testing/scenarios.md#T3-EXAMPLE");
   assert.equal(report.lane, "local");
   assert.match(report.observed, /boom/);
@@ -31,18 +32,18 @@ test("toFailureReports maps a normalized failed result to the issue payload", ()
 });
 
 test("toFailureReports produces payloads only for failed results", () => {
-  const results: FinalTestResultV1[] = [
+  const results: FinalCellResultV1[] = [
     failedResult(),
-    failedResult({ test_id: "T3-B/local", scenario_id: "T3-B", status: "blocked" }),
-    failedResult({ test_id: "T3-C/local", scenario_id: "T3-C", status: "expected_fail" }),
-    failedResult({ test_id: "T3-D/local", scenario_id: "T3-D", status: "cancelled" }),
-    failedResult({ test_id: "T3-E/local", scenario_id: "T3-E", status: "not_run" }),
-    failedResult({ test_id: "T3-F/local", scenario_id: "T3-F", status: "missing" }),
-    failedResult({ test_id: "T3-G/local", scenario_id: "T3-G", status: "green" }),
+    failedResult({ cell_id: "T3-B/local", scenario_id: "T3-B", status: "blocked" }),
+    failedResult({ cell_id: "T3-C/local", scenario_id: "T3-C", status: "expected_fail" }),
+    failedResult({ cell_id: "T3-D/local", scenario_id: "T3-D", status: "cancelled" }),
+    failedResult({ cell_id: "T3-E/local", scenario_id: "T3-E", status: "not_run" }),
+    failedResult({ cell_id: "T3-F/local", scenario_id: "T3-F", status: "missing" }),
+    failedResult({ cell_id: "T3-G/local", scenario_id: "T3-G", status: "green" }),
   ];
   const reports = toFailureReports(results);
   assert.equal(reports.length, 1);
-  assert.equal(reports[0].scenario_id, "T3-EXAMPLE");
+  assert.equal(reports[0].scenario_id, "T3-EXAMPLE/local");
 });
 
 test("toFailureReports handles a failed result with no recorded reason", () => {

--- a/tests/release/src/report/failure-reporter.ts
+++ b/tests/release/src/report/failure-reporter.ts
@@ -1,4 +1,4 @@
-import type { FinalTestResultV1 } from "../runner/result.js";
+import type { FinalCellResultV1 } from "../runner/result.js";
 import type { FailureReport } from "./types.js";
 
 /**
@@ -6,19 +6,25 @@ import type { FailureReport } from "./types.js";
  * issue-filing payload (specs/developing/testing/qualification-runner-core.md
  * "Failure behavior"). Only normalized failed results produce a payload; no
  * status writes a per-failure JSON file — the combined report
- * (src/evidence/write.ts) is the only on-disk artifact.
+ * (src/evidence/write.ts) is the only on-disk artifact. Payloads carry the
+ * exact cell identity (specs/developing/testing/exact-test-matrix.md), so a
+ * failed matrix child (`T3-CHAT-1/local/harness=codex`) files and dedupes as
+ * its own issue rather than collapsing into its scenario.
  */
-export function toFailureReports(failed: readonly FinalTestResultV1[]): FailureReport[] {
+export function toFailureReports(failed: readonly FinalCellResultV1[]): FailureReport[] {
   return failed.filter((result) => result.status === "failed").map(toFailureReport);
 }
 
-function toFailureReport(result: FinalTestResultV1): FailureReport {
+function toFailureReport(result: FinalCellResultV1): FailureReport {
   return {
     flow: result.registry_flow_ref,
-    scenario_id: result.scenario_id,
+    // The issue payload's identity field carries the exact cell id; the
+    // downstream filer's scenario+lane dedupe key therefore distinguishes
+    // matrix children instead of hiding them behind one parent issue.
+    scenario_id: result.cell_id,
     lane: result.runtime_lane,
-    expected: `${result.scenario_id} completes without error on the ${result.runtime_lane} lane`,
-    observed: result.reason?.message ?? "scenario failed with no recorded reason",
+    expected: `${result.cell_id} completes without error`,
+    observed: result.reason?.message ?? "cell failed with no recorded reason",
     logs_excerpt: "",
     correlation_ids: [],
     timestamp: result.finished_at,

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import type { EnvResolution, ResolvedEnvVar } from "../config/env-resolution.js";
-import { validateReport } from "../evidence/schema.js";
-import { gatewayJsonRpc } from "../fixtures/integration-gateway.js";
-import { toFailureReports } from "../report/failure-reporter.js";
-import type { ScenarioDefinition } from "../scenarios/types.js";
+import type {
+  LeafScenarioDefinition,
+  MatrixScenarioDefinition,
+  ScenarioCellOutcome,
+  ScenarioDefinition,
+} from "../scenarios/types.js";
 import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
-import { executeSelectedTests, expandSelectedTests, SelectionError, type ExecuteOptions } from "./execute.js";
+import { executeSelectedCells, type ExecuteOptions } from "./execute.js";
+import { buildPlannedCells } from "./plan.js";
 import type { RunIdentityV1 } from "./identity.js";
 
 const IDENTITY: RunIdentityV1 = {
@@ -22,11 +25,11 @@ interface FakeScenarioOptions {
   id: string;
   lanes?: Array<"local" | "sandbox">;
   requiredEnv?: string[];
-  run?: ScenarioDefinition["run"];
-  plan?: ScenarioDefinition["plan"];
+  run?: LeafScenarioDefinition["run"];
+  plan?: LeafScenarioDefinition["plan"];
 }
 
-function fakeScenario(options: FakeScenarioOptions): ScenarioDefinition {
+function fakeScenario(options: FakeScenarioOptions): LeafScenarioDefinition {
   return {
     id: options.id,
     title: `${options.id} title`,
@@ -35,6 +38,37 @@ function fakeScenario(options: FakeScenarioOptions): ScenarioDefinition {
     requiredEnv: options.requiredEnv ?? [],
     plan: options.plan ?? (() => [{ description: `plan ${options.id}` }]),
     run: options.run ?? (async () => undefined),
+  };
+}
+
+interface FakeMatrixOptions {
+  id: string;
+  lanes?: Array<"local" | "sandbox">;
+  requiredEnv?: string[];
+  cells?: Array<Record<string, string>>;
+  cellRequiredEnv?: Record<string, string[]>;
+  runCells?: MatrixScenarioDefinition["runCells"];
+  planCell?: MatrixScenarioDefinition["planCell"];
+}
+
+function fakeMatrix(options: FakeMatrixOptions): MatrixScenarioDefinition {
+  const dims = options.cells ?? [{ child: "a" }, { child: "b" }, { child: "c" }];
+  return {
+    id: options.id,
+    title: `${options.id} title`,
+    registryFlowRef: `specs#${options.id}`,
+    lanes: options.lanes ?? ["local"],
+    requiredEnv: options.requiredEnv ?? [],
+    kind: "matrix",
+    expandCells: () =>
+      dims.map((dimensions) => ({
+        dimensions,
+        requiredEnv: options.cellRequiredEnv?.[Object.values(dimensions)[0]],
+      })),
+    planCell: options.planCell ?? ((_ctx, cell) => [{ description: `plan ${cell.cell_id}` }]),
+    runCells:
+      options.runCells ??
+      (async (_ctx, cells) => cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }))),
   };
 }
 
@@ -65,51 +99,45 @@ function fakeEnv(presentNames: string[] = [], secretValues: Record<string, strin
   };
 }
 
-function baseOptions(scenarios: ScenarioDefinition[], overrides: Partial<ExecuteOptions> = {}): ExecuteOptions {
+async function optionsFor(
+  scenarios: ScenarioDefinition[],
+  overrides: Partial<ExecuteOptions> = {},
+): Promise<ExecuteOptions> {
+  const cells =
+    overrides.cells ??
+    (await buildPlannedCells(scenarios, {
+      desktop: "web",
+      agents:
+        overrides.inputs?.agents === undefined || overrides.inputs.agents === "all"
+          ? ["all"]
+          : overrides.inputs.agents,
+    }));
   return {
     behavior: "diagnostic",
     execution: "real",
     identity: IDENTITY,
     inputs: { targetLane: "local", desktop: "web", agents: "all", scenarios: "all" },
     scenarios,
+    cells,
     resolveNeededEnv: () => fakeEnv(),
+    resolveSecretValues: () => [],
     ...overrides,
   };
 }
 
-test("expands scenarios across declared lanes with stable unique test ids", () => {
-  const selected = expandSelectedTests([
-    fakeScenario({ id: "A", lanes: ["local", "sandbox"] }),
-    fakeScenario({ id: "B", lanes: ["sandbox"] }),
-  ]);
-  assert.deepEqual(
-    selected.map((testEntry) => testEntry.test_id),
-    ["A/local", "A/sandbox", "B/sandbox"],
-  );
-});
-
-test("rejects duplicate expanded test ids before execution", () => {
-  assert.throws(
-    () => expandSelectedTests([fakeScenario({ id: "A" }), fakeScenario({ id: "A" })]),
-    SelectionError,
-  );
-});
-
-test("rejects a selection that expands to zero tests", () => {
-  assert.throws(() => expandSelectedTests([]), SelectionError);
-});
-
-test("normal return normalizes to green with timestamps and duration", async () => {
-  const report = await executeSelectedTests(baseOptions([fakeScenario({ id: "A" })]));
+test("normal leaf return normalizes to green with timestamps and duration", async () => {
+  const report = await executeSelectedCells(await optionsFor([fakeScenario({ id: "A" })]));
   const [result] = report.results;
   assert.equal(result.status, "green");
+  assert.equal(result.cell_id, "A/local");
+  assert.deepEqual(result.dimensions, {});
   assert.ok(result.started_at !== null);
   assert.ok(typeof result.duration_ms === "number");
   assert.equal(report.verdict.status, "non_qualifying");
   assert.equal(report.summary.intended_exit_code, 0);
 });
 
-test("ScenarioBlockedError, ScenarioExpectedFailError, Error, and non-Error throws normalize correctly", async () => {
+test("leaf ScenarioBlockedError, ScenarioExpectedFailError, Error, and non-Error throws normalize correctly", async () => {
   const scenarios = [
     fakeScenario({ id: "BLOCKED", run: async () => { throw new ScenarioBlockedError("gate"); } }),
     fakeScenario({ id: "XFAIL", run: async () => { throw new ScenarioExpectedFailError("known gap"); } }),
@@ -117,8 +145,8 @@ test("ScenarioBlockedError, ScenarioExpectedFailError, Error, and non-Error thro
     fakeScenario({ id: "WEIRD", run: async () => { throw "a string"; } }),
     fakeScenario({ id: "GREEN" }),
   ];
-  const report = await executeSelectedTests(baseOptions(scenarios));
-  const byId = new Map(report.results.map((result) => [result.test_id, result]));
+  const report = await executeSelectedCells(await optionsFor(scenarios));
+  const byId = new Map(report.results.map((result) => [result.cell_id, result]));
   assert.equal(byId.get("BLOCKED/local")?.status, "blocked");
   assert.equal(byId.get("BLOCKED/local")?.reason?.code, "scenario_blocked");
   assert.equal(byId.get("XFAIL/local")?.status, "expected_fail");
@@ -131,116 +159,250 @@ test("ScenarioBlockedError, ScenarioExpectedFailError, Error, and non-Error thro
   assert.equal(report.summary.intended_exit_code, 1);
 });
 
-test("strict also continues siblings after runtime non-green states", async () => {
-  const ran: string[] = [];
-  const scenarios = [
-    fakeScenario({ id: "RED", run: async () => { ran.push("RED"); throw new Error("boom"); } }),
-    fakeScenario({ id: "GREEN", run: async () => { ran.push("GREEN"); } }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios, { behavior: "strict" }));
-  assert.deepEqual(ran, ["RED", "GREEN"]);
-  assert.equal(report.verdict.status, "selected_tests_failed");
-  assert.equal(report.summary.intended_exit_code, 1);
-});
-
-test("diagnostic missing requirements block only affected tests", async () => {
-  const ran: string[] = [];
-  const scenarios = [
-    fakeScenario({ id: "NEEDY", requiredEnv: ["MISSING_VAR"], run: async () => { ran.push("NEEDY"); } }),
-    fakeScenario({ id: "FREE", run: async () => { ran.push("FREE"); } }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios));
-  const byId = new Map(report.results.map((result) => [result.test_id, result]));
-  assert.equal(byId.get("NEEDY/local")?.status, "blocked");
-  assert.equal(byId.get("NEEDY/local")?.reason?.code, "missing_requirement");
-  assert.equal(byId.get("FREE/local")?.status, "green");
-  assert.deepEqual(ran, ["FREE"]);
-  assert.equal(report.summary.intended_exit_code, 0);
-});
-
-test("strict missing preflight executes zero test bodies, blocks affected, cancels the rest", async () => {
-  const ran: string[] = [];
-  const scenarios = [
-    fakeScenario({ id: "NEEDY", requiredEnv: ["MISSING_VAR"], run: async () => { ran.push("NEEDY"); } }),
-    fakeScenario({ id: "FREE", run: async () => { ran.push("FREE"); } }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios, { behavior: "strict" }));
-  assert.deepEqual(ran, []);
-  const byId = new Map(report.results.map((result) => [result.test_id, result]));
-  assert.equal(byId.get("NEEDY/local")?.status, "blocked");
-  assert.equal(byId.get("NEEDY/local")?.reason?.code, "missing_requirement");
-  assert.equal(byId.get("FREE/local")?.status, "cancelled");
-  assert.equal(byId.get("FREE/local")?.reason?.code, "strict_preflight_failed");
-  assert.equal(report.verdict.status, "selected_tests_failed");
-  assert.equal(report.summary.intended_exit_code, 1);
-});
-
-test("locally seeded vars do not satisfy the sandbox lane", async () => {
-  const scenarios = [
-    fakeScenario({ id: "A", lanes: ["local", "sandbox"], requiredEnv: ["SEEDED_VAR"] }),
-  ];
-  const report = await executeSelectedTests(
-    baseOptions(scenarios, {
-      resolveNeededEnv: () => fakeEnv(["SEEDED_VAR"]),
-      locallySeeded: new Set(["SEEDED_VAR"]),
-    }),
+test("a three-cell collector returning green/failed/green preserves all three; strict exits 1", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    runCells: async (_ctx, cells) =>
+      cells.map((cell, index) => ({
+        cellId: cell.cell_id,
+        status: index === 1 ? ("failed" as const) : ("green" as const),
+        reason: index === 1 ? { code: "scenario_failure" as const, message: "child b broke" } : undefined,
+      })),
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix], { behavior: "strict" }));
+  assert.equal(report.results.length, 3);
+  assert.deepEqual(
+    report.results.map((result) => result.status),
+    ["green", "failed", "green"],
   );
-  const byId = new Map(report.results.map((result) => [result.test_id, result]));
-  assert.equal(byId.get("A/local")?.status, "green");
-  assert.equal(byId.get("A/sandbox")?.status, "blocked");
+  assert.equal(report.verdict.status, "selected_cells_failed");
+  assert.equal(report.summary.intended_exit_code, 1);
 });
 
-test("dry-run calls each plan() exactly once, never run(), and finalizes not_run/dry_run", async () => {
-  const planCalls: string[] = [];
-  let runCalled = false;
-  const scenarios = [
-    fakeScenario({
-      id: "A",
-      lanes: ["local", "sandbox"],
-      plan: ({ runtimeLane }) => {
-        planCalls.push(`A/${runtimeLane}`);
-        return [{ description: `step for ${runtimeLane}` }];
-      },
-      run: async () => { runCalled = true; },
-    }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios, { execution: "dry_run" }));
-  assert.deepEqual(planCalls, ["A/local", "A/sandbox"]);
-  assert.equal(runCalled, false);
-  for (const result of report.results) {
-    assert.equal(result.status, "not_run");
-    assert.equal(result.reason?.code, "dry_run");
-    assert.equal(result.plan_steps.length, 1);
-  }
-  assert.equal(report.run.execution, "dry_run");
-  assert.equal(report.verdict.status, "non_qualifying");
-  assert.equal(report.summary.intended_exit_code, 0);
-});
-
-test("a throwing plan() becomes not_run/plan_error, records a runner error, continues, exits 2", async () => {
-  const scenarios = [
-    fakeScenario({ id: "BROKEN", plan: () => { throw new Error("plan bug"); } }),
-    fakeScenario({ id: "FINE" }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios, { execution: "dry_run" }));
-  const byId = new Map(report.results.map((result) => [result.test_id, result]));
-  assert.equal(byId.get("BROKEN/local")?.status, "not_run");
-  assert.equal(byId.get("BROKEN/local")?.reason?.code, "plan_error");
-  assert.equal(byId.get("FINE/local")?.status, "not_run");
-  assert.equal(byId.get("FINE/local")?.reason?.code, "dry_run");
-  assert.equal(report.summary.runner_errors.length, 1);
-  assert.equal(report.summary.by_status.failed, 0);
-  assert.equal(report.verdict.status, "non_qualifying");
+test("an omitted child outcome is synthesized as missing with integrity exit 2", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    runCells: async (_ctx, cells) =>
+      cells
+        .filter((cell) => cell.dimensions.child !== "b")
+        .map((cell) => ({ cellId: cell.cell_id, status: "green" as const })),
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  const omitted = report.results.find((result) => result.dimensions.child === "b");
+  assert.equal(omitted?.status, "missing");
+  assert.ok(report.summary.integrity_errors.length > 0);
   assert.equal(report.summary.intended_exit_code, 2);
 });
 
-test("a post-selection runner defect finalizes every pending test and still produces a report", async () => {
-  // Simulates e.g. a scenario referencing an env var that resolveEnv rejects
-  // (undeclared in the manifest): the selected set must not be lost.
+test("a duplicate child outcome keeps the first result and records an integrity error", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => [
+      { cellId: cells[0].cell_id, status: "green" as const },
+      { cellId: cells[0].cell_id, status: "failed" as const },
+    ],
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(report.results[0].status, "green");
+  assert.ok(report.summary.integrity_errors.some((error) => error.code === "duplicate_result"));
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("an unknown child outcome — even another group's planned cell — is an integrity error", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => [
+      { cellId: cells[0].cell_id, status: "green" as const },
+      { cellId: "OTHER/local", status: "green" as const },
+    ],
+  });
+  const other = fakeScenario({ id: "OTHER" });
+  const report = await executeSelectedCells(await optionsFor([matrix, other]));
+  // The leaf OTHER/local must carry its own real result, not the collector's.
+  const otherResult = report.results.find((result) => result.cell_id === "OTHER/local");
+  assert.equal(otherResult?.status, "green");
+  assert.ok(report.summary.integrity_errors.some((error) => error.message.includes("unassigned cell")));
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("a one-child matrix still must return one explicit child outcome", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "only" }],
+    runCells: async () => [],
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(report.results[0].status, "missing");
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("a collector-level throw finalizes all assigned runnable cells honestly", async () => {
+  const failing = fakeMatrix({
+    id: "MFAIL",
+    runCells: async () => {
+      throw new Error("shared setup exploded");
+    },
+  });
+  const blocked = fakeMatrix({
+    id: "MBLOCK",
+    runCells: async () => {
+      throw new ScenarioBlockedError("shared gate");
+    },
+  });
+  const xfail = fakeMatrix({
+    id: "MXFAIL",
+    runCells: async () => {
+      throw new ScenarioExpectedFailError("shared known gap");
+    },
+  });
+  const sibling = fakeScenario({ id: "GREEN" });
+  const report = await executeSelectedCells(await optionsFor([failing, blocked, xfail, sibling]));
+  const byId = new Map(report.results.map((result) => [result.cell_id, result]));
+  for (const child of ["a", "b", "c"]) {
+    assert.equal(byId.get(`MFAIL/local/child=${child}`)?.status, "failed");
+    assert.equal(byId.get(`MBLOCK/local/child=${child}`)?.status, "blocked");
+    assert.equal(byId.get(`MXFAIL/local/child=${child}`)?.status, "expected_fail");
+  }
+  // Independent scenario/runtime collectors continue after one collector fails.
+  assert.equal(byId.get("GREEN/local")?.status, "green");
+  assert.equal(report.summary.integrity_errors.length, 0);
+});
+
+test("a collector cannot self-declare runner-only terminal states", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => [
+      { cellId: cells[0].cell_id, status: "cancelled" } as unknown as ScenarioCellOutcome,
+    ],
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(report.results[0].status, "missing");
+  assert.ok(report.summary.integrity_errors.some((error) => error.message.includes("runner-only status")));
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("runCells is invoked once per scenario/runtime lane with its assigned cells", async () => {
+  const invocations: Array<{ lane: string; cellIds: string[] }> = [];
+  const matrix = fakeMatrix({
+    id: "M",
+    lanes: ["local", "sandbox"],
+    runCells: async (ctx, cells) => {
+      invocations.push({ lane: ctx.runtimeLane, cellIds: cells.map((cell) => cell.cell_id) });
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(invocations.length, 2);
+  assert.deepEqual(invocations.map((invocation) => invocation.lane).sort(), ["local", "sandbox"]);
+  for (const invocation of invocations) {
+    assert.equal(invocation.cellIds.length, 3);
+  }
+});
+
+test("diagnostic missing requirements block only affected cells; the collector receives the rest", async () => {
+  let received: string[] = [];
+  const matrix = fakeMatrix({
+    id: "M",
+    cellRequiredEnv: { b: ["MISSING_VAR"] },
+    runCells: async (_ctx, cells) => {
+      received = cells.map((cell) => cell.cell_id);
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  const byId = new Map(report.results.map((result) => [result.cell_id, result]));
+  assert.equal(byId.get("M/local/child=b")?.status, "blocked");
+  assert.equal(byId.get("M/local/child=b")?.reason?.code, "missing_requirement");
+  assert.equal(byId.get("M/local/child=a")?.status, "green");
+  assert.equal(byId.get("M/local/child=c")?.status, "green");
+  assert.deepEqual(received.sort(), ["M/local/child=a", "M/local/child=c"]);
+  assert.equal(report.summary.intended_exit_code, 0);
+});
+
+test("strict missing preflight executes zero collector bodies, blocks affected, cancels the rest", async () => {
+  let collectorRan = false;
+  let leafRan = false;
+  const matrix = fakeMatrix({
+    id: "M",
+    cellRequiredEnv: { b: ["MISSING_VAR"] },
+    runCells: async (_ctx, cells) => {
+      collectorRan = true;
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  const leaf = fakeScenario({
+    id: "FREE",
+    run: async () => {
+      leafRan = true;
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix, leaf], { behavior: "strict" }));
+  assert.equal(collectorRan, false);
+  assert.equal(leafRan, false);
+  const byId = new Map(report.results.map((result) => [result.cell_id, result]));
+  assert.equal(byId.get("M/local/child=b")?.status, "blocked");
+  assert.equal(byId.get("M/local/child=a")?.status, "cancelled");
+  assert.equal(byId.get("FREE/local")?.status, "cancelled");
+  assert.equal(report.verdict.status, "selected_cells_failed");
+  assert.equal(report.summary.intended_exit_code, 1);
+});
+
+test("dry-run lists and reports every exact cell without executing collectors", async () => {
+  let collectorRan = false;
+  const planned: string[] = [];
+  const matrix = fakeMatrix({
+    id: "M",
+    planCell: (_ctx, cell) => {
+      planned.push(cell.cell_id);
+      return [{ description: `steps for ${cell.cell_id}` }];
+    },
+    runCells: async () => {
+      collectorRan = true;
+      return [];
+    },
+  });
+  const leaf = fakeScenario({ id: "LEAF" });
+  const report = await executeSelectedCells(await optionsFor([matrix, leaf], { execution: "dry_run" }));
+  assert.equal(collectorRan, false);
+  assert.equal(planned.length, 3);
+  assert.equal(report.results.length, 4);
+  for (const result of report.results) {
+    assert.equal(result.status, "not_run");
+    assert.equal(result.reason?.code, "dry_run");
+    assert.ok(result.plan_steps.length > 0);
+  }
+  assert.equal(report.summary.intended_exit_code, 0);
+});
+
+test("a throwing planCell becomes not_run/plan_error, records a runner error, continues, exits 2", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }, { child: "b" }],
+    planCell: (_ctx, cell) => {
+      if (cell.dimensions.child === "a") {
+        throw new Error("plan bug");
+      }
+      return [{ description: "fine" }];
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix], { execution: "dry_run" }));
+  const byId = new Map(report.results.map((result) => [result.cell_id, result]));
+  assert.equal(byId.get("M/local/child=a")?.reason?.code, "plan_error");
+  assert.equal(byId.get("M/local/child=b")?.reason?.code, "dry_run");
+  assert.equal(report.summary.runner_errors.length, 1);
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("a post-selection runner defect finalizes every pending cell and still produces a report", async () => {
   const scenarios = [fakeScenario({ id: "A" }), fakeScenario({ id: "B" })];
-  const report = await executeSelectedTests(
-    baseOptions(scenarios, {
-      resolveNeededEnv: () => { throw new Error('resolveEnv: "NOT_IN_MANIFEST" is not declared'); },
+  const report = await executeSelectedCells(
+    await optionsFor(scenarios, {
+      resolveNeededEnv: () => {
+        throw new Error('resolveEnv: "NOT_IN_MANIFEST" is not declared');
+      },
     }),
   );
   assert.equal(report.results.length, 2);
@@ -248,23 +410,7 @@ test("a post-selection runner defect finalizes every pending test and still prod
     assert.equal(result.status, "missing");
   }
   assert.equal(report.summary.runner_errors.length, 1);
-  assert.match(report.summary.runner_errors[0].message, /NOT_IN_MANIFEST/);
   assert.equal(report.summary.intended_exit_code, 2);
-});
-
-test("a diagnostic dry-run runner defect still produces valid persistable evidence", async () => {
-  const report = await executeSelectedTests(
-    baseOptions([fakeScenario({ id: "DRY-A" }), fakeScenario({ id: "DRY-B" })], {
-      execution: "dry_run",
-      resolveNeededEnv: () => { throw new Error("preflight resolver failed"); },
-    }),
-  );
-
-  assert.deepEqual(report.results.map((result) => result.status), ["missing", "missing"]);
-  assert.equal(report.summary.runner_errors.length, 1);
-  assert.equal(report.summary.integrity_errors.length, 2);
-  assert.equal(report.summary.intended_exit_code, 2);
-  assert.doesNotThrow(() => validateReport(report));
 });
 
 test("exact resolved secret values are redacted from the report", async () => {
@@ -273,190 +419,53 @@ test("exact resolved secret values are redacted from the report", async () => {
     fakeScenario({
       id: "LEAKY",
       requiredEnv: ["SECRET_VAR"],
-      run: async () => { throw new Error(`request failed with key ${secret}`); },
+      run: async () => {
+        throw new Error(`request failed with key ${secret}`);
+      },
     }),
   ];
-  const report = await executeSelectedTests(
-    baseOptions(scenarios, {
+  const report = await executeSelectedCells(
+    await optionsFor(scenarios, {
       resolveNeededEnv: () => fakeEnv([], { SECRET_VAR: secret }),
       resolveSecretValues: () => [secret],
     }),
   );
-  const serialized = JSON.stringify(report);
-  assert.ok(!serialized.includes(secret));
+  assert.ok(!JSON.stringify(report).includes(secret));
   assert.match(report.results[0].reason!.message, /\[REDACTED\]/);
 });
 
-test("secrets are redacted even when no selected scenario declares them", async () => {
-  // A fixture can use a secret opportunistically (e.g. an optional GitHub
-  // token in a clone URL) without listing it in requiredEnv; redaction draws
-  // from the full manifest, injected here via resolveSecretValues.
-  const secret = "ghp_undeclared_token";
-  const scenarios = [
-    fakeScenario({ id: "LEAKY", run: async () => { throw new Error(`clone https://x:${secret}@github.com failed`); } }),
-  ];
-  const report = await executeSelectedTests(
-    baseOptions(scenarios, { resolveSecretValues: () => [secret] }),
-  );
-  assert.ok(!JSON.stringify(report).includes(secret));
-});
-
-test("provider response bodies never reach the report or issue payloads", async () => {
-  // The ApiRequestError/LocalRuntimeError shape: Error.message embeds the
-  // complete response body. The normalized evidence must withhold it.
-  const providerPayload = '{"api_key":"sk-live-9999","customer_email":"a@b.c","stack":"Traceback..."}';
-  class FakeApiRequestError extends Error {
-    readonly status = 500;
-    readonly body = providerPayload;
-    constructor() {
-      super(`POST /v1/checkout -> 500: ${providerPayload}`);
-      this.name = "ApiRequestError";
-    }
-  }
-  const scenarios = [fakeScenario({ id: "PROV", run: async () => { throw new FakeApiRequestError(); } })];
-  const report = await executeSelectedTests(baseOptions(scenarios));
-  const serialized = JSON.stringify(report);
-  assert.ok(!serialized.includes("sk-live-9999"));
-  assert.ok(!serialized.includes("customer_email"));
-  assert.match(report.results[0].reason!.message, /POST \/v1\/checkout -> 500/);
-  assert.match(report.results[0].reason!.message, /withheld from evidence/);
-});
-
-test("plain integration-gateway response bodies never reach evidence or issue payloads", async () => {
-  const providerPayload = '{"access_token":"RAW_GATEWAY_TOKEN","detail":"provider traceback"}';
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response(providerPayload, { status: 502 });
-  try {
-    const scenario = fakeScenario({
-      id: "GATEWAY",
-      run: async () => {
-        await gatewayJsonRpc(
-          {
-            workerId: "worker-1",
-            desktopInstallId: "desktop-1",
-            mcpUrl: "https://gateway.example.test/mcp",
-            authorization: "Bearer worker-token",
-          },
-          { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
-        );
-      },
-    });
-    const report = await executeSelectedTests(baseOptions([scenario], { resolveSecretValues: () => [] }));
-    const issues = toFailureReports(report.results);
-
-    assert.equal(report.results[0].status, "failed");
-    assert.ok(!JSON.stringify(report).includes("RAW_GATEWAY_TOKEN"));
-    assert.ok(!JSON.stringify(issues).includes("RAW_GATEWAY_TOKEN"));
-    assert.match(report.results[0].reason!.message, /response body withheld from evidence/);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("provider payloads stay out of blocked and expected-fail evidence", async () => {
-  const blockedPayload = "RAW_BLOCKED_PROVIDER_BODY";
-  const expectedPayload = "RAW_EXPECTED_PROVIDER_BODY";
-  const report = await executeSelectedTests(
-    baseOptions([
-      fakeScenario({
-        id: "BLOCKED-PAYLOAD",
-        run: async () => {
-          throw new ScenarioBlockedError(`gateway unavailable -> 503: ${blockedPayload}`);
-        },
-      }),
-      fakeScenario({
-        id: "EXPECTED-PAYLOAD",
-        run: async () => {
-          throw new ScenarioExpectedFailError(`provisioning failed: ${expectedPayload}`);
-        },
-      }),
-    ]),
-  );
-  const serialized = JSON.stringify(report);
-
-  assert.ok(!serialized.includes(blockedPayload));
-  assert.ok(!serialized.includes(expectedPayload));
-  assert.equal(report.results[0].status, "blocked");
-  assert.equal(report.results[1].status, "expected_fail");
-});
-
-test("runtime-discovered URL credentials are scrubbed even when unknown to the redactor", async () => {
-  // A `gh auth token` embedded in a clone URL is not in the env manifest, so
-  // exact-value redaction cannot know it; the URL-userinfo scrub must catch it.
-  const token = "ghp_dynamicallyDiscovered123";
-  const scenarios = [
-    fakeScenario({
-      id: "GIT",
-      run: async () => {
-        throw new Error(
-          `git clone https://x-access-token:${token}@github.com/o/r.git failed (128): ` +
-            `fatal: unable to access 'https://x-access-token:${token}@github.com/o/r.git'`,
-        );
-      },
-    }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios, { resolveSecretValues: () => [] }));
-  const serialized = JSON.stringify(report);
-  assert.ok(!serialized.includes(token));
-  assert.match(report.results[0].reason!.message, /\[REDACTED\]@github\.com/);
-});
-
-test("rejects duplicate scenario ids even with disjoint lanes", () => {
-  assert.throws(
-    () =>
-      expandSelectedTests([
-        fakeScenario({ id: "A", lanes: ["local"] }),
-        fakeScenario({ id: "A", lanes: ["sandbox"] }),
-      ]),
-    SelectionError,
-  );
-});
-
-test("overlong messages are bounded to 4096 code points", async () => {
-  const scenarios = [
-    fakeScenario({ id: "LOUD", run: async () => { throw new Error("x".repeat(10_000)); } }),
-  ];
-  const report = await executeSelectedTests(baseOptions(scenarios));
-  assert.ok([...report.results[0].reason!.message].length <= 4096);
-});
-
-test("the report records identity, inputs, behavior, and selected/result equality", async () => {
-  const report = await executeSelectedTests(
-    baseOptions([fakeScenario({ id: "A", lanes: ["local", "sandbox"] })], {
+test("the report records identity, inputs, candidate evidence, and selected/result equality", async () => {
+  const evidence = {
+    artifacts: [{ artifact_id: "anyharness/test-host", version: "9.9.9", sha256: "e".repeat(64) }],
+  };
+  const report = await executeSelectedCells(
+    await optionsFor([fakeScenario({ id: "A", lanes: ["local", "sandbox"] })], {
       inputs: { targetLane: "staging", desktop: "native", agents: ["claude"], scenarios: ["A"] },
+      candidateBuild: evidence,
     }),
   );
+  assert.equal(report.schema_version, 3);
   assert.equal(report.run.run_id, "run-1");
-  assert.equal(report.run.behavior, "diagnostic");
   assert.equal(report.inputs.target_lane, "staging");
-  assert.deepEqual(report.inputs.agents, ["claude"]);
+  assert.deepEqual(report.candidate_build, evidence);
   assert.deepEqual(
-    report.selected_tests.map((testEntry) => testEntry.test_id).sort(),
-    report.results.map((result) => result.test_id).sort(),
+    report.selected_cells.map((cell) => cell.cell_id).sort(),
+    report.results.map((result) => result.cell_id).sort(),
   );
   assert.equal(report.summary.selected, report.summary.finalized);
 });
 
-test("strict all-green is the only strict exit-0 result", async () => {
-  const report = await executeSelectedTests(
-    baseOptions([fakeScenario({ id: "A" }), fakeScenario({ id: "B" })], { behavior: "strict" }),
-  );
-  assert.equal(report.verdict.status, "selected_tests_passed");
-  assert.equal(report.verdict.scope, "selected_tests");
-  assert.equal(report.verdict.completeness, "partial");
-  assert.equal(report.summary.intended_exit_code, 0);
+test("candidate evidence defaults to explicit null when omitted", async () => {
+  const report = await executeSelectedCells(await optionsFor([fakeScenario({ id: "A" })]));
+  assert.equal(report.candidate_build, null);
 });
 
-test("the report carries the supplied candidate evidence, or explicit null when omitted", async () => {
-  const omitted = await executeSelectedTests(baseOptions([fakeScenario({ id: "A" })]));
-  assert.equal(omitted.schema_version, 2);
-  assert.equal(omitted.candidate_build, null);
-
-  const evidence = {
-    artifacts: [{ artifact_id: "anyharness/test-host", version: "9.9.9", sha256: "e".repeat(64) }],
-  };
-  const carried = await executeSelectedTests(
-    baseOptions([fakeScenario({ id: "A" })], { candidateBuild: evidence }),
+test("strict all-green across leaf and matrix cells is the only strict exit-0 result", async () => {
+  const report = await executeSelectedCells(
+    await optionsFor([fakeScenario({ id: "A" }), fakeMatrix({ id: "M" })], { behavior: "strict" }),
   );
-  assert.deepEqual(carried.candidate_build, evidence);
+  assert.equal(report.verdict.status, "selected_cells_passed");
+  assert.equal(report.verdict.scope, "selected_cells");
+  assert.equal(report.verdict.completeness, "partial");
+  assert.equal(report.summary.intended_exit_code, 0);
 });

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -469,3 +469,44 @@ test("strict all-green across leaf and matrix cells is the only strict exit-0 re
   assert.equal(report.verdict.completeness, "partial");
   assert.equal(report.summary.intended_exit_code, 0);
 });
+
+test("a collector mutating its received cells cannot alter the plan or evidence (ETM-002)", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => {
+      // Hostile collector: rewrites everything it was handed.
+      const cell = cells[0] as { cell_id: string; dimensions: Record<string, string>; required_env: string[] };
+      const originalId = cell.cell_id;
+      cell.cell_id = "M/local/child=tampered";
+      cell.dimensions.child = "tampered";
+      cell.required_env.push("INJECTED_VAR");
+      return [{ cellId: originalId, status: "green" as const }];
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(report.selected_cells[0].cell_id, "M/local/child=a");
+  assert.deepEqual(report.selected_cells[0].dimensions, { child: "a" });
+  assert.deepEqual(report.selected_cells[0].required_env, []);
+  assert.equal(report.results[0].cell_id, "M/local/child=a");
+  assert.deepEqual(report.results[0].dimensions, { child: "a" });
+  assert.equal(report.results[0].status, "green");
+  assert.equal(report.summary.integrity_errors.length, 0);
+});
+
+test("null, undefined, and malformed collector output is runner integrity, never a product failure (ETM-003)", async () => {
+  for (const bad of [null, undefined, "green", { cellId: 1 }]) {
+    const matrix = fakeMatrix({
+      id: "M",
+      cells: [{ child: "a" }],
+      runCells: (async () => (Array.isArray(bad) || typeof bad !== "object" || bad === null
+        ? bad
+        : [bad])) as unknown as MatrixScenarioDefinition["runCells"],
+    });
+    const report = await executeSelectedCells(await optionsFor([matrix]));
+    assert.equal(report.results[0].status, "missing", `for output ${JSON.stringify(bad)}`);
+    assert.notEqual(report.results[0].status, "failed");
+    assert.ok(report.summary.integrity_errors.length > 0);
+    assert.equal(report.summary.intended_exit_code, 2);
+  }
+});

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -534,7 +534,13 @@ test("a throwing reason getter is runner integrity, never an ordinary failed res
 });
 
 test("a malformed reason value preserves the aggregate as integrity exit 2 (ETM-003)", async () => {
-  for (const badReason of ["oops", 42, { code: "not_a_known_code", message: "x" }, { code: "scenario_failure" }]) {
+  for (const badReason of [
+    null,
+    "oops",
+    42,
+    { code: "not_a_known_code", message: "x" },
+    { code: "scenario_failure" },
+  ]) {
     const matrix = fakeMatrix({
       id: "M",
       cells: [{ child: "a" }],
@@ -550,23 +556,56 @@ test("a malformed reason value preserves the aggregate as integrity exit 2 (ETM-
   }
 });
 
+test("nested reason accessors are read exactly once before their values are persisted (ETM-003)", async () => {
+  let codeReads = 0;
+  let messageReads = 0;
+  const reason = {
+    get code(): unknown {
+      codeReads += 1;
+      return codeReads === 1 ? "scenario_failure" : "evil_code";
+    },
+    get message(): unknown {
+      messageReads += 1;
+      return messageReads === 1 ? "captured failure" : 42;
+    },
+  };
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => [
+      { cellId: cells[0].cell_id, status: "failed", reason } as unknown as ScenarioCellOutcome,
+    ],
+  });
+
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(codeReads, 1);
+  assert.equal(messageReads, 1);
+  assert.equal(report.results[0].status, "failed");
+  assert.deepEqual(report.results[0].reason, {
+    code: "scenario_failure",
+    message: "captured failure",
+  });
+  assert.equal(report.summary.integrity_errors.length, 0);
+  assert.equal(report.summary.intended_exit_code, 1);
+});
+
 test("a poisoned outcome iterator is runner integrity, not a collector failure (ETM-003)", async () => {
   const matrix = fakeMatrix({
     id: "M",
     cells: [{ child: "a" }],
     runCells: async () => {
-      const hostile: unknown = {
-        [Symbol.iterator]() {
+      const hostile: ScenarioCellOutcome[] = [];
+      Object.defineProperty(hostile, Symbol.iterator, {
+        value() {
           throw new Error("hostile iterator");
         },
-      };
-      Object.setPrototypeOf(hostile, Array.prototype);
-      return hostile as ScenarioCellOutcome[];
+      });
+      return hostile;
     },
   });
   const report = await executeSelectedCells(await optionsFor([matrix]));
-  // Not an ordinary failed result either way; the cell must be missing/2.
-  assert.notEqual(report.results[0].status, "failed");
+  assert.equal(report.results[0].status, "missing");
+  assert.ok(report.summary.integrity_errors.length > 0);
   assert.equal(report.summary.intended_exit_code, 2);
 });
 

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -510,3 +510,79 @@ test("null, undefined, and malformed collector output is runner integrity, never
     assert.equal(report.summary.intended_exit_code, 2);
   }
 });
+
+test("a throwing reason getter is runner integrity, never an ordinary failed result (ETM-003)", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (_ctx, cells) => {
+      const poisoned = { cellId: cells[0].cell_id, status: "failed" as const };
+      Object.defineProperty(poisoned, "reason", {
+        get() {
+          throw new Error("hostile getter");
+        },
+        enumerable: true,
+      });
+      return [poisoned as ScenarioCellOutcome];
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(report.results[0].status, "missing");
+  assert.notEqual(report.results[0].status, "failed");
+  assert.ok(report.summary.integrity_errors.length > 0);
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("a malformed reason value preserves the aggregate as integrity exit 2 (ETM-003)", async () => {
+  for (const badReason of ["oops", 42, { code: "not_a_known_code", message: "x" }, { code: "scenario_failure" }]) {
+    const matrix = fakeMatrix({
+      id: "M",
+      cells: [{ child: "a" }],
+      runCells: async (_ctx, cells) => [
+        { cellId: cells[0].cell_id, status: "failed", reason: badReason } as unknown as ScenarioCellOutcome,
+      ],
+    });
+    const report = await executeSelectedCells(await optionsFor([matrix]));
+    assert.equal(report.results[0].status, "missing", `for reason ${JSON.stringify(badReason)}`);
+    assert.equal(report.summary.intended_exit_code, 2);
+    // The aggregate survived — sanitization did not crash on the bad reason.
+    assert.equal(report.schema_version, 3);
+  }
+});
+
+test("a poisoned outcome iterator is runner integrity, not a collector failure (ETM-003)", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async () => {
+      const hostile: unknown = {
+        [Symbol.iterator]() {
+          throw new Error("hostile iterator");
+        },
+      };
+      Object.setPrototypeOf(hostile, Array.prototype);
+      return hostile as ScenarioCellOutcome[];
+    },
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  // Not an ordinary failed result either way; the cell must be missing/2.
+  assert.notEqual(report.results[0].status, "failed");
+  assert.equal(report.summary.intended_exit_code, 2);
+});
+
+test("a collector mutating ctx.agents cannot alter the persisted invocation inputs", async () => {
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (ctx, cells) => {
+      (ctx.agents as string[]).push("injected-agent");
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  const report = await executeSelectedCells(
+    await optionsFor([matrix], {
+      inputs: { targetLane: "local", desktop: "web", agents: ["claude"], scenarios: "all" },
+    }),
+  );
+  assert.deepEqual(report.inputs.agents, ["claude"]);
+});

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -11,18 +11,20 @@ import {
 } from "../scenarios/types.js";
 import type { CandidateBuildEvidenceV1 } from "../artifacts/build-map.js";
 import type { TestRunReportV3 } from "../evidence/schema.js";
-import { sanitizeReport } from "../evidence/schema.js";
+import { expectedVerdict, sanitizeReport } from "../evidence/schema.js";
 import type { RunIdentityV1 } from "./identity.js";
 import {
   clonePlannedCell,
   countByStatus,
   deriveVerdict,
+  RESULT_REASON_CODES,
   ResultTracker,
   SCENARIO_DECLARABLE_STATUSES,
   type FinalCellResultV1,
   type PlannedCellV1,
   type ResultBehavior,
   type ResultReason,
+  type ResultReasonCode,
   type ScenarioDeclarableStatus,
 } from "./result.js";
 
@@ -126,8 +128,10 @@ export async function executeSelectedCells(options: ExecuteOptions): Promise<Tes
     inputs: {
       target_lane: options.inputs.targetLane,
       desktop: options.inputs.desktop,
-      agents: options.inputs.agents,
-      scenarios: options.inputs.scenarios,
+      // Copied so no scenario holding a reference to the selector arrays can
+      // alter the persisted invocation inputs.
+      agents: options.inputs.agents === "all" ? "all" : [...options.inputs.agents],
+      scenarios: options.inputs.scenarios === "all" ? "all" : [...options.inputs.scenarios],
     },
     selected_cells: cells.map(clonePlannedCell),
     results,
@@ -148,7 +152,16 @@ export async function executeSelectedCells(options: ExecuteOptions): Promise<Tes
   };
 
   const resolveSecrets = options.resolveSecretValues ?? defaultResolveSecretValues;
-  return sanitizeReport(report, resolveSecrets());
+  const sanitized = sanitizeReport(report, resolveSecrets());
+  // The persisted verdict (including its reasons) is derived from the
+  // sanitized content through the same single derivation the report
+  // validator recomputes, so validation can require byte-for-byte equality.
+  const finalVerdict = expectedVerdict(sanitized);
+  return {
+    ...sanitized,
+    summary: { ...sanitized.summary, intended_exit_code: finalVerdict.intendedExitCode },
+    verdict: { ...sanitized.verdict, status: finalVerdict.status, reasons: finalVerdict.reasons },
+  };
 }
 
 /**
@@ -199,7 +212,7 @@ function planAll(
   const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
   for (const cell of cells) {
     const scenario = scenariosById.get(cell.scenario_id)!;
-    const planCtx = { runtimeLane: cell.runtime_lane, desktop: options.inputs.desktop, agents };
+    const planCtx = { runtimeLane: cell.runtime_lane, desktop: options.inputs.desktop, agents: [...agents] };
     try {
       const steps = isMatrixScenario(scenario)
         ? scenario.planCell(planCtx, clonePlannedCell(cell))
@@ -302,7 +315,9 @@ async function runAll(
       targetLane: options.inputs.targetLane,
       runtimeLane: first.runtime_lane,
       desktop: options.inputs.desktop,
-      agents,
+      // A fresh copy per invocation: a collector mutating ctx.agents cannot
+      // alter the persisted invocation inputs or a sibling's context.
+      agents: [...agents],
       dryRun: false,
       env: neededEnv,
     };
@@ -323,7 +338,17 @@ async function runAll(
         // Collectors receive independent copies; the canonical plan stays
         // with the tracker.
         const outcomes = await scenario.runCells(ctx, assigned.map(clonePlannedCell));
-        applyCollectorOutcomes(scenario, assigned, outcomes, tracker, finish);
+        try {
+          applyCollectorOutcomes(scenario, assigned, outcomes, tracker, finish);
+        } catch (error) {
+          // A throw while consuming the returned data (e.g. a poisoned
+          // iterator) is malformed collector output — runner integrity, not
+          // a product failure.
+          tracker.recordIntegrityError(
+            "selection_result_mismatch",
+            `Collector "${scenario.id}" output could not be consumed: ${evidenceSafeMessage(error)}`,
+          );
+        }
       } else {
         await scenario.run(ctx);
         finish(first.cell_id, "green", null);
@@ -376,19 +401,19 @@ function applyCollectorOutcomes(
   }
   const assignedIds = new Set(assigned.map((cell) => cell.cell_id));
   for (const raw of outcomes) {
-    if (
-      typeof raw !== "object" ||
-      raw === null ||
-      typeof (raw as { cellId?: unknown }).cellId !== "string" ||
-      typeof (raw as { status?: unknown }).status !== "string"
-    ) {
+    // The complete outcome — including the optional reason — is validated
+    // separately from collector execution, and property reads are guarded:
+    // a throwing getter or a malformed reason is runner integrity (the cell
+    // stays pending and finalizes missing/exit 2), never an ordinary failed
+    // result and never a lost aggregate.
+    const outcome = readCollectorOutcome(raw);
+    if (outcome === null) {
       tracker.recordIntegrityError(
         "selection_result_mismatch",
         `Collector "${scenario.id}" returned a malformed outcome entry.`,
       );
       continue;
     }
-    const outcome = raw as { cellId: string; status: string; reason?: ResultReason };
     if (!assignedIds.has(outcome.cellId)) {
       // Never finalize a cell outside this invocation's assignment — even one
       // that is planned for another collector — or one collector could write
@@ -408,6 +433,50 @@ function applyCollectorOutcomes(
     }
     const status = outcome.status as ScenarioDeclarableStatus;
     finish(outcome.cellId, status, outcome.reason ?? defaultReasonFor(status));
+  }
+}
+
+/**
+ * Reads one raw collector outcome defensively: every property access is
+ * guarded (a throwing getter is malformed data, not a scenario failure) and
+ * the optional reason must be a well-formed `{ code, message }` with a known
+ * reason code and string message — `reason: "oops"` would otherwise crash
+ * sanitization and lose the aggregate. Returns null for any malformed entry.
+ */
+function readCollectorOutcome(
+  raw: unknown,
+): { cellId: string; status: string; reason?: ResultReason } | null {
+  try {
+    if (typeof raw !== "object" || raw === null) {
+      return null;
+    }
+    const cellId = (raw as { cellId?: unknown }).cellId;
+    const status = (raw as { status?: unknown }).status;
+    const reason = (raw as { reason?: unknown }).reason;
+    if (typeof cellId !== "string" || typeof status !== "string") {
+      return null;
+    }
+    if (reason === undefined || reason === null) {
+      return { cellId, status };
+    }
+    if (
+      typeof reason !== "object" ||
+      typeof (reason as { code?: unknown }).code !== "string" ||
+      !(RESULT_REASON_CODES as readonly string[]).includes((reason as { code: string }).code) ||
+      typeof (reason as { message?: unknown }).message !== "string"
+    ) {
+      return null;
+    }
+    return {
+      cellId,
+      status,
+      reason: {
+        code: (reason as { code: ResultReasonCode }).code,
+        message: (reason as { message: string }).message,
+      },
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -456,14 +456,21 @@ function readCollectorOutcome(
     if (typeof cellId !== "string" || typeof status !== "string") {
       return null;
     }
-    if (reason === undefined || reason === null) {
+    if (reason === undefined) {
       return { cellId, status };
     }
+    if (typeof reason !== "object" || reason === null) {
+      return null;
+    }
+    // Snapshot nested accessors exactly once before validating. Re-reading a
+    // stateful getter after validation could otherwise persist a different
+    // code/message (or throw later during sanitization).
+    const code = (reason as { code?: unknown }).code;
+    const message = (reason as { message?: unknown }).message;
     if (
-      typeof reason !== "object" ||
-      typeof (reason as { code?: unknown }).code !== "string" ||
-      !(RESULT_REASON_CODES as readonly string[]).includes((reason as { code: string }).code) ||
-      typeof (reason as { message?: unknown }).message !== "string"
+      typeof code !== "string" ||
+      !(RESULT_REASON_CODES as readonly string[]).includes(code) ||
+      typeof message !== "string"
     ) {
       return null;
     }
@@ -471,8 +478,8 @@ function readCollectorOutcome(
       cellId,
       status,
       reason: {
-        code: (reason as { code: ResultReasonCode }).code,
-        message: (reason as { message: string }).message,
+        code: code as ResultReasonCode,
+        message,
       },
     };
   } catch {

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -14,6 +14,7 @@ import type { TestRunReportV3 } from "../evidence/schema.js";
 import { sanitizeReport } from "../evidence/schema.js";
 import type { RunIdentityV1 } from "./identity.js";
 import {
+  clonePlannedCell,
   countByStatus,
   deriveVerdict,
   ResultTracker,
@@ -75,8 +76,12 @@ export async function executeSelectedCells(options: ExecuteOptions): Promise<Tes
   const now = options.now ?? (() => new Date());
   const log = options.log ?? (() => undefined);
   const startedAt = now().toISOString();
-  const cells = options.cells;
-  const tracker = new ResultTracker(cells);
+  // The tracker deep-copies the plan at construction; everything below —
+  // grouping, collector assignment, finalization, and the persisted
+  // selected_cells — reads the tracker's protected canonical copy, so a
+  // collector mutating the cell objects it received cannot alter evidence.
+  const tracker = new ResultTracker(options.cells);
+  const cells = tracker.selectedCells;
   const scenariosById = new Map(options.scenarios.map((scenario) => [scenario.id, scenario]));
   const locallySeeded = options.locallySeeded ?? new Set<string>();
 
@@ -124,7 +129,7 @@ export async function executeSelectedCells(options: ExecuteOptions): Promise<Tes
       agents: options.inputs.agents,
       scenarios: options.inputs.scenarios,
     },
-    selected_cells: [...cells],
+    selected_cells: cells.map(clonePlannedCell),
     results,
     summary: {
       selected: cells.length,
@@ -196,7 +201,9 @@ function planAll(
     const scenario = scenariosById.get(cell.scenario_id)!;
     const planCtx = { runtimeLane: cell.runtime_lane, desktop: options.inputs.desktop, agents };
     try {
-      const steps = isMatrixScenario(scenario) ? scenario.planCell(planCtx, cell) : scenario.plan(planCtx);
+      const steps = isMatrixScenario(scenario)
+        ? scenario.planCell(planCtx, clonePlannedCell(cell))
+        : scenario.plan(planCtx);
       tracker.finalize(cell.cell_id, {
         status: "not_run",
         reason: { code: "dry_run", message: "Diagnostic dry-run planned this cell instead of executing it." },
@@ -313,7 +320,9 @@ async function runAll(
     try {
       log(`running ${assigned.map((cell) => cell.cell_id).join(", ")}`);
       if (isMatrixScenario(scenario)) {
-        const outcomes = await scenario.runCells(ctx, assigned);
+        // Collectors receive independent copies; the canonical plan stays
+        // with the tracker.
+        const outcomes = await scenario.runCells(ctx, assigned.map(clonePlannedCell));
         applyCollectorOutcomes(scenario, assigned, outcomes, tracker, finish);
       } else {
         await scenario.run(ctx);
@@ -350,12 +359,36 @@ async function runAll(
 function applyCollectorOutcomes(
   scenario: MatrixScenarioDefinition,
   assigned: readonly PlannedCellV1[],
-  outcomes: readonly { cellId: string; status: ScenarioDeclarableStatus; reason?: ResultReason }[],
+  outcomes: unknown,
   tracker: ResultTracker,
   finish: (cellId: string, status: FinalCellResultV1["status"], reason: ResultReason | null) => void,
 ): void {
+  // Malformed collector output (null/undefined/non-array, or entries without
+  // a cell id and status) is a runner-integrity failure, not a product
+  // failure: the affected cells stay pending and finalize as missing with
+  // exit 2 — never as failed/exit 1.
+  if (!Array.isArray(outcomes)) {
+    tracker.recordIntegrityError(
+      "selection_result_mismatch",
+      `Collector "${scenario.id}" returned ${outcomes === null ? "null" : typeof outcomes} instead of an outcome array.`,
+    );
+    return;
+  }
   const assignedIds = new Set(assigned.map((cell) => cell.cell_id));
-  for (const outcome of outcomes) {
+  for (const raw of outcomes) {
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      typeof (raw as { cellId?: unknown }).cellId !== "string" ||
+      typeof (raw as { status?: unknown }).status !== "string"
+    ) {
+      tracker.recordIntegrityError(
+        "selection_result_mismatch",
+        `Collector "${scenario.id}" returned a malformed outcome entry.`,
+      );
+      continue;
+    }
+    const outcome = raw as { cellId: string; status: string; reason?: ResultReason };
     if (!assignedIds.has(outcome.cellId)) {
       // Never finalize a cell outside this invocation's assignment — even one
       // that is planned for another collector — or one collector could write
@@ -373,7 +406,8 @@ function applyCollectorOutcomes(
       );
       continue;
     }
-    finish(outcome.cellId, outcome.status, outcome.reason ?? defaultReasonFor(outcome.status));
+    const status = outcome.status as ScenarioDeclarableStatus;
+    finish(outcome.cellId, status, outcome.reason ?? defaultReasonFor(status));
   }
 }
 

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -2,65 +2,28 @@ import type { EnvResolution } from "../config/env-resolution.js";
 import { blockedReasonForMissingEnv, missingRequiredForLane, resolveEnv } from "../config/env-resolution.js";
 import { envVarNames } from "../config/env-manifest.js";
 import type { DesktopMode, TargetLane } from "../config/types.js";
-import type { ScenarioDefinition } from "../scenarios/types.js";
-import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
+import {
+  isMatrixScenario,
+  ScenarioBlockedError,
+  ScenarioExpectedFailError,
+  type MatrixScenarioDefinition,
+  type ScenarioDefinition,
+} from "../scenarios/types.js";
 import type { CandidateBuildEvidenceV1 } from "../artifacts/build-map.js";
-import type { TestRunReportV2 } from "../evidence/schema.js";
+import type { TestRunReportV3 } from "../evidence/schema.js";
 import { sanitizeReport } from "../evidence/schema.js";
 import type { RunIdentityV1 } from "./identity.js";
 import {
   countByStatus,
   deriveVerdict,
   ResultTracker,
-  type FinalTestResultV1,
+  SCENARIO_DECLARABLE_STATUSES,
+  type FinalCellResultV1,
+  type PlannedCellV1,
   type ResultBehavior,
-  type SelectedTestV1,
+  type ResultReason,
+  type ScenarioDeclarableStatus,
 } from "./result.js";
-
-export class SelectionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SelectionError";
-  }
-}
-
-/**
- * Expands scenarios across their declared runtime lanes into selected tests
- * (`test_id = scenario_id/runtime_lane`) and rejects duplicate expanded ids,
- * so a duplicate cell can never execute or record twice.
- */
-export function expandSelectedTests(scenarios: readonly ScenarioDefinition[]): SelectedTestV1[] {
-  const selected: SelectedTestV1[] = [];
-  const seen = new Set<string>();
-  const seenScenarioIds = new Set<string>();
-  for (const scenario of scenarios) {
-    // Duplicate scenario ids are rejected outright (not only duplicate
-    // expanded test ids): later lookup is by scenario id, so two definitions
-    // sharing an id — even with disjoint lanes — could execute one body
-    // while reporting the other's metadata.
-    if (seenScenarioIds.has(scenario.id)) {
-      throw new SelectionError(`Duplicate scenario id "${scenario.id}" in the selection.`);
-    }
-    seenScenarioIds.add(scenario.id);
-    for (const runtimeLane of scenario.lanes) {
-      const testId = `${scenario.id}/${runtimeLane}`;
-      if (seen.has(testId)) {
-        throw new SelectionError(`Duplicate expanded test id "${testId}".`);
-      }
-      seen.add(testId);
-      selected.push({
-        test_id: testId,
-        scenario_id: scenario.id,
-        registry_flow_ref: scenario.registryFlowRef,
-        runtime_lane: runtimeLane,
-      });
-    }
-  }
-  if (selected.length === 0) {
-    throw new SelectionError("Selection expanded to zero tests.");
-  }
-  return selected;
-}
 
 export interface ExecuteInputs {
   targetLane: TargetLane;
@@ -76,6 +39,12 @@ export interface ExecuteOptions {
   inputs: ExecuteInputs;
   scenarios: readonly ScenarioDefinition[];
   /**
+   * The complete exact test plan, prebuilt and validated by runner/plan.ts
+   * before any setup side effect (cli/command.ts owns the ordering).
+   * Execution never re-expands or reorders cells.
+   */
+  cells: readonly PlannedCellV1[];
+  /**
    * Bounded artifact identity from the validated candidate build map;
    * explicit null when a diagnostic run omitted the map. The caller
    * (cli/command.ts) owns loading and validation before any setup.
@@ -83,7 +52,7 @@ export interface ExecuteOptions {
   candidateBuild?: CandidateBuildEvidenceV1 | null;
   /** Names satisfied only by this run's local durable-user seeding. */
   locallySeeded?: ReadonlySet<string>;
-  /** Injectable for tests; defaults to resolveEnv over the union of requiredEnv. */
+  /** Injectable for tests; defaults to resolveEnv over the union of required env. */
   resolveNeededEnv?: (names: readonly string[]) => EnvResolution;
   /**
    * Injectable for tests; defaults to every present secret value in the full
@@ -96,33 +65,34 @@ export interface ExecuteOptions {
 }
 
 /**
- * Runs the required control flow: initialize one pending slot per selected
- * test, preflight declared requirements, plan or execute per behavior,
- * normalize every outcome, synthesize missing results, and derive the
- * verdict/intended exit — returning an unwritten, sanitized combined report.
+ * Runs the required control flow: one pending slot per planned cell,
+ * per-cell requirement preflight, plan or execute per behavior with matrix
+ * collectors invoked once per scenario/runtime lane, one explicit outcome per
+ * assigned cell, missing synthesis, and the diagnostic/strict verdict —
+ * returning an unwritten, sanitized combined report V3.
  */
-export async function executeSelectedTests(options: ExecuteOptions): Promise<TestRunReportV2> {
+export async function executeSelectedCells(options: ExecuteOptions): Promise<TestRunReportV3> {
   const now = options.now ?? (() => new Date());
   const log = options.log ?? (() => undefined);
   const startedAt = now().toISOString();
-  const selected = expandSelectedTests(options.scenarios);
-  const tracker = new ResultTracker(selected);
+  const cells = options.cells;
+  const tracker = new ResultTracker(cells);
   const scenariosById = new Map(options.scenarios.map((scenario) => [scenario.id, scenario]));
   const locallySeeded = options.locallySeeded ?? new Set<string>();
 
-  // Once a valid selected set exists, a recoverable runner defect (e.g. a
-  // scenario referencing an undeclared env var) must not lose the selected
-  // results: it becomes a runner error, pending tests finalize as missing,
+  // Once a valid planned set exists, a recoverable runner defect (e.g. a
+  // scenario referencing an undeclared env var) must not lose the planned
+  // results: it becomes a runner error, pending cells finalize as missing,
   // and the report is still produced for persistence.
   try {
-    const neededEnvNames = [...new Set(options.scenarios.flatMap((scenario) => scenario.requiredEnv))];
+    const neededEnvNames = [...new Set(cells.flatMap((cell) => cell.required_env))];
     const resolveNeeded = options.resolveNeededEnv ?? ((names: readonly string[]) => resolveEnv(names));
     const neededEnv = resolveNeeded(neededEnvNames);
 
     if (options.execution === "dry_run") {
-      await planAll(selected, scenariosById, tracker, options, now);
+      planAll(cells, scenariosById, tracker, options, now);
     } else {
-      await runAll(selected, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
+      await runAll(cells, scenariosById, tracker, options, neededEnv, locallySeeded, now, log);
     }
   } catch (error) {
     tracker.recordRunnerError("runner_error", `Runner failed after selection: ${evidenceSafeMessage(error)}`);
@@ -137,8 +107,8 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
     runnerErrors: tracker.runnerErrors,
   });
 
-  const report: TestRunReportV2 = {
-    schema_version: 2,
+  const report: TestRunReportV3 = {
+    schema_version: 3,
     kind: "proliferate.test-run",
     candidate_build: options.candidateBuild ?? null,
     run: {
@@ -154,10 +124,10 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
       agents: options.inputs.agents,
       scenarios: options.inputs.scenarios,
     },
-    selected_tests: [...selected],
+    selected_cells: [...cells],
     results,
     summary: {
-      selected: selected.length,
+      selected: cells.length,
       finalized: results.length,
       by_status: countByStatus(results),
       integrity_errors: [...tracker.integrityErrors],
@@ -166,7 +136,7 @@ export async function executeSelectedTests(options: ExecuteOptions): Promise<Tes
     },
     verdict: {
       status: verdict.status,
-      scope: "selected_tests",
+      scope: "selected_cells",
       completeness: "partial",
       reasons: verdict.reasons,
     },
@@ -197,10 +167,7 @@ function evidenceSafeMessage(error: unknown): string {
     const prefix = /^(.*?->\s*\d+)/.exec(error.message)?.[1] ?? `request failed with status ${status}`;
     return `${error.name}: ${prefix} (response body withheld from evidence)`;
   }
-  if (
-    error instanceof Error &&
-    ("stdout" in error || "stderr" in error)
-  ) {
+  if (error instanceof Error && ("stdout" in error || "stderr" in error)) {
     return `${error.name}: external command failed (output withheld from evidence)`;
   }
   return error instanceof Error ? error.message : String(error);
@@ -217,42 +184,39 @@ function defaultResolveSecretValues(): string[] {
     .map((entry) => entry.value as string);
 }
 
-async function planAll(
-  selected: readonly SelectedTestV1[],
+function planAll(
+  cells: readonly PlannedCellV1[],
   scenariosById: ReadonlyMap<string, ScenarioDefinition>,
   tracker: ResultTracker,
   options: ExecuteOptions,
   now: () => Date,
-): Promise<void> {
+): void {
   const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
-  for (const test of selected) {
-    const scenario = scenariosById.get(test.scenario_id)!;
+  for (const cell of cells) {
+    const scenario = scenariosById.get(cell.scenario_id)!;
+    const planCtx = { runtimeLane: cell.runtime_lane, desktop: options.inputs.desktop, agents };
     try {
-      const steps = scenario.plan({
-        runtimeLane: test.runtime_lane,
-        desktop: options.inputs.desktop,
-        agents,
-      });
-      tracker.finalize(test.test_id, {
+      const steps = isMatrixScenario(scenario) ? scenario.planCell(planCtx, cell) : scenario.plan(planCtx);
+      tracker.finalize(cell.cell_id, {
         status: "not_run",
-        reason: { code: "dry_run", message: "Diagnostic dry-run planned this test instead of executing it." },
+        reason: { code: "dry_run", message: "Diagnostic dry-run planned this cell instead of executing it." },
         planSteps: steps.map((step) => step.description),
         finishedAt: now().toISOString(),
       });
     } catch (error) {
       const message = evidenceSafeMessage(error);
-      tracker.finalize(test.test_id, {
+      tracker.finalize(cell.cell_id, {
         status: "not_run",
         reason: { code: "plan_error", message: `plan() threw: ${message}` },
         finishedAt: now().toISOString(),
       });
-      tracker.recordRunnerError("runner_error", `plan() for "${test.test_id}" threw: ${message}`);
+      tracker.recordRunnerError("runner_error", `plan() for "${cell.cell_id}" threw: ${message}`);
     }
   }
 }
 
 async function runAll(
-  selected: readonly SelectedTestV1[],
+  cells: readonly PlannedCellV1[],
   scenariosById: ReadonlyMap<string, ScenarioDefinition>,
   tracker: ResultTracker,
   options: ExecuteOptions,
@@ -261,35 +225,34 @@ async function runAll(
   now: () => Date,
   log: (message: string) => void,
 ): Promise<void> {
-  const missingByTest = new Map<string, string[]>();
-  for (const test of selected) {
-    const scenario = scenariosById.get(test.scenario_id)!;
-    const missing = missingRequiredForLane(scenario.requiredEnv, test.runtime_lane, neededEnv, locallySeeded);
+  const missingByCell = new Map<string, string[]>();
+  for (const cell of cells) {
+    const missing = missingRequiredForLane(cell.required_env, cell.runtime_lane, neededEnv, locallySeeded);
     if (missing.length > 0) {
-      missingByTest.set(test.test_id, missing);
+      missingByCell.set(cell.cell_id, missing);
     }
   }
 
-  // Strict preflight is fail-closed: any unsatisfied selected requirement
-  // means zero scenario bodies execute.
-  if (options.behavior === "strict" && missingByTest.size > 0) {
-    for (const test of selected) {
-      const missing = missingByTest.get(test.test_id);
+  // Strict preflight is fail-closed: any unsatisfied planned requirement
+  // means zero collector bodies execute.
+  if (options.behavior === "strict" && missingByCell.size > 0) {
+    for (const cell of cells) {
+      const missing = missingByCell.get(cell.cell_id);
       if (missing) {
-        tracker.finalize(test.test_id, {
+        tracker.finalize(cell.cell_id, {
           status: "blocked",
           reason: {
             code: "missing_requirement",
-            message: blockedReasonForMissingEnv(test.scenario_id, test.runtime_lane, missing, locallySeeded),
+            message: blockedReasonForMissingEnv(cell.cell_id, cell.runtime_lane, missing, locallySeeded),
           },
           finishedAt: now().toISOString(),
         });
       } else {
-        tracker.finalize(test.test_id, {
+        tracker.finalize(cell.cell_id, {
           status: "cancelled",
           reason: {
             code: "strict_preflight_failed",
-            message: "Strict preflight found unsatisfied requirements on sibling tests; no test body ran.",
+            message: "Strict preflight found unsatisfied requirements on sibling cells; no cell body ran.",
           },
           finishedAt: now().toISOString(),
         });
@@ -298,59 +261,144 @@ async function runAll(
     return;
   }
 
-  const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
-  for (const test of selected) {
-    const scenario = scenariosById.get(test.scenario_id)!;
-    const missing = missingByTest.get(test.test_id);
+  // Diagnostic preflight blocks only affected cells; runnable cells are then
+  // grouped by scenario/runtime lane so a matrix collector is invoked exactly
+  // once per group with its assigned cells (efficient shared setup).
+  const groups = new Map<string, PlannedCellV1[]>();
+  for (const cell of cells) {
+    const missing = missingByCell.get(cell.cell_id);
     if (missing) {
-      tracker.finalize(test.test_id, {
+      tracker.finalize(cell.cell_id, {
         status: "blocked",
         reason: {
           code: "missing_requirement",
-          message: blockedReasonForMissingEnv(test.scenario_id, test.runtime_lane, missing, locallySeeded),
+          message: blockedReasonForMissingEnv(cell.cell_id, cell.runtime_lane, missing, locallySeeded),
         },
         finishedAt: now().toISOString(),
       });
       continue;
     }
+    const groupKey = `${cell.scenario_id}/${cell.runtime_lane}`;
+    const group = groups.get(groupKey);
+    if (group) {
+      group.push(cell);
+    } else {
+      groups.set(groupKey, [cell]);
+    }
+  }
+
+  const agents = options.inputs.agents === "all" ? ["all"] : options.inputs.agents;
+  for (const assigned of groups.values()) {
+    const first = assigned[0];
+    const scenario = scenariosById.get(first.scenario_id)!;
+    const ctx = {
+      targetLane: options.inputs.targetLane,
+      runtimeLane: first.runtime_lane,
+      desktop: options.inputs.desktop,
+      agents,
+      dryRun: false,
+      env: neededEnv,
+    };
     const startedAt = now().toISOString();
     const startedMs = now().getTime();
-    const finish = (status: "green" | "failed" | "blocked" | "expected_fail", reason: FinalTestResultV1["reason"]) =>
-      tracker.finalize(test.test_id, {
+    const finish = (cellId: string, status: FinalCellResultV1["status"], reason: ResultReason | null): void =>
+      tracker.finalize(cellId, {
         status,
         reason: reason ?? undefined,
         startedAt,
         finishedAt: now().toISOString(),
         durationMs: now().getTime() - startedMs,
       });
+
     try {
-      log(`running ${test.test_id}`);
-      await scenario.run({
-        targetLane: options.inputs.targetLane,
-        runtimeLane: test.runtime_lane,
-        desktop: options.inputs.desktop,
-        agents,
-        dryRun: false,
-        env: neededEnv,
-      });
-      finish("green", null);
-    } catch (error) {
-      if (error instanceof ScenarioBlockedError) {
-        finish("blocked", { code: "scenario_blocked", message: error.reason });
-      } else if (error instanceof ScenarioExpectedFailError) {
-        finish("expected_fail", { code: "known_gap", message: error.diagnosis });
+      log(`running ${assigned.map((cell) => cell.cell_id).join(", ")}`);
+      if (isMatrixScenario(scenario)) {
+        const outcomes = await scenario.runCells(ctx, assigned);
+        applyCollectorOutcomes(scenario, assigned, outcomes, tracker, finish);
       } else {
-        // The report stores the normalized message, never the raw stack
-        // (spec: "raw stacks and provider payloads are not serialized");
-        // the stack still reaches the console via the runner's own logging.
-        finish("failed", {
-          code: "scenario_failure",
-          message: evidenceSafeMessage(error),
-        });
+        await scenario.run(ctx);
+        finish(first.cell_id, "green", null);
+      }
+    } catch (error) {
+      // A collector-level throw applies its normalized outcome to every
+      // still-pending cell assigned to this invocation; independent
+      // scenario/runtime collectors continue afterward.
+      const normalized = normalizeThrown(error);
+      const stillPending = new Set(tracker.pendingCells().map((pending) => pending.cell_id));
+      for (const cell of assigned) {
+        if (stillPending.has(cell.cell_id)) {
+          finish(cell.cell_id, normalized.status, normalized.reason);
+        }
+      }
+      if (normalized.status === "failed") {
         log(
-          `failed ${test.test_id}: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+          `failed ${assigned.map((cell) => cell.cell_id).join(", ")}: ${
+            error instanceof Error ? (error.stack ?? error.message) : String(error)
+          }`,
         );
       }
     }
   }
+}
+
+/**
+ * Applies a matrix collector's returned outcomes: exactly one explicit
+ * outcome per assigned cell. Unknown and duplicate cell ids are integrity
+ * errors; omitted cells stay pending and are synthesized as `missing` at
+ * finalization. Scenario code cannot declare runner-only terminal states.
+ */
+function applyCollectorOutcomes(
+  scenario: MatrixScenarioDefinition,
+  assigned: readonly PlannedCellV1[],
+  outcomes: readonly { cellId: string; status: ScenarioDeclarableStatus; reason?: ResultReason }[],
+  tracker: ResultTracker,
+  finish: (cellId: string, status: FinalCellResultV1["status"], reason: ResultReason | null) => void,
+): void {
+  const assignedIds = new Set(assigned.map((cell) => cell.cell_id));
+  for (const outcome of outcomes) {
+    if (!assignedIds.has(outcome.cellId)) {
+      // Never finalize a cell outside this invocation's assignment — even one
+      // that is planned for another collector — or one collector could write
+      // another's results.
+      tracker.recordIntegrityError(
+        "selection_result_mismatch",
+        `Collector "${scenario.id}" returned an outcome for unassigned cell "${outcome.cellId}".`,
+      );
+      continue;
+    }
+    if (!(SCENARIO_DECLARABLE_STATUSES as readonly string[]).includes(outcome.status)) {
+      tracker.recordIntegrityError(
+        "selection_result_mismatch",
+        `Collector "${scenario.id}" declared runner-only status "${outcome.status}" for "${outcome.cellId}".`,
+      );
+      continue;
+    }
+    finish(outcome.cellId, outcome.status, outcome.reason ?? defaultReasonFor(outcome.status));
+  }
+}
+
+function defaultReasonFor(status: ScenarioDeclarableStatus): ResultReason | null {
+  switch (status) {
+    case "green":
+      return null;
+    case "failed":
+      return { code: "scenario_failure", message: "collector reported this cell failed" };
+    case "blocked":
+      return { code: "scenario_blocked", message: "collector reported this cell blocked" };
+    case "expected_fail":
+      return { code: "known_gap", message: "collector reported this cell as a diagnosed known gap" };
+  }
+}
+
+function normalizeThrown(error: unknown): { status: "blocked" | "expected_fail" | "failed"; reason: ResultReason } {
+  if (error instanceof ScenarioBlockedError) {
+    return { status: "blocked", reason: { code: "scenario_blocked", message: error.reason } };
+  }
+  if (error instanceof ScenarioExpectedFailError) {
+    return { status: "expected_fail", reason: { code: "known_gap", message: error.diagnosis } };
+  }
+  // The report stores the normalized message, never the raw stack (spec:
+  // "raw stacks and provider payloads are not serialized"); the stack still
+  // reaches the console via the runner's own logging.
+  return { status: "failed", reason: { code: "scenario_failure", message: evidenceSafeMessage(error) } };
 }

--- a/tests/release/src/runner/plan.test.ts
+++ b/tests/release/src/runner/plan.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { LeafScenarioDefinition, MatrixScenarioDefinition, ScenarioCellSpec } from "../scenarios/types.js";
+import { buildPlannedCells, SelectionError } from "./plan.js";
+
+function leaf(id: string, lanes: Array<"local" | "sandbox"> = ["local"]): LeafScenarioDefinition {
+  return {
+    id,
+    title: id,
+    registryFlowRef: `specs#${id}`,
+    lanes,
+    requiredEnv: ["SCENARIO_VAR"],
+    plan: () => [],
+    run: async () => undefined,
+  };
+}
+
+function matrix(
+  id: string,
+  specs: ScenarioCellSpec[],
+  lanes: Array<"local" | "sandbox"> = ["local"],
+): MatrixScenarioDefinition {
+  return {
+    id,
+    title: id,
+    registryFlowRef: `specs#${id}`,
+    lanes,
+    requiredEnv: ["SCENARIO_VAR"],
+    kind: "matrix",
+    expandCells: () => specs,
+    planCell: () => [],
+    runCells: async () => [],
+  };
+}
+
+const INPUTS = { desktop: "web" as const, agents: ["all"] };
+
+test("leaf scenarios retain one unchanged scenario/lane cell", async () => {
+  const cells = await buildPlannedCells([leaf("T3-BILL-1", ["local", "sandbox"])], INPUTS);
+  assert.deepEqual(
+    cells.map((cell) => cell.cell_id),
+    ["T3-BILL-1/local", "T3-BILL-1/sandbox"],
+  );
+  assert.deepEqual(cells[0].dimensions, {});
+  assert.deepEqual(cells[0].required_env, ["SCENARIO_VAR"]);
+});
+
+test("matrix cell ids are deterministic regardless of declaration order", async () => {
+  const declared = [{ dimensions: { harness: "codex" } }, { dimensions: { harness: "claude" } }];
+  const reversed = [...declared].reverse();
+  const first = await buildPlannedCells([matrix("M", declared)], INPUTS);
+  const second = await buildPlannedCells([matrix("M", reversed)], INPUTS);
+  assert.deepEqual(
+    first.map((cell) => cell.cell_id),
+    second.map((cell) => cell.cell_id),
+  );
+  assert.deepEqual(
+    first.map((cell) => cell.cell_id),
+    ["M/local/harness=claude", "M/local/harness=codex"],
+  );
+});
+
+test("multi-dimension cell ids sort dimension keys lexicographically", async () => {
+  const cells = await buildPlannedCells(
+    [matrix("M", [{ dimensions: { route: "gateway", harness: "claude" } }])],
+    INPUTS,
+  );
+  assert.equal(cells[0].cell_id, "M/local/harness=claude,route=gateway");
+  assert.deepEqual(Object.keys(cells[0].dimensions), ["harness", "route"]);
+});
+
+test("dimension values are safely encoded into the cell id", async () => {
+  const cells = await buildPlannedCells(
+    [matrix("M", [{ dimensions: { model: "anthropic/claude haiku" } }])],
+    INPUTS,
+  );
+  assert.equal(cells[0].cell_id, "M/local/model=anthropic%2Fclaude%20haiku");
+  assert.equal(cells[0].dimensions.model, "anthropic/claude haiku");
+});
+
+test("the final planned list is sorted by cell_id across scenarios and lanes", async () => {
+  const cells = await buildPlannedCells(
+    [leaf("Z-LEAF"), matrix("A-MATRIX", [{ dimensions: { child: "b" } }, { dimensions: { child: "a" } }])],
+    INPUTS,
+  );
+  const ids = cells.map((cell) => cell.cell_id);
+  assert.deepEqual(ids, [...ids].sort());
+  assert.deepEqual(ids, ["A-MATRIX/local/child=a", "A-MATRIX/local/child=b", "Z-LEAF/local"]);
+});
+
+test("cell required_env is the union of scenario and cell requirements", async () => {
+  const cells = await buildPlannedCells(
+    [matrix("M", [{ dimensions: { child: "a" }, requiredEnv: ["CELL_VAR", "SCENARIO_VAR"] }])],
+    INPUTS,
+  );
+  assert.deepEqual(cells[0].required_env, ["SCENARIO_VAR", "CELL_VAR"]);
+});
+
+test("empty matrix expansion rejects before setup", async () => {
+  await assert.rejects(buildPlannedCells([matrix("M", [])], INPUTS), SelectionError);
+});
+
+test("zero total cells reject", async () => {
+  await assert.rejects(buildPlannedCells([], INPUTS), SelectionError);
+});
+
+test("duplicate expanded cell ids reject", async () => {
+  await assert.rejects(
+    buildPlannedCells(
+      [matrix("M", [{ dimensions: { child: "a" } }, { dimensions: { child: "a" } }])],
+      INPUTS,
+    ),
+    SelectionError,
+  );
+});
+
+test("duplicate scenario ids reject even with disjoint lanes", async () => {
+  await assert.rejects(
+    buildPlannedCells([leaf("A", ["local"]), leaf("A", ["sandbox"])], INPUTS),
+    SelectionError,
+  );
+});
+
+test("invalid dimension keys, empty values, and dimensionless matrix cells reject", async () => {
+  await assert.rejects(
+    buildPlannedCells([matrix("M", [{ dimensions: { "Bad Key": "x" } }])], INPUTS),
+    SelectionError,
+  );
+  await assert.rejects(
+    buildPlannedCells([matrix("M", [{ dimensions: { harness: "" } }])], INPUTS),
+    SelectionError,
+  );
+  await assert.rejects(
+    buildPlannedCells([matrix("M", [{ dimensions: { harness: "x".repeat(200) } }])], INPUTS),
+    SelectionError,
+  );
+  await assert.rejects(buildPlannedCells([matrix("M", [{ dimensions: {} }])], INPUTS), SelectionError);
+});
+
+test("a throwing expandCells propagates as a planning failure", async () => {
+  const broken: MatrixScenarioDefinition = {
+    ...matrix("M", []),
+    expandCells: () => {
+      throw new Error("expansion bug");
+    },
+  };
+  await assert.rejects(buildPlannedCells([broken], INPUTS), /expansion bug/);
+});

--- a/tests/release/src/runner/plan.ts
+++ b/tests/release/src/runner/plan.ts
@@ -102,23 +102,38 @@ function addCell(cells: PlannedCellV1[], seen: Set<string>, cell: PlannedCellV1)
   cells.push(cell);
 }
 
+/**
+ * The complete dimension-shape rules, shared between the planner (rejecting a
+ * scenario's expansion) and the report validator (rejecting evidence whose
+ * dimensions the planner could never have produced). Returns a description of
+ * the first problem, or null when the shape is valid. An empty object is a
+ * valid shape here — leaf cells have no dimensions; the matrix-specific
+ * at-least-one-key rule stays with the planner.
+ */
+export function dimensionShapeProblem(dimensions: unknown): string | null {
+  if (typeof dimensions !== "object" || dimensions === null || Array.isArray(dimensions)) {
+    return "dimensions must be a plain object";
+  }
+  for (const [key, value] of Object.entries(dimensions)) {
+    if (!DIMENSION_KEY_PATTERN.test(key)) {
+      return `invalid dimension key "${key}"`;
+    }
+    if (typeof value !== "string" || value.length === 0 || value.length > MAX_DIMENSION_VALUE_LENGTH) {
+      return `empty, non-string, or unbounded value for dimension "${key}"`;
+    }
+  }
+  return null;
+}
+
 function validateDimensions(scenarioId: string, spec: ScenarioCellSpec): Record<string, string> {
-  const keys = Object.keys(spec.dimensions);
-  if (keys.length === 0) {
+  if (Object.keys(spec.dimensions ?? {}).length === 0) {
     // A dimensionless matrix cell would collide with the scenario's own leaf
     // id form; a matrix child must be distinguishable by at least one key.
     throw new SelectionError(`Matrix scenario "${scenarioId}" declared a cell with no dimensions.`);
   }
-  for (const key of keys) {
-    if (!DIMENSION_KEY_PATTERN.test(key)) {
-      throw new SelectionError(`Matrix scenario "${scenarioId}" declared an invalid dimension key "${key}".`);
-    }
-    const value = spec.dimensions[key];
-    if (typeof value !== "string" || value.length === 0 || value.length > MAX_DIMENSION_VALUE_LENGTH) {
-      throw new SelectionError(
-        `Matrix scenario "${scenarioId}" declared an empty or unbounded value for dimension "${key}".`,
-      );
-    }
+  const problem = dimensionShapeProblem(spec.dimensions);
+  if (problem) {
+    throw new SelectionError(`Matrix scenario "${scenarioId}" declared ${problem}.`);
   }
   return spec.dimensions;
 }

--- a/tests/release/src/runner/plan.ts
+++ b/tests/release/src/runner/plan.ts
@@ -131,11 +131,26 @@ function sortedDimensions(dimensions: Record<string, string>): Record<string, st
   );
 }
 
-/** `<scenario>/<lane>/<k>=<encoded v>` with dimension keys sorted lexicographically. */
-function cellIdFor(scenarioId: string, runtimeLane: string, dimensions: Record<string, string>): string {
-  const suffix = Object.keys(dimensions)
-    .sort()
-    .map((key) => `${key}=${encodeURIComponent(dimensions[key])}`)
-    .join(",");
+/**
+ * The canonical runner-created cell id: `<scenario>/<lane>` for leaf cells
+ * (no dimensions) and `<scenario>/<lane>/<k>=<encoded v>` with dimension keys
+ * sorted lexicographically for matrix cells. The report validator recomputes
+ * ids through this same function, so a coordinated cell-id/dimension edit in
+ * persisted evidence cannot validate.
+ */
+export function canonicalCellId(
+  scenarioId: string,
+  runtimeLane: string,
+  dimensions: Record<string, string>,
+): string {
+  const keys = Object.keys(dimensions).sort();
+  if (keys.length === 0) {
+    return `${scenarioId}/${runtimeLane}`;
+  }
+  const suffix = keys.map((key) => `${key}=${encodeURIComponent(dimensions[key])}`).join(",");
   return `${scenarioId}/${runtimeLane}/${suffix}`;
+}
+
+function cellIdFor(scenarioId: string, runtimeLane: string, dimensions: Record<string, string>): string {
+  return canonicalCellId(scenarioId, runtimeLane, dimensions);
 }

--- a/tests/release/src/runner/plan.ts
+++ b/tests/release/src/runner/plan.ts
@@ -1,0 +1,141 @@
+import type { DesktopMode } from "../config/types.js";
+import { isMatrixScenario, type ScenarioCellSpec, type ScenarioDefinition } from "../scenarios/types.js";
+import type { PlannedCellV1 } from "./result.js";
+
+/**
+ * Exact-cell expansion and validation
+ * (specs/developing/testing/exact-test-matrix.md "Cell identity"). The
+ * selected-cell array produced here is the complete test plan for one
+ * invocation: leaf scenarios keep their unchanged `<scenario>/<lane>` cell,
+ * matrix scenarios declare child specs that the runner turns into
+ * `<scenario>/<lane>/<key>=<value>` cells with runner-created ids. Invalid,
+ * empty, or duplicate expansion throws before any setup side effect.
+ */
+
+export class SelectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SelectionError";
+  }
+}
+
+// Bounded stable identifiers for dimension keys; values are non-empty,
+// bounded, and safely encoded into the cell id.
+const DIMENSION_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/;
+const MAX_DIMENSION_VALUE_LENGTH = 128;
+
+export interface PlanInputs {
+  desktop: DesktopMode;
+  /** Resolved `--agents` selection (catalog harness kinds), or ["all"]. */
+  agents: readonly string[];
+}
+
+/**
+ * Deterministically expands the selected scenarios into the exact planned
+ * cell list, sorted by `cell_id` regardless of declaration or selector order.
+ */
+export async function buildPlannedCells(
+  scenarios: readonly ScenarioDefinition[],
+  inputs: PlanInputs,
+): Promise<PlannedCellV1[]> {
+  const cells: PlannedCellV1[] = [];
+  const seenCellIds = new Set<string>();
+  const seenScenarioIds = new Set<string>();
+
+  for (const scenario of scenarios) {
+    // Duplicate scenario ids are rejected outright: later lookup is by
+    // scenario id, so two definitions sharing an id — even with disjoint
+    // lanes — could execute one body while reporting the other's metadata.
+    if (seenScenarioIds.has(scenario.id)) {
+      throw new SelectionError(`Duplicate scenario id "${scenario.id}" in the selection.`);
+    }
+    seenScenarioIds.add(scenario.id);
+
+    for (const runtimeLane of scenario.lanes) {
+      if (!isMatrixScenario(scenario)) {
+        addCell(cells, seenCellIds, {
+          cell_id: `${scenario.id}/${runtimeLane}`,
+          scenario_id: scenario.id,
+          registry_flow_ref: scenario.registryFlowRef,
+          runtime_lane: runtimeLane,
+          dimensions: {},
+          required_env: [...scenario.requiredEnv],
+        });
+        continue;
+      }
+
+      const specs = await scenario.expandCells({
+        runtimeLane,
+        desktop: inputs.desktop,
+        agents: inputs.agents,
+      });
+      if (specs.length === 0) {
+        throw new SelectionError(
+          `Matrix scenario "${scenario.id}" expanded to zero cells for lane "${runtimeLane}".`,
+        );
+      }
+      for (const spec of specs) {
+        addCell(cells, seenCellIds, {
+          cell_id: cellIdFor(scenario.id, runtimeLane, validateDimensions(scenario.id, spec)),
+          scenario_id: scenario.id,
+          registry_flow_ref: scenario.registryFlowRef,
+          runtime_lane: runtimeLane,
+          dimensions: sortedDimensions(spec.dimensions),
+          required_env: [...new Set([...scenario.requiredEnv, ...(spec.requiredEnv ?? [])])],
+        });
+      }
+    }
+  }
+
+  if (cells.length === 0) {
+    throw new SelectionError("Selection expanded to zero cells.");
+  }
+  cells.sort((a, b) => (a.cell_id < b.cell_id ? -1 : a.cell_id > b.cell_id ? 1 : 0));
+  return cells;
+}
+
+function addCell(cells: PlannedCellV1[], seen: Set<string>, cell: PlannedCellV1): void {
+  if (seen.has(cell.cell_id)) {
+    throw new SelectionError(`Duplicate expanded cell id "${cell.cell_id}".`);
+  }
+  seen.add(cell.cell_id);
+  cells.push(cell);
+}
+
+function validateDimensions(scenarioId: string, spec: ScenarioCellSpec): Record<string, string> {
+  const keys = Object.keys(spec.dimensions);
+  if (keys.length === 0) {
+    // A dimensionless matrix cell would collide with the scenario's own leaf
+    // id form; a matrix child must be distinguishable by at least one key.
+    throw new SelectionError(`Matrix scenario "${scenarioId}" declared a cell with no dimensions.`);
+  }
+  for (const key of keys) {
+    if (!DIMENSION_KEY_PATTERN.test(key)) {
+      throw new SelectionError(`Matrix scenario "${scenarioId}" declared an invalid dimension key "${key}".`);
+    }
+    const value = spec.dimensions[key];
+    if (typeof value !== "string" || value.length === 0 || value.length > MAX_DIMENSION_VALUE_LENGTH) {
+      throw new SelectionError(
+        `Matrix scenario "${scenarioId}" declared an empty or unbounded value for dimension "${key}".`,
+      );
+    }
+  }
+  return spec.dimensions;
+}
+
+function sortedDimensions(dimensions: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.keys(dimensions)
+      .sort()
+      .map((key) => [key, dimensions[key]]),
+  );
+}
+
+/** `<scenario>/<lane>/<k>=<encoded v>` with dimension keys sorted lexicographically. */
+function cellIdFor(scenarioId: string, runtimeLane: string, dimensions: Record<string, string>): string {
+  const suffix = Object.keys(dimensions)
+    .sort()
+    .map((key) => `${key}=${encodeURIComponent(dimensions[key])}`)
+    .join(",");
+  return `${scenarioId}/${runtimeLane}/${suffix}`;
+}

--- a/tests/release/src/runner/result.test.ts
+++ b/tests/release/src/runner/result.test.ts
@@ -6,26 +6,29 @@ import {
   countByStatus,
   deriveVerdict,
   ResultTracker,
-  type FinalTestResultV1,
+  type FinalCellResultV1,
   type FinalTestStatus,
-  type SelectedTestV1,
+  type PlannedCellV1,
 } from "./result.js";
 
-function selected(id: string): SelectedTestV1 {
+function selected(id: string): PlannedCellV1 {
   return {
-    test_id: `${id}/local`,
+    cell_id: `${id}/local`,
     scenario_id: id,
     registry_flow_ref: `specs#${id}`,
     runtime_lane: "local",
+    dimensions: {},
+    required_env: [],
   };
 }
 
-function result(id: string, status: FinalTestStatus): FinalTestResultV1 {
+function result(id: string, status: FinalTestStatus): FinalCellResultV1 {
   return {
-    test_id: `${id}/local`,
+    cell_id: `${id}/local`,
     scenario_id: id,
     registry_flow_ref: `specs#${id}`,
     runtime_lane: "local",
+    dimensions: {},
     status,
     started_at: null,
     finished_at: "2026-07-13T00:00:00Z",
@@ -95,37 +98,37 @@ const MATRIX: Array<{
     name: "every selected real test green",
     statuses: ["green", "green"],
     diagnostic: { exit: 0, verdict: "non_qualifying" },
-    strict: { exit: 0, verdict: "selected_tests_passed" },
+    strict: { exit: 0, verdict: "selected_cells_passed" },
   },
   {
     name: "blocked only",
     statuses: ["green", "blocked"],
     diagnostic: { exit: 0, verdict: "non_qualifying" },
-    strict: { exit: 1, verdict: "selected_tests_failed" },
+    strict: { exit: 1, verdict: "selected_cells_failed" },
   },
   {
     name: "expected-fail only",
     statuses: ["green", "expected_fail"],
     diagnostic: { exit: 0, verdict: "non_qualifying" },
-    strict: { exit: 1, verdict: "selected_tests_failed" },
+    strict: { exit: 1, verdict: "selected_cells_failed" },
   },
   {
     name: "any failed",
     statuses: ["green", "failed", "blocked"],
     diagnostic: { exit: 1, verdict: "non_qualifying" },
-    strict: { exit: 1, verdict: "selected_tests_failed" },
+    strict: { exit: 1, verdict: "selected_cells_failed" },
   },
   {
     name: "any cancelled",
     statuses: ["green", "cancelled"],
     diagnostic: { exit: 1, verdict: "non_qualifying" },
-    strict: { exit: 1, verdict: "selected_tests_failed" },
+    strict: { exit: 1, verdict: "selected_cells_failed" },
   },
   {
     name: "any missing",
     statuses: ["green", "missing"],
     diagnostic: { exit: 1, verdict: "non_qualifying" },
-    strict: { exit: 1, verdict: "selected_tests_failed" },
+    strict: { exit: 1, verdict: "selected_cells_failed" },
   },
   {
     name: "successful diagnostic dry-run (every test not_run)",
@@ -163,7 +166,7 @@ test("runner or integrity errors force exit 2 in both behaviors", () => {
 
   const s1 = deriveVerdict({ behavior: "strict", results, integrityErrors: [], runnerErrors: runner });
   assert.equal(s1.intendedExitCode, 2);
-  assert.equal(s1.status, "selected_tests_failed");
+  assert.equal(s1.status, "selected_cells_failed");
 });
 
 test("strict all-green with any error cannot pass", () => {
@@ -173,6 +176,6 @@ test("strict all-green with any error cannot pass", () => {
     integrityErrors: [{ code: "summary_mismatch", message: "off by one" }],
     runnerErrors: [],
   });
-  assert.equal(verdict.status, "selected_tests_failed");
+  assert.equal(verdict.status, "selected_cells_failed");
   assert.equal(verdict.intendedExitCode, 2);
 });

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -35,15 +35,17 @@ export const ALL_FINAL_STATUSES: readonly FinalTestStatus[] = [
 export const SCENARIO_DECLARABLE_STATUSES = ["green", "failed", "blocked", "expected_fail"] as const;
 export type ScenarioDeclarableStatus = (typeof SCENARIO_DECLARABLE_STATUSES)[number];
 
-export type ResultReasonCode =
-  | "missing_requirement"
-  | "scenario_blocked"
-  | "known_gap"
-  | "scenario_failure"
-  | "strict_preflight_failed"
-  | "dry_run"
-  | "plan_error"
-  | "missing_result";
+export const RESULT_REASON_CODES = [
+  "missing_requirement",
+  "scenario_blocked",
+  "known_gap",
+  "scenario_failure",
+  "strict_preflight_failed",
+  "dry_run",
+  "plan_error",
+  "missing_result",
+] as const;
+export type ResultReasonCode = (typeof RESULT_REASON_CODES)[number];
 
 export interface ResultReason {
   code: ResultReasonCode;

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -91,6 +91,18 @@ export interface IntegrityErrorV1 {
 
 export type VerdictStatus = "selected_cells_passed" | "selected_cells_failed" | "non_qualifying";
 
+/** Independent deep copy of a planned cell (dimensions and required_env included). */
+export function clonePlannedCell(cell: PlannedCellV1): PlannedCellV1 {
+  return {
+    cell_id: cell.cell_id,
+    scenario_id: cell.scenario_id,
+    registry_flow_ref: cell.registry_flow_ref,
+    runtime_lane: cell.runtime_lane,
+    dimensions: { ...cell.dimensions },
+    required_env: [...cell.required_env],
+  };
+}
+
 export interface Finalization {
   status: FinalTestStatus;
   reason?: ResultReason;
@@ -112,7 +124,11 @@ export class ResultTracker {
   readonly runnerErrors: RunnerErrorV1[] = [];
 
   constructor(selected: readonly PlannedCellV1[]) {
-    this.selected = selected;
+    // The tracker owns the canonical plan: deep-copied at construction so no
+    // later mutation of the caller's cell objects (or of copies handed to
+    // scenario collectors) can alter what finalization and the persisted
+    // report validate against.
+    this.selected = selected.map(clonePlannedCell);
   }
 
   get selectedCells(): readonly PlannedCellV1[] {

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -3,7 +3,10 @@ import type { RuntimeLane } from "../config/types.js";
 /**
  * Cell state, finalization invariants, behavior policy, verdict, and intended
  * exit code, per specs/developing/testing/qualification-runner-core.md
- * ("Final test results" / "Diagnostic and strict verdicts").
+ * ("Final test results" / "Diagnostic and strict verdicts") as extended by
+ * specs/developing/testing/exact-test-matrix.md: the selected unit is an
+ * exact test cell (`scenario/lane` for leaves, `scenario/lane/dim=value` for
+ * matrix children), and every planned cell must receive exactly one result.
  */
 
 export type ResultBehavior = "diagnostic" | "strict";
@@ -28,6 +31,10 @@ export const ALL_FINAL_STATUSES: readonly FinalTestStatus[] = [
   "missing",
 ];
 
+/** Terminal states scenario code may declare for its own cells; the runner owns the rest. */
+export const SCENARIO_DECLARABLE_STATUSES = ["green", "failed", "blocked", "expected_fail"] as const;
+export type ScenarioDeclarableStatus = (typeof SCENARIO_DECLARABLE_STATUSES)[number];
+
 export type ResultReasonCode =
   | "missing_requirement"
   | "scenario_blocked"
@@ -43,18 +50,27 @@ export interface ResultReason {
   message: string;
 }
 
-export interface SelectedTestV1 {
-  test_id: string;
+/**
+ * One exactly-planned test cell. The selected-cell array is the complete test
+ * plan for an invocation; the runner (runner/plan.ts), not scenario code,
+ * creates cell ids.
+ */
+export interface PlannedCellV1 {
+  cell_id: string;
   scenario_id: string;
   registry_flow_ref: string;
   runtime_lane: RuntimeLane;
+  /** Sorted-key matrix dimensions; empty for leaf cells. */
+  dimensions: Record<string, string>;
+  required_env: string[];
 }
 
-export interface FinalTestResultV1 {
-  test_id: string;
+export interface FinalCellResultV1 {
+  cell_id: string;
   scenario_id: string;
   registry_flow_ref: string;
   runtime_lane: RuntimeLane;
+  dimensions: Record<string, string>;
   status: FinalTestStatus;
   started_at: string | null;
   finished_at: string;
@@ -73,7 +89,7 @@ export interface IntegrityErrorV1 {
   message: string;
 }
 
-export type VerdictStatus = "selected_tests_passed" | "selected_tests_failed" | "non_qualifying";
+export type VerdictStatus = "selected_cells_passed" | "selected_cells_failed" | "non_qualifying";
 
 export interface Finalization {
   status: FinalTestStatus;
@@ -85,53 +101,58 @@ export interface Finalization {
 }
 
 /**
- * Tracks one pending slot per selected test and enforces the finalization
- * invariants: exactly one final result per selected test, first accepted
+ * Tracks one pending slot per planned cell and enforces the finalization
+ * invariants: exactly one final result per planned cell, first accepted
  * result wins, duplicates and missing results are integrity errors.
  */
 export class ResultTracker {
-  private readonly selected: readonly SelectedTestV1[];
-  private readonly results = new Map<string, FinalTestResultV1>();
+  private readonly selected: readonly PlannedCellV1[];
+  private readonly results = new Map<string, FinalCellResultV1>();
   readonly integrityErrors: IntegrityErrorV1[] = [];
   readonly runnerErrors: RunnerErrorV1[] = [];
 
-  constructor(selected: readonly SelectedTestV1[]) {
+  constructor(selected: readonly PlannedCellV1[]) {
     this.selected = selected;
   }
 
-  get selectedTests(): readonly SelectedTestV1[] {
+  get selectedCells(): readonly PlannedCellV1[] {
     return this.selected;
   }
 
-  pendingTests(): SelectedTestV1[] {
-    return this.selected.filter((test) => !this.results.has(test.test_id));
+  pendingCells(): PlannedCellV1[] {
+    return this.selected.filter((cell) => !this.results.has(cell.cell_id));
   }
 
   recordRunnerError(code: RunnerErrorV1["code"], message: string): void {
     this.runnerErrors.push({ code, message });
   }
 
-  finalize(testId: string, finalization: Finalization): void {
-    const test = this.selected.find((candidate) => candidate.test_id === testId);
-    if (!test) {
+  recordIntegrityError(code: IntegrityErrorV1["code"], message: string): void {
+    this.integrityErrors.push({ code, message });
+  }
+
+  finalize(cellId: string, finalization: Finalization): void {
+    const cell = this.selected.find((candidate) => candidate.cell_id === cellId);
+    if (!cell) {
       this.integrityErrors.push({
         code: "selection_result_mismatch",
-        message: `Result recorded for "${testId}", which is not a selected test.`,
+        message: `Result recorded for "${cellId}", which is not a planned cell.`,
       });
       return;
     }
-    if (this.results.has(testId)) {
+    if (this.results.has(cellId)) {
       this.integrityErrors.push({
         code: "duplicate_result",
-        message: `Duplicate finalization for "${testId}" (${finalization.status}); the first result is retained.`,
+        message: `Duplicate finalization for "${cellId}" (${finalization.status}); the first result is retained.`,
       });
       return;
     }
-    this.results.set(testId, {
-      test_id: test.test_id,
-      scenario_id: test.scenario_id,
-      registry_flow_ref: test.registry_flow_ref,
-      runtime_lane: test.runtime_lane,
+    this.results.set(cellId, {
+      cell_id: cell.cell_id,
+      scenario_id: cell.scenario_id,
+      registry_flow_ref: cell.registry_flow_ref,
+      runtime_lane: cell.runtime_lane,
+      dimensions: { ...cell.dimensions },
       status: finalization.status,
       started_at: finalization.startedAt ?? null,
       finished_at: finalization.finishedAt ?? new Date().toISOString(),
@@ -142,27 +163,27 @@ export class ResultTracker {
   }
 
   /**
-   * Synthesizes `missing` for any selected test with no recorded outcome and
+   * Synthesizes `missing` for any planned cell with no recorded outcome and
    * records the integrity error; returns every result in selection order.
    */
-  finalizeRun(execution: "real" | "dry_run"): FinalTestResultV1[] {
-    for (const test of this.pendingTests()) {
+  finalizeRun(execution: "real" | "dry_run"): FinalCellResultV1[] {
+    for (const cell of this.pendingCells()) {
       this.integrityErrors.push({
         code: "selection_result_mismatch",
-        message: `Selected test "${test.test_id}" ended with no recorded result; synthesized as missing.`,
+        message: `Planned cell "${cell.cell_id}" ended with no recorded result; synthesized as missing.`,
       });
-      this.finalize(test.test_id, {
+      this.finalize(cell.cell_id, {
         status: "missing",
-        reason: { code: "missing_result", message: "Finalization found no result for this selected test." },
+        reason: { code: "missing_result", message: "Finalization found no result for this planned cell." },
       });
     }
-    const results = this.selected.map((test) => this.results.get(test.test_id)!);
+    const results = this.selected.map((cell) => this.results.get(cell.cell_id)!);
     if (execution === "real") {
       for (const result of results) {
         if (result.status === "not_run") {
           this.integrityErrors.push({
             code: "real_execution_not_run",
-            message: `"${result.test_id}" is not_run during real execution.`,
+            message: `"${result.cell_id}" is not_run during real execution.`,
           });
         }
       }
@@ -173,7 +194,7 @@ export class ResultTracker {
 
 export interface VerdictInput {
   behavior: ResultBehavior;
-  results: readonly FinalTestResultV1[];
+  results: readonly FinalCellResultV1[];
   integrityErrors: readonly IntegrityErrorV1[];
   runnerErrors: readonly RunnerErrorV1[];
 }
@@ -184,7 +205,7 @@ export interface DerivedVerdict {
   intendedExitCode: 0 | 1 | 2;
 }
 
-export function countByStatus(results: readonly FinalTestResultV1[]): Record<FinalTestStatus, number> {
+export function countByStatus(results: readonly FinalCellResultV1[]): Record<FinalTestStatus, number> {
   const counts = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
     FinalTestStatus,
     number
@@ -197,7 +218,7 @@ export function countByStatus(results: readonly FinalTestResultV1[]): Record<Fin
 
 /**
  * The diagnostic/strict verdict matrix. Diagnostic is always non-qualifying;
- * strict passes only when every selected real test is green and there are no
+ * strict passes only when every selected real cell is green and there are no
  * runner or integrity errors. Any runner/integrity error exits 2 in both
  * behaviors.
  */
@@ -215,7 +236,7 @@ export function deriveVerdict(input: VerdictInput): DerivedVerdict {
 
   const nonGreen = ALL_FINAL_STATUSES.filter((status) => status !== "green" && counts[status] > 0);
   for (const status of nonGreen) {
-    reasons.push(`${counts[status]} selected test(s) finished ${status}`);
+    reasons.push(`${counts[status]} selected cell(s) finished ${status}`);
   }
 
   if (input.behavior === "diagnostic") {
@@ -228,13 +249,13 @@ export function deriveVerdict(input: VerdictInput): DerivedVerdict {
   const allGreen = input.results.length > 0 && input.results.every((result) => result.status === "green");
   if (allGreen && !hasErrors) {
     return {
-      status: "selected_tests_passed",
-      reasons: ["every selected test is green; scope is selected tests only, completeness partial"],
+      status: "selected_cells_passed",
+      reasons: ["every selected cell is green; scope is selected cells only, completeness partial"],
       intendedExitCode: 0,
     };
   }
   return {
-    status: "selected_tests_failed",
+    status: "selected_cells_failed",
     reasons,
     intendedExitCode: hasErrors ? 2 : 1,
   };

--- a/tests/release/src/scenarios/t3-chat-1.test.ts
+++ b/tests/release/src/scenarios/t3-chat-1.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { test } from "node:test";
 
-import { chatCellSpecs, shippedHarnessKinds, t3Chat1 } from "./t3-chat-1.js";
+import { chatCellSpecs, collectChatOutcomes, shippedHarnessKinds, t3Chat1 } from "./t3-chat-1.js";
 import { buildPlannedCells } from "../runner/plan.js";
 import { executeSelectedCells } from "../runner/execute.js";
 import type { EnvResolution } from "../config/env-resolution.js";
@@ -101,4 +101,70 @@ test("the sandbox implementation gap becomes explicit non-green children, not on
     assert.equal(result.reason?.code, "known_gap");
   }
   assert.equal(report.summary.integrity_errors.length, 0);
+});
+
+test("one shared workspace yields green/failed/blocked cells with exactly one create/delete (ETM-005)", async () => {
+  const cells = (await buildPlannedCells([t3Chat1], { desktop: "web", agents: ["claude", "codex", "grok"] }))
+    .filter((cell) => cell.runtime_lane === "local");
+  assert.equal(cells.length, 3);
+
+  let opened = 0;
+  let closed = 0;
+  const outcomes = await collectChatOutcomes(cells, {
+    // grok has no compatible model; claude and codex do.
+    resolveChoices: async () =>
+      new Map([
+        ["claude", { harnessKind: "claude", modelCandidates: ["haiku"], catalogPinVersion: undefined }],
+        ["codex", { harnessKind: "codex", modelCandidates: ["gpt-cheap"], catalogPinVersion: undefined }],
+      ]),
+    openWorkspace: async () => {
+      opened += 1;
+      return {
+        workspaceId: "ws-1",
+        close: async () => {
+          closed += 1;
+        },
+      };
+    },
+    candidatesFor: async (_harness, catalogCandidates) => [...catalogCandidates],
+    attemptModel: async (workspaceId, choice) => {
+      assert.equal(workspaceId, "ws-1");
+      if (choice.harnessKind === "codex") {
+        throw new Error("turn failed: SESSION_MODEL_GATED");
+      }
+    },
+  });
+
+  assert.equal(opened, 1);
+  assert.equal(closed, 1);
+  const byId = new Map(outcomes.map((outcome) => [outcome.cellId, outcome]));
+  assert.equal(byId.get("T3-CHAT-1/local/harness=claude")?.status, "green");
+  assert.equal(byId.get("T3-CHAT-1/local/harness=codex")?.status, "failed");
+  assert.match(byId.get("T3-CHAT-1/local/harness=codex")?.reason?.message ?? "", /SESSION_MODEL_GATED/);
+  assert.equal(byId.get("T3-CHAT-1/local/harness=grok")?.status, "blocked");
+  assert.equal(outcomes.length, 3);
+});
+
+test("the workspace closes exactly once even when the mapping throws mid-batch (ETM-005)", async () => {
+  const cells = (await buildPlannedCells([t3Chat1], { desktop: "web", agents: ["claude"] }))
+    .filter((cell) => cell.runtime_lane === "local");
+  let closed = 0;
+  await assert.rejects(
+    collectChatOutcomes(cells, {
+      resolveChoices: async () =>
+        new Map([["claude", { harnessKind: "claude", modelCandidates: ["haiku"], catalogPinVersion: undefined }]]),
+      openWorkspace: async () => ({
+        workspaceId: "ws-1",
+        close: async () => {
+          closed += 1;
+        },
+      }),
+      candidatesFor: async () => {
+        throw new Error("probe endpoint exploded");
+      },
+      attemptModel: async () => undefined,
+    }),
+    /probe endpoint exploded/,
+  );
+  assert.equal(closed, 1);
 });

--- a/tests/release/src/scenarios/t3-chat-1.test.ts
+++ b/tests/release/src/scenarios/t3-chat-1.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { test } from "node:test";
+
+import { chatCellSpecs, shippedHarnessKinds, t3Chat1 } from "./t3-chat-1.js";
+import { buildPlannedCells } from "../runner/plan.js";
+import { executeSelectedCells } from "../runner/execute.js";
+import type { EnvResolution } from "../config/env-resolution.js";
+
+async function catalogKinds(): Promise<string[]> {
+  const catalogPath = path.resolve(import.meta.dirname, "../../../../catalogs/agents/catalog.json");
+  const catalog = JSON.parse(await readFile(catalogPath, "utf8")) as { agents?: Array<{ kind?: string }> };
+  return (catalog.agents ?? []).map((agent) => agent.kind).filter((kind): kind is string => Boolean(kind));
+}
+
+test("--agents all derives the shipped harness kinds from the catalog, not a hand-written list", async () => {
+  const expected = await catalogKinds();
+  assert.ok(expected.length >= 5);
+  assert.deepEqual(await shippedHarnessKinds(), expected);
+  const specs = await chatCellSpecs(["all"]);
+  assert.deepEqual(
+    specs.map((spec) => spec.dimensions.harness),
+    expected,
+  );
+});
+
+test("explicit --agents selection produces one cell per selected harness", async () => {
+  const specs = await chatCellSpecs(["codex", "claude"]);
+  assert.deepEqual(
+    specs.map((spec) => spec.dimensions.harness),
+    ["codex", "claude"],
+  );
+});
+
+test("T3-CHAT-1 --agents all plans every catalog harness exactly once per lane", async () => {
+  const expected = await catalogKinds();
+  const cells = await buildPlannedCells([t3Chat1], { desktop: "web", agents: ["all"] });
+  assert.equal(cells.length, expected.length * 2);
+  for (const lane of ["local", "sandbox"] as const) {
+    const laneCells = cells.filter((cell) => cell.runtime_lane === lane);
+    assert.deepEqual(
+      laneCells.map((cell) => cell.dimensions.harness).sort(),
+      [...expected].sort(),
+    );
+    for (const cell of laneCells) {
+      assert.equal(cell.cell_id, `T3-CHAT-1/${lane}/harness=${cell.dimensions.harness}`);
+    }
+  }
+});
+
+test("planCell steps name the cell's own harness", () => {
+  const steps = t3Chat1.planCell(
+    { runtimeLane: "local", desktop: "web", agents: ["all"] },
+    {
+      cell_id: "T3-CHAT-1/local/harness=codex",
+      scenario_id: "T3-CHAT-1",
+      registry_flow_ref: t3Chat1.registryFlowRef,
+      runtime_lane: "local",
+      dimensions: { harness: "codex" },
+      required_env: [],
+    },
+  );
+  assert.ok(steps.length > 0);
+  for (const step of steps) {
+    assert.match(step.description, /\[codex\]/);
+  }
+});
+
+test("the sandbox implementation gap becomes explicit non-green children, not one green parent", async () => {
+  const allCells = await buildPlannedCells([t3Chat1], { desktop: "web", agents: ["all"] });
+  const sandboxCells = allCells.filter((cell) => cell.runtime_lane === "sandbox");
+  const fakeEnv: EnvResolution = {
+    all: [],
+    missing: [],
+    present: () => true,
+    get: () => undefined,
+    require: () => {
+      throw new Error("not used");
+    },
+  };
+  const report = await executeSelectedCells({
+    behavior: "diagnostic",
+    execution: "real",
+    identity: {
+      run_id: "run-1",
+      shard_id: "shard-1",
+      attempt: 1,
+      source_sha: "c".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+    },
+    inputs: { targetLane: "local", desktop: "web", agents: "all", scenarios: ["T3-CHAT-1"] },
+    scenarios: [t3Chat1],
+    cells: sandboxCells,
+    resolveNeededEnv: () => fakeEnv,
+    resolveSecretValues: () => [],
+  });
+  assert.equal(report.results.length, sandboxCells.length);
+  for (const result of report.results) {
+    assert.equal(result.status, "expected_fail");
+    assert.equal(result.reason?.code, "known_gap");
+  }
+  assert.equal(report.summary.integrity_errors.length, 0);
+});

--- a/tests/release/src/scenarios/t3-chat-1.ts
+++ b/tests/release/src/scenarios/t3-chat-1.ts
@@ -105,7 +105,7 @@ export async function shippedHarnessKinds(): Promise<string[]> {
   return (catalog.agents ?? []).map((agent) => agent.kind).filter((kind): kind is string => Boolean(kind));
 }
 
-interface HarnessModelChoice {
+export interface HarnessModelChoice {
   harnessKind: string;
   /**
    * Ranked candidates, cheapest-preferred first. More than one candidate is
@@ -120,20 +120,56 @@ interface HarnessModelChoice {
   catalogPinVersion: string | undefined;
 }
 
+/**
+ * The seam between the per-cell outcome mapping and the live runtime, so the
+ * green/failed/blocked classification and the single shared workspace
+ * lifecycle are provable without a running AnyHarness.
+ */
+export interface ChatLaneIO {
+  resolveChoices(harnesses: readonly string[]): Promise<Map<string, HarnessModelChoice>>;
+  /** One shared workspace for every assigned cell; closed exactly once. */
+  openWorkspace(): Promise<{ workspaceId: string; close(): Promise<void> }>;
+  candidatesFor(harnessKind: string, catalogCandidates: readonly string[]): Promise<string[]>;
+  attemptModel(workspaceId: string, choice: HarnessModelChoice & { modelId: string }): Promise<void>;
+}
+
 async function runLocalLane(cells: readonly PlannedCellV1[]): Promise<ScenarioCellOutcome[]> {
   const runtimeUrl = process.env.RELEASE_E2E_LOCAL_RUNTIME_URL ?? DEFAULT_LOCAL_RUNTIME_URL;
   const client = new LocalRuntimeClient({ baseUrl: runtimeUrl });
+  return collectChatOutcomes(cells, {
+    resolveChoices: (harnesses) => catalogHarnesses(harnesses),
+    openWorkspace: async () => {
+      const githubTestRepo = process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO;
+      const repoPath = await ensureLocalClone(githubTestRepo);
+      const { workspace } = await client.createLocalWorkspace(repoPath);
+      return {
+        workspaceId: workspace.id,
+        close: async () => {
+          await client.deleteWorkspace(workspace.id).catch(() => undefined);
+        },
+      };
+    },
+    candidatesFor: (harnessKind, catalogCandidates) =>
+      withGatewayProbedCandidates(client, harnessKind, catalogCandidates),
+    attemptModel: (workspaceId, choice) => runOneHarness(client, workspaceId, choice),
+  });
+}
 
+/**
+ * The real per-cell result mapping: one shared workspace for the whole batch
+ * (opened once, closed once in finally); per assigned cell, no compatible
+ * model → explicit `blocked`, a real failure across every candidate model →
+ * explicit `failed`, a passing model → `green`. Mixed outcomes stay mixed.
+ */
+export async function collectChatOutcomes(
+  cells: readonly PlannedCellV1[],
+  io: ChatLaneIO,
+): Promise<ScenarioCellOutcome[]> {
   const requestedHarnesses = cells.map((cell) => cell.dimensions.harness);
-  const choices = await catalogHarnesses(requestedHarnesses);
+  const choices = await io.resolveChoices(requestedHarnesses);
   const outcomes: ScenarioCellOutcome[] = [];
 
-  // Shared setup stays batched: one clone + one workspace for every assigned
-  // harness cell, torn down once in finally.
-  const githubTestRepo = process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO;
-  const repoPath = await ensureLocalClone(githubTestRepo);
-  const { workspace } = await client.createLocalWorkspace(repoPath);
-
+  const workspace = await io.openWorkspace();
   try {
     for (const cell of cells) {
       const harnessKind = cell.dimensions.harness;
@@ -153,10 +189,10 @@ async function runLocalLane(cells: readonly PlannedCellV1[]): Promise<ScenarioCe
       }
       let lastError: unknown;
       let succeededModel: string | undefined;
-      const candidates = await withGatewayProbedCandidates(client, harnessKind, choice.modelCandidates);
+      const candidates = await io.candidatesFor(harnessKind, choice.modelCandidates);
       for (const modelId of candidates) {
         try {
-          await runOneHarness(client, workspace.id, { ...choice, modelId });
+          await io.attemptModel(workspace.workspaceId, { ...choice, modelId });
           succeededModel = modelId;
           break;
         } catch (error) {
@@ -180,7 +216,7 @@ async function runLocalLane(cells: readonly PlannedCellV1[]): Promise<ScenarioCe
       }
     }
   } finally {
-    await client.deleteWorkspace(workspace.id).catch(() => undefined);
+    await workspace.close();
   }
 
   return outcomes;

--- a/tests/release/src/scenarios/t3-chat-1.ts
+++ b/tests/release/src/scenarios/t3-chat-1.ts
@@ -2,15 +2,28 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import type { ScenarioDefinition } from "./types.js";
+import type {
+  MatrixScenarioDefinition,
+  ScenarioCellOutcome,
+  ScenarioCellSpec,
+} from "./types.js";
 import { ScenarioExpectedFailError } from "./types.js";
 import { DEFAULT_GITHUB_TEST_REPO, DEFAULT_LOCAL_RUNTIME_URL } from "../config/env-manifest.js";
 import { ensureLocalClone } from "../fixtures/git.js";
 import { LocalRuntimeClient, findErrorEvent, findLastAssistantReply, findTurnEndedEvent } from "../fixtures/local-runtime.js";
+import type { PlannedCellV1 } from "../runner/result.js";
 
 /**
  * T3-CHAT-1 — every harness x its cheapest model, via the gateway.
  * specs/developing/testing/scenarios.md#T3-CHAT-1
+ *
+ * First real matrix consumer of the exact-cell contract
+ * (specs/developing/testing/exact-test-matrix.md): each harness is its own
+ * planned cell (`T3-CHAT-1/<lane>/harness=<kind>`), the workspace setup stays
+ * batched in one `runCells()` invocation, and every assigned harness gets one
+ * explicit outcome — one green harness can no longer hide a failed, blocked,
+ * or omitted harness. This remains a legacy diagnostic scenario; it does not
+ * claim canonical LOCAL-2 or any target-manifest row.
  *
  * Model-set resolution is catalog-driven, Anthropic-family only for now (per
  * the build task): `catalogHarnesses()` below reads `catalogs/agents/catalog.json`
@@ -18,44 +31,39 @@ import { LocalRuntimeClient, findErrorEvent, findLastAssistantReply, findTurnEnd
  * `availability` includes an Anthropic source (`anthropic-api` /
  * `anthropic-oauth` / `bedrock`) — `undefined` when a harness has no such
  * model yet (Codex/Gemini CLI/Grok need their own provider family's key,
- * which does not exist yet; they light up automatically once that model-set
- * lookup finds a match, no code change needed).
+ * which does not exist yet). A harness with no compatible model is an
+ * explicit `blocked` child; a real turn/install/reopen failure is an explicit
+ * `failed` child.
  *
  * Local lane: real, against the local AnyHarness runtime directly, using
  * whichever credential source the runtime already resolves for the harness
  * (native CLI login for Claude on this machine — verified for real
  * 2026-07-09: on fresh main the t3local account classifies claude to
- * `["bedrock"]` (the Bedrock flag rides the readiness/auth overlay, not the
- * profile launch.env), so post-#1046 the bare native ids ("haiku"/"default")
- * are correctly gated `SESSION_MODEL_GATED` and the account's real cheapest
- * working model is a gateway/Bedrock id — the candidate resolver below lands
- * on `us.anthropic.claude-sonnet-4-6` for claude and `anthropic/claude-haiku-
- * 4-5-20251001` for opencode, both GREEN. This is exactly the "menu excludes
- * bare ids; pass using the ids the new classification yields" outcome #1046
- * intended.
+ * `["bedrock"]`, so the bare native ids are correctly gated
+ * `SESSION_MODEL_GATED` and the candidate resolver lands on a
+ * gateway/Bedrock id).
  *
- * Sandbox lane: the current_product_user gate is now lifted in single-org mode
- * (`current_product_user` returns the user unconditionally when
- * `single_org_mode` is true — verified 2026-07-09: the durable user gets HTTP
- * 200 from `GET /v1/cloud/cloud-sandbox` despite productReady=false). What
- * remains is a test-implementation gap: driving a full agent chat session
- * inside a real E2B sandbox through the `/v1/gateway/cloud-sandbox/anyharness/*`
- * proxy (server/proliferate/server/cloud/gateway/api.py -- NOT
- * `/v1/cloud/cloud-sandbox/anyharness/*`, see ../fixtures/cloud-sandbox.ts)
- * is not yet written (and needs a running sandbox + a publicly reachable
- * server URL for callbacks). Tracked TODO, not a product gate.
+ * Sandbox lane: the current_product_user gate is lifted in single-org mode
+ * (verified 2026-07-09); what remains is a test-implementation gap: driving a
+ * full agent chat session inside a real E2B sandbox through the
+ * `/v1/gateway/cloud-sandbox/anyharness/*` proxy is not yet written. The
+ * collector throws `ScenarioExpectedFailError`, which the runner applies to
+ * every assigned sandbox child — explicit non-green children rather than one
+ * green parent. Tracked test TODO (#1042).
  */
-export const t3Chat1: ScenarioDefinition = {
+export const t3Chat1: MatrixScenarioDefinition = {
   id: "T3-CHAT-1",
   title: "every harness x its cheapest model, via the gateway",
   registryFlowRef: "specs/developing/testing/scenarios.md#T3-CHAT-1",
   lanes: ["local", "sandbox"],
   requiredEnv: [],
-  plan: ({ runtimeLane, agents }) => {
-    const harnesses = agents.includes("all") ? ["claude", "codex", "cursor", "grok", "opencode"] : [...agents];
-    return harnesses.flatMap((harness) => [
+  kind: "matrix",
+  expandCells: async ({ agents }) => chatCellSpecs(agents),
+  planCell: ({ runtimeLane }, cell) => {
+    const harness = cell.dimensions.harness;
+    return [
       {
-        description: `[${harness}] resolve cheapest Anthropic-family model from catalogs/agents/catalog.json (skip if none)`,
+        description: `[${harness}] resolve cheapest Anthropic-family model from catalogs/agents/catalog.json (blocked child if none)`,
       },
       {
         description: `[${harness}] assert installed CLI version == catalog pin (before chat), ${
@@ -65,12 +73,9 @@ export const t3Chat1: ScenarioDefinition = {
       { description: `[${harness}] create session, send one message, await turn_ended` },
       { description: `[${harness}] assert non-empty assistant reply arrived` },
       { description: `[${harness}] close and reopen the session, assert transcript persists` },
-    ]);
+    ];
   },
-  run: async (ctx) => {
-    if (ctx.dryRun) {
-      return;
-    }
+  runCells: async (ctx, cells) => {
     if (ctx.runtimeLane === "sandbox") {
       throw new ScenarioExpectedFailError(
         "T3-CHAT-1/sandbox: the current_product_user gate is lifted in single-org mode (verified " +
@@ -79,9 +84,26 @@ export const t3Chat1: ScenarioDefinition = {
           "durable sandbox and a publicly reachable RELEASE_E2E_SERVER_URL. Tracked test TODO (#1042).",
       );
     }
-    await runLocalLane(ctx.agents);
+    return runLocalLane(cells);
   },
 };
+
+/**
+ * One cell per harness. `all` derives the shipped harness kinds from
+ * `catalogs/agents/catalog.json` — not a second hand-written list; an
+ * explicit `--agents` selection produces one cell per selected harness. The
+ * same expansion applies independently to each runtime lane.
+ */
+export async function chatCellSpecs(agentsSelector: readonly string[]): Promise<ScenarioCellSpec[]> {
+  const harnesses = agentsSelector.includes("all") ? await shippedHarnessKinds() : [...agentsSelector];
+  return harnesses.map((harness) => ({ dimensions: { harness } }));
+}
+
+/** Every cataloged agent kind, in catalog order. */
+export async function shippedHarnessKinds(): Promise<string[]> {
+  const catalog = await readCatalog();
+  return (catalog.agents ?? []).map((agent) => agent.kind).filter((kind): kind is string => Boolean(kind));
+}
 
 interface HarnessModelChoice {
   harnessKind: string;
@@ -92,47 +114,40 @@ interface HarnessModelChoice {
    * fresh main 2026-07-09) the bare native ids are gated `SESSION_MODEL_GATED`
    * and a `us.anthropic.*`/`anthropic/claude-*` id is the one that passes, so
    * trying candidates in order lands on whatever the live classification
-   * yields. #1024 (opencode's `anthropic/claude-*` ids 400ing
-   * `SESSION_MODEL_UNSUPPORTED`) is resolved by #1034 — verified 2026-07-09
-   * opencode goes GREEN with an explicit gateway id
-   * (`anthropic/claude-haiku-4-5-20251001`), so the earlier per-harness
-   * expected-fail tolerance is no longer needed and opencode is treated like
-   * any other harness (a genuine failure is now a real per-harness red).
+   * yields.
    */
   modelCandidates: string[];
   catalogPinVersion: string | undefined;
 }
 
-/** Per-harness result, so a single harness's failure never fails the whole scenario (per-harness red). */
-export interface PerHarnessChatResult {
-  harnessKind: string;
-  status: "green" | "skipped-no-anthropic-model" | "expected-fail";
-  detail: string;
-}
-
-async function runLocalLane(agentsSelector: readonly string[]): Promise<void> {
+async function runLocalLane(cells: readonly PlannedCellV1[]): Promise<ScenarioCellOutcome[]> {
   const runtimeUrl = process.env.RELEASE_E2E_LOCAL_RUNTIME_URL ?? DEFAULT_LOCAL_RUNTIME_URL;
   const client = new LocalRuntimeClient({ baseUrl: runtimeUrl });
 
-  const requestedHarnesses = agentsSelector.includes("all")
-    ? ["claude", "codex", "cursor", "grok", "opencode"]
-    : [...agentsSelector];
-
+  const requestedHarnesses = cells.map((cell) => cell.dimensions.harness);
   const choices = await catalogHarnesses(requestedHarnesses);
-  const results: PerHarnessChatResult[] = [];
+  const outcomes: ScenarioCellOutcome[] = [];
 
+  // Shared setup stays batched: one clone + one workspace for every assigned
+  // harness cell, torn down once in finally.
   const githubTestRepo = process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO;
   const repoPath = await ensureLocalClone(githubTestRepo);
   const { workspace } = await client.createLocalWorkspace(repoPath);
 
   try {
-    for (const harnessKind of requestedHarnesses) {
+    for (const cell of cells) {
+      const harnessKind = cell.dimensions.harness;
       const choice = choices.get(harnessKind);
       if (!choice) {
-        results.push({
-          harnessKind,
-          status: "skipped-no-anthropic-model",
-          detail: "no Anthropic-family model found for this harness in catalogs/agents/catalog.json (needs its own provider key)",
+        outcomes.push({
+          cellId: cell.cell_id,
+          status: "blocked",
+          reason: {
+            code: "scenario_blocked",
+            message:
+              `[${harnessKind}] no Anthropic-family model found in catalogs/agents/catalog.json ` +
+              "(needs its own provider key before this cell can run for real)",
+          },
         });
         continue;
       }
@@ -149,12 +164,18 @@ async function runLocalLane(agentsSelector: readonly string[]): Promise<void> {
         }
       }
       if (succeededModel) {
-        results.push({ harnessKind, status: "green", detail: `model=${succeededModel}` });
+        console.log(`[${cell.cell_id}] green (model=${succeededModel})`);
+        outcomes.push({ cellId: cell.cell_id, status: "green" });
       } else {
-        results.push({
-          harnessKind,
-          status: "expected-fail",
-          detail: lastError instanceof Error ? lastError.message : String(lastError),
+        // A real turn/install/reopen failure is an explicit failed child —
+        // never expected-fail, never hidden behind a green sibling.
+        outcomes.push({
+          cellId: cell.cell_id,
+          status: "failed",
+          reason: {
+            code: "scenario_failure",
+            message: lastError instanceof Error ? lastError.message : String(lastError),
+          },
         });
       }
     }
@@ -162,24 +183,7 @@ async function runLocalLane(agentsSelector: readonly string[]): Promise<void> {
     await client.deleteWorkspace(workspace.id).catch(() => undefined);
   }
 
-  console.log("[T3-CHAT-1/local] per-harness results:");
-  for (const result of results) {
-    console.log(`  - ${result.harnessKind}: ${result.status} (${result.detail})`);
-  }
-
-  const failed = results.filter((r) => r.status === "expected-fail");
-  const green = results.filter((r) => r.status === "green");
-  assert.ok(green.length > 0, "T3-CHAT-1/local: at least one Anthropic-family harness (claude) must go green");
-  if (failed.length > 0) {
-    // Per-harness red is surfaced but does not fail the whole scenario run —
-    // the contract's own rule ("per-harness failure = per-harness red, not
-    // whole-suite red"). The individual diagnoses are in the console output
-    // above; a real per-harness report wire-up is a follow-up once the
-    // issues-service (specs/tbd/issues-service-v1.md) exists to receive them.
-    console.warn(
-      `[T3-CHAT-1/local] ${failed.length} harness(es) failed: ${failed.map((f) => f.harnessKind).join(", ")}`,
-    );
-  }
+  return outcomes;
 }
 
 async function runOneHarness(
@@ -226,7 +230,8 @@ async function runOneHarness(
  * tier preference) are tried first and the catalog candidates kept as a
  * fallback. With no gateway configured (a native-login laptop) the probe list
  * is empty or the endpoint errs, and the catalog candidates pass through
- * unchanged.
+ * unchanged. Live probing chooses the cheapest usable model; it never removes
+ * a planned harness cell.
  */
 export async function withGatewayProbedCandidates(
   client: LocalRuntimeClient,
@@ -255,6 +260,21 @@ export async function withGatewayProbedCandidates(
 
 const ANTHROPIC_AVAILABILITY_SOURCES = new Set(["anthropic-api", "anthropic-oauth", "bedrock"]);
 
+interface CatalogShape {
+  agents?: Array<{
+    kind?: string;
+    harness?: { native?: { version?: string }; agentProcess?: { version?: string } };
+    session?: {
+      models?: Array<{ id: string; availability?: { anyOf?: string[] } }>;
+    };
+  }>;
+}
+
+async function readCatalog(): Promise<CatalogShape> {
+  const catalogPath = path.resolve(import.meta.dirname, "../../../../catalogs/agents/catalog.json");
+  return JSON.parse(await readFile(catalogPath, "utf8")) as CatalogShape;
+}
+
 /**
  * Reads catalogs/agents/catalog.json and returns, per requested harness kind,
  * its cheapest model with an Anthropic-family availability source — the
@@ -268,17 +288,7 @@ const ANTHROPIC_AVAILABILITY_SOURCES = new Set(["anthropic-api", "anthropic-oaut
 export async function catalogHarnesses(
   requestedHarnesses: readonly string[],
 ): Promise<Map<string, HarnessModelChoice>> {
-  const catalogPath = path.resolve(import.meta.dirname, "../../../../catalogs/agents/catalog.json");
-  const raw = await readFile(catalogPath, "utf8");
-  const catalog = JSON.parse(raw) as {
-    agents?: Array<{
-      kind?: string;
-      harness?: { native?: { version?: string }; agentProcess?: { version?: string } };
-      session?: {
-        models?: Array<{ id: string; availability?: { anyOf?: string[] } }>;
-      };
-    }>;
-  };
+  const catalog = await readCatalog();
 
   const result = new Map<string, HarnessModelChoice>();
   for (const agent of catalog.agents ?? []) {

--- a/tests/release/src/scenarios/types.ts
+++ b/tests/release/src/scenarios/types.ts
@@ -1,5 +1,6 @@
 import type { EnvResolution } from "../config/env-resolution.js";
 import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
+import type { PlannedCellV1, ResultReason, ScenarioDeclarableStatus } from "../runner/result.js";
 
 export interface ScenarioPlanStep {
   description: string;
@@ -9,12 +10,12 @@ export interface ScenarioPlanStep {
  * Thrown when a scenario cannot assert for real because of a known,
  * out-of-band blocker (not a scenario bug, not a product bug this scenario is
  * responsible for) — e.g. the `github_link_required` gate tracked in
- * `src/fixtures/identity.ts`. Distinct from `ScenarioFailure`: a blocked run
- * does not fail the release gate and does not get an issue filed against it
- * (the blocker already has its own tracking); it is reported so the gap stays
- * visible instead of silently passing or silently failing. How a blocked
- * outcome affects the verdict and exit code is owned by the runner policy in
- * `../runner/result.ts`, not by this class.
+ * `src/fixtures/identity.ts`. Distinct from an ordinary failure: a blocked run
+ * does not get an issue filed against it (the blocker already has its own
+ * tracking); it is reported so the gap stays visible instead of silently
+ * passing or silently failing. How a blocked outcome affects the verdict and
+ * exit code is owned by the runner policy in `../runner/result.ts`, not by
+ * this class.
  */
 export class ScenarioBlockedError extends Error {
   readonly reason: string;
@@ -60,22 +61,75 @@ export interface ScenarioPlanContext {
   agents: readonly string[];
 }
 
-export interface ScenarioDefinition {
+/**
+ * One child cell a matrix scenario declares at planning time
+ * (specs/developing/testing/exact-test-matrix.md "Test-cell contract"). The
+ * runner turns each spec into a `PlannedCellV1` with a runner-created cell id;
+ * scenario code never invents cell ids.
+ */
+export interface ScenarioCellSpec {
+  dimensions: Record<string, string>;
+  /** Extra requirements beyond the scenario-level requiredEnv, if any. */
+  requiredEnv?: readonly string[];
+}
+
+/**
+ * One explicit outcome a matrix collector returns for one assigned cell.
+ * Scenario code may declare only real observed states; `cancelled`,
+ * `not_run`, and `missing` remain runner-only terminal states.
+ */
+export interface ScenarioCellOutcome {
+  cellId: string;
+  status: ScenarioDeclarableStatus;
+  reason?: ResultReason;
+}
+
+interface ScenarioBase {
   id: string;
   title: string;
   /** Pointer into the scenario contract doc; the "registry" this runner implements against. */
   registryFlowRef: string;
   /** Runtime lanes this scenario is defined for. */
   lanes: readonly RuntimeLane[];
-  /** Env var names (from src/config/env-manifest.ts) this scenario needs to run for real. */
+  /** Env var names (from src/config/env-manifest.ts) every cell of this scenario needs. */
   requiredEnv: readonly string[];
+}
+
+/**
+ * The existing one-cell-per-lane scenario shape, source-compatible with every
+ * scenario written before the exact-cell contract. The runner plans exactly
+ * one cell per declared lane (`<id>/<lane>`, no dimensions).
+ */
+export interface LeafScenarioDefinition extends ScenarioBase {
+  kind?: "leaf";
   /** Ordered human-readable steps; printed verbatim under --dry-run. */
   plan(ctx: ScenarioPlanContext): ScenarioPlanStep[];
   /**
    * Executes the scenario for one runtime lane. Throws `ScenarioBlockedError`
    * for a known out-of-band gate, `ScenarioExpectedFailError` for a diagnosed
    * real gap, or any other error for a genuine red — the runner
-   * (`src/runner/execute.ts`) normalizes each into a final test status.
+   * (`src/runner/execute.ts`) normalizes each into a final cell status.
    */
   run(ctx: ScenarioRunContext): Promise<void>;
+}
+
+/**
+ * A scenario that owns several independently judged child cells but shares
+ * setup across them. The runner invokes `runCells()` once per selected
+ * scenario/runtime lane with the assigned planned cells; the collector must
+ * return exactly one explicit outcome per assigned cell — returning normally
+ * never turns children green, and an omitted child becomes a `missing`
+ * integrity failure.
+ */
+export interface MatrixScenarioDefinition extends ScenarioBase {
+  kind: "matrix";
+  expandCells(ctx: ScenarioPlanContext): ScenarioCellSpec[] | Promise<ScenarioCellSpec[]>;
+  planCell(ctx: ScenarioPlanContext, cell: PlannedCellV1): ScenarioPlanStep[];
+  runCells(ctx: ScenarioRunContext, cells: readonly PlannedCellV1[]): Promise<ScenarioCellOutcome[]>;
+}
+
+export type ScenarioDefinition = LeafScenarioDefinition | MatrixScenarioDefinition;
+
+export function isMatrixScenario(scenario: ScenarioDefinition): scenario is MatrixScenarioDefinition {
+  return scenario.kind === "matrix";
 }


### PR DESCRIPTION
Implements the frozen **Define the Exact Test Matrix and Verify Every Result**
contract (`specs/developing/testing/exact-test-matrix.md`, revision
`ETM1-frozen-1`, base `aafad3ff2`). The spec-freeze commit (`f4e8c72f8`) was
local-only and rides as this PR's first commit.

## What changes

The selected unit moves from one broad `scenario × lane` test to an exact
test cell, without a second aggregation framework — `ResultTracker` and
`validateReport()` are extended, not duplicated.

- **`runner/plan.ts`** — deterministic exact-cell expansion before any setup
  side effect: leaf scenarios keep their unchanged `<scenario>/<lane>` ids;
  matrix scenarios declare `ScenarioCellSpec`s that become runner-created
  `<scenario>/<lane>/<key>=<value>` ids (keys sorted, values safely encoded,
  bounded), with empty/duplicate/invalid expansion exiting 2 with zero
  user/gateway/fixture/scenario setup and no report. The final plan is sorted
  by `cell_id`. `expandSelectedTests()` is deleted — one planning path.
- **`scenarios/types.ts`** — leaf/matrix discriminated contract
  (`expandCells`/`planCell`/`runCells`); scenario code can declare only
  green/failed/blocked/expected_fail; `cancelled`/`not_run`/`missing` stay
  runner-only.
- **`runner/execute.ts`** — consumes the prebuilt plan; groups runnable cells
  by scenario/lane and invokes each matrix collector exactly once with its
  assigned cells (shared setup stays batched). One explicit outcome per
  assigned cell: unknown or duplicate returned `cellId` → integrity error +
  exit 2 (a collector can never write another group's results); omitted →
  synthesized `missing` + exit 2; a collector-level throw applies its
  normalized outcome to every assigned runnable cell; independent collectors
  continue. Preflight moves to per-cell `required_env`; PR #1156
  diagnostic/strict semantics preserved exactly (proved by the retained
  matrix tests).
- **Report V3** — `selected_cells`/`results` carry dimensions; verdict
  vocabulary `selected_cells_passed`/`selected_cells_failed`/`non_qualifying`;
  `validateReport` additionally requires every result to repeat its planned
  cell's scenario/lane/reference/dimensions exactly and rejects schema
  versions 1 and 2. Candidate-evidence validation, redaction, and the strict
  non-null `candidate_build` rule carry forward unchanged (PR #1159).
- **T3-CHAT-1** — first real matrix consumer: `--agents all` derives the five
  shipped harnesses from `catalogs/agents/catalog.json` (no hand-written
  list); one cell per harness per lane; no-compatible-model → explicit
  `blocked` child; a real turn/install/reopen failure → explicit `failed`
  child; the sandbox implementation gap → explicit `expected_fail` children
  instead of one green parent; workspace setup remains batched. Still a
  legacy diagnostic scenario — no canonical LOCAL-2 or manifest-row claim.
- **Failure reports** carry exact cell identity, so a failed matrix child
  files/dedupes as its own issue.
- **anyharness-smoke** consumes and asserts report V3 only.
- Spec docs: successor notes added to `qualification-runner-core.md` and
  `candidate-build-handoff.md` (README was already aligned by the freeze
  commit). No workflow YAML, CLI flags, plan files, policy selectors, or
  manifest status changes.

## Acceptance evidence

- `pnpm -C tests/release test` — **208 pass / 0 fail** (every acceptance
  bullet in the frozen spec maps to a named test; prior redaction,
  issue-filing, candidate-map, and runner tests remain green)
- `pnpm -C tests/release typecheck` — clean
- `node --test scripts/ci-cd/assemble-candidate-build-map.test.mjs` — 4 pass
- `make qualification-candidate-handoff-smoke` — **real proof passed**: the
  release AnyHarness built, launched, health-verified, and the diagnostic
  runner emitted valid schema_version-3 evidence matching the launched
  artifact identity
- Live dry-run: 37 exact cells (29 unchanged leaf + 10 T3-CHAT-1 per-harness
  cells, 5 per lane), list sorted, every cell `not_run` with its own plan steps
- Independent adversarial review (subagent) mapped all 14 acceptance bullets
  to tests and found no blocker/issue-level findings; its two stale-comment
  nits are fixed in the last commit

## Assumptions / deviations

- Multi-dimension cell ids join sorted `key=value` pairs with `,`
  (spec shows only the single-dimension example); values are
  `encodeURIComponent`-encoded per "safely encoded".
- A matrix cell must declare ≥1 dimension — a dimensionless matrix cell would
  collide with the scenario's own leaf id form.
- Cell `required_env` is the union of scenario-level and cell-level
  requirements.
- `FailureReport.scenario_id` now carries the exact cell id (the spec's "use
  exact cell identity" for failure-reporter.ts); the wire field name is
  unchanged so `issue-filer.ts` stays untouched.
- Explicit `--agents` names pass through to cells verbatim (an unknown
  harness becomes an explicit blocked child at runtime rather than a plan
  error), matching "one cell per selected harness".

🤖 Generated with [Claude Code](https://claude.com/claude-code)