### PR TITLE
docs(testing): move manual release QA under testing

### DIFF
--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -61,7 +61,7 @@ REQUIRED_READMES = (
     "specs/developing/deploying/README.md",
     "specs/developing/operating/README.md",
     "specs/developing/operating/analytics/README.md",
-    "specs/developing/qa/README.md",
+    "specs/developing/testing/manual-release-qa.md",
     "specs/developing/runbooks/README.md",
     "specs/developing/reference/README.md",
     "specs/generated/README.md",

--- a/scripts/test_check_docs.py
+++ b/scripts/test_check_docs.py
@@ -36,6 +36,7 @@ class DocumentationIntegrityTest(unittest.TestCase):
             "specs/codebase/systems/engineering/observability/README.md",
             "specs/developing/operating/README.md",
             "specs/developing/operating/analytics/README.md",
+            "specs/developing/testing/manual-release-qa.md",
         }
 
         self.assertLessEqual(required_indexes, set(check_docs.REQUIRED_READMES))
@@ -46,6 +47,8 @@ class DocumentationIntegrityTest(unittest.TestCase):
         self.assertNotIn(
             "specs/developing/analytics/README.md", check_docs.REQUIRED_READMES
         )
+        legacy_qa_root = "specs/developing/" + "qa/" + "README.md"
+        self.assertNotIn(legacy_qa_root, check_docs.REQUIRED_READMES)
 
     def markdown_errors(self, files: dict[str, str]) -> list[str]:
         with tempfile.TemporaryDirectory() as directory:

--- a/specs/codebase/systems/product/onboarding/README.md
+++ b/specs/codebase/systems/product/onboarding/README.md
@@ -132,7 +132,7 @@ for the operator path.
 ## Verification
 
 For onboarding changes, choose the narrowest useful matrix from
-[../../../../developing/qa/README.md](../../../../developing/qa/README.md) and include the
+[../../../../developing/testing/manual-release-qa.md](../../../../developing/testing/manual-release-qa.md) and include the
 touched surfaces.
 
 Minimum local smoke for end-to-end onboarding changes:

--- a/specs/developing/README.md
+++ b/specs/developing/README.md
@@ -14,7 +14,7 @@ and product behavior belong under [`../codebase/`](../codebase/).
 | Investigate a local or production defect | [`debugging/README.md`](debugging/README.md) |
 | Change CI, package, release, deploy, or promote | [`deploying/README.md`](deploying/README.md) |
 | Inspect or operate analytics, engagement, and observability providers | [`operating/analytics/README.md`](operating/analytics/README.md) |
-| Run manual release QA | [`qa/README.md`](qa/README.md) |
+| Run manual release QA | [`testing/manual-release-qa.md`](testing/manual-release-qa.md) |
 | Follow a focused operational runbook | [`runbooks/README.md`](runbooks/README.md) |
 | Find environment and command reference data | [`reference/README.md`](reference/README.md) |
 

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -19,7 +19,7 @@ the current report V3 aggregate;
 and journey composition. `flows.md` is a legacy current-coverage view being
 replaced by generated manifest/collector output.
 
-Companion: `specs/developing/qa/README.md` owns *manual* release QA. This doc
+Companion: [`manual-release-qa.md`](manual-release-qa.md) owns *manual* release QA. This doc
 owns automated testing. A flow covered by an automated tier here does not also
 need a manual QA checklist entry.
 

--- a/specs/developing/testing/core-release-validation.md
+++ b/specs/developing/testing/core-release-validation.md
@@ -39,7 +39,7 @@ roles:
   worktree because that file referenced collectors absent from current main.
 - Every run emits immutable evidence separately from both manifests. Static
   implementation state never substitutes for an observed result.
-- [`../qa/README.md`](../qa/README.md) owns manual verification that cannot be
+- [`manual-release-qa.md`](manual-release-qa.md) owns manual verification that cannot be
   automated.
 
 When another testing document describes a smaller or provisional matrix, this

--- a/specs/developing/testing/manual-release-qa.md
+++ b/specs/developing/testing/manual-release-qa.md
@@ -1,11 +1,12 @@
-# QA
+# Manual Release QA
 
-Status: authoritative entry point for release QA and manual verification.
+Status: authoritative procedure for release QA and manual verification.
 
-Use this folder for release QA process, smoke matrices, surface-specific
-manual checks, and final QA reporting. Feature-specific acceptance criteria
-stay in the owning feature or primitive spec under `specs/codebase/**`; this
-runbook owns how an operator plans, executes, records, and reports a QA pass.
+Use this procedure for manual release QA: release intake, smoke matrices,
+surface-specific manual checks, and final QA reporting. Feature-specific
+acceptance criteria stay in the owning feature or primitive spec under
+`specs/codebase/**`; this runbook owns how an operator plans, executes,
+records, and reports a QA pass.
 
 ## Read Order
 
@@ -49,8 +50,8 @@ Required tools and surfaces:
 - Browser or Chrome access with the right logged-in profile for local Web,
   Desktop renderer, GitHub, Stripe, PostHog, Sentry, Customer.io, Metabase,
   Vercel, Expo, Apple, or AWS dashboards.
-- Local dev profiles through `make dev-init PROFILE=<name>` and
-  `make dev PROFILE=<name>`.
+- Local dev profiles through `make setup PROFILE=<name>` and
+  `make run PROFILE=<name>`.
 - Stripe CLI when billing checkout, portal, subscription, refill, meter, or
   webhook behavior is in scope.
 - Expo/EAS and an iOS/Android simulator or device when native mobile behavior,
@@ -77,14 +78,15 @@ Required permissions:
   correlation.
 - AWS/Vercel/E2B/Expo/App Store Connect access only for the surfaces that the
   release or incident actually touches.
+- Production and provider verification is read-only unless an approved
+  runbook and explicit authorization permit a write.
 
 Secrets policy:
 
 - Do not paste secret values, refresh tokens, cookies, auth headers, private
   keys, Sentry DSNs, Stripe keys, webhook secrets, GitHub App private keys,
   Apple credentials, or AWS credentials into chat, PRs, issues, docs, or logs.
-- Local env files are QA fixtures and must remain uncommitted:
-  `.env`, `.env.local`, `.env.*`, `server/.env`, and `server/.env.local`.
+- Credential-bearing files must remain uncommitted.
 - Use [../reference/env-vars.yaml](../reference/env-vars.yaml) for canonical
   deployment variable ownership and storage.
 
@@ -141,26 +143,22 @@ build the SDK through the owning SDK workflow.
 Use a named profile for local full-stack QA:
 
 ```bash
-make dev-init PROFILE=<name>
-make dev PROFILE=<name>
-```
-
-Use `STRIPE=1` only when billing, checkout, portal, subscription, refill, or
-webhook behavior is part of the release:
-
-```bash
-make dev PROFILE=<name> STRIPE=1
+make setup PROFILE=<name>
+make build # first clean worktree or after generated/Rust/frontend changes
+make run PROFILE=<name>
+make run PROFILE=<name> STRIPE=1
 ```
 
 Profile QA must use the URLs and ports printed by that profile. Do not mix
 state from the default local stack with a release QA profile.
 
-When provider auth, billing, cloud sandbox materialization, or real user-scoped visibility is
-in scope, copy the developer's local non-example env files into the worktree
-before startup and keep them uncommitted. Without local secrets and a human
-login, QA can still verify type/build behavior but cannot fully verify provider
-auth, cloud materialization, billing/account settings, or user-scoped
-workspace visibility.
+Use `STRIPE=1` only when billing, checkout, portal, subscription, refill, or
+webhook behavior is part of the release. When provider auth, billing, cloud
+sandbox materialization, or real user-scoped visibility is in scope, use the
+credential source named by the applicable procedure and provide only the
+inputs required by the selected surfaces. Keep credential-bearing files
+uncommitted. If required access or input is unavailable, report the affected
+check as blocked.
 
 ## Surface Matrix
 
@@ -218,12 +216,17 @@ When QA fails:
 
 ## Final Report Shape
 
+A manual result is `passed`, `failed`, or `blocked`. Intentionally skipped
+surfaces remain separate. A blocked check names the missing access or input
+and never counts as passed.
+
 A QA report must include:
 
 - commit SHA, branch, PR, release, or deploy run under test
 - surfaces included and surfaces intentionally skipped
 - automated checks run, with pass/fail status
-- manual smoke cases run, with environment/profile and pass/fail status
+- manual smoke cases run, with environment/profile and `passed`, `failed`, or
+  `blocked` status
 - links to relevant GitHub Actions runs, dashboards, issues, or support reports
 - production/staging URLs, updater manifests, TestFlight builds, E2B template
   refs, or artifacts verified when applicable


### PR DESCRIPTION
## Summary

- move manual release QA into the Testing read path without changing automated test law
- use canonical profile commands and explicit passed/failed/blocked/skipped semantics
- remove wholesale env copying and keep provider/production verification read-only by default

## Verification

- `python3 scripts/check_docs.py`
- `python3 -m unittest scripts/test_check_docs.py`
- `git diff --check`
- exact eight-path whole-diff allowlist and three-path Testing allowlist
- three independent reviews: scope, repository facts, and safety

## Stack

Stacked on #1173 (`codex/docs-local-debugging`).