### PR TITLE
docs(local): correct profile and debugging procedures

### DIFF
--- a/specs/developing/debugging/README.md
+++ b/specs/developing/debugging/README.md
@@ -6,102 +6,98 @@ Use this folder for issue triage, support-report correlation, production/local
 debugging, and performance profiling. Product behavior belongs under
 `specs/codebase/**`; this folder owns operator workflow.
 
-## General Issue Runbook
+## Start From The Symptom
 
-1. Start from the GitHub issue when one exists. Support-submitted issues should
-   link to the internal support report and any Linear ticket.
-2. Use the support report id, tenant id, user id, organization id, Cloud
-   sandbox id, provider sandbox id, repo-environment materialization id, Cloud
-   workspace id, AnyHarness workspace id, session id, Worker id, and request id
-   to correlate Cloud records, Sentry events, logs, and S3 diagnostics.
-3. Check Sentry for matching exceptions or native crashes before assuming the
-   report is purely product confusion.
-4. Check recent deploys and release artifacts when the issue follows a deploy,
-   updater publish, runtime rollout, or cloud worker change.
-5. Reproduce locally with an isolated dev profile when the issue needs code
-   inspection or a stateful workflow.
-6. Capture the narrowest useful evidence: failing request, request id, run id,
-   screenshot, sanitized log tail, and exact surface/version.
-7. Update the GitHub issue with the diagnosis, linked PR or deploy, and any
-   user-facing owner needed.
+Write down what failed, where it failed, and when it was observed before
+collecting more context. Start with the strongest stable id already available.
+For a support report, use the support report id. Otherwise use the user id,
+surface, and exact version or source revision when available.
 
-If there is no GitHub issue yet, search for an existing issue before creating a
-new one. If the failure came from a support report, create or update the issue
-with the stable support ids instead of free-form user content.
+Do not request every possible correlation id up front. Add an id only when it
+helps cross the seam that is actually failing:
 
-## Correlation Keys
-
-Use stable ids to move between product surfaces, Cloud state, observability,
-and support artifacts:
-
-| Key | Use |
+| Failing seam | Add only what is useful |
 | --- | --- |
-| Support report id | Find uploaded diagnostics, sanitized logs, screenshots, and support-submitted GitHub/Linear links. |
-| Tenant id / organization id | Scope Cloud DB state, billing/account state, team settings, Metabase rows, and support dashboards. |
-| User id | Correlate account state, auth readiness, provider links, and user-scoped Sentry/PostHog events. |
-| Cloud sandbox id / provider sandbox id | Correlate the user's persisted sandbox, E2B provider state, runtime-access presence, and server logs. |
-| Repo environment / materialization id | Inspect repository setup state, materialization status, and the persisted materialization error. |
-| Cloud workspace id | Inspect the product workspace row, repository environment, archive state, and AnyHarness workspace handoff. |
-| AnyHarness workspace id | Follow local/runtime workspace state, sessions, transcript streams, and runtime diagnostics. |
-| Session id | Match transcript rows, runtime events, pending prompts, and Sentry support tags. |
-| Worker id | Inspect enrollment, heartbeat-derived liveness, reported versions, integration-gateway state, and Worker logs. |
-| Request id | Follow one mounted API, gateway, webhook, or materialization request through structured logs and Sentry. |
+| Hosted account, auth, billing, or control-plane request | organization id, workspace id, or request id |
+| Sandbox provisioning or repository setup | sandbox/provider id or materialization id |
+| Runtime, transcript, or agent session | AnyHarness workspace id or session id |
+| Worker connection or remote execution | Worker id and the relevant request id |
+| Desktop or mobile crash | app version, platform, and matching Sentry event |
+| Deploy, updater, or release regression | release artifact, deploy run, and source revision |
 
-## Tools And Permissions
+The goal is the smallest evidence set that can locate and reproduce the
+failure, not a complete inventory of the user's environment.
 
-Required tools and surfaces:
+## Investigate The Failing Seam
 
-- GitHub MCP, `gh`, or GitHub web access for issues, PRs, labels, linked fixes,
-  workflow runs, and release artifacts.
-- Local shell access with `make dev PROFILE=<name>` for reproduction.
-- Browser or Chrome access with the right logged-in profile for GitHub, Stripe,
-  Vercel, Sentry, PostHog, Customer.io, Metabase, AWS, Apple, or Expo
-  dashboards when needed.
-- S3/support-report access through the internal support tooling, never public
-  object access.
-- Sentry access for production exceptions, native crashes, release health, and
+1. Confirm the symptom, affected surface, environment, observation time, and
+   version or revision.
+2. If a support report exists, use its stable id to retrieve the durable report
+   and diagnostics. The current private Support path provides durable capture
+   plus best-effort Slack delivery. It does not automatically create a GitHub
+   or Linear issue and does not run autonomous triage or fixes.
+3. Choose the failing seam, then collect only the correlation ids required to
+   move between that seam's product state, logs, Sentry events, or provider
+   state.
+4. Check recent deploys or artifacts when timing suggests a release, updater,
+   runtime, Worker, or infrastructure regression.
+5. Inspect the narrowest source of evidence for the seam: a failing request,
+   Sentry event, sanitized log tail, workflow run, provider state, or retained
+   support diagnostic.
+6. Reproduce with an isolated local profile when code inspection or controlled
+   state is needed. Follow [Local Development](../local/README.md).
+7. Record the diagnosis, proof, fix or remaining owner, and user follow-up. If
+   durable issue tracking is needed, search for an existing issue before
+   creating or updating one; do not assume Support already did so.
+
+## Tools And Access
+
+Use only the tools needed for the failing seam:
+
+- GitHub access for issues, PRs, workflow runs, deploys, and release artifacts.
+- Sentry for production exceptions, native crashes, releases, and matching
   support correlation tags.
-- AWS/GitHub Actions access when the issue may be deploy, ECS, S3, CloudFront,
-  updater, ECR, or SSM related.
+- Approved support tooling for support reports and retained diagnostics; do
+  not make report objects public.
+- AWS, Vercel, E2B, Stripe, PostHog, Metabase, Customer.io, Expo/EAS, or App
+  Store Connect only when that provider owns evidence for the failing seam.
+- An isolated local profile for reproduction:
 
-Required permissions depend on the issue surface:
+  ```bash
+  make setup PROFILE=<name>
+  make build # first clean worktree or after generated/Rust/frontend artifacts change
+  make run PROFILE=<name>
+  ```
 
-| Surface | Permissions |
-| --- | --- |
-| GitHub issue/PR triage | repo read access; repo write access when labels, comments, or fixes are needed |
-| Support reports | internal support-report access and S3 diagnostic access through approved tooling |
-| Production errors/crashes | Sentry project access for the affected app/runtime |
-| Hosted deploy or infra | GitHub Actions access and AWS/Vercel/E2B access for the affected lane |
-| Billing | Stripe access plus GitHub/AWS env access only when config repair is required |
-| Analytics/replay | PostHog, Metabase, Customer.io, or Sentry access for the affected tool |
-| Mobile/App Store | Expo/EAS and App Store Connect access when build or submit state is involved |
+Use an appropriately authorized account. Keep secrets, raw user content, and
+unredacted diagnostics out of issues, chat, shared logs, and documentation.
+Start provider investigation read-only. If private or provider access is
+unavailable, retain the stable id and hand off to an authorized operator
+without asking them to copy raw evidence; any provider or production write
+requires separately approved remediation scope and the applicable runbook.
 
-## Specific Runbooks
+## Focused Runbooks
 
-- [support-reports.md](support-reports.md): end-to-end support report triage
-  across Cloud DB state, S3, CloudWatch, Sentry, GitHub, Linear, Slack, and
-  Desktop retry behavior.
-- [performance-profiling.md](performance-profiling.md): privacy-safe renderer
-  and AnyHarness timing baselines.
+- [support-reports.md](support-reports.md): retrieve, correlate, and close out a
+  private support report.
+- [performance-profiling.md](performance-profiling.md): capture privacy-safe
+  renderer and AnyHarness timing baselines.
 - [../runbooks/stripe-webhook-failure.md](../runbooks/stripe-webhook-failure.md):
-  Stripe webhook delivery, replay, and billing mirror recovery.
+  inspect and recover Stripe webhook delivery failures.
 - [../runbooks/e2b-template-rollback.md](../runbooks/e2b-template-rollback.md):
-  E2B template rollback for managed cloud runtime release failures.
-- [../operating/analytics/sentry.md](../operating/analytics/sentry.md): Sentry projects, privacy,
-  support correlation, alerts, and release/debug uploads.
-- [../local/README.md](../local/README.md): local reproduction with dev
-  profiles.
-- [../deploying/ci-cd.md](../deploying/ci-cd.md): deploy and release failure
-  response.
+  roll back a managed-cloud E2B runtime release.
+- [../operating/analytics/sentry.md](../operating/analytics/sentry.md): inspect
+  Sentry projects, releases, alerts, privacy behavior, and support tags.
+- [../deploying/ci-cd.md](../deploying/ci-cd.md): investigate deploy and release
+  failures.
 
-## Final Report Shape
+## Closeout
 
-When finishing debugging work, report:
+Leave a concise record containing:
 
-- GitHub issue, support report, PR, deploy run, or release artifact inspected
-- affected surface, environment, version, commit SHA, tenant/org/user ids, and
-  sandbox/materialization/workspace/session/Worker/request ids when relevant
-- shortest confirmed reproduction path or why reproduction was not possible
-- Sentry, logs, dashboards, or workflow evidence checked
-- diagnosis, linked fix/deploy, remaining owner, and user-facing owner
-- secrets or sensitive content omitted from the report
+- the symptom, surface, environment, and exact version or revision;
+- the stable starting id and only the seam-specific ids used;
+- the shortest confirmed reproduction, or why it could not be reproduced;
+- the evidence checked and the resulting diagnosis;
+- the linked fix, deploy, remaining owner, and required user follow-up; and
+- confirmation that secrets and sensitive user content were omitted.

--- a/specs/developing/debugging/performance-profiling.md
+++ b/specs/developing/debugging/performance-profiling.md
@@ -21,10 +21,11 @@ runs. Existing workflow latency logs can include ids, URLs, and paths.
 For a fresh profile:
 
 ```bash
-make dev-init PROFILE=latency
+make setup PROFILE=latency
+make build # first clean worktree or after generated/Rust/frontend artifacts change
 VITE_PROLIFERATE_DEBUG_MAIN_THREAD=1 \
 VITE_PROLIFERATE_DEBUG_ANYHARNESS_TIMING=1 \
-make dev PROFILE=latency
+make run PROFILE=latency
 ```
 
 Rows printed by the measurement logger are dev-build rows. The logger prints

--- a/specs/developing/local/README.md
+++ b/specs/developing/local/README.md
@@ -1,65 +1,14 @@
 # Running Locally
 
-Status: authoritative for running Proliferate in local development.
+Status: current procedure
 
-Use dev profiles for full-stack development. A profile owns ports, database,
-runtime state, desktop app home, and generated Tauri dev identity for one local
-run. The low-level profile contract lives in
-[`dev-profiles.md`](dev-profiles.md); this runbook
-is the day-to-day path.
-
-## Process Map
-
-Use this folder to answer three local-development questions:
-
-1. Working with Profiles:
-   - full-stack local startup, profile state, profile env loading, desktop,
-     hosted web, tunnels, and verification live in this runbook
-   - profile ownership, ports, generated Tauri identity, gateway tunnels, and
-     profile-scoped state live in [`dev-profiles.md`](dev-profiles.md)
-2. Working with Stripe:
-   - quick local Stripe startup is covered below
-   - billing-specific setup, webhook forwarding, checkout, portal, refill,
-     meter events, and local billing table checks live in
-     [`stripe-local-testing.md`](stripe-local-testing.md)
-3. Working with Mobile:
-   - profile-backed mobile web, native mobile OAuth, Expo overrides, and the
-     dev refresh-token path live in [`mobile.md`](mobile.md)
-
-## Tools And Permissions
-
-Required tools and surfaces:
-
-- Local shell access with Rust stable, Node 22+, pnpm, Python 3.12, and `uv`.
-- Browser or Chrome access for local Web, Desktop renderer, OAuth callbacks,
-  provider consoles, Stripe, and hosted dashboards when a local flow depends on
-  a logged-in external account.
-- GitHub MCP, `gh`, or GitHub web access when local reproduction starts from a
-  PR, issue, Actions artifact, release artifact, or support report.
-- Stripe CLI for checkout, portal, subscription, refill, meter, webhook, or
-  billing-state tests.
-- Expo tooling, an iOS simulator, Android emulator, or physical device for
-  native mobile flows.
-- Optional tunnel tooling, such as ngrok, when testing native mobile OAuth,
-  public callbacks, or agent gateway behavior that needs an external URL.
-
-Required permissions depend on the local surface:
-
-| Surface | Permissions |
-| --- | --- |
-| Baseline profile development | repo checkout access and permission to create local profile state under `~/.proliferate-local/` |
-| GitHub-linked product flows | access to a test GitHub account and any provider app configuration needed for the callback under test |
-| Billing | Stripe test-mode access and permission to run `stripe listen`; production Stripe access is not required for local QA |
-| Native mobile OAuth | provider-console access for callback registration, plus Expo/EAS access only when build or submit behavior is in scope |
-| Agent gateway / public tunnel | access to the relevant local env values and tunnel account; never paste gateway keys or callback secrets into chat, docs, PRs, or logs |
-
-Keep real secrets in ignored env files and use
-[`../reference/env-vars.yaml`](../reference/env-vars.yaml) for canonical
-deployment variable ownership.
+Use one named dev profile per worktree. A profile keeps that worktree's ports,
+Postgres database, AnyHarness runtime, Desktop state, and generated app identity
+separate from other local runs.
 
 ## Quick Start
 
-From a repo worktree:
+From the worktree root:
 
 ```bash
 make setup PROFILE=<name>
@@ -67,293 +16,91 @@ make build # first clean worktree, or after generated/Rust/frontend artifacts ch
 make run PROFILE=<name>
 ```
 
-On Pablo's machine, the shell helper is:
+`setup` allocates the profile and prepares its database. `build` produces the
+runtime and shared frontend artifacts that `run` expects. `run` deliberately
+does not rebuild; when an artifact is missing it reports the narrow build target
+to run.
 
-```bash
-pdev <name>
-```
-
-`pdev` should initialize the profile, ensure the profile database exists, and
-start the same profile-aware dev stack without rebuilding the repo. It is a
-local shell convenience, not a repo contract.
-
-Use explicit build targets when generated artifacts or binaries need refreshing:
-
-```bash
-make build-rust
-make build-frontend
-make build
-```
-
-`make run PROFILE=<name>` never invokes these build targets. It checks for the
-existing AnyHarness debug binary and frontend package build artifacts and tells
-you which explicit build target to run when they are missing.
-
-`make dev PROFILE=<name>` remains a compatibility alias for `setup` plus `run`.
-
-## What Starts
-
-`make run PROFILE=<name>` starts:
-
-- AnyHarness runtime on the profile's `ANYHARNESS_PORT`
-- Proliferate server on the profile's `PROLIFERATE_API_PORT`
-- Desktop renderer on the profile's `PROLIFERATE_WEB_PORT`
-- Hosted web app on the profile's `PROLIFERATE_HOSTED_WEB_PORT`
-- Tauri desktop app with generated profile identity
-
-The profile launcher also starts and waits for local Redis from
-`server/docker-compose.yml`. Redis backs RedBeat and the in-process cloud
-materialization locks used by managed cloud development.
-
-The Celery/RabbitMQ/redbeat worker-tier substrate is available for worker-tier
-migration testing. The profile launcher does not start Celery workers, and the
-automation scheduler is parked while automations are retargeted from legacy
-cloud repo config rows to repo environments.
-For Slice 1 worker-tier checks that need RabbitMQ, start RabbitMQ explicitly:
-
-```bash
-docker compose -f server/docker-compose.yml up -d rabbitmq
-```
-
-Then verify the no-op worker app imports from `server/` without opening a broker
-connection:
-
-```bash
-uv run python -c "from proliferate.background.celery_app import celery_app; print(celery_app.tasks['background.health.noop'].name)"
-```
-
-To run a local Celery worker for manual testing:
-
-```bash
-uv run celery -A proliferate.background.celery_app:celery_app worker -Q periodic.default --loglevel INFO
-uv run celery -A proliferate.background.celery_app:celery_app worker -Q automations.execution --loglevel INFO
-```
-
-Profile state lives under:
-
-```text
-~/.proliferate-local/dev/profiles/<name>/
-```
-
-AnyHarness runtime state lives under:
-
-```text
-~/.proliferate-local/runtimes/<name>/
-```
-
-List profiles and assigned ports:
+List profiles, their worktrees, assigned ports, and probed status with:
 
 ```bash
 make dev-list
 ```
 
-## Local Env Loading
+`make dev-init` and `make dev` remain compatibility aliases. Use the explicit
+`setup`, `build`, and `run` sequence in new instructions and automation.
 
-The profile launcher reads:
+## What Starts
+
+`make run PROFILE=<name>` launches the profile's:
+
+- AnyHarness runtime;
+- Proliferate API server;
+- Desktop renderer and Tauri Desktop app;
+- hosted Web app; and
+- local Redis dependency.
+
+The launcher migrates the selected profile database before starting the apps.
+It reserves a Mobile Web port but does not start Expo. It also does not start
+Celery workers or the optional Stripe, LiteLLM, tunnel, native-Mobile, or SSO
+flows unless their focused command or flag is used.
+
+## Profile State And Environment
+
+The important profile-owned paths are:
 
 ```text
-.env
-.env.local
-server/.env
-server/.env.local
+~/.proliferate-local/dev/profiles/<name>/profile.env   persisted allocation/input
+~/.proliferate-local/dev/profiles/<name>/launch.env    generated launch values
+~/.proliferate-local/dev/profiles/<name>/app/config.json
+~/.proliferate-local/runtimes/<name>/                  AnyHarness runtime state
 ```
 
-Then it writes a profile-specific `launch.env` that includes API, web, mobile
-web, CORS, AnyHarness, and runtime-home values.
+`profile.env` records stable profile allocation such as ports, database name,
+and owned paths. `launch.env` is regenerated by the launcher with the effective
+values used by the apps. Do not edit either file to distribute or copy
+credentials.
 
-Use committed example files to discover available variables, but keep real
-secrets in ignored local env files.
+The launcher reads `.env`, `.env.local`, `server/.env`, and
+`server/.env.local`. Keep real local secrets only in ignored env files. Use
+[`../reference/env-vars.yaml`](../reference/env-vars.yaml) to find the owner of
+an environment variable.
 
-## Local Stripe
+The full state, port, database, identity, SSO, and gateway contract is in
+[`dev-profiles.md`](dev-profiles.md).
 
-Use local Stripe only for billing flows. First create or refresh test-mode
-Stripe resources:
-
-```bash
-make stripe-setup-test
-```
-
-That command creates the local test product, Pro price, overage meter, overage
-price, and refill price, then writes non-secret IDs to `server/.env.local`.
-It does not write Stripe API keys or webhook secrets.
-
-Start the full stack with Stripe webhook forwarding:
+## Common Modes
 
 ```bash
 make run PROFILE=<name> STRIPE=1
-```
-
-This does three useful things:
-
-- reads the Stripe CLI test key into the backend process when
-  `STRIPE_SECRET_KEY` is otherwise unset
-- runs `stripe listen` for checkout/subscription/invoice events
-- injects the listener's `STRIPE_WEBHOOK_SECRET` into the backend process
-
-Use the Stripe test card:
-
-```text
-4242 4242 4242 4242
-any future expiration
-any CVC
-```
-
-The billing-specific runbook is
-[`stripe-local-testing.md`](stripe-local-testing.md).
-
-## Web
-
-The hosted web app starts automatically with the full profile. Open the profile
-hosted web URL printed by `make run` or inspect it with:
-
-```bash
-source ~/.proliferate-local/dev/profiles/<name>/launch.env
-echo "$FRONTEND_BASE_URL"
-```
-
-The web app is launched with:
-
-```text
-VITE_PROLIFERATE_API_BASE_URL=http://127.0.0.1:$PROLIFERATE_API_PORT
-VITE_PROLIFERATE_DEV_TOKEN_LOGIN=true
-```
-
-The development access-token field exists only in Vite dev mode. Prefer normal
-OAuth when testing auth, onboarding, GitHub linking, teams, billing, or product
-readiness.
-
-## Email/Password Test Accounts
-
-Email/password login is for provisioned accounts; public signup is not exposed.
-To create or update a local account password, run:
-
-```bash
-read -r -s PROLIFERATE_REVIEWER_PASSWORD
-uv --directory server run python scripts/provision_password_auth_user.py \
-  --email reviewer@example.com \
-  --password-env PROLIFERATE_REVIEWER_PASSWORD \
-  --display-name 'Reviewer'
-```
-
-The account can sign in on Web and Mobile immediately. It requires a linked
-GitHub identity before cloud workspaces and automations are product-ready.
-Desktop keeps GitHub as the primary sign-in path, but an authenticated user can
-add or change an email/password credential from Account settings.
-
-## Desktop
-
-The desktop app starts automatically at the end of `make run PROFILE=<name>`.
-The generated app identity makes the macOS app bar show the profile name, such
-as:
-
-```text
-Proliferate (<name>)
-```
-
-Desktop auth sessions, pending-auth entries, and stored provider API keys are
-profile-scoped `0600` files under the dev app home. Native provider credential
-files (the user's own Claude/Codex/Gemini CLI auth) and the AnyHarness runtime
-data key (keychain) remain shared user-level secrets.
-
-## Mobile Web Against A Profile
-
-For browser-based mobile smoke testing, use the existing profile server and
-database. The detailed mobile runbook is [`mobile.md`](mobile.md).
-
-```bash
-source ~/.proliferate-local/dev/profiles/<name>/launch.env
-pnpm --dir apps/mobile web:profile
-```
-
-This uses the profile's `EXPO_PUBLIC_PROLIFERATE_API_BASE_URL` and
-`PROLIFERATE_MOBILE_WEB_PORT`.
-
-Mobile web is the preferred first pass for testing mobile screens against a
-profile because it avoids native redirect setup while still exercising the real
-cloud API, SDK, React Query, mobile shell, and mobile screen logic.
-
-## Native Mobile
-
-Use native mobile when testing Expo Go, iOS simulator behavior, native deep
-links, SecureStore, Apple sign-in, physical keyboard/safe-area behavior, or
-React Native-only rendering. The detailed mobile runbook is
-[`mobile.md`](mobile.md).
-
-The existing native helper is:
-
-```bash
-make dev-mobile-auth
-```
-
-It starts local Postgres, migrations, ngrok, the server, and Expo with the API
-base URL set to the ngrok URL. It prints provider redirect URIs to add in the
-provider consoles, including:
-
-```text
-https://<ngrok-host>/auth/mobile/google/callback
-```
-
-Overrides:
-
-```bash
-PROLIFERATE_MOBILE_PORT=8090 make dev-mobile-auth
-MOBILE_EXPO_ARGS="--lan" make dev-mobile-auth
-```
-
-`make dev-mobile-auth` is the canonical path for testing real native mobile
-OAuth. It is not profile-native: it runs its own server process and defaults.
-
-## Mobile Auth In Dev
-
-Do not globally disable mobile auth. Mobile has a dev-only refresh-token path:
-
-```text
-EXPO_PUBLIC_PROLIFERATE_DEV_REFRESH_TOKEN=<refresh-token>
-proliferateDevRefreshToken=<refresh-token>
-```
-
-The mobile app only consumes this in `__DEV__`. The token is exchanged through
-the normal `/auth/mobile/session/refresh` endpoint, so server auth and account
-readiness still run.
-
-For profile-backed native mobile testing, use this pattern only with a refresh
-token minted for a user in the same profile database. Until a repo-owned helper
-exists for minting that token from a profile user, the canonical supported
-paths are:
-
-- mobile web against the profile
-- `make dev-mobile-auth` for native OAuth
-
-## Agent Gateway And Public Tunnels
-
-For local Bifrost/managed-credit work:
-
-```bash
-make run PROFILE=<name> AGENT_GATEWAY=bifrost
-```
-
-For E2B or public sandbox tests that need to call back into the local profile:
-
-```bash
-make run PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
+make run PROFILE=<name> AGENT_GATEWAY=litellm
 make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
 ```
 
-The first command exposes both API callbacks and Bifrost through ngrok. The
-second exposes only API worker callbacks.
+`STRIPE=1` adds test-mode webhook forwarding. `AGENT_GATEWAY=litellm` starts or
+reuses the local LiteLLM gateway. `CLOUD_WORKER_TUNNEL=ngrok` exposes the local
+API for Worker traffic and product-MCP OAuth callbacks; it does not expose
+LiteLLM. Use the tunnel only for an external callback test, and stop the run
+when the test is complete.
 
-## Verification Commands
+## Focused Runbooks
 
-Use the narrowest useful checks for the changed area:
+| Task | Runbook |
+| --- | --- |
+| Understand profile ownership, ports, identity, SSO, or LiteLLM | [`dev-profiles.md`](dev-profiles.md) |
+| Choose a frontend-only, backend-session, or GitHub auth layer | [`feature-worktree-auth.md`](feature-worktree-auth.md) |
+| Exercise local billing and Stripe webhooks | [`stripe-local-testing.md`](stripe-local-testing.md) |
+| Run Mobile Web, native Mobile, or Mobile OAuth | [`mobile.md`](mobile.md) |
+
+## Verification
+
+After startup, use `make dev-list` to confirm the selected profile owns the
+expected worktree and that its ports are reachable. Exercise the changed
+surface through the printed local URL, then run the narrowest code check named
+by that source area's documentation.
+
+For documentation-only changes:
 
 ```bash
-pnpm --filter @proliferate/web typecheck
-pnpm --filter @proliferate/mobile typecheck
-pnpm --filter @proliferate/product-domain test
-cd server && uv run pytest -q
-cargo test --workspace
+python3 scripts/check_docs.py
 ```
-
-For release/deploy changes, read
-[`../deploying/ci-cd.md`](../deploying/ci-cd.md) and run the workflow/helper
-checks documented there.

--- a/specs/developing/local/dev-profiles.md
+++ b/specs/developing/local/dev-profiles.md
@@ -1,250 +1,181 @@
 # Dev Profiles
 
-Use dev profiles when running the full local stack from multiple worktrees.
-The profile is the unit of local dev state: ports, database, AnyHarness runtime
-home, desktop file-backed home, and the macOS dev app label.
+Status: current procedure
+
+A dev profile is the isolation boundary for one full-stack local worktree. It
+owns the worktree binding, ports, Postgres database name, AnyHarness runtime
+home, Desktop state, and generated Tauri identity used by that run.
 
 ## Commands
 
 ```bash
-make setup PROFILE=<name>          # create/update profile state and database
-make build                         # first clean worktree or artifact refresh
-make dev-list                      # list profiles and TCP-probed status
-make run PROFILE=<name>            # full stack for this profile, no rebuild
-make run PROFILE=<name> STRIPE=1   # also run Stripe webhook forwarding
-make run PROFILE=<name> AGENT_GATEWAY=1
-                                    # also run/reuse local Bifrost for gateway work
-make run PROFILE=<name> AGENT_GATEWAY=bifrost
-                                    # also run/reuse local Bifrost for gateway work
-make run PROFILE=<name> AGENT_GATEWAY=bifrost AGENT_GATEWAY_TUNNEL=ngrok
-                                    # expose Bifrost and API worker callbacks through ngrok for E2B/public sandbox tests
-make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
-                                    # expose only API worker callbacks through ngrok
-make run PROFILE=<name> AUTH_PROFILE=google
-                                    # load .auth-env/.env.google for deployment SSO testing
-make seed-sso PROFILE=<name> AUTH_PROFILE=google ORG_ID=<org-id>
-                                    # seed that profile's local org SSO connection from .auth-env/.env.google
-make dev-web-auth                  # standalone web auth helper with ngrok callbacks
+make setup PROFILE=<name>
+make build # first clean worktree or after generated/Rust/frontend artifacts change
+make run PROFILE=<name>
+make dev-list
 ```
 
-Profile names must be lowercase letters, numbers, hyphens, or underscores.
-They are globally unique per machine and are bound to the first worktree that
-uses them.
+Optional modes are explicit:
 
-## What A Profile Owns
+```bash
+make run PROFILE=<name> STRIPE=1
+make run PROFILE=<name> AGENT_GATEWAY=litellm
+make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
+make run PROFILE=<name> AUTH_PROFILE=google
+```
 
-Profile state lives in:
+Profile names match `^[a-z0-9][a-z0-9_-]{0,39}$`: at most 40 lowercase
+letters, numbers, hyphens, or underscores, starting with a letter or number. A
+name is bound to the first worktree that uses it. Give every worktree its own
+name; do not reuse another branch's profile.
+
+`make dev PROFILE=<name>` remains a compatibility alias for `setup` plus `run`.
+The default-port `make dev-runtime`, `make dev-server`, and `make dev-desktop`
+targets are not substitutes for an isolated full-stack profile.
+
+## State Ownership
+
+Profile state lives under:
 
 ```text
 ~/.proliferate-local/dev/profiles/<name>/
+├── profile.env       persisted profile allocation/input
+├── launch.env        generated effective launch values
+├── app/
+│   └── config.json   Desktop host configuration
+├── tauri.dev.json    generated Tauri configuration
+├── instance.json     worktree, branch, state, and port metadata
+└── run.lock          active-launch ownership
+
+~/.proliferate-local/runtimes/<name>/   AnyHarness runtime state
 ```
 
-The profile stores non-secret defaults in `profile.env`, an effective
-`launch.env`, generated Tauri dev config, launch runners, lock/instance state,
-and the desktop file-backed app home. AnyHarness runtime state lives in:
+`profile.env` persists allocated ports and owned paths so the profile remains
+stable across runs. `launch.env` is regenerated from those inputs and contains
+the values consumed by the local apps. They are launcher state, not interfaces
+for copying credentials between profiles.
 
-```text
-~/.proliferate-local/runtimes/<name>/
-```
+Desktop auth sessions, pending-auth entries, and stored provider API keys are
+profile-scoped files under `app/`. Native agent credential files and the
+AnyHarness runtime data key remain user-level state rather than profile state.
 
-The dev launcher also writes `ANYHARNESS_WORKTREES_ROOT` into the profile launch
-environment. By default it points at the standard local worktree checkout root:
+The default Postgres database is `proliferate_dev_<normalized_name>`, with
+profile hyphens replaced by underscores. `setup` prepares it; `run` checks it
+and applies migrations. An explicit invocation-level `DATABASE_URL` bypasses
+the profile database for that invocation. Keep a profile with its branch for
+the lifetime of any one-way Postgres or AnyHarness SQLite migration.
+
+Automatic AnyHarness checkouts default to:
 
 ```text
 ~/.proliferate-local/worktrees/
 ```
 
-That keeps automatic AnyHarness checkout retention aligned with the checkout
-paths normally created by the desktop app. Worktrees outside this managed root
-remain visible as explicit workspace history/checkout actions where applicable,
-but they are excluded from automatic per-repo retention and orphan pruning.
+The launcher writes that path into the profile as
+`ANYHARNESS_WORKTREES_ROOT`. Checkouts elsewhere can still be used explicitly,
+but are outside automatic retention and orphan pruning.
 
-The default database is `proliferate_dev_<name>` on the local Docker Postgres
-server. On macOS, profile database URLs default to `::1` so Docker Desktop's
-Postgres listener is not confused with a Homebrew Postgres bound to
-`127.0.0.1:5432`. Use `DATABASE_URL=... make run PROFILE=<name>` when you
-intentionally want to bypass the profile database for a one-off run, or
-`LOCAL_PGHOST=127.0.0.1` when you intentionally want a separate local Postgres.
-When `DATABASE_URL` is set, profile setup and run skip profile database
-creation/readiness checks and migrate the provided database URL.
+## Environment Composition
 
-`make run PROFILE=<name>` also starts and waits for the local Docker Redis
-service from `server/docker-compose.yml`. Redis backs RedBeat and cloud
-materialization locks in local development. Use `USE_EXISTING_REDIS=1` only
-when an external Redis is already reachable; in that case the server still reads
-the Redis URL from normal configuration, such as `REDBEAT_REDIS_URL`.
-
-Desktop auth sessions, pending-auth entries, and stored provider API keys are
-profile-scoped `0600` files under the dev app home, so per-profile databases do
-not reuse each other's login tokens. The AnyHarness runtime data key stays
-shared in the keychain in v1 because it is a user-level secret, not profile
-state. (See the sidecar spec's Local Secrets for the storage model.)
-
-## Agent Gateway Local Dev
-
-`make run PROFILE=<name> AGENT_GATEWAY=1` and
-`make run PROFILE=<name> AGENT_GATEWAY=bifrost` start or reuse a local Bifrost
-gateway and export the API env needed for Bifrost-backed managed credits and
-personal BYOK development:
+For ordinary variables, later layers override earlier layers:
 
 ```text
-AGENT_GATEWAY_ENABLED=true
-AGENT_GATEWAY_BIFROST_BASE_URL=http://127.0.0.1:8080
-AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL=http://127.0.0.1:8080
-AGENT_GATEWAY_RECONCILER_ENABLED=true
-AGENT_GATEWAY_USER_FREE_CREDIT_ENABLED=true
-AGENT_GATEWAY_USER_FREE_CREDIT_USD=5
-AGENT_GATEWAY_MANAGED_CREDIT_AGENT_KINDS=claude,codex
-AGENT_GATEWAY_BYOK_ENABLED=true
-AGENT_GATEWAY_PERSONAL_BYOK_ENABLED=true
-AGENT_GATEWAY_BIFROST_ISOLATION_VERIFIED=true
-AGENT_GATEWAY_ANTHROPIC_BYOK_ENABLED=true
-AGENT_GATEWAY_OPENAI_BYOK_ENABLED=true
-AGENT_GATEWAY_BEDROCK_BYOK_ENABLED=true
-AGENT_GATEWAY_GEMINI_BYOK_ENABLED=true
+.env
+  < .env.local
+  < server/.env
+  < server/.env.local
+  < generated launch.env for profile-owned values
+  < .auth-env/.env.<AUTH_PROFILE> when AUTH_PROFILE is selected
 ```
 
-For local UI testing, the public Bifrost URL can stay loopback. For E2B or any
-remote managed sandbox that must reach the gateway and enroll its worker, pass
-`AGENT_GATEWAY_TUNNEL=ngrok`. The dev command starts or reuses ngrok tunnels
-for both the API worker callback port and the Bifrost port, then writes those
-HTTPS URLs to `CLOUD_WORKER_BASE_URL`,
-`CLOUD_MCP_OAUTH_CALLBACK_BASE_URL`, and
-`AGENT_GATEWAY_BIFROST_PUBLIC_BASE_URL`. If a test only needs the worker/API
-callback tunnel, use `CLOUD_WORKER_TUNNEL=ngrok`.
+An invocation-level `DATABASE_URL` is captured before file loading and bypasses
+profile database selection; otherwise the launcher resolves and exports the
+profile database after composition. Keep real local secrets in ignored env
+files, not `profile.env`, `launch.env`, chat, issues, or committed
+documentation. The environment-variable ownership reference is
+[`../reference/env-vars.yaml`](../reference/env-vars.yaml).
 
-The dev launcher reads `.env`, `.env.local`, `server/.env`, and
-`server/.env.local`. In Bifrost mode it automatically seeds managed-credit
-provider env from `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` when the dedicated
-`AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY` or
-`AGENT_GATEWAY_MANAGED_OPENAI_API_KEY` variables are not already set. The
-current managed-credit implementation chooses one backing provider for the
-default free-credit pool; if both Anthropic and OpenAI managed keys are set,
-Anthropic is selected first. Personal BYOK forms can still expose both provider
-types at the same time.
+## Ports And App Identity
 
-## Local SSO Auth Profiles
+The profile allocates stable values for:
 
-Manual OIDC SSO QA can load local-only provider credentials from
-`.auth-env/.env.<auth-profile>`. Those files are ignored by git because they
-contain client secrets. To run the deployment/self-hosted SSO path, pass the
-auth profile to the normal dev launcher:
+- `PROLIFERATE_API_PORT`;
+- `PROLIFERATE_WEB_PORT` and `PROLIFERATE_WEB_HMR_PORT` for the Desktop
+  renderer;
+- `PROLIFERATE_HOSTED_WEB_PORT` for Web;
+- `PROLIFERATE_MOBILE_WEB_PORT` for Mobile Web;
+- `PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE` for the local Gmail OAuth
+  callback pool; and
+- `ANYHARNESS_PORT`.
+
+The generated Tauri runner displays the macOS app as `Proliferate (<name>)` and
+points it at the profile renderer and runtime. Server CORS includes the
+profile's Desktop, Web, Mobile Web, and Tauri origins.
+
+Inspect allocation and reachability without sourcing generated env state:
+
+```bash
+make dev-list
+```
+
+## LiteLLM And External Callbacks
+
+Enable the local agent gateway with:
+
+```bash
+make run PROFILE=<name> AGENT_GATEWAY=litellm
+```
+
+The launcher starts or reuses the repository's local LiteLLM service and sets
+the server's LiteLLM gateway values. Its default URL is loopback. The known
+local development master key is accepted only for a loopback gateway; set an
+explicit secret for any shared or remote LiteLLM instance.
+
+If a remote Worker or product-MCP provider must call the local API, use:
+
+```bash
+make run PROFILE=<name> CLOUD_WORKER_TUNNEL=ngrok
+```
+
+This publishes the selected profile's API as `CLOUD_WORKER_BASE_URL` and
+`CLOUD_MCP_OAUTH_CALLBACK_BASE_URL`. It does not tunnel LiteLLM. Use it only
+while an external callback is required, do not publish secrets in the tunnel
+log, and stop it after the test.
+
+## Local SSO
+
+Deployment-style OIDC QA may load ignored provider credentials from
+`.auth-env/.env.<auth-profile>`:
 
 ```bash
 make run PROFILE=sso-google AUTH_PROFILE=google
 ```
 
-To test org-scoped SSO without filling the settings form by hand, run the
-normal profile and seed the local profile database:
+The launcher prints the callback URL to register with the dedicated test
+provider app. Use the same `PROLIFERATE_SSO_*` variables as deployment. When a
+provider requires `localhost` rather than `127.0.0.1`, set
+`PROLIFERATE_SSO_OIDC_CALLBACK_BASE_URL` in the ignored auth profile.
+
+For org-scoped SSO, seed only the selected profile database:
 
 ```bash
-make run PROFILE=sso-org
+make setup PROFILE=sso-org
 make seed-sso PROFILE=sso-org AUTH_PROFILE=google ORG_ID=<org-id>
+make run PROFILE=sso-org AUTH_PROFILE=google
 ```
 
-The auth profile env uses the same `PROLIFERATE_SSO_*` names as deployment SSO,
-including `PROLIFERATE_SSO_OIDC_ISSUER_URL`,
-`PROLIFERATE_SSO_OIDC_CLIENT_ID`, and
-`PROLIFERATE_SSO_OIDC_CLIENT_SECRET`. `PROLIFERATE_SSO_ALLOWED_DOMAINS` may be
-blank for provider-only manual QA, or set to a comma-separated allowlist when
-testing domain policy. If a provider app registration requires a different local
-callback hostname than the API base URL, set
-`PROLIFERATE_SSO_OIDC_CALLBACK_BASE_URL`, for example
-`http://localhost:${PROLIFERATE_API_PORT}` for Microsoft Entra app registrations
-that do not include the `127.0.0.1` callback.
+Never use a production/shared OAuth app for local callback experiments, and do
+not commit `.auth-env` credentials.
 
-## Ports And UI Identity
+## Concurrency And Focused Paths
 
-`scripts/dev.mjs` allocates stable ports for each profile:
+Independent profiles may run concurrently. OAuth and Desktop deep-link tests
+must run serially because generated development apps share the
+`proliferate-local://auth/callback` URL scheme. Concurrent Git operations on the
+same checkout can also contend on Git locks.
 
-- `PROLIFERATE_API_PORT`
-- `PROLIFERATE_WEB_PORT` for the Tauri desktop renderer
-- `PROLIFERATE_WEB_HMR_PORT`
-- `PROLIFERATE_HOSTED_WEB_PORT` for the separate `apps/web/` app
-- `PROLIFERATE_MOBILE_WEB_PORT` for Expo web smoke testing of `apps/mobile/`
-- `PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE`
-- `ANYHARNESS_PORT`
+Use the focused procedures for behavior-specific setup:
 
-The Google Workspace MCP value is the base of a 64-port loopback pool used for
-local Gmail OAuth callbacks. The generated Tauri config points the desktop at
-`PROLIFERATE_WEB_PORT`, while `make run PROFILE=<name>` also starts the hosted
-web app on `PROLIFERATE_HOSTED_WEB_PORT` and sets `FRONTEND_BASE_URL` to that
-hosted web origin. Server CORS includes the desktop renderer, hosted web, Expo
-mobile web, and Tauri origins. For browser-based mobile smoke tests, run Expo
-web from the same profile environment so Mobile uses the profile API and
-reserved mobile web port:
-
-```bash
-source ~/.proliferate-local/dev/profiles/<name>/launch.env
-pnpm --dir apps/mobile web:profile
-```
-
-On macOS, profile dev also uses a generated Tauri runner so the unbundled debug
-app appears as `Proliferate (<profile>)` in the app bar instead of every profile
-appearing as `proliferate`.
-
-## Scope Notes
-
-`make setup PROFILE=<name>` and `make run PROFILE=<name>` are the
-profile-aware workflow. `make dev PROFILE=<name>` remains a compatibility alias
-for setup plus run. The individual
-`make dev-runtime`, `make dev-server`, and `make dev-desktop` shortcuts remain
-default-port shortcuts.
-
-OAuth and deep-link login flows are still single-profile-at-a-time in v1 because
-the OS URL scheme is shared. Concurrent git operations against the same checkout
-can still race on git locks.
-
-## Mobile Auth Testing
-
-Use the mobile auth helper when testing Expo Go on a physical phone:
-
-```bash
-make dev-mobile-auth
-```
-
-The helper starts/checks local Postgres, runs server migrations, starts ngrok
-for the API, starts the server with `API_BASE_URL` set to the ngrok URL, and
-starts Expo with `EXPO_PUBLIC_PROLIFERATE_API_BASE_URL` set to the same URL.
-It prints the Google mobile redirect URI to add in Google Console:
-
-```text
-https://<ngrok-host>/auth/mobile/google/callback
-```
-
-By default Expo runs through its tunnel and picks the first free Metro port at
-or above `8081`. Override with:
-
-```bash
-PROLIFERATE_MOBILE_PORT=8090 make dev-mobile-auth
-MOBILE_EXPO_ARGS="--lan" make dev-mobile-auth
-```
-
-For the full local mobile decision tree, see
-[`mobile.md`](mobile.md).
-
-## Bundled Agent Seed Testing
-
-Packaged desktop builds resolve bundled agent seeds from Tauri resources and
-pass the resolved seed directory to the AnyHarness sidecar. Local development can
-exercise the same hydration path by setting:
-
-```bash
-ANYHARNESS_AGENT_SEED_DIR=/absolute/path/to/agent-seeds make run PROFILE=<name>
-```
-
-The directory should contain the generated target archive and checksum:
-
-```text
-agent-seed-<target>.tar.zst
-agent-seed-<target>.sha256
-```
-
-For normal dev/debug builds, `ANYHARNESS_AGENT_SEED_DIR` is trusted as a local
-developer override and health reports the source as `external_dev`. In packaged
-builds, arbitrary external seed dirs are ignored unless
-`ANYHARNESS_AGENT_SEED_DIR_UNSAFE=1` is also set. That keeps production packaged
-apps on signed Tauri resources by default.
-
-Each profile has its own AnyHarness runtime home, so seed hydration state lives
-under `~/.proliferate-local/runtimes/<name>/` and does not cross profiles.
+- [`feature-worktree-auth.md`](feature-worktree-auth.md) for local auth layers;
+- [`stripe-local-testing.md`](stripe-local-testing.md) for Stripe;
+- [`mobile.md`](mobile.md) for Mobile and native OAuth.

--- a/specs/developing/local/feature-worktree-auth.md
+++ b/specs/developing/local/feature-worktree-auth.md
@@ -1,169 +1,181 @@
-# Running a feature worktree cleanly (profiles + auth)
+# Feature Worktree Auth
 
-You are working in a feature worktree. Run the app under **your own dev profile**
-(never `main`, never another feature's name). Profile name = your feature name
-(e.g. `changes`, `support`, `files`, `offline`). Each profile gets its own ports,
-its own Postgres DB (`proliferate_dev_<profile>`), and its own on-disk state
-(`~/.proliferate-local/dev/profiles/<profile>/`), all collision-checked — so
-several features run simultaneously without stepping on each other.
+Status: current procedure
 
-## Boot
+Run every feature worktree under its own dev profile. Choose the lowest auth
+layer that proves the behavior under test; do not clone another profile's
+database, tokens, or Desktop session.
 
-```bash
-pdevui <profile>    # first boot: builds frontend, creates DB, runs migrations
-prunui <profile>    # every boot after that (fast, no rebuild)
-```
+## Boot The Profile
 
-`pdev`/`prun`/`pdevui`/`prunui`/`pseedauth` are shell helpers from the
-maintainer's `~/.zshrc`. If they don't exist in your shell, use the raw
-equivalents:
+For every layer, begin with the repository-owned flow:
 
 ```bash
-# pdev <profile>  ≈
-USE_EXISTING_POSTGRES=1 make dev-init PROFILE=<profile>
-USE_EXISTING_POSTGRES=1 node scripts/dev.mjs ensure-db --db-name proliferate_dev_<profile>
-USE_EXISTING_POSTGRES=1 make rebuild dev PROFILE=<profile>
-
-# prun <profile>  ≈
-USE_EXISTING_POSTGRES=1 make dev PROFILE=<profile>
-
-# pdevui/prunui = the same with SKIP_RUST=1 and a prebuilt runtime binary:
-SKIP_RUST=1 ANYHARNESS_DEV_RUNTIME_BIN=<path-to-anyharness-bin> make dev PROFILE=<profile>
-
-# pui <pkg>  ≈  pnpm --filter "@proliferate/<pkg>" build   (all: make shared-build)
+make setup PROFILE=<profile>
+make build # first clean worktree or after generated/Rust/frontend artifacts change
+make run PROFILE=<profile>
 ```
 
-These skip the Rust build and use the shared prebuilt runtime binary — which is
-built from **main**. So this rule is load-bearing, not a footnote:
+See [`dev-profiles.md`](dev-profiles.md) for profile state, ports, and app
+identity.
 
-> **If your branch changes any Rust/anyharness code, you MUST use
-> `pdev <profile>` / `prun <profile>` instead.** With `pdevui` you'd silently
-> run main's runtime and your feature simply won't exist at runtime.
-> Check with: `git diff main...HEAD --name-only | grep -c '\.rs$'` — nonzero
-> means `pdev`. Never run two full `pdev` cargo builds at the same time
-> (file-lock contention); stagger first boots.
+## Choose One Auth Layer
 
-If you edit shared packages (`packages/product-ui` etc.), run `pui <pkg>` after
-edits — apps consume built dist, HMR won't pick it up.
+Layers B and C require real auth. Remove `VITE_DEV_DISABLE_AUTH` from ignored
+`apps/desktop/.env.local`, or set it to `false`, and restart the profile before
+using either layer. Otherwise the Desktop installs the fake Layer A session and
+returns before real auth bootstrap.
 
-## Auth — pick exactly one layer
+### Layer A — feature does not need a backend identity
 
-Pick the *lowest* layer that covers what your feature actually exercises.
-
-### Layer A — feature doesn't care who's logged in (default)
-
-In this worktree's `apps/desktop/.env.local`:
+For frontend-only work, enable the development auth bypass in the worktree's
+ignored `apps/desktop/.env.local`:
 
 ```bash
 VITE_DEV_DISABLE_AUTH=true
-# remove/comment VITE_REQUIRE_AUTH=true
 ```
 
-Boots straight into a fake local session. No OAuth, no backend user.
-**Limit:** frontend-only session — cloud-workspace calls are hard-blocked, and
-there is no real user row behind authed API routes.
+Restart the profile after changing the value. This creates a development-only
+frontend session; there is no backing user or organization. Authenticated API
+routes, personal workflow definitions, and cloud workspaces intentionally
+remain unavailable. Use Layer B or C when the feature crosses that boundary.
 
 ### Layer B — feature needs a real backend session (admin/org/authed APIs)
 
-Blank the GitHub vars in this worktree's `server/.env` (they're what force the
-GitHub login screen):
+Use a fresh profile in single-org mode and provide a local setup-token path.
+To expose password sign-in even when another env file contains normal product
+GitHub credentials, override them to empty in ignored `server/.env.local` and
+restart:
 
 ```bash
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 ```
 
-**Boot with single-org mode on** — local dev pins `SINGLE_ORG_MODE=false`
-(`scripts/dev.mjs`), which unmounts `/setup` and `/register`; without this the
-desktop shows sign-in with no way to ever create an account:
+Then run:
 
 ```bash
-SINGLE_ORG_MODE=true SETUP_TOKEN_FILE=/tmp/proliferate-<profile>-setup-token \
-  pdevui <profile>
+make setup PROFILE=<profile>
+make build
+SINGLE_ORG_MODE=true \
+SETUP_TOKEN_FILE=/tmp/proliferate-<profile>-setup-token \
+make run PROFILE=<profile>
 ```
 
-(`SETUP_TOKEN_FILE` is needed because the default `/var/lib/proliferate/...`
-path isn't writable on macOS. Keep both vars on every boot of this profile.)
+Read `PROLIFERATE_API_PORT` from:
 
-Then, because the profile DB is fresh, the first-run claim page is open:
+```text
+~/.proliferate-local/dev/profiles/<profile>/profile.env
+```
 
-1. `cat /tmp/proliferate-<profile>-setup-token`
-2. Open `http://127.0.0.1:<PROLIFERATE_API_PORT>/setup` (port is in
-   `~/.proliferate-local/dev/profiles/<profile>/profile.env`), paste the token,
-   choose email + password + org name.
-3. Sign in on the desktop password form (it's the default whenever GitHub isn't
-   configured). Real JWT, real user row — everything works except
-   GitHub-specific integration.
+Then open:
 
-Note: after a successful claim, `/setup` permanently shows "Not found — There
-is nothing to set up here". That page means the claim **worked** (setup closes
-once any user exists) — don't retry; go sign in on the desktop. If you lost the
-password, reset the profile DB (`dropdb proliferate_dev_<profile>` + reboot)
-and claim again.
+```text
+http://127.0.0.1:<PROLIFERATE_API_PORT>/setup
+```
 
-Extra teammates/users: invite from the app, or use the `/register` page with an
-invitation id.
+Use the token from `/tmp/proliferate-<profile>-setup-token` to claim the local
+instance, create the owner account and organization, and sign in with that
+account. Setup closes after the first successful claim.
+
+Treat the setup token and local server logs as secrets. The server writes the
+token file with mode `0600`, logs the plaintext token locally at info level as
+a fallback, and deletes the file after a successful claim. Never copy the
+token into chat, issues, shared logs, committed docs, or a PR.
 
 ### Layer C — feature needs GitHub specifically (repo connect, GitHub integration UI)
 
-**Do not attempt GitHub OAuth from a feature profile** — the dev GitHub app's
-callback URL is registered against main's port; it will not work. Instead,
-borrow main's already-authenticated state:
+Product GitHub identity and GitHub App repository authority are separate
+subflows. Configure the one the feature actually crosses; repository
+connection requires both.
 
-```bash
-pseedauth <profile>       # run while the feature profile is NOT running
-pdevui <profile>
+#### Product GitHub identity
+
+Create a dedicated test GitHub OAuth app for the selected profile. Read
+`PROLIFERATE_API_PORT` from that profile's `profile.env` and register this
+callback:
+
+```text
+http://127.0.0.1:<PROLIFERATE_API_PORT>/auth/desktop/github/callback
 ```
 
-`pseedauth` clones main's dev DB into your profile's DB (user, oauth_account,
-auth_identity, provider_grant, org membership, GitHub App authorizations,
-integration accounts — everything) and copies main's desktop session file
-(`auth-session.json`), so the app boots already logged in as the main user with
-working GitHub credentials.
+Keep the test app's client id and client secret in ignored
+`server/.env.local` as `GITHUB_OAUTH_CLIENT_ID` and
+`GITHUB_OAUTH_CLIENT_SECRET`. Never put the secret in chat, docs, logs,
+`profile.env`, `launch.env`, or a committed file. Start the profile with the
+normal `setup`, first-time `build`, and `run` commands, then exercise GitHub
+sign-in or connection through the product.
 
-Preconditions (normally true automatically):
-- Your worktree's `server/.env` is a copy of main's — `JWT_SECRET` and
-  `CLOUD_SECRET_KEY` must match or the copied tokens/ciphertext are useless.
-  Keep `GITHUB_OAUTH_CLIENT_ID/SECRET` **set** in this layer.
-- Someone has signed into the `main` profile recently (the copied access token
-  expires; refresh works as long as the user's `token_generation` hasn't been
-  bumped by a logout/password change on main).
+Do not reconfigure a production or shared OAuth app for a feature profile.
+Run OAuth and Desktop deep-link profiles serially: the generated development
+apps share `proliferate-local://auth/callback`, so the operating system may
+deliver a callback to the wrong concurrently running profile.
 
-**It drops and replaces your profile's DB** — any local test data in that
-profile is gone. Re-run it any time you want to resync from main.
+For a Hosted-Web-only OAuth test, use:
 
-## Quick reference
+```bash
+make dev-web-auth
+```
 
-| You need | Do |
-|---|---|
-| Just run the UI | `VITE_DEV_DISABLE_AUTH=true` in `apps/desktop/.env.local`, then `pdevui <profile>` |
-| Real login / admin flows | blank GitHub vars in `server/.env`, boot with `SINGLE_ORG_MODE=true` + `SETUP_TOKEN_FILE`, claim `/setup`, password sign-in |
-| GitHub integration | `pseedauth <profile>`, then boot |
-| Branch changes Rust | same auth layers, but boot with `pdev`/`prun` (not `pdevui`) |
-| Branch changes DB schema | dedicate the profile to this branch (see below) |
+That helper starts its own local server and Web app and publicly exposes the
+callback API through ngrok. Register only the callback it prints, use dedicated
+test-provider credentials, and stop the helper immediately after the test.
 
-One profile per worktree. Don't share a profile name across worktrees, don't
-reuse `main`.
+#### Repository connection and GitHub App authority
 
-## Schema-changing branches: dedicate the profile
+Repository connection additionally requires a dedicated test GitHub App. Keep
+its current configuration only in ignored `server/.env.local`:
 
-Migrations only run **forward**, in two places:
+```text
+GITHUB_APP_ID
+GITHUB_APP_SLUG
+GITHUB_APP_CLIENT_ID
+GITHUB_APP_CLIENT_SECRET
+GITHUB_APP_WEBHOOK_SECRET
+GITHUB_APP_CALLBACK_BASE_URL
+GITHUB_APP_PRIVATE_KEY or GITHUB_APP_PRIVATE_KEY_PATH
+```
 
-- **Runtime SQLite** (`~/.proliferate-local/runtimes/<profile>/db.sqlite`):
-  anyharness migrations run at boot. If your branch adds runtime migrations
-  (e.g. goals/workflows), booting it upgrades the profile's SQLite — and then
-  booting *older* code (main, another branch) under the **same profile** hits a
-  schema it doesn't understand.
-- **Server Postgres** (`proliferate_dev_<profile>`): alembic migrations run at
-  boot; same one-way property.
+Never print or copy those secret values. Follow the
+[GitHub App manual profile procedure](../../codebase/platforms/product/sandbox-github-auth.md#manual-profile-qa)
+to expose this profile's API with `CLOUD_WORKER_TUNNEL=ngrok`, set the callback
+base to the public API URL for the run, and register the test App's callback
+and setup URLs. Stop the tunnel after the test.
 
-Rules:
-- A branch that changes either schema gets its **own profile name, kept for the
-  branch's lifetime** — never reused for other branches or main.
-- Fresh profiles are always fine: migrations bring a new DB fully up
-  automatically. `pseedauth` is also fine — the clone of main's DB is upgraded
-  forward on first boot.
-- If a profile does get crossed over a schema boundary, reset it: delete
-  `~/.proliferate-local/runtimes/<profile>/` for SQLite, and/or re-run
-  `pseedauth <profile>` (or `dropdb proliferate_dev_<profile>` + reboot) for
-  Postgres.
+Through the product UI, complete all three distinct proofs:
+
+```text
+authorize the signed-in user for the test GitHub App
+install/grant the test GitHub App to the test organization or repository
+verify the selected repository reports ready authority/coverage
+```
+
+Product OAuth alone does not prove installation or repository coverage.
+
+## Decision Table
+
+| Behavior under test | Layer |
+| --- | --- |
+| Rendering or interaction with no authenticated API call | A |
+| Admin, organization, password-auth, or authenticated API behavior | B |
+| GitHub sign-in only | C — Product GitHub identity |
+| Repository connection or GitHub integration UI | C — Product identity plus GitHub App authority |
+| Hosted-Web OAuth without the Desktop profile | `make dev-web-auth` |
+
+## Profile And Schema Safety
+
+Use one profile for one worktree. A branch with Postgres or AnyHarness SQLite
+migrations keeps its profile for the branch's lifetime because migrations only
+move forward. If a test needs a different identity or a clean database, create
+a new profile; copying another profile's database, auth rows, refresh tokens,
+provider grants, or Desktop session is unsupported.
+
+## Verification
+
+- Confirm the selected profile and its reachable ports with `make dev-list`.
+- Prove that Layer A cannot call authenticated Cloud APIs.
+- For Layer B, verify `/setup` closes after claim and the created account can
+  use the required authenticated route.
+- For Layer C, verify the browser callback returns to the intended profile and
+  the required GitHub-backed operation succeeds.
+- Stop any public auth helper or tunnel after the callback test.

--- a/specs/developing/local/stripe-local-testing.md
+++ b/specs/developing/local/stripe-local-testing.md
@@ -181,7 +181,7 @@ stripe trigger invoice.payment_failed
 Inspect local billing tables:
 
 ```bash
-make db-local
+make db-local PROFILE=billing
 select status, event_type, attempt_count from webhook_event_receipt order by received_at desc limit 10;
 select grant_type, remaining_seconds, source_ref from billing_grant order by created_at desc limit 10;
 select status, quantity_seconds, error from billing_usage_export order by created_at desc limit 10;


### PR DESCRIPTION
## Summary

- replace private/Bifrost-era local instructions with repository-owned profile and LiteLLM procedures
- separate product GitHub identity from GitHub App repository authority without auth-state cloning
- make debugging symptom-first and request only seam-relevant evidence

## Verification

- `python3 scripts/check_docs.py`
- `python3 -m unittest scripts/test_check_docs.py`
- `git diff --check`
- frozen acceptance checks for exact auth anchors, forbidden legacy helpers, protected files, and six-file scope
- three independent reviews: scope, repository facts, and safety

## Stack

Stacked on #1172 (`codex/docs-telemetry-ownership`).