### PR TITLE
feat(workflows): add portable invocation and target resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2",
  "subtle",
@@ -4266,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4962,6 +4963,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,6 +5369,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tower = "0.5"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_jcs = "0.2"
 jsonwebtoken = "9"
 
 # OpenAPI / schema

--- a/anyharness/crates/anyharness-contract/src/v1/mod.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/mod.rs
@@ -25,6 +25,7 @@ pub mod session_config;
 pub mod sessions;
 pub mod terminals;
 pub mod workflow_runs;
+pub mod workflow_runs_v2;
 pub mod workspaces;
 pub mod worktrees;
 
@@ -55,5 +56,6 @@ pub use session_config::*;
 pub use sessions::*;
 pub use terminals::*;
 pub use workflow_runs::*;
+pub use workflow_runs_v2::*;
 pub use workspaces::*;
 pub use worktrees::*;

--- a/anyharness/crates/anyharness-contract/src/v1/workflow_runs_v2.rs
+++ b/anyharness/crates/anyharness-contract/src/v1/workflow_runs_v2.rs
@@ -1,0 +1,198 @@
+//! Portable schema-v2 workflow-run wire contract.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::workflow_runs::{
+    PutWorkflowRunRequest, WorkflowRunArgumentValue, WorkflowRunInput, WorkflowRunPromptStep,
+    WorkflowRunResponse, WorkflowRunStatus, WorkflowRunStepStatus,
+};
+
+/// Operation-level PUT union. API decoding first inspects the required integer
+/// `schemaVersion`, then strictly decodes the selected member.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum VersionedPutWorkflowRunRequest {
+    V1(PutWorkflowRunRequest),
+    V2(PutWorkflowRunRequestV2),
+}
+
+/// Schema-v2 portable invocation. Model, mode, and optional effort are target
+/// intent until AnyHarness resolves and persists a concrete plan.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PutWorkflowRunRequestV2 {
+    pub schema_version: i64,
+    pub workspace_id: String,
+    pub definition: WorkflowRunDefinitionV2,
+    #[serde(default)]
+    pub arguments: BTreeMap<String, WorkflowRunArgumentValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkflowRunDefinitionV2 {
+    #[serde(default)]
+    pub inputs: Vec<WorkflowRunInput>,
+    pub stages: Vec<WorkflowRunStageV2>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkflowRunStageV2 {
+    pub harness_config: WorkflowRunHarnessConfigV2,
+    pub steps: Vec<WorkflowRunPromptStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkflowRunHarnessConfigV2 {
+    pub agent_kind: String,
+    pub model_selection: WorkflowRunModelSelection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    pub permission_policy: WorkflowRunPermissionPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum WorkflowRunModelSelection {
+    TargetDefault,
+    Exact {
+        #[serde(rename = "modelId")]
+        #[schema(rename = "modelId")]
+        model_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkflowRunPermissionPolicy {
+    WorkflowDefault,
+}
+
+/// V2 extends, but does not widen, the stable V1 failure-code component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowRunFailureCodeV2 {
+    WorkspaceUnavailable,
+    SessionCreateFailed,
+    SessionStartFailed,
+    PromptDispatchFailed,
+    SessionTurnFailed,
+    SessionTurnCancelled,
+    RuntimeRestarted,
+    SessionConfigApplyFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunResolvedHarnessV2 {
+    pub agent_kind: String,
+    pub model_id: String,
+    pub mode_id: String,
+    #[schema(required = true)]
+    pub effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunResponseV2 {
+    pub run: WorkflowRunV2,
+    pub steps: Vec<WorkflowRunStepV2>,
+    pub resolved_harness: WorkflowRunResolvedHarnessV2,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunV2 {
+    pub id: String,
+    pub schema_version: i64,
+    pub definition: WorkflowRunDefinitionV2,
+    pub arguments: BTreeMap<String, WorkflowRunArgumentValue>,
+    pub status: WorkflowRunStatus,
+    pub workspace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<WorkflowRunFailureCodeV2>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunStepV2 {
+    pub stage_index: i64,
+    pub step_index: i64,
+    pub status: WorkflowRunStepStatus,
+    pub prompt_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<WorkflowRunFailureCodeV2>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum VersionedWorkflowRunResponse {
+    V1(WorkflowRunResponse),
+    V2(WorkflowRunResponseV2),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v1::WorkflowRunFailureCode;
+
+    #[test]
+    fn exact_model_uses_model_id_and_is_strict() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../../fixtures/contracts/workflow-portable-execution/v1.json"
+        ))
+        .expect("portable workflow fixture");
+        let request: PutWorkflowRunRequestV2 =
+            serde_json::from_value(fixture["anyHarnessRequest"].clone())
+                .expect("decode v2 fixture");
+        let encoded = serde_json::to_value(&request).expect("encode v2 request");
+        let selection = &encoded["definition"]["stages"][0]["harnessConfig"]["modelSelection"];
+        assert_eq!(selection["kind"], "exact");
+        assert_eq!(selection["modelId"], "claude-sonnet-4-5");
+        assert!(selection.get("model_id").is_none());
+
+        let mut unknown = fixture["anyHarnessRequest"].clone();
+        unknown["definition"]["stages"][0]["harnessConfig"]["modelSelection"]["extra"] =
+            serde_json::json!(true);
+        assert!(serde_json::from_value::<PutWorkflowRunRequestV2>(unknown).is_err());
+    }
+
+    #[test]
+    fn v1_failure_component_does_not_gain_v2_only_code() {
+        assert!(
+            serde_json::from_str::<WorkflowRunFailureCode>("\"session_config_apply_failed\"")
+                .is_err()
+        );
+        assert_eq!(
+            serde_json::to_string(&WorkflowRunFailureCodeV2::SessionConfigApplyFailed)
+                .expect("serialize v2 failure"),
+            "\"session_config_apply_failed\""
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/Cargo.toml
+++ b/anyharness/crates/anyharness-lib/Cargo.toml
@@ -14,6 +14,7 @@ tower-http.workspace = true
 tower.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_jcs.workspace = true
 jsonwebtoken.workspace = true
 utoipa.workspace = true
 utoipa-axum.workspace = true

--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
@@ -2,7 +2,7 @@
 //! map wire/domain shapes, make one runtime call, and let typed errors ride
 //! `?`. No product validation, SQL, spawning, session calls, or orchestration.
 
-use anyharness_contract::v1::WorkflowRunResponse;
+use anyharness_contract::v1::VersionedWorkflowRunResponse;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -12,7 +12,9 @@ use axum::{
 
 use super::access::assert_workspace_auth_scope;
 use super::error::ApiError;
-use super::workflow_runs_contract::{decode_put_workflow_run, view_to_response};
+use super::workflow_runs_contract::{
+    decode_put_workflow_run, input_workspace_id, view_to_response, view_workspace_id,
+};
 use crate::api::auth::AuthContext;
 use crate::app::AppState;
 use crate::domains::workflows::runtime::WorkflowPutSuccess;
@@ -21,12 +23,15 @@ use crate::domains::workflows::runtime::WorkflowPutSuccess;
     put,
     path = "/v1/workflow-runs/{run_id}",
     params(("run_id" = String, Path, description = "Canonical UUID for the workflow run")),
-    request_body = anyharness_contract::v1::PutWorkflowRunRequest,
+    request_body = anyharness_contract::v1::VersionedPutWorkflowRunRequest,
     responses(
-        (status = 201, description = "New durable acceptance", body = WorkflowRunResponse),
-        (status = 200, description = "Exact replay of an identical invocation", body = WorkflowRunResponse),
+        (status = 201, description = "New durable acceptance", body = VersionedWorkflowRunResponse),
+        (status = 200, description = "Exact replay of an identical invocation", body = VersionedWorkflowRunResponse),
         (status = 400, description = "Invalid ID, definition, arguments, or rendered prompt", body = anyharness_contract::v1::ProblemDetails),
-        (status = 409, description = "Same ID, different invocation", body = anyharness_contract::v1::ProblemDetails),
+        (status = 403, description = "Direct-attach token is outside its workspace scope", body = anyharness_contract::v1::ProblemDetails),
+        (status = 404, description = "Workspace not found", body = anyharness_contract::v1::ProblemDetails),
+        (status = 409, description = "Same ID with different invocation, or workspace mutation blocked", body = anyharness_contract::v1::ProblemDetails),
+        (status = 422, description = "Portable target cannot be resolved", body = anyharness_contract::v1::ProblemDetails),
         (status = 500, description = "Acceptance storage failure; no committed run or step", body = anyharness_contract::v1::ProblemDetails),
     ),
     tag = "workflow-runs"
@@ -38,14 +43,14 @@ pub async fn put_workflow_run(
     Json(body): Json<serde_json::Value>,
 ) -> Result<Response, ApiError> {
     let input = decode_put_workflow_run(body)?;
-    assert_workspace_auth_scope(&auth, &input.workspace_id)?;
+    assert_workspace_auth_scope(&auth, input_workspace_id(&input))?;
     let outcome = state.workflow_run_runtime.put(run_id, input).await?;
     Ok(match outcome {
         WorkflowPutSuccess::Created(view) => {
-            (StatusCode::CREATED, Json(view_to_response(view))).into_response()
+            (StatusCode::CREATED, Json(view_to_response(view)?)).into_response()
         }
         WorkflowPutSuccess::Replay(view) => {
-            (StatusCode::OK, Json(view_to_response(view))).into_response()
+            (StatusCode::OK, Json(view_to_response(view)?)).into_response()
         }
     })
 }
@@ -55,8 +60,9 @@ pub async fn put_workflow_run(
     path = "/v1/workflow-runs/{run_id}",
     params(("run_id" = String, Path, description = "Canonical UUID for the workflow run")),
     responses(
-        (status = 200, description = "Durable run and step status", body = WorkflowRunResponse),
+        (status = 200, description = "Durable run and step status", body = VersionedWorkflowRunResponse),
         (status = 400, description = "Non-canonical run ID", body = anyharness_contract::v1::ProblemDetails),
+        (status = 403, description = "Direct-attach token is outside its workspace scope", body = anyharness_contract::v1::ProblemDetails),
         (status = 404, description = "Unknown workflow run", body = anyharness_contract::v1::ProblemDetails),
     ),
     tag = "workflow-runs"
@@ -65,12 +71,12 @@ pub async fn get_workflow_run(
     State(state): State<AppState>,
     Extension(auth): Extension<AuthContext>,
     Path(run_id): Path<String>,
-) -> Result<Json<WorkflowRunResponse>, ApiError> {
+) -> Result<Json<VersionedWorkflowRunResponse>, ApiError> {
     let view = state
         .workflow_run_runtime
         .get(run_id)
         .await?
         .ok_or_else(|| ApiError::not_found("Workflow run not found", "WORKFLOW_RUN_NOT_FOUND"))?;
-    assert_workspace_auth_scope(&auth, &view.run.workspace_id)?;
-    Ok(Json(view_to_response(view)))
+    assert_workspace_auth_scope(&auth, view_workspace_id(&view))?;
+    Ok(Json(view_to_response(view)?))
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_runs_contract.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_runs_contract.rs
@@ -6,54 +6,145 @@
 use std::collections::BTreeMap;
 
 use anyharness_contract::v1::{
-    PutWorkflowRunRequest, WorkflowRun, WorkflowRunArgumentValue as WireArgumentValue,
-    WorkflowRunDefinition, WorkflowRunFailureCode as WireFailureCode, WorkflowRunHarnessConfig,
-    WorkflowRunInput, WorkflowRunInputType, WorkflowRunPromptStep, WorkflowRunResponse,
-    WorkflowRunStage, WorkflowRunStatus, WorkflowRunStep, WorkflowRunStepStatus,
+    PutWorkflowRunRequest, PutWorkflowRunRequestV2, VersionedWorkflowRunResponse, WorkflowRun,
+    WorkflowRunArgumentValue as WireArgumentValue, WorkflowRunDefinition,
+    WorkflowRunDefinitionV2 as WireDefinitionV2, WorkflowRunFailureCode as WireFailureCode,
+    WorkflowRunFailureCodeV2 as WireFailureCodeV2, WorkflowRunHarnessConfig,
+    WorkflowRunHarnessConfigV2 as WireHarnessConfigV2, WorkflowRunInput, WorkflowRunInputType,
+    WorkflowRunModelSelection as WireModelSelection,
+    WorkflowRunPermissionPolicy as WirePermissionPolicy, WorkflowRunPromptStep,
+    WorkflowRunResolvedHarnessV2, WorkflowRunResponse, WorkflowRunResponseV2, WorkflowRunStage,
+    WorkflowRunStageV2 as WireStageV2, WorkflowRunStatus, WorkflowRunStep, WorkflowRunStepStatus,
+    WorkflowRunStepV2, WorkflowRunV2,
 };
 
 use crate::domains::workflows::model::{
-    PutWorkflowRunInput, WorkflowArgumentValue, WorkflowDefinition, WorkflowHarnessConfig,
-    WorkflowInput, WorkflowInputType, WorkflowPromptStep, WorkflowRunFailureCode,
-    WorkflowRunRecord, WorkflowRunStatus as DomainRunStatus, WorkflowRunStepRecord, WorkflowStage,
+    PutWorkflowRunInput, PutWorkflowRunInputV2, VersionedPutWorkflowRunInput,
+    WorkflowArgumentValue, WorkflowDefinition, WorkflowDefinitionV2, WorkflowHarnessConfig,
+    WorkflowHarnessConfigV2, WorkflowInput, WorkflowInputType, WorkflowModelSelection,
+    WorkflowPermissionPolicy, WorkflowPromptStep, WorkflowRunFailureCode, WorkflowRunRecord,
+    WorkflowRunStatus as DomainRunStatus, WorkflowRunStepRecord, WorkflowStage, WorkflowStageV2,
     WorkflowStepStatus,
 };
-use crate::domains::workflows::service::WorkflowRunView;
+use crate::domains::workflows::service::{
+    VersionedWorkflowRunView, WorkflowRunView, WorkflowRunViewV2,
+};
 
 /// A strict-shape decode failure. Detail is intentionally generic so caller
 /// argument values never leak back through the error body.
 #[derive(Debug)]
 pub struct WorkflowRunDecodeError;
 
+/// Stored v1 rows can never contain the v2-only failure code. Treat a corrupt
+/// combination as an internal mapping failure instead of widening the frozen
+/// v1 wire component or silently remapping the code.
+#[derive(Debug)]
+pub struct WorkflowRunEncodeError;
+
 /// Decode and normalize the PUT body into the runtime's domain input.
 pub fn decode_put_workflow_run(
     body: serde_json::Value,
-) -> Result<PutWorkflowRunInput, WorkflowRunDecodeError> {
-    let request: PutWorkflowRunRequest =
-        serde_json::from_value(body).map_err(|_| WorkflowRunDecodeError)?;
-    Ok(PutWorkflowRunInput {
-        schema_version: request.schema_version,
-        workspace_id: request.workspace_id,
-        definition: definition_to_domain(request.definition),
-        arguments: request
-            .arguments
-            .into_iter()
-            .map(|(name, value)| (name, wire_argument_to_value(value)))
-            .collect(),
-    })
+) -> Result<VersionedPutWorkflowRunInput, WorkflowRunDecodeError> {
+    let schema_version = body
+        .get("schemaVersion")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or(WorkflowRunDecodeError)?;
+    match schema_version {
+        1 => {
+            let request: PutWorkflowRunRequest =
+                serde_json::from_value(body).map_err(|_| WorkflowRunDecodeError)?;
+            Ok(VersionedPutWorkflowRunInput::V1(PutWorkflowRunInput {
+                schema_version: request.schema_version,
+                workspace_id: request.workspace_id,
+                definition: definition_to_domain(request.definition),
+                arguments: arguments_to_domain(request.arguments),
+            }))
+        }
+        2 => {
+            let request: PutWorkflowRunRequestV2 =
+                serde_json::from_value(body).map_err(|_| WorkflowRunDecodeError)?;
+            Ok(VersionedPutWorkflowRunInput::V2(PutWorkflowRunInputV2 {
+                schema_version: request.schema_version,
+                workspace_id: request.workspace_id,
+                definition: definition_v2_to_domain(request.definition),
+                arguments: arguments_to_domain(request.arguments),
+            }))
+        }
+        _ => Err(WorkflowRunDecodeError),
+    }
 }
 
 /// Compose the wire response from the domain read view.
-pub fn view_to_response(view: WorkflowRunView) -> WorkflowRunResponse {
+pub fn view_to_response(
+    view: VersionedWorkflowRunView,
+) -> Result<VersionedWorkflowRunResponse, WorkflowRunEncodeError> {
+    match view {
+        VersionedWorkflowRunView::V1(view) => {
+            v1_view_to_response(view).map(VersionedWorkflowRunResponse::V1)
+        }
+        VersionedWorkflowRunView::V2(view) => {
+            Ok(VersionedWorkflowRunResponse::V2(v2_view_to_response(view)))
+        }
+    }
+}
+
+pub fn view_workspace_id(view: &VersionedWorkflowRunView) -> &str {
+    match view {
+        VersionedWorkflowRunView::V1(view) => &view.run.workspace_id,
+        VersionedWorkflowRunView::V2(view) => &view.run.workspace_id,
+    }
+}
+
+pub fn input_workspace_id(input: &VersionedPutWorkflowRunInput) -> &str {
+    match input {
+        VersionedPutWorkflowRunInput::V1(input) => &input.workspace_id,
+        VersionedPutWorkflowRunInput::V2(input) => &input.workspace_id,
+    }
+}
+
+fn v1_view_to_response(
+    view: WorkflowRunView,
+) -> Result<WorkflowRunResponse, WorkflowRunEncodeError> {
     let WorkflowRunView {
         run,
         invocation,
         steps,
     } = view;
-    WorkflowRunResponse {
-        run: run_to_wire(run, invocation.definition, invocation.arguments),
-        steps: steps.into_iter().map(step_to_wire).collect(),
+    Ok(WorkflowRunResponse {
+        run: run_to_wire(run, invocation.definition, invocation.arguments)?,
+        steps: steps
+            .into_iter()
+            .map(step_to_wire)
+            .collect::<Result<Vec<_>, _>>()?,
+    })
+}
+
+fn v2_view_to_response(view: WorkflowRunViewV2) -> WorkflowRunResponseV2 {
+    let WorkflowRunViewV2 {
+        run,
+        source,
+        resolved_plan,
+        steps,
+    } = view;
+    WorkflowRunResponseV2 {
+        run: run_v2_to_wire(run, source.definition, source.arguments),
+        steps: steps.into_iter().map(step_v2_to_wire).collect(),
+        resolved_harness: WorkflowRunResolvedHarnessV2 {
+            agent_kind: resolved_plan.agent_kind,
+            model_id: resolved_plan.model_id,
+            mode_id: resolved_plan.mode_id,
+            effort: resolved_plan.effort_config.map(|effort| effort.value),
+        },
     }
+}
+
+fn arguments_to_domain(
+    arguments: BTreeMap<String, WireArgumentValue>,
+) -> BTreeMap<String, serde_json::Value> {
+    arguments
+        .into_iter()
+        .map(|(name, value)| (name, wire_argument_to_value(value)))
+        .collect()
 }
 
 fn definition_to_domain(definition: WorkflowRunDefinition) -> WorkflowDefinition {
@@ -85,6 +176,36 @@ fn stage_to_domain(stage: WorkflowRunStage) -> WorkflowStage {
             agent_kind: stage.harness_config.agent_kind,
             model_id: stage.harness_config.model_id,
             mode_id: stage.harness_config.mode_id,
+        },
+        steps: stage.steps.into_iter().map(step_kind_to_domain).collect(),
+    }
+}
+
+fn definition_v2_to_domain(definition: WireDefinitionV2) -> WorkflowDefinitionV2 {
+    WorkflowDefinitionV2 {
+        inputs: definition.inputs.into_iter().map(input_to_domain).collect(),
+        stages: definition
+            .stages
+            .into_iter()
+            .map(stage_v2_to_domain)
+            .collect(),
+    }
+}
+
+fn stage_v2_to_domain(stage: WireStageV2) -> WorkflowStageV2 {
+    WorkflowStageV2 {
+        harness_config: WorkflowHarnessConfigV2 {
+            agent_kind: stage.harness_config.agent_kind,
+            model_selection: match stage.harness_config.model_selection {
+                WireModelSelection::TargetDefault => WorkflowModelSelection::TargetDefault,
+                WireModelSelection::Exact { model_id } => {
+                    WorkflowModelSelection::Exact { model_id }
+                }
+            },
+            effort: stage.harness_config.effort,
+            permission_policy: match stage.harness_config.permission_policy {
+                WirePermissionPolicy::WorkflowDefault => WorkflowPermissionPolicy::WorkflowDefault,
+            },
         },
         steps: stage.steps.into_iter().map(step_kind_to_domain).collect(),
     }
@@ -134,6 +255,43 @@ fn stage_to_wire(stage: WorkflowStage) -> WorkflowRunStage {
     }
 }
 
+fn definition_v2_to_wire(definition: WorkflowDefinitionV2) -> WireDefinitionV2 {
+    WireDefinitionV2 {
+        inputs: definition.inputs.into_iter().map(input_to_wire).collect(),
+        stages: definition
+            .stages
+            .into_iter()
+            .map(stage_v2_to_wire)
+            .collect(),
+    }
+}
+
+fn stage_v2_to_wire(stage: WorkflowStageV2) -> WireStageV2 {
+    WireStageV2 {
+        harness_config: WireHarnessConfigV2 {
+            agent_kind: stage.harness_config.agent_kind,
+            model_selection: match stage.harness_config.model_selection {
+                WorkflowModelSelection::TargetDefault => WireModelSelection::TargetDefault,
+                WorkflowModelSelection::Exact { model_id } => {
+                    WireModelSelection::Exact { model_id }
+                }
+            },
+            effort: stage.harness_config.effort,
+            permission_policy: match stage.harness_config.permission_policy {
+                WorkflowPermissionPolicy::WorkflowDefault => WirePermissionPolicy::WorkflowDefault,
+            },
+        },
+        steps: stage
+            .steps
+            .into_iter()
+            .map(|step| WorkflowRunPromptStep {
+                kind: step.kind,
+                prompt: step.prompt,
+            })
+            .collect(),
+    }
+}
+
 fn wire_argument_to_value(value: WireArgumentValue) -> serde_json::Value {
     match value {
         WireArgumentValue::Boolean(flag) => serde_json::Value::Bool(flag),
@@ -154,8 +312,8 @@ fn run_to_wire(
     run: WorkflowRunRecord,
     definition: WorkflowDefinition,
     arguments: BTreeMap<String, WorkflowArgumentValue>,
-) -> WorkflowRun {
-    WorkflowRun {
+) -> Result<WorkflowRun, WorkflowRunEncodeError> {
+    Ok(WorkflowRun {
         id: run.id,
         schema_version: run.schema_version,
         definition: definition_to_wire(definition),
@@ -166,7 +324,46 @@ fn run_to_wire(
         status: run_status_to_wire(run.status),
         workspace_id: run.workspace_id,
         session_id: run.session_id,
-        failure_code: run.failure_code.map(failure_code_to_wire),
+        failure_code: run.failure_code.map(failure_code_to_wire).transpose()?,
+        created_at: run.created_at,
+        updated_at: run.updated_at,
+        started_at: run.started_at,
+        finished_at: run.finished_at,
+    })
+}
+
+fn step_to_wire(step: WorkflowRunStepRecord) -> Result<WorkflowRunStep, WorkflowRunEncodeError> {
+    Ok(WorkflowRunStep {
+        stage_index: step.stage_index,
+        step_index: step.step_index,
+        status: step_status_to_wire(step.status),
+        prompt_id: step.prompt_id,
+        turn_id: step.turn_id,
+        failure_code: step.failure_code.map(failure_code_to_wire).transpose()?,
+        created_at: step.created_at,
+        updated_at: step.updated_at,
+        started_at: step.started_at,
+        finished_at: step.finished_at,
+    })
+}
+
+fn run_v2_to_wire(
+    run: WorkflowRunRecord,
+    definition: WorkflowDefinitionV2,
+    arguments: BTreeMap<String, WorkflowArgumentValue>,
+) -> WorkflowRunV2 {
+    WorkflowRunV2 {
+        id: run.id,
+        schema_version: run.schema_version,
+        definition: definition_v2_to_wire(definition),
+        arguments: arguments
+            .into_iter()
+            .map(|(name, value)| (name, argument_to_wire(value)))
+            .collect(),
+        status: run_status_to_wire(run.status),
+        workspace_id: run.workspace_id,
+        session_id: run.session_id,
+        failure_code: run.failure_code.map(failure_code_v2_to_wire),
         created_at: run.created_at,
         updated_at: run.updated_at,
         started_at: run.started_at,
@@ -174,14 +371,14 @@ fn run_to_wire(
     }
 }
 
-fn step_to_wire(step: WorkflowRunStepRecord) -> WorkflowRunStep {
-    WorkflowRunStep {
+fn step_v2_to_wire(step: WorkflowRunStepRecord) -> WorkflowRunStepV2 {
+    WorkflowRunStepV2 {
         stage_index: step.stage_index,
         step_index: step.step_index,
         status: step_status_to_wire(step.status),
         prompt_id: step.prompt_id,
         turn_id: step.turn_id,
-        failure_code: step.failure_code.map(failure_code_to_wire),
+        failure_code: step.failure_code.map(failure_code_v2_to_wire),
         created_at: step.created_at,
         updated_at: step.updated_at,
         started_at: step.started_at,
@@ -207,8 +404,10 @@ fn step_status_to_wire(status: WorkflowStepStatus) -> WorkflowRunStepStatus {
     }
 }
 
-fn failure_code_to_wire(code: WorkflowRunFailureCode) -> WireFailureCode {
-    match code {
+fn failure_code_to_wire(
+    code: WorkflowRunFailureCode,
+) -> Result<WireFailureCode, WorkflowRunEncodeError> {
+    Ok(match code {
         WorkflowRunFailureCode::WorkspaceUnavailable => WireFailureCode::WorkspaceUnavailable,
         WorkflowRunFailureCode::SessionCreateFailed => WireFailureCode::SessionCreateFailed,
         WorkflowRunFailureCode::SessionStartFailed => WireFailureCode::SessionStartFailed,
@@ -216,5 +415,23 @@ fn failure_code_to_wire(code: WorkflowRunFailureCode) -> WireFailureCode {
         WorkflowRunFailureCode::SessionTurnFailed => WireFailureCode::SessionTurnFailed,
         WorkflowRunFailureCode::SessionTurnCancelled => WireFailureCode::SessionTurnCancelled,
         WorkflowRunFailureCode::RuntimeRestarted => WireFailureCode::RuntimeRestarted,
+        WorkflowRunFailureCode::SessionConfigApplyFailed => {
+            return Err(WorkflowRunEncodeError);
+        }
+    })
+}
+
+fn failure_code_v2_to_wire(code: WorkflowRunFailureCode) -> WireFailureCodeV2 {
+    match code {
+        WorkflowRunFailureCode::WorkspaceUnavailable => WireFailureCodeV2::WorkspaceUnavailable,
+        WorkflowRunFailureCode::SessionCreateFailed => WireFailureCodeV2::SessionCreateFailed,
+        WorkflowRunFailureCode::SessionStartFailed => WireFailureCodeV2::SessionStartFailed,
+        WorkflowRunFailureCode::PromptDispatchFailed => WireFailureCodeV2::PromptDispatchFailed,
+        WorkflowRunFailureCode::SessionTurnFailed => WireFailureCodeV2::SessionTurnFailed,
+        WorkflowRunFailureCode::SessionTurnCancelled => WireFailureCodeV2::SessionTurnCancelled,
+        WorkflowRunFailureCode::RuntimeRestarted => WireFailureCodeV2::RuntimeRestarted,
+        WorkflowRunFailureCode::SessionConfigApplyFailed => {
+            WireFailureCodeV2::SessionConfigApplyFailed
+        }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_runs_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_runs_errors.rs
@@ -2,9 +2,13 @@
 //! impls let handlers ride `?`. Storage/internal failures collapse to a generic
 //! 500 body — raw error chains, prompts, and arguments never reach the wire.
 
+use axum::http::StatusCode;
+
+use super::access::map_access_error;
 use super::error::ApiError;
-use super::workflow_runs_contract::WorkflowRunDecodeError;
+use super::workflow_runs_contract::{WorkflowRunDecodeError, WorkflowRunEncodeError};
 use crate::domains::workflows::runtime::{WorkflowGetError, WorkflowPutError};
+use crate::domains::workspaces::access_gate::WorkspaceAccessError;
 
 impl From<WorkflowRunDecodeError> for ApiError {
     fn from(_error: WorkflowRunDecodeError) -> Self {
@@ -12,6 +16,12 @@ impl From<WorkflowRunDecodeError> for ApiError {
             "The request body does not match the workflow run schema.",
             "WORKFLOW_RUN_INVALID",
         )
+    }
+}
+
+impl From<WorkflowRunEncodeError> for ApiError {
+    fn from(_error: WorkflowRunEncodeError) -> Self {
+        ApiError::internal("workflow run response mapping failure")
     }
 }
 
@@ -24,6 +34,16 @@ impl From<WorkflowPutError> for ApiError {
             WorkflowPutError::Conflict => ApiError::conflict(
                 "A workflow run with this ID already exists with a different invocation.",
                 "WORKFLOW_RUN_CONFLICT",
+            ),
+            WorkflowPutError::WorkspaceAccess(WorkspaceAccessError::Unexpected(_)) => {
+                ApiError::internal("workflow workspace access could not be verified")
+            }
+            WorkflowPutError::WorkspaceAccess(error) => map_access_error(error),
+            WorkflowPutError::TargetUnresolvable(_) => ApiError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Unprocessable entity",
+                Some("The workflow target cannot be resolved in this workspace.".into()),
+                Some("WORKFLOW_RUN_TARGET_UNRESOLVABLE"),
             ),
             WorkflowPutError::Store(_) | WorkflowPutError::Internal(_) => {
                 ApiError::internal("workflow run storage failure")

--- a/anyharness/crates/anyharness-lib/src/api/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/api/mod.rs
@@ -10,4 +10,8 @@ mod openapi_tests;
 #[cfg(test)]
 mod router_tests;
 #[cfg(test)]
+mod workflow_runs_portable_contract_tests;
+#[cfg(test)]
+mod workflow_runs_scripted_tests;
+#[cfg(test)]
 mod workflow_runs_tests;

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_portable_contract_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_portable_contract_tests.rs
@@ -1,0 +1,164 @@
+//! Portable workflow HTTP contract, dispatch, access, and target-resolution tests.
+
+use std::sync::Mutex;
+
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+
+use super::workflow_runs_tests::{get, put, test_state};
+use crate::app::test_support;
+
+fn valid_v2_body(workspace_id: &str) -> Value {
+    json!({
+        "schemaVersion": 2,
+        "workspaceId": workspace_id,
+        "definition": {
+            "inputs": [{ "name": "ticket", "type": "string", "required": true }],
+            "stages": [{
+                "harnessConfig": {
+                    "agentKind": "claude",
+                    "modelSelection": {
+                        "kind": "exact",
+                        "modelId": "definitely-not-a-real-model"
+                    },
+                    "permissionPolicy": "workflowDefault"
+                },
+                "steps": [{ "kind": "agent.prompt", "prompt": "Investigate {{inputs.ticket}}" }]
+            }]
+        },
+        "arguments": { "ticket": "PROL-123" }
+    })
+}
+
+#[test]
+fn openapi_documents_model_and_mode_ids_as_required_nullable() {
+    // Spec §3.1/§8.1: modelId/modeId are required keys that may be null, and
+    // the generated OpenAPI (thus the generated SDK) must say so.
+    let doc: Value =
+        serde_json::from_str(&super::openapi::openapi_json()).expect("parse openapi document");
+    let schema = &doc["components"]["schemas"]["WorkflowRunHarnessConfig"];
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .map(|value| value.as_str().expect("required entry"))
+        .collect();
+    assert!(required.contains(&"agentKind"), "required: {required:?}");
+    assert!(required.contains(&"modelId"), "required: {required:?}");
+    assert!(required.contains(&"modeId"), "required: {required:?}");
+    assert_eq!(
+        schema["properties"]["modelId"]["type"],
+        json!(["string", "null"])
+    );
+    assert_eq!(
+        schema["properties"]["modeId"]["type"],
+        json!(["string", "null"])
+    );
+}
+
+#[test]
+fn openapi_keeps_v1_components_and_adds_versioned_operation_wrappers() {
+    let doc: Value =
+        serde_json::from_str(&super::openapi::openapi_json()).expect("parse openapi document");
+    let schemas = doc["components"]["schemas"]
+        .as_object()
+        .expect("schemas object");
+    for name in [
+        "PutWorkflowRunRequest",
+        "WorkflowRunResponse",
+        "WorkflowRun",
+        "WorkflowRunStep",
+        "WorkflowRunFailureCode",
+        "PutWorkflowRunRequestV2",
+        "WorkflowRunResponseV2",
+        "VersionedPutWorkflowRunRequest",
+        "VersionedWorkflowRunResponse",
+    ] {
+        assert!(schemas.contains_key(name), "missing component {name}");
+    }
+    let model_selection = serde_json::to_string(&schemas["WorkflowRunModelSelection"])
+        .expect("serialize model selection schema");
+    assert!(model_selection.contains("modelId"));
+    assert!(!model_selection.contains("model_id"));
+    let put = &doc["paths"]["/v1/workflow-runs/{run_id}"]["put"];
+    assert_eq!(
+        put["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/VersionedPutWorkflowRunRequest"
+    );
+    for status in ["200", "201", "400", "403", "404", "409", "422", "500"] {
+        assert!(
+            put["responses"].get(status).is_some(),
+            "missing PUT {status}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn v2_access_and_target_resolution_fail_before_acceptance() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+
+    let missing_workspace = "39999999-9999-4999-8999-999999999999";
+    let mut malformed_prompt = valid_v2_body(missing_workspace);
+    malformed_prompt["definition"]["stages"][0]["steps"][0]["prompt"] = json!("{{inputs.missing}}");
+    let missing_run = uuid::Uuid::new_v4().to_string();
+    let (status, body) = put(&state, &missing_run, malformed_prompt).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["code"], "WORKSPACE_NOT_FOUND");
+    let (status, _) = get(&state, &missing_run).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "pre-acceptance failure stored a row"
+    );
+
+    let workspace_id = "30000000-0000-4000-8000-000000000099";
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        workspace_id,
+        "worktree",
+        "/tmp/workflow-v2-unresolvable",
+    );
+    let target_run = uuid::Uuid::new_v4().to_string();
+    let (status, body) = put(&state, &target_run, valid_v2_body(workspace_id)).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["code"], "WORKFLOW_RUN_TARGET_UNRESOLVABLE");
+    let (status, _) = get(&state, &target_run).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "unresolved target stored a row"
+    );
+}
+
+#[tokio::test]
+async fn schema_version_dispatch_is_strict_for_v1_and_v2() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+
+    for invalid_version in [Value::Null, json!("2"), json!(2.0), json!(3)] {
+        let mut body = valid_v2_body("workspace");
+        body["schemaVersion"] = invalid_version;
+        let (status, response) = put(&state, &uuid::Uuid::new_v4().to_string(), body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(response["code"], "WORKFLOW_RUN_INVALID");
+    }
+
+    let mut snake_case = valid_v2_body("workspace");
+    let selection = snake_case["definition"]["stages"][0]["harnessConfig"]["modelSelection"]
+        .as_object_mut()
+        .expect("selection");
+    let model_id = selection.remove("modelId").expect("modelId");
+    selection.insert("model_id".to_string(), model_id);
+    let (status, response) = put(&state, &uuid::Uuid::new_v4().to_string(), snake_case).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(response["code"], "WORKFLOW_RUN_INVALID");
+}

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_scripted_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_scripted_tests.rs
@@ -1,0 +1,525 @@
+//! Scripted ACP proofs for portable workflow effort ordering and exact replay.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+
+use super::workflow_runs_tests::{get, poll_run_until, put, session_count};
+use crate::{
+    app::{test_support, AppState},
+    domains::agents::installer::seed::AgentSeedStore,
+    persistence::Db,
+};
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}
+
+fn write_scripted_claude_agent(runtime_home: &std::path::Path) -> (PathBuf, PathBuf) {
+    std::fs::create_dir_all(runtime_home.join("secrets")).expect("create secrets directory");
+    std::fs::write(
+        runtime_home.join("secrets/global.env"),
+        "ANTHROPIC_API_KEY=test-not-a-real-key\nCLAUDE_CODE_USE_BEDROCK=0\n",
+    )
+    .expect("write test credential");
+
+    let native = runtime_home.join("agents/claude/native/claude");
+    std::fs::create_dir_all(native.parent().expect("native parent"))
+        .expect("create native directory");
+    std::fs::write(&native, "#!/bin/sh\nexit 0\n").expect("write native stub");
+    crate::integrations::agent_cli::executable::make_executable(&native)
+        .expect("make native stub executable");
+
+    let script = runtime_home.join("scripted-claude-agent.py");
+    std::fs::write(
+        &script,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+log_path = sys.argv[-2]
+behavior = sys.argv[-1]
+
+
+def effort_option(current_value):
+    return {
+        "id": "effort",
+        "name": "Effort",
+        "category": "thought_level",
+        "type": "select",
+        "currentValue": current_value,
+        "options": [
+            {"value": "default", "name": "Default"},
+            {"value": "high", "name": "High"},
+        ],
+    }
+
+
+def emit(payload):
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+for raw_line in sys.stdin:
+    message = json.loads(raw_line)
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write(json.dumps(message, separators=(",", ":")) + "\n")
+    if "id" not in message:
+        continue
+    request_id = message["id"]
+    method = message.get("method")
+    if method == "initialize":
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": 1,
+                "agentCapabilities": {},
+                "authMethods": [],
+            },
+        })
+    elif method == "session/new":
+        result = {
+            "sessionId": "scripted-native-session",
+            "modes": {
+                "currentModeId": "bypassPermissions",
+                "availableModes": [
+                    {"id": "bypassPermissions", "name": "Bypass permissions"}
+                ],
+            },
+        }
+        if behavior != "missing":
+            result["configOptions"] = [effort_option("default")]
+        emit({"jsonrpc": "2.0", "id": request_id, "result": result})
+    elif method in ("session/set_model", "session/set_mode"):
+        emit({"jsonrpc": "2.0", "id": request_id, "result": {}})
+    elif method == "session/set_config_option":
+        if behavior == "timeout":
+            continue
+        if behavior == "error":
+            emit({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"unexpected": True},
+            })
+            continue
+        if behavior == "rejected":
+            emit({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32602, "message": "scripted rejection"},
+            })
+        else:
+            emit({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"configOptions": [effort_option("high")]},
+            })
+    elif method == "session/prompt":
+        emit({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "scripted-native-session",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "workflow-ok"},
+                    "messageId": "scripted-message",
+                },
+            },
+        })
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"stopReason": "end_turn"},
+        })
+    else:
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method not found"},
+        })
+"#,
+    )
+    .expect("write scripted ACP agent");
+    crate::integrations::agent_cli::executable::make_executable(&script)
+        .expect("make scripted ACP agent executable");
+    (script, runtime_home.join("agent-requests.jsonl"))
+}
+
+fn scripted_v2_body(workspace_id: &str, attempt: Value) -> Value {
+    json!({
+        "schemaVersion": 2,
+        "workspaceId": workspace_id,
+        "definition": {
+            "inputs": [
+                { "name": "ticket", "type": "string", "required": true },
+                { "name": "attempt", "type": "number", "required": true }
+            ],
+            "stages": [{
+                "harnessConfig": {
+                    "agentKind": "claude",
+                    "modelSelection": { "kind": "exact", "modelId": "default" },
+                    "effort": "high",
+                    "permissionPolicy": "workflowDefault"
+                },
+                "steps": [{
+                    "kind": "agent.prompt",
+                    "prompt": "Return {{inputs.ticket}} attempt {{inputs.attempt}}"
+                }]
+            }]
+        },
+        "arguments": { "ticket": "PROL-321", "attempt": attempt }
+    })
+}
+
+fn read_scripted_requests(path: &std::path::Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .expect("read scripted request log")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parse scripted request"))
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn v2_scripted_agent_applies_effort_runs_one_turn_and_replays_without_effects() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix timestamp")
+        .as_nanos();
+    let runtime_home = PathBuf::from(format!("/tmp/anyharness-workflow-scripted-{unique}"));
+    let (agent_program, request_log) = write_scripted_claude_agent(&runtime_home);
+    let _program_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &agent_program);
+    let agent_args = serde_json::to_string(&vec![
+        request_log.to_string_lossy().to_string(),
+        "applied".to_string(),
+    ])
+    .expect("serialize agent args");
+    let _args_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_ARGS_JSON", &agent_args);
+
+    {
+        let state = AppState::new(
+            runtime_home.clone(),
+            "http://127.0.0.1:8457".to_string(),
+            Db::open_in_memory().expect("in-memory db"),
+            false,
+            AgentSeedStore::not_configured_dev(),
+        )
+        .expect("app state");
+        let workspace_id = "30000000-0000-4000-8000-000000000036";
+        let workspace_dir = runtime_home.join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace directory");
+        test_support::seed_workspace_with_repo_root(
+            &state.db,
+            workspace_id,
+            "worktree",
+            workspace_dir.to_str().expect("utf-8 workspace path"),
+        );
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let first_attempt: Value = serde_json::from_str("1.0").expect("numeric argument");
+        let first_request = scripted_v2_body(workspace_id, first_attempt);
+        let (status, created) = put(&state, &run_id, first_request).await;
+        assert_eq!(status, StatusCode::CREATED, "response: {created}");
+        assert_eq!(created["run"]["arguments"]["attempt"], json!(1));
+        assert_eq!(created["resolvedHarness"]["agentKind"], "claude");
+        assert_eq!(created["resolvedHarness"]["modelId"], "default");
+        assert_eq!(created["resolvedHarness"]["modeId"], "bypassPermissions");
+        assert_eq!(created["resolvedHarness"]["effort"], "high");
+
+        let completed = poll_run_until(&state, &run_id, "scripted workflow completion", |body| {
+            body["run"]["status"] == "completed"
+        })
+        .await;
+        assert_eq!(completed["run"]["arguments"], created["run"]["arguments"]);
+        assert_eq!(completed["steps"][0]["status"], "completed");
+        assert_eq!(
+            completed["steps"][0]["promptId"],
+            format!("workflow:{run_id}:0:0")
+        );
+        assert!(completed["steps"][0]["turnId"]
+            .as_str()
+            .is_some_and(|turn_id| !turn_id.is_empty()));
+        assert!(completed["run"]["sessionId"]
+            .as_str()
+            .is_some_and(|session_id| !session_id.is_empty()));
+        assert_eq!(session_count(&state), 1);
+
+        let requests = read_scripted_requests(&request_log);
+        let methods: Vec<&str> = requests
+            .iter()
+            .filter_map(|request| request["method"].as_str())
+            .collect();
+        assert_eq!(
+            methods
+                .iter()
+                .filter(|method| **method == "session/new")
+                .count(),
+            1
+        );
+        assert_eq!(
+            methods
+                .iter()
+                .filter(|method| **method == "session/set_config_option")
+                .count(),
+            1
+        );
+        assert_eq!(
+            methods
+                .iter()
+                .filter(|method| **method == "session/prompt")
+                .count(),
+            1
+        );
+        let new_index = methods
+            .iter()
+            .position(|method| *method == "session/new")
+            .expect("session/new request");
+        let config_index = methods
+            .iter()
+            .position(|method| *method == "session/set_config_option")
+            .expect("config request");
+        let prompt_index = methods
+            .iter()
+            .position(|method| *method == "session/prompt")
+            .expect("prompt request");
+        assert!(new_index < config_index && config_index < prompt_index);
+        let config = requests
+            .iter()
+            .find(|request| request["method"] == "session/set_config_option")
+            .expect("config request payload");
+        assert_eq!(config["params"]["configId"], "effort");
+        assert_eq!(config["params"]["value"], "high");
+        let prompt = requests
+            .iter()
+            .find(|request| request["method"] == "session/prompt")
+            .expect("prompt request payload");
+        assert_eq!(
+            prompt["params"]["prompt"][0]["text"],
+            "Return PROL-321 attempt 1"
+        );
+
+        let effects_before_replay = requests.len();
+        let sessions_before_replay = session_count(&state);
+        let replay_attempt: Value = serde_json::from_str("1e0").expect("replay number");
+        let (replay_status, replay) = put(
+            &state,
+            &run_id,
+            scripted_v2_body(workspace_id, replay_attempt),
+        )
+        .await;
+        assert_eq!(replay_status, StatusCode::OK);
+        assert_eq!(replay, completed);
+        assert_eq!(session_count(&state), sessions_before_replay);
+        assert_eq!(
+            read_scripted_requests(&request_log).len(),
+            effects_before_replay
+        );
+        let (get_status, after_replay) = get(&state, &run_id).await;
+        assert_eq!(get_status, StatusCode::OK);
+        assert_eq!(after_replay, completed);
+    }
+
+    let _ = std::fs::remove_dir_all(&runtime_home);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn v2_effort_missing_rejected_or_response_error_fails_before_prompt() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+
+    for (case_index, behavior) in ["missing", "rejected", "error"].into_iter().enumerate() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unix timestamp")
+            .as_nanos();
+        let runtime_home = PathBuf::from(format!(
+            "/tmp/anyharness-workflow-effort-{behavior}-{unique}"
+        ));
+        let (agent_program, request_log) = write_scripted_claude_agent(&runtime_home);
+        let _program_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &agent_program);
+        let agent_args = serde_json::to_string(&vec![
+            request_log.to_string_lossy().to_string(),
+            behavior.to_string(),
+        ])
+        .expect("serialize agent args");
+        let _args_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_ARGS_JSON", &agent_args);
+
+        {
+            let state = AppState::new(
+                runtime_home.clone(),
+                "http://127.0.0.1:8457".to_string(),
+                Db::open_in_memory().expect("in-memory db"),
+                false,
+                AgentSeedStore::not_configured_dev(),
+            )
+            .expect("app state");
+            let workspace_id = format!("30000000-0000-4000-8000-00000000004{case_index}");
+            let workspace_dir = runtime_home.join("workspace");
+            std::fs::create_dir_all(&workspace_dir).expect("create workspace directory");
+            test_support::seed_workspace_with_repo_root(
+                &state.db,
+                &workspace_id,
+                "worktree",
+                workspace_dir.to_str().expect("utf-8 workspace path"),
+            );
+            let run_id = uuid::Uuid::new_v4().to_string();
+            let (status, _) = put(&state, &run_id, scripted_v2_body(&workspace_id, json!(1))).await;
+            assert_eq!(status, StatusCode::CREATED, "behavior: {behavior}");
+
+            let failed = poll_run_until(&state, &run_id, "effort apply failure", |body| {
+                body["run"]["status"] == "failed"
+            })
+            .await;
+            assert_eq!(
+                failed["run"]["failureCode"], "session_config_apply_failed",
+                "behavior: {behavior}"
+            );
+            assert_eq!(
+                failed["steps"][0]["failureCode"], "session_config_apply_failed",
+                "behavior: {behavior}"
+            );
+            assert_eq!(session_count(&state), 1, "behavior: {behavior}");
+
+            let requests = read_scripted_requests(&request_log);
+            assert_eq!(
+                requests
+                    .iter()
+                    .filter(|request| request["method"] == "session/new")
+                    .count(),
+                1,
+                "behavior: {behavior}"
+            );
+            assert_eq!(
+                requests
+                    .iter()
+                    .filter(|request| request["method"] == "session/prompt")
+                    .count(),
+                0,
+                "behavior: {behavior}"
+            );
+            let expected_config_requests = usize::from(behavior != "missing");
+            assert_eq!(
+                requests
+                    .iter()
+                    .filter(|request| request["method"] == "session/set_config_option")
+                    .count(),
+                expected_config_requests,
+                "behavior: {behavior}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&runtime_home);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn v2_effort_timeout_fails_durably_before_prompt() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix timestamp")
+        .as_nanos();
+    let runtime_home = PathBuf::from(format!("/tmp/anyharness-workflow-effort-timeout-{unique}"));
+    let (agent_program, request_log) = write_scripted_claude_agent(&runtime_home);
+    let _program_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &agent_program);
+    let agent_args = serde_json::to_string(&vec![
+        request_log.to_string_lossy().to_string(),
+        "timeout".to_string(),
+    ])
+    .expect("serialize agent args");
+    let _args_guard = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_ARGS_JSON", &agent_args);
+
+    {
+        let state = AppState::new(
+            runtime_home.clone(),
+            "http://127.0.0.1:8457".to_string(),
+            Db::open_in_memory().expect("in-memory db"),
+            false,
+            AgentSeedStore::not_configured_dev(),
+        )
+        .expect("app state");
+        let workspace_id = "30000000-0000-4000-8000-000000000043";
+        let workspace_dir = runtime_home.join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace directory");
+        test_support::seed_workspace_with_repo_root(
+            &state.db,
+            workspace_id,
+            "worktree",
+            workspace_dir.to_str().expect("utf-8 workspace path"),
+        );
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let (status, _) = put(&state, &run_id, scripted_v2_body(workspace_id, json!(1))).await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let wall_deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let config_was_sent = request_log.exists()
+                && read_scripted_requests(&request_log)
+                    .iter()
+                    .any(|request| request["method"] == "session/set_config_option");
+            if config_was_sent {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < wall_deadline,
+                "scripted agent never received effort config"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        tokio::time::advance(Duration::from_secs(46)).await;
+        let failed = poll_run_until(&state, &run_id, "effort apply timeout", |body| {
+            body["run"]["status"] == "failed"
+        })
+        .await;
+        assert_eq!(failed["run"]["failureCode"], "session_config_apply_failed");
+        assert_eq!(
+            failed["steps"][0]["failureCode"],
+            "session_config_apply_failed"
+        );
+        assert_eq!(failed["steps"][0]["status"], "failed");
+        let requests = read_scripted_requests(&request_log);
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request["method"] == "session/prompt")
+                .count(),
+            0
+        );
+        assert_eq!(session_count(&state), 1);
+    }
+
+    let _ = std::fs::remove_dir_all(&runtime_home);
+}

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
@@ -23,7 +23,7 @@ use crate::{
 
 const RUN_ID: &str = "11111111-1111-4111-8111-111111111111";
 
-fn test_state() -> AppState {
+pub(super) fn test_state() -> AppState {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("unix timestamp")
@@ -57,7 +57,7 @@ fn valid_body() -> Value {
     })
 }
 
-async fn put(state: &AppState, run_id: &str, body: Value) -> (StatusCode, Value) {
+pub(super) async fn put(state: &AppState, run_id: &str, body: Value) -> (StatusCode, Value) {
     let response = build_router(state.clone())
         .oneshot(
             Request::builder()
@@ -81,7 +81,7 @@ async fn put(state: &AppState, run_id: &str, body: Value) -> (StatusCode, Value)
     (status, payload)
 }
 
-async fn get(state: &AppState, run_id: &str) -> (StatusCode, Value) {
+pub(super) async fn get(state: &AppState, run_id: &str) -> (StatusCode, Value) {
     let response = build_router(state.clone())
         .oneshot(
             Request::builder()
@@ -147,32 +147,6 @@ async fn put_replay_conflict_get_and_not_found() {
     assert_eq!(body["code"], "WORKFLOW_RUN_NOT_FOUND");
 }
 
-#[test]
-fn openapi_documents_model_and_mode_ids_as_required_nullable() {
-    // Spec §3.1/§8.1: modelId/modeId are required keys that may be null, and
-    // the generated OpenAPI (thus the generated SDK) must say so.
-    let doc: Value =
-        serde_json::from_str(&super::openapi::openapi_json()).expect("parse openapi document");
-    let schema = &doc["components"]["schemas"]["WorkflowRunHarnessConfig"];
-    let required: Vec<&str> = schema["required"]
-        .as_array()
-        .expect("required array")
-        .iter()
-        .map(|value| value.as_str().expect("required entry"))
-        .collect();
-    assert!(required.contains(&"agentKind"), "required: {required:?}");
-    assert!(required.contains(&"modelId"), "required: {required:?}");
-    assert!(required.contains(&"modeId"), "required: {required:?}");
-    assert_eq!(
-        schema["properties"]["modelId"]["type"],
-        json!(["string", "null"])
-    );
-    assert_eq!(
-        schema["properties"]["modeId"]["type"],
-        json!(["string", "null"])
-    );
-}
-
 #[tokio::test]
 async fn strict_shape_and_invalid_definitions_return_coded_400() {
     let _lock = test_support::ENV_MUTEX
@@ -221,7 +195,6 @@ async fn strict_shape_and_invalid_definitions_return_coded_400() {
 // ---------------------------------------------------------------------------
 
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -233,8 +206,8 @@ use crate::domains::sessions::extensions::{
     SessionExtension, SessionTurnFinishedContext, SessionTurnOutcome,
 };
 use crate::domains::workflows::model::{
-    workflow_prompt_id, PutWorkflowRunInput, WorkflowDefinition, WorkflowHarnessConfig,
-    WorkflowInput, WorkflowInputType, WorkflowPromptStep, WorkflowStage,
+    workflow_prompt_id, PutWorkflowRunInput, VersionedPutWorkflowRunInput, WorkflowDefinition,
+    WorkflowHarnessConfig, WorkflowInput, WorkflowInputType, WorkflowPromptStep, WorkflowStage,
 };
 use crate::domains::workflows::service::WorkflowRunService;
 use crate::domains::workflows::session_extension::WorkflowRunSessionExtension;
@@ -295,7 +268,7 @@ fn domain_input_for_workspace(workspace_id: &str) -> PutWorkflowRunInput {
 
 /// Poll GET until the predicate holds or a hard deadline expires. Polling is
 /// the proof mechanism; sleeps only pace the polls.
-async fn poll_run_until(
+pub(super) async fn poll_run_until(
     state: &AppState,
     run_id: &str,
     what: &str,
@@ -316,7 +289,7 @@ async fn poll_run_until(
     }
 }
 
-fn session_count(state: &AppState) -> i64 {
+pub(super) fn session_count(state: &AppState) -> i64 {
     state
         .db
         .with_conn(|conn| conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0)))
@@ -701,7 +674,11 @@ async fn dropped_put_future_never_orphans_an_accepted_run() {
     {
         let runtime = state.workflow_run_runtime.clone();
         let put_run_id = run_id.clone();
-        let mut put_future = Box::pin(async move { runtime.put(put_run_id, input).await });
+        let mut put_future = Box::pin(async move {
+            runtime
+                .put(put_run_id, VersionedPutWorkflowRunInput::V1(input))
+                .await
+        });
         let waker = std::task::Waker::noop();
         let mut context = std::task::Context::from_waker(waker);
         // One poll spawns the detached handoff; the no-op waker guarantees the

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -394,6 +394,7 @@ impl AppState {
             workflow_wiring,
             session_runtime.clone(),
             workspace_operation_gate.clone(),
+            workspace_access_gate.clone(),
         );
         let retire_preflight_checker = Arc::new(RetirePreflightChecker::new(
             workspace_runtime.clone(),
@@ -620,6 +621,5 @@ pub fn ensure_runtime_home(path: &std::path::Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 pub(crate) mod test_support;
-
 #[cfg(test)]
 mod tests;

--- a/anyharness/crates/anyharness-lib/src/app/workflows.rs
+++ b/anyharness/crates/anyharness-lib/src/app/workflows.rs
@@ -13,6 +13,7 @@ use crate::domains::workflows::runtime::WorkflowRunRuntime;
 use crate::domains::workflows::service::WorkflowRunService;
 use crate::domains::workflows::session_extension::WorkflowRunSessionExtension;
 use crate::domains::workflows::store::WorkflowRunStore;
+use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationGate;
 use crate::persistence::Db;
 
@@ -54,11 +55,13 @@ pub(super) fn wire_workflow_runtime(
     phase_one: WorkflowWiringPhaseOne,
     session_runtime: Arc<SessionRuntime>,
     operation_gate: Arc<WorkspaceOperationGate>,
+    access_gate: Arc<WorkspaceAccessGate>,
 ) -> Arc<WorkflowRunRuntime> {
     Arc::new(WorkflowRunRuntime::new(
         phase_one.service,
         session_runtime,
         operation_gate,
+        access_gate,
         phase_one.main_handle,
     ))
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/readiness/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/readiness/launch_options.rs
@@ -12,6 +12,15 @@ pub struct ResolvedModelEffort {
     pub default: Option<String>,
 }
 
+/// Internal live-application metadata. This remains separate from `effort` so
+/// public launch-option projection keeps its existing first-control behavior.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedLiveModelEffortCandidate {
+    pub(crate) control_key: String,
+    pub(crate) values: Vec<String>,
+    pub(crate) live_config_id: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct ResolvedLaunchModelOption {
     pub id: String,
@@ -25,6 +34,7 @@ pub struct ResolvedLaunchModelOption {
     pub provider: Option<String>,
     pub status: Option<crate::domains::agents::model::ModelCatalogStatus>,
     pub effort: Option<ResolvedModelEffort>,
+    pub(crate) live_effort_candidates: Vec<ResolvedLiveModelEffortCandidate>,
     pub fast_mode: bool,
     /// The permission/agent modes the model supports (`controls.mode.values`);
     /// `None` when the model declares no mode control (contract §5).

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
@@ -11,15 +11,52 @@ use std::path::Path;
 use super::SessionService;
 use crate::domains::agents::auth::context::{classify, ActiveAuthContexts};
 use crate::domains::agents::auth::launch_facts::collect_launch_env_facts;
-use crate::domains::agents::model::ResolvedAgentStatus;
 use crate::domains::agents::catalog::gateway_resolver;
+use crate::domains::agents::catalog::schema::{
+    AgentCatalogModelControl, AgentCatalogSessionControl,
+};
+use crate::domains::agents::model::ResolvedAgentStatus;
 use crate::domains::agents::readiness::launch_options::{
-    ResolvedLaunchAgentOption, ResolvedLaunchModelOption, ResolvedModelEffort,
-    ResolvedWorkspaceLaunchOptions,
+    ResolvedLaunchAgentOption, ResolvedLaunchModelOption, ResolvedLiveModelEffortCandidate,
+    ResolvedModelEffort, ResolvedWorkspaceLaunchOptions,
 };
 use crate::domains::agents::readiness::service::resolve_launch_agent;
 use crate::domains::agents::registry;
 use crate::domains::workspaces::env::read_materialized_launch_env;
+
+fn projected_model_effort(
+    model_controls: &BTreeMap<String, AgentCatalogModelControl>,
+) -> Option<ResolvedModelEffort> {
+    model_controls
+        .get("effort")
+        .or_else(|| model_controls.get("reasoning_effort"))
+        .map(|control| ResolvedModelEffort {
+            values: control.values.clone(),
+            default: control.observed_value.clone(),
+        })
+}
+
+fn live_model_effort_candidates(
+    model_controls: &BTreeMap<String, AgentCatalogModelControl>,
+    session_controls: &[AgentCatalogSessionControl],
+) -> Vec<ResolvedLiveModelEffortCandidate> {
+    ["effort", "reasoning_effort"]
+        .iter()
+        .filter_map(|key| {
+            let control = model_controls.get(*key)?;
+            let live_config_id = session_controls
+                .iter()
+                .find(|candidate| candidate.key == *key)
+                .and_then(|candidate| candidate.mapping.as_ref())
+                .and_then(|mapping| mapping.live_config_id.clone())?;
+            Some(ResolvedLiveModelEffortCandidate {
+                control_key: (*key).to_string(),
+                values: control.values.clone(),
+                live_config_id,
+            })
+        })
+        .collect()
+}
 
 impl SessionService {
     /// Is `value` a model this SESSION may switch to live? The catalog is
@@ -106,14 +143,11 @@ impl SessionService {
                         provider: gateway_resolver::provider_for_model(&model.id)
                             .map(str::to_string),
                         status: Some(model.status),
-                        effort: model
-                            .controls
-                            .get("effort")
-                            .or_else(|| model.controls.get("reasoning_effort"))
-                            .map(|control| ResolvedModelEffort {
-                                values: control.values.clone(),
-                                default: control.observed_value.clone(),
-                            }),
+                        effort: projected_model_effort(&model.controls),
+                        live_effort_candidates: live_model_effort_candidates(
+                            &model.controls,
+                            &agent.session.controls,
+                        ),
                         fast_mode: model.controls.contains_key("fast_mode"),
                         modes: model
                             .controls
@@ -125,5 +159,65 @@ impl SessionService {
         }
 
         Ok(ResolvedWorkspaceLaunchOptions { agents })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::catalog::schema::AgentCatalogControlMapping;
+
+    fn model_control(value: &str) -> AgentCatalogModelControl {
+        AgentCatalogModelControl {
+            values: vec![value.to_string()],
+            default: None,
+            observed_value: Some(value.to_string()),
+        }
+    }
+
+    fn session_control(key: &str, live_config_id: Option<&str>) -> AgentCatalogSessionControl {
+        AgentCatalogSessionControl {
+            key: key.to_string(),
+            label: None,
+            values: Vec::new(),
+            mapping: Some(AgentCatalogControlMapping {
+                create_field: None,
+                live_config_id: live_config_id.map(str::to_string),
+                switch_via: None,
+                variant_syntax: None,
+                missing_live_config_policy: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn public_effort_projection_is_unchanged_while_live_candidates_skip_unmapped_keys() {
+        let model_controls = BTreeMap::from([
+            ("effort".to_string(), model_control("high")),
+            ("reasoning_effort".to_string(), model_control("xhigh")),
+        ]);
+        let mut session_controls = vec![
+            session_control("effort", None),
+            session_control("reasoning_effort", Some("reasoning_effort")),
+        ];
+
+        let projected = projected_model_effort(&model_controls).expect("public projection");
+        assert_eq!(projected.values, vec!["high"]);
+        assert_eq!(projected.default.as_deref(), Some("high"));
+
+        let candidates = live_model_effort_candidates(&model_controls, &session_controls);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].control_key, "reasoning_effort");
+        assert_eq!(candidates[0].values, vec!["xhigh"]);
+        assert_eq!(candidates[0].live_config_id, "reasoning_effort");
+
+        session_controls[1].mapping = None;
+        assert!(live_model_effort_candidates(&model_controls, &session_controls).is_empty());
+        assert_eq!(
+            projected_model_effort(&model_controls)
+                .expect("public projection remains")
+                .values,
+            vec!["high"]
+        );
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/mod.rs
@@ -4,10 +4,15 @@
 //! than a sessions subdomain.
 
 pub mod model;
+mod portable_service;
+mod portable_validation;
+pub mod resolution;
 pub mod runtime;
 pub mod service;
 pub mod session_extension;
 pub mod store;
 
+#[cfg(test)]
+mod portable_service_tests;
 #[cfg(test)]
 mod service_tests;

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
@@ -95,6 +95,7 @@ pub enum WorkflowRunFailureCode {
     SessionTurnFailed,
     SessionTurnCancelled,
     RuntimeRestarted,
+    SessionConfigApplyFailed,
 }
 
 impl WorkflowRunFailureCode {
@@ -107,6 +108,7 @@ impl WorkflowRunFailureCode {
             Self::SessionTurnFailed => "session_turn_failed",
             Self::SessionTurnCancelled => "session_turn_cancelled",
             Self::RuntimeRestarted => "runtime_restarted",
+            Self::SessionConfigApplyFailed => "session_config_apply_failed",
         }
     }
 
@@ -119,6 +121,7 @@ impl WorkflowRunFailureCode {
             "session_turn_failed" => Some(Self::SessionTurnFailed),
             "session_turn_cancelled" => Some(Self::SessionTurnCancelled),
             "runtime_restarted" => Some(Self::RuntimeRestarted),
+            "session_config_apply_failed" => Some(Self::SessionConfigApplyFailed),
             _ => None,
         }
     }
@@ -170,6 +173,7 @@ pub struct WorkflowRunRecord {
     pub id: String,
     pub schema_version: i64,
     pub invocation_json: String,
+    pub resolved_plan_json: Option<String>,
     pub status: WorkflowRunStatus,
     pub workspace_id: String,
     pub session_id: Option<String>,
@@ -280,6 +284,111 @@ pub struct WorkflowRunInvocation {
     pub workspace_id: String,
     pub definition: WorkflowDefinition,
     pub arguments: BTreeMap<String, WorkflowArgumentValue>,
+}
+
+/// Schema-v2 portable model intent. Resolution produces one concrete model
+/// before the durable acceptance transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum WorkflowModelSelection {
+    TargetDefault,
+    Exact {
+        #[serde(rename = "modelId")]
+        model_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkflowPermissionPolicy {
+    WorkflowDefault,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowHarnessConfigV2 {
+    pub agent_kind: String,
+    pub model_selection: WorkflowModelSelection,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    pub permission_policy: WorkflowPermissionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowStageV2 {
+    pub harness_config: WorkflowHarnessConfigV2,
+    pub steps: Vec<WorkflowPromptStep>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowDefinitionV2 {
+    pub inputs: Vec<WorkflowInput>,
+    pub stages: Vec<WorkflowStageV2>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PutWorkflowRunInputV2 {
+    pub schema_version: i64,
+    pub workspace_id: String,
+    pub definition: WorkflowDefinitionV2,
+    pub arguments: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub enum VersionedPutWorkflowRunInput {
+    V1(PutWorkflowRunInput),
+    V2(PutWorkflowRunInputV2),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunStoredSourceV2 {
+    pub workspace_id: String,
+    pub definition: WorkflowDefinitionV2,
+    pub arguments: BTreeMap<String, WorkflowArgumentValue>,
+}
+
+impl WorkflowRunStoredSourceV2 {
+    pub fn to_canonical_json(&self) -> serde_json::Result<String> {
+        serde_jcs::to_string(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VersionedWorkflowRunStoredSource {
+    V1(WorkflowRunInvocation),
+    V2(WorkflowRunStoredSourceV2),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowResolvedEffortConfig {
+    pub config_id: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowResolvedPlanV2 {
+    pub workspace_id: String,
+    pub agent_kind: String,
+    pub model_id: String,
+    pub mode_id: String,
+    pub effort_config: Option<WorkflowResolvedEffortConfig>,
+    pub rendered_prompt: String,
+    pub prompt_id: String,
+}
+
+impl WorkflowResolvedPlanV2 {
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
 }
 
 impl WorkflowRunInvocation {

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/portable_service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/portable_service.rs
@@ -1,0 +1,210 @@
+//! Schema-v2 portable workflow acceptance and durable read composition.
+//! Execution remains on the single [`WorkflowRunRuntime`](super::runtime::WorkflowRunRuntime)
+//! facade; this module only extends the existing synchronous service/store.
+
+use crate::domains::workflows::model::{
+    workflow_prompt_id, PutWorkflowRunInputV2, WorkflowResolvedPlanV2, WorkflowRunInvocation,
+    WorkflowRunRecord, WorkflowRunStatus, WorkflowRunStepRecord, WorkflowRunStoredSourceV2,
+    WorkflowStepStatus,
+};
+use crate::domains::workflows::portable_validation::{
+    render_source_prompt_v2, validate_invocation_v2,
+};
+use crate::domains::workflows::service::{
+    WorkflowRunService, WorkflowRunValidationError, WorkflowRunView, WorkflowServiceError,
+};
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRunViewV2 {
+    pub run: WorkflowRunRecord,
+    pub source: WorkflowRunStoredSourceV2,
+    pub resolved_plan: WorkflowResolvedPlanV2,
+    pub steps: Vec<WorkflowRunStepRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub enum VersionedWorkflowRunView {
+    V1(WorkflowRunView),
+    V2(WorkflowRunViewV2),
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedWorkflowRunV2 {
+    pub run_id: String,
+    pub source: WorkflowRunStoredSourceV2,
+    pub source_json: String,
+    pub prompt_id: String,
+}
+
+#[derive(Debug)]
+pub enum InspectV2Outcome {
+    Missing(PreparedWorkflowRunV2),
+    ExactReplay(WorkflowRunViewV2),
+    Conflict,
+}
+
+#[derive(Debug)]
+pub enum AcceptV2Outcome {
+    Created {
+        plan: WorkflowResolvedPlanV2,
+        view: WorkflowRunViewV2,
+    },
+    ExactReplay(WorkflowRunViewV2),
+    Conflict,
+}
+
+impl WorkflowRunService {
+    /// Normalize schema-v2 portable intent before any launch-option or access
+    /// lookup. The returned canonical source is the complete replay identity.
+    pub fn prepare_v2(
+        &self,
+        run_id: &str,
+        input: PutWorkflowRunInputV2,
+    ) -> Result<PreparedWorkflowRunV2, WorkflowRunValidationError> {
+        let validated = validate_invocation_v2(run_id, &input)?;
+        let source_json = validated
+            .source
+            .to_canonical_json()
+            .map_err(|_| WorkflowRunValidationError::NonPortableNumber)?;
+        let source = serde_json::from_str(&source_json)
+            .map_err(|_| WorkflowRunValidationError::NonPortableNumber)?;
+        Ok(PreparedWorkflowRunV2 {
+            run_id: run_id.to_string(),
+            source,
+            source_json,
+            prompt_id: workflow_prompt_id(run_id),
+        })
+    }
+
+    /// Render and validate the portable prompt only after target access and
+    /// target resolution have succeeded. Exact replay never calls this seam.
+    pub fn render_v2(
+        &self,
+        prepared: &PreparedWorkflowRunV2,
+    ) -> Result<String, WorkflowRunValidationError> {
+        render_source_prompt_v2(&prepared.source)
+    }
+
+    /// Read-before-resolve replay gate. An existing exact v2 source returns
+    /// its stored concrete plan without consulting workspace launch options.
+    pub fn inspect_v2(
+        &self,
+        prepared: PreparedWorkflowRunV2,
+    ) -> Result<InspectV2Outcome, WorkflowServiceError> {
+        let Some((run, steps)) = self.store.get(&prepared.run_id)? else {
+            return Ok(InspectV2Outcome::Missing(prepared));
+        };
+        if run.schema_version != 2 || run.invocation_json != prepared.source_json {
+            return Ok(InspectV2Outcome::Conflict);
+        }
+        Ok(InspectV2Outcome::ExactReplay(parse_v2_view(run, steps)?))
+    }
+
+    /// Atomically accept source + resolved plan + materialized step. A race
+    /// winner's already-stored plan is returned on exact replay.
+    pub fn accept_v2(
+        &self,
+        prepared: PreparedWorkflowRunV2,
+        plan: WorkflowResolvedPlanV2,
+    ) -> Result<AcceptV2Outcome, WorkflowServiceError> {
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let resolved_plan_json = plan
+            .to_json()
+            .map_err(|error| WorkflowServiceError::Store(error.into()))?;
+        let run = WorkflowRunRecord {
+            id: prepared.run_id.clone(),
+            schema_version: 2,
+            invocation_json: prepared.source_json,
+            resolved_plan_json: Some(resolved_plan_json),
+            status: WorkflowRunStatus::Accepted,
+            workspace_id: prepared.source.workspace_id.clone(),
+            session_id: None,
+            failure_code: None,
+            created_at: created_at.clone(),
+            updated_at: created_at.clone(),
+            started_at: None,
+            finished_at: None,
+        };
+        let step = WorkflowRunStepRecord {
+            run_id: prepared.run_id,
+            stage_index: 0,
+            step_index: 0,
+            status: WorkflowStepStatus::Pending,
+            prompt_id: plan.prompt_id.clone(),
+            turn_id: None,
+            failure_code: None,
+            created_at: created_at.clone(),
+            updated_at: created_at,
+            started_at: None,
+            finished_at: None,
+        };
+
+        match self.store.accept(&run, &step)? {
+            crate::domains::workflows::store::StoreAcceptOutcome::Created => {
+                Ok(AcceptV2Outcome::Created {
+                    plan: plan.clone(),
+                    view: WorkflowRunViewV2 {
+                        run,
+                        source: prepared.source,
+                        resolved_plan: plan,
+                        steps: vec![step],
+                    },
+                })
+            }
+            crate::domains::workflows::store::StoreAcceptOutcome::ExactReplay { run, steps } => {
+                Ok(AcceptV2Outcome::ExactReplay(parse_v2_view(run, steps)?))
+            }
+            crate::domains::workflows::store::StoreAcceptOutcome::Conflict => {
+                Ok(AcceptV2Outcome::Conflict)
+            }
+        }
+    }
+
+    pub fn get_versioned(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<VersionedWorkflowRunView>, WorkflowServiceError> {
+        let Some((run, steps)) = self.store.get(run_id)? else {
+            return Ok(None);
+        };
+        match run.schema_version {
+            1 => {
+                let invocation =
+                    serde_json::from_str::<WorkflowRunInvocation>(&run.invocation_json)
+                        .map_err(|error| WorkflowServiceError::Store(error.into()))?;
+                Ok(Some(VersionedWorkflowRunView::V1(WorkflowRunView {
+                    run,
+                    invocation,
+                    steps,
+                })))
+            }
+            2 => Ok(Some(VersionedWorkflowRunView::V2(parse_v2_view(
+                run, steps,
+            )?))),
+            version => Err(WorkflowServiceError::Store(anyhow::anyhow!(
+                "unsupported stored workflow schema version {version}"
+            ))),
+        }
+    }
+}
+
+fn parse_v2_view(
+    run: WorkflowRunRecord,
+    steps: Vec<WorkflowRunStepRecord>,
+) -> Result<WorkflowRunViewV2, WorkflowServiceError> {
+    let source = serde_json::from_str::<WorkflowRunStoredSourceV2>(&run.invocation_json)
+        .map_err(|error| WorkflowServiceError::Store(error.into()))?;
+    let plan_json = run.resolved_plan_json.as_deref().ok_or_else(|| {
+        WorkflowServiceError::Store(anyhow::anyhow!(
+            "schema-v2 workflow run has no resolved plan"
+        ))
+    })?;
+    let resolved_plan = serde_json::from_str::<WorkflowResolvedPlanV2>(plan_json)
+        .map_err(|error| WorkflowServiceError::Store(error.into()))?;
+    Ok(WorkflowRunViewV2 {
+        run,
+        source,
+        resolved_plan,
+        steps,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/portable_service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/portable_service_tests.rs
@@ -1,0 +1,233 @@
+//! Schema-v2 portable source, plan, and concurrency tests.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Barrier};
+
+use serde_json::{json, Value};
+
+use super::model::{
+    workflow_prompt_id, PutWorkflowRunInputV2, WorkflowDefinitionV2, WorkflowHarnessConfigV2,
+    WorkflowInput, WorkflowInputType, WorkflowModelSelection, WorkflowPermissionPolicy,
+    WorkflowPromptStep, WorkflowResolvedEffortConfig, WorkflowResolvedPlanV2, WorkflowStageV2,
+};
+use super::service::{
+    AcceptV2Outcome, InspectV2Outcome, VersionedWorkflowRunView, WorkflowRunService,
+    WorkflowRunValidationError,
+};
+use super::store::WorkflowRunStore;
+use crate::persistence::Db;
+
+const WORKSPACE: &str = "20000000-0000-4000-8000-000000000002";
+
+fn service() -> WorkflowRunService {
+    WorkflowRunService::new(WorkflowRunStore::new(
+        Db::open_in_memory().expect("in-memory db"),
+    ))
+}
+
+fn new_run_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+fn valid_input(number: Value) -> PutWorkflowRunInputV2 {
+    PutWorkflowRunInputV2 {
+        schema_version: 2,
+        workspace_id: WORKSPACE.to_string(),
+        definition: WorkflowDefinitionV2 {
+            inputs: vec![
+                WorkflowInput {
+                    name: "ticket".to_string(),
+                    input_type: WorkflowInputType::String,
+                    required: true,
+                },
+                WorkflowInput {
+                    name: "attempt".to_string(),
+                    input_type: WorkflowInputType::Number,
+                    required: true,
+                },
+            ],
+            stages: vec![WorkflowStageV2 {
+                harness_config: WorkflowHarnessConfigV2 {
+                    agent_kind: "claude".to_string(),
+                    model_selection: WorkflowModelSelection::Exact {
+                        model_id: "claude-sonnet-4-5".to_string(),
+                    },
+                    effort: Some("high".to_string()),
+                    permission_policy: WorkflowPermissionPolicy::WorkflowDefault,
+                },
+                steps: vec![WorkflowPromptStep {
+                    kind: "agent.prompt".to_string(),
+                    prompt: "Investigate {{inputs.ticket}} attempt {{inputs.attempt}}".to_string(),
+                }],
+            }],
+        },
+        arguments: BTreeMap::from([
+            ("ticket".to_string(), json!("PROL-123")),
+            ("attempt".to_string(), number),
+        ]),
+    }
+}
+
+fn resolved_plan(run_id: &str, rendered_prompt: &str) -> WorkflowResolvedPlanV2 {
+    WorkflowResolvedPlanV2 {
+        workspace_id: WORKSPACE.to_string(),
+        agent_kind: "claude".to_string(),
+        model_id: "claude-sonnet-4-5".to_string(),
+        mode_id: "bypassPermissions".to_string(),
+        effort_config: Some(WorkflowResolvedEffortConfig {
+            config_id: "effort".to_string(),
+            value: "high".to_string(),
+        }),
+        rendered_prompt: rendered_prompt.to_string(),
+        prompt_id: workflow_prompt_id(run_id),
+    }
+}
+
+#[test]
+fn portable_fixture_numbers_follow_rfc8785_and_safe_integer_rules() {
+    let fixture: Value = serde_json::from_str(include_str!(
+        "../../../../../../fixtures/contracts/workflow-portable-execution/v1.json"
+    ))
+    .expect("portable workflow fixture");
+    for case in fixture["canonicalNumberCases"]
+        .as_array()
+        .expect("canonical cases")
+    {
+        let source = case["source"].as_str().expect("source");
+        let number: Value = serde_json::from_str(source).expect("number source");
+        assert_eq!(
+            serde_jcs::to_string(&number).expect("RFC8785 canonical number"),
+            case["canonical"].as_str().expect("canonical"),
+            "source {source}"
+        );
+        let result = service().prepare_v2(&new_run_id(), valid_input(number));
+        if case["portable"] == true {
+            assert!(result.is_ok(), "portable source rejected: {source}");
+        } else {
+            assert!(matches!(
+                result,
+                Err(WorkflowRunValidationError::NonPortableNumber)
+            ));
+        }
+    }
+}
+
+#[test]
+fn source_replay_is_canonical_and_returns_the_stored_plan() {
+    let service = service();
+    let run_id = new_run_id();
+    let prepared = service
+        .prepare_v2(&run_id, valid_input(serde_json::from_str("1.0").unwrap()))
+        .expect("prepare v2");
+    assert!(matches!(
+        service
+            .inspect_v2(prepared.clone())
+            .expect("inspect missing"),
+        InspectV2Outcome::Missing(_)
+    ));
+    let rendered = service.render_v2(&prepared).expect("render v2");
+    assert_eq!(rendered, "Investigate PROL-123 attempt 1");
+    let stored_plan = resolved_plan(&run_id, &rendered);
+    let created = match service
+        .accept_v2(prepared, stored_plan.clone())
+        .expect("accept v2")
+    {
+        AcceptV2Outcome::Created { view, .. } => view,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let equivalent = service
+        .prepare_v2(&run_id, valid_input(serde_json::from_str("1e0").unwrap()))
+        .expect("prepare equivalent");
+    let InspectV2Outcome::ExactReplay(replay) =
+        service.inspect_v2(equivalent).expect("inspect replay")
+    else {
+        panic!("expected exact replay");
+    };
+    assert_eq!(replay.resolved_plan, stored_plan);
+    assert_eq!(created.source, replay.source);
+    assert_eq!(
+        created.source.to_canonical_json().expect("created source"),
+        replay.source.to_canonical_json().expect("replay source")
+    );
+    let Some(VersionedWorkflowRunView::V2(loaded)) =
+        service.get_versioned(&run_id).expect("get v2")
+    else {
+        panic!("expected stored v2 view");
+    };
+    assert_eq!(loaded.source, created.source);
+}
+
+#[test]
+fn replay_gate_precedes_prompt_rendering() {
+    let service = service();
+    let run_id = new_run_id();
+    let mut input = valid_input(json!(1));
+    input.definition.stages[0].steps[0].prompt = "{{inputs.missing}}".to_string();
+    let prepared = service
+        .prepare_v2(&run_id, input)
+        .expect("source normalization does not render");
+    assert!(matches!(
+        service.inspect_v2(prepared.clone()).expect("inspect"),
+        InspectV2Outcome::Missing(_)
+    ));
+    assert!(matches!(
+        service.render_v2(&prepared),
+        Err(WorkflowRunValidationError::UnknownPortableTemplateReference)
+    ));
+}
+
+#[test]
+fn input_names_must_start_with_a_letter() {
+    let mut input = valid_input(json!(1));
+    input.definition.inputs[0].name = "_ticket".to_string();
+    input.arguments.remove("ticket");
+    input.arguments.insert("_ticket".to_string(), json!("x"));
+    assert!(matches!(
+        service().prepare_v2(&new_run_id(), input),
+        Err(WorkflowRunValidationError::InvalidInputName(_))
+    ));
+}
+
+#[test]
+fn concurrent_acceptance_has_one_winner_and_one_stored_plan() {
+    let service = Arc::new(service());
+    let run_id = new_run_id();
+    let barrier = Arc::new(Barrier::new(8));
+    let handles: Vec<_> = (0..8)
+        .map(|index| {
+            let service = service.clone();
+            let run_id = run_id.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                let prepared = service
+                    .prepare_v2(&run_id, valid_input(json!(1)))
+                    .expect("prepare");
+                let rendered = service.render_v2(&prepared).expect("render");
+                let mut plan = resolved_plan(&run_id, &rendered);
+                plan.model_id = format!("candidate-{index}");
+                barrier.wait();
+                service.accept_v2(prepared, plan).expect("accept")
+            })
+        })
+        .collect();
+    let mut created = 0;
+    let mut model_ids = Vec::new();
+    for handle in handles {
+        match handle.join().expect("join") {
+            AcceptV2Outcome::Created { view, .. } => {
+                created += 1;
+                model_ids.push(view.resolved_plan.model_id);
+            }
+            AcceptV2Outcome::ExactReplay(view) => model_ids.push(view.resolved_plan.model_id),
+            AcceptV2Outcome::Conflict => panic!("same canonical source must replay"),
+        }
+    }
+    assert_eq!(created, 1);
+    assert_eq!(
+        model_ids
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        1
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/portable_validation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/portable_validation.rs
@@ -1,0 +1,227 @@
+//! Schema-v2 portable workflow validation and prompt rendering. This is a
+//! narrow split from the synchronous workflow service so the service stays
+//! within the repository size limit; it owns no IO, persistence, resolution,
+//! or execution behavior.
+
+use std::collections::BTreeMap;
+
+use crate::domains::workflows::model::{
+    PutWorkflowRunInputV2, WorkflowArgumentValue, WorkflowInputType, WorkflowModelSelection,
+    WorkflowRunStoredSourceV2,
+};
+
+use super::service::{coerce_argument, validate_run_id, WorkflowRunValidationError};
+
+const AGENT_PROMPT_STEP_KIND: &str = "agent.prompt";
+const MAX_RENDERED_PROMPT_BYTES: usize = 16_384;
+const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+
+pub(super) struct ValidatedInvocationV2 {
+    pub(super) source: WorkflowRunStoredSourceV2,
+}
+
+pub(super) fn validate_invocation_v2(
+    run_id: &str,
+    input: &PutWorkflowRunInputV2,
+) -> Result<ValidatedInvocationV2, WorkflowRunValidationError> {
+    validate_run_id(run_id)?;
+    if input.schema_version != 2 {
+        return Err(WorkflowRunValidationError::UnsupportedSchemaVersion(
+            input.schema_version,
+        ));
+    }
+    if input.workspace_id.trim().is_empty() {
+        return Err(WorkflowRunValidationError::BlankWorkspaceId);
+    }
+    if input.definition.stages.len() != 1 {
+        return Err(WorkflowRunValidationError::StageCount(
+            input.definition.stages.len(),
+        ));
+    }
+    let stage = &input.definition.stages[0];
+    if stage.steps.len() != 1 {
+        return Err(WorkflowRunValidationError::StepCount(stage.steps.len()));
+    }
+    let step = &stage.steps[0];
+    if step.kind != AGENT_PROMPT_STEP_KIND {
+        return Err(WorkflowRunValidationError::UnsupportedStepKind(
+            step.kind.clone(),
+        ));
+    }
+
+    let harness = &stage.harness_config;
+    if harness.agent_kind.trim().is_empty() {
+        return Err(WorkflowRunValidationError::BlankAgentKind);
+    }
+    if harness.agent_kind.trim() != harness.agent_kind {
+        return Err(WorkflowRunValidationError::AgentKindSurroundingWhitespace);
+    }
+    if let WorkflowModelSelection::Exact { model_id } = &harness.model_selection {
+        if model_id.trim().is_empty() {
+            return Err(WorkflowRunValidationError::BlankModelId);
+        }
+    }
+    if let Some(effort) = &harness.effort {
+        if effort.trim().is_empty() {
+            return Err(WorkflowRunValidationError::BlankEffort);
+        }
+        if !matches!(
+            harness.model_selection,
+            WorkflowModelSelection::Exact { .. }
+        ) {
+            return Err(WorkflowRunValidationError::EffortRequiresExactModel);
+        }
+    }
+
+    let mut declared = BTreeMap::new();
+    for input_decl in &input.definition.inputs {
+        if input_decl.name.trim().is_empty() {
+            return Err(WorkflowRunValidationError::BlankInputName);
+        }
+        if !is_identifier(&input_decl.name) {
+            return Err(WorkflowRunValidationError::InvalidInputName(
+                input_decl.name.clone(),
+            ));
+        }
+        if declared
+            .insert(input_decl.name.clone(), input_decl.input_type)
+            .is_some()
+        {
+            return Err(WorkflowRunValidationError::DuplicateInputName(
+                input_decl.name.clone(),
+            ));
+        }
+    }
+
+    let mut arguments = BTreeMap::new();
+    for (name, value) in &input.arguments {
+        let Some(declared_type) = declared.get(name) else {
+            return Err(WorkflowRunValidationError::UndeclaredArgument(name.clone()));
+        };
+        let typed = coerce_argument(name, value, *declared_type)?;
+        ensure_portable_number(&typed)?;
+        arguments.insert(name.clone(), typed);
+    }
+    for input_decl in &input.definition.inputs {
+        if input_decl.required && !arguments.contains_key(&input_decl.name) {
+            return Err(WorkflowRunValidationError::MissingRequiredArgument(
+                input_decl.name.clone(),
+            ));
+        }
+    }
+
+    Ok(ValidatedInvocationV2 {
+        source: WorkflowRunStoredSourceV2 {
+            workspace_id: input.workspace_id.clone(),
+            definition: input.definition.clone(),
+            arguments,
+        },
+    })
+}
+
+pub(super) fn render_source_prompt_v2(
+    source: &WorkflowRunStoredSourceV2,
+) -> Result<String, WorkflowRunValidationError> {
+    let declared = source
+        .definition
+        .inputs
+        .iter()
+        .map(|input| (input.name.clone(), input.input_type))
+        .collect();
+    let prompt = &source.definition.stages[0].steps[0].prompt;
+    let rendered = render_prompt(prompt, &declared, &source.arguments)?;
+    if rendered.trim().is_empty() {
+        return Err(WorkflowRunValidationError::BlankRenderedPrompt);
+    }
+    if rendered.len() > MAX_RENDERED_PROMPT_BYTES {
+        return Err(WorkflowRunValidationError::RenderedPromptTooLarge(
+            rendered.len(),
+        ));
+    }
+    Ok(rendered)
+}
+
+fn render_prompt(
+    prompt: &str,
+    declared: &BTreeMap<String, WorkflowInputType>,
+    arguments: &BTreeMap<String, WorkflowArgumentValue>,
+) -> Result<String, WorkflowRunValidationError> {
+    const OPEN: &str = "{{";
+    const CLOSE: &str = "}}";
+    let mut rendered = String::with_capacity(prompt.len());
+    let mut rest = prompt;
+
+    while let Some(open_idx) = rest.find(OPEN) {
+        if rest[..open_idx].contains(CLOSE) {
+            return Err(WorkflowRunValidationError::MalformedTemplate);
+        }
+        rendered.push_str(&rest[..open_idx]);
+        let after_open = &rest[open_idx + OPEN.len()..];
+        let Some(close_idx) = after_open.find(CLOSE) else {
+            return Err(WorkflowRunValidationError::MalformedTemplate);
+        };
+        let inner = &after_open[..close_idx];
+        let Some(name) = inner.strip_prefix("inputs.") else {
+            return Err(WorkflowRunValidationError::UnknownPortableTemplateReference);
+        };
+        if name.is_empty() || !declared.contains_key(name) {
+            return Err(WorkflowRunValidationError::UnknownPortableTemplateReference);
+        }
+        let Some(value) = arguments.get(name) else {
+            return Err(WorkflowRunValidationError::MissingReferencedArgument(
+                name.to_string(),
+            ));
+        };
+        rendered.push_str(&render_value(value)?);
+        rest = &after_open[close_idx + CLOSE.len()..];
+    }
+    if rest.contains(CLOSE) {
+        return Err(WorkflowRunValidationError::MalformedTemplate);
+    }
+    rendered.push_str(rest);
+    Ok(rendered)
+}
+
+fn render_value(value: &WorkflowArgumentValue) -> Result<String, WorkflowRunValidationError> {
+    match value {
+        WorkflowArgumentValue::String(text) => Ok(text.clone()),
+        WorkflowArgumentValue::Bool(flag) => Ok(if *flag { "true" } else { "false" }.to_string()),
+        WorkflowArgumentValue::Number(number) => {
+            serde_jcs::to_string(number).map_err(|_| WorkflowRunValidationError::NonPortableNumber)
+        }
+    }
+}
+
+fn ensure_portable_number(value: &WorkflowArgumentValue) -> Result<(), WorkflowRunValidationError> {
+    let WorkflowArgumentValue::Number(number) = value else {
+        return Ok(());
+    };
+    if let Some(integer) = number.as_i64() {
+        if !(-MAX_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&integer) {
+            return Err(WorkflowRunValidationError::NonPortableNumber);
+        }
+        return Ok(());
+    }
+    if let Some(integer) = number.as_u64() {
+        if integer > MAX_SAFE_INTEGER as u64 {
+            return Err(WorkflowRunValidationError::NonPortableNumber);
+        }
+        return Ok(());
+    }
+    if let Some(float) = number.as_f64().filter(|float| float.is_finite()) {
+        if float.fract() == 0.0 && float.abs() > MAX_SAFE_INTEGER as f64 {
+            return Err(WorkflowRunValidationError::NonPortableNumber);
+        }
+        return Ok(());
+    }
+    Err(WorkflowRunValidationError::NonPortableNumber)
+}
+
+fn is_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/resolution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/resolution.rs
@@ -1,0 +1,293 @@
+//! Pure target resolution for schema-v2 workflow intent. Live launch options
+//! are fetched by the runtime; this module makes the workflow-owned model,
+//! mode, and effort decision without IO or session side effects.
+
+use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
+use crate::domains::workflows::model::{
+    WorkflowHarnessConfigV2, WorkflowModelSelection, WorkflowResolvedEffortConfig,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowResolutionError {
+    AgentUnavailable,
+    ModelUnavailable,
+    ModeUnavailable,
+    EffortUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowResolvedTargetV2 {
+    pub agent_kind: String,
+    pub model_id: String,
+    pub mode_id: String,
+    pub effort_config: Option<WorkflowResolvedEffortConfig>,
+}
+
+pub fn resolve_workflow_target(
+    options: &ResolvedWorkspaceLaunchOptions,
+    harness: &WorkflowHarnessConfigV2,
+) -> Result<WorkflowResolvedTargetV2, WorkflowResolutionError> {
+    let agent = options
+        .agents
+        .iter()
+        .find(|candidate| candidate.kind == harness.agent_kind)
+        .ok_or(WorkflowResolutionError::AgentUnavailable)?;
+
+    let model_id = match &harness.model_selection {
+        WorkflowModelSelection::Exact { model_id } => model_id.clone(),
+        WorkflowModelSelection::TargetDefault => agent
+            .default_model_id
+            .clone()
+            .ok_or(WorkflowResolutionError::ModelUnavailable)?,
+    };
+    let model = agent
+        .models
+        .iter()
+        .find(|candidate| candidate.id == model_id)
+        .ok_or(WorkflowResolutionError::ModelUnavailable)?;
+
+    let mode_id = match harness.agent_kind.as_str() {
+        "claude" => "bypassPermissions",
+        "codex" => "full-access",
+        _ => return Err(WorkflowResolutionError::ModeUnavailable),
+    };
+    if !model
+        .modes
+        .as_ref()
+        .is_some_and(|modes| modes.iter().any(|mode| mode == mode_id))
+    {
+        return Err(WorkflowResolutionError::ModeUnavailable);
+    }
+
+    let effort_config = match &harness.effort {
+        None => None,
+        Some(value) => {
+            if !matches!(
+                harness.model_selection,
+                WorkflowModelSelection::Exact { .. }
+            ) {
+                return Err(WorkflowResolutionError::EffortUnavailable);
+            }
+            let effort = ["effort", "reasoning_effort"]
+                .iter()
+                .find_map(|key| {
+                    model
+                        .live_effort_candidates
+                        .iter()
+                        .find(|candidate| candidate.control_key == *key)
+                })
+                .filter(|effort| effort.values.iter().any(|candidate| candidate == value))
+                .ok_or(WorkflowResolutionError::EffortUnavailable)?;
+            Some(WorkflowResolvedEffortConfig {
+                config_id: effort.live_config_id.clone(),
+                value: value.clone(),
+            })
+        }
+    };
+
+    Ok(WorkflowResolvedTargetV2 {
+        agent_kind: harness.agent_kind.clone(),
+        model_id,
+        mode_id: mode_id.to_string(),
+        effort_config,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::readiness::launch_options::{
+        ResolvedLaunchAgentOption, ResolvedLaunchModelOption, ResolvedLiveModelEffortCandidate,
+        ResolvedModelEffort,
+    };
+    use crate::domains::workflows::model::WorkflowPermissionPolicy;
+
+    fn model(
+        id: &str,
+        modes: &[&str],
+        effort: Option<(&[&str], Option<&str>)>,
+    ) -> ResolvedLaunchModelOption {
+        ResolvedLaunchModelOption {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            aliases: Vec::new(),
+            is_default: false,
+            default_opt_in: None,
+            description: None,
+            provider: None,
+            status: None,
+            effort: effort.map(|(values, _)| ResolvedModelEffort {
+                values: values.iter().map(|value| (*value).to_string()).collect(),
+                default: None,
+            }),
+            live_effort_candidates: effort
+                .and_then(|(values, config_id)| {
+                    config_id.map(|config_id| ResolvedLiveModelEffortCandidate {
+                        control_key: "effort".to_string(),
+                        values: values.iter().map(|value| (*value).to_string()).collect(),
+                        live_config_id: config_id.to_string(),
+                    })
+                })
+                .into_iter()
+                .collect(),
+            fast_mode: false,
+            modes: Some(modes.iter().map(|mode| (*mode).to_string()).collect()),
+        }
+    }
+
+    fn options() -> ResolvedWorkspaceLaunchOptions {
+        ResolvedWorkspaceLaunchOptions {
+            agents: vec![
+                ResolvedLaunchAgentOption {
+                    kind: "claude".to_string(),
+                    display_name: "Claude".to_string(),
+                    default_model_id: Some("sonnet".to_string()),
+                    models: vec![model(
+                        "sonnet",
+                        &["bypassPermissions"],
+                        Some((&["low", "high"], Some("effort"))),
+                    )],
+                },
+                ResolvedLaunchAgentOption {
+                    kind: "codex".to_string(),
+                    display_name: "Codex".to_string(),
+                    default_model_id: Some("gpt".to_string()),
+                    models: vec![model("gpt", &["full-access"], None)],
+                },
+            ],
+        }
+    }
+
+    fn harness(
+        agent_kind: &str,
+        model_selection: WorkflowModelSelection,
+    ) -> WorkflowHarnessConfigV2 {
+        WorkflowHarnessConfigV2 {
+            agent_kind: agent_kind.to_string(),
+            model_selection,
+            effort: None,
+            permission_policy: WorkflowPermissionPolicy::WorkflowDefault,
+        }
+    }
+
+    #[test]
+    fn resolves_target_default_and_workflow_modes() {
+        let claude = resolve_workflow_target(
+            &options(),
+            &harness("claude", WorkflowModelSelection::TargetDefault),
+        )
+        .expect("claude target");
+        assert_eq!(claude.model_id, "sonnet");
+        assert_eq!(claude.mode_id, "bypassPermissions");
+
+        let codex = resolve_workflow_target(
+            &options(),
+            &harness("codex", WorkflowModelSelection::TargetDefault),
+        )
+        .expect("codex target");
+        assert_eq!(codex.model_id, "gpt");
+        assert_eq!(codex.mode_id, "full-access");
+    }
+
+    #[test]
+    fn effort_requires_exact_value_and_same_key_live_mapping() {
+        let mut valid = harness(
+            "claude",
+            WorkflowModelSelection::Exact {
+                model_id: "sonnet".to_string(),
+            },
+        );
+        valid.effort = Some("high".to_string());
+        let resolved = resolve_workflow_target(&options(), &valid).expect("resolve effort");
+        assert_eq!(
+            resolved.effort_config,
+            Some(WorkflowResolvedEffortConfig {
+                config_id: "effort".to_string(),
+                value: "high".to_string(),
+            })
+        );
+
+        let mut no_mapping = options();
+        no_mapping.agents[0].models[0]
+            .live_effort_candidates
+            .clear();
+        assert_eq!(
+            resolve_workflow_target(&no_mapping, &valid),
+            Err(WorkflowResolutionError::EffortUnavailable)
+        );
+    }
+
+    #[test]
+    fn workflow_effort_uses_mapped_fallback_without_changing_public_projection() {
+        let mut options = options();
+        let model = &mut options.agents[0].models[0];
+        model.effort = Some(ResolvedModelEffort {
+            values: vec!["high".to_string()],
+            default: Some("high".to_string()),
+        });
+        model.live_effort_candidates = vec![ResolvedLiveModelEffortCandidate {
+            control_key: "reasoning_effort".to_string(),
+            values: vec!["xhigh".to_string()],
+            live_config_id: "reasoning_effort".to_string(),
+        }];
+        assert_eq!(
+            model.effort.as_ref().expect("public effort").values,
+            vec!["high"]
+        );
+        let mut request = harness(
+            "claude",
+            WorkflowModelSelection::Exact {
+                model_id: "sonnet".to_string(),
+            },
+        );
+        request.effort = Some("xhigh".to_string());
+
+        let resolved = resolve_workflow_target(&options, &request).expect("mapped fallback");
+        assert_eq!(
+            resolved.effort_config,
+            Some(WorkflowResolvedEffortConfig {
+                config_id: "reasoning_effort".to_string(),
+                value: "xhigh".to_string(),
+            })
+        );
+
+        options.agents[0].models[0].live_effort_candidates.clear();
+        assert_eq!(
+            resolve_workflow_target(&options, &request),
+            Err(WorkflowResolutionError::EffortUnavailable)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_agent_model_and_missing_mode() {
+        assert_eq!(
+            resolve_workflow_target(
+                &options(),
+                &harness("other", WorkflowModelSelection::TargetDefault)
+            ),
+            Err(WorkflowResolutionError::AgentUnavailable)
+        );
+        assert_eq!(
+            resolve_workflow_target(
+                &options(),
+                &harness(
+                    "claude",
+                    WorkflowModelSelection::Exact {
+                        model_id: "missing".to_string()
+                    }
+                )
+            ),
+            Err(WorkflowResolutionError::ModelUnavailable)
+        );
+
+        let mut no_mode = options();
+        no_mode.agents[0].models[0].modes = Some(vec!["default".to_string()]);
+        assert_eq!(
+            resolve_workflow_target(
+                &no_mode,
+                &harness("claude", WorkflowModelSelection::TargetDefault)
+            ),
+            Err(WorkflowResolutionError::ModeUnavailable)
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/runtime.rs
@@ -6,19 +6,29 @@
 //! blocking pool; no lease, transaction, or connection ever survives an
 //! unrelated await.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
+use std::time::Duration;
 
 use tokio::runtime::Handle;
+use tokio::sync::Mutex as AsyncMutex;
+
+use anyharness_contract::v1::ConfigApplyState;
 
 use crate::domains::sessions::runtime::{
     CreateAndStartSessionError, InternalSessionCreateError, InternalSessionCreateInput,
     SendPromptError, SendPromptOutcome, SessionRuntime,
 };
-use crate::domains::workflows::model::WorkflowRunFailureCode;
-use crate::domains::workflows::service::{
-    AcceptOutcome, WorkflowAcceptError, WorkflowExecutionPlan, WorkflowRunService,
-    WorkflowRunValidationError, WorkflowRunView, WorkflowServiceError,
+use crate::domains::workflows::model::{
+    VersionedPutWorkflowRunInput, WorkflowResolvedPlanV2, WorkflowRunFailureCode,
 };
+use crate::domains::workflows::resolution::{resolve_workflow_target, WorkflowResolutionError};
+use crate::domains::workflows::service::{
+    AcceptOutcome, AcceptV2Outcome, InspectV2Outcome, VersionedWorkflowRunView,
+    WorkflowAcceptError, WorkflowExecutionPlan, WorkflowRunService, WorkflowRunValidationError,
+    WorkflowServiceError,
+};
+use crate::domains::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
 use crate::domains::workspaces::operation_gate::{WorkspaceOperationGate, WorkspaceOperationKind};
 use crate::origin::OriginContext;
 
@@ -26,8 +36,8 @@ use crate::origin::OriginContext;
 /// exactly replayed (200), with the durable view either way.
 #[derive(Debug)]
 pub enum WorkflowPutSuccess {
-    Created(WorkflowRunView),
-    Replay(WorkflowRunView),
+    Created(VersionedWorkflowRunView),
+    Replay(VersionedWorkflowRunView),
 }
 
 /// The PUT failure arm.
@@ -35,6 +45,8 @@ pub enum WorkflowPutSuccess {
 pub enum WorkflowPutError {
     Invalid(WorkflowRunValidationError),
     Conflict,
+    WorkspaceAccess(WorkspaceAccessError),
+    TargetUnresolvable(WorkflowResolutionError),
     Store(WorkflowServiceError),
     /// Blocking-pool join failure (task panic/cancel).
     Internal(anyhow::Error),
@@ -63,20 +75,48 @@ pub struct WorkflowRunRuntime {
     service: Arc<WorkflowRunService>,
     session_runtime: Arc<SessionRuntime>,
     operation_gate: Arc<WorkspaceOperationGate>,
+    access_gate: Arc<WorkspaceAccessGate>,
+    accept_gates: Arc<StdMutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
     main_handle: Handle,
 }
+
+fn workflow_accept_gate_slot(
+    gates: &StdMutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+    run_id: &str,
+) -> Result<Arc<AsyncMutex<()>>, WorkflowPutError> {
+    let mut gates = gates.lock().map_err(|_| {
+        WorkflowPutError::Internal(anyhow::anyhow!("workflow run gate lock poisoned"))
+    })?;
+    gates.retain(|_, gate| gate.strong_count() > 0);
+    if let Some(gate) = gates.get(run_id).and_then(Weak::upgrade) {
+        return Ok(gate);
+    }
+
+    let gate = Arc::new(AsyncMutex::new(()));
+    gates.insert(run_id.to_string(), Arc::downgrade(&gate));
+    Ok(gate)
+}
+
+fn effort_apply_allows_step(state: Option<&ConfigApplyState>) -> bool {
+    matches!(state, Some(ConfigApplyState::Applied))
+}
+
+const WORKFLOW_EFFORT_APPLY_TIMEOUT: Duration = Duration::from_secs(45);
 
 impl WorkflowRunRuntime {
     pub fn new(
         service: Arc<WorkflowRunService>,
         session_runtime: Arc<SessionRuntime>,
         operation_gate: Arc<WorkspaceOperationGate>,
+        access_gate: Arc<WorkspaceAccessGate>,
         main_handle: Handle,
     ) -> Self {
         Self {
             service,
             session_runtime,
             operation_gate,
+            access_gate,
+            accept_gates: Arc::new(StdMutex::new(HashMap::new())),
             main_handle,
         }
     }
@@ -94,32 +134,162 @@ impl WorkflowRunRuntime {
     pub async fn put(
         &self,
         run_id: String,
-        input: crate::domains::workflows::model::PutWorkflowRunInput,
+        input: VersionedPutWorkflowRunInput,
     ) -> Result<WorkflowPutSuccess, WorkflowPutError> {
         let service = self.service.clone();
         let session_runtime = self.session_runtime.clone();
         let operation_gate = self.operation_gate.clone();
+        let access_gate = self.access_gate.clone();
+        let accept_gates = self.accept_gates.clone();
         let execution_handle = self.main_handle.clone();
 
         let handoff = self.main_handle.spawn(async move {
-            let accept_service = service.clone();
-            let accept_run_id = run_id.clone();
-            let outcome =
-                tokio::task::spawn_blocking(move || accept_service.accept(&accept_run_id, input))
+            match input {
+                VersionedPutWorkflowRunInput::V1(input) => {
+                    let run_gate = workflow_accept_gate_slot(&accept_gates, &run_id)?;
+                    let _run_guard = run_gate.lock_owned().await;
+                    let accept_service = service.clone();
+                    let accept_run_id = run_id.clone();
+                    let outcome = tokio::task::spawn_blocking(move || {
+                        accept_service.accept(&accept_run_id, input)
+                    })
                     .await
                     .map_err(|error| WorkflowPutError::Internal(error.into()))?;
 
-            match outcome {
-                Ok(AcceptOutcome::Created { plan, view }) => {
-                    execution_handle.spawn(async move {
-                        execute(service, session_runtime, operation_gate, plan).await;
-                    });
-                    Ok(WorkflowPutSuccess::Created(view))
+                    match outcome {
+                        Ok(AcceptOutcome::Created { plan, view }) => {
+                            execution_handle.spawn(async move {
+                                execute(service, session_runtime, operation_gate, plan).await;
+                            });
+                            Ok(WorkflowPutSuccess::Created(VersionedWorkflowRunView::V1(
+                                view,
+                            )))
+                        }
+                        Ok(AcceptOutcome::ExactReplay(view)) => Ok(WorkflowPutSuccess::Replay(
+                            VersionedWorkflowRunView::V1(view),
+                        )),
+                        Ok(AcceptOutcome::Conflict) => Err(WorkflowPutError::Conflict),
+                        Err(WorkflowAcceptError::Invalid(error)) => {
+                            Err(WorkflowPutError::Invalid(error))
+                        }
+                        Err(WorkflowAcceptError::Store(error)) => {
+                            Err(WorkflowPutError::Store(error))
+                        }
+                    }
                 }
-                Ok(AcceptOutcome::ExactReplay(view)) => Ok(WorkflowPutSuccess::Replay(view)),
-                Ok(AcceptOutcome::Conflict) => Err(WorkflowPutError::Conflict),
-                Err(WorkflowAcceptError::Invalid(error)) => Err(WorkflowPutError::Invalid(error)),
-                Err(WorkflowAcceptError::Store(error)) => Err(WorkflowPutError::Store(error)),
+                VersionedPutWorkflowRunInput::V2(input) => {
+                    let prepare_service = service.clone();
+                    let prepare_run_id = run_id.clone();
+                    let prepared = tokio::task::spawn_blocking(move || {
+                        prepare_service.prepare_v2(&prepare_run_id, input)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(WorkflowPutError::Invalid)?;
+
+                    // SQLite remains the replay authority. This narrow keyed
+                    // gate only prevents same-process racers from both
+                    // performing target lookup before one durable winner is
+                    // visible to the other.
+                    let run_gate = workflow_accept_gate_slot(&accept_gates, &run_id)?;
+                    let _run_guard = run_gate.lock_owned().await;
+
+                    let inspect_service = service.clone();
+                    let prepared_for_inspect = prepared.clone();
+                    let inspected = tokio::task::spawn_blocking(move || {
+                        inspect_service.inspect_v2(prepared_for_inspect)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(WorkflowPutError::Store)?;
+                    let prepared = match inspected {
+                        InspectV2Outcome::Missing(_) => prepared,
+                        InspectV2Outcome::ExactReplay(view) => {
+                            return Ok(WorkflowPutSuccess::Replay(VersionedWorkflowRunView::V2(
+                                view,
+                            )));
+                        }
+                        InspectV2Outcome::Conflict => {
+                            return Err(WorkflowPutError::Conflict);
+                        }
+                    };
+
+                    let workspace_id = prepared.source.workspace_id.clone();
+                    let harness = prepared.source.definition.stages[0].harness_config.clone();
+                    let access_workspace_id = workspace_id.clone();
+                    tokio::task::spawn_blocking(move || {
+                        access_gate.assert_can_mutate_for_workspace(&access_workspace_id)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(WorkflowPutError::WorkspaceAccess)?;
+
+                    let launch_runtime = session_runtime.clone();
+                    let launch_workspace_id = workspace_id.clone();
+                    let options = tokio::task::spawn_blocking(move || {
+                        launch_runtime.resolved_workspace_launch_options(&launch_workspace_id)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(|_error| {
+                        WorkflowPutError::Internal(anyhow::anyhow!(
+                            "workflow launch-options lookup failed"
+                        ))
+                    })?;
+                    let target = resolve_workflow_target(&options, &harness)
+                        .map_err(WorkflowPutError::TargetUnresolvable)?;
+
+                    let render_service = service.clone();
+                    let prepared_for_render = prepared.clone();
+                    let rendered_prompt = tokio::task::spawn_blocking(move || {
+                        render_service.render_v2(&prepared_for_render)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(WorkflowPutError::Invalid)?;
+                    let resolved = WorkflowResolvedPlanV2 {
+                        workspace_id,
+                        agent_kind: target.agent_kind,
+                        model_id: target.model_id,
+                        mode_id: target.mode_id,
+                        effort_config: target.effort_config,
+                        rendered_prompt,
+                        prompt_id: prepared.prompt_id.clone(),
+                    };
+
+                    let accept_service = service.clone();
+                    let accepted = tokio::task::spawn_blocking(move || {
+                        accept_service.accept_v2(prepared, resolved)
+                    })
+                    .await
+                    .map_err(|error| WorkflowPutError::Internal(error.into()))?
+                    .map_err(WorkflowPutError::Store)?;
+                    match accepted {
+                        AcceptV2Outcome::Created { plan, view } => {
+                            let execution_plan = WorkflowExecutionPlan {
+                                run_id: view.run.id.clone(),
+                                workspace_id: plan.workspace_id.clone(),
+                                agent_kind: plan.agent_kind.clone(),
+                                model_id: Some(plan.model_id.clone()),
+                                mode_id: Some(plan.mode_id.clone()),
+                                effort_config: plan.effort_config.clone(),
+                                rendered_prompt: plan.rendered_prompt.clone(),
+                                prompt_id: plan.prompt_id.clone(),
+                            };
+                            execution_handle.spawn(async move {
+                                execute(service, session_runtime, operation_gate, execution_plan)
+                                    .await;
+                            });
+                            Ok(WorkflowPutSuccess::Created(VersionedWorkflowRunView::V2(
+                                view,
+                            )))
+                        }
+                        AcceptV2Outcome::ExactReplay(view) => Ok(WorkflowPutSuccess::Replay(
+                            VersionedWorkflowRunView::V2(view),
+                        )),
+                        AcceptV2Outcome::Conflict => Err(WorkflowPutError::Conflict),
+                    }
+                }
             }
         });
 
@@ -130,12 +300,15 @@ impl WorkflowRunRuntime {
 
     /// GET the durable view. A non-canonical `runId` is a typed 400, not a 404.
     #[tracing::instrument(skip_all, fields(run_id = %run_id))]
-    pub async fn get(&self, run_id: String) -> Result<Option<WorkflowRunView>, WorkflowGetError> {
+    pub async fn get(
+        &self,
+        run_id: String,
+    ) -> Result<Option<VersionedWorkflowRunView>, WorkflowGetError> {
         if let Err(error) = crate::domains::workflows::service::validate_run_id(&run_id) {
             return Err(WorkflowGetError::InvalidRunId(error));
         }
         let service = self.service.clone();
-        tokio::task::spawn_blocking(move || service.get(&run_id))
+        tokio::task::spawn_blocking(move || service.get_versioned(&run_id))
             .await
             .map_err(|error| WorkflowGetError::Internal(error.into()))?
             .map_err(WorkflowGetError::Store)
@@ -248,7 +421,36 @@ async fn run_execution(
         ));
     }
 
-    // 6. Step pending -> running immediately before dispatch.
+    // 6. Apply schema-v2 effort after startup and before the step can begin.
+    if let Some(effort) = &plan.effort_config {
+        let applied = tokio::time::timeout(
+            WORKFLOW_EFFORT_APPLY_TIMEOUT,
+            session_runtime.set_live_session_config_option(
+                &session_id,
+                &effort.config_id,
+                &effort.value,
+            ),
+        )
+        .await;
+        let apply_state = applied
+            .as_ref()
+            .ok()
+            .and_then(|result| result.as_ref().ok())
+            .map(|(_, _, state)| state);
+        if !effort_apply_allows_step(apply_state) {
+            tracing::warn!(
+                run_id = %run_id,
+                session_id = %session_id,
+                timed_out = applied.is_err(),
+                "workflow session effort configuration was not applied"
+            );
+            return Err(ExecutionAbort::Fail(
+                WorkflowRunFailureCode::SessionConfigApplyFailed,
+            ));
+        }
+    }
+
+    // 7. Step pending -> running immediately before dispatch.
     if !blocking_bool(&run_id, "begin_step", {
         let service = service.clone();
         let run_id = run_id.clone();
@@ -259,7 +461,7 @@ async fn run_execution(
         return Ok(());
     }
 
-    // 7. Dispatch the one rendered prompt with the deterministic prompt id.
+    // 8. Dispatch the one rendered prompt with the deterministic prompt id.
     let acceptance = session_runtime
         .send_text_prompt_with_id(
             &session_id,
@@ -287,7 +489,7 @@ async fn run_execution(
         }
     }
 
-    // 8. Drop the lease (on scope exit) — completion arrives via the extension.
+    // 9. Drop the lease (on scope exit) — completion arrives via the extension.
     Ok(())
 }
 
@@ -392,3 +594,7 @@ fn map_create_error(error: &InternalSessionCreateError) -> WorkflowRunFailureCod
         InternalSessionCreateError::Create(_) => WorkflowRunFailureCode::SessionCreateFailed,
     }
 }
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/runtime_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/runtime_tests.rs
@@ -1,0 +1,212 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use serde_json::json;
+
+use super::*;
+use crate::domains::workflows::model::{
+    workflow_prompt_id, PutWorkflowRunInput, PutWorkflowRunInputV2, WorkflowDefinition,
+    WorkflowDefinitionV2, WorkflowHarnessConfig, WorkflowHarnessConfigV2, WorkflowInput,
+    WorkflowInputType, WorkflowModelSelection, WorkflowPermissionPolicy, WorkflowPromptStep,
+    WorkflowStage, WorkflowStageV2,
+};
+use crate::domains::workflows::store::WorkflowRunStore;
+use crate::persistence::Db;
+
+fn portable_input(workspace_id: &str) -> PutWorkflowRunInputV2 {
+    PutWorkflowRunInputV2 {
+        schema_version: 2,
+        workspace_id: workspace_id.to_string(),
+        definition: WorkflowDefinitionV2 {
+            inputs: vec![WorkflowInput {
+                name: "ticket".to_string(),
+                input_type: WorkflowInputType::String,
+                required: true,
+            }],
+            stages: vec![WorkflowStageV2 {
+                harness_config: WorkflowHarnessConfigV2 {
+                    agent_kind: "claude".to_string(),
+                    model_selection: WorkflowModelSelection::Exact {
+                        model_id: "sonnet".to_string(),
+                    },
+                    effort: None,
+                    permission_policy: WorkflowPermissionPolicy::WorkflowDefault,
+                },
+                steps: vec![WorkflowPromptStep {
+                    kind: "agent.prompt".to_string(),
+                    prompt: "Investigate {{inputs.ticket}}".to_string(),
+                }],
+            }],
+        },
+        arguments: BTreeMap::from([("ticket".to_string(), json!("PROL-123"))]),
+    }
+}
+
+#[test]
+fn only_applied_effort_allows_the_workflow_step() {
+    assert!(effort_apply_allows_step(Some(&ConfigApplyState::Applied)));
+    assert!(!effort_apply_allows_step(Some(&ConfigApplyState::Queued)));
+    assert!(!effort_apply_allows_step(None));
+}
+
+fn v1_input(workspace_id: &str) -> PutWorkflowRunInput {
+    PutWorkflowRunInput {
+        schema_version: 1,
+        workspace_id: workspace_id.to_string(),
+        definition: WorkflowDefinition {
+            inputs: vec![WorkflowInput {
+                name: "ticket".to_string(),
+                input_type: WorkflowInputType::String,
+                required: true,
+            }],
+            stages: vec![WorkflowStage {
+                harness_config: WorkflowHarnessConfig {
+                    agent_kind: "claude".to_string(),
+                    model_id: Some("sonnet".to_string()),
+                    mode_id: Some("bypassPermissions".to_string()),
+                },
+                steps: vec![WorkflowPromptStep {
+                    kind: "agent.prompt".to_string(),
+                    prompt: "Investigate {{inputs.ticket}}".to_string(),
+                }],
+            }],
+        },
+        arguments: BTreeMap::from([("ticket".to_string(), json!("PROL-123"))]),
+    }
+}
+
+#[tokio::test]
+async fn v2_run_gate_allows_one_lookup_and_schedule_then_replays_stored_plan() {
+    const WORKSPACE_ID: &str = "20000000-0000-4000-8000-000000000002";
+    let service = Arc::new(WorkflowRunService::new(WorkflowRunStore::new(
+        Db::open_in_memory().expect("in-memory db"),
+    )));
+    let gates = Arc::new(StdMutex::new(HashMap::new()));
+    let lookup_available = Arc::new(AtomicBool::new(true));
+    let lookup_count = Arc::new(AtomicUsize::new(0));
+    let schedule_count = Arc::new(AtomicUsize::new(0));
+    let run_id = uuid::Uuid::new_v4().to_string();
+
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let service = service.clone();
+        let gates = gates.clone();
+        let lookup_available = lookup_available.clone();
+        let lookup_count = lookup_count.clone();
+        let schedule_count = schedule_count.clone();
+        let run_id = run_id.clone();
+        tasks.push(tokio::spawn(async move {
+            let prepared = service
+                .prepare_v2(&run_id, portable_input(WORKSPACE_ID))
+                .expect("prepare");
+            let gate = workflow_accept_gate_slot(&gates, &run_id).expect("gate");
+            let _guard = gate.lock_owned().await;
+            match service.inspect_v2(prepared.clone()).expect("inspect") {
+                InspectV2Outcome::ExactReplay(view) => {
+                    assert_eq!(view.resolved_plan.model_id, "sonnet");
+                    false
+                }
+                InspectV2Outcome::Conflict => panic!("identical source conflicted"),
+                InspectV2Outcome::Missing(_) => {
+                    lookup_count.fetch_add(1, Ordering::SeqCst);
+                    assert!(
+                        lookup_available.swap(false, Ordering::SeqCst),
+                        "a replay performed target lookup after the winner"
+                    );
+                    let rendered_prompt = service.render_v2(&prepared).expect("render");
+                    let resolved = WorkflowResolvedPlanV2 {
+                        workspace_id: WORKSPACE_ID.to_string(),
+                        agent_kind: "claude".to_string(),
+                        model_id: "sonnet".to_string(),
+                        mode_id: "bypassPermissions".to_string(),
+                        effort_config: None,
+                        rendered_prompt,
+                        prompt_id: workflow_prompt_id(&run_id),
+                    };
+                    match service.accept_v2(prepared, resolved).expect("accept") {
+                        AcceptV2Outcome::Created { .. } => {
+                            schedule_count.fetch_add(1, Ordering::SeqCst);
+                            true
+                        }
+                        other => panic!("gate winner was not created: {other:?}"),
+                    }
+                }
+            }
+        }));
+    }
+
+    let mut created = 0;
+    for task in tasks {
+        created += usize::from(task.await.expect("join"));
+    }
+    assert_eq!(created, 1);
+    assert_eq!(lookup_count.load(Ordering::SeqCst), 1);
+    assert_eq!(schedule_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn shared_run_gate_makes_v1_winner_conflict_v2_without_lookup() {
+    const WORKSPACE_ID: &str = "20000000-0000-4000-8000-000000000002";
+    let service = Arc::new(WorkflowRunService::new(WorkflowRunStore::new(
+        Db::open_in_memory().expect("in-memory db"),
+    )));
+    let gates = Arc::new(StdMutex::new(HashMap::new()));
+    let lookup_count = Arc::new(AtomicUsize::new(0));
+    let schedule_count = Arc::new(AtomicUsize::new(0));
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let (v1_locked_tx, v1_locked_rx) = tokio::sync::oneshot::channel();
+    let release_v1 = Arc::new(tokio::sync::Notify::new());
+
+    let v1_task = {
+        let service = service.clone();
+        let gates = gates.clone();
+        let schedule_count = schedule_count.clone();
+        let run_id = run_id.clone();
+        let release_v1 = release_v1.clone();
+        tokio::spawn(async move {
+            let gate = workflow_accept_gate_slot(&gates, &run_id).expect("v1 gate");
+            let _guard = gate.lock_owned().await;
+            v1_locked_tx.send(()).expect("signal v1 lock");
+            release_v1.notified().await;
+            match service
+                .accept(&run_id, v1_input(WORKSPACE_ID))
+                .expect("accept v1")
+            {
+                AcceptOutcome::Created { .. } => {
+                    schedule_count.fetch_add(1, Ordering::SeqCst);
+                    true
+                }
+                other => panic!("v1 winner was not created: {other:?}"),
+            }
+        })
+    };
+
+    v1_locked_rx.await.expect("v1 acquired gate");
+    let v2_task = {
+        let service = service.clone();
+        let gates = gates.clone();
+        let lookup_count = lookup_count.clone();
+        let run_id = run_id.clone();
+        tokio::spawn(async move {
+            let prepared = service
+                .prepare_v2(&run_id, portable_input(WORKSPACE_ID))
+                .expect("prepare v2");
+            let gate = workflow_accept_gate_slot(&gates, &run_id).expect("v2 gate");
+            let _guard = gate.lock_owned().await;
+            match service.inspect_v2(prepared).expect("inspect v2") {
+                InspectV2Outcome::Conflict => true,
+                InspectV2Outcome::Missing(_) => {
+                    lookup_count.fetch_add(1, Ordering::SeqCst);
+                    false
+                }
+                InspectV2Outcome::ExactReplay(_) => false,
+            }
+        })
+    };
+
+    release_v1.notify_one();
+    assert!(v1_task.await.expect("join v1"));
+    assert!(v2_task.await.expect("join v2"));
+    assert_eq!(schedule_count.load(Ordering::SeqCst), 1);
+    assert_eq!(lookup_count.load(Ordering::SeqCst), 0);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service.rs
@@ -18,6 +18,11 @@ use crate::domains::workflows::model::{
 };
 use crate::domains::workflows::store::{FinishTurnStoreOutcome, WorkflowRunStore};
 
+pub use super::portable_service::{
+    AcceptV2Outcome, InspectV2Outcome, PreparedWorkflowRunV2, VersionedWorkflowRunView,
+    WorkflowRunViewV2,
+};
+
 /// The maximum rendered-prompt size in UTF-8 bytes.
 const MAX_RENDERED_PROMPT_BYTES: usize = 16_384;
 
@@ -46,12 +51,16 @@ pub enum WorkflowRunValidationError {
     MissingReferencedArgument(String),
     MalformedTemplate,
     UnknownTemplateReference(String),
+    UnknownPortableTemplateReference,
     BlankRenderedPrompt,
     RenderedPromptTooLarge(usize),
     BlankAgentKind,
     AgentKindSurroundingWhitespace,
     BlankModelId,
     BlankModeId,
+    EffortRequiresExactModel,
+    BlankEffort,
+    NonPortableNumber,
 }
 
 impl std::fmt::Display for WorkflowRunValidationError {
@@ -88,6 +97,9 @@ impl std::fmt::Display for WorkflowRunValidationError {
             Self::UnknownTemplateReference(reference) => {
                 write!(f, "the prompt references undeclared placeholder '{reference}'")
             }
+            Self::UnknownPortableTemplateReference => {
+                write!(f, "the prompt contains an unknown input placeholder")
+            }
             Self::BlankRenderedPrompt => write!(f, "the rendered prompt must be nonblank"),
             Self::RenderedPromptTooLarge(bytes) => write!(
                 f,
@@ -99,6 +111,14 @@ impl std::fmt::Display for WorkflowRunValidationError {
             }
             Self::BlankModelId => write!(f, "modelId must be nonblank when present"),
             Self::BlankModeId => write!(f, "modeId must be nonblank when present"),
+            Self::EffortRequiresExactModel => {
+                write!(f, "effort requires an exact model selection")
+            }
+            Self::BlankEffort => write!(f, "effort must be nonblank when present"),
+            Self::NonPortableNumber => write!(
+                f,
+                "numbers must be finite IEEE-754 values and integers must be in the I-JSON safe range"
+            ),
         }
     }
 }
@@ -125,6 +145,7 @@ pub struct WorkflowExecutionPlan {
     pub agent_kind: String,
     pub model_id: Option<String>,
     pub mode_id: Option<String>,
+    pub effort_config: Option<crate::domains::workflows::model::WorkflowResolvedEffortConfig>,
     pub rendered_prompt: String,
     pub prompt_id: String,
 }
@@ -158,7 +179,7 @@ pub enum WorkflowAcceptError {
 }
 
 pub struct WorkflowRunService {
-    store: WorkflowRunStore,
+    pub(super) store: WorkflowRunStore,
 }
 
 impl WorkflowRunService {
@@ -189,6 +210,7 @@ impl WorkflowRunService {
             id: run_id.to_string(),
             schema_version: 1,
             invocation_json,
+            resolved_plan_json: None,
             status: WorkflowRunStatus::Accepted,
             workspace_id: input.workspace_id.clone(),
             session_id: None,
@@ -225,6 +247,7 @@ impl WorkflowRunService {
                     agent_kind: validated.agent_kind,
                     model_id: validated.model_id,
                     mode_id: validated.mode_id,
+                    effort_config: None,
                     rendered_prompt: validated.rendered_prompt,
                     prompt_id,
                 };
@@ -470,7 +493,7 @@ fn validate_invocation(
     })
 }
 
-fn coerce_argument(
+pub(super) fn coerce_argument(
     name: &str,
     value: &serde_json::Value,
     declared: WorkflowInputType,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store/mod.rs
@@ -71,7 +71,10 @@ impl WorkflowRunStore {
                     steps::insert_step(conn, step)?;
                     Ok(StoreAcceptOutcome::Created)
                 }
-                Some(existing) if existing.invocation_json == run.invocation_json => {
+                Some(existing)
+                    if existing.schema_version == run.schema_version
+                        && existing.invocation_json == run.invocation_json =>
+                {
                     let steps = steps::find_steps_for_run(conn, &existing.id)?;
                     Ok(StoreAcceptOutcome::ExactReplay {
                         run: existing,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store/runs.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store/runs.rs
@@ -11,13 +11,15 @@ use crate::domains::workflows::model::{
 pub(super) fn insert_run(conn: &Connection, run: &WorkflowRunRecord) -> rusqlite::Result<()> {
     conn.execute(
         "INSERT INTO workflow_runs (
-            id, schema_version, invocation_json, status, workspace_id, session_id,
-            failure_code, created_at, updated_at, started_at, finished_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            id, schema_version, invocation_json, resolved_plan_json, status,
+            workspace_id, session_id, failure_code, created_at, updated_at,
+            started_at, finished_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![
             run.id,
             run.schema_version,
             run.invocation_json,
+            run.resolved_plan_json,
             run.status.as_str(),
             run.workspace_id,
             run.session_id,
@@ -127,6 +129,7 @@ pub(super) fn map_run(row: &Row<'_>) -> rusqlite::Result<WorkflowRunRecord> {
         id: row.get("id")?,
         schema_version: row.get("schema_version")?,
         invocation_json: row.get("invocation_json")?,
+        resolved_plan_json: row.get("resolved_plan_json")?,
         status: parse_status(row.get::<_, String>("status")?.as_str())?,
         workspace_id: row.get("workspace_id")?,
         session_id: row.get("session_id")?,

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migration_registry_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migration_registry_tests.rs
@@ -1,4 +1,22 @@
-use super::custom_migrations::CUSTOM_MIGRATIONS;
+use rusqlite::Connection;
+
+use super::custom_migrations::{CUSTOM_FOREIGN_KEY_MIGRATIONS, CUSTOM_MIGRATIONS};
+
+pub(super) fn mark_foreign_key_migrations_applied(conn: &Connection) {
+    for (name, _) in CUSTOM_FOREIGN_KEY_MIGRATIONS {
+        conn.execute("INSERT INTO _migrations (name) VALUES (?1)", [name])
+            .expect("mark foreign-key migration applied");
+    }
+}
+
+pub(super) fn table_column_names(conn: &Connection, table_name: &str) -> Vec<String> {
+    let pragma = format!("PRAGMA table_info({table_name})");
+    let mut stmt = conn.prepare(&pragma).expect("prepare pragma");
+    stmt.query_map([], |row| row.get::<_, String>(1))
+        .expect("query columns")
+        .collect::<Result<_, _>>()
+        .expect("collect columns")
+}
 
 #[test]
 fn custom_migrations_register_review_auto_iterate_rename() {

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migration_registry_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migration_registry_tests.rs
@@ -1,0 +1,8 @@
+use super::custom_migrations::CUSTOM_MIGRATIONS;
+
+#[test]
+fn custom_migrations_register_review_auto_iterate_rename() {
+    assert!(CUSTOM_MIGRATIONS
+        .iter()
+        .any(|(name, _)| *name == "0036_rename_review_auto_iterate"));
+}

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migration_schema.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migration_schema.rs
@@ -1,0 +1,13 @@
+//! Shared schema inspection for custom SQLite migrations.
+
+use rusqlite::Transaction;
+
+pub(super) fn table_columns(
+    tx: &Transaction<'_>,
+    table_name: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let pragma = format!("PRAGMA table_info({table_name})");
+    let mut stmt = tx.prepare(&pragma)?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    rows.collect()
+}

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
@@ -729,6 +729,9 @@ mod tests {
     use rusqlite::Connection;
 
     use super::table_columns;
+    use crate::persistence::custom_migration_registry_tests::{
+        mark_foreign_key_migrations_applied, table_column_names,
+    };
     use crate::persistence::migrations::{run_migrations, MIGRATIONS};
 
     #[test]
@@ -932,6 +935,7 @@ mod tests {
             [],
         )
         .expect("mark 0016 custom migration applied");
+        mark_foreign_key_migrations_applied(&conn);
 
         run_migrations(&mut conn).expect("run migrations");
 
@@ -976,6 +980,7 @@ mod tests {
             [],
         )
         .expect("mark 0016 custom migration applied");
+        mark_foreign_key_migrations_applied(&conn);
 
         run_migrations(&mut conn).expect("run migrations");
 
@@ -1059,6 +1064,7 @@ mod tests {
             conn.execute("INSERT INTO _migrations (name) VALUES (?1)", [name])
                 .expect("mark sql migration applied");
         }
+        mark_foreign_key_migrations_applied(&conn);
 
         run_migrations(&mut conn).expect("run migrations");
 
@@ -1093,14 +1099,5 @@ mod tests {
         assert_eq!(backfilled.1, "claude");
         assert_eq!(backfilled.2, "/tmp/backfill.output");
         assert_eq!(backfilled.3, "2026-04-11T00:01:00Z");
-    }
-
-    fn table_column_names(conn: &Connection, table_name: &str) -> Vec<String> {
-        let pragma = format!("PRAGMA table_info({table_name})");
-        let mut stmt = conn.prepare(&pragma).expect("prepare pragma");
-        stmt.query_map([], |row| row.get::<_, String>(1))
-            .expect("query columns")
-            .collect::<Result<_, _>>()
-            .expect("collect columns")
     }
 }

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
@@ -1,6 +1,8 @@
 use rusqlite::Transaction;
 use serde_json::Value;
 
+use super::custom_migration_schema::table_columns;
+
 pub(super) const CUSTOM_MIGRATIONS: &[(&str, fn(&Transaction<'_>) -> rusqlite::Result<()>)] = &[
     (
         "0016_backfill_session_background_work_timestamps",
@@ -15,10 +17,16 @@ pub(super) const CUSTOM_MIGRATIONS: &[(&str, fn(&Transaction<'_>) -> rusqlite::R
 pub(super) const CUSTOM_FOREIGN_KEY_MIGRATIONS: &[(
     &str,
     fn(&Transaction<'_>) -> rusqlite::Result<()>,
-)] = &[(
-    "0049_simplify_workspace_records",
-    migrate_simplify_workspace_records,
-)];
+)] = &[
+    (
+        "0049_simplify_workspace_records",
+        migrate_simplify_workspace_records,
+    ),
+    (
+        "0061_workflow_runs_v2",
+        super::workflow_runs_v2_migration::migrate_workflow_runs_v2,
+    ),
+];
 
 fn migrate_session_background_work_timestamps(tx: &Transaction<'_>) -> rusqlite::Result<()> {
     let columns = table_columns(tx, "session_background_work")?;
@@ -596,13 +604,6 @@ fn migrate_simplify_workspace_records(tx: &Transaction<'_>) -> rusqlite::Result<
     Ok(())
 }
 
-fn table_columns(tx: &Transaction<'_>, table_name: &str) -> rusqlite::Result<Vec<String>> {
-    let pragma = format!("PRAGMA table_info({table_name})");
-    let mut stmt = tx.prepare(&pragma)?;
-    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
-    rows.collect()
-}
-
 fn backfill_pending_background_work(tx: &Transaction<'_>) -> rusqlite::Result<()> {
     let mut stmt = tx.prepare(
         "SELECT session_id, turn_id, timestamp, payload_json
@@ -727,15 +728,8 @@ fn pending_background_work_from_completed_event(
 mod tests {
     use rusqlite::Connection;
 
-    use super::{table_columns, CUSTOM_MIGRATIONS};
+    use super::table_columns;
     use crate::persistence::migrations::{run_migrations, MIGRATIONS};
-
-    #[test]
-    fn custom_migrations_register_review_auto_iterate_rename() {
-        assert!(CUSTOM_MIGRATIONS
-            .iter()
-            .any(|(name, _)| *name == "0036_rename_review_auto_iterate"));
-    }
 
     #[test]
     fn simplify_workspace_records_migration_remaps_repo_workspaces_and_drops_legacy_columns() {

--- a/anyharness/crates/anyharness-lib/src/persistence/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/mod.rs
@@ -1,8 +1,14 @@
+mod custom_migration_schema;
 mod custom_migrations;
 pub mod migrations;
 pub mod sqlite;
+mod workflow_runs_v2_migration;
 
 #[cfg(test)]
+mod custom_migration_registry_tests;
+#[cfg(test)]
 mod schema_snapshot_tests;
+#[cfg(test)]
+mod workflow_runs_v2_migration_tests;
 
 pub use sqlite::Db;

--- a/anyharness/crates/anyharness-lib/src/persistence/workflow_runs_v2_migration.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/workflow_runs_v2_migration.rs
@@ -1,0 +1,81 @@
+//! Custom foreign-key migration for portable workflow runs.
+
+use rusqlite::Transaction;
+
+use super::custom_migration_schema::table_columns;
+
+pub(super) fn migrate_workflow_runs_v2(tx: &Transaction<'_>) -> rusqlite::Result<()> {
+    let columns = table_columns(tx, "workflow_runs")?;
+    if columns.iter().any(|column| column == "resolved_plan_json") {
+        return Ok(());
+    }
+
+    tx.execute_batch(
+        "
+        PRAGMA legacy_alter_table = ON;
+        ALTER TABLE workflow_run_steps RENAME TO workflow_run_steps_old;
+        ALTER TABLE workflow_runs RENAME TO workflow_runs_old;
+
+        CREATE TABLE workflow_runs (
+            id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version IN (1, 2)),
+            invocation_json TEXT NOT NULL CHECK (json_valid(invocation_json)),
+            resolved_plan_json TEXT CHECK (
+                resolved_plan_json IS NULL OR json_valid(resolved_plan_json)
+            ),
+            status TEXT NOT NULL CHECK (status IN ('accepted','running','completed','failed')),
+            workspace_id TEXT NOT NULL,
+            session_id TEXT,
+            failure_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            CHECK (
+                (schema_version = 1 AND resolved_plan_json IS NULL)
+                OR (schema_version = 2 AND resolved_plan_json IS NOT NULL)
+            )
+        );
+
+        INSERT INTO workflow_runs (
+            id, schema_version, invocation_json, resolved_plan_json, status,
+            workspace_id, session_id, failure_code, created_at, updated_at,
+            started_at, finished_at
+        )
+        SELECT
+            id, schema_version, invocation_json, NULL, status,
+            workspace_id, session_id, failure_code, created_at, updated_at,
+            started_at, finished_at
+        FROM workflow_runs_old;
+
+        CREATE TABLE workflow_run_steps (
+            run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+            stage_index INTEGER NOT NULL,
+            step_index INTEGER NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
+            prompt_id TEXT NOT NULL UNIQUE,
+            turn_id TEXT,
+            failure_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            PRIMARY KEY (run_id, stage_index, step_index)
+        );
+
+        INSERT INTO workflow_run_steps (
+            run_id, stage_index, step_index, status, prompt_id, turn_id,
+            failure_code, created_at, updated_at, started_at, finished_at
+        )
+        SELECT
+            run_id, stage_index, step_index, status, prompt_id, turn_id,
+            failure_code, created_at, updated_at, started_at, finished_at
+        FROM workflow_run_steps_old;
+
+        DROP TABLE workflow_run_steps_old;
+        DROP TABLE workflow_runs_old;
+        PRAGMA legacy_alter_table = OFF;
+        ",
+    )?;
+    Ok(())
+}

--- a/anyharness/crates/anyharness-lib/src/persistence/workflow_runs_v2_migration_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/workflow_runs_v2_migration_tests.rs
@@ -1,0 +1,162 @@
+//! File-backed upgrade proof for the portable workflow-run migration.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+
+use super::custom_migrations::{CUSTOM_FOREIGN_KEY_MIGRATIONS, CUSTOM_MIGRATIONS};
+use super::migrations::{run_migrations, MIGRATIONS};
+
+struct TempDatabase {
+    path: PathBuf,
+}
+
+impl TempDatabase {
+    fn new() -> Self {
+        Self {
+            path: std::env::temp_dir().join(format!(
+                "anyharness-workflow-v2-migration-{}.sqlite",
+                uuid::Uuid::new_v4()
+            )),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDatabase {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_file(self.path.with_extension("sqlite-shm"));
+        let _ = std::fs::remove_file(self.path.with_extension("sqlite-wal"));
+    }
+}
+
+#[test]
+fn workflow_v2_migration_upgrades_and_reopens_pre_0061_file() {
+    let database = TempDatabase::new();
+    {
+        let mut conn = Connection::open(database.path()).expect("open migration fixture");
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE _migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE TABLE workflow_runs (
+                id TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+                invocation_json TEXT NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('accepted','running','completed','failed')),
+                workspace_id TEXT NOT NULL,
+                session_id TEXT,
+                failure_code TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT
+             );
+             CREATE TABLE workflow_run_steps (
+                run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+                stage_index INTEGER NOT NULL,
+                step_index INTEGER NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
+                prompt_id TEXT NOT NULL UNIQUE,
+                turn_id TEXT,
+                failure_code TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT,
+                PRIMARY KEY (run_id, stage_index, step_index)
+             );
+             INSERT INTO workflow_runs (
+                id, schema_version, invocation_json, status, workspace_id,
+                created_at, updated_at
+             ) VALUES (
+                'run-v1', 1, '{\"workspaceId\":\"ws\",\"definition\":{\"inputs\":[],\"stages\":[]},\"arguments\":{}}',
+                'accepted', 'ws', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+             );
+             INSERT INTO workflow_run_steps (
+                run_id, stage_index, step_index, status, prompt_id,
+                created_at, updated_at
+             ) VALUES (
+                'run-v1', 0, 0, 'pending', 'workflow:run-v1:0:0',
+                '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+             );",
+        )
+        .expect("seed pre-0061 schema");
+        for (name, _) in MIGRATIONS {
+            conn.execute("INSERT INTO _migrations (name) VALUES (?1)", [name])
+                .expect("mark SQL migration");
+        }
+        for (name, _) in CUSTOM_MIGRATIONS {
+            conn.execute("INSERT INTO _migrations (name) VALUES (?1)", [name])
+                .expect("mark custom migration");
+        }
+        for (name, _) in CUSTOM_FOREIGN_KEY_MIGRATIONS {
+            if *name != "0061_workflow_runs_v2" {
+                conn.execute("INSERT INTO _migrations (name) VALUES (?1)", [name])
+                    .expect("mark FK migration");
+            }
+        }
+        run_migrations(&mut conn).expect("upgrade through 0061");
+    }
+
+    let conn = Connection::open(database.path()).expect("reopen upgraded database");
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
+        .expect("enable foreign keys after reopen");
+    let parent: (i64, String, Option<String>) = conn
+        .query_row(
+            "SELECT schema_version, invocation_json, resolved_plan_json
+             FROM workflow_runs WHERE id = 'run-v1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("copied v1 parent");
+    assert_eq!(parent.0, 1);
+    assert!(parent.1.contains("workspaceId"));
+    assert!(parent.2.is_none());
+
+    let child: (String, String) = conn
+        .query_row(
+            "SELECT prompt_id, status FROM workflow_run_steps
+             WHERE run_id = 'run-v1' AND stage_index = 0 AND step_index = 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("copied v1 child");
+    assert_eq!(child, ("workflow:run-v1:0:0".into(), "pending".into()));
+
+    let columns: Vec<String> = conn
+        .prepare("PRAGMA table_info(workflow_runs)")
+        .expect("prepare workflow columns")
+        .query_map([], |row| row.get(1))
+        .expect("query workflow columns")
+        .collect::<Result<_, _>>()
+        .expect("collect workflow columns");
+    assert!(columns.contains(&"resolved_plan_json".to_string()));
+    assert!(conn
+        .execute(
+            "INSERT INTO workflow_runs (
+                id, schema_version, invocation_json, resolved_plan_json,
+                status, workspace_id, created_at, updated_at
+             ) VALUES ('bad-v2', 2, '{}', NULL, 'accepted', 'ws', 't', 't')",
+            [],
+        )
+        .is_err());
+    assert_eq!(
+        conn.query_row("PRAGMA foreign_keys", [], |row| row.get::<_, i64>(0))
+            .expect("foreign key state after reopen"),
+        1
+    );
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("foreign key check after reopen"),
+        0
+    );
+}

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -3635,13 +3635,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                  "$ref": "#/components/schemas/VersionedWorkflowRunResponse"
                 }
               }
             }
           },
           "400": {
             "description": "Non-canonical run ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Direct-attach token is outside its workspace scope",
             "content": {
               "application/json": {
                 "schema": {
@@ -3682,7 +3692,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PutWorkflowRunRequest"
+                "$ref": "#/components/schemas/VersionedPutWorkflowRunRequest"
               }
             }
           },
@@ -3694,7 +3704,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                  "$ref": "#/components/schemas/VersionedWorkflowRunResponse"
                 }
               }
             }
@@ -3704,7 +3714,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                  "$ref": "#/components/schemas/VersionedWorkflowRunResponse"
                 }
               }
             }
@@ -3719,8 +3729,38 @@
               }
             }
           },
+          "403": {
+            "description": "Direct-attach token is outside its workspace scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "409": {
-            "description": "Same ID, different invocation",
+            "description": "Same ID with different invocation, or workspace mutation blocked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Portable target cannot be resolved",
             "content": {
               "application/json": {
                 "schema": {
@@ -13597,6 +13637,37 @@
         },
         "additionalProperties": false
       },
+      "PutWorkflowRunRequestV2": {
+        "type": "object",
+        "description": "Schema-v2 portable invocation. Model, mode, and optional effort are target\nintent until AnyHarness resolves and persists a concrete plan.",
+        "required": [
+          "schemaVersion",
+          "workspaceId",
+          "definition"
+        ],
+        "properties": {
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WorkflowRunArgumentValue"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "definition": {
+            "$ref": "#/components/schemas/WorkflowRunDefinitionV2"
+          },
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "workspaceId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "RawSessionConfigOption": {
         "type": "object",
         "description": "A raw ACP session configuration option as exposed by the active session.\n\nThis is the transport-fidelity layer. It should match the live ACP state as\nclosely as possible without applying product-specific interpretation.",
@@ -17752,6 +17823,27 @@
           }
         }
       },
+      "VersionedPutWorkflowRunRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PutWorkflowRunRequest"
+          },
+          {
+            "$ref": "#/components/schemas/PutWorkflowRunRequestV2"
+          }
+        ],
+        "description": "Operation-level PUT union. API decoding first inspects the required integer\n`schemaVersion`, then strictly decodes the selected member."
+      },
+      "VersionedWorkflowRunResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowRunResponse"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowRunResponseV2"
+          }
+        ]
+      },
       "WorkflowRun": {
         "type": "object",
         "description": "The durable run view.",
@@ -17862,6 +17954,27 @@
         },
         "additionalProperties": false
       },
+      "WorkflowRunDefinitionV2": {
+        "type": "object",
+        "required": [
+          "stages"
+        ],
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowRunInput"
+            }
+          },
+          "stages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowRunStageV2"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "WorkflowRunFailureCode": {
         "type": "string",
         "description": "The stable machine failure result on failed runs and steps (spec §6.1).",
@@ -17873,6 +17986,20 @@
           "session_turn_failed",
           "session_turn_cancelled",
           "runtime_restarted"
+        ]
+      },
+      "WorkflowRunFailureCodeV2": {
+        "type": "string",
+        "description": "V2 extends, but does not widen, the stable V1 failure-code component.",
+        "enum": [
+          "workspace_unavailable",
+          "session_create_failed",
+          "session_start_failed",
+          "prompt_dispatch_failed",
+          "session_turn_failed",
+          "session_turn_cancelled",
+          "runtime_restarted",
+          "session_config_apply_failed"
         ]
       },
       "WorkflowRunHarnessConfig": {
@@ -17900,6 +18027,32 @@
               "null"
             ],
             "description": "Required key; `null` requests the target-default model. The\n`schema(required)` override keeps the generated OpenAPI/SDK in sync\nwith the wire rule (present key, nullable value) that `nullable_string`\nenforces at deserialization."
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkflowRunHarnessConfigV2": {
+        "type": "object",
+        "required": [
+          "agentKind",
+          "modelSelection",
+          "permissionPolicy"
+        ],
+        "properties": {
+          "agentKind": {
+            "type": "string"
+          },
+          "effort": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modelSelection": {
+            "$ref": "#/components/schemas/WorkflowRunModelSelection"
+          },
+          "permissionPolicy": {
+            "$ref": "#/components/schemas/WorkflowRunPermissionPolicy"
           }
         },
         "additionalProperties": false
@@ -17934,6 +18087,48 @@
           "boolean"
         ]
       },
+      "WorkflowRunModelSelection": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "targetDefault"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "modelId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "exact"
+                ]
+              },
+              "modelId": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "WorkflowRunPermissionPolicy": {
+        "type": "string",
+        "enum": [
+          "workflowDefault"
+        ]
+      },
       "WorkflowRunPromptStep": {
         "type": "object",
         "description": "The single `agent.prompt` step.",
@@ -17950,6 +18145,32 @@
           }
         },
         "additionalProperties": false
+      },
+      "WorkflowRunResolvedHarnessV2": {
+        "type": "object",
+        "required": [
+          "agentKind",
+          "modelId",
+          "modeId",
+          "effort"
+        ],
+        "properties": {
+          "agentKind": {
+            "type": "string"
+          },
+          "effort": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modeId": {
+            "type": "string"
+          },
+          "modelId": {
+            "type": "string"
+          }
+        }
       },
       "WorkflowRunResponse": {
         "type": "object",
@@ -17970,6 +18191,28 @@
           }
         }
       },
+      "WorkflowRunResponseV2": {
+        "type": "object",
+        "required": [
+          "run",
+          "steps",
+          "resolvedHarness"
+        ],
+        "properties": {
+          "resolvedHarness": {
+            "$ref": "#/components/schemas/WorkflowRunResolvedHarnessV2"
+          },
+          "run": {
+            "$ref": "#/components/schemas/WorkflowRunV2"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowRunStepV2"
+            }
+          }
+        }
+      },
       "WorkflowRunStage": {
         "type": "object",
         "description": "Exactly one stage: a harness configuration plus exactly one prompt step.",
@@ -17980,6 +18223,25 @@
         "properties": {
           "harnessConfig": {
             "$ref": "#/components/schemas/WorkflowRunHarnessConfig"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowRunPromptStep"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkflowRunStageV2": {
+        "type": "object",
+        "required": [
+          "harnessConfig",
+          "steps"
+        ],
+        "properties": {
+          "harnessConfig": {
+            "$ref": "#/components/schemas/WorkflowRunHarnessConfigV2"
           },
           "steps": {
             "type": "array",
@@ -18071,6 +18333,141 @@
           "completed",
           "failed"
         ]
+      },
+      "WorkflowRunStepV2": {
+        "type": "object",
+        "required": [
+          "stageIndex",
+          "stepIndex",
+          "status",
+          "promptId",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "failureCode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WorkflowRunFailureCodeV2"
+              }
+            ]
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "promptId": {
+            "type": "string"
+          },
+          "stageIndex": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "startedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkflowRunStepStatus"
+          },
+          "stepIndex": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "turnId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowRunV2": {
+        "type": "object",
+        "required": [
+          "id",
+          "schemaVersion",
+          "definition",
+          "arguments",
+          "status",
+          "workspaceId",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "arguments": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WorkflowRunArgumentValue"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "definition": {
+            "$ref": "#/components/schemas/WorkflowRunDefinitionV2"
+          },
+          "failureCode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WorkflowRunFailureCodeV2"
+              }
+            ]
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "sessionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkflowRunStatus"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "workspaceId": {
+            "type": "string"
+          }
+        }
       },
       "Workspace": {
         "type": "object",

--- a/anyharness/sdk/package.json
+++ b/anyharness/sdk/package.json
@@ -21,7 +21,8 @@
     "generate": "npm run generate:openapi && npm run generate:types",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "typecheck:contracts": "tsc -p tsconfig.type-tests.json",
+    "test": "npm run typecheck:contracts && vitest run",
     "test:watch": "vitest"
   },
   "license": "AGPL-3.0",

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -3628,6 +3628,19 @@ export interface components {
             workspaceId: string;
         };
         /**
+         * @description Schema-v2 portable invocation. Model, mode, and optional effort are target
+         *     intent until AnyHarness resolves and persists a concrete plan.
+         */
+        PutWorkflowRunRequestV2: {
+            arguments?: {
+                [key: string]: components["schemas"]["WorkflowRunArgumentValue"];
+            };
+            definition: components["schemas"]["WorkflowRunDefinitionV2"];
+            /** Format: int64 */
+            schemaVersion: number;
+            workspaceId: string;
+        };
+        /**
          * @description A raw ACP session configuration option as exposed by the active session.
          *
          *     This is the transport-fidelity layer. It should match the live ACP state as
@@ -4598,6 +4611,12 @@ export interface components {
             selectedOptionLabel?: string | null;
             text?: string | null;
         };
+        /**
+         * @description Operation-level PUT union. API decoding first inspects the required integer
+         *     `schemaVersion`, then strictly decodes the selected member.
+         */
+        VersionedPutWorkflowRunRequest: components["schemas"]["PutWorkflowRunRequest"] | components["schemas"]["PutWorkflowRunRequestV2"];
+        VersionedWorkflowRunResponse: components["schemas"]["WorkflowRunResponse"] | components["schemas"]["WorkflowRunResponseV2"];
         /** @description The durable run view. */
         WorkflowRun: {
             arguments: {
@@ -4622,11 +4641,20 @@ export interface components {
             inputs?: components["schemas"]["WorkflowRunInput"][];
             stages: components["schemas"]["WorkflowRunStage"][];
         };
+        WorkflowRunDefinitionV2: {
+            inputs?: components["schemas"]["WorkflowRunInput"][];
+            stages: components["schemas"]["WorkflowRunStageV2"][];
+        };
         /**
          * @description The stable machine failure result on failed runs and steps (spec §6.1).
          * @enum {string}
          */
         WorkflowRunFailureCode: "workspace_unavailable" | "session_create_failed" | "session_start_failed" | "prompt_dispatch_failed" | "session_turn_failed" | "session_turn_cancelled" | "runtime_restarted";
+        /**
+         * @description V2 extends, but does not widen, the stable V1 failure-code component.
+         * @enum {string}
+         */
+        WorkflowRunFailureCodeV2: "workspace_unavailable" | "session_create_failed" | "session_start_failed" | "prompt_dispatch_failed" | "session_turn_failed" | "session_turn_cancelled" | "runtime_restarted" | "session_config_apply_failed";
         /** @description Harness selection for the stage's session. */
         WorkflowRunHarnessConfig: {
             agentKind: string;
@@ -4640,6 +4668,12 @@ export interface components {
              */
             modelId: string | null;
         };
+        WorkflowRunHarnessConfigV2: {
+            agentKind: string;
+            effort?: string | null;
+            modelSelection: components["schemas"]["WorkflowRunModelSelection"];
+            permissionPolicy: components["schemas"]["WorkflowRunPermissionPolicy"];
+        };
         /** @description A declared scalar input. */
         WorkflowRunInput: {
             name: string;
@@ -4652,19 +4686,44 @@ export interface components {
          * @enum {string}
          */
         WorkflowRunInputType: "string" | "number" | "boolean";
+        WorkflowRunModelSelection: {
+            /** @enum {string} */
+            kind: "targetDefault";
+        } | {
+            /** @enum {string} */
+            kind: "exact";
+            modelId: string;
+        };
+        /** @enum {string} */
+        WorkflowRunPermissionPolicy: "workflowDefault";
         /** @description The single `agent.prompt` step. */
         WorkflowRunPromptStep: {
             kind: string;
             prompt: string;
+        };
+        WorkflowRunResolvedHarnessV2: {
+            agentKind: string;
+            effort: string | null;
+            modeId: string;
+            modelId: string;
         };
         /** @description PUT/GET response envelope. */
         WorkflowRunResponse: {
             run: components["schemas"]["WorkflowRun"];
             steps: components["schemas"]["WorkflowRunStep"][];
         };
+        WorkflowRunResponseV2: {
+            resolvedHarness: components["schemas"]["WorkflowRunResolvedHarnessV2"];
+            run: components["schemas"]["WorkflowRunV2"];
+            steps: components["schemas"]["WorkflowRunStepV2"][];
+        };
         /** @description Exactly one stage: a harness configuration plus exactly one prompt step. */
         WorkflowRunStage: {
             harnessConfig: components["schemas"]["WorkflowRunHarnessConfig"];
+            steps: components["schemas"]["WorkflowRunPromptStep"][];
+        };
+        WorkflowRunStageV2: {
+            harnessConfig: components["schemas"]["WorkflowRunHarnessConfigV2"];
             steps: components["schemas"]["WorkflowRunPromptStep"][];
         };
         /**
@@ -4692,6 +4751,37 @@ export interface components {
          * @enum {string}
          */
         WorkflowRunStepStatus: "pending" | "running" | "completed" | "failed";
+        WorkflowRunStepV2: {
+            createdAt: string;
+            failureCode?: null | components["schemas"]["WorkflowRunFailureCodeV2"];
+            finishedAt?: string | null;
+            promptId: string;
+            /** Format: int64 */
+            stageIndex: number;
+            startedAt?: string | null;
+            status: components["schemas"]["WorkflowRunStepStatus"];
+            /** Format: int64 */
+            stepIndex: number;
+            turnId?: string | null;
+            updatedAt: string;
+        };
+        WorkflowRunV2: {
+            arguments: {
+                [key: string]: components["schemas"]["WorkflowRunArgumentValue"];
+            };
+            createdAt: string;
+            definition: components["schemas"]["WorkflowRunDefinitionV2"];
+            failureCode?: null | components["schemas"]["WorkflowRunFailureCodeV2"];
+            finishedAt?: string | null;
+            id: string;
+            /** Format: int64 */
+            schemaVersion: number;
+            sessionId?: string | null;
+            startedAt?: string | null;
+            status: components["schemas"]["WorkflowRunStatus"];
+            updatedAt: string;
+            workspaceId: string;
+        };
         Workspace: {
             cleanupAttemptedAt?: string | null;
             cleanupErrorMessage?: string | null;
@@ -7744,11 +7834,20 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowRunResponse"];
+                    "application/json": components["schemas"]["VersionedWorkflowRunResponse"];
                 };
             };
             /** @description Non-canonical run ID */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Direct-attach token is outside its workspace scope */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7779,7 +7878,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["PutWorkflowRunRequest"];
+                "application/json": components["schemas"]["VersionedPutWorkflowRunRequest"];
             };
         };
         responses: {
@@ -7789,7 +7888,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowRunResponse"];
+                    "application/json": components["schemas"]["VersionedWorkflowRunResponse"];
                 };
             };
             /** @description New durable acceptance */
@@ -7798,7 +7897,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowRunResponse"];
+                    "application/json": components["schemas"]["VersionedWorkflowRunResponse"];
                 };
             };
             /** @description Invalid ID, definition, arguments, or rendered prompt */
@@ -7810,8 +7909,35 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
-            /** @description Same ID, different invocation */
+            /** @description Direct-attach token is outside its workspace scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Same ID with different invocation, or workspace mutation blocked */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Portable target cannot be resolved */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/anyharness/sdk/src/workflow-runs.test.ts
+++ b/anyharness/sdk/src/workflow-runs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import fixture from "../../../fixtures/contracts/workflow-portable-execution/v1.json";
+import type { components } from "./generated/openapi.js";
+
+type PortableRequest = components["schemas"]["PutWorkflowRunRequestV2"];
+type ModelSelection = components["schemas"]["WorkflowRunModelSelection"];
+
+const exactSelection: ModelSelection = { kind: "exact", modelId: "sonnet" };
+
+function assertPortableRequest(value: unknown): asserts value is PortableRequest {
+  if (typeof value !== "object" || value === null) throw new Error("request object");
+  const request = value as Record<string, unknown>;
+  if (request.schemaVersion !== 2 || typeof request.workspaceId !== "string") {
+    throw new Error("request header");
+  }
+  if (typeof request.definition !== "object" || request.definition === null) {
+    throw new Error("definition");
+  }
+  const definition = request.definition as Record<string, unknown>;
+  if (!Array.isArray(definition.inputs) || !Array.isArray(definition.stages)) {
+    throw new Error("definition collections");
+  }
+  if (definition.stages.length !== 1) throw new Error("stage count");
+  const stage = definition.stages[0] as Record<string, unknown>;
+  const harness = stage.harnessConfig as Record<string, unknown>;
+  const selection = harness.modelSelection as Record<string, unknown>;
+  if (
+    harness.permissionPolicy !== "workflowDefault"
+    || selection.kind !== "exact"
+    || typeof selection.modelId !== "string"
+  ) {
+    throw new Error("portable harness");
+  }
+  if (!Array.isArray(stage.steps) || stage.steps.length !== 1) {
+    throw new Error("prompt step");
+  }
+  const step = stage.steps[0] as Record<string, unknown>;
+  if (step.kind !== "agent.prompt" || typeof step.prompt !== "string") {
+    throw new Error("prompt shape");
+  }
+  if (typeof request.arguments !== "object" || request.arguments === null) {
+    throw new Error("arguments");
+  }
+}
+
+describe("portable workflow contract fixture", () => {
+  it("pins the exact-model generated type to required camelCase modelId", () => {
+    expect(exactSelection).toEqual({ kind: "exact", modelId: "sonnet" });
+  });
+
+  it("parses as the generated schema-v2 request type", () => {
+    const request: unknown = fixture.anyHarnessRequest;
+    assertPortableRequest(request);
+    expectTypeOf(request).toMatchTypeOf<PortableRequest>();
+    expect(request.definition.stages[0].harnessConfig.modelSelection).toEqual({
+      kind: "exact",
+      modelId: "claude-sonnet-4-5",
+    });
+  });
+
+  it("contains parseable canonical-number cases and unsafe lexical variants", () => {
+    for (const testCase of fixture.canonicalNumberCases) {
+      expect(typeof JSON.parse(testCase.source)).toBe("number");
+      expect(typeof testCase.canonical).toBe("string");
+      expect(typeof testCase.portable).toBe("boolean");
+    }
+    const rejected = fixture.canonicalNumberCases
+      .filter((testCase) => !testCase.portable)
+      .map((testCase) => testCase.source);
+    expect(rejected).toContain("9007199254740992.0");
+    expect(rejected).toContain("9.007199254740992e15");
+  });
+});

--- a/anyharness/sdk/src/workflow-runs.type-test.ts
+++ b/anyharness/sdk/src/workflow-runs.type-test.ts
@@ -1,0 +1,13 @@
+import type { components } from "./generated/openapi.js";
+
+type ModelSelection = components["schemas"]["WorkflowRunModelSelection"];
+
+const exactSelection: ModelSelection = { kind: "exact", modelId: "sonnet" };
+// @ts-expect-error exact selection requires generated camelCase modelId.
+const missingExactModel: ModelSelection = { kind: "exact" };
+// @ts-expect-error generated contract must never accept snake_case model_id.
+const snakeCaseExactModel: ModelSelection = { kind: "exact", model_id: "sonnet" };
+
+void exactSelection;
+void missingExactModel;
+void snakeCaseExactModel;

--- a/anyharness/sdk/tsconfig.json
+++ b/anyharness/sdk/tsconfig.json
@@ -16,5 +16,11 @@
     "isolatedModules": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.type-test.ts"
+  ]
 }

--- a/anyharness/sdk/tsconfig.type-tests.json
+++ b/anyharness/sdk/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "sourceMap": false
+  },
+  "include": ["src/workflow-runs.type-test.ts"],
+  "exclude": []
+}

--- a/cloud/sdk/src/client/workflows.ts
+++ b/cloud/sdk/src/client/workflows.ts
@@ -3,6 +3,9 @@ import type {
   WorkflowDefinitionListResponse,
   WorkflowDefinitionResponse,
   WorkflowDefinitionUpdateRequest,
+  WorkflowInvocationCreateRequest,
+  WorkflowInvocationResponse,
+  WorkflowRunEligibilityResponse,
 } from "../types/index.js";
 import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
 
@@ -23,6 +26,41 @@ export async function getWorkflowDefinition(
     method: "GET",
     path: "/v1/workflows/{workflow_definition_id}",
     pathParams: { workflow_definition_id: workflowDefinitionId },
+  });
+}
+
+export async function getWorkflowRunEligibility(
+  workflowDefinitionId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<WorkflowRunEligibilityResponse> {
+  return client.requestJson<WorkflowRunEligibilityResponse>({
+    method: "GET",
+    path: "/v1/workflows/{workflow_definition_id}/run-eligibility",
+    pathParams: { workflow_definition_id: workflowDefinitionId },
+  });
+}
+
+export async function putWorkflowInvocation(
+  invocationId: string,
+  body: WorkflowInvocationCreateRequest,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<WorkflowInvocationResponse> {
+  return client.requestJson<WorkflowInvocationResponse>({
+    method: "PUT",
+    path: "/v1/workflow-invocations/{invocation_id}",
+    pathParams: { invocation_id: invocationId },
+    body,
+  });
+}
+
+export async function getWorkflowInvocation(
+  invocationId: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<WorkflowInvocationResponse> {
+  return client.requestJson<WorkflowInvocationResponse>({
+    method: "GET",
+    path: "/v1/workflow-invocations/{invocation_id}",
+    pathParams: { invocation_id: invocationId },
   });
 }
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1963,6 +1963,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/workflows/{workflow_definition_id}/run-eligibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Workflow Run Eligibility Endpoint */
+        get: operations["get_workflow_run_eligibility_endpoint_v1_workflows__workflow_definition_id__run_eligibility_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/workflows/{workflow_definition_id}": {
         parameters: {
             query?: never;
@@ -1977,6 +1994,24 @@ export interface paths {
         post?: never;
         /** Delete Workflow Definition Endpoint */
         delete: operations["delete_workflow_definition_endpoint_v1_workflows__workflow_definition_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workflow-invocations/{invocation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Workflow Invocation Endpoint */
+        get: operations["get_workflow_invocation_endpoint_v1_workflow_invocations__invocation_id__get"];
+        /** Put Workflow Invocation Endpoint */
+        put: operations["put_workflow_invocation_endpoint_v1_workflow_invocations__invocation_id__put"];
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -4526,6 +4561,14 @@ export interface components {
             /** Remainingusd */
             remainingUsd: number;
         };
+        /** ManagedCloudWorkflowTarget */
+        ManagedCloudWorkflowTarget: {
+            /**
+             * Kind
+             * @constant
+             */
+            kind: "managedCloud";
+        };
         /** MetaResponse */
         MetaResponse: {
             /** Serverversion */
@@ -5122,6 +5165,43 @@ export interface components {
             /** Probillingenabled */
             proBillingEnabled: boolean;
         };
+        /** PortableWorkflowDefinition */
+        PortableWorkflowDefinition: {
+            /** Inputs */
+            inputs: components["schemas"]["WorkflowInputDefinition"][];
+            /** Stages */
+            stages: components["schemas"]["PortableWorkflowStage"][];
+        };
+        /** PortableWorkflowHarnessConfig */
+        PortableWorkflowHarnessConfig: {
+            /** Agentkind */
+            agentKind: string;
+            /** Modelselection */
+            modelSelection: components["schemas"]["WorkflowTargetDefaultModelSelection"] | components["schemas"]["WorkflowExactModelSelection"];
+            /** Effort */
+            effort?: string | null;
+            /**
+             * Permissionpolicy
+             * @constant
+             */
+            permissionPolicy: "workflowDefault";
+        };
+        /** PortableWorkflowPromptStep */
+        PortableWorkflowPromptStep: {
+            /**
+             * Kind
+             * @constant
+             */
+            kind: "agent.prompt";
+            /** Prompt */
+            prompt: string;
+        };
+        /** PortableWorkflowStage */
+        PortableWorkflowStage: {
+            harnessConfig: components["schemas"]["PortableWorkflowHarnessConfig"];
+            /** Steps */
+            steps: components["schemas"]["PortableWorkflowPromptStep"][];
+        };
         /**
          * PricingCapability
          * @description Whether a vendor pricing page is meaningful for this deployment.
@@ -5261,6 +5341,19 @@ export interface components {
             /** Basebranch */
             baseBranch: string;
         };
+        /** RepositoryWorktreePlacement */
+        RepositoryWorktreePlacement: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "repositoryWorktree";
+            /**
+             * Repoconfigid
+             * Format: uuid
+             */
+            repoConfigId: string;
+        };
         /** SaveRepoEnvironmentRequest */
         SaveRepoEnvironmentRequest: {
             kind: components["schemas"]["RepoEnvironmentKind"];
@@ -5282,6 +5375,14 @@ export interface components {
              * @default
              */
             runCommand: string;
+        };
+        /** ScratchPlacement */
+        ScratchPlacement: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "scratch";
         };
         /**
          * ServerCapabilities
@@ -6169,6 +6270,16 @@ export interface components {
             /** Expectedrevision */
             expectedRevision: number;
         };
+        /** WorkflowExactModelSelection */
+        WorkflowExactModelSelection: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "exact";
+            /** Modelid */
+            modelId: string;
+        };
         /** WorkflowGoalDefinition */
         WorkflowGoalDefinition: {
             /** Objective */
@@ -6195,6 +6306,63 @@ export interface components {
             /** Required */
             required: boolean;
         };
+        /** WorkflowInvocationCreateRequest */
+        WorkflowInvocationCreateRequest: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 1;
+            /**
+             * Workflowdefinitionid
+             * Format: uuid
+             */
+            workflowDefinitionId: string;
+            /** Expectedrevision */
+            expectedRevision: number;
+            /** Arguments */
+            arguments: {
+                [key: string]: boolean | number | string;
+            };
+            target: components["schemas"]["ManagedCloudWorkflowTarget"];
+        };
+        /** WorkflowInvocationResponse */
+        WorkflowInvocationResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 1;
+            /**
+             * Workflowdefinitionid
+             * Format: uuid
+             */
+            workflowDefinitionId: string;
+            /** Definitionrevision */
+            definitionRevision: number;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            definition: components["schemas"]["PortableWorkflowDefinition"];
+            /** Arguments */
+            arguments: {
+                [key: string]: boolean | number | string;
+            };
+            /** Placement */
+            placement: components["schemas"]["RepositoryWorktreePlacement"] | components["schemas"]["ScratchPlacement"];
+            target: components["schemas"]["ManagedCloudWorkflowTarget"];
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+        };
         /** WorkflowPromptStep */
         WorkflowPromptStep: {
             /**
@@ -6206,11 +6374,38 @@ export interface components {
             prompt: string;
             goal?: components["schemas"]["WorkflowGoalDefinition"] | null;
         };
+        /** WorkflowRunEligibilityBlocker */
+        WorkflowRunEligibilityBlocker: {
+            /**
+             * Code
+             * @enum {string}
+             */
+            code: "stage_count_not_supported" | "step_count_not_supported" | "goal_not_supported" | "agent_catalog_selection_unavailable" | "model_catalog_selection_unavailable" | "effort_catalog_selection_unavailable" | "default_repository_unavailable";
+            /** Path */
+            path: string;
+            /** Message */
+            message: string;
+        };
+        /** WorkflowRunEligibilityResponse */
+        WorkflowRunEligibilityResponse: {
+            /** Eligible */
+            eligible: boolean;
+            /** Blockers */
+            blockers: components["schemas"]["WorkflowRunEligibilityBlocker"][];
+        };
         /** WorkflowStageDefinition */
         WorkflowStageDefinition: {
             harnessConfig: components["schemas"]["WorkflowHarnessConfig"];
             /** Steps */
             steps: components["schemas"]["WorkflowPromptStep"][];
+        };
+        /** WorkflowTargetDefaultModelSelection */
+        WorkflowTargetDefaultModelSelection: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "targetDefault";
         };
         /** WorkspaceCloudAccessSummary */
         WorkspaceCloudAccessSummary: {
@@ -10558,6 +10753,37 @@ export interface operations {
             };
         };
     };
+    get_workflow_run_eligibility_endpoint_v1_workflows__workflow_definition_id__run_eligibility_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_definition_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowRunEligibilityResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_workflow_definition_endpoint_v1_workflows__workflow_definition_id__get: {
         parameters: {
             query?: never;
@@ -10643,6 +10869,81 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_workflow_invocation_endpoint_v1_workflow_invocations__invocation_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                invocation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowInvocationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_workflow_invocation_endpoint_v1_workflow_invocations__invocation_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                invocation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkflowInvocationCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowInvocationResponse"];
+                };
+            };
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowInvocationResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/cloud/sdk/src/types/workflows.ts
+++ b/cloud/sdk/src/types/workflows.ts
@@ -26,3 +26,9 @@ export type WorkflowDefinitionResponse =
 export type WorkflowDefinitionListResponse =
   Omit<GeneratedWorkflowDefinitionListResponse, "workflows">
   & { workflows: WorkflowDefinitionResponse[] };
+
+export type WorkflowRunEligibilityBlocker = Schema<"WorkflowRunEligibilityBlocker">;
+export type WorkflowRunEligibilityResponse = Schema<"WorkflowRunEligibilityResponse">;
+export type WorkflowInvocationCreateRequest = Schema<"WorkflowInvocationCreateRequest">;
+export type WorkflowInvocationResponse = Schema<"WorkflowInvocationResponse">;
+export type PortableWorkflowDefinition = Schema<"PortableWorkflowDefinition">;

--- a/fixtures/contracts/workflow-portable-execution/v1.json
+++ b/fixtures/contracts/workflow-portable-execution/v1.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "canonicalNumberCases": [
+    { "source": "1", "canonical": "1", "portable": true },
+    { "source": "1.0", "canonical": "1", "portable": true },
+    { "source": "1e0", "canonical": "1", "portable": true },
+    { "source": "-0", "canonical": "0", "portable": true },
+    { "source": "0.0", "canonical": "0", "portable": true },
+    { "source": "1.5", "canonical": "1.5", "portable": true },
+    { "source": "9007199254740991", "canonical": "9007199254740991", "portable": true },
+    { "source": "-9007199254740991", "canonical": "-9007199254740991", "portable": true },
+    { "source": "9007199254740992", "canonical": "9007199254740992", "portable": false },
+    { "source": "9007199254740992.0", "canonical": "9007199254740992", "portable": false },
+    { "source": "9.007199254740992e15", "canonical": "9007199254740992", "portable": false }
+  ],
+  "anyHarnessRequest": {
+    "schemaVersion": 2,
+    "workspaceId": "30000000-0000-4000-8000-000000000001",
+    "definition": {
+      "inputs": [
+        { "name": "ticket", "type": "string", "required": true },
+        { "name": "attempt", "type": "number", "required": true }
+      ],
+      "stages": [
+        {
+          "harnessConfig": {
+            "agentKind": "claude",
+            "modelSelection": { "kind": "exact", "modelId": "claude-sonnet-4-5" },
+            "effort": "high",
+            "permissionPolicy": "workflowDefault"
+          },
+          "steps": [
+            {
+              "kind": "agent.prompt",
+              "prompt": "Investigate {{inputs.ticket}} attempt {{inputs.attempt}}"
+            }
+          ]
+        }
+      ]
+    },
+    "arguments": { "ticket": "PROL-123", "attempt": 1 }
+  }
+}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -26,7 +26,7 @@ anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 680 exist
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
-anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1106 custom migration with legacy schema coverage
+anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1103 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 773 existing generated cloud SDK type surface (+billing budget-limit/usage types)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -12,7 +12,7 @@ anyharness/crates/anyharness-contract/src/v1/sessions.rs 767 existing AnyHarness
 anyharness/crates/anyharness-lib/src/api/openapi.rs 652 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1) + workflow-runs paths/schemas
 anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarness oversized test file (+hosting PR-status route tests, +catalog version + enrichment tests)
 anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 923 workflow-runs merge-gated domain suite (validation matrix, rendering, replay/conflict, transitions, completion races, restart fencing)
-anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 839 workflow-runs HTTP + runtime/extension crossing suite (routes, execution failures, cancellation handoff, fencing abort, bearer/direct-attach admission)
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 816 workflow-runs HTTP + runtime/extension crossing suite (routes, execution failures, cancellation handoff, fencing abort, bearer/direct-attach admission)
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
@@ -26,7 +26,7 @@ anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 680 exist
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
-anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1112 custom migration with legacy schema coverage
+anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1106 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 773 existing generated cloud SDK type surface (+billing budget-limit/usage types)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file

--- a/server/alembic/versions/e7f8a9b0c1d3_workflow_invocations.py
+++ b/server/alembic/versions/e7f8a9b0c1d3_workflow_invocations.py
@@ -1,0 +1,75 @@
+"""immutable workflow invocations
+
+Revision ID: e7f8a9b0c1d3
+Revises: d6e7f8a9b0c2
+Create Date: 2026-07-14 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e7f8a9b0c1d3"
+down_revision: str | Sequence[str] | None = "d6e7f8a9b0c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_invocation",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("workflow_definition_id", sa.Uuid(), nullable=False),
+        sa.Column("definition_revision", sa.Integer(), nullable=False),
+        sa.Column("title_snapshot", sa.String(length=255), nullable=False),
+        sa.Column("description_snapshot", sa.Text(), nullable=False),
+        sa.Column("schema_version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+        sa.Column(
+            "creation_request_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "invocation_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "schema_version = 1",
+            name="ck_workflow_invocation_schema_version",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_workflow_invocation_user_created",
+        "workflow_invocation",
+        ["user_id", "created_at", "id"],
+    )
+    op.create_index(
+        "ix_workflow_invocation_definition",
+        "workflow_invocation",
+        ["workflow_definition_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workflow_invocation")

--- a/server/proliferate/db/models/workflows.py
+++ b/server/proliferate/db/models/workflows.py
@@ -78,3 +78,42 @@ class WorkflowDefinition(Base):
         onupdate=utcnow,
     )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class WorkflowInvocation(Base):
+    __tablename__ = "workflow_invocation"
+    __table_args__ = (
+        CheckConstraint(
+            "schema_version = 1",
+            name="ck_workflow_invocation_schema_version",
+        ),
+        Index("ix_workflow_invocation_user_created", "user_id", "created_at", "id"),
+        Index("ix_workflow_invocation_definition", "workflow_definition_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+    )
+    workflow_definition_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    definition_revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    title_snapshot: Mapped[str] = mapped_column(String(255), nullable=False)
+    description_snapshot: Mapped[str] = mapped_column(Text, nullable=False)
+    schema_version: Mapped[int] = mapped_column(
+        Integer,
+        default=1,
+        server_default=text("1"),
+    )
+    creation_request_json: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    invocation_json: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+        server_default=text("now()"),
+        onupdate=utcnow,
+    )

--- a/server/proliferate/db/store/workflow_invocations.py
+++ b/server/proliferate/db/store/workflow_invocations.py
@@ -1,0 +1,119 @@
+"""Persistence for immutable, user-owned workflow invocations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.workflows import WorkflowInvocation
+
+
+@dataclass(frozen=True)
+class WorkflowInvocationSnapshot:
+    id: UUID
+    user_id: UUID
+    workflow_definition_id: UUID
+    definition_revision: int
+    title_snapshot: str
+    description_snapshot: str
+    schema_version: int
+    creation_request_json: dict[str, object]
+    invocation_json: dict[str, object]
+    created_at: datetime
+    updated_at: datetime
+
+
+def _snapshot(row: WorkflowInvocation) -> WorkflowInvocationSnapshot:
+    return WorkflowInvocationSnapshot(
+        id=row.id,
+        user_id=row.user_id,
+        workflow_definition_id=row.workflow_definition_id,
+        definition_revision=row.definition_revision,
+        title_snapshot=row.title_snapshot,
+        description_snapshot=row.description_snapshot,
+        schema_version=row.schema_version,
+        creation_request_json=deepcopy(row.creation_request_json),
+        invocation_json=deepcopy(row.invocation_json),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def acquire_workflow_invocation_acceptance_lock(
+    db: AsyncSession,
+    *,
+    invocation_id: UUID,
+) -> None:
+    """Serialize acceptance for one caller-supplied UUID for this transaction."""
+
+    await db.execute(
+        text(
+            "SELECT pg_advisory_xact_lock("
+            "hashtextextended('workflow-invocation:' || CAST(:invocation_id AS text), 0))"
+        ),
+        {"invocation_id": str(invocation_id)},
+    )
+
+
+async def get_workflow_invocation_global(
+    db: AsyncSession,
+    *,
+    invocation_id: UUID,
+) -> WorkflowInvocationSnapshot | None:
+    row = (
+        await db.execute(select(WorkflowInvocation).where(WorkflowInvocation.id == invocation_id))
+    ).scalar_one_or_none()
+    return None if row is None else _snapshot(row)
+
+
+async def get_workflow_invocation_for_user(
+    db: AsyncSession,
+    *,
+    invocation_id: UUID,
+    user_id: UUID,
+) -> WorkflowInvocationSnapshot | None:
+    row = (
+        await db.execute(
+            select(WorkflowInvocation).where(
+                WorkflowInvocation.id == invocation_id,
+                WorkflowInvocation.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    return None if row is None else _snapshot(row)
+
+
+async def create_workflow_invocation(
+    db: AsyncSession,
+    *,
+    invocation_id: UUID,
+    user_id: UUID,
+    workflow_definition_id: UUID,
+    definition_revision: int,
+    title_snapshot: str,
+    description_snapshot: str,
+    creation_request_json: dict[str, object],
+    invocation_json: dict[str, object],
+    created_at: datetime,
+) -> WorkflowInvocationSnapshot:
+    row = WorkflowInvocation(
+        id=invocation_id,
+        user_id=user_id,
+        workflow_definition_id=workflow_definition_id,
+        definition_revision=definition_revision,
+        title_snapshot=title_snapshot,
+        description_snapshot=description_snapshot,
+        schema_version=1,
+        creation_request_json=deepcopy(creation_request_json),
+        invocation_json=deepcopy(invocation_json),
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db.add(row)
+    await db.flush()
+    return _snapshot(row)

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -80,6 +80,7 @@ from proliferate.server.setup.lifecycle import ensure_first_run_setup_token
 from proliferate.server.support.api import router as support_router
 from proliferate.server.support.feed.api import router as support_feed_router
 from proliferate.server.version import server_version
+from proliferate.server.workflows.api import invocations_router as workflow_invocations_router
 from proliferate.server.workflows.api import router as workflows_router
 from proliferate.utils.logging import configure_server_logging
 
@@ -153,6 +154,14 @@ def _redacts_entire_body(request: Request) -> bool:
     return request.method == "POST" and request.url.path.endswith("/agent-gateway/keys")
 
 
+def _is_workflow_invocation_argument_error(request: Request, loc: object) -> bool:
+    if request.method != "PUT" or "/workflow-invocations/" not in request.url.path:
+        return False
+    if not isinstance(loc, tuple | list):
+        return False
+    return len(loc) >= 2 and loc[0] == "body" and "arguments" in loc[1:]
+
+
 async def _validation_error_handler(
     request: Request,
     error: RequestValidationError,
@@ -163,7 +172,11 @@ async def _validation_error_handler(
         item = dict(raw)
         if "input" in item:
             loc = item.get("loc") or ()
-            if redact_all or (loc and _is_sensitive_field(loc[-1])):
+            if (
+                redact_all
+                or (loc and _is_sensitive_field(loc[-1]))
+                or _is_workflow_invocation_argument_error(request, loc)
+            ):
                 item["input"] = _REDACTED_INPUT
             else:
                 item["input"] = _redact_validation_input(item["input"])
@@ -290,6 +303,11 @@ def create_app() -> FastAPI:
     app.include_router(gateway_router, prefix=f"{api_prefix}/v1/gateway", tags=["gateway"])
     app.include_router(catalogs_router, prefix=f"{api_prefix}/v1", tags=["catalogs"])
     app.include_router(workflows_router, prefix=f"{api_prefix}/v1", tags=["workflows"])
+    app.include_router(
+        workflow_invocations_router,
+        prefix=f"{api_prefix}/v1",
+        tags=["workflow-invocations"],
+    )
     app.include_router(ai_magic_router, prefix=f"{api_prefix}/v1", tags=["ai_magic"])
     app.include_router(support_router, prefix=f"{api_prefix}/v1", tags=["support"])
     # Private completed-report feed. Logical route /internal/support/reports

--- a/server/proliferate/server/workflows/access.py
+++ b/server/proliferate/server/workflows/access.py
@@ -17,8 +17,14 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.db.store import workflow_definitions as workflow_store
+from proliferate.db.store import workflow_invocations as invocation_store
 from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
-from proliferate.server.workflows.errors import WorkflowDefinitionNotFound
+from proliferate.db.store.workflow_invocations import WorkflowInvocationSnapshot
+from proliferate.server.workflows.errors import (
+    InvalidWorkflowInvocation,
+    WorkflowDefinitionNotFound,
+    WorkflowInvocationNotFound,
+)
 
 
 async def workflow_definition_for_user(
@@ -45,4 +51,33 @@ async def workflow_definition_for_user(
 WorkflowDefinitionDependency = Annotated[
     WorkflowDefinitionSnapshot,
     Depends(workflow_definition_for_user),
+]
+
+
+async def workflow_invocation_for_user(
+    invocation_id: str,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkflowInvocationSnapshot:
+    try:
+        parsed_id = UUID(invocation_id)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation(
+            "invocationId must be a canonical lowercase UUID."
+        ) from error
+    if str(parsed_id) != invocation_id:
+        raise InvalidWorkflowInvocation("invocationId must be a canonical lowercase UUID.")
+    value = await invocation_store.get_workflow_invocation_for_user(
+        db,
+        invocation_id=parsed_id,
+        user_id=user.id,
+    )
+    if value is None:
+        raise WorkflowInvocationNotFound()
+    return value
+
+
+WorkflowInvocationDependency = Annotated[
+    WorkflowInvocationSnapshot,
+    Depends(workflow_invocation_for_user),
 ]

--- a/server/proliferate/server/workflows/api.py
+++ b/server/proliferate/server/workflows/api.py
@@ -5,27 +5,39 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
-from proliferate.server.workflows.access import WorkflowDefinitionDependency
+from proliferate.server.workflows.access import (
+    WorkflowDefinitionDependency,
+    WorkflowInvocationDependency,
+)
 from proliferate.server.workflows.models import (
     WorkflowDefinitionCreateRequest,
     WorkflowDefinitionListResponse,
     WorkflowDefinitionResponse,
     WorkflowDefinitionUpdateRequest,
+    WorkflowInvocationCreateRequest,
+    WorkflowInvocationResponse,
+    WorkflowRunEligibilityBlocker,
+    WorkflowRunEligibilityResponse,
     workflow_definition_response,
+    workflow_invocation_response,
 )
 from proliferate.server.workflows.service import (
     create_workflow_definition,
     delete_workflow_definition,
     list_workflow_definitions,
+    put_workflow_invocation,
     update_workflow_definition,
+    workflow_run_eligibility,
 )
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
+invocations_router = APIRouter(prefix="/workflow-invocations", tags=["workflow-invocations"])
 
 
 @router.get(
@@ -56,6 +68,28 @@ async def create_workflow_definition_endpoint(
 ) -> WorkflowDefinitionResponse:
     value = await create_workflow_definition(db, user_id=user.id, body=body)
     return workflow_definition_response(value)
+
+
+@router.get(
+    "/{workflow_definition_id}/run-eligibility",
+    response_model=WorkflowRunEligibilityResponse,
+)
+async def get_workflow_run_eligibility_endpoint(
+    definition: WorkflowDefinitionDependency,
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkflowRunEligibilityResponse:
+    blockers = await workflow_run_eligibility(db, definition=definition)
+    return WorkflowRunEligibilityResponse(
+        eligible=not blockers,
+        blockers=[
+            WorkflowRunEligibilityBlocker(
+                code=blocker.code,
+                path=blocker.path,
+                message=blocker.message,
+            )
+            for blocker in blockers
+        ],
+    )
 
 
 @router.get(
@@ -95,3 +129,42 @@ async def delete_workflow_definition_endpoint(
         expected_revision=expected_revision,
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@invocations_router.put(
+    "/{invocation_id}",
+    response_model=WorkflowInvocationResponse,
+    response_model_exclude_none=True,
+    responses={
+        status.HTTP_200_OK: {"model": WorkflowInvocationResponse},
+        status.HTTP_201_CREATED: {"model": WorkflowInvocationResponse},
+    },
+)
+async def put_workflow_invocation_endpoint(
+    invocation_id: str,
+    body: WorkflowInvocationCreateRequest,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> JSONResponse:
+    result = await put_workflow_invocation(
+        db,
+        invocation_id_text=invocation_id,
+        user_id=user.id,
+        body=body,
+    )
+    response = workflow_invocation_response(result.value)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED if result.created else status.HTTP_200_OK,
+        content=response.model_dump(by_alias=True, mode="json", exclude_none=True),
+    )
+
+
+@invocations_router.get(
+    "/{invocation_id}",
+    response_model=WorkflowInvocationResponse,
+    response_model_exclude_none=True,
+)
+async def get_workflow_invocation_endpoint(
+    invocation: WorkflowInvocationDependency,
+) -> WorkflowInvocationResponse:
+    return workflow_invocation_response(invocation)

--- a/server/proliferate/server/workflows/domain/invocation.py
+++ b/server/proliferate/server/workflows/domain/invocation.py
@@ -1,0 +1,246 @@
+"""Pure eligibility, portable-definition, argument, and identity rules."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Literal, cast
+
+import rfc8785
+
+from proliferate.server.catalogs.domain.selection import (
+    applicable_model_control,
+    catalog_agent,
+    catalog_model,
+)
+from proliferate.server.catalogs.models import AgentCatalogResponse
+
+_INPUT_REFERENCE_PATTERN = re.compile(r"(?<!\{)\{\{inputs\.([A-Za-z][A-Za-z0-9_]*)\}\}(?!\})")
+_EFFORT_CONTROL_KEYS = ("effort", "reasoning_effort")
+_SAFE_INTEGER_MAX = 9_007_199_254_740_991
+
+EligibilityCode = Literal[
+    "stage_count_not_supported",
+    "step_count_not_supported",
+    "goal_not_supported",
+    "agent_catalog_selection_unavailable",
+    "model_catalog_selection_unavailable",
+    "effort_catalog_selection_unavailable",
+    "default_repository_unavailable",
+]
+ScalarValue = str | bool | int | float
+type CanonicalJsonValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list[CanonicalJsonValue]
+    | tuple[CanonicalJsonValue, ...]
+    | dict[str, CanonicalJsonValue]
+)
+
+
+@dataclass(frozen=True)
+class EligibilityBlocker:
+    code: EligibilityCode
+    path: str
+    message: str
+
+
+def collect_run_eligibility_blockers(
+    catalog: AgentCatalogResponse,
+    *,
+    stages: tuple[dict[str, object], ...],
+    default_repo_config_id: object | None,
+    default_repository_available: bool,
+) -> tuple[EligibilityBlocker, ...]:
+    blockers: list[EligibilityBlocker] = []
+    if len(stages) != 1:
+        blockers.append(
+            EligibilityBlocker(
+                code="stage_count_not_supported",
+                path="stages",
+                message="The current Workflow runner requires exactly one stage.",
+            )
+        )
+
+    for stage_index, stage in enumerate(stages):
+        harness = cast(dict[str, object], stage.get("harnessConfig", {}))
+        steps = cast(list[dict[str, object]], stage.get("steps", []))
+        if len(steps) != 1:
+            blockers.append(
+                EligibilityBlocker(
+                    code="step_count_not_supported",
+                    path=f"stages[{stage_index}].steps",
+                    message="The current Workflow runner requires exactly one prompt step.",
+                )
+            )
+
+        for step_index, step in enumerate(steps):
+            if step.get("goal") is not None:
+                blockers.append(
+                    EligibilityBlocker(
+                        code="goal_not_supported",
+                        path=f"stages[{stage_index}].steps[{step_index}].goal",
+                        message="Goals are not supported by the current Workflow runner.",
+                    )
+                )
+
+        agent_kind = str(harness.get("agentKind", ""))
+        agent = catalog_agent(catalog, agent_kind)
+        if agent is None:
+            blockers.append(
+                EligibilityBlocker(
+                    code="agent_catalog_selection_unavailable",
+                    path=f"stages[{stage_index}].harnessConfig.agentKind",
+                    message=f"Agent harness '{agent_kind}' is not in the current catalog.",
+                )
+            )
+            continue
+
+        model_id = harness.get("modelId")
+        effort = harness.get("effort")
+        model = None
+        if model_id is not None:
+            model = catalog_model(
+                agent,
+                str(model_id),
+                statuses={"active"},
+                default_visible_only=True,
+            )
+            if model is None:
+                blockers.append(
+                    EligibilityBlocker(
+                        code="model_catalog_selection_unavailable",
+                        path=f"stages[{stage_index}].harnessConfig.modelId",
+                        message=f"Model '{model_id}' is not in the current catalog selection.",
+                    )
+                )
+
+        if effort is not None:
+            resolved = (
+                None
+                if model is None
+                else applicable_model_control(agent, model, *_EFFORT_CONTROL_KEYS)
+            )
+            if resolved is None or str(effort) not in resolved[1].values:
+                blockers.append(
+                    EligibilityBlocker(
+                        code="effort_catalog_selection_unavailable",
+                        path=f"stages[{stage_index}].harnessConfig.effort",
+                        message=(
+                            f"Effort '{effort}' is not in the selected model's current catalog."
+                        ),
+                    )
+                )
+
+    if default_repo_config_id is not None and not default_repository_available:
+        blockers.append(
+            EligibilityBlocker(
+                code="default_repository_unavailable",
+                path="defaultRepoConfigId",
+                message="The default repository is missing, deleted, or not owned by this user.",
+            )
+        )
+
+    return tuple(sorted(blockers, key=lambda blocker: (blocker.path, blocker.code)))
+
+
+def build_portable_definition(
+    catalog: AgentCatalogResponse,
+    *,
+    inputs: tuple[dict[str, object], ...],
+    stages: tuple[dict[str, object], ...],
+) -> dict[str, object]:
+    stage = stages[0]
+    harness = cast(dict[str, object], stage["harnessConfig"])
+    step = cast(list[dict[str, object]], stage["steps"])[0]
+    agent = catalog_agent(catalog, str(harness["agentKind"]))
+    if agent is None:
+        raise ValueError("eligible definition lost its catalog agent")
+
+    model_id = harness.get("modelId")
+    if model_id is None:
+        model_selection: dict[str, object] = {"kind": "targetDefault"}
+    else:
+        model = catalog_model(
+            agent,
+            str(model_id),
+            statuses={"active"},
+            default_visible_only=True,
+        )
+        if model is None:
+            raise ValueError("eligible definition lost its catalog model")
+        model_selection = {"kind": "exact", "modelId": model.id}
+
+    portable_harness: dict[str, object] = {
+        "agentKind": agent.kind,
+        "modelSelection": model_selection,
+        "permissionPolicy": "workflowDefault",
+    }
+    if harness.get("effort") is not None:
+        portable_harness["effort"] = str(harness["effort"])
+
+    return {
+        "inputs": [dict(input_definition) for input_definition in inputs],
+        "stages": [
+            {
+                "harnessConfig": portable_harness,
+                "steps": [{"kind": "agent.prompt", "prompt": str(step["prompt"])}],
+            }
+        ],
+    }
+
+
+def validate_invocation_arguments(
+    definition: dict[str, object],
+    arguments: dict[str, ScalarValue],
+) -> None:
+    inputs = cast(list[dict[str, object]], definition["inputs"])
+    stage = cast(list[dict[str, object]], definition["stages"])[0]
+    step = cast(list[dict[str, object]], stage["steps"])[0]
+    declared = {str(value["name"]): value for value in inputs}
+
+    for name, value in arguments.items():
+        input_definition = declared.get(name)
+        if input_definition is None:
+            raise ValueError(f"argument '{name}' is not a declared input")
+        _validate_scalar(name, value, str(input_definition["type"]))
+
+    for name, input_definition in declared.items():
+        if bool(input_definition["required"]) and name not in arguments:
+            raise ValueError(f"required input '{name}' has no argument")
+
+    prompt = str(step["prompt"])
+    references = _INPUT_REFERENCE_PATTERN.findall(prompt)
+    remaining = _INPUT_REFERENCE_PATTERN.sub("", prompt)
+    if "{{" in remaining or "}}" in remaining:
+        raise ValueError("prompt contains a malformed input placeholder")
+    for name in references:
+        if name not in declared:
+            raise ValueError(f"prompt references undeclared input '{name}'")
+        if name not in arguments:
+            raise ValueError(f"prompt input '{name}' has no argument")
+
+
+def canonical_json(value: object) -> str:
+    return rfc8785.dumps(cast(CanonicalJsonValue, value)).decode("utf-8")
+
+
+def _validate_scalar(name: str, value: ScalarValue, expected: str) -> None:
+    if expected == "string" and isinstance(value, str):
+        return
+    if expected == "boolean" and isinstance(value, bool):
+        return
+    if expected == "number" and not isinstance(value, bool) and isinstance(value, int | float):
+        if isinstance(value, int) and not -_SAFE_INTEGER_MAX <= value <= _SAFE_INTEGER_MAX:
+            raise ValueError(f"argument '{name}' is outside the portable integer range")
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"argument '{name}' must be finite")
+            if value.is_integer() and abs(value) > _SAFE_INTEGER_MAX:
+                raise ValueError(f"argument '{name}' is outside the portable integer range")
+        return
+    raise ValueError(f"argument '{name}' must be a {expected}")

--- a/server/proliferate/server/workflows/errors.py
+++ b/server/proliferate/server/workflows/errors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from proliferate.errors import Conflict, InvalidRequest, NotFoundError
+from proliferate.errors import Conflict, InvalidRequest, NotFoundError, ProliferateError
 
 
 class WorkflowDefinitionNotFound(NotFoundError):
@@ -37,3 +37,30 @@ class WorkflowDefinitionRevisionConflict(Conflict):
             "expectedRevision": expected_revision,
             "currentRevision": current_revision,
         }
+
+
+class InvalidWorkflowInvocation(InvalidRequest):
+    code = "invalid_workflow_invocation"
+
+
+class WorkflowInvocationNotFound(NotFoundError):
+    code = "workflow_invocation_not_found"
+
+    def __init__(self) -> None:
+        super().__init__("Workflow invocation not found.")
+
+
+class WorkflowInvocationConflict(Conflict):
+    code = "workflow_invocation_conflict"
+
+    def __init__(self) -> None:
+        super().__init__("A workflow invocation with this ID already exists with different input.")
+
+
+class WorkflowInvocationIneligible(ProliferateError):
+    code = "workflow_invocation_ineligible"
+    status_code = 422
+
+    def __init__(self, blockers: list[dict[str, str]]) -> None:
+        super().__init__("Workflow definition is not eligible for execution.")
+        self.extra_detail = {"blockers": blockers}

--- a/server/proliferate/server/workflows/models.py
+++ b/server/proliferate/server/workflows/models.py
@@ -6,10 +6,21 @@ from datetime import datetime
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    StringConstraints,
+    field_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
+from proliferate.db.store.workflow_invocations import WorkflowInvocationSnapshot
 
 
 class WorkflowWireModel(BaseModel):
@@ -104,6 +115,120 @@ class WorkflowDefinitionListResponse(WorkflowWireModel):
     workflows: list[WorkflowDefinitionResponse]
 
 
+class WorkflowRunEligibilityBlocker(WorkflowWireModel):
+    code: Literal[
+        "stage_count_not_supported",
+        "step_count_not_supported",
+        "goal_not_supported",
+        "agent_catalog_selection_unavailable",
+        "model_catalog_selection_unavailable",
+        "effort_catalog_selection_unavailable",
+        "default_repository_unavailable",
+    ]
+    path: str
+    message: str
+
+
+class WorkflowRunEligibilityResponse(WorkflowWireModel):
+    eligible: bool
+    blockers: list[WorkflowRunEligibilityBlocker]
+
+
+class WorkflowInvocationWireModel(WorkflowWireModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+    )
+
+
+WorkflowInvocationScalar = StrictBool | StrictInt | StrictFloat | StrictStr
+
+
+class ManagedCloudWorkflowTarget(WorkflowInvocationWireModel):
+    kind: Literal["managedCloud"]
+
+
+class WorkflowInvocationCreateRequest(WorkflowInvocationWireModel):
+    schema_version: Literal[1]
+    workflow_definition_id: UUID
+    expected_revision: StrictInt = Field(ge=1)
+    arguments: dict[str, WorkflowInvocationScalar]
+    target: ManagedCloudWorkflowTarget
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def schema_version_is_an_exact_integer(cls, value: object) -> object:
+        if type(value) is not int:
+            raise ValueError("schemaVersion must be the integer 1.")
+        return value
+
+
+class WorkflowTargetDefaultModelSelection(WorkflowInvocationWireModel):
+    kind: Literal["targetDefault"]
+
+
+class WorkflowExactModelSelection(WorkflowInvocationWireModel):
+    kind: Literal["exact"]
+    model_id: str
+
+
+WorkflowModelSelection = Annotated[
+    WorkflowTargetDefaultModelSelection | WorkflowExactModelSelection,
+    Field(discriminator="kind"),
+]
+
+
+class PortableWorkflowHarnessConfig(WorkflowInvocationWireModel):
+    agent_kind: str
+    model_selection: WorkflowModelSelection
+    effort: str | None = None
+    permission_policy: Literal["workflowDefault"]
+
+
+class PortableWorkflowPromptStep(WorkflowInvocationWireModel):
+    kind: Literal["agent.prompt"]
+    prompt: str
+
+
+class PortableWorkflowStage(WorkflowInvocationWireModel):
+    harness_config: PortableWorkflowHarnessConfig
+    steps: list[PortableWorkflowPromptStep]
+
+
+class PortableWorkflowDefinition(WorkflowInvocationWireModel):
+    inputs: list[WorkflowInputDefinition]
+    stages: list[PortableWorkflowStage]
+
+
+class RepositoryWorktreePlacement(WorkflowInvocationWireModel):
+    kind: Literal["repositoryWorktree"]
+    repo_config_id: UUID
+
+
+class ScratchPlacement(WorkflowInvocationWireModel):
+    kind: Literal["scratch"]
+
+
+WorkflowInvocationPlacement = Annotated[
+    RepositoryWorktreePlacement | ScratchPlacement,
+    Field(discriminator="kind"),
+]
+
+
+class WorkflowInvocationResponse(WorkflowInvocationWireModel):
+    id: UUID
+    schema_version: Literal[1]
+    workflow_definition_id: UUID
+    definition_revision: int
+    title: str
+    description: str
+    definition: PortableWorkflowDefinition
+    arguments: dict[str, WorkflowInvocationScalar]
+    placement: WorkflowInvocationPlacement
+    target: ManagedCloudWorkflowTarget
+    created_at: datetime
+
+
 def workflow_definition_response(
     value: WorkflowDefinitionSnapshot,
 ) -> WorkflowDefinitionResponse:
@@ -124,3 +249,9 @@ def workflow_definition_response(
             "deletedAt": value.deleted_at,
         }
     )
+
+
+def workflow_invocation_response(
+    value: WorkflowInvocationSnapshot,
+) -> WorkflowInvocationResponse:
+    return WorkflowInvocationResponse.model_validate(value.invocation_json)

--- a/server/proliferate/server/workflows/service.py
+++ b/server/proliferate/server/workflows/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import cast
 from uuid import UUID
 
@@ -9,9 +10,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store import repositories as repository_store
 from proliferate.db.store import workflow_definitions as workflow_store
+from proliferate.db.store import workflow_invocations as invocation_store
 from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
+from proliferate.db.store.workflow_invocations import WorkflowInvocationSnapshot
 from proliferate.server.catalogs.models import AgentCatalogResponse
 from proliferate.server.catalogs.service import read_agent_catalog
+from proliferate.server.workflows.domain.invocation import (
+    EligibilityBlocker,
+    ScalarValue,
+    build_portable_definition,
+    canonical_json,
+    collect_run_eligibility_blockers,
+    validate_invocation_arguments,
+)
 from proliferate.server.workflows.domain.validation import (
     DefinitionIssue,
     ValidatedDefinitionDocument,
@@ -19,13 +30,27 @@ from proliferate.server.workflows.domain.validation import (
 )
 from proliferate.server.workflows.errors import (
     InvalidWorkflowDefinition,
+    InvalidWorkflowInvocation,
     UnavailableWorkflowCatalogSelection,
+    WorkflowDefinitionNotFound,
     WorkflowDefinitionRevisionConflict,
+    WorkflowInvocationConflict,
+    WorkflowInvocationIneligible,
+    WorkflowInvocationNotFound,
 )
 from proliferate.server.workflows.models import (
     WorkflowDefinitionCreateRequest,
     WorkflowDefinitionUpdateRequest,
+    WorkflowInvocationCreateRequest,
+    workflow_invocation_response,
 )
+from proliferate.utils.time import utcnow
+
+
+@dataclass(frozen=True)
+class WorkflowInvocationPutResult:
+    value: WorkflowInvocationSnapshot
+    created: bool
 
 
 async def list_workflow_definitions(
@@ -127,6 +152,194 @@ async def delete_workflow_definition(
         expected_revision=expected_revision,
         current_revision=None if latest is None else latest.revision,
     )
+
+
+async def workflow_run_eligibility(
+    db: AsyncSession,
+    *,
+    definition: WorkflowDefinitionSnapshot,
+) -> tuple[EligibilityBlocker, ...]:
+    return await _workflow_run_eligibility(
+        db,
+        definition=definition,
+        catalog=read_agent_catalog().catalog,
+    )
+
+
+async def _workflow_run_eligibility(
+    db: AsyncSession,
+    *,
+    definition: WorkflowDefinitionSnapshot,
+    catalog: AgentCatalogResponse,
+) -> tuple[EligibilityBlocker, ...]:
+    default_repository_available = True
+    if definition.default_repo_config_id is not None:
+        default_repository_available = (
+            await repository_store.get_repo_config_by_id_for_user(
+                db,
+                user_id=definition.user_id,
+                repo_config_id=definition.default_repo_config_id,
+            )
+            is not None
+        )
+    return collect_run_eligibility_blockers(
+        catalog,
+        stages=definition.stages_json,
+        default_repo_config_id=definition.default_repo_config_id,
+        default_repository_available=default_repository_available,
+    )
+
+
+async def put_workflow_invocation(
+    db: AsyncSession,
+    *,
+    invocation_id_text: str,
+    user_id: UUID,
+    body: WorkflowInvocationCreateRequest,
+) -> WorkflowInvocationPutResult:
+    invocation_id = _canonical_uuid(invocation_id_text)
+    request_json = cast(
+        dict[str, object],
+        body.model_dump(by_alias=True, mode="json"),
+    )
+    try:
+        request_identity = canonical_json(request_json)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation("Workflow invocation is not portable JSON.") from error
+
+    await invocation_store.acquire_workflow_invocation_acceptance_lock(
+        db,
+        invocation_id=invocation_id,
+    )
+    existing = await invocation_store.get_workflow_invocation_global(
+        db,
+        invocation_id=invocation_id,
+    )
+    if existing is not None:
+        if existing.user_id != user_id:
+            raise WorkflowInvocationNotFound()
+        try:
+            stored = WorkflowInvocationCreateRequest.model_validate(existing.creation_request_json)
+            stored_identity = canonical_json(stored.model_dump(by_alias=True, mode="json"))
+        except ValueError as error:
+            raise InvalidWorkflowInvocation("Stored workflow invocation is invalid.") from error
+        if stored_identity != request_identity:
+            raise WorkflowInvocationConflict()
+        return WorkflowInvocationPutResult(value=existing, created=False)
+
+    definition = await workflow_store.get_workflow_definition(
+        db,
+        user_id=user_id,
+        workflow_definition_id=body.workflow_definition_id,
+    )
+    if definition is None:
+        raise WorkflowDefinitionNotFound()
+    if definition.revision != body.expected_revision:
+        raise WorkflowDefinitionRevisionConflict(
+            expected_revision=body.expected_revision,
+            current_revision=definition.revision,
+        )
+
+    catalog = read_agent_catalog().catalog
+    blockers = await _workflow_run_eligibility(
+        db,
+        definition=definition,
+        catalog=catalog,
+    )
+    if blockers:
+        raise WorkflowInvocationIneligible(
+            [
+                {"code": blocker.code, "path": blocker.path, "message": blocker.message}
+                for blocker in blockers
+            ]
+        )
+
+    portable_definition = build_portable_definition(
+        catalog,
+        inputs=definition.inputs_json,
+        stages=definition.stages_json,
+    )
+    arguments: dict[str, ScalarValue] = dict(body.arguments)
+    try:
+        validate_invocation_arguments(portable_definition, arguments)
+        canonical_json(arguments)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation(str(error)) from error
+
+    placement: dict[str, object]
+    if definition.default_repo_config_id is None:
+        placement = {"kind": "scratch"}
+    else:
+        placement = {
+            "kind": "repositoryWorktree",
+            "repoConfigId": str(definition.default_repo_config_id),
+        }
+
+    created_at = utcnow()
+    invocation_json: dict[str, object] = {
+        "id": str(invocation_id),
+        "schemaVersion": 1,
+        "workflowDefinitionId": str(definition.id),
+        "definitionRevision": definition.revision,
+        "title": definition.title,
+        "description": definition.description,
+        "definition": portable_definition,
+        "arguments": arguments,
+        "placement": placement,
+        "target": {"kind": "managedCloud"},
+        "createdAt": created_at.isoformat().replace("+00:00", "Z"),
+    }
+    try:
+        # Validate the immutable response before persistence. The parsed model
+        # also rejects any accidental widening of the snapshot shape.
+        response = workflow_invocation_response(
+            WorkflowInvocationSnapshot(
+                id=invocation_id,
+                user_id=user_id,
+                workflow_definition_id=definition.id,
+                definition_revision=definition.revision,
+                title_snapshot=definition.title,
+                description_snapshot=definition.description,
+                schema_version=1,
+                creation_request_json=request_json,
+                invocation_json=invocation_json,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        normalized_invocation_json = cast(
+            dict[str, object],
+            response.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
+        canonical_json(normalized_invocation_json)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation("Workflow invocation could not be normalized.") from error
+
+    created = await invocation_store.create_workflow_invocation(
+        db,
+        invocation_id=invocation_id,
+        user_id=user_id,
+        workflow_definition_id=definition.id,
+        definition_revision=definition.revision,
+        title_snapshot=definition.title,
+        description_snapshot=definition.description,
+        creation_request_json=request_json,
+        invocation_json=normalized_invocation_json,
+        created_at=created_at,
+    )
+    return WorkflowInvocationPutResult(value=created, created=True)
+
+
+def _canonical_uuid(value: str) -> UUID:
+    try:
+        parsed = UUID(value)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation(
+            "invocationId must be a canonical lowercase UUID."
+        ) from error
+    if str(parsed) != value:
+        raise InvalidWorkflowInvocation("invocationId must be a canonical lowercase UUID.")
+    return parsed
 
 
 async def _validate_default_repository(

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "passlib[bcrypt]>=1.7.0",
     "python-multipart>=0.0.32",
     "python-dateutil>=2.9.0",
+    "rfc8785>=0.1.4",
     "e2b>=2.29.0",
     "sentry-sdk[fastapi]>=2.62.0",
     "boto3>=1.43.30",

--- a/server/tests/integration/test_workflow_invocations_api.py
+++ b/server/tests/integration/test_workflow_invocations_api.py
@@ -1,0 +1,526 @@
+"""Immutable workflow invocation API over real PostgreSQL."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import GitProvider
+from proliferate.db.models.cloud.repositories import RepoConfig
+from proliferate.db.models.workflows import WorkflowDefinition
+from proliferate.utils.time import utcnow
+from tests.integration.cloud_api_helpers import register_and_login
+
+
+def _headers(tokens: dict[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def _definition_payload(*, number: bool = False) -> dict[str, object]:
+    input_type = "number" if number else "string"
+    return {
+        "title": "Portable workflow",
+        "description": "",
+        "defaultRepoConfigId": None,
+        "inputs": [{"name": "ticket", "type": input_type, "required": True}],
+        "stages": [
+            {
+                "harnessConfig": {"agentKind": "claude", "modelId": None, "effort": None},
+                "steps": [
+                    {
+                        "kind": "agent.prompt",
+                        "prompt": "Investigate {{inputs.ticket}}",
+                        "goal": None,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _invocation_body(definition_id: str, argument: object) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "workflowDefinitionId": definition_id,
+        "expectedRevision": 1,
+        "arguments": {"ticket": argument},
+        "target": {"kind": "managedCloud"},
+    }
+
+
+async def _seed_repo(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    name: str,
+    deleted: bool = False,
+) -> RepoConfig:
+    now = utcnow()
+    repo = RepoConfig(
+        user_id=UUID(user_id),
+        git_provider=GitProvider.github,
+        git_owner="proliferate-ai",
+        git_repo_name=name,
+        created_at=now,
+        updated_at=now,
+        deleted_at=now if deleted else None,
+    )
+    db.add(repo)
+    await db.commit()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_invocation_snapshot_replay_conflict_get_and_owner_isolation(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-owner@example.com")
+    intruder = await register_and_login(client, "invocation-intruder@example.com")
+    created_definition = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert created_definition.status_code == 201
+    definition = created_definition.json()
+
+    eligibility = await client.get(
+        f"/v1/workflows/{definition['id']}/run-eligibility",
+        headers=_headers(owner),
+    )
+    assert eligibility.status_code == 200
+    assert eligibility.json() == {"eligible": True, "blockers": []}
+
+    invocation_id = str(uuid4())
+    request = _invocation_body(definition["id"], "PROL-123")
+    created = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=request,
+    )
+    assert created.status_code == 201
+    frozen = created.json()
+    assert frozen["id"] == invocation_id
+    assert frozen["definitionRevision"] == 1
+    assert frozen["placement"] == {"kind": "scratch"}
+    harness = frozen["definition"]["stages"][0]["harnessConfig"]
+    assert harness == {
+        "agentKind": "claude",
+        "modelSelection": {"kind": "targetDefault"},
+        "permissionPolicy": "workflowDefault",
+    }
+
+    update = deepcopy(_definition_payload())
+    update.update(
+        {
+            "title": "Changed after invocation",
+            "description": "new",
+            "expectedRevision": 1,
+        }
+    )
+    update["stages"][0]["steps"][0]["prompt"] = "A different prompt"  # type: ignore[index]
+    updated = await client.put(
+        f"/v1/workflows/{definition['id']}",
+        headers=_headers(owner),
+        json=update,
+    )
+    assert updated.status_code == 200
+
+    replay = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=request,
+    )
+    assert replay.status_code == 200
+    assert replay.json() == frozen
+    loaded = await client.get(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+    )
+    assert loaded.status_code == 200
+    assert loaded.json() == frozen
+
+    mismatch = deepcopy(request)
+    mismatch["arguments"] = {"ticket": "OTHER"}
+    conflict = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=mismatch,
+    )
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["code"] == "workflow_invocation_conflict"
+
+    hidden_get = await client.get(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(intruder),
+    )
+    assert hidden_get.status_code == 404
+    hidden_put = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(intruder),
+        json=request,
+    )
+    assert hidden_put.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_advisory_lock_races(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-race-owner@example.com")
+    other = await register_and_login(client, "invocation-race-other@example.com")
+    definition_response = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert definition_response.status_code == 201
+    definition_id = definition_response.json()["id"]
+    body = _invocation_body(definition_id, "SAME")
+    other_definition_response = await client.post(
+        "/v1/workflows",
+        headers=_headers(other),
+        json=_definition_payload(),
+    )
+    assert other_definition_response.status_code == 201
+    other_body = _invocation_body(other_definition_response.json()["id"], "SAME")
+
+    identical_id = str(uuid4())
+    identical = await asyncio.gather(
+        client.put(
+            f"/v1/workflow-invocations/{identical_id}",
+            headers=_headers(owner),
+            json=body,
+        ),
+        client.put(
+            f"/v1/workflow-invocations/{identical_id}",
+            headers=_headers(owner),
+            json=body,
+        ),
+    )
+    assert sorted(response.status_code for response in identical) == [200, 201]
+    assert identical[0].json() == identical[1].json()
+
+    mismatch_id = str(uuid4())
+    different = deepcopy(body)
+    different["arguments"] = {"ticket": "DIFFERENT"}
+    mismatch = await asyncio.gather(
+        client.put(
+            f"/v1/workflow-invocations/{mismatch_id}",
+            headers=_headers(owner),
+            json=body,
+        ),
+        client.put(
+            f"/v1/workflow-invocations/{mismatch_id}",
+            headers=_headers(owner),
+            json=different,
+        ),
+    )
+    assert sorted(response.status_code for response in mismatch) == [201, 409]
+
+    foreign_id = str(uuid4())
+    foreign = await asyncio.gather(
+        client.put(
+            f"/v1/workflow-invocations/{foreign_id}",
+            headers=_headers(owner),
+            json=body,
+        ),
+        client.put(
+            f"/v1/workflow-invocations/{foreign_id}",
+            headers=_headers(other),
+            json=other_body,
+        ),
+    )
+    assert sorted(response.status_code for response in foreign) == [201, 404]
+    loser = next(response for response in foreign if response.status_code == 404)
+    assert loser.json()["detail"]["code"] == "workflow_invocation_not_found"
+    winner_index = next(
+        index for index, response in enumerate(foreign) if response.status_code == 201
+    )
+    winner = owner if winner_index == 0 else other
+    losing_user = other if winner_index == 0 else owner
+    assert (
+        await client.get(
+            f"/v1/workflow-invocations/{foreign_id}",
+            headers=_headers(winner),
+        )
+    ).status_code == 200
+    assert (
+        await client.get(
+            f"/v1/workflow-invocations/{foreign_id}",
+            headers=_headers(losing_user),
+        )
+    ).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_repository_worktree_snapshot_and_unavailable_repository_outcomes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "invocation-repo-owner@example.com")
+    other = await register_and_login(client, "invocation-repo-other@example.com")
+    owner_repo = await _seed_repo(
+        db_session,
+        user_id=owner["user_id"],
+        name="invocation-owner-repo",
+    )
+    other_repo = await _seed_repo(
+        db_session,
+        user_id=other["user_id"],
+        name="invocation-other-repo",
+    )
+
+    missing_repo_body = _definition_payload()
+    missing_repo_body["defaultRepoConfigId"] = str(uuid4())
+    missing_repo = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=missing_repo_body,
+    )
+    assert missing_repo.status_code == 400
+    assert missing_repo.json()["detail"] == {
+        "code": "invalid_workflow_definition",
+        "message": "Default repository was not found.",
+        "path": "defaultRepoConfigId",
+    }
+
+    body = _definition_payload()
+    body["defaultRepoConfigId"] = str(owner_repo.id)
+    created = await client.post("/v1/workflows", headers=_headers(owner), json=body)
+    assert created.status_code == 201
+    definition_id = created.json()["id"]
+    invocation = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, "PROL-123"),
+    )
+    assert invocation.status_code == 201
+    assert invocation.json()["placement"] == {
+        "kind": "repositoryWorktree",
+        "repoConfigId": str(owner_repo.id),
+    }
+
+    await db_session.execute(
+        update(RepoConfig).where(RepoConfig.id == owner_repo.id).values(deleted_at=utcnow())
+    )
+    await db_session.commit()
+    deleted_repo = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, "PROL-124"),
+    )
+    assert deleted_repo.status_code == 422
+    assert deleted_repo.json()["detail"]["blockers"] == [
+        {
+            "code": "default_repository_unavailable",
+            "path": "defaultRepoConfigId",
+            "message": "The default repository is missing, deleted, or not owned by this user.",
+        }
+    ]
+
+    await db_session.execute(
+        update(WorkflowDefinition)
+        .where(WorkflowDefinition.id == UUID(definition_id))
+        .values(default_repo_config_id=other_repo.id)
+    )
+    await db_session.commit()
+    foreign_repo = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, "PROL-125"),
+    )
+    assert foreign_repo.status_code == 422
+    assert foreign_repo.json()["detail"]["blockers"][0]["code"] == (
+        "default_repository_unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_invocation_requires_current_active_owned_definition(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-definition-owner@example.com")
+    other = await register_and_login(client, "invocation-definition-other@example.com")
+
+    stale_created = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert stale_created.status_code == 201
+    stale_id = stale_created.json()["id"]
+    update_body = _definition_payload()
+    update_body["expectedRevision"] = 1
+    updated = await client.put(
+        f"/v1/workflows/{stale_id}",
+        headers=_headers(owner),
+        json=update_body,
+    )
+    assert updated.status_code == 200
+    stale = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(stale_id, "PROL-123"),
+    )
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "workflow_definition_revision_conflict"
+
+    deleted_created = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert deleted_created.status_code == 201
+    deleted_id = deleted_created.json()["id"]
+    deleted = await client.delete(
+        f"/v1/workflows/{deleted_id}",
+        params={"expectedRevision": 1},
+        headers=_headers(owner),
+    )
+    assert deleted.status_code == 204
+    absent = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(deleted_id, "PROL-123"),
+    )
+    assert absent.status_code == 404
+    assert absent.json()["detail"]["code"] == "workflow_definition_not_found"
+
+    foreign_created = await client.post(
+        "/v1/workflows",
+        headers=_headers(other),
+        json=_definition_payload(),
+    )
+    assert foreign_created.status_code == 201
+    foreign = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(foreign_created.json()["id"], "PROL-123"),
+    )
+    assert foreign.status_code == 404
+    assert foreign.json()["detail"]["code"] == "workflow_definition_not_found"
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_replay_canonicalizes_key_order_and_equal_numbers(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-canonical-owner@example.com")
+    definition = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(number=True),
+    )
+    assert definition.status_code == 201
+    definition_id = definition.json()["id"]
+    invocation_id = str(uuid4())
+    bodies = [
+        (
+            '{"schemaVersion":1,"workflowDefinitionId":"'
+            + definition_id
+            + '","expectedRevision":1,"arguments":{"ticket":1},'
+            '"target":{"kind":"managedCloud"}}'
+        ),
+        (
+            '{"target":{"kind":"managedCloud"},"arguments":{"ticket":1.0},'
+            '"expectedRevision":1,"workflowDefinitionId":"'
+            + definition_id
+            + '","schemaVersion":1}'
+        ),
+        (
+            '{"arguments":{"ticket":1e0},"schemaVersion":1,'
+            '"target":{"kind":"managedCloud"},"workflowDefinitionId":"'
+            + definition_id
+            + '","expectedRevision":1}'
+        ),
+    ]
+
+    responses = []
+    for raw in bodies:
+        responses.append(
+            await client.put(
+                f"/v1/workflow-invocations/{invocation_id}",
+                headers={**_headers(owner), "Content-Type": "application/json"},
+                content=raw,
+            )
+        )
+    assert [response.status_code for response in responses] == [201, 200, 200]
+    assert responses[0].json() == responses[1].json() == responses[2].json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "number_source",
+    ["9007199254740992", "9007199254740992.0", "9.007199254740992e15"],
+)
+async def test_nonportable_numbers_are_coded_400_not_framework_422(
+    client: AsyncClient,
+    number_source: str,
+) -> None:
+    owner = await register_and_login(
+        client,
+        f"invocation-number-{number_source.replace('.', '-')[:20]}@example.com",
+    )
+    definition_response = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(number=True),
+    )
+    assert definition_response.status_code == 201
+    definition_id = definition_response.json()["id"]
+    raw = (
+        '{"schemaVersion":1,"workflowDefinitionId":"'
+        + definition_id
+        + '","expectedRevision":1,"arguments":{"ticket":'
+        + number_source
+        + '},"target":{"kind":"managedCloud"}}'
+    )
+    response = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers={**_headers(owner), "Content-Type": "application/json"},
+        content=raw,
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_workflow_invocation"
+
+
+@pytest.mark.asyncio
+async def test_malformed_argument_422_never_reflects_value(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-redaction@example.com")
+    response = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json={
+            "schemaVersion": 1,
+            "workflowDefinitionId": str(uuid4()),
+            "expectedRevision": 1,
+            "arguments": {"ticket": ["ARGUMENT_VALUE_MUST_NOT_LEAK"]},
+            "target": {"kind": "managedCloud"},
+        },
+    )
+    assert response.status_code == 422
+    assert "ARGUMENT_VALUE_MUST_NOT_LEAK" not in response.text
+    assert "[redacted]" in response.text
+
+    for invalid_version in (True, 1.0, "1"):
+        wrong_version = await client.put(
+            f"/v1/workflow-invocations/{uuid4()}",
+            headers=_headers(owner),
+            json={
+                "schemaVersion": invalid_version,
+                "workflowDefinitionId": str(uuid4()),
+                "expectedRevision": 1,
+                "arguments": {},
+                "target": {"kind": "managedCloud"},
+            },
+        )
+        assert wrong_version.status_code == 422

--- a/server/tests/unit/test_workflow_invocations.py
+++ b/server/tests/unit/test_workflow_invocations.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
+from starlette.requests import Request
+
+from proliferate.main import _validation_error_handler, create_app
+from proliferate.server.catalogs.models import AgentCatalogResponse
+from proliferate.server.workflows.domain.invocation import (
+    build_portable_definition,
+    canonical_json,
+    collect_run_eligibility_blockers,
+    validate_invocation_arguments,
+)
+from proliferate.server.workflows.models import WorkflowInvocationCreateRequest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE = REPO_ROOT / "fixtures/contracts/workflow-portable-execution/v1.json"
+
+
+def _catalog() -> AgentCatalogResponse:
+    return AgentCatalogResponse.model_validate(
+        {
+            "schemaVersion": 2,
+            "catalogVersion": "workflow-invocation-test",
+            "generatedAt": "2026-07-14T00:00:00Z",
+            "agents": [
+                {
+                    "kind": "claude",
+                    "displayName": "Claude",
+                    "harness": {"agentProcess": {"version": "test"}},
+                    "authContexts": [{"id": "baseline"}],
+                    "session": {
+                        "supportsGoals": True,
+                        "controls": [
+                            {
+                                "key": "effort",
+                                "values": ["low", "high"],
+                                "mapping": {"liveConfigId": "effort"},
+                            }
+                        ],
+                        "models": [
+                            {
+                                "id": "sonnet",
+                                "displayName": "Sonnet",
+                                "aliases": ["claude-sonnet"],
+                                "availability": {"anyOf": ["baseline"]},
+                                "defaultVisible": True,
+                                "controls": {"effort": {"values": ["low", "high"]}},
+                                "status": "active",
+                            }
+                        ],
+                    },
+                    "provenance": {"probedAt": "2026-07-14T00:00:00Z"},
+                }
+            ],
+        }
+    )
+
+
+def _number_definition() -> dict[str, object]:
+    return {
+        "inputs": [{"name": "value", "type": "number", "required": True}],
+        "stages": [
+            {
+                "harnessConfig": {
+                    "agentKind": "claude",
+                    "modelSelection": {"kind": "targetDefault"},
+                    "permissionPolicy": "workflowDefault",
+                },
+                "steps": [{"kind": "agent.prompt", "prompt": "Use {{inputs.value}}"}],
+            }
+        ],
+    }
+
+
+def test_shared_number_fixture_is_canonical_and_portable() -> None:
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    for case in fixture["canonicalNumberCases"]:
+        value = json.loads(case["source"])
+        if case["portable"]:
+            assert canonical_json(value) == case["canonical"]
+            validate_invocation_arguments(_number_definition(), {"value": value})
+        else:
+            with pytest.raises(ValueError):
+                validate_invocation_arguments(_number_definition(), {"value": value})
+
+
+def test_invocation_wire_requires_arguments_but_leaves_portability_to_domain() -> None:
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    body = {
+        "schemaVersion": 1,
+        "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+        "expectedRevision": 1,
+        "arguments": {"value": 9_007_199_254_740_992},
+        "target": {"kind": "managedCloud"},
+    }
+    parsed = WorkflowInvocationCreateRequest.model_validate(body)
+    assert parsed.arguments["value"] == 9_007_199_254_740_992
+    body.pop("arguments")
+    with pytest.raises(ValidationError):
+        WorkflowInvocationCreateRequest.model_validate(body)
+    assert (
+        fixture["anyHarnessRequest"]["definition"]["stages"][0]["harnessConfig"]["modelSelection"][
+            "modelId"
+        ]
+        == "claude-sonnet-4-5"
+    )
+
+
+@pytest.mark.parametrize("value", [True, 1.0, "1"])
+def test_invocation_schema_version_requires_exact_integer(value: object) -> None:
+    with pytest.raises(ValidationError):
+        WorkflowInvocationCreateRequest.model_validate(
+            {
+                "schemaVersion": value,
+                "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+                "expectedRevision": 1,
+                "arguments": {},
+                "target": {"kind": "managedCloud"},
+            }
+        )
+
+
+def test_eligibility_collects_every_closed_blocker_in_stable_order() -> None:
+    stages = (
+        {
+            "harnessConfig": {
+                "agentKind": "claude",
+                "modelId": "missing",
+                "effort": "impossible",
+            },
+            "steps": [
+                {"kind": "agent.prompt", "prompt": "one", "goal": {"objective": "g"}},
+                {"kind": "agent.prompt", "prompt": "two"},
+            ],
+        },
+        {
+            "harnessConfig": {"agentKind": "unknown"},
+            "steps": [],
+        },
+    )
+    blockers = collect_run_eligibility_blockers(
+        _catalog(),
+        stages=stages,
+        default_repo_config_id="repo",
+        default_repository_available=False,
+    )
+    assert [blocker.code for blocker in blockers] == [
+        "default_repository_unavailable",
+        "stage_count_not_supported",
+        "effort_catalog_selection_unavailable",
+        "model_catalog_selection_unavailable",
+        "step_count_not_supported",
+        "goal_not_supported",
+        "agent_catalog_selection_unavailable",
+        "step_count_not_supported",
+    ]
+    assert list(blockers) == sorted(blockers, key=lambda blocker: (blocker.path, blocker.code))
+
+
+def test_portable_definition_omits_effort_and_canonicalizes_exact_model() -> None:
+    definition = build_portable_definition(
+        _catalog(),
+        inputs=(),
+        stages=(
+            {
+                "harnessConfig": {"agentKind": "claude", "modelId": "claude-sonnet"},
+                "steps": [{"kind": "agent.prompt", "prompt": "Inspect."}],
+            },
+        ),
+    )
+    harness = definition["stages"][0]["harnessConfig"]  # type: ignore[index]
+    assert harness == {
+        "agentKind": "claude",
+        "modelSelection": {"kind": "exact", "modelId": "sonnet"},
+        "permissionPolicy": "workflowDefault",
+    }
+
+
+def test_portable_definition_preserves_exact_model_effort() -> None:
+    definition = build_portable_definition(
+        _catalog(),
+        inputs=(),
+        stages=(
+            {
+                "harnessConfig": {
+                    "agentKind": "claude",
+                    "modelId": "claude-sonnet",
+                    "effort": "high",
+                },
+                "steps": [{"kind": "agent.prompt", "prompt": "Inspect."}],
+            },
+        ),
+    )
+    assert definition["stages"][0]["harnessConfig"] == {  # type: ignore[index]
+        "agentKind": "claude",
+        "modelSelection": {"kind": "exact", "modelId": "sonnet"},
+        "effort": "high",
+        "permissionPolicy": "workflowDefault",
+    }
+
+
+def _argument_definition(*, prompt: str) -> dict[str, object]:
+    return {
+        "inputs": [
+            {"name": "required", "type": "string", "required": True},
+            {"name": "count", "type": "number", "required": False},
+            {"name": "enabled", "type": "boolean", "required": False},
+            {"name": "note", "type": "string", "required": False},
+        ],
+        "stages": [
+            {
+                "harnessConfig": {
+                    "agentKind": "claude",
+                    "modelSelection": {"kind": "targetDefault"},
+                    "permissionPolicy": "workflowDefault",
+                },
+                "steps": [{"kind": "agent.prompt", "prompt": prompt}],
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ({}, "required input 'required' has no argument"),
+        (
+            {"required": "ok", "extra": "no"},
+            "argument 'extra' is not a declared input",
+        ),
+        ({"required": 1}, "argument 'required' must be a string"),
+        (
+            {"required": "ok", "count": True},
+            "argument 'count' must be a number",
+        ),
+        (
+            {"required": "ok", "enabled": "yes"},
+            "argument 'enabled' must be a boolean",
+        ),
+    ],
+)
+def test_invocation_arguments_reject_missing_extra_and_wrong_types(
+    arguments: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message.replace("'", "\\'")):
+        validate_invocation_arguments(  # type: ignore[arg-type]
+            _argument_definition(prompt="Use {{inputs.required}}"),
+            arguments,
+        )
+
+
+def test_optional_input_is_required_only_when_referenced() -> None:
+    arguments = {"required": "ok"}
+    validate_invocation_arguments(
+        _argument_definition(prompt="Use {{inputs.required}}"),
+        arguments,
+    )  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="prompt input 'note' has no argument"):
+        validate_invocation_arguments(
+            _argument_definition(prompt="Use {{inputs.required}} {{inputs.note}}"),
+            arguments,
+        )  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "schemaVersion": 1,
+            "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+            "expectedRevision": 1,
+            "arguments": {},
+            "target": {"kind": "managedCloud"},
+            "unexpected": True,
+        },
+        {
+            "schemaVersion": 1,
+            "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+            "expectedRevision": 1,
+            "arguments": {},
+            "target": {"kind": "managedCloud", "unexpected": True},
+        },
+    ],
+)
+def test_invocation_request_rejects_unknown_top_level_and_target_fields(
+    body: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError) as captured:
+        WorkflowInvocationCreateRequest.model_validate(body)
+    assert any(error["type"] == "extra_forbidden" for error in captured.value.errors())
+
+
+def test_invocation_openapi_pins_exact_request_and_response_shapes() -> None:
+    schema = create_app().openapi()
+    operation = schema["paths"]["/v1/workflow-invocations/{invocation_id}"]
+    assert operation["put"]["requestBody"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/WorkflowInvocationCreateRequest"
+    }
+    for method in ("put", "get"):
+        assert operation[method]["responses"]["200"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/WorkflowInvocationResponse"
+        }
+    assert operation["put"]["responses"]["201"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/WorkflowInvocationResponse"
+    }
+
+    components = schema["components"]["schemas"]
+    request = components["WorkflowInvocationCreateRequest"]
+    assert request["additionalProperties"] is False
+    assert request["required"] == [
+        "schemaVersion",
+        "workflowDefinitionId",
+        "expectedRevision",
+        "arguments",
+        "target",
+    ]
+    assert set(request["properties"]) == set(request["required"])
+    assert request["properties"]["schemaVersion"]["const"] == 1
+    assert request["properties"]["target"] == {
+        "$ref": "#/components/schemas/ManagedCloudWorkflowTarget"
+    }
+
+    response = components["WorkflowInvocationResponse"]
+    assert response["additionalProperties"] is False
+    assert set(response["properties"]) == {
+        "id",
+        "schemaVersion",
+        "workflowDefinitionId",
+        "definitionRevision",
+        "title",
+        "description",
+        "definition",
+        "arguments",
+        "placement",
+        "target",
+        "createdAt",
+    }
+    assert set(response["required"]) == set(response["properties"])
+    assert components["ManagedCloudWorkflowTarget"]["additionalProperties"] is False
+    assert components["ManagedCloudWorkflowTarget"]["properties"]["kind"]["const"] == (
+        "managedCloud"
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_invocation_422_redacts_argument_values_only_for_this_route() -> None:
+    body = {
+        "schemaVersion": 1,
+        "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+        "expectedRevision": 1,
+        "arguments": {"ticket": ["ARGUMENT_VALUE_MUST_NOT_LEAK"]},
+        "target": {"kind": "managedCloud"},
+    }
+    with pytest.raises(ValidationError) as captured:
+        WorkflowInvocationCreateRequest.model_validate(body)
+    request = Request(
+        {
+            "type": "http",
+            "method": "PUT",
+            "path": "/v1/workflow-invocations/40000000-0000-4000-8000-000000000001",
+            "headers": [],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("test", 80),
+            "client": ("test", 1),
+        }
+    )
+    response = await _validation_error_handler(
+        request,
+        RequestValidationError(
+            [{**error, "loc": ("body", *error["loc"])} for error in captured.value.errors()]
+        ),
+    )
+    encoded = response.body.decode("utf-8")
+    assert response.status_code == 422
+    assert "ARGUMENT_VALUE_MUST_NOT_LEAK" not in encoded
+    assert "[redacted]" in encoded

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1118,6 +1118,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "rfc8785" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -1159,6 +1160,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
+    { name = "rfc8785", specifier = ">=0.1.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.17" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.62.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
@@ -1488,6 +1490,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]

--- a/specs/codebase/features/README.md
+++ b/specs/codebase/features/README.md
@@ -20,7 +20,7 @@ low-level runtime contracts.
 | Chat transcript | Transcript streaming, replay, transcript row models, long-history behavior, optimistic/waiting rows, and reconnect semantics. | [chat-transcript.md](chat-transcript.md) |
 | Workspace files | Workspace file browsing, file viewing, diff viewing, Changes, and all-changes review. | [workspace-files.md](workspace-files.md) |
 | Mobile cloud client | Mobile auth, cloud chat, sessions, automations, settings, device/mobile-web smoke, and mobile acceptance matrix. | [mobile-cloud-client.md](mobile-cloud-client.md) |
-| Workflows | User-owned workflow definitions, ordered stages and prompt steps, catalog-backed harness validation, revisioning, optional default repository configuration, and definition-authoring UX. | [workflows.md](workflows.md) |
+| Workflows | User-owned definitions plus immutable portable invocation and one-time AnyHarness target-resolution contracts. | [workflows.md](workflows.md), [workflow-invocations.md](workflow-invocations.md), [workflow-runs.md](workflow-runs.md) |
 | Automations | Scheduled/manual automations, runs, trigger behavior, ownership, permissions, snapshots, and smoke coverage. | [automations.md](automations.md) |
 | Slack bot | Slack connection, bot config, event handling, commands, claim flows, and Slack-origin workspace behavior. | [slack-bot.md](slack-bot.md) |
 | Delegated work / subagents | Delegated work lifecycle, parent/subagent coordination, review agents, queued wakes, and transcript/composer integration. | [delegated-work.md](delegated-work.md), [agent-features/definitions/subagents.md](agent-features/definitions/subagents.md) |

--- a/specs/codebase/features/workflow-invocations.md
+++ b/specs/codebase/features/workflow-invocations.md
@@ -1,0 +1,401 @@
+# Portable Invocation and Target Resolution
+
+Status: authoritative implementation contract, revision `1.0`.
+
+Owner: Cloud Workflow invocations and AnyHarness Workflow target resolution.
+
+Read with [`workflows.md`](workflows.md), [`workflow-runs.md`](workflow-runs.md),
+the Server and AnyHarness structure guides, and the repository testing standard.
+
+## Outcome and boundary
+
+Cloud freezes one exact current saved-definition revision, scalar arguments,
+placement intent, and managed target into an immutable user-owned invocation.
+AnyHarness schema v2 accepts the same portable one-stage/one-prompt meaning,
+resolves model, mode, and optional effort against one existing workspace once,
+stores the concrete plan before effects, and uses the existing
+`WorkflowRunRuntime` to execute it.
+
+This PR proves manual/test transfer. It does not own automated delivery,
+background work, target custody, workspace creation/materialization,
+cancellation, takeover, UI, Desktop, goals, multiple steps/stages, grants, MCP,
+subagents, schedules, retry, recovery, a generalized compiler/resolver, a new
+actor/manager/scheduler, or a Cowork refactor.
+
+## Cloud API
+
+```http
+GET /v1/workflows/{definitionId}/run-eligibility
+PUT /v1/workflow-invocations/{invocationId}
+GET /v1/workflow-invocations/{invocationId}
+```
+
+`invocationId` is a canonical lowercase hyphenated UUID: parse it and require
+its lowercase `8-4-4-4-12` rendering to equal the original path segment.
+
+### Eligibility
+
+```json
+{
+  "eligible": false,
+  "blockers": [{
+    "code": "goal_not_supported",
+    "path": "stages[0].steps[0].goal",
+    "message": "Goals are not supported by the current Workflow runner."
+  }]
+}
+```
+
+Positive is exactly `{ "eligible": true, "blockers": [] }`. Paths use the
+bracketed grammar above. Collect all blockers, sorted by `path` then `code`.
+Closed codes:
+
+```text
+stage_count_not_supported
+step_count_not_supported
+goal_not_supported
+agent_catalog_selection_unavailable
+model_catalog_selection_unavailable
+effort_catalog_selection_unavailable
+default_repository_unavailable
+```
+
+Check one stage, one prompt, no goal, current Cloud catalog identity, and an
+owner-matched non-deleted default repo. Do not claim target readiness. PUT
+reuses this collector and never drops an unsupported field.
+
+### Immutable invocation
+
+Strict create body:
+
+```json
+{
+  "schemaVersion": 1,
+  "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+  "expectedRevision": 3,
+  "arguments": { "ticket": "PROL-123" },
+  "target": { "kind": "managedCloud" }
+}
+```
+
+ID is path-only. `expectedRevision` must equal the current active definition
+row; there is no historical revision body. Only `managedCloud` is accepted.
+
+Strict response:
+
+```json
+{
+  "id": "40000000-0000-4000-8000-000000000001",
+  "schemaVersion": 1,
+  "workflowDefinitionId": "10000000-0000-4000-8000-000000000001",
+  "definitionRevision": 3,
+  "title": "Diagnose a ticket",
+  "description": "",
+  "definition": {
+    "inputs": [{ "name": "ticket", "type": "string", "required": true }],
+    "stages": [{
+      "harnessConfig": {
+        "agentKind": "claude",
+        "modelSelection": { "kind": "targetDefault" },
+        "permissionPolicy": "workflowDefault"
+      },
+      "steps": [{
+        "kind": "agent.prompt",
+        "prompt": "Investigate {{inputs.ticket}}"
+      }]
+    }]
+  },
+  "arguments": { "ticket": "PROL-123" },
+  "placement": {
+    "kind": "repositoryWorktree",
+    "repoConfigId": "20000000-0000-4000-8000-000000000001"
+  },
+  "target": { "kind": "managedCloud" },
+  "createdAt": "2026-07-14T12:00:00Z"
+}
+```
+
+No default repo yields `{ "kind": "scratch" }`. No workspace/path/branch,
+concrete target model/mode, credential, token, delivery state, or execution
+state is exposed. First PUT is `201`; exact replay and GET are `200` with the
+stored typed response. Definition changes never mutate it.
+
+## Shared execution contract
+
+Cloud maps an explicit authored model to `{kind: exact, modelId: canonicalId}`
+and omission to `{kind: targetDefault}`. Effort requires an exact model.
+Permission is always `workflowDefault`; Cloud never chooses `modeId`.
+
+AnyHarness request:
+
+```json
+{
+  "schemaVersion": 2,
+  "workspaceId": "30000000-0000-4000-8000-000000000001",
+  "definition": {
+    "inputs": [{ "name": "ticket", "type": "string", "required": true }],
+    "stages": [{
+      "harnessConfig": {
+        "agentKind": "claude",
+        "modelSelection": { "kind": "exact", "modelId": "claude-sonnet-4-5" },
+        "effort": "high",
+        "permissionPolicy": "workflowDefault"
+      },
+      "steps": [{
+        "kind": "agent.prompt",
+        "prompt": "Investigate {{inputs.ticket}}"
+      }]
+    }]
+  },
+  "arguments": { "ticket": "PROL-123" }
+}
+```
+
+V2 is strict: one stage/prompt, scalar inputs/arguments, no goal, input names
+`^[A-Za-z][A-Za-z0-9_]*$`. Consume only exact `{{inputs.name}}`; remaining
+`{{`/`}}` rejects. Required and referenced inputs need arguments. Rendering is
+one pass: strings verbatim, canonical number scalar, booleans lowercase. Result
+is nonblank and <=16,384 UTF-8 bytes. V1 validation/replay remains exact,
+including underscore-leading names.
+
+## AnyHarness version boundary
+
+Do not rename or widen the existing v1 components:
+
+```text
+PutWorkflowRunRequest
+WorkflowRunResponse
+WorkflowRun
+WorkflowRunStep
+WorkflowRunFailureCode
+```
+
+Add strict v2 members and separately named operation unions:
+
+```text
+VersionedPutWorkflowRunRequest
+  = PutWorkflowRunRequest | PutWorkflowRunRequestV2
+VersionedWorkflowRunStoredSource
+  = WorkflowRunInvocation | WorkflowRunStoredSourceV2
+VersionedWorkflowRunResponse
+  = WorkflowRunResponse | WorkflowRunResponseV2
+```
+
+Dispatch on required integer `schemaVersion` before strict member decode; GET
+dispatches from stored version. V2 keeps `run + steps` and adds safe
+`resolvedHarness {agentKind, modelId, modeId, effort}`. It never exposes effort
+config ID, rendered prompt, launch options, or credentials.
+
+Keep `WorkflowRunFailureCode` exact. V2 run/step use
+`WorkflowRunFailureCodeV2 = v1 values + session_config_apply_failed`.
+
+## Portable numbers
+
+V2 accepts finite IEEE-754 binary64/I-JSON numbers and rejects integers outside
+`[-9007199254740991, 9007199254740991]`. Replay and prompt scalar rendering use
+RFC 8785: `-0` equals `0`; `1`, `1.0`, and `1e0` are equal. Python and Rust own
+production canonicalization. TypeScript only parses/validates the shared
+fixture and generated types. JSONB or raw `serde_json::Number` equality is not
+the contract. V1 is unchanged.
+
+## Target resolution and execution
+
+For a new v2 run before acceptance:
+
+1. Enforce HTTP workspace auth scope.
+2. Run `WorkspaceAccessGate::assert_can_mutate_for_workspace`.
+3. Read workspace `resolved_workspace_launch_options`.
+4. Require the agent and an exact model, or require target `default_model_id`
+   to yield one concrete model.
+5. In `domains/workflows/resolution.rs`, map `workflowDefault`:
+   Claude -> `bypassPermissions`; Codex -> `full-access`.
+6. Require that mode in the selected model's mode list; other agents reject.
+7. For effort, require the selected exact model's `effort` or
+   `reasoning_effort` value and same-key active session control
+   `mapping.liveConfigId`; persist `{configId,value}`.
+8. Render, validate, and persist source + resolved plan before effects.
+
+Workflow owns the policy. Do not import/edit Cowork. One narrow generic
+session/catalog read seam may expose `liveConfigId`; do not move Workflow policy
+into sessions/agents or broaden raw launch options.
+
+Resolved plan is exactly:
+
+```text
+workspaceId, agentKind, modelId, modeId,
+effortConfig: null | {configId,value}, renderedPrompt, promptId
+```
+
+Reuse the normal InternalOnly, subagents-disabled session. After start and
+before `begin_step`, call `set_live_session_config_option` when effort exists
+and require `Applied`. Queued/rejected/missing/other fails run+step as
+`session_config_apply_failed` and sends no prompt. Replay never resolves or
+executes again.
+
+## Persistence
+
+Postgres:
+
+```text
+workflow_invocation
+  id uuid primary key
+  user_id uuid not null FK user.id on delete cascade
+  workflow_definition_id uuid not null, non-FK correlation
+  definition_revision integer not null
+  title_snapshot text not null
+  description_snapshot text not null
+  schema_version integer not null, exactly 1
+  creation_request_json jsonb not null
+  invocation_json jsonb not null
+  created_at timestamptz not null default now()
+  updated_at timestamptz not null default now()
+```
+
+Reparse and RFC-8785-canonicalize stored typed `creation_request_json` for
+replay; never use JSONB equality. `invocation_json` is the immutable response
+and later delivery payload. This PR adds no delivery/execution status.
+
+AnyHarness keeps `workflow_runs.invocation_json`; replay identity becomes
+`(schema_version, canonical invocation_json)`. Add nullable
+`resolved_plan_json`, required for v2 and nullable for v1. Do not backfill
+guessed v1 resolution.
+
+Register `0061_workflow_runs_v2` in `CUSTOM_FOREIGN_KEY_MIGRATIONS` and use
+`run_named_foreign_key_migration`, because steps reference the rebuilt parent.
+Copy all rows, allow only v1/v2, require plan for v2, restore FK enforcement,
+run `foreign_key_check`, and update schema snapshot. Do not use plain SQL.
+
+## Replay and concurrency
+
+Cloud:
+
+```text
+strict request + canonical UUID
+  -> acquire_workflow_invocation_acceptance_lock
+       pg_advisory_xact_lock(hashtextextended(
+         'workflow-invocation:' + invocationId, 0))
+  -> global ID lookup
+       foreign owner -> 404 workflow_invocation_not_found
+       same owner + exact request -> stored 200, no definition read
+       same owner + mismatch -> 409
+  -> current owned definition + exact revision + eligibility
+  -> snapshot and insert -> 201
+```
+
+PUT authenticates but does not preload a definition dependency. Service returns
+`Created` or `Replay`; HTTP glue chooses status.
+
+AnyHarness:
+
+```text
+strict version + canonical source
+  -> narrow run-ID gate
+  -> exact existing version/source -> 200 without launch lookup
+  -> mismatch -> 409
+  -> access + resolve + render
+  -> atomic run/source/plan/step insert
+  -> Created only schedules existing executor
+```
+
+Keep lookup through scheduling inside the existing detached,
+cancellation-safe `WorkflowRunRuntime::put` handoff. SQLite remains persistent
+correctness authority.
+
+## Failure contract
+
+Cloud:
+
+- malformed wire -> existing Pydantic `422`, no row;
+- semantic args/nonportable number/noncanonical UUID ->
+  `400 invalid_workflow_invocation`;
+- definition absent/foreign -> `404 workflow_definition_not_found`;
+- stale revision -> `409 workflow_definition_revision_conflict`;
+- invocation mismatch -> `409 workflow_invocation_conflict`;
+- invocation absent/foreign -> `404 workflow_invocation_not_found`;
+- unsupported definition/catalog/repo ->
+  `422 workflow_invocation_ineligible` with blockers.
+
+AnyHarness pre-acceptance:
+
+- missing workspace -> `404 WORKSPACE_NOT_FOUND`;
+- direct-attach scope -> existing `403 DIRECT_ATTACH_SCOPE_MISMATCH` or
+  `DIRECT_ATTACH_FORBIDDEN`;
+- blocked/retired -> `409 WORKSPACE_MUTATION_BLOCKED` / `WORKSPACE_RETIRED`;
+- access-store failure -> generic `500`;
+- unresolved agent/model/mode/effort/mapping/default ->
+  `422 WORKFLOW_RUN_TARGET_UNRESOLVABLE`;
+- invalid prompt -> existing `400 WORKFLOW_RUN_INVALID`;
+- replay mismatch -> existing `409 WORKFLOW_RUN_CONFLICT`.
+
+Never persist/log/return prompts, argument values, credentials, environment,
+launch payloads, provider bodies, or raw error chains as error detail.
+
+## Ownership
+
+```text
+fixtures/contracts/workflow-portable-execution/v1.json
+server/proliferate/db/models/workflows.py
+server/proliferate/db/store/workflow_invocations.py
+server/proliferate/server/workflows/{api,models,service,access,errors}.py
+server/proliferate/server/workflows/domain/invocation.py
+server/proliferate/main.py
+server/alembic/versions/<revision>_workflow_invocations.py
+cloud/sdk/src/{generated/openapi,types/workflows,client/workflows}.ts
+
+anyharness/crates/anyharness-contract/src/v1/workflow_runs.rs
+anyharness/crates/anyharness-lib/src/domains/workflows/{model,resolution,service,runtime}.rs
+anyharness/crates/anyharness-lib/src/domains/workflows/store/**
+anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
+anyharness/crates/anyharness-lib/src/persistence/{custom_migrations,migrations}.rs
+anyharness/crates/anyharness-lib/src/api/http/workflow_runs*.rs
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
+anyharness/sdk/{generated/openapi.json,src/generated/openapi.ts}
+```
+
+Existing `/workflows` router owns eligibility. Add `invocations_router` with
+prefix `/workflow-invocations` and mount it in `main.py`. Invocation GET uses an
+owner-scoped access dependency; PUT must decide replay before definition read.
+
+Server stores own SQL/snapshots, service owns orchestration without SQL/commit,
+and API owns transport. Workflow service owns sync validation/persistence;
+`WorkflowRunRuntime` owns async sequencing. Cloud regenerates through
+`make cloud-client-generate` and adds thin Workflow SDK aliases/methods.
+AnyHarness regenerates Rust-owned OpenAPI artifacts only; no handwritten
+Workflow SDK wrapper.
+
+## Required proof
+
+- eligibility positive/full blocker matrix and ordering;
+- strict Cloud shapes, codes, current revision, snapshots, repo/user isolation;
+- real Postgres identical/mismatch/foreign-owner advisory-lock races;
+- Python/Rust RFC-8785 fixture and TypeScript fixture/type validation;
+- exact v1 component/behavior compatibility and strict v1/v2 dispatch;
+- pre-0061 file upgrade, copied rows, schema snapshot, `foreign_key_check`;
+- real SQLite races and stored-plan replay without launch lookup;
+- exact/default model, Claude/Codex mode, effort mapping, unsupported targets;
+- access denial before acceptance;
+- effort Applied before step; every other result sends no prompt;
+- dropped PUT detached handoff, worker bearer, direct-attach exclusion/scope;
+- one session/prompt/turn under replay; and generated OpenAPI/SDK ratchets.
+
+Acceptance:
+
+```text
+create eligible definition -> Cloud PUT 201
+edit definition/defaults -> exact replay 200 and GET same stored invocation
+changed arguments/same UUID -> 409
+manually transfer definition+arguments to AnyHarness v2 with existing workspace
+-> one normal session completes
+change launch defaults -> replay same plan, no second session/prompt/turn
+```
+
+Scripted/fake agent execution is sufficient here. Real-agent Tier 3 is later.
+
+## Handoff metadata
+
+| Field | Value |
+| --- | --- |
+| Spec revision | `1.0` |
+| Base SHA | `0eab251fd35d26022165f7f0852db2885a8c4093` |
+| Predecessor | PR #1158 |
+| Founder approval | 2026-07-14 |

--- a/specs/generated/anyharness-db-schema.sql
+++ b/specs/generated/anyharness-db-schema.sql
@@ -568,34 +568,41 @@ CREATE TABLE terminal_command_runs (
 
 -- table: workflow_run_steps
 CREATE TABLE workflow_run_steps (
-    run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
-    stage_index INTEGER NOT NULL,
-    step_index INTEGER NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
-    prompt_id TEXT NOT NULL UNIQUE,
-    turn_id TEXT,
-    failure_code TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    started_at TEXT,
-    finished_at TEXT,
-    PRIMARY KEY (run_id, stage_index, step_index)
-);
+            run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+            stage_index INTEGER NOT NULL,
+            step_index INTEGER NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('pending','running','completed','failed')),
+            prompt_id TEXT NOT NULL UNIQUE,
+            turn_id TEXT,
+            failure_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            PRIMARY KEY (run_id, stage_index, step_index)
+        );
 
 -- table: workflow_runs
 CREATE TABLE workflow_runs (
-    id TEXT PRIMARY KEY,
-    schema_version INTEGER NOT NULL CHECK (schema_version = 1),
-    invocation_json TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('accepted','running','completed','failed')),
-    workspace_id TEXT NOT NULL,
-    session_id TEXT,
-    failure_code TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    started_at TEXT,
-    finished_at TEXT
-);
+            id TEXT PRIMARY KEY,
+            schema_version INTEGER NOT NULL CHECK (schema_version IN (1, 2)),
+            invocation_json TEXT NOT NULL CHECK (json_valid(invocation_json)),
+            resolved_plan_json TEXT CHECK (
+                resolved_plan_json IS NULL OR json_valid(resolved_plan_json)
+            ),
+            status TEXT NOT NULL CHECK (status IN ('accepted','running','completed','failed')),
+            workspace_id TEXT NOT NULL,
+            session_id TEXT,
+            failure_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            CHECK (
+                (schema_version = 1 AND resolved_plan_json IS NULL)
+                OR (schema_version = 2 AND resolved_plan_json IS NOT NULL)
+            )
+        );
 
 -- table: workspace_access_modes
 CREATE TABLE workspace_access_modes (


### PR DESCRIPTION
## Summary

- Add immutable, user-owned Cloud workflow invocations with eligibility, exact replay/conflict handling, current-definition snapshots, repository placement intent, and real-Postgres advisory-lock concurrency.
- Add strict AnyHarness workflow-run schema v2 for portable one-stage/one-prompt definitions, scalar arguments, RFC 8785 replay identity, workspace-scoped target resolution, and persisted concrete plans before effects.
- Resolve exact/default models, Workflow-owned Claude/Codex permission modes, and same-key live effort configuration before the normal session prompt; preserve every existing v1 workflow-run component and behavior.
- Add the SQLite 0061 parent/child migration, generated Cloud/AnyHarness SDK surfaces, shared contract fixture, and focused compatibility, migration, race, failure, and scripted execution proofs.

This is the next frozen slice after #1158. It proves manual/test Cloud-to-AnyHarness transfer; it intentionally does not add delivery, Desktop custody, cancellation, takeover, schedules, grants, UI, multiple stages/steps, retry, or production release behavior.

## PR Metadata

- Title format: `feat(workflows): add portable invocation and target resolution`
- Release label: `release:minor-feature`
- Areas: `area:anyharness`, `area:server`, `area:cloud`, `area:sdk`, `area:docs`

## Verification

- AnyHarness contract: 38 passed; frozen v1 OpenAPI components unchanged.
- AnyHarness workflow domain/API/execution/migration: 70 passed, including real SQLite races, file-backed pre-0061 close/reopen upgrade, effort-before-prompt behavior, cancellation-safe handoff, and replay with zero duplicate effects.
- Cloud invocation unit + real-Postgres integration: 27 passed, including identical/mismatch/foreign-owner advisory-lock races, owner isolation, snapshots, strict errors, and RFC 8785 numbers.
- AnyHarness SDK: 84 passed; checked negative contract type tests, typecheck, and build passed.
- Cloud SDK: typecheck and build passed.
- Generated AnyHarness OpenAPI/TypeScript and Cloud client reruns were byte-identical.
- Max-lines, AnyHarness boundaries, server boundaries, Ruff, focused mypy, scoped Rust/Python formatting, and `git diff --check` passed.
- Two independent final reviews cleared replay/concurrency, v1 compatibility, target resolution, public launch-option preservation, redaction, migration integrity, ownership, and non-goal scope.

## Release boundary

- No deployment or production promotion is authorized by this PR.
- Hard stop before production remains in effect.
