### PR TITLE
refactor(desktop): route local runtime through ProductHost

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -43,7 +43,6 @@ import {
   recordBootDiagnostic,
   recordBootDiagnosticOnce,
 } from "@/lib/infra/measurement/boot-stall-diagnostics"
-import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap"
 import { AppErrorBoundary } from "@/components/app/AppErrorBoundary"
 import { RepoSetupModalHost } from "@/components/workspace/repo-setup/RepoSetupModalHost"
 import { SupportModalHost } from "@/components/support/SupportModalHost"
@@ -228,24 +227,6 @@ function AppRuntime() {
       })
     })
   }, [bootstrapAuth])
-
-  useEffect(() => {
-    if (authStatus !== "bootstrapping") {
-      const runtimeBootstrapStartedAt = startStartupTimer()
-      recordAppRendererEvent("app.runtime_bootstrap.start")
-      logStartupDebug("app.runtime_bootstrap.start", { authStatus })
-      void bootstrapHarnessRuntime().finally(() => {
-        recordAppRendererEvent(
-          "app.runtime_bootstrap.completed",
-          elapsedStartupMs(runtimeBootstrapStartedAt),
-        )
-        logStartupDebug("app.runtime_bootstrap.completed", {
-          elapsedMs: elapsedStartupMs(runtimeBootstrapStartedAt),
-          authStatus,
-        })
-      })
-    }
-  }, [authStatus])
 
   recordBootDiagnosticOnce("app_runtime.render.before_return", { authStatus })
 

--- a/apps/desktop/src/hooks/access/tauri/use-credentials-actions.ts
+++ b/apps/desktop/src/hooks/access/tauri/use-credentials-actions.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import {
   deleteEnvVarSecret,
   listConfiguredEnvVarNames,
-  restartRuntime,
   setEnvVarSecret,
 } from "@/lib/access/tauri/credentials";
 
@@ -10,7 +9,6 @@ export function useTauriCredentialsActions() {
   return useMemo(() => ({
     deleteEnvVarSecret,
     listConfiguredEnvVarNames,
-    restartRuntime,
     setEnvVarSecret,
   }), []);
 }

--- a/apps/desktop/src/hooks/agents/workflows/use-agent-setup-workflow.ts
+++ b/apps/desktop/src/hooks/agents/workflows/use-agent-setup-workflow.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useReducer } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useStartAgentLoginMutation } from "@anyharness/sdk-react";
 import type {
   AgentSummary,
@@ -51,6 +52,7 @@ export function useAgentSetupWorkflow({
   reconcileState = "idle",
   reconcileResult,
 }: UseAgentSetupWorkflowArgs) {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   // Owns the agent setup modal workflow and local credential form state. Does
   // not own catalog derivation or automatic reconcile lifecycle.
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
@@ -186,7 +188,10 @@ export function useAgentSetupWorkflow({
     dispatch({ type: "restart_started" });
 
     try {
-      await restartHarnessRuntime();
+      if (!localRuntime) {
+        throw new Error("A local AnyHarness runtime is only available in Desktop.");
+      }
+      await restartHarnessRuntime(localRuntime);
       await refreshAgentResources();
       clearRestartRequired();
       onClose();
@@ -195,7 +200,7 @@ export function useAgentSetupWorkflow({
     } finally {
       dispatch({ type: "restart_finished" });
     }
-  }, [clearRestartRequired, onClose, refreshAgentResources]);
+  }, [clearRestartRequired, localRuntime, onClose, refreshAgentResources]);
 
   return {
     subtitle,

--- a/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
+import type { AuthState } from "@proliferate/product-client/host/product-host";
+
+const mocks = vi.hoisted(() => ({
+  bootstrapHarnessRuntime: vi.fn(),
+  logRendererEvent: vi.fn(),
+  recordBootDiagnostic: vi.fn(),
+  logStartupDebug: vi.fn(),
+}));
+
+vi.mock("@/lib/access/anyharness/runtime-bootstrap", () => ({
+  bootstrapHarnessRuntime: mocks.bootstrapHarnessRuntime,
+}));
+vi.mock("@/lib/access/tauri/diagnostics", () => ({
+  logRendererEvent: mocks.logRendererEvent,
+}));
+vi.mock("@/lib/infra/measurement/boot-stall-diagnostics", () => ({
+  recordBootDiagnostic: mocks.recordBootDiagnostic,
+}));
+vi.mock("@/lib/infra/measurement/debug-startup", () => ({
+  elapsedStartupMs: () => 10,
+  logStartupDebug: mocks.logStartupDebug,
+  startStartupTimer: () => 1,
+}));
+
+import { useDesktopRuntimeBootstrapLifecycle } from "./use-desktop-runtime-bootstrap-lifecycle";
+
+function makeRuntime(): DesktopRuntimeBridge {
+  return {
+    getConnection: vi.fn(),
+    restart: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.bootstrapHarnessRuntime.mockResolvedValue(undefined);
+  mocks.logRendererEvent.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe("useDesktopRuntimeBootstrapLifecycle", () => {
+  it("waits for auth loading to finish", async () => {
+    const runtime = makeRuntime();
+    const { rerender, unmount } = renderHook(
+      ({ status }: { status: AuthState["status"] }) =>
+        useDesktopRuntimeBootstrapLifecycle(runtime, status),
+      { initialProps: { status: "loading" as AuthState["status"] } },
+    );
+
+    expect(mocks.bootstrapHarnessRuntime).not.toHaveBeenCalled();
+
+    rerender({ status: "anonymous" });
+    await waitFor(() => expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1));
+    expect(mocks.bootstrapHarnessRuntime.mock.calls[0]?.[0]).toBe(runtime);
+    const signal = mocks.bootstrapHarnessRuntime.mock.calls[0]?.[1] as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("does not duplicate bootstrap when unrelated parent input changes", async () => {
+    const runtime = makeRuntime();
+    const { rerender } = renderHook(
+      ({ runtimeValue, status }: {
+        runtimeValue: DesktopRuntimeBridge;
+        status: AuthState["status"];
+        unrelatedValue: number;
+      }) =>
+        useDesktopRuntimeBootstrapLifecycle(runtimeValue, status),
+      {
+        initialProps: {
+          runtimeValue: runtime,
+          status: "authenticated" as AuthState["status"],
+          unrelatedValue: 1,
+        },
+      },
+    );
+
+    await waitFor(() => expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1));
+    rerender({
+      runtimeValue: runtime,
+      status: "authenticated",
+      unrelatedValue: 2,
+    });
+
+    expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx
+++ b/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
 import type { AuthState } from "@proliferate/product-client/host/product-host";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 const mocks = vi.hoisted(() => ({
   bootstrapHarnessRuntime: vi.fn(),
@@ -39,6 +40,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.bootstrapHarnessRuntime.mockResolvedValue(undefined);
   mocks.logRendererEvent.mockResolvedValue(undefined);
+  useHarnessConnectionStore.getState().resetConnectionState();
 });
 
 afterEach(cleanup);
@@ -90,5 +92,46 @@ describe("useDesktopRuntimeBootstrapLifecycle", () => {
     });
 
     expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one bootstrap when auth changes between ready states", async () => {
+    const runtime = makeRuntime();
+    const { rerender } = renderHook(
+      ({ status }: { status: AuthState["status"] }) =>
+        useDesktopRuntimeBootstrapLifecycle(runtime, status),
+      { initialProps: { status: "anonymous" as AuthState["status"] } },
+    );
+
+    await waitFor(() => expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1));
+    const signal = mocks.bootstrapHarnessRuntime.mock.calls[0]?.[1] as AbortSignal;
+
+    rerender({ status: "authenticated" });
+    expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+    expect(signal.aborted).toBe(false);
+
+    rerender({ status: "anonymous" });
+    expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("revokes the published runtime state when its bridge lifecycle ends", async () => {
+    const runtime = makeRuntime();
+    const { unmount } = renderHook(() =>
+      useDesktopRuntimeBootstrapLifecycle(runtime, "authenticated"),
+    );
+    await waitFor(() => expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1));
+    useHarnessConnectionStore.setState({
+      runtimeUrl: "http://127.0.0.1:9999",
+      connectionState: "healthy",
+      error: null,
+    });
+
+    unmount();
+
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "",
+      connectionState: "connecting",
+      error: null,
+    });
   });
 });

--- a/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts
@@ -16,20 +16,23 @@ import {
   logStartupDebug,
   startStartupTimer,
 } from "@/lib/infra/measurement/debug-startup";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 export function useDesktopRuntimeBootstrapLifecycle(
   runtime: DesktopRuntimeBridge,
   authStatus: AuthState["status"],
 ): void {
+  const authReady = authStatus !== "loading";
+
   useEffect(() => {
-    if (authStatus === "loading") {
+    if (!authReady) {
       return;
     }
 
     const runtimeBootstrapStartedAt = startStartupTimer();
     const controller = new AbortController();
     recordAppRendererEvent("app.runtime_bootstrap.start");
-    logStartupDebug("app.runtime_bootstrap.start", { authStatus });
+    logStartupDebug("app.runtime_bootstrap.start", { authStatus: "ready" });
     void bootstrapHarnessRuntime(runtime, controller.signal).finally(() => {
       if (controller.signal.aborted) {
         return;
@@ -40,11 +43,14 @@ export function useDesktopRuntimeBootstrapLifecycle(
       );
       logStartupDebug("app.runtime_bootstrap.completed", {
         elapsedMs: elapsedStartupMs(runtimeBootstrapStartedAt),
-        authStatus,
+        authStatus: "ready",
       });
     });
-    return () => controller.abort();
-  }, [authStatus, runtime]);
+    return () => {
+      controller.abort();
+      useHarnessConnectionStore.getState().resetConnectionState();
+    };
+  }, [authReady, runtime]);
 }
 
 function recordAppRendererEvent(message: string, elapsedMs?: number): void {

--- a/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts
+++ b/apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import type {
+  AuthState,
+} from "@proliferate/product-client/host/product-host";
+import type {
+  DesktopRuntimeBridge,
+} from "@proliferate/product-client/host/desktop-bridge";
+
+import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap";
+import { logRendererEvent } from "@/lib/access/tauri/diagnostics";
+import {
+  recordBootDiagnostic,
+} from "@/lib/infra/measurement/boot-stall-diagnostics";
+import {
+  elapsedStartupMs,
+  logStartupDebug,
+  startStartupTimer,
+} from "@/lib/infra/measurement/debug-startup";
+
+export function useDesktopRuntimeBootstrapLifecycle(
+  runtime: DesktopRuntimeBridge,
+  authStatus: AuthState["status"],
+): void {
+  useEffect(() => {
+    if (authStatus === "loading") {
+      return;
+    }
+
+    const runtimeBootstrapStartedAt = startStartupTimer();
+    const controller = new AbortController();
+    recordAppRendererEvent("app.runtime_bootstrap.start");
+    logStartupDebug("app.runtime_bootstrap.start", { authStatus });
+    void bootstrapHarnessRuntime(runtime, controller.signal).finally(() => {
+      if (controller.signal.aborted) {
+        return;
+      }
+      recordAppRendererEvent(
+        "app.runtime_bootstrap.completed",
+        elapsedStartupMs(runtimeBootstrapStartedAt),
+      );
+      logStartupDebug("app.runtime_bootstrap.completed", {
+        elapsedMs: elapsedStartupMs(runtimeBootstrapStartedAt),
+        authStatus,
+      });
+    });
+    return () => controller.abort();
+  }, [authStatus, runtime]);
+}
+
+function recordAppRendererEvent(message: string, elapsedMs?: number): void {
+  recordBootDiagnostic(
+    `app_bootstrap.${message}`,
+    elapsedMs === undefined ? undefined : { elapsedMs },
+  );
+  void logRendererEvent({
+    source: "app_bootstrap",
+    message,
+    elapsedMs,
+  }).catch(() => {
+    // Native logging is diagnostic-only; app startup should never depend on it.
+  });
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   applySessionLaunchDefaults: vi.fn(),
   createSession: vi.fn(),
   dismissSession: vi.fn(() => new Promise<void>(() => undefined)),
+  resolveDesktopRuntimeUrlForWorkspace: vi.fn(async () => "http://runtime.test"),
   writeTombstones: vi.fn(() => true),
 }));
 
@@ -53,7 +54,7 @@ vi.mock("@/lib/access/anyharness/runtime-target", () => ({
 
 vi.mock("@/hooks/sessions/workflows/session-creation-runtime", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/hooks/sessions/workflows/session-creation-runtime")>(),
-  resolveDesktopRuntimeUrlForWorkspace: vi.fn(async () => "http://runtime.test"),
+  resolveDesktopRuntimeUrlForWorkspace: mocks.resolveDesktopRuntimeUrlForWorkspace,
 }));
 
 vi.mock("@/lib/access/anyharness/direct-session-create-guard", () => ({
@@ -72,6 +73,7 @@ beforeEach(() => {
   mocks.writeTombstones.mockReturnValue(true);
   mocks.applySessionLaunchDefaults.mockReset();
   mocks.createSession.mockReset();
+  mocks.resolveDesktopRuntimeUrlForWorkspace.mockClear();
   resetReplacedSessionTombstonesForTests();
   resetSessionReplacementDismissalsForTests();
   resetSessionCreationSupersessionForTests();
@@ -131,11 +133,13 @@ describe("created runtime cleanup", () => {
     mocks.writeTombstones.mockReturnValue(false);
     mocks.dismissSession.mockRejectedValue(new Error("runtime unavailable"));
     const upsertWorkspaceSessionRecord = vi.fn();
+    const localRuntime = { getConnection: vi.fn(), restart: vi.fn() };
 
     await expect(materializeSessionCreation({
       ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
       existingProjectedRecord: projectedRecord,
       frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      localRuntime,
       options: {
         text: "",
         agentKind: "claude",
@@ -148,6 +152,10 @@ describe("created runtime cleanup", () => {
       workspaceId: "workspace-1",
     })).resolves.toBe(pendingSessionId);
 
+    expect(mocks.resolveDesktopRuntimeUrlForWorkspace).toHaveBeenCalledWith(
+      "workspace-1",
+      localRuntime,
+    );
     expect(getSessionRecord(pendingSessionId)?.materializedSessionId)
       .toBe("runtime-retained");
     expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
@@ -181,6 +189,7 @@ describe("created runtime cleanup", () => {
       ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
       existingProjectedRecord: projectedRecord,
       frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      localRuntime: null,
       options: {
         text: "",
         agentKind: "claude",
@@ -242,6 +251,7 @@ describe("created runtime cleanup", () => {
       ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
       existingProjectedRecord: projectedRecord,
       frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      localRuntime: null,
       options: {
         text: "",
         agentKind: "claude",

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -1,4 +1,5 @@
 import type { Session } from "@anyharness/sdk";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
 import { applySessionLaunchDefaults } from "@/lib/workflows/sessions/session-launch-defaults";
 import { createSessionLaunchDefaultsClient } from "@/lib/access/anyharness/session-launch-defaults-client";
 import {
@@ -60,6 +61,7 @@ interface MaterializeSessionCreationInput {
   }>;
   existingProjectedRecord: SessionRuntimeRecord | null;
   frozenDefaultLiveSessionControlValuesByAgentKind: Record<string, Record<string, string>>;
+  localRuntime: DesktopRuntimeBridge | null;
   options: CreateSessionWithResolvedConfigOptions;
   pendingSessionId: string;
   resolvedModeId: string | null;
@@ -99,6 +101,7 @@ async function runSessionCreationMaterialization({
   ensureCloudAgentCatalog,
   existingProjectedRecord,
   frozenDefaultLiveSessionControlValuesByAgentKind,
+  localRuntime,
   options,
   pendingSessionId,
   resolvedModeId,
@@ -114,7 +117,7 @@ async function runSessionCreationMaterialization({
     modelId: options.modelId,
     modeId: resolvedModeId,
   });
-  const runtimeUrl = await resolveDesktopRuntimeUrlForWorkspace(workspaceId);
+  const runtimeUrl = await resolveDesktopRuntimeUrlForWorkspace(workspaceId, localRuntime);
   logLatency("session.create.materialize.runtime_url_resolved", {
     clientSessionId: pendingSessionId,
     workspaceId,

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
+
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+const mocks = vi.hoisted(() => ({
+  bootstrapHarnessRuntime: vi.fn(),
+}));
+
+vi.mock("@/lib/access/anyharness/runtime-bootstrap", () => ({
+  bootstrapHarnessRuntime: mocks.bootstrapHarnessRuntime,
+}));
+
+import { resolveDesktopRuntimeUrlForWorkspace } from "./session-creation-runtime";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "",
+    connectionState: "connecting",
+    error: null,
+  });
+});
+
+describe("session creation runtime resolution", () => {
+  it("uses the injected Desktop runtime for a local workspace", async () => {
+    const runtime = {
+      getConnection: vi.fn(),
+      restart: vi.fn(),
+    } satisfies DesktopRuntimeBridge;
+    mocks.bootstrapHarnessRuntime.mockImplementation(async () => {
+      useHarnessConnectionStore.setState({
+        runtimeUrl: "http://runtime.test",
+        connectionState: "healthy",
+        error: null,
+      });
+    });
+
+    await expect(
+      resolveDesktopRuntimeUrlForWorkspace("workspace-local", runtime),
+    ).resolves.toBe("http://runtime.test");
+    expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledWith(runtime);
+  });
+
+  it.each(["cloud:cloud-1", "target:target-1:workspace-runtime"])(
+    "does not discover a local runtime for %s",
+    async (workspaceId) => {
+      await expect(
+        resolveDesktopRuntimeUrlForWorkspace(workspaceId, null),
+      ).resolves.toBe("");
+      expect(mocks.bootstrapHarnessRuntime).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.ts
@@ -1,4 +1,5 @@
 import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
 import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import {
@@ -41,10 +42,16 @@ export const sessionStreamPruningDeps: SessionStreamPruningDeps = {
   isPendingSessionId,
 };
 
-export async function ensureRuntimeReadyForSessions(): Promise<string> {
+export async function ensureRuntimeReadyForSessions(
+  runtime: DesktopRuntimeBridge | null,
+): Promise<string> {
+  if (!runtime) {
+    throw new Error("A local AnyHarness runtime is only available in Desktop.");
+  }
+
   const state = useHarnessConnectionStore.getState();
   if (state.connectionState !== "healthy" || state.runtimeUrl.trim().length === 0) {
-    await bootstrapHarnessRuntime();
+    await bootstrapHarnessRuntime(runtime);
   }
 
   const readyState = useHarnessConnectionStore.getState();
@@ -55,13 +62,12 @@ export async function ensureRuntimeReadyForSessions(): Promise<string> {
   return readyState.runtimeUrl;
 }
 
-export async function resolveDesktopRuntimeUrlForWorkspace(workspaceId: string): Promise<string> {
+export async function resolveDesktopRuntimeUrlForWorkspace(
+  workspaceId: string,
+  runtime: DesktopRuntimeBridge | null,
+): Promise<string> {
   if (parseTargetWorkspaceSyntheticId(workspaceId) || parseCloudWorkspaceSyntheticId(workspaceId)) {
-    const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl.trim();
-    if (!runtimeUrl) {
-      throw new Error("AnyHarness runtime URL is not available yet.");
-    }
-    return runtimeUrl;
+    return useHarnessConnectionStore.getState().runtimeUrl.trim();
   }
-  return ensureRuntimeReadyForSessions();
+  return ensureRuntimeReadyForSessions(runtime);
 }

--- a/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.test.ts
@@ -5,9 +5,14 @@ import {
   resetReplacedSessionTombstonesForTests,
   stageReplacedSessionTombstone,
 } from "@/hooks/sessions/workflows/session-replacement-tombstones";
-import { fetchWorkspaceSessions } from "./session-selection-runtime";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import {
+  fetchWorkspaceSessions,
+  resolveRuntimeUrlForWorkspaceSessions,
+} from "./session-selection-runtime";
 
 const mocks = vi.hoisted(() => ({
+  bootstrapHarnessRuntime: vi.fn(),
   fetchWorkspaceSessionSummaries: vi.fn(),
 }));
 
@@ -16,12 +21,44 @@ vi.mock("@/lib/access/anyharness/session-runtime", () => ({
 }));
 
 vi.mock("@/lib/access/anyharness/runtime-bootstrap", () => ({
-  bootstrapHarnessRuntime: vi.fn(),
+  bootstrapHarnessRuntime: mocks.bootstrapHarnessRuntime,
 }));
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mocks.fetchWorkspaceSessionSummaries.mockReset();
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "",
+    connectionState: "connecting",
+    error: null,
+  });
   resetReplacedSessionTombstonesForTests();
+});
+
+describe("session runtime selection", () => {
+  it.each(["cloud:cloud-1", "target:target-1:workspace-1"])(
+    "does not discover a local runtime for %s",
+    async (workspaceId) => {
+      await expect(resolveRuntimeUrlForWorkspaceSessions(workspaceId, null)).resolves.toBe("");
+      expect(mocks.bootstrapHarnessRuntime).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses the injected Desktop bridge for a local workspace", async () => {
+    const runtime = { getConnection: vi.fn(), restart: vi.fn() };
+    mocks.bootstrapHarnessRuntime.mockImplementation(async () => {
+      useHarnessConnectionStore.setState({
+        runtimeUrl: "http://runtime.test",
+        connectionState: "healthy",
+        error: null,
+      });
+    });
+
+    await expect(
+      resolveRuntimeUrlForWorkspaceSessions("workspace-1", runtime),
+    ).resolves.toBe("http://runtime.test");
+    expect(mocks.bootstrapHarnessRuntime).toHaveBeenCalledWith(runtime);
+  });
 });
 
 describe("selection session-list filtering", () => {

--- a/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.ts
@@ -1,6 +1,9 @@
 import {
   getLatencyFlowRequestHeaders,
 } from "@/lib/infra/measurement/latency-flow";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
+import { parseTargetWorkspaceSyntheticId } from "@/lib/domain/compute/target-workspace-id";
+import { parseCloudWorkspaceSyntheticId } from "@/lib/domain/workspaces/cloud/cloud-ids";
 import { getMeasurementRequestOptions } from "@/lib/infra/measurement/debug-measurement-request-options";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap";
@@ -16,10 +19,16 @@ export function buildLatencyRequestOptions(latencyFlowId?: string | null) {
   return headers ? { headers } : undefined;
 }
 
-export async function ensureRuntimeReadyForSessions(): Promise<string> {
+export async function ensureRuntimeReadyForSessions(
+  runtime: DesktopRuntimeBridge | null,
+): Promise<string> {
+  if (!runtime) {
+    throw new Error("A local AnyHarness runtime is only available in Desktop.");
+  }
+
   const state = useHarnessConnectionStore.getState();
   if (state.connectionState !== "healthy" || state.runtimeUrl.trim().length === 0) {
-    await bootstrapHarnessRuntime();
+    await bootstrapHarnessRuntime(runtime);
   }
 
   const readyState = useHarnessConnectionStore.getState();
@@ -28,6 +37,16 @@ export async function ensureRuntimeReadyForSessions(): Promise<string> {
   }
 
   return readyState.runtimeUrl;
+}
+
+export async function resolveRuntimeUrlForWorkspaceSessions(
+  workspaceId: string,
+  runtime: DesktopRuntimeBridge | null,
+): Promise<string> {
+  if (parseTargetWorkspaceSyntheticId(workspaceId) || parseCloudWorkspaceSyntheticId(workspaceId)) {
+    return useHarnessConnectionStore.getState().runtimeUrl.trim();
+  }
+  return ensureRuntimeReadyForSessions(runtime);
 }
 
 export async function fetchWorkspaceSessions(

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { hasPromptContent } from "@/lib/domain/chat/composer/prompt-input";
 import { createPromptId } from "@/lib/domain/chat/composer/prompt-id";
 import {
@@ -68,6 +69,7 @@ import { cleanupSessionCreationFailure } from "@/hooks/sessions/workflows/sessio
 import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
 
 export function useSessionCreationActions() {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
   const { promptSession } = useSessionPromptWorkflow();
@@ -292,6 +294,7 @@ export function useSessionCreationActions() {
       ensureCloudAgentCatalog,
       existingProjectedRecord,
       frozenDefaultLiveSessionControlValuesByAgentKind,
+      localRuntime,
       options,
       pendingSessionId,
       resolvedModeId: resolvedModeId ?? null,
@@ -368,6 +371,7 @@ export function useSessionCreationActions() {
     ensureCloudAgentCatalog,
     getWorkspaceRuntimeBlockReason,
     getWorkspaceSurface,
+    localRuntime,
     promptSession,
     removeWorkspaceSessionRecord,
     showToast,
@@ -392,8 +396,5 @@ export function useSessionCreationActions() {
     });
   }, [createSessionWithResolvedConfig]);
 
-  return {
-    createEmptySessionWithResolvedConfig,
-    createSessionWithResolvedConfig,
-  };
+  return { createEmptySessionWithResolvedConfig, createSessionWithResolvedConfig };
 }

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts
@@ -16,6 +16,7 @@ import { useSessionSelectionStore } from "@/stores/sessions/session-selection-st
 import { useSessionRestoreActions } from "./use-session-restore-actions";
 
 const mocks = vi.hoisted(() => ({
+  localRuntime: {},
   getWorkspaceClientAndId: vi.fn(async () => ({
     target: {
       anyharnessWorkspaceId: "workspace-1",
@@ -24,9 +25,14 @@ const mocks = vi.hoisted(() => ({
   })),
   dismissMutateAsync: vi.fn(),
   restoreMutateAsync: vi.fn(),
+  resolveRuntimeUrlForWorkspaceSessions: vi.fn(async () => "http://runtime.test"),
   showToast: vi.fn(),
   upsertWorkspaceSessionRecord: vi.fn(),
   writeSessionReplacementTombstones: vi.fn(() => true),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: { runtime: mocks.localRuntime } }),
 }));
 
 vi.mock("@/lib/access/browser/session-replacement-tombstones-storage", () => ({
@@ -53,7 +59,7 @@ vi.mock("@/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
 
 vi.mock("@/hooks/sessions/workflows/session-selection-runtime", () => ({
   buildLatencyRequestOptions: () => undefined,
-  ensureRuntimeReadyForSessions: async () => "http://runtime.test",
+  resolveRuntimeUrlForWorkspaceSessions: mocks.resolveRuntimeUrlForWorkspaceSessions,
 }));
 
 vi.mock("@/lib/access/anyharness/session-runtime", () => ({
@@ -117,6 +123,10 @@ describe("useSessionRestoreActions", () => {
     });
 
     expect(restoredId).toBe("runtime-old");
+    expect(mocks.resolveRuntimeUrlForWorkspaceSessions).toHaveBeenCalledWith(
+      "workspace-1",
+      mocks.localRuntime,
+    );
     expect(isReplacedSessionTombstoned("workspace-1", "runtime-old")).toBe(false);
     expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(false);
     expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledWith(

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import {
   useDismissSessionMutation,
   useRestoreDismissedSessionMutation,
@@ -7,7 +8,7 @@ import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use
 import type { SessionLatencyFlowOptions } from "@/hooks/sessions/workflows/session-selection-options";
 import {
   buildLatencyRequestOptions,
-  ensureRuntimeReadyForSessions,
+  resolveRuntimeUrlForWorkspaceSessions,
 } from "@/hooks/sessions/workflows/session-selection-runtime";
 import { useWorkspaceRuntimeBlock } from "@/hooks/workspaces/derived/use-workspace-runtime-block";
 import {
@@ -32,6 +33,7 @@ import {
 } from "@/hooks/sessions/workflows/session-replacement-dismissals";
 
 export function useSessionRestoreActions() {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const showToast = useToastStore((state) => state.show);
   const { upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
@@ -77,7 +79,7 @@ export function useSessionRestoreActions() {
 
     try {
       const runtimeReadyStartedAt = startLatencyTimer();
-      const runtimeUrl = await ensureRuntimeReadyForSessions();
+      const runtimeUrl = await resolveRuntimeUrlForWorkspaceSessions(workspaceId, localRuntime);
       logLatency("session.restore.runtime_ready", {
         workspaceId,
         flowId: options?.latencyFlowId ?? null,
@@ -172,6 +174,7 @@ export function useSessionRestoreActions() {
     }
   }, [
     getWorkspaceRuntimeBlockReason,
+    localRuntime,
     dismissSessionMutation,
     restoreDismissedSessionMutation,
     showToast,

--- a/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts
@@ -9,11 +9,16 @@ import {
 import { useWorkspaceSessionLoader } from "./use-workspace-session-loader";
 
 const mocks = vi.hoisted(() => ({
+  localRuntime: {},
   ensureRuntimeReadyForSessions: vi.fn(async () => "http://runtime.test"),
   fetchWorkspaceSessions: vi.fn(),
   getWorkspaceRuntimeBlockReason: vi.fn(() => null),
   getWorkspaceSessionCacheSnapshot: vi.fn(),
   setWorkspaceSessions: vi.fn(),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: { runtime: mocks.localRuntime } }),
 }));
 
 vi.mock("@/hooks/access/anyharness/sessions/use-workspace-session-cache", () => ({
@@ -76,6 +81,7 @@ describe("useWorkspaceSessionLoader replacement filtering", () => {
     const sessions = await result.current.ensureWorkspaceSessions("workspace-1");
 
     expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
+    expect(mocks.ensureRuntimeReadyForSessions).toHaveBeenCalledWith(mocks.localRuntime);
     const updater = mocks.setWorkspaceSessions.mock.calls[0]?.[1] as
       ((current: unknown) => unknown) | undefined;
     expect(updater?.(undefined)).toEqual([

--- a/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useWorkspaceSessionCache } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import type { WorkspaceSession } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import type { SessionLatencyFlowOptions } from "@/hooks/sessions/workflows/session-selection-options";
@@ -17,6 +18,7 @@ import {
 } from "@/hooks/sessions/workflows/session-replacement-tombstones";
 
 export function useWorkspaceSessionLoader() {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const {
     getWorkspaceSessionCacheSnapshot,
@@ -34,7 +36,7 @@ export function useWorkspaceSessionLoader() {
 
     const runtimeUrl = workspaceUsesResolvedRemoteRuntime(workspaceId)
       ? useHarnessConnectionStore.getState().runtimeUrl
-      : await ensureRuntimeReadyForSessions();
+      : await ensureRuntimeReadyForSessions(localRuntime);
     const requestHeaders = getLatencyFlowRequestHeaders(options?.latencyFlowId);
     const cacheSnapshot = getWorkspaceSessionCacheSnapshot(workspaceId);
     if (options?.measurementOperationId) {
@@ -82,6 +84,7 @@ export function useWorkspaceSessionLoader() {
   }, [
     getWorkspaceRuntimeBlockReason,
     getWorkspaceSessionCacheSnapshot,
+    localRuntime,
     setWorkspaceSessions,
   ]);
 

--- a/apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
+++ b/apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
@@ -131,6 +131,14 @@ export function useWorkspaceCollectionsMutationCache(runtimeUrl: string) {
 export function useWorkspaceCollectionsMutationCacheActions() {
   const queryClient = useQueryClient();
 
+  const upsertLocalWorkspaceInWorkspaceCollections = useCallback((
+    runtimeUrl: string,
+    workspace: Workspace,
+    repoRoot?: RepoRoot | null,
+  ): WorkspaceCollectionsLocalUpsertSummary =>
+    upsertLocalWorkspaceForRuntime(queryClient, runtimeUrl, workspace, repoRoot),
+  [queryClient]);
+
   const upsertRepoRootInWorkspaceCollections = useCallback((
     runtimeUrl: string,
     repoRoot: RepoRoot,
@@ -139,6 +147,7 @@ export function useWorkspaceCollectionsMutationCacheActions() {
   }, [queryClient]);
 
   return {
+    upsertLocalWorkspaceInWorkspaceCollections,
     upsertRepoRootInWorkspaceCollections,
   };
 }

--- a/apps/desktop/src/hooks/workspaces/workflows/runtime-ready.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/runtime-ready.ts
@@ -1,10 +1,17 @@
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
 import { bootstrapHarnessRuntime } from "@/lib/access/anyharness/runtime-bootstrap";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
-export async function ensureRuntimeReady(): Promise<string> {
+export async function ensureRuntimeReady(
+  runtime: DesktopRuntimeBridge | null,
+): Promise<string> {
+  if (!runtime) {
+    throw new Error("A local AnyHarness runtime is only available in Desktop.");
+  }
+
   const state = useHarnessConnectionStore.getState();
   if (state.connectionState !== "healthy" || state.runtimeUrl.trim().length === 0) {
-    await bootstrapHarnessRuntime();
+    await bootstrapHarnessRuntime(runtime);
   }
 
   const readyState = useHarnessConnectionStore.getState();

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/connection.test.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/connection.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
+
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import type {
+  WorkspaceSelectionContext,
+  WorkspaceSelectionDeps,
+} from "./types";
+
+const mocks = vi.hoisted(() => ({
+  ensureRuntimeReady: vi.fn(),
+  resolveWorkspaceConnection: vi.fn(),
+}));
+
+vi.mock("@/hooks/workspaces/workflows/runtime-ready", () => ({
+  ensureRuntimeReady: mocks.ensureRuntimeReady,
+}));
+vi.mock("@/lib/access/anyharness/resolve-workspace-connection", () => ({
+  resolveWorkspaceConnection: mocks.resolveWorkspaceConnection,
+}));
+
+import { resolveSelectionConnection } from "./connection";
+
+const context = (workspaceId: string): WorkspaceSelectionContext => ({
+  workspaceId,
+  logicalWorkspaceId: `logical:${workspaceId}`,
+  selectionNonce: 1,
+  selectionStartedAt: 1,
+  cloudWorkspaceId: null,
+});
+
+function deps(
+  localRuntime: DesktopRuntimeBridge | null,
+  refreshCloudWorkspaceConnection = vi.fn(),
+): WorkspaceSelectionDeps {
+  return {
+    localRuntime,
+    logicalWorkspaces: [],
+    rawWorkspaces: [],
+    cache: {
+      cancelPreviousWorkspaceDisplayQueries: vi.fn(),
+      invalidateCloudWorkspaceStartState: vi.fn(),
+      refreshCloudWorkspaceConnection,
+    },
+    setSelectedLogicalWorkspaceId: vi.fn(),
+    setSelectedWorkspace: vi.fn(),
+    removeWorkspaceSlots: vi.fn(),
+    clearSelection: vi.fn(),
+    bootstrapWorkspace: vi.fn(),
+    reconcileHotWorkspace: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "",
+    connectionState: "connecting",
+    error: null,
+  });
+});
+
+describe("resolveSelectionConnection", () => {
+  it("uses the injected Desktop runtime for a local workspace", async () => {
+    const runtime = {
+      getConnection: vi.fn(),
+      restart: vi.fn(),
+    } satisfies DesktopRuntimeBridge;
+    mocks.ensureRuntimeReady.mockResolvedValue("http://runtime.test");
+    mocks.resolveWorkspaceConnection.mockResolvedValue({
+      runtimeUrl: "http://runtime.test",
+      anyharnessWorkspaceId: "workspace-runtime",
+    });
+
+    const result = await resolveSelectionConnection(
+      deps(runtime),
+      context("workspace-local"),
+      { kind: "local", runtimeWorkspaceId: "workspace-runtime" },
+    );
+
+    expect(mocks.ensureRuntimeReady).toHaveBeenCalledWith(runtime);
+    expect(mocks.resolveWorkspaceConnection).toHaveBeenCalledWith(
+      "http://runtime.test",
+      "workspace-runtime",
+    );
+    expect(result.runtimeUrl).toBe("http://runtime.test");
+  });
+
+  it("does not discover a local runtime for an SSH target workspace", async () => {
+    mocks.resolveWorkspaceConnection.mockResolvedValue({
+      runtimeUrl: "https://target.test",
+      anyharnessWorkspaceId: "workspace-runtime",
+    });
+
+    await resolveSelectionConnection(
+      deps(null),
+      context("target:target-1:workspace-runtime"),
+      { kind: "local" },
+    );
+
+    expect(mocks.ensureRuntimeReady).not.toHaveBeenCalled();
+    expect(mocks.resolveWorkspaceConnection).toHaveBeenCalledWith(
+      "",
+      "target:target-1:workspace-runtime",
+    );
+  });
+
+  it("does not discover a local runtime for a Cloud workspace", async () => {
+    const refreshCloudWorkspaceConnection = vi.fn().mockResolvedValue({
+      runtimeUrl: "https://cloud.test",
+      accessToken: "cloud-token",
+      anyharnessWorkspaceId: "workspace-runtime",
+    });
+
+    const result = await resolveSelectionConnection(
+      deps(null, refreshCloudWorkspaceConnection),
+      { ...context("cloud:cloud-1"), cloudWorkspaceId: "cloud-1" },
+      { kind: "cloud-ready", cloudWorkspaceId: "cloud-1" },
+    );
+
+    expect(mocks.ensureRuntimeReady).not.toHaveBeenCalled();
+    expect(mocks.resolveWorkspaceConnection).not.toHaveBeenCalled();
+    expect(result.workspaceConnection).toMatchObject({
+      runtimeUrl: "https://cloud.test",
+      authToken: "cloud-token",
+      anyharnessWorkspaceId: "workspace-runtime",
+    });
+  });
+});

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/connection.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/connection.ts
@@ -25,7 +25,7 @@ export async function resolveSelectionConnection(
     ? cloudReadiness.runtimeWorkspaceId ?? context.workspaceId
     : context.workspaceId;
   const desktopRuntimeUrl = cloudReadiness.kind === "local" && !targetWorkspace
-    ? await ensureRuntimeReady()
+    ? await ensureRuntimeReady(deps.localRuntime)
     : useHarnessConnectionStore.getState().runtimeUrl;
   logLatency("workspace.select.runtime_ready", {
     workspaceId: context.workspaceId,

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
@@ -117,6 +117,7 @@ describe("runHotWorkspaceReopen", () => {
 
 function depsForHotReopen(): WorkspaceSelectionDeps {
   return {
+    localRuntime: null,
     cache: {
       cancelPreviousWorkspaceDisplayQueries: vi.fn(),
       invalidateCloudWorkspaceStartState: vi.fn().mockResolvedValue(undefined),

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
@@ -97,6 +97,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -119,6 +120,7 @@ describe("runWorkspaceSelection", () => {
     vi.mocked(resolveCloudWorkspaceReadiness).mockReset();
 
     await expect(runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces: [
         ...logicalWorkspaces,
@@ -174,6 +176,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache,
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -209,6 +212,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -251,6 +255,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -287,6 +292,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -319,6 +325,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],
@@ -385,6 +392,7 @@ describe("runWorkspaceSelection", () => {
     });
 
     await runWorkspaceSelection({
+      localRuntime: null,
       cache: selectionCache(),
       logicalWorkspaces,
       rawWorkspaces: [],

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
@@ -1,4 +1,5 @@
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
 import type { Workspace } from "@anyharness/sdk";
 import type { WorkspaceSession } from "@/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import type { LogicalWorkspace } from "@/lib/domain/workspaces/cloud/logical-workspace-model";
@@ -25,6 +26,7 @@ export interface WorkspaceSelectionContext {
 }
 
 export interface WorkspaceSelectionDeps {
+  localRuntime: DesktopRuntimeBridge | null;
   logicalWorkspaces: LogicalWorkspace[];
   rawWorkspaces: Workspace[];
   cache: {

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useWorkspaceBootstrapActions } from "@/hooks/workspaces/workflows/use-workspace-bootstrap-actions";
 import { useCloudWorkspaceConnectionCache } from "@/hooks/access/cloud/use-cloud-workspace-connection-cache";
 import { useWorkspaceSelectionCache } from "@/hooks/workspaces/cache/use-workspace-selection-cache";
@@ -19,6 +20,7 @@ function removeWorkspaceSessionRecordsForWorkspace(workspaceId: string): void {
 }
 
 export function useWorkspaceSelection() {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   const {
     cancelPreviousWorkspaceDisplayQueries,
     getWorkspaceSelectionSnapshot,
@@ -67,6 +69,7 @@ export function useWorkspaceSelection() {
         })
         : [];
       const deps = {
+        localRuntime,
         cache: {
           cancelPreviousWorkspaceDisplayQueries,
           invalidateCloudWorkspaceStartState,
@@ -105,6 +108,7 @@ export function useWorkspaceSelection() {
       clearSelection,
       getWorkspaceSelectionSnapshot,
       invalidateCloudWorkspaceStartState,
+      localRuntime,
       reconcileHotWorkspace,
       refreshCloudWorkspaceConnection,
       setSelectedLogicalWorkspaceId,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-add-repo.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-add-repo.ts
@@ -1,6 +1,7 @@
 import { AnyHarnessError, type RepoRoot } from "@anyharness/sdk";
 import { useResolveRepoRootFromPathMutation } from "@anyharness/sdk-react";
 import { useSaveRepoEnvironment } from "@proliferate/cloud-sdk-react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useCallback, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { runAddRepoWorkflow } from "@/lib/domain/workspaces/creation/add-repo-workflow";
@@ -39,6 +40,7 @@ function isRepoEntryBlockedPath(pathname: string): boolean {
 }
 
 export function useAddRepo() {
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
   const location = useLocation();
   const { upsertRepoRootInWorkspaceCollections } = useWorkspaceCollectionsMutationCacheActions();
   const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
@@ -94,7 +96,7 @@ export function useAddRepo() {
     try {
       const repoRoot = await runAddRepoWorkflow({
         path,
-        ensureRuntimeReady,
+        ensureRuntimeReady: () => ensureRuntimeReady(localRuntime),
         resolveRepoRootFromPath: (repoPath) => resolveRepoRootFromPath(repoPath),
         upsertRepoRootInWorkspaceCollections,
         invalidateWorkspaceCollections: invalidateWorkspaceCollectionsForRuntime,
@@ -117,6 +119,7 @@ export function useAddRepo() {
   }, [
     canAddRepo,
     invalidateWorkspaceCollectionsForRuntime,
+    localRuntime,
     openRepoSetupModal,
     resolveRepoRootFromPath,
     saveLocalRepoEnvironment,

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => {
   }));
 
   return {
+    localRuntime: {},
     create,
     resolveFromPath,
     createWorktree,
@@ -37,6 +38,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@anyharness/sdk-react", () => ({
   getAnyHarnessClient: mocks.getAnyHarnessClient,
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: { runtime: mocks.localRuntime } }),
 }));
 
 vi.mock("./runtime-ready", () => ({
@@ -105,9 +110,46 @@ describe("useWorkspaceActions local workspace creation", () => {
       origin: { kind: "human", entrypoint: "desktop" },
     });
     expect(mocks.resolveFromPath).not.toHaveBeenCalled();
+    expect(mocks.ensureRuntimeReady).toHaveBeenCalledWith(mocks.localRuntime);
     expect(mocks.trackProductEvent).toHaveBeenCalledWith("workspace_created", {
       workspace_kind: "local",
       creation_kind: "local",
+    });
+  });
+
+  it("updates the cache scoped to the runtime returned by bridge readiness", async () => {
+    const readyRuntimeUrl = "http://localhost:8111";
+    const workspace = localWorkspace("workspace-dynamic-runtime");
+    const repoRoot = localRepoRoot();
+    mocks.ensureRuntimeReady.mockResolvedValueOnce(readyRuntimeUrl);
+    mocks.create.mockResolvedValueOnce({ repoRoot, workspace });
+
+    const { result, queryClient } = renderActions();
+    queryClient.setQueryData(
+      workspaceCollectionsKey(readyRuntimeUrl, false),
+      buildWorkspaceCollections([], [], []),
+    );
+    queryClient.setQueryData(
+      workspaceCollectionsKey("http://localhost:7007", false),
+      buildWorkspaceCollections([], [], []),
+    );
+
+    await act(async () => {
+      await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+    });
+
+    const readyCollections = queryClient.getQueryData<WorkspaceCollections>(
+      workspaceCollectionsKey(readyRuntimeUrl, false),
+    );
+    const staleCollections = queryClient.getQueryData<WorkspaceCollections>(
+      workspaceCollectionsKey("http://localhost:7007", false),
+    );
+    expect(readyCollections?.localWorkspaces.map((entry) => entry.id)).toEqual([
+      "workspace-dynamic-runtime",
+    ]);
+    expect(staleCollections?.localWorkspaces).toEqual([]);
+    expect(mocks.getAnyHarnessClient).toHaveBeenCalledWith({
+      runtimeUrl: readyRuntimeUrl,
     });
   });
 

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.ts
@@ -1,13 +1,13 @@
 import { useMutation } from "@tanstack/react-query";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import {
   type CreateWorktreeWorkspaceResponse,
   type RepoRoot,
   type ResolveWorkspaceResponse,
   type Workspace,
 } from "@anyharness/sdk";
-import { useWorkspaceCollectionsInvalidation } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
-import { useWorkspaceCollectionsMutationCache } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
-import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+import { useWorkspaceCollectionsInvalidationActions } from "@/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCacheActions } from "@/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
 import { useRepoPreferencesStore } from "@/stores/preferences/repo-preferences-store";
 import { useUserPreferencesStore } from "@/stores/preferences/user-preferences-store";
 import { getHomeDir } from "@/lib/access/tauri/shell";
@@ -47,18 +47,32 @@ interface CreateWorktreeMutationInput {
   latencyFlowId?: string | null;
 }
 
+interface RuntimeBoundResult<T> {
+  result: T;
+  runtimeUrl: string;
+}
+
 export function useWorkspaceActions() {
-  const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
-  const { upsertLocalWorkspace } = useWorkspaceCollectionsMutationCache(runtimeUrl);
-  const invalidateWorkspaceCollections = useWorkspaceCollectionsInvalidation(runtimeUrl);
+  const localRuntime = useProductHost().desktop?.runtime ?? null;
+  const {
+    upsertLocalWorkspaceInWorkspaceCollections,
+  } = useWorkspaceCollectionsMutationCacheActions();
+  const {
+    invalidateWorkspaceCollectionsForRuntime,
+  } = useWorkspaceCollectionsInvalidationActions();
   const { data: workspaceCollections } = useWorkspaces();
   const primeWorkspaceCollections = (
+    runtimeUrl: string,
     workspace: Workspace,
     source: "local_create" | "worktree_create",
     repoRoot?: RepoRoot | null,
   ) => {
     const startedAt = startLatencyTimer();
-    const summary = upsertLocalWorkspace(workspace, repoRoot);
+    const summary = upsertLocalWorkspaceInWorkspaceCollections(
+      runtimeUrl,
+      workspace,
+      repoRoot,
+    );
 
     logLatency("workspace.collections.cache_upsert", {
       source,
@@ -72,17 +86,17 @@ export function useWorkspaceActions() {
   };
 
   const refreshWorkspaceCollections = (
+    runtimeUrl: string,
     source: "local_create" | "worktree_create",
     workspaceId: string,
   ) => {
-    const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;
     const startedAt = startLatencyTimer();
     logLatency("workspace.collections.invalidate.start", {
       source,
       workspaceId,
       runtimeUrl,
     });
-    void invalidateWorkspaceCollections().then(() => {
+    void invalidateWorkspaceCollectionsForRuntime(runtimeUrl).then(() => {
       logLatency("workspace.collections.invalidate.success", {
         source,
         workspaceId,
@@ -92,23 +106,35 @@ export function useWorkspaceActions() {
     });
   };
 
-  const createLocalWorkspaceMutation = useMutation<ResolveWorkspaceResponse, Error, string>({
+  const createLocalWorkspaceMutation = useMutation<
+    RuntimeBoundResult<ResolveWorkspaceResponse>,
+    Error,
+    string
+  >({
     meta: {
       telemetryHandled: true,
     },
     mutationFn: async (sourceRoot) => {
-      const readyRuntimeUrl = await ensureRuntimeReady();
+      const readyRuntimeUrl = await ensureRuntimeReady(localRuntime);
       const connection = { runtimeUrl: readyRuntimeUrl };
       const request = {
         path: sourceRoot,
         origin: DESKTOP_ORIGIN,
       };
 
-      return createWorkspace(connection, request);
+      return {
+        result: await createWorkspace(connection, request),
+        runtimeUrl: readyRuntimeUrl,
+      };
     },
-    onSuccess: (response) => {
-      primeWorkspaceCollections(response.workspace, "local_create", response.repoRoot);
-      refreshWorkspaceCollections("local_create", response.workspace.id);
+    onSuccess: ({ result, runtimeUrl }) => {
+      primeWorkspaceCollections(
+        runtimeUrl,
+        result.workspace,
+        "local_create",
+        result.repoRoot,
+      );
+      refreshWorkspaceCollections(runtimeUrl, "local_create", result.workspace.id);
       trackProductEvent("workspace_created", {
         workspace_kind: "local",
         creation_kind: "local",
@@ -126,7 +152,7 @@ export function useWorkspaceActions() {
   });
 
   const createWorktreeMutation = useMutation<
-    CreateWorktreeWorkspaceResponse,
+    RuntimeBoundResult<CreateWorktreeWorkspaceResponse>,
     Error,
     CreateWorktreeMutationInput
   >({
@@ -134,23 +160,26 @@ export function useWorkspaceActions() {
       telemetryHandled: true,
     },
     mutationFn: async ({ params, latencyFlowId }) => {
-      const readyRuntimeUrl = await ensureRuntimeReady();
-      return createWorktreeWorkspace({ runtimeUrl: readyRuntimeUrl }, {
-        repoRootId: params.repoRootId,
-        targetPath: params.targetPath,
-        newBranchName: params.branchName,
-        baseBranch: params.baseRef || undefined,
-        checkoutMode: params.checkoutMode,
-        setupScript: params.setupScript?.trim() || undefined,
-        nameConflictPolicy: params.nameConflictPolicy,
-        origin: DESKTOP_ORIGIN,
-      }, latencyFlowId
-        ? { headers: getLatencyFlowRequestHeaders(latencyFlowId) }
-        : undefined);
+      const readyRuntimeUrl = await ensureRuntimeReady(localRuntime);
+      return {
+        result: await createWorktreeWorkspace({ runtimeUrl: readyRuntimeUrl }, {
+          repoRootId: params.repoRootId,
+          targetPath: params.targetPath,
+          newBranchName: params.branchName,
+          baseBranch: params.baseRef || undefined,
+          checkoutMode: params.checkoutMode,
+          setupScript: params.setupScript?.trim() || undefined,
+          nameConflictPolicy: params.nameConflictPolicy,
+          origin: DESKTOP_ORIGIN,
+        }, latencyFlowId
+          ? { headers: getLatencyFlowRequestHeaders(latencyFlowId) }
+          : undefined),
+        runtimeUrl: readyRuntimeUrl,
+      };
     },
-    onSuccess: (result) => {
-      primeWorkspaceCollections(result.workspace, "worktree_create");
-      refreshWorkspaceCollections("worktree_create", result.workspace.id);
+    onSuccess: ({ result, runtimeUrl }) => {
+      primeWorkspaceCollections(runtimeUrl, result.workspace, "worktree_create");
+      refreshWorkspaceCollections(runtimeUrl, "worktree_create", result.workspace.id);
       trackProductEvent("workspace_created", {
         workspace_kind: "local",
         creation_kind: "worktree",
@@ -234,8 +263,8 @@ export function useWorkspaceActions() {
       });
     },
     createLocalWorkspace: async (sourceRoot: string) => {
-      const response = await createLocalWorkspaceMutation.mutateAsync(sourceRoot);
-      return response.workspace;
+      const { result } = await createLocalWorkspaceMutation.mutateAsync(sourceRoot);
+      return result.workspace;
     },
     isCreatingLocalWorkspace: createLocalWorkspaceMutation.isPending,
     createWorktreeWorkspace: (
@@ -244,7 +273,7 @@ export function useWorkspaceActions() {
     ) => createWorktreeMutation.mutateAsync({
       params,
       latencyFlowId: options?.latencyFlowId,
-    }),
+    }).then(({ result }) => result),
     isCreatingWorktreeWorkspace: createWorktreeMutation.isPending,
   };
 }

--- a/apps/desktop/src/lib/access/anyharness/runtime-bootstrap.test.ts
+++ b/apps/desktop/src/lib/access/anyharness/runtime-bootstrap.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopRuntimeBridge } from "@proliferate/product-client/host/desktop-bridge";
+
+const mocks = vi.hoisted(() => ({
+  getHealth: vi.fn(),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  getAnyHarnessClient: () => ({
+    runtime: { getHealth: mocks.getHealth },
+  }),
+}));
+
+import { DEFAULT_RUNTIME_URL } from "@/config/runtime";
+import {
+  bootstrapHarnessRuntime,
+  restartHarnessRuntime,
+} from "@/lib/access/anyharness/runtime-bootstrap";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
+
+function makeRuntime(): DesktopRuntimeBridge {
+  return {
+    getConnection: vi.fn(),
+    restart: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "",
+    connectionState: "connecting",
+    error: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("bootstrapHarnessRuntime", () => {
+  it("activates an already healthy bridge connection immediately", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection).mockResolvedValue({
+      connection: { runtimeUrl: "http://127.0.0.1:9001" },
+      status: "healthy",
+    });
+    mocks.getHealth.mockResolvedValue({ status: "ok" });
+
+    await bootstrapHarnessRuntime(runtime);
+
+    expect(runtime.getConnection).toHaveBeenCalledTimes(1);
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "http://127.0.0.1:9001",
+      connectionState: "healthy",
+      error: null,
+    });
+  });
+
+  it("polls through the bridge, adopts a changed url, and becomes healthy", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection)
+      .mockResolvedValueOnce({
+        connection: { runtimeUrl: "http://127.0.0.1:9001" },
+        status: "starting",
+      })
+      .mockResolvedValueOnce({
+        connection: { runtimeUrl: "http://127.0.0.1:9002" },
+        status: "healthy",
+      });
+    mocks.getHealth
+      .mockRejectedValueOnce(new Error("starting"))
+      .mockResolvedValueOnce({ status: "ok" });
+
+    const bootstrap = bootstrapHarnessRuntime(runtime);
+    await vi.advanceTimersByTimeAsync(500);
+    await bootstrap;
+
+    expect(runtime.getConnection).toHaveBeenCalledTimes(2);
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "http://127.0.0.1:9002",
+      connectionState: "healthy",
+      error: null,
+    });
+  });
+
+  it("fails immediately when the native snapshot reports failure", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection).mockResolvedValue({
+      connection: { runtimeUrl: "http://127.0.0.1:9001" },
+      status: "failed",
+    });
+    mocks.getHealth.mockRejectedValue(new Error("unavailable"));
+
+    await bootstrapHarnessRuntime(runtime);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "http://127.0.0.1:9001",
+      connectionState: "failed",
+      error: "Runtime status: failed",
+    });
+  });
+
+  it("retains the browser-only Desktop fallback when native discovery is unavailable", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection).mockRejectedValue(new Error("Tauri unavailable"));
+    mocks.getHealth.mockResolvedValue({ status: "ok" });
+
+    const bootstrap = bootstrapHarnessRuntime(runtime);
+    await vi.advanceTimersByTimeAsync(500);
+    await bootstrap;
+
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: DEFAULT_RUNTIME_URL,
+      connectionState: "healthy",
+      error: null,
+    });
+  });
+
+  it("preserves the bounded timeout failure", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection).mockResolvedValue({
+      connection: { runtimeUrl: "http://127.0.0.1:9001" },
+      status: "starting",
+    });
+    mocks.getHealth.mockRejectedValue(new Error("starting"));
+
+    const bootstrap = bootstrapHarnessRuntime(runtime);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await bootstrap;
+
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      connectionState: "failed",
+      error: "Runtime did not become healthy in time.",
+    });
+  });
+
+  it("stops polling without publishing new state when its lifecycle is cancelled", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.getConnection).mockResolvedValue({
+      connection: { runtimeUrl: "http://127.0.0.1:9001" },
+      status: "starting",
+    });
+    mocks.getHealth.mockRejectedValue(new Error("starting"));
+    const controller = new AbortController();
+
+    const bootstrap = bootstrapHarnessRuntime(runtime, controller.signal);
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await bootstrap;
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(runtime.getConnection).toHaveBeenCalledTimes(1);
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "http://127.0.0.1:9001",
+      connectionState: "connecting",
+      error: null,
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("restartHarnessRuntime", () => {
+  it("calls the bridge restart exactly once and reconnects", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.restart).mockResolvedValue({
+      connection: { runtimeUrl: "http://127.0.0.1:9010" },
+      status: "healthy",
+    });
+    mocks.getHealth.mockResolvedValue({ status: "ok" });
+
+    await restartHarnessRuntime(runtime);
+
+    expect(runtime.restart).toHaveBeenCalledTimes(1);
+    expect(runtime.getConnection).not.toHaveBeenCalled();
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "http://127.0.0.1:9010",
+      connectionState: "healthy",
+      error: null,
+    });
+  });
+
+  it("publishes a failed state when bridge restart rejects", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.restart).mockRejectedValue(new Error("restart failed"));
+
+    await restartHarnessRuntime(runtime);
+
+    expect(runtime.restart).toHaveBeenCalledTimes(1);
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      connectionState: "failed",
+      error: "Error: restart failed",
+    });
+  });
+});

--- a/apps/desktop/src/lib/access/anyharness/runtime-bootstrap.ts
+++ b/apps/desktop/src/lib/access/anyharness/runtime-bootstrap.ts
@@ -1,87 +1,148 @@
 import { getAnyHarnessClient } from "@anyharness/sdk-react";
-import { getRuntimeInfo, type RuntimeInfo } from "@/lib/access/tauri/runtime";
-import {
-  restartRuntime as tauriRestartRuntime,
-} from "@/lib/access/tauri/credentials";
+import type {
+  DesktopRuntimeBridge,
+  LocalRuntimeSnapshot,
+} from "@proliferate/product-client/host/desktop-bridge";
 // Narrow bootstrap wiring: this module is the canonical boot orchestrator for
 // AnyHarness runtime connection state.
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 import { DEFAULT_RUNTIME_URL } from "@/config/runtime";
 
-export async function bootstrapHarnessRuntime(): Promise<void> {
+export async function bootstrapHarnessRuntime(
+  runtime: DesktopRuntimeBridge,
+  signal?: AbortSignal,
+): Promise<void> {
   try {
-    await connectToRuntime(getRuntimeInfo);
+    await connectToRuntime(runtime, () => runtime.getConnection(), signal);
   } catch {
+    if (signal?.aborted) {
+      return;
+    }
     // Tauri commands unavailable (e.g. dev mode) — try fallback URL
     useHarnessConnectionStore.setState({ connectionState: "connecting", error: null });
     setRuntimeUrlIfChanged(DEFAULT_RUNTIME_URL);
-    await pollUntilHealthy(DEFAULT_RUNTIME_URL);
+    await pollUntilHealthy(runtime, DEFAULT_RUNTIME_URL, signal);
   }
 }
 
-export async function restartHarnessRuntime(): Promise<void> {
+export async function restartHarnessRuntime(
+  runtime: DesktopRuntimeBridge,
+): Promise<void> {
   try {
-    await connectToRuntime(tauriRestartRuntime);
+    await connectToRuntime(runtime, () => runtime.restart());
   } catch (error) {
     useHarnessConnectionStore.setState({ connectionState: "failed", error: String(error) });
   }
 }
 
 async function connectToRuntime(
-  getRuntimeInfoFn: () => Promise<RuntimeInfo>,
+  runtime: DesktopRuntimeBridge,
+  getRuntimeSnapshot: () => Promise<LocalRuntimeSnapshot>,
+  signal?: AbortSignal,
 ): Promise<void> {
+  if (signal?.aborted) {
+    return;
+  }
   useHarnessConnectionStore.setState({ connectionState: "connecting", error: null });
 
-  const info = await getRuntimeInfoFn();
-  setRuntimeUrlIfChanged(info.url);
+  const snapshot = await getRuntimeSnapshot();
+  if (signal?.aborted) {
+    return;
+  }
+  const runtimeUrl = snapshot.connection.runtimeUrl;
+  setRuntimeUrlIfChanged(runtimeUrl);
 
-  if (await confirmRuntimeReady(info.url)) {
+  const runtimeReady = await confirmRuntimeReady(runtimeUrl);
+  if (signal?.aborted) {
+    return;
+  }
+  if (runtimeReady) {
     useHarnessConnectionStore.setState({ connectionState: "healthy", error: null });
     return;
   }
 
-  if (info.status === "failed") {
+  if (snapshot.status === "failed") {
     useHarnessConnectionStore.setState({
       connectionState: "failed",
-      error: `Runtime status: ${info.status}`,
+      error: `Runtime status: ${snapshot.status}`,
     });
     return;
   }
 
-  await pollUntilHealthy(info.url);
+  await pollUntilHealthy(runtime, runtimeUrl, signal);
 }
 
-async function pollUntilHealthy(seedRuntimeUrl?: string): Promise<void> {
+async function pollUntilHealthy(
+  runtime: DesktopRuntimeBridge,
+  seedRuntimeUrl?: string,
+  signal?: AbortSignal,
+): Promise<void> {
   const maxAttempts = 120;
   let currentRuntimeUrl = seedRuntimeUrl ?? useHarnessConnectionStore.getState().runtimeUrl;
 
   for (let i = 0; i < maxAttempts; i += 1) {
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    let runtimeInfo: RuntimeInfo | null = null;
+    if (!await waitForPollInterval(signal)) {
+      return;
+    }
+    let runtimeSnapshot: LocalRuntimeSnapshot | null = null;
     try {
-      runtimeInfo = await getRuntimeInfo();
-      if (runtimeInfo.url !== currentRuntimeUrl) {
-        currentRuntimeUrl = runtimeInfo.url;
-        useHarnessConnectionStore.setState({ runtimeUrl: runtimeInfo.url });
+      runtimeSnapshot = await runtime.getConnection();
+      if (signal?.aborted) {
+        return;
+      }
+      if (runtimeSnapshot.connection.runtimeUrl !== currentRuntimeUrl) {
+        currentRuntimeUrl = runtimeSnapshot.connection.runtimeUrl;
+        useHarnessConnectionStore.setState({ runtimeUrl: currentRuntimeUrl });
       }
     } catch {
-      runtimeInfo = null;
+      if (signal?.aborted) {
+        return;
+      }
+      runtimeSnapshot = null;
     }
 
-    if (currentRuntimeUrl && await confirmRuntimeReady(currentRuntimeUrl)) {
+    const runtimeReady = currentRuntimeUrl
+      ? await confirmRuntimeReady(currentRuntimeUrl)
+      : false;
+    if (signal?.aborted) {
+      return;
+    }
+    if (runtimeReady) {
       useHarnessConnectionStore.setState({ connectionState: "healthy", error: null });
       return;
     }
-    if (runtimeInfo?.status === "failed") {
+    if (runtimeSnapshot?.status === "failed") {
       useHarnessConnectionStore.setState({
         connectionState: "failed",
-        error: `Runtime ${runtimeInfo.status}`,
+        error: `Runtime ${runtimeSnapshot.status}`,
       });
       return;
     }
   }
+  if (signal?.aborted) {
+    return;
+  }
   console.error("[harness] pollUntilHealthy: gave up after %d attempts", maxAttempts);
   useHarnessConnectionStore.setState({ connectionState: "failed", error: "Runtime did not become healthy in time." });
+}
+
+function waitForPollInterval(signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve(true);
+    }, 500);
+    const handleAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", handleAbort);
+      resolve(false);
+    };
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
 }
 
 function setRuntimeUrlIfChanged(runtimeUrl: string): void {

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
@@ -130,31 +130,37 @@ describe("desktopBridge identity", () => {
 });
 
 describe("runtime", () => {
-  it("maps RuntimeInfo.url to a runtime connection without an auth token", async () => {
+  it("maps RuntimeInfo to a runtime snapshot without an auth token", async () => {
     mocks.getRuntimeInfo.mockResolvedValue({
       url: "http://127.0.0.1:8457",
       port: 8457,
       status: "healthy",
     });
 
-    const connection = await desktopBridge.runtime.getConnection();
+    const snapshot = await desktopBridge.runtime.getConnection();
 
     expect(mocks.getRuntimeInfo).toHaveBeenCalledTimes(1);
-    expect(connection).toEqual({ runtimeUrl: "http://127.0.0.1:8457" });
-    expect(connection).not.toHaveProperty("authToken");
+    expect(snapshot).toEqual({
+      connection: { runtimeUrl: "http://127.0.0.1:8457" },
+      status: "healthy",
+    });
+    expect(snapshot.connection).not.toHaveProperty("authToken");
   });
 
-  it("maps the restarted runtime url the same way", async () => {
+  it("preserves the restarted runtime status and url", async () => {
     mocks.restartRuntime.mockResolvedValue({
       url: "http://127.0.0.1:9000",
       port: 9000,
       status: "starting",
     });
 
-    const connection = await desktopBridge.runtime.restart();
+    const snapshot = await desktopBridge.runtime.restart();
 
     expect(mocks.restartRuntime).toHaveBeenCalledTimes(1);
-    expect(connection).toEqual({ runtimeUrl: "http://127.0.0.1:9000" });
+    expect(snapshot).toEqual({
+      connection: { runtimeUrl: "http://127.0.0.1:9000" },
+      status: "starting",
+    });
   });
 });
 

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
@@ -2,6 +2,7 @@ import type {
   DesktopBridge,
   DesktopUpdate,
   LocalRuntimeConnection,
+  LocalRuntimeSnapshot,
   ProductCommand,
   ScratchRecord,
   ScratchWriteResult,
@@ -73,13 +74,19 @@ import {
  */
 export const desktopBridge: DesktopBridge = {
   runtime: {
-    async getConnection(): Promise<LocalRuntimeConnection> {
+    async getConnection(): Promise<LocalRuntimeSnapshot> {
       const info = await getRuntimeInfo();
-      return { runtimeUrl: info.url };
+      return {
+        connection: { runtimeUrl: info.url },
+        status: info.status,
+      };
     },
-    async restart(): Promise<LocalRuntimeConnection> {
+    async restart(): Promise<LocalRuntimeSnapshot> {
       const info = await restartRuntime();
-      return { runtimeUrl: info.url };
+      return {
+        connection: { runtimeUrl: info.url },
+        status: info.status,
+      };
     },
   },
 

--- a/apps/desktop/src/providers/AppProviders.tsx
+++ b/apps/desktop/src/providers/AppProviders.tsx
@@ -178,7 +178,7 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
   );
 
   return (
-    <AnyHarnessRuntime runtimeUrl={runtimeUrl} cacheScopeKey={cacheScopeKey}>
+    <AnyHarnessRuntime runtimeUrl={runtimeUrl || null} cacheScopeKey={cacheScopeKey}>
       <CloudWorkspaceMaterializationCacheBoundary>
         <AnyHarnessWorkspace
           workspaceId={providerWorkspaceId}

--- a/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
+++ b/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
@@ -10,6 +10,7 @@ import type {
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 const runtimeMocks = vi.hoisted(() => ({
   bootstrapHarnessRuntime: vi.fn().mockResolvedValue(undefined),
@@ -126,6 +127,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   runtimeMocks.bootstrapHarnessRuntime.mockResolvedValue(undefined);
   setEntries({});
+  useHarnessConnectionStore.getState().resetConnectionState();
 });
 
 afterEach(() => {
@@ -161,6 +163,28 @@ describe("DesktopProductLifecycleRoot", () => {
       </ProductHostProvider>,
     );
     expect(signal.aborted).toBe(true);
+  });
+
+  it("clears the published local runtime when the Desktop capability is removed", () => {
+    const bridge = makeBridge(vi.fn().mockResolvedValue(undefined));
+    const { rerender } = renderRoot(makeHost(bridge, "authenticated"));
+    useHarnessConnectionStore.setState({
+      runtimeUrl: "http://127.0.0.1:9999",
+      connectionState: "healthy",
+      error: null,
+    });
+
+    rerender(
+      <ProductHostProvider host={makeHost(null, "authenticated")}>
+        <DesktopProductLifecycleRoot />
+      </ProductHostProvider>,
+    );
+
+    expect(useHarnessConnectionStore.getState()).toMatchObject({
+      runtimeUrl: "",
+      connectionState: "connecting",
+      error: null,
+    });
   });
 
   it("does not export or subscribe when desktop is null", () => {

--- a/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
+++ b/apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx
@@ -3,10 +3,21 @@ import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DesktopBridge } from "@proliferate/product-client/host/desktop-bridge";
-import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import type {
+  AuthState,
+  ProductHost,
+} from "@proliferate/product-client/host/product-host";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 
 import { useSessionDirectoryStore } from "@/stores/sessions/session-directory-store";
+
+const runtimeMocks = vi.hoisted(() => ({
+  bootstrapHarnessRuntime: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/access/anyharness/runtime-bootstrap", () => ({
+  bootstrapHarnessRuntime: runtimeMocks.bootstrapHarnessRuntime,
+}));
 
 vi.mock("@proliferate/product-domain/sessions/activity", () => ({
   isSessionSlotBusy: (snapshot: { busy?: boolean } | null) =>
@@ -39,6 +50,10 @@ function makeBridge(
   nativeUiOverrides: Partial<DesktopBridge["nativeUi"]> = {},
 ) {
   return {
+    runtime: {
+      getConnection: vi.fn(),
+      restart: vi.fn(),
+    },
     nativeUi: {
       setRunningAgentCount,
       subscribeMenuCommands: () => () => {},
@@ -49,13 +64,16 @@ function makeBridge(
   } as unknown as DesktopBridge;
 }
 
-function makeHost(desktop: DesktopBridge | null): ProductHost {
+function makeHost(
+  desktop: DesktopBridge | null,
+  authStatus: ProductHost["auth"]["state"]["status"] = "loading",
+): ProductHost {
   return {
     surface: desktop ? "desktop" : "web",
     deployment: { apiBaseUrl: "https://api.example.test" },
     auth: {
       authRequired: true,
-      state: { status: "loading" },
+      state: makeAuthState(authStatus),
       restoreSession: async () => {},
       startLogin: async () => {},
       finishLogin: async () => {},
@@ -86,6 +104,16 @@ function makeHost(desktop: DesktopBridge | null): ProductHost {
   };
 }
 
+function makeAuthState(status: AuthState["status"]): AuthState {
+  if (status === "authenticated") {
+    return { status, user: { id: "user-1" } };
+  }
+  if (status === "anonymous") {
+    return { status, methods: [] };
+  }
+  return { status };
+}
+
 function renderRoot(host: ProductHost) {
   return render(
     <ProductHostProvider host={host}>
@@ -96,6 +124,7 @@ function renderRoot(host: ProductHost) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  runtimeMocks.bootstrapHarnessRuntime.mockResolvedValue(undefined);
   setEntries({});
 });
 
@@ -105,6 +134,35 @@ afterEach(() => {
 });
 
 describe("DesktopProductLifecycleRoot", () => {
+  it("does not bootstrap a local runtime when desktop is null", () => {
+    renderRoot(makeHost(null, "authenticated"));
+    expect(runtimeMocks.bootstrapHarnessRuntime).not.toHaveBeenCalled();
+  });
+
+  it("keeps one runtime bootstrap across a host snapshot replacement", () => {
+    const bridge = makeBridge(vi.fn().mockResolvedValue(undefined));
+    const { rerender } = renderRoot(makeHost(bridge, "authenticated"));
+
+    expect(runtimeMocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.bootstrapHarnessRuntime.mock.calls[0]?.[0]).toBe(bridge.runtime);
+    const signal = runtimeMocks.bootstrapHarnessRuntime.mock.calls[0]?.[1] as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    rerender(
+      <ProductHostProvider host={makeHost(bridge, "authenticated")}>
+        <DesktopProductLifecycleRoot />
+      </ProductHostProvider>,
+    );
+    expect(runtimeMocks.bootstrapHarnessRuntime).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProductHostProvider host={makeHost(null, "authenticated")}>
+        <DesktopProductLifecycleRoot />
+      </ProductHostProvider>,
+    );
+    expect(signal.aborted).toBe(true);
+  });
+
   it("does not export or subscribe when desktop is null", () => {
     const subscribeSpy = vi.spyOn(useSessionDirectoryStore, "subscribe");
     renderRoot(makeHost(null));

--- a/apps/desktop/src/providers/DesktopProductLifecycleRoot.tsx
+++ b/apps/desktop/src/providers/DesktopProductLifecycleRoot.tsx
@@ -5,6 +5,7 @@ import type {
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 
 import { useExportRunningAgentCount } from "@/hooks/app/lifecycle/use-export-running-agent-count";
+import { useDesktopRuntimeBootstrapLifecycle } from "@/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle";
 import { useWorkspaceActivityIndicator } from "@/hooks/app/lifecycle/use-workspace-activity-indicator";
 import { useDesktopZoomPreferenceLifecycle } from "@/hooks/preferences/lifecycle/use-desktop-zoom-preference-lifecycle";
 import { useNativeMenuCommandDispatcher } from "@/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher";
@@ -13,17 +14,26 @@ import { recordBootDiagnosticOnce } from "@/lib/infra/measurement/boot-stall-dia
 /**
  * The single Desktop product-lifecycle root, mounted outside auth and route
  * gates. It reads the Desktop bridge from the host and, when present, mounts
- * the native UI lifecycles through `desktop.nativeUi`. On a non-Desktop host
- * (`desktop === null`) it renders nothing.
+ * local-runtime and native-UI lifecycles through that bridge. On a non-Desktop
+ * host (`desktop === null`) it renders nothing.
  */
 export function DesktopProductLifecycleRoot() {
-  const { desktop } = useProductHost();
-  return desktop === null ? null : <DesktopNativeUiLifecycles desktop={desktop} />;
+  const { auth, desktop } = useProductHost();
+  return desktop === null
+    ? null
+    : <DesktopProductLifecycles desktop={desktop} authStatus={auth.state.status} />;
 }
 
 // Nested so hook membership stays valid if `desktop` flips between a bridge and
 // null across a host replacement.
-function DesktopNativeUiLifecycles({ desktop }: { desktop: DesktopBridge }) {
+function DesktopProductLifecycles({
+  desktop,
+  authStatus,
+}: {
+  desktop: DesktopBridge;
+  authStatus: "loading" | "anonymous" | "authenticated";
+}) {
+  useDesktopRuntimeBootstrapLifecycle(desktop.runtime, authStatus);
   const nativeUi: DesktopNativeUiBridge = desktop.nativeUi;
   useExportRunningAgentCount(nativeUi.setRunningAgentCount);
   useNativeMenuCommandDispatcher(nativeUi.subscribeMenuCommands);

--- a/apps/desktop/src/stores/sessions/harness-connection-store.ts
+++ b/apps/desktop/src/stores/sessions/harness-connection-store.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { DEFAULT_RUNTIME_URL } from "@/config/runtime";
 import type { HarnessConnectionState } from "@/stores/sessions/session-types";
 
 interface HarnessConnectionStoreState {
@@ -13,14 +12,14 @@ interface HarnessConnectionStoreState {
 }
 
 export const useHarnessConnectionStore = create<HarnessConnectionStoreState>((set) => ({
-  runtimeUrl: DEFAULT_RUNTIME_URL,
+  runtimeUrl: "",
   connectionState: "connecting",
   error: null,
   setRuntimeUrl: (runtimeUrl) => set({ runtimeUrl }),
   setConnectionState: (connectionState) => set({ connectionState }),
   setError: (error) => set({ error }),
   resetConnectionState: () => set({
-    runtimeUrl: DEFAULT_RUNTIME_URL,
+    runtimeUrl: "",
     connectionState: "connecting",
     error: null,
   }),

--- a/apps/packages/product-client/src/host/desktop-bridge.ts
+++ b/apps/packages/product-client/src/host/desktop-bridge.ts
@@ -8,8 +8,8 @@ import type { AnyHarnessClientConnection } from "@anyharness/sdk-react";
  * (those flow through AnyHarness). Methods are added only when a migrated
  * product consumer actually needs them.
  *
- * This package defines the shared contract; the Desktop adapter is implemented
- * in a later PR. Types here mirror the concrete shapes Desktop already uses so
+ * This package defines the shared contract; Desktop supplies the concrete
+ * adapter. Types here mirror the concrete shapes Desktop already uses so
  * migrated product code keeps its behavior.
  */
 export interface DesktopBridge {
@@ -33,9 +33,21 @@ export interface DesktopBridge {
  */
 export type LocalRuntimeConnection = AnyHarnessClientConnection;
 
+export type LocalRuntimeStatus = "starting" | "healthy" | "failed" | "stopped";
+
+/**
+ * The latest native sidecar snapshot. ProductClient uses the connection with
+ * the normal AnyHarness SDK and uses the status only to preserve Desktop's
+ * startup/restart failure behavior.
+ */
+export interface LocalRuntimeSnapshot {
+  connection: LocalRuntimeConnection;
+  status: LocalRuntimeStatus;
+}
+
 export interface DesktopRuntimeBridge {
-  getConnection(): Promise<LocalRuntimeConnection>;
-  restart(): Promise<LocalRuntimeConnection>;
+  getConnection(): Promise<LocalRuntimeSnapshot>;
+  restart(): Promise<LocalRuntimeSnapshot>;
 }
 
 // --- Local files and repositories -----------------------------------------

--- a/specs/codebase/features/web-desktop-client-unification-d1b.md
+++ b/specs/codebase/features/web-desktop-client-unification-d1b.md
@@ -1,6 +1,6 @@
 # Desktop Native UI Adoption (D1b)
 
-Status: **current implementation scope**.
+Status: **complete**.
 
 - Revision: `D1b-r2`
 - Approved starting scope: 2026-07-13
@@ -9,6 +9,9 @@ Status: **current implementation scope**.
 - Prior implementation: PR #1157, reviewed head
   `90926523c3662067e02f8511db6c8e0058e119f1`, merge
   `a76ab5911e2af39593b4b31530535f0811a3558b`
+- Final implementation: PR #1165, reviewed head
+  `32632bd487e9be28592579728b87f0c18d73ee9c`, merge
+  `736d181575e4d81389d19ba7a78afd14566e1fda`
 - Parent architecture:
   [`web-desktop-client-unification.md`](web-desktop-client-unification.md)
 - Prior completed contract:
@@ -16,10 +19,7 @@ Status: **current implementation scope**.
 - Pipeline ledger:
   [`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md)
 
-This is the current implementation contract for Desktop Native UI Adoption
-only. The founder and implementation agent may update it together when code
-evidence requires a material adjustment; record that decision before
-broadening the slice.
+This is the completed implementation contract for Desktop Native UI Adoption.
 
 ## 1. Observable outcome
 

--- a/specs/codebase/features/web-desktop-client-unification-d1c.md
+++ b/specs/codebase/features/web-desktop-client-unification-d1c.md
@@ -96,9 +96,10 @@ not become a workspace, session, chat, or repository service.
 4. Initial bootstrap moves from `AppRuntime` into the existing
    `DesktopProductLifecycleRoot`. It waits for normalized auth loading to
    finish and does not repeat when a new host snapshot carries the same stable
-   runtime bridge and auth status. Removing or replacing the Desktop capability
-   cancels any active poll before it can call the removed bridge or publish more
-   connection state.
+   runtime bridge, including when auth changes between anonymous and
+   authenticated. Removing or replacing the Desktop capability cancels any
+   active poll, clears the published local-runtime state, and prevents later
+   calls or connection-state publication from that lifecycle.
 
 5. The local runtime URL starts empty. Until Desktop discovery or the existing
    browser-development fallback succeeds, SDK runtime queries stay disabled.
@@ -148,8 +149,9 @@ succeeds.
 - Exhausted polling retains the existing “did not become healthy in time”
   error.
 - Restart rejection publishes the existing failed connection state.
-- Removing the Desktop lifecycle cancels active polling without later bridge
-  calls, timeout errors, or connection-state publication.
+- Removing the Desktop lifecycle cancels active polling and clears the local
+  runtime URL without later bridge calls, timeout errors, or connection-state
+  publication.
 - Missing Desktop capability fails a local action without probing loopback or
   starting a local query.
 
@@ -177,7 +179,9 @@ Automated proof covers:
 - initial bootstrap mounts only inside the Desktop lifecycle boundary;
 - a host snapshot replacement with the same runtime inputs does not duplicate
   bootstrap;
-- removing the Desktop capability cancels an active runtime poll;
+- auth changes between ready states do not duplicate bootstrap;
+- removing the Desktop capability cancels an active runtime poll and clears
+  the published local runtime;
 - an empty runtime disables local inventory queries;
 - local create updates and invalidates the cache for the post-bootstrap runtime
   URL;

--- a/specs/codebase/features/web-desktop-client-unification-d1c.md
+++ b/specs/codebase/features/web-desktop-client-unification-d1c.md
@@ -1,0 +1,193 @@
+# Desktop Local Runtime Adoption (D1c)
+
+Status: **current implementation scope**.
+
+- Exact implementation base:
+  `736d181575e4d81389d19ba7a78afd14566e1fda`
+- Prior completed implementation: PR #1165, reviewed head
+  `32632bd487e9be28592579728b87f0c18d73ee9c`, merge
+  `736d181575e4d81389d19ba7a78afd14566e1fda`
+- Parent architecture:
+  [`web-desktop-client-unification.md`](web-desktop-client-unification.md)
+- Pipeline ledger:
+  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md)
+
+This is the living contract for Desktop Local Runtime Adoption. The founder
+and implementation agent may update it together when concrete code evidence
+requires a material adjustment. Product behavior outside this boundary is
+unchanged.
+
+## Observable outcome
+
+The existing Desktop product obtains local AnyHarness discovery and restart
+through `host.desktop.runtime`. The single Desktop product-lifecycle root owns
+initial runtime bootstrap. Product workflows receive the mounted runtime
+capability explicitly and then use the normal AnyHarness SDK with the resolved
+connection.
+
+When `host.desktop` is `null`, the product performs no local discovery,
+restart, polling, or local-inventory request. Managed-cloud and SSH-target
+workspace resolution do not depend on a local runtime.
+
+All product source remains under `apps/desktop`. This slice does not move the
+product into ProductClient or implement Web.
+
+## Current to target flow
+
+```text
+Before
+
+AppRuntime effect ----------------------> raw get_runtime_info
+product restart/readiness workflows ----> raw restart_runtime/get_runtime_info
+                                         -> AnyHarness SDK
+
+After
+
+ProductHostProvider
+  -> host.desktop.runtime
+       -> thin Desktop adapter
+            -> existing raw Tauri runtime commands
+
+DesktopProductLifecycleRoot
+  -> bootstrap product workflow
+       -> host.desktop.runtime.getConnection()
+       -> normal AnyHarness health client
+       -> shared connection store
+
+Local workspace/session workflows
+  -> injected host.desktop.runtime
+  -> readiness workflow
+  -> normal AnyHarness workspace/session clients
+
+Web (desktop: null)
+  -> no local runtime work
+  -> cloud workspace connection through the existing gateway path
+```
+
+Raw sidecar discovery, process launch, health/status reporting, restart, and
+runtime-info persistence remain owned by Desktop native code. The bridge does
+not become a workspace, session, chat, or repository service.
+
+## Material decisions
+
+1. `DesktopRuntimeBridge` returns a runtime snapshot containing both the SDK
+   connection and the existing native status:
+
+   ```ts
+   interface LocalRuntimeSnapshot {
+     connection: AnyHarnessClientConnection;
+     status: "starting" | "healthy" | "failed" | "stopped";
+   }
+   ```
+
+   The status is required to preserve immediate native failure instead of
+   waiting for the polling timeout. SSH tunnels continue returning an ordinary
+   runtime connection and do not use this snapshot.
+
+2. The concrete bridge remains a thin shape adapter over the existing
+   `getRuntimeInfo` and `restartRuntime` wrappers. It adds no retry, cache,
+   logging, fallback, or process policy.
+
+3. Bootstrap, polling, health confirmation, fallback, store updates, timeout,
+   and error presentation remain product workflows. They receive the runtime
+   bridge as an argument; there is no module-global bridge registry and no
+   second provider.
+
+4. Initial bootstrap moves from `AppRuntime` into the existing
+   `DesktopProductLifecycleRoot`. It waits for normalized auth loading to
+   finish and does not repeat when a new host snapshot carries the same stable
+   runtime bridge and auth status. Removing or replacing the Desktop capability
+   cancels any active poll before it can call the removed bridge or publish more
+   connection state.
+
+5. The local runtime URL starts empty. Until Desktop discovery or the existing
+   browser-development fallback succeeds, SDK runtime queries stay disabled.
+   `AnyHarnessRuntime` receives `null`, not a guessed loopback URL.
+
+6. Browser-only Desktop development preserves the existing
+   `DEFAULT_RUNTIME_URL` fallback when native discovery is unavailable.
+
+7. Local-only actions fail clearly when `host.desktop` is absent. Cloud and
+   SSH-target flows skip local discovery and may pass an empty neutral base to
+   resolvers that ignore it for remote targets.
+
+8. After readiness, workspace/session CRUD, chat, transcript, agent, and file
+   behavior continues through the normal AnyHarness SDK. These operations are
+   not added to `DesktopBridge`.
+
+9. A local create carries the bridge-resolved runtime URL through its mutation
+   result. Cache upsert and invalidation use that URL rather than a render-time
+   URL captured before bootstrap.
+
+## Owned call sites
+
+The slice adopts the existing consumers that discover, restart, or require the
+local runtime:
+
+- initial Desktop runtime bootstrap;
+- local workspace and worktree creation;
+- local repository registration;
+- local workspace open/selection;
+- local session create, load, restore, and resume;
+- agent credential Apply & Restart; and
+- the runtime URL supplied to shared AnyHarness providers and caches.
+
+Product lifecycles that merely consume the activated URL remain unchanged.
+Their existing empty-URL/healthy-state gates keep them inert until bootstrap
+succeeds.
+
+## Failure behavior
+
+- An already healthy connection becomes active immediately.
+- A starting runtime is polled every 500 ms for at most 120 attempts.
+- Polling re-reads the bridge snapshot and adopts a changed runtime URL.
+- A native `failed` snapshot stops immediately with the existing runtime
+  failure state.
+- Native discovery unavailable in browser-only Desktop uses the existing
+  default URL fallback.
+- Exhausted polling retains the existing “did not become healthy in time”
+  error.
+- Restart rejection publishes the existing failed connection state.
+- Removing the Desktop lifecycle cancels active polling without later bridge
+  calls, timeout errors, or connection-state publication.
+- Missing Desktop capability fails a local action without probing loopback or
+  starting a local query.
+
+## Non-goals
+
+This slice does not:
+
+- change Rust sidecar/process startup, runtime-info persistence, or native
+  Tauri commands;
+- adopt SSH profile/tunnel, files, credentials beyond runtime restart, worker,
+  updater, automation, scratch, diagnostics, or support bridge groups;
+- move workspace/session/chat/repository operations into `DesktopBridge`;
+- redesign auth, query caches, streams, timers, or runtime retry policy;
+- change visual UI, CSS, Web, self-hosted Web, or ProductClient source
+  ownership; or
+- fix unrelated existing behavior.
+
+## Acceptance proof
+
+Automated proof covers:
+
+- discovery and restart preserve status and URL;
+- healthy, starting, changed-URL, native-failed, fallback, timeout, and restart
+  failure paths;
+- initial bootstrap mounts only inside the Desktop lifecycle boundary;
+- a host snapshot replacement with the same runtime inputs does not duplicate
+  bootstrap;
+- removing the Desktop capability cancels an active runtime poll;
+- an empty runtime disables local inventory queries;
+- local create updates and invalidates the cache for the post-bootstrap runtime
+  URL;
+- local workspace/session workflows receive the mounted runtime capability;
+- cloud and SSH-target session resolution does not discover/restart local
+  AnyHarness; and
+- no product-owned raw `getRuntimeInfo` or `restartRuntime` import remains.
+
+The final review also runs ProductClient and Desktop typechecks/tests/builds,
+frontend structure checks, and a named-profile Desktop smoke that discovers
+the dynamically assigned runtime, activates local inventory, persists local
+workspace state, and reconnects after a full profile restart. Focused tests
+separately prove the ProductHost restart action.

--- a/specs/codebase/features/web-desktop-client-unification.md
+++ b/specs/codebase/features/web-desktop-client-unification.md
@@ -611,16 +611,19 @@ export through one Desktop-only product-lifecycle root. The complete contract
 and acceptance record is
 [`web-desktop-client-unification-d1a.md`](web-desktop-client-unification-d1a.md).
 
-Desktop Native UI Adoption is the current implementation slice. Its revision r1
-contract routes existing native menus, native menu commands, Dock attention,
-and Desktop zoom through the merged `host.desktop.nativeUi` boundary while
-product files stay under `apps/desktop`. The complete contract is
+Desktop Native UI Adoption is complete at PR #1165 merge
+`736d181575e4d81389d19ba7a78afd14566e1fda`. It routes existing native menus,
+native menu commands, Dock attention, and Desktop zoom through the merged
+`host.desktop.nativeUi` boundary while product files stay under
+`apps/desktop`. The complete contract is
 [`web-desktop-client-unification-d1b.md`](web-desktop-client-unification-d1b.md).
 
-Desktop Local Runtime Adoption is the expected next slice. It is queued and
-not yet specified. Its purpose is to
-route product-owned local AnyHarness discovery/restart/connection through the
-Desktop bridge while raw sidecar process ownership remains in Desktop.
+Desktop Local Runtime Adoption is the current implementation slice. It routes
+product-owned local AnyHarness discovery, restart, readiness, and connection
+through `host.desktop.runtime`, moves initial bootstrap under the existing
+Desktop-only product-lifecycle root, and leaves raw sidecar process ownership
+in Desktop. The complete living contract is
+[`web-desktop-client-unification-d1c.md`](web-desktop-client-unification-d1c.md).
 
 Related authoritative docs:
 

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -37,8 +37,8 @@ canonical feature spec are the durable handoff.
 
 Current handoff:
 
-- Current PR: Desktop Native UI Adoption — implementing.
-- Next PR: Desktop Local Runtime Adoption — queued.
+- Current PR: Desktop Local Runtime Adoption — implementing.
+- Next PR: not yet selected — not started.
 
 - Repository: `proliferate-ai/proliferate`.
 - Canonical contract:
@@ -55,8 +55,12 @@ Current handoff:
   `90926523c3662067e02f8511db6c8e0058e119f1`.
 - Desktop Native UI Adoption contract:
   `specs/codebase/features/web-desktop-client-unification-d1b.md`, revision
-  `D1b-r1`, exact implementation base
-  `2ec6907391f57a3e449b5b77c43c18600f64fdaa`.
+  `D1b-r2`, final PR #1165 reviewed head
+  `32632bd487e9be28592579728b87f0c18d73ee9c`, merge
+  `736d181575e4d81389d19ba7a78afd14566e1fda`.
+- Desktop Local Runtime Adoption contract:
+  `specs/codebase/features/web-desktop-client-unification-d1c.md`, exact
+  implementation base `736d181575e4d81389d19ba7a78afd14566e1fda`.
 - Current role: implementation. Material scope changes are decided with the
   founder and recorded before the slice broadens.
 
@@ -67,8 +71,8 @@ Current handoff:
 | Preparation: embedded browser | Delete the embedded workspace browser and its native child-WebView capability. | PR #1154, merge `4f7fe6ee5` | Complete |
 | Preparation: ProductClient foundation | Add the compiled package, `ProductHost`, `DesktopBridge`, `ProductHostProvider`, tests, and enforcement. | PR #1153, merge `0b33e116d` | Complete |
 | Desktop Host Adoption | Construct the concrete Desktop host, mount the provider, replace reactive snapshots, and gate running-agent export through one Desktop-only lifecycle root while product files remain in Desktop. | [`web-desktop-client-unification-d1a.md`](../../codebase/features/web-desktop-client-unification-d1a.md), `D1a-r2`; PR #1157 merge `a76ab5911e2af39593b4b31530535f0811a3558b` | Complete |
-| Desktop Native UI Adoption | Route native menus, native commands, Dock attention, and Desktop zoom through the mounted bridge while product files remain in Desktop. | [`web-desktop-client-unification-d1b.md`](../../codebase/features/web-desktop-client-unification-d1b.md), `D1b-r1`, base `2ec6907391f57a3e449b5b77c43c18600f64fdaa` | Implementing |
-| Desktop Local Runtime Adoption | Route product-owned local AnyHarness discovery, restart, and connection through the Desktop bridge while raw sidecar/process startup remains Desktop-owned. | Shape directly with the founder after the current PR is reviewed. | Queued |
+| Desktop Native UI Adoption | Route native menus, native commands, Dock attention, and Desktop zoom through the mounted bridge while product files remain in Desktop. | [`web-desktop-client-unification-d1b.md`](../../codebase/features/web-desktop-client-unification-d1b.md); PR #1165 merge `736d181575e4d81389d19ba7a78afd14566e1fda` | Complete |
+| Desktop Local Runtime Adoption | Route product-owned local AnyHarness discovery, restart, readiness, and connection through the Desktop bridge while raw sidecar/process startup remains Desktop-owned. | [`web-desktop-client-unification-d1c.md`](../../codebase/features/web-desktop-client-unification-d1c.md), base `736d181575e4d81389d19ba7a78afd14566e1fda` | Implementing |
 | Remaining Desktop capability adoption | Route only real remaining product consumers through coherent bridge slices while paths remain stable. | Specify only from current consumers; no bridge-completeness work for its own sake. | Directional |
 | Shared-client extraction readiness | Prove the host mount envelope, compiled assets/builds, move ledger/codemod, minimal browser host, and fail-closed boundaries. | Shape the focused checklist together before the source move. | Directional |
 | Mechanical Desktop extraction | Move the working Desktop product into ProductClient and leave Desktop as a thin native host. | Exact file ledger, landing window, codemod, builds, and behavior proof required. | Directional |
@@ -104,7 +108,7 @@ The accepted r2 deviations are narrow and recorded in the complete contract:
 - the exact Desktop test command has one founder-approved waiver for
   base-identical pretest violations in unchanged files.
 
-## 3. Desktop Native UI Adoption working record
+## 3. Desktop Native UI Adoption acceptance record
 
 Desktop Native UI Adoption has one observable outcome: every product-owned
 native menu, native menu-command subscription, Dock attention export, and
@@ -127,10 +131,29 @@ microtask, and disables later native attempts for that hook instance. This
 adds no availability capability, retry, persistence, queue, or nullable
 Desktop host.
 
-The complete frozen contract is
+The implementation merged in PR #1165 from reviewed head
+`32632bd487e9be28592579728b87f0c18d73ee9c` at merge
+`736d181575e4d81389d19ba7a78afd14566e1fda`. The complete contract is
 [`web-desktop-client-unification-d1b.md`](../../codebase/features/web-desktop-client-unification-d1b.md).
 
-## 4. Remaining migration map and gates
+## 4. Desktop Local Runtime Adoption working record
+
+Desktop Local Runtime Adoption routes local runtime discovery, restart,
+readiness, and connection through `host.desktop.runtime`. Raw Tauri commands
+and sidecar/process ownership remain Desktop-native; resolved workspace and
+session operations continue through the AnyHarness SDK.
+
+The exact implementation base is
+`736d181575e4d81389d19ba7a78afd14566e1fda`. The contract preserves native
+runtime status so a failed sidecar remains an immediate failure, moves initial
+bootstrap beneath the existing Desktop-only lifecycle root, starts the shared
+runtime scope empty/fail-closed, and explicitly keeps cloud and SSH-target
+flows independent of local discovery.
+
+The complete living contract is
+[`web-desktop-client-unification-d1c.md`](../../codebase/features/web-desktop-client-unification-d1c.md).
+
+## 5. Remaining migration map and gates
 
 The plain sequence after the current PR is:
 
@@ -160,7 +183,7 @@ exact base and acceptance proof. The durable external-configuration evidence
 requirements in §5 remain binding. Do not reuse retired phase mechanics by
 implication.
 
-## 5. Later Web cutover external-configuration gate
+## 6. Later Web cutover external-configuration gate
 
 The future Web cutover must inventory every external producer of a hosted Web
 URL, including OAuth registrations, Stripe checkout/portal return URLs,


### PR DESCRIPTION
## Summary

- Route Desktop local AnyHarness discovery, restart, and connection state through `ProductHost.desktop.runtime`.
- Move initial local-runtime bootstrap into the single Desktop-gated product lifecycle root, with cancellation when the capability disappears.
- Pass the mounted runtime capability through local workspace and session workflows while leaving cloud and SSH-target flows independent of local discovery.
- Keep raw Tauri runtime commands confined to the Desktop bridge and carry the living Web/Desktop migration documentation with the implementation.

## Why

This is the next in-place Web/Desktop unification step. Product workflows previously reached Desktop runtime behavior through app-owned helpers and an eager fallback URL. That ownership would prevent the product from moving cleanly into ProductClient and could query or cache against the wrong local runtime before native discovery completed.

## Impact

- Desktop preserves its existing local AnyHarness startup, polling, restart, workspace, and session behavior.
- Local inventory now fails closed until the native runtime URL is known.
- Runtime bootstrap is cancelled if Desktop capability ownership is removed or the lifecycle unmounts.
- Cloud and SSH-target work do not trigger local AnyHarness discovery.
- No product source moves into ProductClient in this PR.

## Verification

- Focused Desktop suite: 13 files, 82 tests passed.
- ProductClient suite: 6 tests passed.
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --dir apps/desktop build` — 4,724 modules built; only existing Vite warnings.
- `python3 scripts/report_frontend_structure.py --strict --summary-only` — 0 violations.
- `git diff --check`
- Two independent code/flow reviews found no remaining blockers after cancellation, raw-restart ownership, and dynamic cache-scope fixes.
- Named-profile Tauri smoke: Desktop discovered the dynamic AnyHarness URL, activated local inventory, persisted a local workspace and repo root, and reconnected after a full profile restart.
- The broader Desktop Vitest suite still has 37 unrelated existing failures; every affected regression test in this slice passes.

## PR Metadata

- Release: `release:maintenance`
- Areas: `area:desktop`, `area:product`, `area:docs`
